### PR TITLE
feat(updater): auto-cleanup old downloaded APKs

### DIFF
--- a/app/src/main/java/com/nuvio/tv/updater/UpdateViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/updater/UpdateViewModel.kt
@@ -104,8 +104,14 @@ class UpdateViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isDownloading = true, downloadProgress = 0f, errorMessage = null) }
 
+            // Auto-cleanup: Delete any previously downloaded APKs to save storage space
+            val updatesDir = File(context.cacheDir, "updates")
+            if (updatesDir.exists()) {
+                updatesDir.deleteRecursively()
+            }
+
             val safeName = update.assetName.replace(Regex("[^a-zA-Z0-9._-]"), "_")
-            val dest = File(File(context.cacheDir, "updates"), safeName)
+            val dest = File(updatesDir, safeName)
 
             val result = withContext(Dispatchers.IO) {
                 apkDownloader.download(update.assetUrl, dest) { downloaded, total ->


### PR DESCRIPTION
## Summary

Added a quick auto-cleanup functionality for the application updater. The updater now completely clears its own `.apk` cache directory right before fetching and starting a new version download.

## Why

To fix an issue where old installation files (`.apk`s) were permanently accumulating and unnecessarily consuming valuable storage space on Android TV devices. Cleaning the cache directory ensures only the latest update file exists on the device.

## Testing

- Initiated a new update download and verified that any existing `.apk` files from previous updates within the cache directory were successfully deleted prior to the new download starting.
- Confirmed that the new `.apk` file downloads successfully after the cleanup process.

## Screenshots / Video (UI changes only)

No UI changes were made.

## Breaking changes

No breaking changes were made.

## Linked issues

Fixes #249
