### PR TITLE
feat: show buffer track on player seek bar

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -27,7 +27,8 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                 _uiState.update {
                     it.copy(
                         currentPosition = displayPosition,
-                        duration = playerDuration.coerceAtLeast(0L)
+                        duration = playerDuration.coerceAtLeast(0L),
+                        bufferedPosition = player.bufferedPosition.coerceAtLeast(0L)
                     )
                 }
                 updateActiveSkipInterval(pos)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1134,6 +1134,7 @@ private fun PlayerControlsOverlay(
             ProgressBar(
                 currentPosition = uiState.currentPosition,
                 duration = uiState.duration,
+                bufferedPosition = uiState.bufferedPosition,
                 onSeekTo = onSeekTo
             )
 
@@ -1317,10 +1318,15 @@ private fun ControlButton(
 private fun ProgressBar(
     currentPosition: Long,
     duration: Long,
+    bufferedPosition: Long = 0L,
     onSeekTo: (Long) -> Unit
 ) {
     val progress = if (duration > 0) {
         (currentPosition.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    val bufferedProgress = if (duration > 0) {
+        (bufferedPosition.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
     } else 0f
 
     val animatedProgress by animateFloatAsState(
@@ -1329,13 +1335,28 @@ private fun ProgressBar(
         label = "progress"
     )
 
+    val animatedBufferedProgress by animateFloatAsState(
+        targetValue = bufferedProgress,
+        animationSpec = tween(300),
+        label = "bufferedProgress"
+    )
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(6.dp)
             .clip(RoundedCornerShape(3.dp))
-            .background(Color.White.copy(alpha = 0.3f))
+            .background(Color.White.copy(alpha = 0.2f))
     ) {
+        // Buffer track
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(animatedBufferedProgress)
+                .clip(RoundedCornerShape(3.dp))
+                .background(Color.White.copy(alpha = 0.35f))
+        )
+        // Playback progress track
         Box(
             modifier = Modifier
                 .fillMaxHeight()
@@ -1356,6 +1377,7 @@ private fun SeekOverlay(uiState: PlayerUiState) {
         ProgressBar(
             currentPosition = uiState.currentPosition,
             duration = uiState.duration,
+            bufferedPosition = uiState.bufferedPosition,
             onSeekTo = {}
         )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -20,6 +20,7 @@ data class PlayerUiState(
     val playbackEnded: Boolean = false,
     val currentPosition: Long = 0L,
     val duration: Long = 0L,
+    val bufferedPosition: Long = 0L,
     val title: String = "",
     val contentName: String? = null, // Series/show name (for series content)
     val releaseYear: String? = null, // Release year for movies


### PR DESCRIPTION
Adds a buffered position indicator to the player progress bar, showing how much content is buffered ahead with a semi-transparent track between playback progress and the bar background.

<img width="3840" height="2160" alt="Screenshot_20260301_015841" src="https://github.com/user-attachments/assets/94e79662-4e24-42c8-916b-5944678d1b38" />
