### PR TITLE
Close when pressing back two times

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -182,6 +183,22 @@ class MainActivity : ComponentActivity() {
 
                     val updateViewModel: UpdateViewModel = hiltViewModel(this@MainActivity)
                     val updateState by updateViewModel.uiState.collectAsState()
+
+                    var backPressedOnce by remember { mutableStateOf(false) }
+                    BackHandler(enabled = true) {
+                        if (backPressedOnce) {
+                            this@MainActivity.finish()
+                        } else {
+                            backPressedOnce = true
+                            Toast.makeText(this@MainActivity, "Press back one more time to close the app", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                    LaunchedEffect(backPressedOnce) {
+                        if (backPressedOnce) {
+                            delay(2000L)
+                            backPressedOnce = false
+                        }
+                    }
 
                     val startDestination = if (layoutChosen) Screen.Home.route else Screen.LayoutSelection.route
                     val navController = rememberNavController()


### PR DESCRIPTION
Quick change to close the app instead of minimizing it when pressing back at the navigation root.

Now, the first back press shows a toast: "_Press back one more time to close the app_", and a second press within 2 seconds calls `finish()` to fully close it.

I was thinking about hiding this behind a setting, but if user want to minimize the app pressing the "**home**" button does it, so functionality is not lost