### PR TITLE
Fix "prefer meta from external addon" for Grid and Modern layouts

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -61,6 +61,7 @@ fun GridHomeContent(
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit,
     onRemoveContinueWatching: (String, Int?, Int?, Boolean) -> Unit,
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
+    onItemFocus: (com.nuvio.tv.domain.model.MetaPreview) -> Unit = {},
     onSaveGridFocusState: (Int, Int) -> Unit
 ) {
     val gridState = rememberLazyGridState(
@@ -266,6 +267,7 @@ fun GridHomeContent(
                                 focusRequester = focusRequester,
                                 posterCardStyle = posterCardStyle,
                                 showLabel = uiState.posterLabelsEnabled,
+                                onFocused = { onItemFocus(gridItem.item) },
                                 onClick = {
                                     onNavigateToDetail(
                                         gridItem.item.id,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -213,6 +213,9 @@ private fun GridHomeRoute(
         onRemoveContinueWatching = { contentId, season, episode, isNextUp ->
             viewModel.onEvent(HomeEvent.OnRemoveContinueWatching(contentId, season, episode, isNextUp))
         },
+        onItemFocus = { item ->
+            viewModel.onItemFocus(item)
+        },
         onSaveGridFocusState = { vi, vo ->
             viewModel.saveGridFocusState(vi, vo)
         }
@@ -241,6 +244,9 @@ private fun ModernHomeRoute(
         },
         onRemoveContinueWatching = { contentId, season, episode, isNextUp ->
             viewModel.onEvent(HomeEvent.OnRemoveContinueWatching(contentId, season, episode, isNextUp))
+        },
+        onItemFocus = { item ->
+            viewModel.onItemFocus(item)
         },
         onSaveFocusState = { vi, vo, ri, ii, m ->
             viewModel.saveFocusState(vi, vo, ri, ii, m)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -130,7 +130,8 @@ private data class ModernCarouselItem(
     val subtitle: String?,
     val imageUrl: String?,
     val heroPreview: HeroPreview,
-    val payload: ModernPayload
+    val payload: ModernPayload,
+    val metaPreview: MetaPreview? = null
 )
 
 private data class HeroCarouselRow(
@@ -157,6 +158,7 @@ fun ModernHomeContent(
     onRequestTrailerPreview: (String, String, String?, String) -> Unit,
     onLoadMoreCatalog: (String, String, String) -> Unit,
     onRemoveContinueWatching: (String, Int?, Int?, Boolean) -> Unit,
+    onItemFocus: (MetaPreview) -> Unit = {},
     onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit
 ) {
     val useLandscapePosters = uiState.modernLandscapePostersEnabled
@@ -699,6 +701,7 @@ fun ModernHomeContent(
                                         if (focusedCatalogSelection != nextSelection) {
                                             focusedCatalogSelection = nextSelection
                                         }
+                                        item.metaPreview?.let { onItemFocus(it) }
                                     },
                                     onClick = {
                                         onNavigateToDetail(
@@ -1059,7 +1062,8 @@ private fun buildCatalogItem(
             trailerTitle = item.name,
             trailerReleaseInfo = item.releaseInfo,
             trailerApiType = item.apiType
-        )
+        ),
+        metaPreview = item
     )
 }
 


### PR DESCRIPTION
onItemFocus was only wired in Classic - added to GridHomeContent and ModernHomeContent so external meta prefetch on card focus works consistently across all home layouts

fixes for #148 