### PR TITLE
Adjust Subtitles Delay

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicLong
 
 class PlayerRuntimeController(
     internal val context: Context,
@@ -114,6 +115,7 @@ class PlayerRuntimeController(
     internal var frameRateProbeToken: Long = 0L
     internal var hideAspectRatioIndicatorJob: Job? = null
     internal var hideStreamSourceIndicatorJob: Job? = null
+    internal var hideSubtitleDelayOverlayJob: Job? = null
     internal var nextEpisodeAutoPlayJob: Job? = null
     internal var sourceStreamsJob: Job? = null
     internal var sourceStreamsCacheRequestKey: String? = null
@@ -156,6 +158,7 @@ class PlayerRuntimeController(
     internal var currentMediaSession: MediaSession? = null
     internal var pauseOverlayJob: Job? = null
     internal val pauseOverlayDelayMs = 5000L
+    internal val subtitleDelayUs = AtomicLong(0L)
     internal var pendingPreviewSeekPosition: Long? = null
     internal var pendingResumeProgress: WatchProgress? = null
     internal var hasRetriedCurrentStreamAfter416: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -34,6 +34,7 @@ internal fun PlayerRuntimeController.releasePlayer() {
     watchProgressSaveJob?.cancel()
     frameRateProbeJob?.cancel()
     hideStreamSourceIndicatorJob?.cancel()
+    hideSubtitleDelayOverlayJob?.cancel()
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null
     _exoPlayer?.release()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -41,6 +41,8 @@ data class PlayerUiState(
     val showAudioDialog: Boolean = false,
     val showSubtitleDialog: Boolean = false,
     val showSubtitleStylePanel: Boolean = false,
+    val showSubtitleDelayOverlay: Boolean = false,
+    val subtitleDelayMs: Int = 0,
     val showSpeedDialog: Boolean = false,
     // Subtitle style settings
     val subtitleStyle: SubtitleStyleSettings = SubtitleStyleSettings(),
@@ -154,6 +156,9 @@ sealed class PlayerEvent {
     data object OnShowSubtitleDialog : PlayerEvent()
     data object OnOpenSubtitleStylePanel : PlayerEvent()
     data object OnDismissSubtitleStylePanel : PlayerEvent()
+    data object OnShowSubtitleDelayOverlay : PlayerEvent()
+    data object OnHideSubtitleDelayOverlay : PlayerEvent()
+    data class OnAdjustSubtitleDelay(val deltaMs: Int) : PlayerEvent()
     data object OnShowSpeedDialog : PlayerEvent()
     data object OnShowEpisodesPanel : PlayerEvent()
     data object OnDismissEpisodesPanel : PlayerEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleDelayConfig.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleDelayConfig.kt
@@ -1,0 +1,6 @@
+package com.nuvio.tv.ui.screens.player
+
+internal const val SUBTITLE_DELAY_MIN_MS = -60_000
+internal const val SUBTITLE_DELAY_MAX_MS = 60_000
+internal const val SUBTITLE_DELAY_STEP_MS = 100
+internal const val SUBTITLE_DELAY_OVERLAY_TIMEOUT_MS = 5_000L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleDialog.kt
@@ -90,6 +90,7 @@ internal fun SubtitleSelectionDialog(
     onAddonSubtitleSelected: (Subtitle) -> Unit,
     onDisableSubtitles: () -> Unit,
     onOpenStylePanel: () -> Unit,
+    onOpenDelayOverlay: () -> Unit,
     onDismiss: () -> Unit
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
@@ -104,7 +105,7 @@ internal fun SubtitleSelectionDialog(
         SubtitleOrganizationMode.NONE,
         SubtitleOrganizationMode.BY_ADDON -> "Addons"
     }
-    val tabs = listOf("Built-in", addonsTabTitle, "Style")
+    val tabs = listOf("Built-in", addonsTabTitle, "Style", "Delay")
     val tabFocusRequesters = remember { tabs.map { FocusRequester() } }
 
     Dialog(onDismissRequest = onDismiss) {
@@ -132,13 +133,15 @@ internal fun SubtitleSelectionDialog(
                         .padding(bottom = 16.dp)
                 ) {
                     tabs.forEachIndexed { index, _ ->
-                        val onTabClick = if (index == 2) {
-                            {
-                                onOpenStylePanel()
+                        val onTabClick = when (index) {
+                            2 -> {
+                                { onOpenStylePanel() }
                             }
-                        } else {
-                            {
-                                selectedTabIndex = index
+                            3 -> {
+                                { onOpenDelayOverlay() }
+                            }
+                            else -> {
+                                { selectedTabIndex = index }
                             }
                         }
                         SubtitleTab(
@@ -173,6 +176,7 @@ internal fun SubtitleSelectionDialog(
                         onSubtitleSelected = onAddonSubtitleSelected
                     )
                     2 -> Unit
+                    3 -> Unit
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR adds subtitle delay adjustment directly in the player UI and applies the delay at runtime in the subtitle renderer.

## What changed
- Added a new `Delay` tab in the subtitle dialog.
- Added subtitle delay overlay UI with live offset display.
- Added player events/state for subtitle delay:
  - show overlay
  - hide overlay
  - adjust delay
- Added subtitle delay config constants (`min`, `max`, `step`, `timeout`).
- Implemented runtime subtitle offset via a renderer wrapper (`SubtitleOffsetRenderer`).
- Integrated behavior with controls/dialog visibility and back/key handling.

## Behavior
- Delay range: `-60s` to `+60s`
- Step: `100ms`
- Overlay auto-hide timeout: `5s`


<img width="756" height="245" alt="image" src="https://github.com/user-attachments/assets/ec6cfeed-e62d-4f98-9abe-4d99e7516985" />

<img width="1084" height="627" alt="image" src="https://github.com/user-attachments/assets/e419d810-51e6-44a1-b0a9-f12c38587dbe" />


