### PR TITLE
feat: introduce trakt integration scrobble_only mode setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/LibrarySyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/LibrarySyncService.kt
@@ -5,6 +5,7 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.LibraryPreferences
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.remote.supabase.SupabaseLibraryItem
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.model.SavedLibraryItem
@@ -27,6 +28,7 @@ class LibrarySyncService @Inject constructor(
     private val postgrest: Postgrest,
     private val libraryPreferences: LibraryPreferences,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val profileManager: ProfileManager
 ) {
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
@@ -40,8 +42,8 @@ class LibrarySyncService @Inject constructor(
 
     suspend fun pushToRemote(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping library push")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping library push")
                 return@withContext Result.success(Unit)
             }
 
@@ -85,8 +87,8 @@ class LibrarySyncService @Inject constructor(
 
     suspend fun pullFromRemote(): Result<List<SavedLibraryItem>> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping library pull")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping library pull")
                 return@withContext Result.success(emptyList())
             }
 
@@ -120,5 +122,12 @@ class LibrarySyncService @Inject constructor(
             Log.e(TAG, "Failed to pull library from remote", e)
             Result.failure(e)
         }
+    }
+
+    private suspend fun shouldSkipBecauseTraktOwnsData(): Boolean {
+        val isAuthenticated = traktAuthDataStore.isAuthenticated.first()
+        val integrationMode = traktSettingsDataStore.integrationMode.first()
+        return isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
     }
 }

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -6,6 +6,7 @@ import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.LibraryPreferences
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.repository.AddonRepositoryImpl
@@ -38,6 +39,7 @@ class StartupSyncService @Inject constructor(
     private val watchProgressRepository: WatchProgressRepositoryImpl,
     private val libraryRepository: LibraryRepositoryImpl,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val watchProgressPreferences: WatchProgressPreferences,
     private val libraryPreferences: LibraryPreferences,
     private val watchedItemsPreferences: WatchedItemsPreferences,
@@ -169,7 +171,9 @@ class StartupSyncService @Inject constructor(
             }
 
             val isPrimaryProfile = profileManager.activeProfileId.value == 1
-            val isTraktConnected = isPrimaryProfile && traktAuthDataStore.isAuthenticated.first()
+            val isTraktConnected = isPrimaryProfile &&
+                traktAuthDataStore.isAuthenticated.first() &&
+                traktSettingsDataStore.integrationMode.first() == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
             Log.d(TAG, "Watch progress sync: isTraktConnected=$isTraktConnected isPrimaryProfile=$isPrimaryProfile")
             if (!isTraktConnected) {
                 // Pull library and watched items first — these are lightweight and critical.

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.remote.supabase.SupabaseWatchProgress
 import com.nuvio.tv.domain.model.WatchProgress
@@ -27,6 +28,7 @@ class WatchProgressSyncService @Inject constructor(
     private val postgrest: Postgrest,
     private val watchProgressPreferences: WatchProgressPreferences,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val profileManager: ProfileManager
 ) {
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
@@ -40,8 +42,8 @@ class WatchProgressSyncService @Inject constructor(
 
     suspend fun deleteFromRemote(keys: Collection<String>): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping watch progress delete")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping watch progress delete")
                 return@withContext Result.success(Unit)
             }
 
@@ -77,8 +79,8 @@ class WatchProgressSyncService @Inject constructor(
      */
     suspend fun pushToRemote(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping watch progress push")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping watch progress push")
                 return@withContext Result.success(Unit)
             }
 
@@ -125,8 +127,8 @@ class WatchProgressSyncService @Inject constructor(
     
     suspend fun pushSingleToRemote(key: String, progress: WatchProgress): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping single watch progress push")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping single watch progress push")
                 return@withContext Result.success(Unit)
             }
 
@@ -168,8 +170,8 @@ class WatchProgressSyncService @Inject constructor(
      */
     suspend fun pullFromRemote(): Result<List<Pair<String, WatchProgress>>> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping watch progress pull")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping watch progress pull")
                 return@withContext Result.success(emptyList())
             }
 
@@ -213,6 +215,13 @@ class WatchProgressSyncService @Inject constructor(
             Log.e(TAG, "Failed to pull watch progress from remote", e)
             Result.failure(e)
         }
+    }
+
+    private suspend fun shouldSkipBecauseTraktOwnsData(): Boolean {
+        val isAuthenticated = traktAuthDataStore.isAuthenticated.first()
+        val integrationMode = traktSettingsDataStore.integrationMode.first()
+        return isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
     }
 
     private fun canonicalizeForRemote(

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.remote.supabase.SupabaseWatchedItem
 import com.nuvio.tv.domain.model.WatchedItem
@@ -27,6 +28,7 @@ class WatchedItemsSyncService @Inject constructor(
     private val postgrest: Postgrest,
     private val watchedItemsPreferences: WatchedItemsPreferences,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val profileManager: ProfileManager
 ) {
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
@@ -40,8 +42,8 @@ class WatchedItemsSyncService @Inject constructor(
 
     suspend fun pushToRemote(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping watched items push")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping watched items push")
                 return@withContext Result.success(Unit)
             }
 
@@ -80,8 +82,8 @@ class WatchedItemsSyncService @Inject constructor(
 
     suspend fun pullFromRemote(): Result<List<WatchedItem>> = withContext(Dispatchers.IO) {
         try {
-            if (traktAuthDataStore.isAuthenticated.first()) {
-                Log.d(TAG, "Trakt connected, skipping watched items pull")
+            if (shouldSkipBecauseTraktOwnsData()) {
+                Log.d(TAG, "Trakt full-sync mode active, skipping watched items pull")
                 return@withContext Result.success(emptyList())
             }
 
@@ -110,5 +112,12 @@ class WatchedItemsSyncService @Inject constructor(
             Log.e(TAG, "Failed to pull watched items from remote", e)
             Result.failure(e)
         }
+    }
+
+    private suspend fun shouldSkipBecauseTraktOwnsData(): Boolean {
+        val isAuthenticated = traktAuthDataStore.isAuthenticated.first()
+        val integrationMode = traktSettingsDataStore.integrationMode.first()
+        return isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -9,9 +9,11 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.domain.model.PlaybackCompletionThresholds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -348,6 +350,13 @@ class PlayerSettingsDataStore @Inject constructor(
                 }
             }
         }
+        ioScope.launch {
+            playerSettings.collectLatest { settings ->
+                PlaybackCompletionThresholds.setCompletionThresholdPercent(
+                    settings.nextEpisodeThresholdPercent
+                )
+            }
+        }
     }
 
     /**
@@ -609,7 +618,7 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             prefs[nextEpisodeThresholdPercentKey] = normalizeHalfStep(
                 value = percent,
-                min = 97f,
+                min = 90f,
                 max = 99.5f
             )
         }

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.local
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
 import kotlinx.coroutines.flow.Flow
@@ -16,6 +17,20 @@ class TraktSettingsDataStore @Inject constructor(
     private val factory: ProfileDataStoreFactory,
     private val profileManager: ProfileManager
 ) {
+    enum class TraktIntegrationMode(val storageValue: String) {
+        FULL_SYNC("full_sync"),
+        SCROBBLE_ONLY("scrobble_only");
+
+        companion object {
+            fun fromStorageValue(value: String?): TraktIntegrationMode {
+                return when (value) {
+                    SCROBBLE_ONLY.storageValue -> SCROBBLE_ONLY
+                    else -> FULL_SYNC
+                }
+            }
+        }
+    }
+
     companion object {
         private const val FEATURE = "trakt_settings"
         const val CONTINUE_WATCHING_DAYS_CAP_ALL = 0
@@ -31,6 +46,7 @@ class TraktSettingsDataStore @Inject constructor(
     private val continueWatchingDaysCapKey = intPreferencesKey("continue_watching_days_cap")
     private val dismissedNextUpKeysKey = stringSetPreferencesKey("dismissed_next_up_keys")
     private val showUnairedNextUpKey = booleanPreferencesKey("show_unaired_next_up")
+    private val integrationModeKey = stringPreferencesKey("integration_mode")
 
     val continueWatchingDaysCap: Flow<Int> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { prefs ->
@@ -49,6 +65,12 @@ class TraktSettingsDataStore @Inject constructor(
     val showUnairedNextUp: Flow<Boolean> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { prefs ->
             prefs[showUnairedNextUpKey] ?: DEFAULT_SHOW_UNAIRED_NEXT_UP
+        }
+    }
+
+    val integrationMode: Flow<TraktIntegrationMode> = profileManager.activeProfileId.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map { prefs ->
+            TraktIntegrationMode.fromStorageValue(prefs[integrationModeKey])
         }
     }
 
@@ -77,6 +99,12 @@ class TraktSettingsDataStore @Inject constructor(
     suspend fun setShowUnairedNextUp(enabled: Boolean) {
         store().edit { prefs ->
             prefs[showUnairedNextUpKey] = enabled
+        }
+    }
+
+    suspend fun setIntegrationMode(mode: TraktIntegrationMode) {
+        store().edit { prefs ->
+            prefs[integrationModeKey] = mode.storageValue
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
@@ -83,6 +83,12 @@ interface TraktApi {
         @Body body: TraktScrobbleRequestDto
     ): Response<TraktScrobbleResponseDto>
 
+    @POST("scrobble/pause")
+    suspend fun scrobblePause(
+        @Header("Authorization") authorization: String,
+        @Body body: TraktScrobbleRequestDto
+    ): Response<TraktScrobbleResponseDto>
+
     @GET("sync/last_activities")
     suspend fun getLastActivities(
         @Header("Authorization") authorization: String

--- a/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.sync.LibrarySyncService
 import com.nuvio.tv.data.local.LibraryPreferences
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.domain.model.LibraryEntry
 import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.LibraryListTab
@@ -20,6 +21,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -34,6 +36,7 @@ import javax.inject.Singleton
 class LibraryRepositoryImpl @Inject constructor(
     private val libraryPreferences: LibraryPreferences,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val traktLibraryService: TraktLibraryService,
     private val librarySyncService: LibrarySyncService,
     private val authManager: AuthManager
@@ -55,9 +58,18 @@ class LibraryRepositoryImpl @Inject constructor(
         }
     }
 
-    override val sourceMode: Flow<LibrarySourceMode> = traktAuthDataStore.isEffectivelyAuthenticated
-        .map { isAuthenticated ->
-            if (isAuthenticated) LibrarySourceMode.TRAKT else LibrarySourceMode.LOCAL
+    override val sourceMode: Flow<LibrarySourceMode> = combine(
+        traktAuthDataStore.isEffectivelyAuthenticated,
+        traktSettingsDataStore.integrationMode
+    ) { isAuthenticated, integrationMode ->
+            if (
+                isAuthenticated &&
+                integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
+            ) {
+                LibrarySourceMode.TRAKT
+            } else {
+                LibrarySourceMode.LOCAL
+            }
         }
         .distinctUntilChanged()
 
@@ -132,7 +144,7 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun toggleDefault(item: LibraryEntryInput) {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (isTraktLibraryModeEnabled()) {
             traktLibraryService.toggleWatchlist(item)
             return
         }
@@ -147,7 +159,7 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getMembershipSnapshot(item: LibraryEntryInput): ListMembershipSnapshot {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (isTraktLibraryModeEnabled()) {
             return traktLibraryService.getMembershipSnapshot(item)
         }
         val inLocal = libraryPreferences.isInLibrary(item.itemId, item.itemType).first()
@@ -155,7 +167,7 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun applyMembershipChanges(item: LibraryEntryInput, changes: ListMembershipChanges) {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (isTraktLibraryModeEnabled()) {
             traktLibraryService.applyMembershipChanges(item, changes)
             return
         }
@@ -200,15 +212,22 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun refreshNow() {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (isTraktLibraryModeEnabled()) {
             traktLibraryService.refreshNow()
         }
     }
 
     private suspend fun requireTraktAuth() {
-        if (!traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (!isTraktLibraryModeEnabled()) {
             throw IllegalStateException("Trakt authentication required")
         }
+    }
+
+    private suspend fun isTraktLibraryModeEnabled(): Boolean {
+        val isAuthenticated = traktAuthDataStore.isEffectivelyAuthenticated.first()
+        val integrationMode = traktSettingsDataStore.integrationMode.first()
+        return isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
     }
 
     private fun LibraryEntryInput.toSavedLibraryItem(): SavedLibraryItem {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -177,6 +177,8 @@ class TraktProgressService @Inject constructor(
     private var consecutiveRefreshFailures = 0
     @Volatile
     private var continueWatchingWindowDays: Int = TraktSettingsDataStore.DEFAULT_CONTINUE_WATCHING_DAYS_CAP
+    @Volatile
+    private var useTraktDataSource: Boolean = true
 
     init {
         scope.launch {
@@ -185,7 +187,13 @@ class TraktProgressService @Inject constructor(
             }
         }
         scope.launch {
+            traktSettingsDataStore.integrationMode.collectLatest { mode ->
+                useTraktDataSource = mode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
+            }
+        }
+        scope.launch {
             refreshEvents().collectLatest {
+                if (!useTraktDataSource) return@collectLatest
                 val success = try {
                     refreshRemoteSnapshot()
                     true

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktScrobbleService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktScrobbleService.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.repository
 
+import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.data.remote.dto.trakt.TraktEpisodeDto
@@ -8,6 +9,10 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktMovieDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktScrobbleRequestDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktShowDto
 import com.nuvio.tv.core.profile.ProfileManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.abs
@@ -44,6 +49,10 @@ class TraktScrobbleService @Inject constructor(
     private val traktProgressService: TraktProgressService,
     private val profileManager: ProfileManager
 ) {
+    companion object {
+        private const val TAG = "TraktScrobbleSvc"
+    }
+
     private data class ScrobbleStamp(
         val action: String,
         val itemKey: String,
@@ -54,6 +63,7 @@ class TraktScrobbleService @Inject constructor(
     private var lastScrobbleStamp: ScrobbleStamp? = null
     private val minSendIntervalMs = 8_000L
     private val progressWindow = 1.5f
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     suspend fun scrobbleStart(item: TraktScrobbleItem, progressPercent: Float) {
         sendScrobble(action = "start", item = item, progressPercent = progressPercent)
@@ -65,6 +75,38 @@ class TraktScrobbleService @Inject constructor(
 
     suspend fun scrobblePause(item: TraktScrobbleItem, progressPercent: Float) {
         sendScrobble(action = "pause", item = item, progressPercent = progressPercent)
+    }
+
+    fun scrobbleStartAsync(item: TraktScrobbleItem, progressPercent: Float) {
+        serviceScope.launch {
+            scrobbleStart(item = item, progressPercent = progressPercent)
+        }
+    }
+
+    fun scrobbleStopAsync(item: TraktScrobbleItem, progressPercent: Float) {
+        serviceScope.launch {
+            scrobbleStop(item = item, progressPercent = progressPercent)
+        }
+    }
+
+    fun scrobblePauseAsync(item: TraktScrobbleItem, progressPercent: Float) {
+        serviceScope.launch {
+            scrobblePause(item = item, progressPercent = progressPercent)
+        }
+    }
+
+    fun scrobbleStartThenPauseAsync(item: TraktScrobbleItem, progressPercent: Float) {
+        serviceScope.launch {
+            scrobbleStart(item = item, progressPercent = progressPercent)
+            scrobblePause(item = item, progressPercent = progressPercent)
+        }
+    }
+
+    fun scrobbleStartThenStopAsync(item: TraktScrobbleItem, progressPercent: Float) {
+        serviceScope.launch {
+            scrobbleStart(item = item, progressPercent = progressPercent)
+            scrobbleStop(item = item, progressPercent = progressPercent)
+        }
     }
 
     private suspend fun sendScrobble(
@@ -84,20 +126,30 @@ class TraktScrobbleService @Inject constructor(
         val response = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
             when (action) {
                 "start" -> traktApi.scrobbleStart(authHeader, requestBody)
+                "pause" -> traktApi.scrobblePause(authHeader, requestBody)
                 else -> traktApi.scrobbleStop(authHeader, requestBody)
             }
-        } ?: return
+        } ?: run {
+            Log.w(TAG, "Trakt scrobble $action failed: no response")
+            return
+        }
 
         if (response.isSuccessful || response.code() == 409) {
+            Log.d(
+                TAG,
+                "Trakt scrobble $action accepted (HTTP ${response.code()}) progress=$clampedProgress item=${item.itemKey}"
+            )
             lastScrobbleStamp = ScrobbleStamp(
                 action = action,
                 itemKey = item.itemKey,
                 progress = clampedProgress,
                 timestampMs = System.currentTimeMillis()
             )
-            if (action == "stop") {
+            if (action == "pause" || action == "stop") {
                 traktProgressService.refreshNow()
             }
+        } else {
+            Log.w(TAG, "Trakt scrobble $action failed with HTTP ${response.code()} for ${item.itemKey}")
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -5,7 +5,9 @@ import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.sync.WatchProgressSyncService
 import com.nuvio.tv.core.sync.WatchedItemsSyncService
 import android.util.Log
+import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.domain.model.WatchProgress
@@ -38,7 +40,9 @@ import javax.inject.Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class WatchProgressRepositoryImpl @Inject constructor(
     private val watchProgressPreferences: WatchProgressPreferences,
+    private val playerSettingsDataStore: PlayerSettingsDataStore,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val traktProgressService: TraktProgressService,
     private val watchProgressSyncService: WatchProgressSyncService,
     private val watchedItemsPreferences: WatchedItemsPreferences,
@@ -74,6 +78,13 @@ class WatchProgressRepositoryImpl @Inject constructor(
     private val metadataMutex = Mutex()
     private val inFlightMetadataKeys = mutableSetOf<String>()
     private val metadataHydrationLimit = 30
+    private val useTraktProgressDataSource: Flow<Boolean> = combine(
+        traktAuthDataStore.isEffectivelyAuthenticated,
+        traktSettingsDataStore.integrationMode
+    ) { isAuthenticated, integrationMode ->
+        isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
+    }.distinctUntilChanged()
 
     private fun triggerRemoteSync() {
         if (isSyncingFromRemote) return
@@ -214,10 +225,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override val allProgress: Flow<List<WatchProgress>>
-        get() = traktAuthDataStore.isEffectivelyAuthenticated
-            .distinctUntilChanged()
-            .flatMapLatest { isAuthenticated ->
-                if (isAuthenticated) {
+        get() = useTraktProgressDataSource
+            .flatMapLatest { useTraktSource ->
+                if (useTraktSource) {
                     combine(
                         traktProgressService.observeAllProgress()
                             .onStart {
@@ -247,10 +257,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
         get() = allProgress.map { list -> list.filter { it.isInProgress() } }
 
     override fun getProgress(contentId: String): Flow<WatchProgress?> {
-        return traktAuthDataStore.isEffectivelyAuthenticated
-            .distinctUntilChanged()
-            .flatMapLatest { isAuthenticated ->
-                if (isAuthenticated) {
+        return useTraktProgressDataSource
+            .flatMapLatest { useTraktSource ->
+                if (useTraktSource) {
                     allProgress.map { items ->
                         items
                             .filter { it.contentId == contentId }
@@ -263,10 +272,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override fun getEpisodeProgress(contentId: String, season: Int, episode: Int): Flow<WatchProgress?> {
-        return traktAuthDataStore.isEffectivelyAuthenticated
-            .distinctUntilChanged()
-            .flatMapLatest { isAuthenticated ->
-                if (isAuthenticated) {
+        return useTraktProgressDataSource
+            .flatMapLatest { useTraktSource ->
+                if (useTraktSource) {
                     allProgress.map { items ->
                         items.firstOrNull {
                             it.contentId == contentId && it.season == season && it.episode == episode
@@ -279,10 +287,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override fun getAllEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> {
-        return traktAuthDataStore.isEffectivelyAuthenticated
-            .distinctUntilChanged()
-            .flatMapLatest { isAuthenticated ->
-                if (isAuthenticated) {
+        return useTraktProgressDataSource
+            .flatMapLatest { useTraktSource ->
+                if (useTraktSource) {
                     combine(
                         traktProgressService.observeEpisodeProgress(contentId),
                         allProgress.map { items ->
@@ -304,10 +311,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override fun isWatched(contentId: String, season: Int?, episode: Int?): Flow<Boolean> {
-        return traktAuthDataStore.isEffectivelyAuthenticated
-            .distinctUntilChanged()
-            .flatMapLatest { isAuthenticated ->
-                if (!isAuthenticated) {
+        return useTraktProgressDataSource
+            .flatMapLatest { useTraktSource ->
+                if (!useTraktSource) {
                     val progressFlow = if (season != null && episode != null) {
                         watchProgressPreferences.getEpisodeProgress(contentId, season, episode)
                     } else {
@@ -343,7 +349,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveProgress(progress: WatchProgress, syncRemote: Boolean) {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (shouldUseTraktProgressDataSource()) {
             traktProgressService.applyOptimisticProgress(progress)
             watchProgressPreferences.saveProgress(progress)
             return
@@ -376,12 +382,12 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun removeProgress(contentId: String, season: Int?, episode: Int?) {
-        val isAuthenticated = traktAuthDataStore.isEffectivelyAuthenticated.first()
+        val shouldUseTraktSource = shouldUseTraktProgressDataSource()
         Log.d(
             TAG,
-            "removeProgress called contentId=$contentId season=$season episode=$episode authenticated=$isAuthenticated"
+            "removeProgress called contentId=$contentId season=$season episode=$episode useTraktSource=$shouldUseTraktSource"
         )
-        if (isAuthenticated) {
+        if (shouldUseTraktSource) {
             traktProgressService.applyOptimisticRemoval(contentId, season, episode)
             traktProgressService.removeProgress(contentId, season, episode)
             watchProgressPreferences.removeProgress(contentId, season, episode)
@@ -399,7 +405,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun removeFromHistory(contentId: String, season: Int?, episode: Int?) {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (shouldUseTraktProgressDataSource()) {
             traktProgressService.removeFromHistory(contentId, season, episode)
             watchProgressPreferences.removeProgress(contentId, season, episode)
             return
@@ -418,7 +424,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markAsCompleted(progress: WatchProgress) {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (shouldUseTraktProgressDataSource()) {
             val now = System.currentTimeMillis()
             val duration = progress.duration.takeIf { it > 0L } ?: 1L
             val completed = progress.copy(
@@ -444,6 +450,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
             return
         }
+
         watchProgressPreferences.markAsCompleted(progress)
         watchedItemsPreferences.markAsWatched(
             WatchedItem(
@@ -455,12 +462,31 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 watchedAt = System.currentTimeMillis()
             )
         )
+        if (shouldWriteToTraktScrobbleMode()) {
+            val now = System.currentTimeMillis()
+            val duration = progress.duration.takeIf { it > 0L } ?: 1L
+            val completed = progress.copy(
+                position = duration,
+                duration = duration,
+                progressPercent = 100f,
+                lastWatched = now
+            )
+            runCatching {
+                traktProgressService.markAsWatched(
+                    progress = completed,
+                    title = completed.name.takeIf { it.isNotBlank() },
+                    year = null
+                )
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to write completed item to Trakt in scrobble-only mode", error)
+            }
+        }
         triggerRemoteSync()
         triggerWatchedItemsSync()
     }
 
     override suspend fun clearAll() {
-        if (traktAuthDataStore.isEffectivelyAuthenticated.first()) {
+        if (shouldUseTraktProgressDataSource()) {
             traktProgressService.clearOptimistic()
             watchProgressPreferences.clearAll()
             return
@@ -496,6 +522,20 @@ class WatchProgressRepositoryImpl @Inject constructor(
             .map { it.trim() }
             .filter { it.isNotEmpty() }
             .distinct()
+    }
+
+    private suspend fun shouldUseTraktProgressDataSource(): Boolean {
+        val isAuthenticated = traktAuthDataStore.isEffectivelyAuthenticated.first()
+        val integrationMode = traktSettingsDataStore.integrationMode.first()
+        return isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
+    }
+
+    private suspend fun shouldWriteToTraktScrobbleMode(): Boolean {
+        val isAuthenticated = traktAuthDataStore.isEffectivelyAuthenticated.first()
+        val integrationMode = traktSettingsDataStore.integrationMode.first()
+        return isAuthenticated &&
+            integrationMode == TraktSettingsDataStore.TraktIntegrationMode.SCROBBLE_ONLY
     }
 
     private fun mergeProgressLists(

--- a/app/src/main/java/com/nuvio/tv/domain/model/PlaybackCompletionThresholds.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/PlaybackCompletionThresholds.kt
@@ -1,0 +1,14 @@
+package com.nuvio.tv.domain.model
+
+object PlaybackCompletionThresholds {
+    @Volatile
+    private var completionThresholdFraction: Float = 0.90f
+
+    fun getCompletionThresholdFraction(): Float = completionThresholdFraction
+
+    fun getCompletionThresholdPercent(): Float = completionThresholdFraction * 100f
+
+    fun setCompletionThresholdPercent(percent: Float) {
+        completionThresholdFraction = (percent / 100f).coerceIn(0.90f, 0.995f)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
@@ -47,14 +47,19 @@ data class WatchProgress(
         }
 
     /**
-     * Returns true if the content has been watched past the threshold (default 85%)
+     * Returns true if the content has been watched past the configured completion threshold.
      */
-    fun isCompleted(threshold: Float = 0.85f): Boolean = progressPercentage >= threshold
+    fun isCompleted(
+        threshold: Float = PlaybackCompletionThresholds.getCompletionThresholdFraction()
+    ): Boolean = progressPercentage >= threshold
 
     /**
-     * Returns true if the content has been started but not completed
+     * Returns true if the content has been started but not completed.
      */
-    fun isInProgress(startThreshold: Float = 0.02f, endThreshold: Float = 0.85f): Boolean =
+    fun isInProgress(
+        startThreshold: Float = 0.02f,
+        endThreshold: Float = PlaybackCompletionThresholds.getCompletionThresholdFraction()
+    ): Boolean =
         progressPercentage >= startThreshold && progressPercentage < endThreshold
 
     /**

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -19,6 +19,7 @@ import com.nuvio.tv.core.sync.WatchedItemsSyncService
 import com.nuvio.tv.data.local.LibraryPreferences
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.repository.AddonRepositoryImpl
 import com.nuvio.tv.data.repository.LibraryRepositoryImpl
@@ -60,6 +61,7 @@ class AccountViewModel @Inject constructor(
     private val libraryPreferences: LibraryPreferences,
     private val watchedItemsPreferences: WatchedItemsPreferences,
     private val traktAuthDataStore: TraktAuthDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val postgrest: Postgrest,
     private val profileManager: ProfileManager,
     @dagger.hilt.android.qualifiers.ApplicationContext private val context: Context
@@ -593,7 +595,9 @@ class AccountViewModel @Inject constructor(
             addonRepository.isSyncingFromRemote = false
 
             val isPrimaryProfile = profileManager.activeProfileId.value == 1
-            val isTraktConnected = isPrimaryProfile && traktAuthDataStore.isAuthenticated.first()
+            val isTraktConnected = isPrimaryProfile &&
+                traktAuthDataStore.isAuthenticated.first() &&
+                traktSettingsDataStore.integrationMode.first() == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
             Log.d("AccountViewModel", "pullRemoteData: isTraktConnected=$isTraktConnected isPrimaryProfile=$isPrimaryProfile")
             if (!isTraktConnected) {
                 watchProgressRepository.isSyncingFromRemote = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -43,7 +43,7 @@ object PlayerNextEpisodeRules {
             if (durationMs <= 0L) return false
             when (thresholdMode) {
                 NextEpisodeThresholdMode.PERCENTAGE -> {
-                    val clampedPercent = thresholdPercent.coerceIn(97f, 99.5f)
+                    val clampedPercent = thresholdPercent.coerceIn(90f, 99.5f)
                     (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
                 }
                 NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -10,6 +10,7 @@ import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.StreamLinkCacheDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.repository.ParentalGuideRepository
 import com.nuvio.tv.data.repository.SkipIntroRepository
@@ -43,6 +44,7 @@ class PlayerRuntimeController(
     internal val traktScrobbleService: TraktScrobbleService,
     internal val skipIntroRepository: SkipIntroRepository,
     internal val playerSettingsDataStore: PlayerSettingsDataStore,
+    internal val traktSettingsDataStore: TraktSettingsDataStore,
     internal val streamLinkCacheDataStore: StreamLinkCacheDataStore,
     internal val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     internal val watchedItemsPreferences: com.nuvio.tv.data.local.WatchedItemsPreferences,
@@ -179,8 +181,10 @@ class PlayerRuntimeController(
     internal var streamAutoPlayNextEpisodeEnabledSetting: Boolean = false
     internal var streamAutoPlayPreferBingeGroupForNextEpisodeSetting: Boolean = false
     internal var nextEpisodeThresholdModeSetting: NextEpisodeThresholdMode = NextEpisodeThresholdMode.PERCENTAGE
-    internal var nextEpisodeThresholdPercentSetting: Float = 98f
+    internal var nextEpisodeThresholdPercentSetting: Float = 90f
     internal var nextEpisodeThresholdMinutesBeforeEndSetting: Float = 2f
+    internal var traktIntegrationModeSetting: TraktSettingsDataStore.TraktIntegrationMode =
+        TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
     internal var currentStreamBingeGroup: String? = navigationArgs.bingeGroup
     internal var hasAppliedRememberedAudioSelection: Boolean = false
 
@@ -201,6 +205,7 @@ class PlayerRuntimeController(
     internal var hasRequestedScrobbleStartForCurrentItem: Boolean = false
     internal var scrobbleStartRequestGeneration: Long = 0L
     internal var hasSentCompletionScrobbleForCurrentItem: Boolean = false
+    internal var isReleasingPlayer: Boolean = false
     internal var episodeStreamsJob: Job? = null
     internal var episodeStreamsCacheRequestKey: String? = null
     internal val streamCacheKey: String? by lazy {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -52,6 +52,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
 
     scope.launch {
         try {
+            isReleasingPlayer = false
             autoSubtitleSelected = false
             hasScannedTextTracksOnce = false
             resetLoadingOverlayForNewStream()
@@ -284,11 +285,12 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                             }
                             stopProgressUpdates()
                             stopWatchProgressSaving()
-                            if (playbackState != Player.STATE_BUFFERING) {
-                                emitStopScrobbleForCurrentProgress()
+                            if (!isReleasingPlayer) {
+                                if (playbackState != Player.STATE_BUFFERING) {
+                                    emitStopScrobbleForCurrentProgress()
+                                }
+                                saveWatchProgress()
                             }
-                            
-                            saveWatchProgress()
                         }
                     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -7,6 +7,7 @@ internal fun PlayerRuntimeController.releasePlayer() {
     flushPlaybackSnapshotForSwitchOrExit()
 
     notifyAudioSessionUpdate(false)
+    isReleasingPlayer = true
 
     try {
         loudnessEnhancer?.release()
@@ -31,6 +32,7 @@ internal fun PlayerRuntimeController.releasePlayer() {
     nextEpisodeAutoPlayJob = null
     _exoPlayer?.release()
     _exoPlayer = null
+    isReleasingPlayer = false
 }
 
 internal fun PlayerRuntimeController.notifyAudioSessionUpdate(active: Boolean) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -219,6 +219,12 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             }
         }
     }
+
+    scope.launch {
+        traktSettingsDataStore.integrationMode.collectLatest { mode ->
+            traktIntegrationModeSetting = mode
+        }
+    }
 }
 
 internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode: Int?) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.util.Log
 import androidx.media3.common.Player
 import com.nuvio.tv.data.local.SubtitleStyleSettings
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.repository.TraktScrobbleItem
 import com.nuvio.tv.data.repository.extractYear
 import com.nuvio.tv.data.repository.parseContentIds
@@ -202,8 +203,13 @@ internal fun PlayerRuntimeController.emitScrobbleStop(progressPercent: Float? = 
     val item = currentScrobbleItem
     if (item == null) return
 
+    val stopThresholdPercent = if (usesLegacyFullSyncScrobbleFlow()) {
+        80f
+    } else {
+        scrobbleCompletionThresholdPercent()
+    }
     val provided = progressPercent
-    if (!hasRequestedScrobbleStartForCurrentItem && (provided ?: 0f) < 80f) return
+    if (!hasRequestedScrobbleStartForCurrentItem && (provided ?: 0f) < stopThresholdPercent) return
 
     val percent = provided ?: currentPlaybackProgressPercent()
     scope.launch {
@@ -218,13 +224,37 @@ internal fun PlayerRuntimeController.emitScrobbleStop(progressPercent: Float? = 
 }
 
 internal fun PlayerRuntimeController.emitPauseScrobbleStop(progressPercent: Float) {
-    if (progressPercent < 1f || progressPercent >= 80f) return
+    val pauseThresholdPercent = if (usesLegacyFullSyncScrobbleFlow()) {
+        80f
+    } else {
+        scrobbleCompletionThresholdPercent()
+    }
+    if (progressPercent < 1f || progressPercent >= pauseThresholdPercent) return
     val item = currentScrobbleItem
     if (item == null) return
     if (!hasRequestedScrobbleStartForCurrentItem) return
 
-    scope.launch {
-        traktScrobbleService.scrobbleStop(
+    if (usesLegacyFullSyncScrobbleFlow()) {
+        scope.launch {
+            traktScrobbleService.scrobbleStop(
+                item = item,
+                progressPercent = progressPercent
+            )
+        }
+        scrobbleStartRequestGeneration++
+        hasRequestedScrobbleStartForCurrentItem = false
+        hasSentScrobbleStartForCurrentItem = false
+        return
+    }
+
+    if (!hasSentScrobbleStartForCurrentItem) {
+        // If user exits quickly, ensure Trakt sees a valid in-progress transition.
+        traktScrobbleService.scrobbleStartThenPauseAsync(
+            item = item,
+            progressPercent = progressPercent
+        )
+    } else {
+        traktScrobbleService.scrobblePauseAsync(
             item = item,
             progressPercent = progressPercent
         )
@@ -235,7 +265,12 @@ internal fun PlayerRuntimeController.emitPauseScrobbleStop(progressPercent: Floa
 }
 
 internal fun PlayerRuntimeController.emitCompletionScrobbleStop(progressPercent: Float) {
-    if (progressPercent < 80f || hasSentCompletionScrobbleForCurrentItem) return
+    val completionThresholdPercent = if (usesLegacyFullSyncScrobbleFlow()) {
+        80f
+    } else {
+        scrobbleCompletionThresholdPercent()
+    }
+    if (progressPercent < completionThresholdPercent || hasSentCompletionScrobbleForCurrentItem) return
     hasSentCompletionScrobbleForCurrentItem = true
     emitScrobbleStop(progressPercent = progressPercent)
 }
@@ -247,7 +282,27 @@ internal fun PlayerRuntimeController.emitStopScrobbleForCurrentProgress() {
 }
 
 internal fun PlayerRuntimeController.flushPlaybackSnapshotForSwitchOrExit() {
-    emitStopScrobbleForCurrentProgress()
+    if (usesLegacyFullSyncScrobbleFlow()) {
+        emitStopScrobbleForCurrentProgress()
+        saveWatchProgress()
+        return
+    }
+
+    val progressPercent = currentPlaybackProgressPercent()
+    val completionThresholdPercent = scrobbleCompletionThresholdPercent()
+    if (progressPercent >= 1f && progressPercent < completionThresholdPercent) {
+        val item = currentScrobbleItem ?: buildScrobbleItem().also { currentScrobbleItem = it }
+        if (item != null) {
+            // For exit below completion threshold, force a valid start->pause sequence.
+            traktScrobbleService.scrobbleStartThenPauseAsync(
+                item = item,
+                progressPercent = progressPercent
+            )
+            hasSentScrobbleStartForCurrentItem = false
+        }
+    } else {
+        emitStopScrobbleForCurrentProgress()
+    }
     saveWatchProgress()
 }
 
@@ -260,10 +315,24 @@ internal fun PlayerRuntimeController.scheduleProgressSyncAfterSeek() {
         val progressPercent = currentPlaybackProgressPercent()
         emitPauseScrobbleStop(progressPercent = progressPercent)
 
-        if (_exoPlayer?.isPlaying == true && progressPercent >= 1f && progressPercent < 80f) {
+        val restartThresholdPercent = if (usesLegacyFullSyncScrobbleFlow()) {
+            80f
+        } else {
+            scrobbleCompletionThresholdPercent()
+        }
+        if (_exoPlayer?.isPlaying == true && progressPercent >= 1f && progressPercent < restartThresholdPercent) {
             emitScrobbleStart()
         }
     }
+}
+
+private fun PlayerRuntimeController.scrobbleCompletionThresholdPercent(): Float {
+    val configured = nextEpisodeThresholdPercentSetting
+    return if (configured.isFinite()) configured.coerceIn(90f, 99.5f) else 90f
+}
+
+private fun PlayerRuntimeController.usesLegacyFullSyncScrobbleFlow(): Boolean {
+    return traktIntegrationModeSetting == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
 }
 
 fun PlayerRuntimeController.scheduleHideControls() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.StreamLinkCacheDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.repository.ParentalGuideRepository
 import com.nuvio.tv.data.repository.SkipIntroRepository
 import com.nuvio.tv.data.repository.TraktScrobbleService
@@ -33,6 +34,7 @@ class PlayerViewModel @Inject constructor(
     private val traktScrobbleService: TraktScrobbleService,
     private val skipIntroRepository: SkipIntroRepository,
     private val playerSettingsDataStore: PlayerSettingsDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
     private val streamLinkCacheDataStore: StreamLinkCacheDataStore,
     private val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     private val watchedItemsPreferences: com.nuvio.tv.data.local.WatchedItemsPreferences,
@@ -51,6 +53,7 @@ class PlayerViewModel @Inject constructor(
         traktScrobbleService = traktScrobbleService,
         skipIntroRepository = skipIntroRepository,
         playerSettingsDataStore = playerSettingsDataStore,
+        traktSettingsDataStore = traktSettingsDataStore,
         streamLinkCacheDataStore = streamLinkCacheDataStore,
         layoutPreferenceDataStore = layoutPreferenceDataStore,
         watchedItemsPreferences = watchedItemsPreferences,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -167,7 +167,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                     subtitle = stringResource(R.string.autoplay_threshold_pct_sub),
                     value = (playerSettings.nextEpisodeThresholdPercent * 2f).roundToInt(),
                     valueText = "${formatHalfStepValue(playerSettings.nextEpisodeThresholdPercent)}%",
-                    minValue = 194,
+                    minValue = 180,
                     maxValue = 199,
                     step = 1,
                     onValueChange = { onSetNextEpisodeThresholdPercent(it / 2f) },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktScreen.kt
@@ -6,6 +6,8 @@ import androidx.annotation.RawRes
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +36,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
@@ -70,6 +73,7 @@ fun TraktScreen(
     var showDisconnectConfirm by remember { mutableStateOf(false) }
     var showDaysCapDialog by remember { mutableStateOf(false) }
     var showUnairedNextUpDialog by remember { mutableStateOf(false) }
+    var showIntegrationModeDialog by remember { mutableStateOf(false) }
     val strAllHistory = stringResource(R.string.trakt_all_history)
     val strDaysFormat = stringResource(R.string.trakt_days_format)
     val cwWindowFormatter: (Int) -> String = { days ->
@@ -155,8 +159,9 @@ fun TraktScreen(
                 .fillMaxHeight()
                 .border(1.dp, NuvioColors.Border.copy(alpha = 0.5f), RoundedCornerShape(18.dp))
                 .background(NuvioColors.BackgroundElevated.copy(alpha = 0.35f), RoundedCornerShape(18.dp))
-                .padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(26.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
             val expiresAt = uiState.deviceCodeExpiresAtMillis
             val remaining = expiresAt?.let { (it - nowMillis).coerceAtLeast(0L) } ?: 0L
@@ -261,17 +266,29 @@ fun TraktScreen(
 
             if (uiState.mode == TraktConnectionMode.CONNECTED) {
                 SettingsActionRow(
-                    title = stringResource(R.string.trakt_continue_watching_window),
-                    subtitle = stringResource(R.string.trakt_continue_watching_subtitle),
-                    value = cwWindowFormatter(uiState.continueWatchingDaysCap),
-                    onClick = { showDaysCapDialog = true }
+                    title = stringResource(R.string.trakt_integration_mode),
+                    subtitle = stringResource(R.string.trakt_integration_mode_subtitle),
+                    value = if (uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC) {
+                        stringResource(R.string.trakt_mode_full_sync)
+                    } else {
+                        stringResource(R.string.trakt_mode_scrobble_only)
+                    },
+                    onClick = { showIntegrationModeDialog = true }
                 )
-                SettingsActionRow(
-                    title = stringResource(R.string.trakt_unaired_next_up),
-                    subtitle = stringResource(R.string.trakt_unaired_next_up_subtitle),
-                    value = if (uiState.showUnairedNextUp) stringResource(R.string.trakt_unaired_shown) else stringResource(R.string.trakt_unaired_hidden),
-                    onClick = { showUnairedNextUpDialog = true }
-                )
+                if (uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC) {
+                    SettingsActionRow(
+                        title = stringResource(R.string.trakt_continue_watching_window),
+                        subtitle = stringResource(R.string.trakt_continue_watching_subtitle),
+                        value = cwWindowFormatter(uiState.continueWatchingDaysCap),
+                        onClick = { showDaysCapDialog = true }
+                    )
+                    SettingsActionRow(
+                        title = stringResource(R.string.trakt_unaired_next_up),
+                        subtitle = stringResource(R.string.trakt_unaired_next_up_subtitle),
+                        value = if (uiState.showUnairedNextUp) stringResource(R.string.trakt_unaired_shown) else stringResource(R.string.trakt_unaired_hidden),
+                        onClick = { showUnairedNextUpDialog = true }
+                    )
+                }
             }
 
             if (uiState.mode != TraktConnectionMode.CONNECTED) {
@@ -292,7 +309,7 @@ fun TraktScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(8.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (uiState.mode == TraktConnectionMode.AWAITING_APPROVAL) {
@@ -317,7 +334,10 @@ fun TraktScreen(
         }
     }
 
-    if (showDaysCapDialog) {
+    if (
+        showDaysCapDialog &&
+        uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
+    ) {
         NuvioDialog(
             onDismiss = { showDaysCapDialog = false },
             title = stringResource(R.string.trakt_cw_window_title),
@@ -371,7 +391,10 @@ fun TraktScreen(
         }
     }
 
-    if (showUnairedNextUpDialog) {
+    if (
+        showUnairedNextUpDialog &&
+        uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC
+    ) {
         NuvioDialog(
             onDismiss = { showUnairedNextUpDialog = false },
             title = stringResource(R.string.trakt_unaired_dialog_title),
@@ -412,6 +435,86 @@ fun TraktScreen(
                 ) {
                     Button(
                         onClick = { showUnairedNextUpDialog = false },
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioColors.BackgroundCard,
+                            contentColor = NuvioColors.TextPrimary
+                        )
+                    ) {
+                        Text(stringResource(R.string.action_cancel))
+                    }
+                }
+            }
+        }
+    }
+
+    if (showIntegrationModeDialog) {
+        Dialog(onDismissRequest = { showIntegrationModeDialog = false }) {
+            Column(
+                modifier = Modifier
+                    .width(620.dp)
+                    .background(NuvioColors.BackgroundElevated, RoundedCornerShape(16.dp))
+                    .border(1.dp, NuvioColors.Border, RoundedCornerShape(16.dp))
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.trakt_mode_dialog_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = NuvioColors.TextPrimary
+                )
+                Text(
+                    text = stringResource(R.string.trakt_mode_dialog_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary
+                )
+                Button(
+                    onClick = {
+                        viewModel.onIntegrationModeSelected(TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC)
+                        showIntegrationModeDialog = false
+                    },
+                    colors = ButtonDefaults.colors(
+                        containerColor = if (uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC) {
+                            NuvioColors.Primary
+                        } else {
+                            NuvioColors.BackgroundCard
+                        },
+                        contentColor = if (uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC) {
+                            Color.Black
+                        } else {
+                            NuvioColors.TextPrimary
+                        }
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.trakt_mode_full_sync))
+                }
+                Button(
+                    onClick = {
+                        viewModel.onIntegrationModeSelected(TraktSettingsDataStore.TraktIntegrationMode.SCROBBLE_ONLY)
+                        showIntegrationModeDialog = false
+                    },
+                    colors = ButtonDefaults.colors(
+                        containerColor = if (uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.SCROBBLE_ONLY) {
+                            NuvioColors.Primary
+                        } else {
+                            NuvioColors.BackgroundCard
+                        },
+                        contentColor = if (uiState.integrationMode == TraktSettingsDataStore.TraktIntegrationMode.SCROBBLE_ONLY) {
+                            Color.Black
+                        } else {
+                            NuvioColors.TextPrimary
+                        }
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.trakt_mode_scrobble_only))
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Button(
+                        onClick = { showIntegrationModeDialog = false },
                         colors = ButtonDefaults.colors(
                             containerColor = NuvioColors.BackgroundCard,
                             contentColor = NuvioColors.TextPrimary

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -42,6 +42,7 @@ data class TraktUiState(
     val deviceCodeExpiresAtMillis: Long? = null,
     val continueWatchingDaysCap: Int = TraktSettingsDataStore.DEFAULT_CONTINUE_WATCHING_DAYS_CAP,
     val showUnairedNextUp: Boolean = TraktSettingsDataStore.DEFAULT_SHOW_UNAIRED_NEXT_UP,
+    val integrationMode: TraktSettingsDataStore.TraktIntegrationMode = TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC,
     val connectedStats: TraktProgressService.TraktCachedStats? = null,
     val statusMessage: String? = null,
     val errorMessage: String? = null
@@ -93,6 +94,23 @@ class TraktViewModel @Inject constructor(
                         context.getString(R.string.trakt_unaired_now_shown)
                     } else {
                         context.getString(R.string.trakt_unaired_now_hidden)
+                    }
+                )
+            }
+        }
+    }
+
+    fun onIntegrationModeSelected(mode: TraktSettingsDataStore.TraktIntegrationMode) {
+        viewModelScope.launch {
+            traktSettingsDataStore.setIntegrationMode(mode)
+            traktProgressService.refreshNow()
+            _uiState.update {
+                it.copy(
+                    integrationMode = mode,
+                    statusMessage = if (mode == TraktSettingsDataStore.TraktIntegrationMode.FULL_SYNC) {
+                        "Trakt full sync enabled"
+                    } else {
+                        "Trakt scrobble-only mode enabled"
                     }
                 )
             }
@@ -195,14 +213,16 @@ class TraktViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 traktSettingsDataStore.continueWatchingDaysCap,
-                traktSettingsDataStore.showUnairedNextUp
-            ) { daysCap, showUnairedNextUp ->
-                daysCap to showUnairedNextUp
-            }.collectLatest { (daysCap, showUnairedNextUp) ->
+                traktSettingsDataStore.showUnairedNextUp,
+                traktSettingsDataStore.integrationMode
+            ) { daysCap, showUnairedNextUp, integrationMode ->
+                Triple(daysCap, showUnairedNextUp, integrationMode)
+            }.collectLatest { (daysCap, showUnairedNextUp, integrationMode) ->
                 _uiState.update {
                     it.copy(
                         continueWatchingDaysCap = daysCap,
-                        showUnairedNextUp = showUnairedNextUp
+                        showUnairedNextUp = showUnairedNextUp,
+                        integrationMode = integrationMode
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,6 +468,8 @@
     <string name="trakt_missing_credentials">Missing TRAKT_CLIENT_ID / TRAKT_CLIENT_SECRET in local.properties.</string>
     <string name="trakt_continue_watching_window">Continue Watching Window</string>
     <string name="trakt_continue_watching_subtitle">Trakt history considered for continue watching</string>
+    <string name="trakt_integration_mode">Integration Mode</string>
+    <string name="trakt_integration_mode_subtitle">Choose whether Trakt is full sync or send-updates-only mode</string>
     <string name="trakt_unaired_next_up">Unaired Next Up Episodes</string>
     <string name="trakt_unaired_next_up_subtitle">Show upcoming episodes before they air</string>
     <string name="trakt_unaired_shown">Shown</string>
@@ -491,6 +493,10 @@
     <string name="trakt_unaired_dialog_subtitle">Choose whether Continue Watching should include upcoming episodes before release.</string>
     <string name="trakt_show_unaired">Show unaired episodes</string>
     <string name="trakt_hide_unaired">Hide unaired episodes</string>
+    <string name="trakt_mode_dialog_title">Trakt Integration Mode</string>
+    <string name="trakt_mode_dialog_subtitle">Full Sync uses Trakt for app library/progress. Scrobble Only keeps local library/progress and only sends scrobble and watched updates to Trakt.</string>
+    <string name="trakt_mode_full_sync">Full Sync</string>
+    <string name="trakt_mode_scrobble_only">Scrobble Only</string>
     <string name="trakt_all_history">All history</string>
     <string name="trakt_days_format">%1$d days</string>
 


### PR DESCRIPTION
## Summary

This PR adds a new Trakt integration mode selector with two options:

- `FULL_SYNC`
- `SCROBBLE_ONLY`

### Mode behavior

#### `FULL_SYNC`

Trakt remains the source for:

- library
- continue watching / progress
- watched state

Existing full-sync repository behavior is preserved.

#### `SCROBBLE_ONLY`

Local data remains the source for:

- library
- continue watching
- watched/progress UI

Trakt is used as background scrobble/history tracking (send playback updates, without using Trakt-driven library/continue-watching UI in-app).

## Why

Some users want Trakt only as a background tracking/scrobble/history integration, without using Trakt lists, Trakt library, or Trakt continue-watching inside the app.

This mode supports that workflow while preserving `FULL_SYNC` for users who want full Trakt-driven integration.

## Testing

- Manual checks:
  - Integration mode can be switched between `FULL_SYNC` and `SCROBBLE_ONLY`.
  - In `SCROBBLE_ONLY` tv shows episodes were added (after finished) to Trakt history on the web app.
  - In `SCROBBLE_ONLY`, full-sync-only Trakt settings are hidden:
    - Continue Watching Window
    - Unaired Next Up Episodes
- Known limitation for this draft:
  - Due to current Trakt instability, full end-to-end verification of Trakt-side `currently watching` / `continue watching` remains pending but `FULL_SYNC` remained untouched so it should work the same way.

## Breaking changes

No breaking changes expected.

## Linked issues

Refs #133 