### PR TITLE
Fix subtitle addons - wrong content ID, addon tracks in built-in list, videoHash/videoSize/filename pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ scripts
 supabase
 tv-samples
 HOME_UI_OPTIMIZATION_NOTES.local.md
+.kotlin/

--- a/app/src/main/java/com/nuvio/tv/core/player/OpenSubtitlesHasher.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/OpenSubtitlesHasher.kt
@@ -1,0 +1,91 @@
+package com.nuvio.tv.core.player
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Calculates the OpenSubtitles file hash for a video stream.
+ * Algorithm: hash = fileSize + sum of first 64KB longs + sum of last 64KB longs (little-endian)
+ * https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes
+ */
+object OpenSubtitlesHasher {
+
+    private const val CHUNK_SIZE = 65536L // 64 KB
+    private const val LONG_SIZE = 8
+
+    data class Result(val hash: String, val fileSize: Long)
+
+    suspend fun compute(url: String, headers: Map<String, String>): Result? =
+        withContext(Dispatchers.IO) {
+            try {
+                val fileSize = getContentLength(url, headers) ?: return@withContext null
+                if (fileSize < CHUNK_SIZE * 2) return@withContext null
+
+                var hash = fileSize
+                hash += readChunkSum(url, headers, offset = 0, length = CHUNK_SIZE)
+                hash += readChunkSum(url, headers, offset = fileSize - CHUNK_SIZE, length = CHUNK_SIZE)
+
+                Result(
+                    hash = "%016x".format(hash),
+                    fileSize = fileSize
+                )
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+    private fun getContentLength(url: String, headers: Map<String, String>): Long? {
+        val conn = openConnection(url, headers, method = "HEAD")
+        return try {
+            conn.connect()
+            conn.contentLengthLong.takeIf { it > 0 }
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun readChunkSum(url: String, headers: Map<String, String>, offset: Long, length: Long): Long {
+        val conn = openConnection(url, headers, method = "GET")
+        conn.setRequestProperty("Range", "bytes=$offset-${offset + length - 1}")
+        var sum = 0L
+        try {
+            conn.connect()
+            val stream: InputStream = conn.inputStream
+            val buf = ByteArray(LONG_SIZE)
+            var remaining = length
+            while (remaining >= LONG_SIZE) {
+                var read = 0
+                while (read < LONG_SIZE) {
+                    val n = stream.read(buf, read, LONG_SIZE - read)
+                    if (n < 0) break
+                    read += n
+                }
+                if (read < LONG_SIZE) break
+                sum += buf.toLongLE()
+                remaining -= LONG_SIZE
+            }
+            stream.close()
+        } finally {
+            conn.disconnect()
+        }
+        return sum
+    }
+
+    private fun openConnection(url: String, headers: Map<String, String>, method: String): HttpURLConnection {
+        val conn = URL(url).openConnection() as HttpURLConnection
+        conn.requestMethod = method
+        conn.connectTimeout = 8_000
+        conn.readTimeout = 8_000
+        headers.forEach { (k, v) -> conn.setRequestProperty(k, v) }
+        return conn
+    }
+
+    private fun ByteArray.toLongLE(): Long {
+        var v = 0L
+        for (i in 0 until LONG_SIZE) v = v or ((this[i].toLong() and 0xFF) shl (i * 8))
+        return v
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
@@ -25,7 +25,10 @@ fun BehaviorHintsDto.toDomain(): StreamBehaviorHints = StreamBehaviorHints(
     notWebReady = notWebReady,
     bingeGroup = bingeGroup,
     countryWhitelist = countryWhitelist,
-    proxyHeaders = proxyHeaders?.toDomain()
+    proxyHeaders = proxyHeaders?.toDomain(),
+    videoHash = videoHash,
+    videoSize = videoSize,
+    filename = filename
 )
 
 fun ProxyHeadersDto.toDomain(): ProxyHeaders = ProxyHeaders(

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -55,7 +55,10 @@ data class StreamBehaviorHints(
     val notWebReady: Boolean?,
     val bingeGroup: String?,
     val countryWhitelist: List<String>?,
-    val proxyHeaders: ProxyHeaders?
+    val proxyHeaders: ProxyHeaders?,
+    val videoHash: String? = null,
+    val videoSize: Long? = null,
+    val filename: String? = null
 )
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -342,7 +342,10 @@ fun NuvioNavHost(
                                 rememberedAudioLanguage = playbackInfo.rememberedAudioLanguage,
                                 rememberedAudioName = playbackInfo.rememberedAudioName,
                                 autoPlayNav = false,
-                                returnToDetailOnBack = returnToDetailOnBack
+                                returnToDetailOnBack = returnToDetailOnBack,
+                                filename = playbackInfo.filename,
+                                videoHash = playbackInfo.videoHash,
+                                videoSize = playbackInfo.videoSize
                             )
                         )
                     }
@@ -370,7 +373,10 @@ fun NuvioNavHost(
                                 rememberedAudioLanguage = playbackInfo.rememberedAudioLanguage,
                                 rememberedAudioName = playbackInfo.rememberedAudioName,
                                 autoPlayNav = true,
-                                returnToDetailOnBack = returnToDetailOnBack
+                                returnToDetailOnBack = returnToDetailOnBack,
+                                filename = playbackInfo.filename,
+                                videoHash = playbackInfo.videoHash,
+                                videoSize = playbackInfo.videoSize
                             )
                         ) {
                             popUpTo(Screen.Stream.route) { inclusive = true }
@@ -474,6 +480,21 @@ fun NuvioNavHost(
                     type = NavType.StringType
                     nullable = true
                     defaultValue = "false"
+                },
+                navArgument("filename") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+                navArgument("videoHash") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+                navArgument("videoSize") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
                 }
             )
         ) { backStackEntry ->

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -57,7 +57,7 @@ sealed class Screen(val route: String) {
             return "stream/$encodedVideoId/$encodedContentTypePath/$encodedTitle?poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&season=${season ?: ""}&episode=${episode ?: ""}&episodeName=$encodedEpisodeName&genres=$encodedGenres&year=$encodedYear&contentId=$encodedContentId&contentName=$encodedContentName&runtime=${runtime ?: ""}&manualSelection=$manualSelection&returnToDetailOnBack=$returnToDetailOnBack"
         }
     }
-    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&rememberedAudioLanguage={rememberedAudioLanguage}&rememberedAudioName={rememberedAudioName}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}") {
+    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&rememberedAudioLanguage={rememberedAudioLanguage}&rememberedAudioName={rememberedAudioName}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}") {
         private fun encode(value: String): String =
             URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
@@ -81,7 +81,10 @@ sealed class Screen(val route: String) {
             rememberedAudioLanguage: String? = null,
             rememberedAudioName: String? = null,
             autoPlayNav: Boolean = false,
-            returnToDetailOnBack: Boolean = false
+            returnToDetailOnBack: Boolean = false,
+            filename: String? = null,
+            videoHash: String? = null,
+            videoSize: Long? = null
         ): String {
             val encodedUrl = encode(streamUrl)
             val encodedTitle = encode(title)
@@ -101,7 +104,9 @@ sealed class Screen(val route: String) {
             val encodedBingeGroup = bingeGroup?.let { encode(it) } ?: ""
             val encodedRememberedAudioLanguage = rememberedAudioLanguage?.let { encode(it) } ?: ""
             val encodedRememberedAudioName = rememberedAudioName?.let { encode(it) } ?: ""
-            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&rememberedAudioLanguage=$encodedRememberedAudioLanguage&rememberedAudioName=$encodedRememberedAudioName&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack"
+            val encodedFilename = filename?.let { encode(it) } ?: ""
+            val encodedVideoHash = videoHash ?: ""
+            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&rememberedAudioLanguage=$encodedRememberedAudioLanguage&rememberedAudioName=$encodedRememberedAudioName&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}"
         }
     }
     data object Search : Screen("search")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
@@ -21,7 +21,10 @@ internal data class PlayerNavigationArgs(
     val initialEpisodeTitle: String?,
     val bingeGroup: String?,
     val rememberedAudioLanguage: String?,
-    val rememberedAudioName: String?
+    val rememberedAudioName: String?,
+    val filename: String?,
+    val videoHash: String?,
+    val videoSize: Long?
 ) {
     companion object {
         fun from(savedStateHandle: SavedStateHandle): PlayerNavigationArgs {
@@ -49,7 +52,10 @@ internal data class PlayerNavigationArgs(
                 initialEpisodeTitle = decodedOrNull("episodeTitle"),
                 bingeGroup = decodedOrNull("bingeGroup"),
                 rememberedAudioLanguage = decodedOrNull("rememberedAudioLanguage"),
-                rememberedAudioName = decodedOrNull("rememberedAudioName")
+                rememberedAudioName = decodedOrNull("rememberedAudioName"),
+                filename = decodedOrNull("filename"),
+                videoHash = savedStateHandle.get<String>("videoHash")?.takeIf { it.isNotEmpty() },
+                videoSize = savedStateHandle.get<String>("videoSize")?.toLongOrNull()
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -84,6 +84,11 @@ class PlayerRuntimeController(
     internal val rememberedAudioName: String? = navigationArgs.rememberedAudioName
     internal val mediaSourceFactory = PlayerMediaSourceFactory()
 
+    internal var currentVideoHash: String? = navigationArgs.videoHash
+    internal var currentVideoSize: Long? = navigationArgs.videoSize
+    internal var currentFilename: String? = navigationArgs.filename
+        ?: initialStreamUrl.substringBefore('?').substringAfterLast('/', "")
+            .takeIf { it.isNotBlank() && it.contains('.') }
     internal var currentStreamUrl: String = initialStreamUrl
     internal var currentHeaders: Map<String, String> = PlayerMediaSourceFactory.parseHeaders(headersJson)
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -182,6 +182,11 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
     currentStreamUrl = url
     currentHeaders = newHeaders
     currentStreamBingeGroup = stream.behaviorHints?.bingeGroup
+    currentVideoHash = stream.behaviorHints?.videoHash
+    currentVideoSize = stream.behaviorHints?.videoSize
+    currentFilename = stream.behaviorHints?.filename
+        ?: url.substringBefore('?').substringAfterLast('/', "")
+            .takeIf { it.isNotBlank() && it.contains('.') }
     pendingAddonSubtitleLanguage = null
     pendingAddonSubtitleTrackId = null
     pendingAudioSelectionAfterSubtitleRefresh = null
@@ -457,6 +462,11 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(stream: Stream, force
     currentStreamUrl = url
     currentHeaders = newHeaders
     currentStreamBingeGroup = stream.behaviorHints?.bingeGroup
+    currentVideoHash = stream.behaviorHints?.videoHash
+    currentVideoSize = stream.behaviorHints?.videoSize
+    currentFilename = stream.behaviorHints?.filename
+        ?: url.substringBefore('?').substringAfterLast('/', "")
+            .takeIf { it.isNotBlank() && it.contains('.') }
     pendingAddonSubtitleLanguage = null
     pendingAddonSubtitleTrackId = null
     pendingAudioSelectionAfterSubtitleRefresh = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -92,6 +92,8 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
             C.TRACK_TYPE_TEXT -> {
                 for (i in 0 until trackGroup.length) {
                     val format = trackGroup.getTrackFormat(i)
+                    // Skip addon subtitle tracks — they are managed separately
+                    if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) continue
                     val isSelected = trackGroup.isTrackSelected(i)
                     if (isSelected) selectedSubtitleIndex = subtitleTracks.size
                     
@@ -118,33 +120,11 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
     )
 
     val pendingAddonTrackId = pendingAddonSubtitleTrackId
-    if (!pendingAddonTrackId.isNullOrBlank() && subtitleTracks.isNotEmpty()) {
-        val addonTrackIndex = subtitleTracks.indexOfFirst { it.trackId == pendingAddonTrackId }
-        if (addonTrackIndex >= 0) {
-            Log.d(
-                PlayerRuntimeController.TAG,
-                "Selecting pending addon subtitle track id=$pendingAddonTrackId index=$addonTrackIndex"
-            )
-            selectSubtitleTrack(addonTrackIndex)
-            selectedSubtitleIndex = if (_uiState.value.selectedAddonSubtitle != null) -1 else addonTrackIndex
+    if (!pendingAddonTrackId.isNullOrBlank()) {
+        if (applyAddonSubtitleOverride(pendingAddonTrackId)) {
+            Log.d(PlayerRuntimeController.TAG, "Selecting pending addon subtitle track id=$pendingAddonTrackId")
             pendingAddonSubtitleTrackId = null
             pendingAddonSubtitleLanguage = null
-        } else {
-            val pendingLang = pendingAddonSubtitleLanguage
-            val hasManualAddonSelection = _uiState.value.selectedAddonSubtitle != null
-            if (hasManualAddonSelection) {
-                if (!pendingLang.isNullOrBlank()) {
-                    val addonFallbackIndex = subtitleTracks.indexOfLast {
-                        PlayerSubtitleUtils.matchesLanguageCode(it.language, pendingLang)
-                    }
-                    if (addonFallbackIndex >= 0) {
-                        selectSubtitleTrack(addonFallbackIndex)
-                        selectedSubtitleIndex = -1
-                        pendingAddonSubtitleTrackId = null
-                        pendingAddonSubtitleLanguage = null
-                    }
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -427,7 +427,10 @@ class StreamScreenViewModel @Inject constructor(
             episodeTitle = episodeName,
             bingeGroup = stream.behaviorHints?.bingeGroup,
             rememberedAudioLanguage = null,
-            rememberedAudioName = null
+            rememberedAudioName = null,
+            filename = stream.behaviorHints?.filename,
+            videoHash = stream.behaviorHints?.videoHash,
+            videoSize = stream.behaviorHints?.videoSize
         )
 
         val url = playbackInfo.url
@@ -475,5 +478,8 @@ data class StreamPlaybackInfo(
     val episodeTitle: String?,
     val bingeGroup: String?,
     val rememberedAudioLanguage: String?,
-    val rememberedAudioName: String?
+    val rememberedAudioName: String?,
+    val filename: String? = null,
+    val videoHash: String? = null,
+    val videoSize: Long? = null
 )


### PR DESCRIPTION
Fix subtitle addons
- Addon subtitles no longer appear in the built-in subtitles tab (ExoPlayer prepends group index to track IDs, fixed startsWith -> contains)
- Fixed wrong content ID being sent to subtitle addons
- Added videoHash/videoSize/filename pipeline from stream to subtitle requests; OpenSubtitlesHasher computes hash on-the-fly when not provided by stream