### PR TITLE
Show next-episode threshold settings in manual mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -128,53 +128,56 @@ internal fun LazyListScope.autoPlaySettingsItems(
                 onFocused = onItemFocused
             )
         }
+    }
 
-        item {
-            val thresholdModeSubtitle = when (playerSettings.nextEpisodeThresholdMode) {
-                NextEpisodeThresholdMode.PERCENTAGE -> "Percentage"
-                NextEpisodeThresholdMode.MINUTES_BEFORE_END -> "Minutes before end"
-            }
-            NavigationSettingsItem(
-                icon = Icons.Default.Tune,
-                title = "Next Episode Threshold Mode",
-                subtitle = thresholdModeSubtitle,
-                onClick = onShowNextEpisodeThresholdModeDialog,
-                onFocused = onItemFocused
-            )
+    item {
+        val thresholdModeSubtitle = when (playerSettings.nextEpisodeThresholdMode) {
+            NextEpisodeThresholdMode.PERCENTAGE -> "Percentage"
+            NextEpisodeThresholdMode.MINUTES_BEFORE_END -> "Minutes before end"
         }
+        NavigationSettingsItem(
+            icon = Icons.Default.Tune,
+            title = "Next Episode Threshold Mode",
+            subtitle = thresholdModeSubtitle,
+            onClick = onShowNextEpisodeThresholdModeDialog,
+            onFocused = onItemFocused
+        )
+    }
 
-        item {
-            when (playerSettings.nextEpisodeThresholdMode) {
-                NextEpisodeThresholdMode.PERCENTAGE -> {
-                    SliderSettingsItem(
-                        icon = Icons.Default.Tune,
-                        title = "Threshold Percentage",
-                        subtitle = "Fallback when no outro timestamp exists.",
-                        value = playerSettings.nextEpisodeThresholdPercent,
-                        valueText = "${playerSettings.nextEpisodeThresholdPercent}%",
-                        minValue = 50,
-                        maxValue = 99,
-                        step = 1,
-                        onValueChange = onSetNextEpisodeThresholdPercent,
-                        onFocused = onItemFocused
-                    )
-                }
-                NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
-                    SliderSettingsItem(
-                        icon = Icons.Default.Tune,
-                        title = "Threshold Minutes",
-                        subtitle = "Fallback when no outro timestamp exists.",
-                        value = playerSettings.nextEpisodeThresholdMinutesBeforeEnd,
-                        valueText = "${playerSettings.nextEpisodeThresholdMinutesBeforeEnd} min",
-                        minValue = 1,
-                        maxValue = 30,
-                        step = 1,
-                        onValueChange = onSetNextEpisodeThresholdMinutesBeforeEnd,
-                        onFocused = onItemFocused
-                    )
-                }
+    item {
+        when (playerSettings.nextEpisodeThresholdMode) {
+            NextEpisodeThresholdMode.PERCENTAGE -> {
+                SliderSettingsItem(
+                    icon = Icons.Default.Tune,
+                    title = "Threshold Percentage",
+                    subtitle = "Fallback when no outro timestamp exists.",
+                    value = playerSettings.nextEpisodeThresholdPercent,
+                    valueText = "${playerSettings.nextEpisodeThresholdPercent}%",
+                    minValue = 50,
+                    maxValue = 99,
+                    step = 1,
+                    onValueChange = onSetNextEpisodeThresholdPercent,
+                    onFocused = onItemFocused
+                )
+            }
+            NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                SliderSettingsItem(
+                    icon = Icons.Default.Tune,
+                    title = "Threshold Minutes",
+                    subtitle = "Fallback when no outro timestamp exists.",
+                    value = playerSettings.nextEpisodeThresholdMinutesBeforeEnd,
+                    valueText = "${playerSettings.nextEpisodeThresholdMinutesBeforeEnd} min",
+                    minValue = 1,
+                    maxValue = 30,
+                    step = 1,
+                    onValueChange = onSetNextEpisodeThresholdMinutesBeforeEnd,
+                    onFocused = onItemFocused
+                )
             }
         }
+    }
+
+    if (playerSettings.streamAutoPlayMode != StreamAutoPlayMode.MANUAL) {
 
         item {
             val sourceLabel = when (playerSettings.streamAutoPlaySource) {


### PR DESCRIPTION

- Makes **Next Episode Threshold Mode** always visible.
- Makes **Threshold Percentage / Threshold Minutes** always visible, including in `Manual` mode.


## Why
In `Manual` mode, threshold settings still affect when the **Next Episode** card appears, so hiding them was confusing.

## Behavior Notes
- No change to core playback logic.
- In `Manual`, next episode still requires stream selection.
- Auto-play of next episode remains dependent on non-manual stream auto-selection modes.

## Testing
- Verified threshold settings are visible in `Manual`.
- Verified `Auto-play Next Episode` is hidden in `Manual`.
- Verified existing stream auto-play options still appear in non-manual modes.

<img width="1015" height="527" alt="image" src="https://github.com/user-attachments/assets/0c2f2b84-36d4-45e1-9c9c-ab2e3e18c103" />

