### PR TITLE
Fix plugin subtitle selection and sidecar subtitle reliability

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -48,14 +48,20 @@ internal class PlayerMediaSourceFactory {
         }
 
         val mediaItem = mediaItemBuilder.build()
+        val defaultFactory = DefaultMediaSourceFactory(okHttpFactory)
+
+        // Sidecar subtitles are more reliable through DefaultMediaSourceFactory.
+        if (subtitleConfigurations.isNotEmpty()) {
+            return defaultFactory.createMediaSource(mediaItem)
+        }
+
         return when {
             isHls -> HlsMediaSource.Factory(okHttpFactory)
                 .setAllowChunklessPreparation(true)
                 .createMediaSource(mediaItem)
             isDash -> DashMediaSource.Factory(okHttpFactory)
                 .createMediaSource(mediaItem)
-            else -> DefaultMediaSourceFactory(okHttpFactory)
-                .createMediaSource(mediaItem)
+            else -> defaultFactory.createMediaSource(mediaItem)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -120,7 +120,8 @@ internal fun PlayerRuntimeController.disableSubtitles() {
 
 internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: com.nuvio.tv.domain.model.Subtitle) {
     _exoPlayer?.let { player ->
-        if (_uiState.value.selectedAddonSubtitle?.id == subtitle.id) {
+        val currentlySelected = _uiState.value.selectedAddonSubtitle
+        if (currentlySelected?.id == subtitle.id && currentlySelected.url == subtitle.url) {
             return@let
         }
         Log.d(PlayerRuntimeController.TAG, "Selecting ADDON subtitle lang=${subtitle.lang} id=${subtitle.id}")
@@ -131,16 +132,16 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: com.nuvio.tv.
         pendingAddonSubtitleTrackId = addonTrackId
         pendingAudioSelectionAfterSubtitleRefresh =
             captureCurrentAudioSelectionForSubtitleRefresh(player)
+        val subtitleMimeType = PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url)
 
-        
-        val subtitleConfig = MediaItem.SubtitleConfiguration.Builder(
+        val subtitleConfigBuilder = MediaItem.SubtitleConfiguration.Builder(
             android.net.Uri.parse(subtitle.url)
         )
             .setId(addonTrackId)
-            .setMimeType(PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url))
             .setLanguage(normalizedLang)
+            .setMimeType(subtitleMimeType)
             .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
-            .build()
+        val subtitleConfig = subtitleConfigBuilder.build()
 
         val currentPosition = player.currentPosition
         val playWhenReady = player.playWhenReady

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -132,19 +132,17 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
         } else {
             val pendingLang = pendingAddonSubtitleLanguage
             val hasManualAddonSelection = _uiState.value.selectedAddonSubtitle != null
-            if (hasManualAddonSelection && !pendingLang.isNullOrBlank()) {
-                val addonFallbackIndex = subtitleTracks.indexOfLast {
-                    PlayerSubtitleUtils.matchesLanguageCode(it.language, pendingLang)
-                }
-                if (addonFallbackIndex >= 0) {
-                    Log.d(
-                        PlayerRuntimeController.TAG,
-                        "Addon track id not found; falling back to last language match index=$addonFallbackIndex lang=$pendingLang"
-                    )
-                    selectSubtitleTrack(addonFallbackIndex)
-                    selectedSubtitleIndex = -1
-                    pendingAddonSubtitleTrackId = null
-                    pendingAddonSubtitleLanguage = null
+            if (hasManualAddonSelection) {
+                if (!pendingLang.isNullOrBlank()) {
+                    val addonFallbackIndex = subtitleTracks.indexOfLast {
+                        PlayerSubtitleUtils.matchesLanguageCode(it.language, pendingLang)
+                    }
+                    if (addonFallbackIndex >= 0) {
+                        selectSubtitleTrack(addonFallbackIndex)
+                        selectedSubtitleIndex = -1
+                        pendingAddonSubtitleTrackId = null
+                        pendingAddonSubtitleLanguage = null
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -58,12 +58,16 @@ internal object PlayerSubtitleUtils {
     }
 
     fun mimeTypeFromUrl(url: String): String {
-        val lowerUrl = url.lowercase()
+        val normalizedPath = url
+            .substringBefore('#')
+            .substringBefore('?')
+            .lowercase()
+
         return when {
-            lowerUrl.endsWith(".srt") -> MimeTypes.APPLICATION_SUBRIP
-            lowerUrl.endsWith(".vtt") || lowerUrl.endsWith(".webvtt") -> MimeTypes.TEXT_VTT
-            lowerUrl.endsWith(".ass") || lowerUrl.endsWith(".ssa") -> MimeTypes.TEXT_SSA
-            lowerUrl.endsWith(".ttml") || lowerUrl.endsWith(".dfxp") -> MimeTypes.APPLICATION_TTML
+            normalizedPath.endsWith(".srt") -> MimeTypes.APPLICATION_SUBRIP
+            normalizedPath.endsWith(".vtt") || normalizedPath.endsWith(".webvtt") -> MimeTypes.TEXT_VTT
+            normalizedPath.endsWith(".ass") || normalizedPath.endsWith(".ssa") -> MimeTypes.TEXT_SSA
+            normalizedPath.endsWith(".ttml") || normalizedPath.endsWith(".dfxp") -> MimeTypes.APPLICATION_TTML
             else -> MimeTypes.APPLICATION_SUBRIP
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes subtitle selection issues on plugin sources where the selected subtitle could map to the wrong track or fail to load.

Closes #199.

## Changes
- Keep pending addon subtitle selection until a matching track is available.
- Avoid no-op when selecting a subtitle with the same `id` but a different `url`.
- Improve sidecar subtitle reliability by using `DefaultMediaSourceFactory` when `subtitleConfigurations` are attached.
- Fix subtitle MIME detection for URLs containing query strings or fragments (e.g. `...?token=...`, `#...`).

## Scope
- `app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt`
- `app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt`
- `app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt`
- `app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt`


