### PR TITLE
Add Android TV voice search input (mic + auto-focus)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
@@ -36,7 +36,13 @@ class CatalogRepositoryImpl @Inject constructor(
         extraArgs: Map<String, String>,
         supportsSkip: Boolean
     ): Flow<NetworkResult<CatalogRow>> = flow {
-        val cacheKey = "${addonId}_${type}_${catalogId}_$skip"
+        val cacheKey = buildCacheKey(
+            addonId = addonId,
+            type = type,
+            catalogId = catalogId,
+            skip = skip,
+            extraArgs = extraArgs
+        )
 
         // Emit cached data immediately if available
         val cached = catalogCache[cacheKey]
@@ -128,5 +134,18 @@ class CatalogRepositoryImpl @Inject constructor(
 
     private fun encodeArg(value: String): String {
         return URLEncoder.encode(value, "UTF-8").replace("+", "%20")
+    }
+
+    private fun buildCacheKey(
+        addonId: String,
+        type: String,
+        catalogId: String,
+        skip: Int,
+        extraArgs: Map<String, String>
+    ): String {
+        val normalizedArgs = extraArgs.entries
+            .sortedBy { it.key }
+            .joinToString("&") { "${it.key}=${it.value}" }
+        return "${addonId}_${type}_${catalogId}_${skip}_${normalizedArgs}"
     }
 }


### PR DESCRIPTION
## Summary
- add Android TV voice search mic button beside search input
- make mic the default focused control when available, with matching focus-accent border styling
- keep voice availability guarded by recognizer capability checks and fail-safe toasts
- stabilize search-focus handoff so results receive focus only after the active search completes
- ensure top-row return focus goes back to mic (when available) instead of text field
- remove initial discover-grid visibility from Search screen to avoid pre-search focus targets
- normalize search row titles to `Search Movies` / `Search Series`
- fix catalog cache keying to include `extraArgs` so search requests cannot reuse cached popular/discover rows

## Scope
- focused to search flow, search row labeling, and catalog fetch caching for search correctness
- no player pipeline changes

## Files Changed
- app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
- app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
- app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt

## Validation
- initial search no longer flashes cached popular/discover rows before search rows
- initial and subsequent searches move focus consistently to first result row/item
- text and voice search paths now use deterministic first-item focus handoff
- moving up from first results row returns to mic button when available
- mic button remains hidden on unsupported devices