### PR TITLE
Handle Kitsu and Mal content ids for AniSkip

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/remote/api/SkipIntroApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/SkipIntroApi.kt
@@ -78,6 +78,12 @@ interface ArmApi {
         @Query("id") imdbId: String,
         @Query("include") include: String = "myanimelist"
     ): Response<List<ArmEntry>>
+
+    @GET("kitsu")
+    suspend fun resolveByKitsu(
+        @Query("id") kitsuId: String,
+        @Query("include") include: String = "myanimelist"
+    ): Response<List<ArmEntry>>
 }
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -209,6 +209,35 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
 internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int?, episode: Int?) {
     if (!skipIntroEnabled) return
     if (id.isNullOrBlank()) return
+
+    // MAL ID format: "mal:57658:1" (malId:episode)
+    if (id.startsWith("mal:")) {
+        val parts = id.split(":")
+        val malId = parts.getOrNull(1) ?: return
+        val malEpisode = parts.getOrNull(2)?.toIntOrNull() ?: episode ?: return
+        val key = "mal:$malId:$malEpisode"
+        if (skipIntroFetchedKey == key) return
+        skipIntroFetchedKey = key
+        scope.launch {
+            skipIntervals = skipIntroRepository.getSkipIntervalsForMal(malId, malEpisode)
+        }
+        return
+    }
+
+    // Kitsu ID format: "kitsu:12345:1" (kitsuId:episode)
+    if (id.startsWith("kitsu:")) {
+        val parts = id.split(":")
+        val kitsuId = parts.getOrNull(1) ?: return
+        val kitsuEpisode = parts.getOrNull(2)?.toIntOrNull() ?: episode ?: return
+        val key = "kitsu:$kitsuId:$kitsuEpisode"
+        if (skipIntroFetchedKey == key) return
+        skipIntroFetchedKey = key
+        scope.launch {
+            skipIntervals = skipIntroRepository.getSkipIntervalsForKitsu(kitsuId, kitsuEpisode)
+        }
+        return
+    }
+
     val imdbId = id.split(":").firstOrNull()?.takeIf { it.startsWith("tt") } ?: return
     if (season == null || episode == null) return
 


### PR DESCRIPTION
Noticed that AniSkip was only being triggered for content with an IMDB ID - anime that use MAL or Kitsu IDs as their content identifier would silently skip the skip intro feature entirely. This PR adds native support for both mal: and kitsu: content ID formats