### PR TITLE
skip regex search if pattern is null to facilitate binge group speed 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
@@ -58,7 +58,11 @@ object StreamAutoPlaySelector {
             StreamAutoPlayMode.FIRST_STREAM -> candidateStreams.firstOrNull { it.getStreamUrl() != null }
             StreamAutoPlayMode.REGEX_MATCH -> {
                 val pattern = regexPattern.trim()
-                if (pattern.isBlank()) return null
+
+                // Skip regex entirely if pattern is blank
+                if (pattern.isBlank()) {
+                    return null
+                }
  
                 // Try to compile the user regex
                 val userRegex = runCatching { Regex(pattern, RegexOption.IGNORE_CASE) }.getOrNull() ?: return null


### PR DESCRIPTION
Fixes #351 

In a scenario where users select regex to auto select a stream but don't supply a pattern - the regex function will conduct a search which can take up to a minute (depending on the source scope).

This can become an issue when the user has episode auto-play enabled coupled with binge group functionality.
The next binge group will only be selected after the regex search completes.

By skipping regex search if the pattern is empty , the next binge group episode should load as fast as the source addon/plugin allows.

 