### PR TITLE
AFR UX: show display mode info only on switch and flag fallback-applied mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/DisplayModeOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/DisplayModeOverlay.kt
@@ -99,53 +99,71 @@ fun DisplayModeOverlay(
 
     if (containerAlpha.value <= 0f) return
 
-    Row(
+    Column(
         modifier = modifier
             .alpha(containerAlpha.value)
             .padding(end = 32.dp, top = 24.dp),
-        verticalAlignment = Alignment.Top
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.End
     ) {
-        Column(
-            modifier = Modifier.padding(end = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(ROW_GAP),
-            horizontalAlignment = Alignment.End
-        ) {
-            items.forEachIndexed { index, item ->
-                Row(
-                    modifier = Modifier
-                        .height(ROW_HEIGHT)
-                        .alpha(itemAlphas.getOrNull(index)?.value ?: 0f),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = item.first,
-                        fontSize = 11.sp,
-                        color = Color.White.copy(alpha = 0.85f),
-                        fontWeight = FontWeight.SemiBold,
-                        textAlign = TextAlign.End
-                    )
-                    Text(
-                        text = " - ",
-                        fontSize = 11.sp,
-                        color = Color.White.copy(alpha = 0.4f),
-                    )
-                    Text(
-                        text = item.second,
-                        fontSize = 11.sp,
-                        color = Color.White.copy(alpha = 0.6f),
-                        textAlign = TextAlign.End
-                    )
-                }
-            }
+        val statusMessage = info.statusMessage?.takeIf { it.isNotBlank() }
+        if (statusMessage != null) {
+            Text(
+                text = statusMessage,
+                fontSize = 11.sp,
+                color = NuvioColors.Secondary,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.End,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(Color.Black.copy(alpha = 0.45f))
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
+            )
         }
 
-        Box(
-            modifier = Modifier
-                .width(3.dp)
-                .height((totalLineHeight * lineHeightFraction.value).dp)
-                .clip(RoundedCornerShape(1.dp))
-                .background(NuvioColors.Secondary)
-        )
+        Row(verticalAlignment = Alignment.Top) {
+            Column(
+                modifier = Modifier.padding(end = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(ROW_GAP),
+                horizontalAlignment = Alignment.End
+            ) {
+                items.forEachIndexed { index, item ->
+                    Row(
+                        modifier = Modifier
+                            .height(ROW_HEIGHT)
+                            .alpha(itemAlphas.getOrNull(index)?.value ?: 0f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = item.first,
+                            fontSize = 11.sp,
+                            color = Color.White.copy(alpha = 0.85f),
+                            fontWeight = FontWeight.SemiBold,
+                            textAlign = TextAlign.End
+                        )
+                        Text(
+                            text = " - ",
+                            fontSize = 11.sp,
+                            color = Color.White.copy(alpha = 0.4f),
+                        )
+                        Text(
+                            text = item.second,
+                            fontSize = 11.sp,
+                            color = Color.White.copy(alpha = 0.6f),
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .width(3.dp)
+                    .height((totalLineHeight * lineHeightFraction.value).dp)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(NuvioColors.Secondary)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -205,11 +205,11 @@ fun PlayerScreen(
                 prefer23976Near24 = prefer23976ProbeBias
             )
             val wasPlaying = uiState.isPlaying
-            val switched = com.nuvio.tv.core.player.FrameRateUtils.matchFrameRate(
+            com.nuvio.tv.core.player.FrameRateUtils.matchFrameRate(
                 activity,
                 targetFrameRate,
                 onBeforeSwitch = { if (wasPlaying) viewModel.exoPlayer?.pause() },
-                onAfterSwitch = { mode ->
+                onAfterSwitch = { result ->
                     if (wasPlaying) {
                         coroutineScope.launch {
                             kotlinx.coroutines.delay(2000)
@@ -219,28 +219,15 @@ fun PlayerScreen(
                     viewModel.onEvent(
                         PlayerEvent.OnShowDisplayModeInfo(
                             DisplayModeInfo(
-                                width = mode.physicalWidth,
-                                height = mode.physicalHeight,
-                                refreshRate = mode.refreshRate
+                                width = result.appliedMode.physicalWidth,
+                                height = result.appliedMode.physicalHeight,
+                                refreshRate = result.appliedMode.refreshRate,
+                                statusMessage = if (result.isFallback) "Fallback applied" else null
                             )
                         )
                     )
                 }
             )
-            if (!switched) {
-                val mode = activity.window?.decorView?.display?.mode
-                if (mode != null) {
-                    viewModel.onEvent(
-                        PlayerEvent.OnShowDisplayModeInfo(
-                            DisplayModeInfo(
-                                width = mode.physicalWidth,
-                                height = mode.physicalHeight,
-                                refreshRate = mode.refreshRate
-                            )
-                        )
-                    )
-                }
-            }
             if (allowSourceCorrection) {
                 afrCorrectionUsed = true
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -194,7 +194,8 @@ data class ParentalWarning(
 data class DisplayModeInfo(
     val width: Int,
     val height: Int,
-    val refreshRate: Float
+    val refreshRate: Float,
+    val statusMessage: String? = null
 )
 
 enum class FrameRateSource {


### PR DESCRIPTION
PR Description

Summary
This PR improves AFR display-mode feedback to make it clearer and less noisy.

What changed
Display mode overlay is now shown only when a switch attempt actually occurs. For devices that don's support AFR,
if no switch is performed, no AFR overlay is shown.
onAfterSwitch now prefers the real applied display mode from the system display API.
If the real applied mode differs from the requested mode, the overlay shows a Fallback applied status.
Overlay still shows refresh rate and resolution as before.
Notes
This does not change AFR switching strategy itself; it only improves the information shown to the user.
Playback resume delay behavior remains tied to the switch callback path.