### PR TITLE
fix[#156]: fix load more resetting to beginning

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
@@ -13,8 +13,7 @@ sealed interface SearchEvent {
     data class SelectDiscoverType(val type: String) : SearchEvent
     data class SelectDiscoverCatalog(val catalogKey: String) : SearchEvent
     data class SelectDiscoverGenre(val genre: String?) : SearchEvent
-    data object ShowMoreDiscoverResults : SearchEvent
-    data object LoadMoreDiscoverResults : SearchEvent
+    data object LoadNextDiscoverResults : SearchEvent
 
     data object Retry : SearchEvent
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -188,15 +188,10 @@ fun SearchScreen(
                     onDiscoverItemFocused = { index ->
                         discoverFocusedItemIndex = index
                     },
-                    onRequestRestoreFocus = { index ->
-                        discoverFocusedItemIndex = index
-                        restoreDiscoverFocus = true
-                    },
                     onSelectType = { viewModel.onEvent(SearchEvent.SelectDiscoverType(it)) },
                     onSelectCatalog = { viewModel.onEvent(SearchEvent.SelectDiscoverCatalog(it)) },
                     onSelectGenre = { viewModel.onEvent(SearchEvent.SelectDiscoverGenre(it)) },
-                    onShowMore = { viewModel.onEvent(SearchEvent.ShowMoreDiscoverResults) },
-                    onLoadMore = { viewModel.onEvent(SearchEvent.LoadMoreDiscoverResults) },
+                    onLoadMore = { viewModel.onEvent(SearchEvent.LoadNextDiscoverResults) },
                     modifier = Modifier.weight(1f)
                 )
             }


### PR DESCRIPTION
This PR fixes the discover pagination/focus issues reported in #156:

- Discover no longer resets visible items back to the first batch after loading more pages.
- `Load more` now works as a single action flow (no extra click needed after fetch).
- Focus behavior after loading is stabilized so navigation no longer jumps unpredictably.
- Right navigation from the action card is constrained to avoid jumping to items in upper rows.
- Action label is unified as `Load more` (with `Loading...` while in progress).

### Root Cause
There were a few interacting issues:
1. Pagination merge logic re-sliced to the initial limit on later fetches.
2. Load flow split between fetch and reveal created a “double click” pattern in some states.
3. Focus index/action-card transitions in a TV grid caused directional navigation leaks and row jumps.

### Changes
- Updated Discover merge logic to preserve current visible count on non-reset loads.
- Unified Discover action handling into a single `Load next` flow.
- Adjusted action-card/focus handling to restore focus to the intended new item after load.
- Blocked `DPAD_RIGHT` on the action card when active to prevent unintended cross-row focus jumps.
- Kept Discover action UI consistent (`Load more` / `Loading...`).


I recorded the behavior but I don't really know the best platform to post the video on, GitHub only allows up to 10MB...
Steps to test this are pretty easy:
1. Open Discover and load several pages.
2. Confirm no reset to earlier batches.
3. Confirm no double-click requirement after larger item counts.
4. Confirm focus remains predictable after load.
5. Confirm pressing right on action card no longer jumps to upper-row items.


Fixes #156
