### PR TITLE
Fix last expanded poster cuttoff in classic view 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -173,7 +173,7 @@ fun CatalogRowSection(
                         Modifier
                     }
                 ),
-            contentPadding = PaddingValues(horizontal = 48.dp),
+            contentPadding = PaddingValues(start = 48.dp, end = 200.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             itemsIndexed(


### PR DESCRIPTION
Fixes #97

<img width="1206" height="530" alt="image" src="https://github.com/user-attachments/assets/4b08cd62-46c4-4db4-8991-dff7611ae5b2" />

<img width="1205" height="559" alt="image" src="https://github.com/user-attachments/assets/ab669129-5159-41ee-bcf0-5563ea14af82" />

 