### PR TITLE
losen regex-filtered url health checks

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
@@ -30,6 +30,12 @@ object StreamAutoPlaySelector {
     private fun urlWorks(url: String): Boolean {
         val lower = url.lowercase()
 
+        // Excempt pixeldrain and cloudnestra from health check
+                if (lower.contains("pixeldrain") || lower.contains("cloudnestra")) {
+            
+            return true
+        }
+
         // Skip probing for signed or tokened URLs
         if (listOf("expires=", "signature=", "sig=", "auth=", "key=", "hash=", "x-amz-", "hdnts=", "cf_")
                 .any { lower.contains(it) }) {
@@ -120,7 +126,7 @@ object StreamAutoPlaySelector {
                         append(stream.name.orEmpty()).append(' ')
                         append(stream.title.orEmpty()).append(' ')
                         append(stream.description.orEmpty()).append(' ')
-                        append(url)
+                        
                     }
 
                     // Must match include pattern


### PR DESCRIPTION
## Summary

Made regex-filtered health check less strict  

## Why

To allow certain cloudnestra/pixeldrain links to be available for regex auto-select

## Testing

Manually tested various movies and reality shows link from the webstreamr addon 

## Screenshots / Video (UI changes only)

Nothing to add

## Breaking changes

Nothing to add

## Linked issues

No Bug , only Improvements

