### PR TITLE
feat(player): improve and add seek speed in holding

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -406,14 +406,31 @@ fun PlayerScreen(
                             if (!uiState.showControls) {
                                 val repeatCount = keyEvent.nativeKeyEvent.repeatCount
                                 val deltaMs = when {
-                                    repeatCount >= 8 -> 30_000L
-                                    repeatCount >= 3 -> 20_000L
+                                    repeatCount >= 30 -> 120_000L
+                                    repeatCount >= 15 -> 60_000L
+                                    repeatCount >= 8  -> 30_000L
+                                    repeatCount >= 3  -> 15_000L
                                     else -> 10_000L
                                 }
                                 viewModel.onEvent(PlayerEvent.OnPreviewSeekBy(deltaMs))
                                 true
                             } else {
-                                // Let focus system handle navigation when controls are visible
+                                false
+                            }
+                        }
+                        KeyEvent.KEYCODE_DPAD_LEFT -> {
+                            if (!uiState.showControls) {
+                                val repeatCount = keyEvent.nativeKeyEvent.repeatCount
+                                val deltaMs = when {
+                                    repeatCount >= 30 -> -120_000L
+                                    repeatCount >= 15 -> -60_000L
+                                    repeatCount >= 8  -> -30_000L
+                                    repeatCount >= 3  -> -15_000L
+                                    else -> -10_000L
+                                }
+                                viewModel.onEvent(PlayerEvent.OnPreviewSeekBy(deltaMs))
+                                true
+                            } else {
                                 false
                             }
                         }
@@ -471,7 +488,9 @@ fun PlayerScreen(
                         }
                         else -> false
                     }
-                } else false
+                } else {
+                    false
+                }
             }
     ) {
         // Video Player
@@ -1393,6 +1412,15 @@ private fun ProgressBar(
             }
             .focusable()
             .onPreviewKeyEvent { keyEvent ->
+                val repeatCount = keyEvent.nativeKeyEvent.repeatCount
+                val deltaMs = when {
+                    repeatCount >= 30 -> 120_000L
+                    repeatCount >= 15 -> 60_000L
+                    repeatCount >= 8  -> 30_000L
+                    repeatCount >= 3  -> 15_000L
+                    else -> 10_000L
+                }
+
                 if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_UP) {
                     when (keyEvent.nativeKeyEvent.keyCode) {
                         KeyEvent.KEYCODE_DPAD_LEFT,
@@ -1404,37 +1432,22 @@ private fun ProgressBar(
                     return@onPreviewKeyEvent false
                 }
 
-                // testing additional key handling for DPAD_LEFT and DPAD_RIGHT to allow seek in focus (check)
                 if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
                     when (keyEvent.nativeKeyEvent.keyCode) {
-                        KeyEvent.KEYCODE_DPAD_DOWN -> {
-                            if (downFocusRequester != null) {
-                                try {
-                                    downFocusRequester.requestFocus()
-                                } catch (_: Exception) {
-                                }
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                        KeyEvent.KEYCODE_DPAD_UP -> {
-                            if (upFocusRequester != null) {
-                                try {
-                                    upFocusRequester.requestFocus()
-                                } catch (_: Exception) {
-                                }
-                                true
-                            } else {
-                                false
-                            }
-                        }
                         KeyEvent.KEYCODE_DPAD_LEFT -> {
-                            onSeekPreview(-10_000L)
+                            onSeekPreview(-deltaMs) 
                             true
                         }
                         KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                            onSeekPreview(10_000L)
+                            onSeekPreview(deltaMs) 
+                            true
+                        }
+                        KeyEvent.KEYCODE_DPAD_DOWN -> {
+                            downFocusRequester?.requestFocus()
+                            true
+                        }
+                        KeyEvent.KEYCODE_DPAD_UP -> {
+                            upFocusRequester?.requestFocus()
                             true
                         }
                         else -> false


### PR DESCRIPTION
## Summary

**Progressive Seek Acceleration**: Implemented dynamic seek logic using `nativeKeyEvent.repeatCount`. The jump interval is now scaled based on the press duration, starting at 10 seconds and gradually increasing to 2-minute jumps (10s -> 15s -> 30s -> 1min -> 2min).

**Key Interception**: Updated the global `onKeyEvent` event to handle search events differently depending on the user interface state.

## Why

**Efficient Navigation**: Navigating through long movies or series was tedious with fixed 20/30-seconds timestamps. This acceleration allows users to quickly scroll through long timelines while maintaining precise control.

## Testing

**Stress Test**: Verified that the speed increase was achieved by holding down the right directional pad for more than 10 seconds; the search correctly reached the 2-minute jump limit.

**Visual Synchronization**: Verified that the search overlay correctly reflects the accelerated time jumps in real time.

## Screenshots / Video (UI changes only)

https://github.com/user-attachments/assets/f9bf4ac7-85c4-41d9-a085-52dc42484ffb

## Breaking changes

**None**.

## Linked issues

<img width="1219" height="470" alt="image" src="https://github.com/user-attachments/assets/a513f55d-3112-4860-9736-9d47dd9995c5" />