### PR TITLE
fix: resolve detail page D-pad navigation issues (#214)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CastSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CastSection.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
@@ -41,9 +42,10 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.domain.model.MetaCastMember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import com.nuvio.tv.ui.theme.NuvioColors
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun CastSection(
     cast: List<MetaCastMember>,
@@ -94,7 +96,9 @@ fun CastSection(
         }
 
         LazyRow(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRestorer(),
             contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.Start
         ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.zIndex
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -68,7 +70,7 @@ import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.ui.theme.NuvioTheme
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun SeasonTabs(
     seasons: List<Int>,
@@ -164,7 +166,7 @@ fun SeasonTabs(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun EpisodesRow(
     episodes: List<Video>,
@@ -197,7 +199,8 @@ fun EpisodesRow(
 
     LazyRow(
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .focusRestorer(),
         contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -90,6 +90,7 @@ fun HeroContentSection(
     hideMetaInfoImdb: Boolean = false,
     isTrailerPlaying: Boolean = false,
     playButtonFocusRequester: FocusRequester? = null,
+    downFocusRequester: FocusRequester? = null,
     restorePlayFocusToken: Int = 0,
     onPlayFocusRestored: () -> Unit = {}
 ) {
@@ -186,6 +187,7 @@ fun HeroContentSection(
                             },
                             onClick = onPlayClick,
                             focusRequester = playButtonFocusRequester,
+                            downFocusRequester = downFocusRequester,
                             restoreFocusToken = restorePlayFocusToken,
                             onFocusRestored = onPlayFocusRestored
                         )
@@ -202,7 +204,8 @@ fun HeroContentSection(
                             },
                             contentDescription = if (isInLibrary) "Remove from library" else "Add to library",
                             onClick = onToggleLibrary,
-                            onLongPress = onLibraryLongPress
+                            onLongPress = onLibraryLongPress,
+                            downFocusRequester = downFocusRequester
                         )
 
                         if (meta.apiType == "movie") {
@@ -221,7 +224,8 @@ fun HeroContentSection(
                                 enabled = !isMovieWatchedPending,
                                 selected = isMovieWatched,
                                 selectedContainerColor = Color.White,
-                                selectedContentColor = Color.Black
+                                selectedContentColor = Color.Black,
+                                downFocusRequester = downFocusRequester
                             )
                         }
 
@@ -234,7 +238,8 @@ fun HeroContentSection(
                             ActionIconButtonPainter(
                                 painter = trailerPainter,
                                 contentDescription = "Play trailer",
-                                onClick = onTrailerClick
+                                onClick = onTrailerClick,
+                                downFocusRequester = downFocusRequester
                             )
                         }
                     }
@@ -299,6 +304,7 @@ private fun PlayButton(
     text: String,
     onClick: () -> Unit,
     focusRequester: FocusRequester? = null,
+    downFocusRequester: FocusRequester? = null,
     restoreFocusToken: Int = 0,
     onFocusRestored: () -> Unit = {}
 ) {
@@ -322,7 +328,10 @@ private fun PlayButton(
                     onFocusRestored()
                 }
             }
-            .focusProperties { up = FocusRequester.Cancel },
+            .focusProperties {
+                up = FocusRequester.Cancel
+                if (downFocusRequester != null) down = downFocusRequester
+            },
         colors = ButtonDefaults.colors(
             containerColor = androidx.compose.ui.graphics.Color.White,
             focusedContainerColor = androidx.compose.ui.graphics.Color.White,
@@ -363,14 +372,18 @@ private fun ActionIconButtonPainter(
     painter: Painter,
     contentDescription: String,
     onClick: () -> Unit,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    downFocusRequester: FocusRequester? = null
 ) {
     IconButton(
         onClick = onClick,
         enabled = enabled,
         modifier = Modifier
             .size(48.dp)
-            .focusProperties { up = FocusRequester.Cancel },
+            .focusProperties {
+                up = FocusRequester.Cancel
+                if (downFocusRequester != null) down = downFocusRequester
+            },
         colors = IconButtonDefaults.colors(
             containerColor = NuvioColors.BackgroundCard,
             focusedContainerColor = NuvioColors.Secondary,
@@ -406,7 +419,8 @@ private fun ActionIconButton(
     enabled: Boolean = true,
     selected: Boolean = false,
     selectedContainerColor: Color = Color(0xFF7CFF9B),
-    selectedContentColor: Color = Color.Black
+    selectedContentColor: Color = Color.Black,
+    downFocusRequester: FocusRequester? = null
 ) {
     var longPressTriggered by remember { mutableStateOf(false) }
 
@@ -449,7 +463,10 @@ private fun ActionIconButton(
                 }
                 false
             }
-            .focusProperties { up = FocusRequester.Cancel },
+            .focusProperties {
+                up = FocusRequester.Cancel
+                if (downFocusRequester != null) down = downFocusRequester
+            },
         colors = IconButtonDefaults.colors(
             containerColor = if (selected) selectedContainerColor else NuvioColors.BackgroundCard,
             focusedContainerColor = NuvioColors.Secondary,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MoreLikeThisSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MoreLikeThisSection.kt
@@ -10,13 +10,16 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.unit.dp
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.PosterCardStyle
 
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 fun MoreLikeThisSection(
     items: List<MetaPreview>,
@@ -53,7 +56,9 @@ fun MoreLikeThisSection(
             .padding(top = 8.dp, bottom = 8.dp)
     ) {
         LazyRow(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRestorer(),
             contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {


### PR DESCRIPTION
## Summary

Fixes the odd D-pad navigation behavior on the Detail Page reported in #214.

## Problem

Three distinct navigation bugs were reported:

1. **Inconsistent downward navigation from hero buttons**: Pressing D-pad down from "Play" and "Add to Library" navigated to "Creator and Cast", while pressing down from "Mark as Watched" and "Trailer" navigated to "More like this". The expected behavior is that all hero buttons should navigate to the same section.

2. **Lateral drift in Cast/More Like This**: After scrolling right in "Creator and Cast", pressing up then down shifted the selection one position to the left instead of returning to the previously focused item.

3. **Automatic rightward shift without "More like this"**: When "More like this" was not available, scrolling up and down caused an automatic shift to the right.

## Root Cause

### Issue 1: Spatial Navigation Landing on Wrong Tab
The hero action buttons (Play, Add to Library, Mark as Watched, Trailer) are laid out horizontally. Below them sits the tabbed section (Creator and Cast | Ratings | More like this). Android TV's default spatial navigation algorithm picks the **geometrically closest** focusable element — so left-side buttons land on the "Cast" tab while right-side buttons land on the "More like this" tab. Since each tab auto-activates on focus, this caused unexpected section switching.

### Issue 2 & 3: LazyRow Focus Not Preserved
The `LazyRow` components in Cast, More Like This, and Episodes sections did not use `focusRestorer()`. When focus left a row (via up/down navigation) and returned, the framework fell back to spatial proximity instead of restoring the previously focused item, causing lateral drift.

## Fix

### 1. Explicit `down` Focus Targets on Hero Buttons (`HeroSection.kt`, `MetaDetailsScreen.kt`)
- Added a `downFocusRequester` parameter to `HeroContentSection`, `PlayButton`, `ActionIconButton`, and `ActionIconButtonPainter`
- All hero buttons now explicitly navigate down to:
  - **Series**: Season tabs (`selectedSeasonFocusRequester`)
  - **Movies with people tabs**: The currently active people tab
  - **Movies with only ratings**: The ratings content
- This eliminates the spatial navigation guesswork entirely

### 2. Focus Restoration on LazyRows (`CastSection.kt`, `MoreLikeThisSection.kt`, `EpisodesSection.kt`)
- Added `focusRestorer()` modifier to the `LazyRow` in:
  - `CastSection`
  - `MoreLikeThisSection`
  - `EpisodesRow`
- This ensures the previously focused item is restored when focus returns to the row after vertical navigation

### 3. Tab Switching Only on Horizontal Navigation (`MetaDetailsScreen.kt`)
- Updated `PeopleSectionTabButton` to track whether a lateral (left/right) D-pad key was pressed
- Tab switching (`onFocused()` callback) now only fires when:
  - The tab is already the selected/active tab (re-entry), OR
  - A horizontal D-pad key was pressed (explicit lateral navigation)
- This prevents unintended tab switching when focus arrives from vertical navigation (e.g., pressing down from hero or episodes)

## Files Changed

| File | Changes |
|---|---|
| `HeroSection.kt` | Added `downFocusRequester` param to all button composables, wired through `focusProperties { down = ... }` |
| `MetaDetailsScreen.kt` | Computed `heroDownFocusRequester`, passed to hero section; updated `PeopleSectionTabButton` with lateral key tracking |
| `CastSection.kt` | Added `focusRestorer()` to `LazyRow` |
| `MoreLikeThisSection.kt` | Added `focusRestorer()` to `LazyRow` |
| `EpisodesSection.kt` | Added `focusRestorer()` to `LazyRow` |

## Testing

- `compileDebugKotlin` passes successfully
- All changes are backwards compatible — no API surface changes to public composables beyond the new optional `downFocusRequester` parameter

Closes #214
