### PR TITLE
fix: improve image loading reliability

### DIFF
--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -5,9 +5,12 @@ import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
+import coil.request.CachePolicy
 import com.nuvio.tv.core.sync.StartupSyncService
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.Dispatchers
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -20,10 +23,27 @@ class NuvioApplication : Application(), ImageLoaderFactory {
     }
 
     override fun newImageLoader(): ImageLoader {
+        val okHttpClient = OkHttpClient.Builder()
+            .retryOnConnectionFailure(true)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .dns(object : okhttp3.Dns {
+                override fun lookup(hostname: String): List<java.net.InetAddress> {
+                    return okhttp3.Dns.SYSTEM.lookup(hostname)
+                        .filterIsInstance<java.net.Inet4Address>()
+                        .ifEmpty {
+                            okhttp3.Dns.SYSTEM.lookup(hostname)
+                        }
+                }
+            })
+            .build()
+
         return ImageLoader.Builder(this)
+            .okHttpClient(okHttpClient)
             .memoryCache {
                 MemoryCache.Builder(this)
-                    .maxSizePercent(0.25)
+                    .maxSizePercent(0.30)
+                    .strongReferencesEnabled(false)
                     .build()
             }
             .diskCache {
@@ -32,9 +52,12 @@ class NuvioApplication : Application(), ImageLoaderFactory {
                     .maxSizeBytes(200L * 1024 * 1024)
                     .build()
             }
-            .decoderDispatcher(Dispatchers.IO.limitedParallelism(2))
-            .fetcherDispatcher(Dispatchers.IO.limitedParallelism(4))
-            .bitmapFactoryMaxParallelism(2)
+            .decoderDispatcher(Dispatchers.IO.limitedParallelism(4))
+            .fetcherDispatcher(Dispatchers.IO.limitedParallelism(8))
+            .bitmapFactoryMaxParallelism(4)
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .networkCachePolicy(CachePolicy.ENABLED)
             .allowRgb565(true)
             .crossfade(false)
             .build()


### PR DESCRIPTION
- Configure Coil with custom OkHttpClient
- Add IPv4 DNS prioritization and connection retry
- Optimize cache settings (memory 30%, disk 200MB)
- Set appropriate timeouts and parallelism limits

Resolves poster and image loading failures