### PR TITLE
Fix #403: Implement fuzzy matching for dynamic catalog sorting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
@@ -453,15 +453,67 @@ class AddonManagerViewModel @Inject constructor(
         val defaultEntries = buildDefaultCatalogEntries(addons)
         val entryByKey = defaultEntries.associateBy { it.key }
         val defaultOrderKeys = defaultEntries.map { it.key }
-        val savedValid = savedOrderKeys
-            .asSequence()
-            .filter { it in entryByKey }
-            .distinct()
-            .toList()
-        val savedSet = savedValid.toSet()
-        val effectiveOrder = savedValid + defaultOrderKeys.filterNot { it in savedSet }
 
-        return effectiveOrder.mapNotNull { key ->
+        // Build a map of catalog key patterns for fuzzy matching
+        val keyToAddonAndType = mutableMapOf<String, Pair<String, String>>()
+        defaultEntries.forEach { entry ->
+            // Key format: ${addonId}_${type}_${catalogId}
+            // We need to extract addonId and type, but catalogId can contain underscores
+            val firstUnderscore = entry.key.indexOf('_')
+            if (firstUnderscore > 0) {
+                val addonId = entry.key.substring(0, firstUnderscore)
+                val remaining = entry.key.substring(firstUnderscore + 1)
+                val secondUnderscore = remaining.indexOf('_')
+                if (secondUnderscore > 0) {
+                    val type = remaining.substring(0, secondUnderscore)
+                    keyToAddonAndType[entry.key] = addonId to type
+                }
+            }
+        }
+
+        // Build final order with fuzzy matching for dynamic catalogs
+        val finalOrder = mutableListOf<String>()
+        val usedKeys = mutableSetOf<String>()
+
+        savedOrderKeys.forEach { savedKey ->
+            if (savedKey in entryByKey) {
+                // Exact match found
+                if (savedKey !in usedKeys) {
+                    finalOrder.add(savedKey)
+                    usedKeys.add(savedKey)
+                }
+            } else {
+                // Try fuzzy match: find a catalog from same addon+type that hasn't been used
+                val firstUnderscore = savedKey.indexOf('_')
+                if (firstUnderscore > 0) {
+                    val addonId = savedKey.substring(0, firstUnderscore)
+                    val remaining = savedKey.substring(firstUnderscore + 1)
+                    val secondUnderscore = remaining.indexOf('_')
+                    if (secondUnderscore > 0) {
+                        val type = remaining.substring(0, secondUnderscore)
+                        val matchingKey = defaultOrderKeys.firstOrNull { availableKey ->
+                            availableKey !in usedKeys &&
+                            keyToAddonAndType[availableKey]?.let { (aid, t) ->
+                                aid == addonId && t == type
+                            } == true
+                        }
+                        if (matchingKey != null) {
+                            finalOrder.add(matchingKey)
+                            usedKeys.add(matchingKey)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add any remaining catalogs that weren't matched
+        defaultOrderKeys.forEach { key ->
+            if (key !in usedKeys) {
+                finalOrder.add(key)
+            }
+        }
+
+        return finalOrder.mapNotNull { key ->
             val entry = entryByKey[key] ?: return@mapNotNull null
             entry.copy(isDisabled = entry.disableKey in disabledKeys)
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -98,18 +98,67 @@ class CatalogOrderViewModel @Inject constructor(
         val availableMap = defaultEntries.associateBy { it.key }
         val defaultOrderKeys = defaultEntries.map { it.key }
 
-        val savedValid = savedOrderKeys
-            .asSequence()
-            .filter { it in availableMap }
-            .distinct()
-            .toList()
+        // Build a map of catalog key patterns for fuzzy matching
+        val keyToAddonAndType = mutableMapOf<String, Pair<String, String>>()
+        defaultEntries.forEach { entry ->
+            // Key format: ${addonId}_${type}_${catalogId}
+            // We need to extract addonId and type, but catalogId can contain underscores
+            val firstUnderscore = entry.key.indexOf('_')
+            if (firstUnderscore > 0) {
+                val addonId = entry.key.substring(0, firstUnderscore)
+                val remaining = entry.key.substring(firstUnderscore + 1)
+                val secondUnderscore = remaining.indexOf('_')
+                if (secondUnderscore > 0) {
+                    val type = remaining.substring(0, secondUnderscore)
+                    keyToAddonAndType[entry.key] = addonId to type
+                }
+            }
+        }
 
-        val savedKeySet = savedValid.toSet()
-        val missing = defaultOrderKeys.filterNot { it in savedKeySet }
-        val effectiveOrder = savedValid + missing
+        // Build final order with fuzzy matching for dynamic catalogs
+        val finalOrder = mutableListOf<String>()
+        val usedKeys = mutableSetOf<String>()
 
-        return effectiveOrder.mapIndexedNotNull { index, key ->
-            val entry = availableMap[key] ?: return@mapIndexedNotNull null
+        savedOrderKeys.forEach { savedKey ->
+            if (savedKey in availableMap) {
+                // Exact match found
+                if (savedKey !in usedKeys) {
+                    finalOrder.add(savedKey)
+                    usedKeys.add(savedKey)
+                }
+            } else {
+                // Try fuzzy match: find a catalog from same addon+type that hasn't been used
+                val firstUnderscore = savedKey.indexOf('_')
+                if (firstUnderscore > 0) {
+                    val addonId = savedKey.substring(0, firstUnderscore)
+                    val remaining = savedKey.substring(firstUnderscore + 1)
+                    val secondUnderscore = remaining.indexOf('_')
+                    if (secondUnderscore > 0) {
+                        val type = remaining.substring(0, secondUnderscore)
+                        val matchingKey = defaultOrderKeys.firstOrNull { availableKey ->
+                            availableKey !in usedKeys &&
+                            keyToAddonAndType[availableKey]?.let { (aid, t) ->
+                                aid == addonId && t == type
+                            } == true
+                        }
+                        if (matchingKey != null) {
+                            finalOrder.add(matchingKey)
+                            usedKeys.add(matchingKey)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add any remaining catalogs that weren't matched
+        defaultOrderKeys.forEach { key ->
+            if (key !in usedKeys) {
+                finalOrder.add(key)
+            }
+        }
+
+        return finalOrder.mapIndexed { index, key ->
+            val entry = availableMap[key]!!
             CatalogOrderItem(
                 key = entry.key,
                 disableKey = entry.disableKey,
@@ -118,7 +167,7 @@ class CatalogOrderViewModel @Inject constructor(
                 typeLabel = entry.typeLabel,
                 isDisabled = entry.disableKey in disabledKeys,
                 canMoveUp = index > 0,
-                canMoveDown = index < effectiveOrder.lastIndex
+                canMoveDown = index < finalOrder.lastIndex
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -1772,17 +1772,68 @@ class HomeViewModel @Inject constructor(
         val defaultOrder = buildDefaultCatalogOrder(addons)
         val availableSet = defaultOrder.toSet()
 
-        val savedValid = homeCatalogOrderKeys
-            .asSequence()
-            .filter { it in availableSet }
-            .distinct()
-            .toList()
+        // Build a map of catalog key patterns for fuzzy matching
+        // This helps match catalogs even if their IDs change (e.g., dynamic catalogs from Watchly)
+        val keyToAddonAndType = mutableMapOf<String, Pair<String, String>>()
+        defaultOrder.forEach { key ->
+            // Key format: ${addonId}_${type}_${catalogId}
+            // We need to extract addonId and type, but catalogId can contain underscores
+            val firstUnderscore = key.indexOf('_')
+            if (firstUnderscore > 0) {
+                val addonId = key.substring(0, firstUnderscore)
+                val remaining = key.substring(firstUnderscore + 1)
+                val secondUnderscore = remaining.indexOf('_')
+                if (secondUnderscore > 0) {
+                    val type = remaining.substring(0, secondUnderscore)
+                    keyToAddonAndType[key] = addonId to type
+                }
+            }
+        }
 
-        val savedSet = savedValid.toSet()
-        val mergedOrder = savedValid + defaultOrder.filterNot { it in savedSet }
+        // For each position in saved order, try to find a matching catalog
+        val finalOrder = mutableListOf<String>()
+        val usedKeys = mutableSetOf<String>()
+
+        homeCatalogOrderKeys.forEach { savedKey ->
+            if (savedKey in availableSet) {
+                // Exact match found
+                if (savedKey !in usedKeys) {
+                    finalOrder.add(savedKey)
+                    usedKeys.add(savedKey)
+                }
+            } else {
+                // Try fuzzy match: find a catalog from same addon+type that hasn't been used
+                val firstUnderscore = savedKey.indexOf('_')
+                if (firstUnderscore > 0) {
+                    val addonId = savedKey.substring(0, firstUnderscore)
+                    val remaining = savedKey.substring(firstUnderscore + 1)
+                    val secondUnderscore = remaining.indexOf('_')
+                    if (secondUnderscore > 0) {
+                        val type = remaining.substring(0, secondUnderscore)
+                        val matchingKey = defaultOrder.firstOrNull { availableKey ->
+                            availableKey !in usedKeys &&
+                            keyToAddonAndType[availableKey]?.let { (aid, t) ->
+                                aid == addonId && t == type
+                            } == true
+                        }
+                        if (matchingKey != null) {
+                            finalOrder.add(matchingKey)
+                            usedKeys.add(matchingKey)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add any remaining catalogs that weren't matched
+        defaultOrder.forEach { key ->
+            if (key !in usedKeys) {
+                finalOrder.add(key)
+            }
+        }
 
         catalogOrder.clear()
-        catalogOrder.addAll(mergedOrder)
+        catalogOrder.addAll(finalOrder)
     }
 
     private fun buildDefaultCatalogOrder(addons: List<Addon>): List<String> {


### PR DESCRIPTION
- Add fuzzy matching algorithm to preserve catalog positions when IDs change
- Match catalogs by addon+type combination when exact match fails
- Fix parsing of catalog keys with underscores in catalog IDs
- Apply fix to HomeViewModel, CatalogOrderViewModel, and AddonManagerViewModel
- Maintain backward compatibility with existing saved orders
- Support both static and dynamic addons (e.g., Watchly, Trakt)

This fixes the issue where dynamic catalogs (like Watchly recommendations)
would jump to the bottom of the home screen after updates or app restarts,
even when manually reordered by the user.

fixes #403 