### PR TITLE
feat(player): implement better style seek and focus management

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -407,44 +407,31 @@ fun PlayerScreen(
                                 false
                             }
                         }
-                        KeyEvent.KEYCODE_DPAD_LEFT -> {
-                            if (!uiState.showControls) {
-                                val repeatCount = keyEvent.nativeKeyEvent.repeatCount
-                                val deltaMs = when {
-                                    repeatCount >= 8 -> -30_000L
-                                    repeatCount >= 3 -> -20_000L
-                                    else -> -10_000L
-                                }
-                                viewModel.onEvent(PlayerEvent.OnPreviewSeekBy(deltaMs))
-                                true
-                            } else {
-                                // Let focus system handle navigation when controls are visible
-                                false
-                            }
-                        }
                         KeyEvent.KEYCODE_DPAD_UP -> {
-                            if (!uiState.showControls) {
-                                viewModel.onEvent(PlayerEvent.OnToggleControls)
-                            } else {
-                                val skipVisible = skipButtonActuallyVisible
-                                if (skipVisible) {
-                                    try {
-                                        skipIntroFocusRequester.requestFocus()
-                                    } catch (_: Exception) {
-                                        // Focus requester may not be ready yet
-                                    }
-                                } else if (uiState.showNextEpisodeCard && uiState.nextEpisode != null) {
-                                    try {
-                                        nextEpisodeFocusRequester.requestFocus()
-                                    } catch (_: Exception) {
-                                        // Focus requester may not be ready yet
-                                    }
+                                if (!uiState.showControls) {
+                                    viewModel.onEvent(PlayerEvent.OnToggleControls)
                                 } else {
-                                    viewModel.hideControls()
+                                    try {
+                                        progressBarFocusRequester.requestFocus()
+                                    } catch (_: Exception) {
+                                        val skipVisible = skipButtonActuallyVisible
+                                        if (skipVisible) {
+                                            try {
+                                                skipIntroFocusRequester.requestFocus()
+                                            } catch (_: Exception) {
+                                            }
+                                        } else if (uiState.showNextEpisodeCard && uiState.nextEpisode != null) {
+                                            try {
+                                                nextEpisodeFocusRequester.requestFocus()
+                                            } catch (_: Exception) {
+                                            }
+                                        } else {
+                                            viewModel.hideControls()
+                                        }
+                                    }
                                 }
+                                true
                             }
-                            true
-                        }
                         KeyEvent.KEYCODE_DPAD_DOWN -> {
                             if (!uiState.showControls) {
                                 viewModel.onEvent(PlayerEvent.OnToggleControls)
@@ -705,6 +692,7 @@ fun PlayerScreen(
             val context = LocalContext.current
             PlayerControlsOverlay(
                 uiState = uiState,
+                viewModel = viewModel,
                 playPauseFocusRequester = playPauseFocusRequester,
                 progressBarFocusRequester = progressBarFocusRequester,
                 onPlayPause = { viewModel.onEvent(PlayerEvent.OnPlayPause) },
@@ -969,6 +957,7 @@ fun PlayerScreen(
 @Composable
 private fun PlayerControlsOverlay(
     uiState: PlayerUiState,
+    viewModel: PlayerViewModel,
     playPauseFocusRequester: FocusRequester,
     progressBarFocusRequester: FocusRequester,
     onPlayPause: () -> Unit,
@@ -1109,13 +1098,18 @@ private fun PlayerControlsOverlay(
 
             // Progress bar
             ProgressBar(
-                currentPosition = uiState.currentPosition,
+                currentPosition = uiState.pendingPreviewSeekPosition ?: uiState.currentPosition,
                 duration = uiState.duration,
-                onSeekTo = onSeekTo,
+                onSeekPreview = { delta -> 
+                    viewModel.onEvent(PlayerEvent.OnPreviewSeekBy(delta))
+                },
+                onSeekCommit = { 
+                    viewModel.onEvent(PlayerEvent.OnCommitPreviewSeek)
+                },
                 focusRequester = progressBarFocusRequester,
                 downFocusRequester = playPauseFocusRequester,
                 onFocused = onResetHideTimer
-            )
+)
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -1339,7 +1333,8 @@ private fun ControlButton(
 private fun ProgressBar(
     currentPosition: Long,
     duration: Long,
-    onSeekTo: (Long) -> Unit,
+    onSeekPreview: (Long) -> Unit, 
+    onSeekCommit: () -> Unit,      
     focusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
     onFocused: (() -> Unit)? = null
@@ -1376,28 +1371,43 @@ private fun ProgressBar(
             }
             .focusable()
             .onPreviewKeyEvent { keyEvent ->
-                if (keyEvent.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) {
-                    return@onPreviewKeyEvent false
-                }
-                when (keyEvent.nativeKeyEvent.keyCode) {
-                    KeyEvent.KEYCODE_DPAD_DOWN -> {
-                        if (downFocusRequester != null) {
-                            try { downFocusRequester.requestFocus() } catch (_: Exception) {}
-                            true
-                        } else {
-                            false
+                if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_UP) {
+                    when (keyEvent.nativeKeyEvent.keyCode) {
+                        KeyEvent.KEYCODE_DPAD_LEFT,
+                        KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                            onSeekCommit()
+                            return@onPreviewKeyEvent true
                         }
                     }
-                    KeyEvent.KEYCODE_DPAD_LEFT -> {
-                        onSeekTo((currentPosition - 10_000L).coerceAtLeast(0L))
-                        true
+                    return@onPreviewKeyEvent false
+                }
+
+                // testing additional key handling for DPAD_LEFT and DPAD_RIGHT to allow seek in focus (check)
+                if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+                    when (keyEvent.nativeKeyEvent.keyCode) {
+                        KeyEvent.KEYCODE_DPAD_DOWN -> {
+                            if (downFocusRequester != null) {
+                                try {
+                                    downFocusRequester.requestFocus()
+                                } catch (_: Exception) {
+                                }
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        KeyEvent.KEYCODE_DPAD_LEFT -> {
+                            onSeekPreview(-10_000L)
+                            true
+                        }
+                        KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                            onSeekPreview(10_000L)
+                            true
+                        }
+                        else -> false
                     }
-                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                        val maxTarget = duration.takeIf { it > 0L } ?: Long.MAX_VALUE
-                        onSeekTo((currentPosition + 10_000L).coerceAtMost(maxTarget))
-                        true
-                    }
-                    else -> false
+                } else {
+                    false
                 }
             }
             .clip(RoundedCornerShape(3.dp))
@@ -1429,7 +1439,8 @@ private fun SeekOverlay(uiState: PlayerUiState) {
         ProgressBar(
             currentPosition = uiState.currentPosition,
             duration = uiState.duration,
-            onSeekTo = {}
+            onSeekPreview = {},
+            onSeekCommit = {}
         )
 
         Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -32,6 +32,7 @@ data class PlayerUiState(
     val castMembers: List<MetaCastMember> = emptyList(),
     val showControls: Boolean = true,
     val showSeekOverlay: Boolean = false,
+    val pendingPreviewSeekPosition: Long? = null,
     val playbackSpeed: Float = 1f,
     val loadingOverlayEnabled: Boolean = true,
     val showLoadingOverlay: Boolean = true,


### PR DESCRIPTION
**The change focuses on allowing the user to seek the video while the player options are displayed, allowing them to access the progress bar, which was previously only possible if the player options were hidden.**

Performance and layout improvements were made to the search action, directly inspired by Stremio's search function. Stream buffering only occurs after the seek is completed.

This improvement is based on usage suggestions from community users. Changes tested and functional.


https://github.com/user-attachments/assets/fac37569-50ca-41eb-99d1-e956cd6a161c

