### PR TITLE
fix[#263]: refactor air date to use system default locale

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -54,7 +54,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import java.util.Locale
@@ -773,8 +773,8 @@ class HomeViewModel @Inject constructor(
         val released = video.released?.trim()?.takeIf { it.isNotEmpty() }
             ?: artworkFallback?.airDate
         val releaseDate = parseEpisodeReleaseDate(released)
-        val todayUtc = LocalDate.now(ZoneOffset.UTC)
-        val hasAired = releaseDate?.let { !it.isAfter(todayUtc) } ?: true
+        val todayLocal = LocalDate.now(ZoneId.systemDefault())
+        val hasAired = releaseDate?.let { !it.isAfter(todayLocal) } ?: true
         val info = NextUpInfo(
             contentId = progress.contentId,
             contentType = progress.contentType,
@@ -886,18 +886,19 @@ class HomeViewModel @Inject constructor(
         if (showUnairedNextUp) return true
         val releaseDate = parseEpisodeReleaseDate(nextEpisode.released)
             ?: return true
-        val todayUtc = LocalDate.now(ZoneOffset.UTC)
-        return !releaseDate.isAfter(todayUtc)
+        val todayLocal = LocalDate.now(ZoneId.systemDefault())
+        return !releaseDate.isAfter(todayLocal)
     }
 
     private fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
         if (raw.isNullOrBlank()) return null
         val value = raw.trim()
+        val zone = ZoneId.systemDefault()
 
         return runCatching {
-            Instant.parse(value).atOffset(ZoneOffset.UTC).toLocalDate()
+            Instant.parse(value).atZone(zone).toLocalDate()
         }.getOrNull() ?: runCatching {
-            OffsetDateTime.parse(value).toLocalDate()
+            OffsetDateTime.parse(value).toInstant().atZone(zone).toLocalDate()
         }.getOrNull() ?: runCatching {
             LocalDateTime.parse(value).toLocalDate()
         }.getOrNull() ?: runCatching {
@@ -976,8 +977,8 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun formatEpisodeAirDateLabel(releaseDate: LocalDate): String {
-        val todayUtc = LocalDate.now(ZoneOffset.UTC)
-        val formatter = if (releaseDate.year == todayUtc.year) {
+        val todayLocal = LocalDate.now(ZoneId.systemDefault())
+        val formatter = if (releaseDate.year == todayLocal.year) {
             DateTimeFormatter.ofPattern("MMM d", Locale.getDefault())
         } else {
             DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())


### PR DESCRIPTION
This PR fixes a date mismatch where the Continue Watching Airs badge could show +1 day compared to the episode list.

UTC-based parsing was causing day shifts for some release timestamps, while episode list dates were shown in local time, so I updated Continue Watching next-episode date to use local timezone (ZoneId.systemDefault()) instead of UTC.

Closes #263 