### PR TITLE
fix: skip intro button to start on bottom and get pushed by controls

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.Brush
@@ -120,6 +121,7 @@ fun PlayerScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val containerFocusRequester = remember { FocusRequester() }
     val playPauseFocusRequester = remember { FocusRequester() }
+    val progressBarFocusRequester = remember { FocusRequester() }
     val episodesFocusRequester = remember { FocusRequester() }
     val streamsFocusRequester = remember { FocusRequester() }
     val sourceStreamsFocusRequester = remember { FocusRequester() }
@@ -568,7 +570,13 @@ fun PlayerScreen(
             )
         }
 
-        // Skip Intro button (bottom-left, independent of controls)
+        val skipButtonBottomPadding by animateDpAsState(
+            targetValue = if (uiState.showControls) 122.dp else 30.dp,
+            animationSpec = tween(durationMillis = 180),
+            label = "skipButtonBottomPadding"
+        )
+
+        // Skip Intro button (bottom-left, lifted when controls are visible)
         SkipIntroButton(
             interval = if (uiState.showPauseOverlay || uiState.showLoadingOverlay) null else uiState.activeSkipInterval,
             dismissed = uiState.skipIntervalDismissed,
@@ -578,10 +586,11 @@ fun PlayerScreen(
             onVisibilityChanged = { skipButtonActuallyVisible = it },
             onFocused = { viewModel.scheduleHideControls() },
             focusRequester = skipIntroFocusRequester,
+            downFocusRequester = if (uiState.showControls) progressBarFocusRequester else null,
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .padding(start = 32.dp, bottom = 120.dp)
-                
+                .padding(start = 32.dp, bottom = skipButtonBottomPadding)
+                .zIndex(2.1f)
         )
         NextEpisodeCardOverlay(
             nextEpisode = uiState.nextEpisode,
@@ -679,6 +688,7 @@ fun PlayerScreen(
             PlayerControlsOverlay(
                 uiState = uiState,
                 playPauseFocusRequester = playPauseFocusRequester,
+                progressBarFocusRequester = progressBarFocusRequester,
                 onPlayPause = { viewModel.onEvent(PlayerEvent.OnPlayPause) },
                 onPlayNextEpisode = { viewModel.onEvent(PlayerEvent.OnPlayNextEpisode) },
                 onSeekForward = { viewModel.onEvent(PlayerEvent.OnSeekForward) },
@@ -942,6 +952,7 @@ fun PlayerScreen(
 private fun PlayerControlsOverlay(
     uiState: PlayerUiState,
     playPauseFocusRequester: FocusRequester,
+    progressBarFocusRequester: FocusRequester,
     onPlayPause: () -> Unit,
     onPlayNextEpisode: () -> Unit,
     onSeekForward: () -> Unit,
@@ -1082,7 +1093,10 @@ private fun PlayerControlsOverlay(
             ProgressBar(
                 currentPosition = uiState.currentPosition,
                 duration = uiState.duration,
-                onSeekTo = onSeekTo
+                onSeekTo = onSeekTo,
+                focusRequester = progressBarFocusRequester,
+                downFocusRequester = playPauseFocusRequester,
+                onFocused = onResetHideTimer
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -1110,6 +1124,7 @@ private fun PlayerControlsOverlay(
                         contentDescription = if (uiState.isPlaying) "Pause" else "Play",
                         onClick = onPlayPause,
                         focusRequester = playPauseFocusRequester,
+                        upFocusRequester = progressBarFocusRequester,
                         onFocused = onResetHideTimer
                     )
 
@@ -1118,6 +1133,7 @@ private fun PlayerControlsOverlay(
                             icon = Icons.Default.SkipNext,
                             contentDescription = stringResource(R.string.next_episode_label),
                             onClick = onPlayNextEpisode,
+                            upFocusRequester = progressBarFocusRequester,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1128,6 +1144,7 @@ private fun PlayerControlsOverlay(
                             iconPainter = customSubtitlePainter,
                             contentDescription = "Subtitles",
                             onClick = onShowSubtitleDialog,
+                            upFocusRequester = progressBarFocusRequester,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1138,6 +1155,7 @@ private fun PlayerControlsOverlay(
                             iconPainter = customAudioPainter,
                             contentDescription = "Audio tracks",
                             onClick = onShowAudioDialog,
+                            upFocusRequester = progressBarFocusRequester,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1147,6 +1165,7 @@ private fun PlayerControlsOverlay(
                         iconPainter = customSourcePainter,
                         contentDescription = "Sources",
                         onClick = onShowSourcesPanel,
+                        upFocusRequester = progressBarFocusRequester,
                         onFocused = onResetHideTimer
                     )
 
@@ -1156,6 +1175,7 @@ private fun PlayerControlsOverlay(
                             iconPainter = customEpisodesPainter,
                             contentDescription = "Episodes",
                             onClick = onShowEpisodesPanel,
+                            upFocusRequester = progressBarFocusRequester,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1181,6 +1201,7 @@ private fun PlayerControlsOverlay(
                                 onClick = {
                                     onShowSpeedDialog()
                                 },
+                                upFocusRequester = progressBarFocusRequester,
                                 onFocused = onResetHideTimer
                             )
                             ControlButton(
@@ -1190,6 +1211,7 @@ private fun PlayerControlsOverlay(
                                 onClick = {
                                     onToggleAspectRatio()
                                 },
+                                upFocusRequester = progressBarFocusRequester,
                                 onFocused = onResetHideTimer
                             )
                             ControlButton(
@@ -1198,6 +1220,7 @@ private fun PlayerControlsOverlay(
                                 onClick = {
                                     onOpenInExternalPlayer()
                                 },
+                                upFocusRequester = progressBarFocusRequester,
                                 onFocused = onResetHideTimer
                             )
                         }
@@ -1211,6 +1234,7 @@ private fun PlayerControlsOverlay(
                         },
                         contentDescription = if (uiState.showMoreDialog) "Close more actions" else "More actions",
                         onClick = onToggleMoreActions,
+                        upFocusRequester = progressBarFocusRequester,
                         onFocused = onResetHideTimer
                     )
                 }
@@ -1233,6 +1257,7 @@ private fun ControlButton(
     contentDescription: String,
     onClick: () -> Unit,
     focusRequester: FocusRequester? = null,
+    upFocusRequester: FocusRequester? = null,
     onFocused: (() -> Unit)? = null
 ) {
     var isFocused by remember { mutableStateOf(false) }
@@ -1245,6 +1270,25 @@ private fun ControlButton(
                 if (focusRequester != null) Modifier.focusRequester(focusRequester)
                 else Modifier
             )
+            .then(
+                if (upFocusRequester != null) {
+                    Modifier.focusProperties { up = upFocusRequester }
+                } else {
+                    Modifier
+                }
+            )
+            .onPreviewKeyEvent { keyEvent ->
+                if (
+                    upFocusRequester != null &&
+                    keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
+                    keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_UP
+                ) {
+                    try { upFocusRequester.requestFocus() } catch (_: Exception) {}
+                    true
+                } else {
+                    false
+                }
+            }
             .onFocusChanged {
                 isFocused = it.isFocused
                 if (it.isFocused) onFocused?.invoke()
@@ -1277,7 +1321,10 @@ private fun ControlButton(
 private fun ProgressBar(
     currentPosition: Long,
     duration: Long,
-    onSeekTo: (Long) -> Unit
+    onSeekTo: (Long) -> Unit,
+    focusRequester: FocusRequester? = null,
+    downFocusRequester: FocusRequester? = null,
+    onFocused: (() -> Unit)? = null
 ) {
     val progress = if (duration > 0) {
         (currentPosition.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
@@ -1288,20 +1335,68 @@ private fun ProgressBar(
         animationSpec = tween(100),
         label = "progress"
     )
+    var isFocused by remember { mutableStateOf(false) }
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(6.dp)
+            .height(if (isFocused) 10.dp else 6.dp)
+            .then(
+                if (focusRequester != null) Modifier.focusRequester(focusRequester)
+                else Modifier
+            )
+            .then(
+                if (downFocusRequester != null) {
+                    Modifier.focusProperties { down = downFocusRequester }
+                } else {
+                    Modifier
+                }
+            )
+            .onFocusChanged {
+                isFocused = it.isFocused
+                if (it.isFocused) onFocused?.invoke()
+            }
+            .focusable()
+            .onPreviewKeyEvent { keyEvent ->
+                if (keyEvent.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) {
+                    return@onPreviewKeyEvent false
+                }
+                when (keyEvent.nativeKeyEvent.keyCode) {
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        if (downFocusRequester != null) {
+                            try { downFocusRequester.requestFocus() } catch (_: Exception) {}
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                        onSeekTo((currentPosition - 10_000L).coerceAtLeast(0L))
+                        true
+                    }
+                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                        val maxTarget = duration.takeIf { it > 0L } ?: Long.MAX_VALUE
+                        onSeekTo((currentPosition + 10_000L).coerceAtMost(maxTarget))
+                        true
+                    }
+                    else -> false
+                }
+            }
             .clip(RoundedCornerShape(3.dp))
-            .background(Color.White.copy(alpha = 0.3f))
+            .background(
+                if (isFocused) Color.White.copy(alpha = 0.45f)
+                else Color.White.copy(alpha = 0.3f)
+            )
     ) {
         Box(
             modifier = Modifier
                 .fillMaxHeight()
                 .fillMaxWidth(animatedProgress)
                 .clip(RoundedCornerShape(3.dp))
-                .background(NuvioColors.Secondary)
+                .background(
+                    if (isFocused) NuvioColors.Primary
+                    else NuvioColors.Secondary
+                )
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
@@ -34,8 +34,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Card
@@ -63,6 +65,7 @@ fun SkipIntroButton(
     onVisibilityChanged: (Boolean) -> Unit = {},
     onFocused: (() -> Unit)? = null,
     focusRequester: FocusRequester? = null,
+    downFocusRequester: FocusRequester? = null,
     modifier: Modifier = Modifier
 ) {
     var lastType by remember { mutableStateOf(interval?.type) }
@@ -134,6 +137,25 @@ fun SkipIntroButton(
             onClick = onSkip,
             modifier = Modifier
                 .focusRequester(activeFocusRequester)
+                .then(
+                    if (downFocusRequester != null) {
+                        Modifier.focusProperties { down = downFocusRequester }
+                    } else {
+                        Modifier
+                    }
+                )
+                .onPreviewKeyEvent { keyEvent ->
+                    if (
+                        downFocusRequester != null &&
+                        keyEvent.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN &&
+                        keyEvent.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DPAD_DOWN
+                    ) {
+                        try { downFocusRequester.requestFocus() } catch (_: Exception) {}
+                        true
+                    } else {
+                        false
+                    }
+                }
                 .onFocusChanged {
                     isFocused = it.isFocused
                     if (it.isFocused) onFocused?.invoke()


### PR DESCRIPTION
As discussed with @skoruppa on Discord, would look better if the skip button could start in the bottom left corner instead of floating around expecting the controls height. Also improved focus/navigation so the timeline is the primary upward target from the controls instead of the skip button.

https://github.com/user-attachments/assets/eba75100-1418-447c-af70-6c5f147a7b86

