### PR TITLE
Add missing Turkish translations from #546 and fix incorrect translations

### DIFF
--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -122,7 +122,7 @@
     <string name="settings_profiles_subtitle">Kullanıcı profillerini yönetin.</string>
     <string name="settings_layout">Düzen</string>
     <string name="settings_layout_subtitle">Ana sayfa düzeni ve poster stilleri.</string>
-    <string name="settings_plugins">Eklentiler</string>
+    <string name="settings_plugins">Uzantılar</string>
     <string name="settings_plugins_subtitle">Depolar ve sağlayıcılar.</string>
     <string name="settings_integration">Entegrasyon</string>
     <string name="settings_playback">Oynatma</string>
@@ -134,7 +134,7 @@
     <string name="settings_plugins_section_subtitle">Depoları, sağlayıcıları ve eklenti durumlarını yönetin.</string>
     <string name="settings_account_section_subtitle">Hesap ve senkronizasyon durumu.</string>
     <string name="account_stat_addons">eklentiler</string>
-    <string name="account_stat_plugins">pluginler</string>
+    <string name="account_stat_plugins">uzantılar</string>
     <string name="account_stat_library">kütüphane</string>
     <string name="account_stat_progress">ilerleme</string>
     <string name="account_stat_watched">izlenen</string>
@@ -255,6 +255,8 @@
     <string name="autoplay_stream_selection">Otomatik Kaynak Seçimi</string>
     <string name="autoplay_next_episode">Sonraki Bölümü Otomatik Oynat</string>
     <string name="autoplay_next_episode_sub">Ekran çıktığında sonraki bölümü otomatik olarak başlat.</string>
+    <string name="autoplay_prefer_binge_group">Binge Grubunu Tercih Et (Sonraki Bölüm)</string>
+    <string name="autoplay_prefer_binge_group_sub">Normal otomatik oynatma kurallarından önce aynı kaynak profilini (aynı eklenti/kalite grubu) deneyin.</string>
     <string name="autoplay_threshold_pct">Yüzde</string>
     <string name="autoplay_threshold_min">Bitişten önceki dakika</string>
     <string name="autoplay_threshold_mode">Sonraki Bölüm Eşiği Mantığı</string>
@@ -264,21 +266,21 @@
     <string name="autoplay_threshold_min_sub">Bitiş zaman damgası olmadığında kullanılacak alternatif süre.</string>
     <string name="autoplay_scope_all">Tüm kaynaklar</string>
     <string name="autoplay_scope_addons">Yalnızca kurulu eklentiler</string>
-    <string name="autoplay_scope_plugins">Yalnızca etkin eklentiler</string>
+    <string name="autoplay_scope_plugins">Yalnızca etkin uzantılar</string>
     <string name="autoplay_scope">Otomatik Oynatma Kaynak Kapsamı</string>
     <string name="autoplay_allowed_addons">İzin Verilen Eklentiler</string>
     <string name="autoplay_all_addons">Tüm kurulu eklentiler</string>
-    <string name="autoplay_allowed_plugins">İzin Verilen Pluginler</string>
-    <string name="autoplay_all_plugins">Tüm etkin pluginler</string>
+    <string name="autoplay_allowed_plugins">İzin Verilen Uzantılar</string>
+    <string name="autoplay_all_plugins">Tüm etkin uzantılar</string>
     <string name="autoplay_regex_placeholder">Desen ayarlanmadı. Örnek: 4K|2160p|Remux</string>
     <string name="autoplay_regex_title">Regex Deseni</string>
     <string name="autoplay_no_items">Öğe bulunamadı</string>
     <string name="autoplay_mode_manual_desc">Her zaman kaynak listesini göster ve benim seçmeme izin ver.</string>
     <string name="autoplay_mode_first_desc">Mevcut olan ilk kaynağı otomatik olarak oynat.</string>
     <string name="autoplay_mode_regex_desc">Metni regex deseninizle eşleşen ilk kaynağı oynat.</string>
-    <string name="autoplay_scope_all_desc">Otomatik oynatma, hem kurulu eklentileri hem de etkin pluginleri kullanabilir.</string>
+    <string name="autoplay_scope_all_desc">Otomatik oynatma, hem kurulu eklentileri hem de etkin uzantıları kullanabilir.</string>
     <string name="autoplay_scope_addons_desc">Otomatik oynatma yalnızca kurulu eklentilerinizden gelen yayınları dikkate alır.</string>
-    <string name="autoplay_scope_plugins_desc">Otomatik oynatma yalnızca etkin eklentilerinizden gelen yayınları dikkate alır.</string>
+    <string name="autoplay_scope_plugins_desc">Otomatik oynatma yalnızca etkin uzantılarınızdan gelen yayınları dikkate alır.</string>
     <string name="autoplay_threshold_pct_desc">Bitiş zaman damgası mevcut olmadığında yüzdeye göre göster.</string>
     <string name="autoplay_threshold_min_desc">Bitiş zaman damgası mevcut olmadığında bölümün bitmesine bu kadar dakika kala göster.</string>
     <string name="autoplay_regex_matches">Yayın adı/başlık/açıklama/eklenti/url ile eşleşir. Örnek: 4K|2160p|Remux</string>
@@ -393,7 +395,11 @@
     <string name="mdblist_dialog_subtitle">Harici verileri çekmek için API anahtarınızı girin</string>
     <string name="mdblist_dialog_placeholder">MDBList API Anahtarını Girin</string>
     <string name="mdblist_not_set">Ayarlanmadı</string>
+    <string name="mdblist_invalid_api_key">Geçersiz MDBList API anahtarı</string>
     <string name="action_clear">Temizle</string>
+
+    <!-- Anime-Skip -->
+    <string name="animeskip_invalid_client_id">Geçersiz Client ID</string>
 
     <!-- TmdbSettingsScreen -->
     <string name="tmdb_title">TMDB Zenginleştirme</string>
@@ -439,6 +445,8 @@
     <string name="trakt_unaired_next_up_subtitle">Yaklaşan bölümleri yayınlanmadan önce göster</string>
     <string name="trakt_unaired_shown">Gösterilen</string>
     <string name="trakt_unaired_hidden">Gizlenen</string>
+    <string name="trakt_unaired_now_shown">Yayınlanmamış sıradaki bölümler artık gösteriliyor</string>
+    <string name="trakt_unaired_now_hidden">Yayınlanmamış sıradaki bölümler artık gizleniyor</string>
     <string name="trakt_cached_label">Önbellekte</string>
     <string name="trakt_stat_movies">Filmler</string>
     <string name="trakt_stat_shows">Diziler</string>
@@ -493,13 +501,13 @@
     <string name="profile_name_placeholder">Profil Adı</string>
     <string name="profile_avatar_color">Avatar Rengi</string>
     <string name="profile_use_primary_addons">Birincil profilin eklentilerini kullan</string>
-    <string name="profile_use_primary_plugins">Birincil profilin pluginlerini kullan</string>
+    <string name="profile_use_primary_plugins">Birincil profilin uzantılarını kullan</string>
     <string name="profile_creating">Oluşturuluyor\u2026</string>
     <string name="profile_create_btn">Oluştur</string>
     <string name="profile_confirm">Onayla</string>
     <string name="profile_delete">Sil</string>
     <string name="profile_addons">eklentiler</string>
-    <string name="profile_plugins">pluginler</string>
+    <string name="profile_plugins">uzantılar</string>
 
 
     <!-- AddonManagerScreen -->
@@ -551,6 +559,7 @@
     <string name="stream_player_external">Harici Oynatıcı</string>
 
     <!-- PlayerScreen -->
+    <string name="player_no_external_player">Harici oynatıcı bulunamadı</string>
     <string name="player_ends_at">Bitiş saati: %1$s</string>
     <string name="player_via">Sağlayıcı: %1$s</string>
     <string name="player_subtitle_delay">Altyazı Gecikmesi</string>
@@ -561,6 +570,16 @@
     <string name="player_more_speed">Oynatma Hızı</string>
     <string name="player_more_aspect_ratio">Görüntü Oranı</string>
     <string name="player_more_open_external">Harici Oynatıcıda Aç</string>
+
+    <!-- ParentalGuideOverlay -->
+    <string name="parental_nudity">Çıplaklık</string>
+    <string name="parental_violence">Şiddet</string>
+    <string name="parental_profanity">Küfür</string>
+    <string name="parental_alcohol">Alkol/Uyuşturucu</string>
+    <string name="parental_frightening">Korkutucu</string>
+    <string name="parental_severity_severe">Şiddetli</string>
+    <string name="parental_severity_moderate">Orta</string>
+    <string name="parental_severity_mild">Hafif</string>
 
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Kaynaklar</string>
@@ -636,6 +655,7 @@
     <string name="next_episode_playing_via">%1$s üzerinden %2$d sn içinde oynatılıyor</string>
     <string name="next_episode_play">Oynat</string>
     <string name="next_episode_unaired">Yayınlanmadı</string>
+    <string name="next_episode_not_aired_yet">Sonraki bölüm henüz yayınlanmadı</string>
     <string name="skip_intro">İntroyu Atla</string>
     <string name="skip_ending">Kapanışı Atla</string>
     <string name="skip_recap">Özeti Atla</string>
@@ -650,6 +670,10 @@
     <string name="search_start_title">Aramaya Başlayın</string>
     <string name="search_start_subtitle">En az 2 karakter girin</string>
     <string name="search_start_subtitle_no_discover">Keşfet kapalı. En az 2 karakter girin</string>
+    <string name="search_voice_no_speech">Konuşma algılanamadı. Tekrar deneyin.</string>
+    <string name="search_voice_mic_permission">Sesli arama için mikrofon izni gereklidir.</string>
+    <string name="search_voice_failed">Ses tanıma başarısız oldu. Tekrar deneyin.</string>
+    <string name="search_voice_unavailable">Bu cihazda sesli arama kullanılamıyor.</string>
 
     <!-- LibraryScreen -->
     <string name="library_syncing">Trakt kütüphanesi senkronize ediliyor\u2026</string>
@@ -682,7 +706,7 @@
 
     <!-- AccountSettingsContent -->
     <string name="account_loading">Yükleniyor\u2026</string>
-    <string name="account_sync_description">Kütüphanenizi, görüntüleme ilerlemenizi, eklentilerinizi ve pluginlerinizi cihazlar arasında eşitleyin.</string>
+    <string name="account_sync_description">Kütüphanenizi, görüntüleme ilerlemenizi, eklentilerinizi ve uzantılarınızı cihazlar arasında eşitleyin.</string>
     <string name="account_signin_qr_title">QR ile Oturum Aç</string>
     <string name="account_signin_qr_subtitle">QR kodunu taratıp e-posta ile girişinizi telefondan tamamlayın</string>
     <string name="account_signed_in_label">Oturum açıldı</string>
@@ -726,7 +750,7 @@
     <!-- SyncCodeClaimScreen -->
     <string name="sync_claim_title">Cihazı Bağla</string>
     <string name="sync_claim_subtitle">Cihazınızı eşleştirmek için diğer cihazdan aldığınız senkronizasyon kodunu ve PIN\'i girin.</string>
-    <string name="sync_claim_success">Cihaz eşleştirildi. Eklenti ve pluginleriniz arka planda kopyalanacak.</string>
+    <string name="sync_claim_success">Cihaz eşleştirildi. Eklenti ve uzantılarınız arka planda kopyalanacak.</string>
     <string name="sync_claim_done">Bitti</string>
     <string name="sync_claim_code_label">Senkronizasyon Kodu</string>
     <string name="sync_claim_code_placeholder">XXXX-XXXX-XXXX-XXXX-XXXX</string>
@@ -734,15 +758,15 @@
     <string name="sync_claim_pin_placeholder">PIN numarasını gir</string>
 
     <!-- PluginScreen -->
-    <string name="plugin_readonly_notice">Birincil profilin eklentileri eşleştirildi. Başka değişiklik yapmanız kısıtlanmıştır.</string>
+    <string name="plugin_readonly_notice">Birincil profilin uzantıları eşleştirildi. Başka değişiklik yapmanız kısıtlanmıştır.</string>
     <string name="plugin_repositories_section">Depolar (%1$d)</string>
     <string name="plugin_providers_section">Sağlayıcılar (%1$d)</string>
-    <string name="plugin_title">Pluginler</string>
+    <string name="plugin_title">Uzantılar</string>
     <string name="plugin_subtitle">Sağlayıcıları ve bağımsız geliştirici depolarını yönet</string>
     <string name="plugin_add_repository">Depo ekle</string>
     <string name="plugin_add_btn">Ekle</string>
     <string name="plugin_manage_from_phone_title">Telefondan Yönet</string>
-    <string name="plugin_manage_from_phone_subtitle">Yeni bir eklenti deposu eklemek ya da silmek için telefondan kodu tarayın</string>
+    <string name="plugin_manage_from_phone_subtitle">Yeni bir uzantı deposu eklemek ya da silmek için telefondan kodu tarayın</string>
     <string name="plugin_qr_instruction">Depoları yönetmek için bu adresi açıp kontrol edin.</string>
     <string name="plugin_qr_close">Kapat</string>
     <string name="plugin_confirm_title">Depo Değişikliklerini Uygula</string>


### PR DESCRIPTION
## Summary

- Added missing Turkish translations for features introduced in PR #546 (such as parental guide, voice search, API validation, and autoplay binge group).
- Corrected terminology inconsistencies in the Turkish resources by properly differentiating between "Addons" (Eklentiler) and "Plugins" (Uzantılar) throughout the entire application strings.

## Why

To ensure complete and accurate Turkish localization for the newly added functionalities. Additionally, maintaining consistent terminology between "Addons" and "Plugins" prevents confusion for Turkish users navigating the app's settings and menus.

## Testing

- Manually reviewed the new Turkish strings in context (parental guide, voice search, API validation) to ensure they display correctly.
- Checked the app's UI elements referencing "Addons" and "Plugins" to confirm the terminology is now consistently translated as "Eklentiler" and "Uzantılar" respectively.

## Screenshots / Video (UI changes only)

No UI changes were made.

## Breaking changes

No breaking changes were made.

## Linked issues

Follow-up to #546
