### PR TITLE
Tweak episode and continue-watching progress bars

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -429,21 +429,25 @@ fun ContinueWatchingCard(
                         color = NuvioColors.TextPrimary
                     )
                 }
-            }
 
-            if (progress != null) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(4.dp)
-                        .background(NuvioColors.SurfaceVariant)
-                ) {
+                if (progress != null) {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth(progressFraction)
-                            .height(4.dp)
-                            .background(NuvioColors.Primary)
-                    )
+                            .align(Alignment.BottomStart)
+                            .padding(horizontal = 10.dp, vertical = 4.dp)
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(1.5.dp))
+                            .height(3.dp)
+                            .background(Color.Black.copy(alpha = 0.3f))
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(progressFraction)
+                                .clip(RoundedCornerShape(1.5.dp))
+                                .height(3.dp)
+                                .background(NuvioColors.Primary)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -591,13 +591,20 @@ private fun EpisodeCard(
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
+                        .padding(
+                            start = cardMetrics.contentPadding,
+                            end = cardMetrics.contentPadding,
+                            bottom = cardMetrics.contentPadding * 0.5f
+                        )
                         .fillMaxWidth()
+                        .clip(RoundedCornerShape(cardMetrics.progressBarHeight / 2))
                         .height(cardMetrics.progressBarHeight)
-                        .background(Color.White.copy(alpha = 0.2f))
+                        .background(Color.Black.copy(alpha = 0.45f))
                 ) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth(progressPercent)
+                            .clip(RoundedCornerShape(cardMetrics.progressBarHeight / 2))
                             .height(cardMetrics.progressBarHeight)
                             .background(NuvioColors.Primary)
                     )
@@ -807,7 +814,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 metadataIconSize = 16.dp,
                 imdbLogoWidth = 28.dp,
                 imdbLogoHeight = 14.dp,
-                progressBarHeight = 3.dp,
+                progressBarHeight = 4.dp,
                 statusBadgeSize = 32.dp,
                 statusIconSize = 20.dp,
                 statusBadgeInset = 16.dp
@@ -832,7 +839,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 metadataIconSize = 15.dp,
                 imdbLogoWidth = 26.dp,
                 imdbLogoHeight = 13.dp,
-                progressBarHeight = 3.dp,
+                progressBarHeight = 4.dp,
                 statusBadgeSize = 28.dp,
                 statusIconSize = 18.dp,
                 statusBadgeInset = 14.dp
@@ -857,7 +864,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 metadataIconSize = 14.dp,
                 imdbLogoWidth = 24.dp,
                 imdbLogoHeight = 12.dp,
-                progressBarHeight = 3.dp,
+                progressBarHeight = 4.dp,
                 statusBadgeSize = 24.dp,
                 statusIconSize = 16.dp,
                 statusBadgeInset = 12.dp
@@ -882,7 +889,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 metadataIconSize = 13.dp,
                 imdbLogoWidth = 22.dp,
                 imdbLogoHeight = 11.dp,
-                progressBarHeight = 3.dp,
+                progressBarHeight = 4.dp,
                 statusBadgeSize = 22.dp,
                 statusIconSize = 14.dp,
                 statusBadgeInset = 10.dp


### PR DESCRIPTION
  ## Summary
Refined the continue-watching and episode progress bar styling, as the previous bar was too subtle to clearly show progress.
  

<img width="1429" height="724" alt="Screenshot 2026-02-27 at 22 46 13" src="https://github.com/user-attachments/assets/963141d5-0562-4d28-a077-22271a1d46a1" />
<img width="1434" height="730" alt="Screenshot 2026-02-27 at 22 46 31" src="https://github.com/user-attachments/assets/c183ebdd-4032-46aa-8d30-9075399f1400" />

### Before
<img width="988" height="570" alt="Screenshot 2026-02-27 at 21 46 08" src="https://github.com/user-attachments/assets/98c52755-73e4-4559-9581-ac187c33e259" />
