### PR TITLE
Replace expanding card with focused overlay for episode details

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.zIndex
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -308,7 +308,7 @@ private fun EpisodeCard(
         },
         modifier = Modifier
             .width(cardWidth)
-            .graphicsLayer { alpha = cardAlpha }
+            .alpha(cardAlpha)
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
             .onFocusChanged {
                 isFocused = it.isFocused
@@ -444,14 +444,14 @@ private fun EpisodeCard(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .graphicsLayer { alpha = overlayAlpha }
+                        .alpha(overlayAlpha)
                         .background(overlayBrush)
                 )
                 Column(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .fillMaxWidth()
-                        .graphicsLayer { alpha = overlayAlpha }
+                        .alpha(overlayAlpha)
                         .padding(start = 10.dp, end = 10.dp, bottom = 10.dp, top = 4.dp),
                     verticalArrangement = Arrangement.spacedBy(3.dp)
                 ) {


### PR DESCRIPTION
I noticed that during scrolling through episodes there is a rebound effect because previously focused item shrinks, and newly focus one takes the new free space, adding this unnecessary small animation to the left. 

https://github.com/user-attachments/assets/696a10c9-6fbf-4f75-9124-20e014642ff6


With my change, episode cards now have fixed width (no rebound effect when navigating). On focus, episode title, overview and date fade in as an animated overlay on the thumbnail instead of expanding the card sideways


https://github.com/user-attachments/assets/3484f180-aa59-4547-a166-6b7393ffd11d

