### PR TITLE
change focus to nextToWatch season, and scroll to nextToWatch episode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -20,7 +20,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -77,7 +79,7 @@ import java.util.TimeZone
 
 private const val EPISODE_CARD_CONTENT_TYPE = "episode_card"
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 fun SeasonTabs(
     seasons: List<Int>,
@@ -95,7 +97,9 @@ fun SeasonTabs(
     }
 
     LazyRow(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRestorer { selectedTabFocusRequester },
         contentPadding = PaddingValues(horizontal = 48.dp, vertical = 24.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -202,11 +206,14 @@ fun EpisodesRow(
     restoreEpisodeId: String? = null,
     restoreFocusToken: Int = 0,
     onRestoreFocusHandled: () -> Unit = {},
-    onEpisodeFocused: (episodeId: String) -> Unit = {}
+    onEpisodeFocused: (episodeId: String) -> Unit = {},
+    scrollToEpisodeId: String? = null
 ) {
     val restoreTargetRequester = restoreEpisodeId?.let { episodeFocusRequesters[it] }
     var optionsEpisode by remember { mutableStateOf<Video?>(null) }
     val cardMetrics = rememberEpisodeCardMetrics()
+    val density = LocalDensity.current
+    val lazyListState = rememberLazyListState()
 
     LaunchedEffect(restoreFocusToken, restoreEpisodeId, restoreTargetRequester, episodes) {
         if (restoreFocusToken <= 0 || restoreEpisodeId.isNullOrBlank()) return@LaunchedEffect
@@ -214,9 +221,18 @@ fun EpisodesRow(
         restoreTargetRequester?.requestFocusAfterFrames()
     }
 
+    LaunchedEffect(scrollToEpisodeId, episodes) {
+        if (scrollToEpisodeId.isNullOrBlank()) return@LaunchedEffect
+        val index = episodes.indexOfFirst { it.id == scrollToEpisodeId }
+        if (index < 0) return@LaunchedEffect
+        val offsetPx = with(density) { (cardMetrics.cardWidth * 2f / 3f - cardMetrics.itemSpacing).roundToPx() }
+        lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
+    }
+
     LazyRow(
         modifier = Modifier
             .fillMaxWidth(),
+        state = lazyListState,
         contentPadding = PaddingValues(
             horizontal = cardMetrics.rowHorizontalPadding,
             vertical = cardMetrics.rowVerticalPadding

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -815,8 +815,11 @@ private fun MetaDetailsContent(
         byEpisodeId.keys.retainAll(episodesForSeason.map { it.id }.toSet())
         byEpisodeId
     }
-    val seasonDownFocusRequester = remember(selectedSeason, episodesForSeason, seasonEpisodeFocusRequesters, lastFocusedEpisodeIdBySeason[selectedSeason]) {
+    val seasonDownFocusRequester = remember(selectedSeason, episodesForSeason, seasonEpisodeFocusRequesters, lastFocusedEpisodeIdBySeason[selectedSeason], nextToWatch) {
+        val nextEpisodeId = nextToWatch?.nextVideoId
+            ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
         val preferredEpisodeId = lastFocusedEpisodeIdBySeason[selectedSeason]
+            ?: nextEpisodeId?.takeIf { episodesForSeason.any { ep -> ep.id == it } }
         (preferredEpisodeId?.let { seasonEpisodeFocusRequesters[it] })
             ?: episodesForSeason.firstOrNull()?.id?.let { seasonEpisodeFocusRequesters[it] }
     }
@@ -1095,7 +1098,11 @@ private fun MetaDetailsContent(
                         },
                         onEpisodeFocused = { episodeId ->
                             lastFocusedEpisodeIdBySeason[selectedSeason] = episodeId
-                        }
+                        },
+                        scrollToEpisodeId = if (lastFocusedEpisodeIdBySeason[selectedSeason] == null) {
+                            nextToWatch?.nextVideoId
+                                ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
+                        } else null
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -145,8 +145,19 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun updateNextToWatch(nextToWatch: NextToWatch) {
         _uiState.update { state ->
-            if (state.nextToWatch == nextToWatch) {
-                state
+            if (state.nextToWatch == nextToWatch) return@update state
+            val nextSeason = nextToWatch.nextSeason
+            val meta = state.meta
+            val shouldSwitchSeason = nextSeason != null &&
+                nextSeason != state.selectedSeason &&
+                meta != null &&
+                state.seasons.contains(nextSeason)
+            if (shouldSwitchSeason && meta != null && nextSeason != null) {
+                state.copy(
+                    nextToWatch = nextToWatch,
+                    selectedSeason = nextSeason,
+                    episodesForSeason = getEpisodesForSeason(meta.videos, nextSeason)
+                )
             } else {
                 state.copy(nextToWatch = nextToWatch)
             }


### PR DESCRIPTION
Simple change so that when scrolling down on meta view, when nextToWatch is filled, season is focused on a correct one, and episode is scrolled to the next one 