### PR TITLE
feat(detail): add TMDB reviews tab with auto-scroll and pause/resume …

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -7,10 +7,12 @@ import com.nuvio.tv.data.remote.api.TmdbImage
 import com.nuvio.tv.data.remote.api.TmdbPersonCreditCast
 import com.nuvio.tv.data.remote.api.TmdbPersonCreditCrew
 import com.nuvio.tv.data.remote.api.TmdbRecommendationResult
+import com.nuvio.tv.data.remote.api.TmdbReviewResult
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.MetaCastMember
 import com.nuvio.tv.domain.model.MetaCompany
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.MetaReview
 import com.nuvio.tv.domain.model.PersonDetail
 import com.nuvio.tv.domain.model.PosterShape
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +37,7 @@ class TmdbMetadataService @Inject constructor(
     private val episodeCache = ConcurrentHashMap<String, Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
     private val personCache = ConcurrentHashMap<String, PersonDetail>()
     private val moreLikeThisCache = ConcurrentHashMap<String, List<MetaPreview>>()
+    private val reviewsCache = ConcurrentHashMap<String, List<MetaReview>>()
 
     suspend fun fetchEnrichment(
         tmdbId: String,
@@ -451,6 +454,45 @@ class TmdbMetadataService @Inject constructor(
         }
     }
 
+    suspend fun fetchReviews(
+        tmdbId: String,
+        contentType: ContentType,
+        language: String = "en",
+        maxItems: Int = 8
+    ): List<MetaReview> = withContext(Dispatchers.IO) {
+        val normalizedLanguage = normalizeTmdbLanguage(language)
+        val cacheKey = "$tmdbId:${contentType.name}:$normalizedLanguage:reviews:$maxItems"
+        reviewsCache[cacheKey]?.let { return@withContext it }
+
+        val numericId = tmdbId.toIntOrNull() ?: return@withContext emptyList()
+        val tmdbType = when (contentType) {
+            ContentType.SERIES, ContentType.TV -> "tv"
+            else -> "movie"
+        }
+
+        try {
+            val response = when (tmdbType) {
+                "tv" -> tmdbApi.getTvReviews(numericId, TMDB_API_KEY, normalizedLanguage).body()
+                else -> tmdbApi.getMovieReviews(numericId, TMDB_API_KEY, normalizedLanguage).body()
+            }
+
+            val mapped = response?.results
+                .orEmpty()
+                .mapNotNull { it.toMetaReview() }
+                .sortedWith(
+                    compareByDescending<MetaReview> { it.updatedAt ?: it.createdAt ?: "" }
+                        .thenByDescending { it.rating ?: -1.0 }
+                )
+                .take(maxItems.coerceAtLeast(1))
+
+            reviewsCache[cacheKey] = mapped
+            mapped
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch reviews for $tmdbId: ${e.message}")
+            emptyList()
+        }
+    }
+
     private val collectionCache = ConcurrentHashMap<String, List<MetaPreview>>()
 
     suspend fun fetchMovieCollection(
@@ -720,6 +762,24 @@ class TmdbMetadataService @Inject constructor(
                 )
             }
     }
+}
+
+private fun TmdbReviewResult.toMetaReview(): MetaReview? {
+    val text = content?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    val fallbackAuthor = author?.trim()?.takeIf { it.isNotBlank() } ?: "TMDB user"
+    val authorName = authorDetails?.name?.trim()?.takeIf { it.isNotBlank() }
+        ?: authorDetails?.username?.trim()?.takeIf { it.isNotBlank() }
+        ?: fallbackAuthor
+
+    return MetaReview(
+        id = id,
+        author = authorName,
+        content = text,
+        rating = authorDetails?.rating,
+        createdAt = createdAt?.takeIf { it.isNotBlank() },
+        updatedAt = updatedAt?.takeIf { it.isNotBlank() },
+        url = url?.takeIf { it.isNotBlank() }
+    )
 }
 
 private data class Quadruple<A, B, C, D>(

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -112,6 +112,22 @@ interface TmdbApi {
         @Query("page") page: Int = 1
     ): Response<TmdbRecommendationsResponse>
 
+    @GET("movie/{movie_id}/reviews")
+    suspend fun getMovieReviews(
+        @Path("movie_id") movieId: Int,
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String? = null,
+        @Query("page") page: Int = 1
+    ): Response<TmdbReviewsResponse>
+
+    @GET("tv/{tv_id}/reviews")
+    suspend fun getTvReviews(
+        @Path("tv_id") tvId: Int,
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String? = null,
+        @Query("page") page: Int = 1
+    ): Response<TmdbReviewsResponse>
+
     @GET("collection/{collection_id}")
     suspend fun getCollectionDetails(
         @Path("collection_id") collectionId: Int,
@@ -343,6 +359,30 @@ data class TmdbRecommendationResult(
 )
 
 // ── Person / Cast Detail DTOs ──
+
+@JsonClass(generateAdapter = true)
+data class TmdbReviewsResponse(
+    @Json(name = "results") val results: List<TmdbReviewResult>? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class TmdbReviewResult(
+    @Json(name = "id") val id: String,
+    @Json(name = "author") val author: String? = null,
+    @Json(name = "author_details") val authorDetails: TmdbReviewAuthorDetails? = null,
+    @Json(name = "content") val content: String? = null,
+    @Json(name = "created_at") val createdAt: String? = null,
+    @Json(name = "updated_at") val updatedAt: String? = null,
+    @Json(name = "url") val url: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class TmdbReviewAuthorDetails(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "username") val username: String? = null,
+    @Json(name = "rating") val rating: Double? = null,
+    @Json(name = "avatar_path") val avatarPath: String? = null
+)
 
 @JsonClass(generateAdapter = true)
 data class TmdbPersonResponse(

--- a/app/src/main/java/com/nuvio/tv/domain/model/MetaReview.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/MetaReview.kt
@@ -1,0 +1,14 @@
+package com.nuvio.tv.domain.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class MetaReview(
+    val id: String,
+    val author: String,
+    val content: String,
+    val rating: Double? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+    val url: String? = null
+)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -87,6 +87,7 @@ import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaCastMember
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.MetaReview
 import com.nuvio.tv.domain.model.MDBListRatings
 import com.nuvio.tv.domain.model.NextToWatch
 import com.nuvio.tv.domain.model.Video
@@ -113,6 +114,7 @@ private enum class PeopleSectionTab {
     CAST,
     RATINGS,
     MORE_LIKE_THIS,
+    REVIEWS,
     COLLECTION
 }
 
@@ -333,6 +335,9 @@ fun MetaDetailsScreen(
                     isMovieWatched = uiState.isMovieWatched,
                     isMovieWatchedPending = uiState.isMovieWatchedPending,
                     moreLikeThis = uiState.moreLikeThis,
+                    reviews = uiState.reviews,
+                    isReviewsLoading = uiState.isReviewsLoading,
+                    reviewsError = uiState.reviewsError,
                     collection = uiState.collection,
                     collectionName = uiState.collectionName,
                     episodeImdbRatings = uiState.episodeImdbRatings,
@@ -531,6 +536,9 @@ private fun MetaDetailsContent(
     isMovieWatched: Boolean,
     isMovieWatchedPending: Boolean,
     moreLikeThis: List<MetaPreview>,
+    reviews: List<MetaReview>,
+    isReviewsLoading: Boolean,
+    reviewsError: String?,
     collection: List<MetaPreview>,
     collectionName: String?,
     episodeImdbRatings: Map<Pair<Int, Int>, Double>,
@@ -595,6 +603,7 @@ private fun MetaDetailsContent(
     val heroPlayFocusRequester = remember { FocusRequester() }
     val castTabFocusRequester = remember { FocusRequester() }
     val moreLikeTabFocusRequester = remember { FocusRequester() }
+    val reviewsTabFocusRequester = remember { FocusRequester() }
     val collectionTabFocusRequester = remember { FocusRequester() }
     val ratingsTabFocusRequester = remember { FocusRequester() }
     val ratingsContentFocusRequester = remember { FocusRequester() }
@@ -770,21 +779,30 @@ private fun MetaDetailsContent(
     }
     val hasCastSection = directorWriterMembers.isNotEmpty() || normalCastMembers.isNotEmpty()
     val hasMoreLikeThisSection = moreLikeThis.isNotEmpty()
+    val hasReviewsSection = isReviewsLoading || reviews.isNotEmpty() || !reviewsError.isNullOrBlank()
     val hasRatingsSection = isTvShow
     val strTabCast = stringResource(R.string.detail_tab_cast)
     val strTabRatings = stringResource(R.string.detail_tab_ratings)
     val strTabMoreLikeThis = stringResource(R.string.detail_tab_more_like_this)
+    val strTabReviews = stringResource(R.string.detail_tab_reviews)
     val strTabCollection = stringResource(R.string.tmdb_collections_title)
     val peopleTabItems = remember(
         hasCastSection,
         hasMoreLikeThisSection,
+        hasReviewsSection,
         hasRatingsSection,
         collection,
         castTabFocusRequester,
         ratingsTabFocusRequester,
         moreLikeTabFocusRequester,
+        reviewsTabFocusRequester,
         collectionTabFocusRequester,
-        collectionName
+        collectionName,
+        strTabCast,
+        strTabRatings,
+        strTabMoreLikeThis,
+        strTabReviews,
+        strTabCollection
     ) {
         buildList {
             if (hasCastSection) {
@@ -811,6 +829,15 @@ private fun MetaDetailsContent(
                         tab = PeopleSectionTab.MORE_LIKE_THIS,
                         label = strTabMoreLikeThis,
                         focusRequester = moreLikeTabFocusRequester
+                    )
+                )
+            }
+            if (hasReviewsSection) {
+                add(
+                    PeopleTabItem(
+                        tab = PeopleSectionTab.REVIEWS,
+                        label = strTabReviews,
+                        focusRequester = reviewsTabFocusRequester
                     )
                 )
             }
@@ -1203,6 +1230,20 @@ private fun MetaDetailsContent(
                                     onItemClick = { item ->
                                         markMoreLikeThisRestore(item.id)
                                         onNavigateToDetail(item.id, item.apiType, null)
+                                    }
+                                )
+                            }
+
+                            PeopleSectionTab.REVIEWS -> {
+                                ReviewsSection(
+                                    reviews = reviews,
+                                    isLoading = isReviewsLoading,
+                                    error = reviewsError,
+                                    title = if (hasPeopleTabs) "" else strTabReviews,
+                                    upFocusRequester = if (hasPeopleTabs) {
+                                        reviewsTabFocusRequester
+                                    } else {
+                                        seasonDownFocusRequester ?: selectedSeasonFocusRequester
                                     }
                                 )
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsUiState.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.detail
 
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.MetaReview
 import com.nuvio.tv.domain.model.NextToWatch
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
@@ -39,6 +40,9 @@ data class MetaDetailsUiState(
     val episodeWatchedPendingKeys: Set<String> = emptySet(),
     val blurUnwatchedEpisodes: Boolean = false,
     val moreLikeThis: List<MetaPreview> = emptyList(),
+    val reviews: List<MetaReview> = emptyList(),
+    val isReviewsLoading: Boolean = false,
+    val reviewsError: String? = null,
     val collection: List<MetaPreview> = emptyList(),
     val collectionName: String? = null,
     val episodeImdbRatings: Map<Pair<Int, Int>, Double> = emptyMap(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -75,6 +75,7 @@ class MetaDetailsViewModel @Inject constructor(
     private var idleTimerJob: Job? = null
     private var trailerFetchJob: Job? = null
     private var moreLikeThisJob: Job? = null
+    private var reviewsJob: Job? = null
     private var collectionJob: Job? = null
     private var episodeRatingsJob: Job? = null
     private var nextToWatchJob: Job? = null
@@ -337,6 +338,9 @@ class MetaDetailsViewModel @Inject constructor(
                     mdbListRatings = null,
                     showMdbListImdb = false,
                     moreLikeThis = emptyList(),
+                    reviews = emptyList(),
+                    isReviewsLoading = false,
+                    reviewsError = null,
                     collection = emptyList(),
                     collectionName = null
                 )
@@ -448,6 +452,7 @@ class MetaDetailsViewModel @Inject constructor(
     private suspend fun applyMetaWithEnrichment(meta: Meta) {
         // Start recommendations fetch early so it can run in parallel with enrichment.
         loadMoreLikeThisAsync(meta)
+        loadReviewsAsync(meta)
         val enriched = enrichMeta(meta)
         applyMeta(enriched)
         loadEpisodeRatingsAsync(enriched)
@@ -502,6 +507,81 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun shouldLoadMoreLikeThis(settings: TmdbSettings): Boolean {
         return settings.enabled && settings.useMoreLikeThis
+    }
+
+    private fun shouldLoadReviews(settings: TmdbSettings): Boolean {
+        return settings.enabled
+    }
+
+    private fun loadReviewsAsync(meta: Meta) {
+        reviewsJob?.cancel()
+        reviewsJob = viewModelScope.launch {
+            val settings = tmdbSettingsDataStore.settings.first()
+            if (!shouldLoadReviews(settings)) {
+                _uiState.update {
+                    it.copy(
+                        reviews = emptyList(),
+                        isReviewsLoading = false,
+                        reviewsError = null
+                    )
+                }
+                return@launch
+            }
+
+            _uiState.update { state ->
+                if (state.meta == null || state.meta.id == meta.id) {
+                    state.copy(
+                        reviews = emptyList(),
+                        isReviewsLoading = true,
+                        reviewsError = null
+                    )
+                } else {
+                    state
+                }
+            }
+
+            val tmdbContentType = resolveTmdbContentType(meta)
+            val tmdbLookupType = tmdbContentType.toApiString()
+            val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
+                ?: tmdbService.ensureTmdbId(itemId, itemType)
+            if (tmdbId.isNullOrBlank()) {
+                _uiState.update { state ->
+                    if (state.meta == null || state.meta.id == meta.id) {
+                        state.copy(
+                            reviews = emptyList(),
+                            isReviewsLoading = false,
+                            reviewsError = null
+                        )
+                    } else {
+                        state
+                    }
+                }
+                return@launch
+            }
+
+            val reviews = runCatching {
+                tmdbMetadataService.fetchReviews(
+                    tmdbId = tmdbId,
+                    contentType = tmdbContentType,
+                    language = settings.language
+                )
+            }.getOrElse {
+                Log.w(TAG, "Failed to load reviews for ${meta.id}: ${it.message}")
+                emptyList()
+            }
+
+            _uiState.update { state ->
+                if (state.meta == null || state.meta.id == meta.id) {
+                    state.copy(
+                        reviews = reviews,
+                        isReviewsLoading = false,
+                        reviewsError = if (reviews.isEmpty()) "Reviews are unavailable for this title." else null
+                    )
+                } else {
+                    state
+                }
+            }
+        }
     }
 
     private fun loadCollectionAsync(collectionId: Int, collectionName: String?, settings: TmdbSettings) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/ReviewsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/ReviewsSection.kt
@@ -1,0 +1,263 @@
+package com.nuvio.tv.ui.screens.detail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import androidx.tv.material3.Border
+import androidx.tv.material3.Card
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.MetaReview
+import com.nuvio.tv.ui.theme.NuvioColors
+import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
+
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+fun ReviewsSection(
+    reviews: List<MetaReview>,
+    isLoading: Boolean,
+    error: String?,
+    modifier: Modifier = Modifier,
+    title: String = "Reviews",
+    upFocusRequester: FocusRequester? = null
+) {
+    val hasTitle = title.isNotBlank()
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = if (hasTitle) 14.dp else 6.dp, bottom = 8.dp)
+    ) {
+        if (hasTitle) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioColors.TextPrimary,
+                modifier = Modifier.padding(horizontal = 48.dp)
+            )
+        }
+
+        when {
+            isLoading -> {
+                Text(
+                    text = stringResource(R.string.reviews_loading),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(horizontal = 48.dp, vertical = 12.dp)
+                )
+            }
+
+            !error.isNullOrBlank() -> {
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(horizontal = 48.dp, vertical = 12.dp)
+                )
+            }
+
+            reviews.isEmpty() -> {
+                Text(
+                    text = stringResource(R.string.reviews_unavailable),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(horizontal = 48.dp, vertical = 12.dp)
+                )
+            }
+
+            else -> {
+                val firstItemFocusRequester = remember { FocusRequester() }
+
+                LazyRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRestorer { firstItemFocusRequester },
+                    contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    itemsIndexed(
+                        items = reviews,
+                        key = { index, item -> "${item.id}|$index" }
+                    ) { index, review ->
+                        var isCardFocused by remember(review.id) { mutableStateOf(false) }
+                        var isScrollPaused by rememberSaveable(review.id) { mutableStateOf(false) }
+                        val cardModifier = Modifier
+                            .width(440.dp)
+                            .heightIn(min = 220.dp)
+                            .then(
+                                if (upFocusRequester != null) {
+                                    Modifier.focusProperties { up = upFocusRequester }
+                                } else {
+                                    Modifier
+                                }
+                            )
+                            .then(
+                                if (index == 0) {
+                                    Modifier.focusRequester(firstItemFocusRequester)
+                                } else {
+                                    Modifier
+                                }
+                            )
+                            .onFocusChanged { state ->
+                                isCardFocused = state.isFocused || state.hasFocus
+                            }
+
+                        Card(
+                            onClick = {
+                                isScrollPaused = !isScrollPaused
+                            },
+                            modifier = cardModifier,
+                            shape = CardDefaults.shape(shape = RoundedCornerShape(14.dp)),
+                            colors = CardDefaults.colors(
+                                containerColor = NuvioColors.BackgroundCard,
+                                focusedContainerColor = NuvioColors.BackgroundCard
+                            ),
+                            border = CardDefaults.border(
+                                focusedBorder = Border(
+                                    border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                                    shape = RoundedCornerShape(14.dp)
+                                )
+                            ),
+                            scale = CardDefaults.scale(focusedScale = 1f)
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 14.dp, vertical = 12.dp)
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(
+                                        text = review.author,
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = NuvioColors.TextPrimary,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f, fill = false)
+                                    )
+
+                                    review.rating?.let { rating ->
+                                        Text(
+                                            text = String.format("%.1f/10", rating),
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = NuvioColors.TextTertiary
+                                        )
+                                    }
+                                }
+
+                                val date = (review.updatedAt ?: review.createdAt)?.take(10)
+                                if (!date.isNullOrBlank()) {
+                                    Text(
+                                        text = date,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = NuvioColors.TextTertiary,
+                                        modifier = Modifier.padding(top = 2.dp, bottom = 8.dp)
+                                    )
+                                }
+
+                                AutoScrollingReviewText(
+                                    text = review.content,
+                                    isFocused = isCardFocused,
+                                    isPaused = isScrollPaused
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AutoScrollingReviewText(
+    text: String,
+    isFocused: Boolean,
+    isPaused: Boolean
+) {
+    val scrollState = rememberScrollState()
+    var shouldDelayOnStart by remember(text) { mutableStateOf(true) }
+
+    LaunchedEffect(text) {
+        scrollState.scrollTo(0)
+    }
+
+    LaunchedEffect(isFocused, text) {
+        if (!isFocused) {
+            scrollState.scrollTo(0)
+            shouldDelayOnStart = true
+        }
+    }
+
+    LaunchedEffect(isFocused, isPaused, text, scrollState.maxValue) {
+        if (!isFocused || isPaused) return@LaunchedEffect
+        if (scrollState.maxValue <= 0) return@LaunchedEffect
+
+        if (shouldDelayOnStart) {
+            delay(4_200L)
+            shouldDelayOnStart = false
+        }
+        val distancePx = (scrollState.maxValue - scrollState.value).coerceAtLeast(0)
+        if (distancePx <= 0) return@LaunchedEffect
+
+        val pixelsPerSecond = 20f
+        val durationMs = ((distancePx / pixelsPerSecond) * 1_000f)
+            .roundToInt()
+            .coerceAtLeast(800)
+
+        scrollState.animateScrollTo(
+            value = scrollState.maxValue,
+            animationSpec = tween(durationMillis = durationMs, easing = LinearEasing)
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(128.dp)
+            .clipToBounds()
+            .verticalScroll(scrollState, enabled = false)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = NuvioColors.TextSecondary
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="cast_role_writer">Writer</string>
     <string name="detail_tab_ratings">Ratings</string>
     <string name="detail_tab_more_like_this">More like this</string>
+    <string name="detail_tab_reviews">Reviews</string>
     <string name="detail_section_network">Network</string>
     <string name="detail_section_production">Production</string>
     <string name="detail_lists_fallback">Lists</string>
@@ -847,6 +848,8 @@
     <string name="ratings_loading">Loading episode ratings...</string>
     <string name="ratings_unavailable">Episode ratings are unavailable.</string>
     <string name="ratings_season_summary">Season %1$d - %2$d episodes</string>
+    <string name="reviews_loading">Loading reviews...</string>
+    <string name="reviews_unavailable">Reviews are unavailable.</string>
 
     <!-- SearchDiscoverSection -->
     <string name="discover_title">Discover</string>


### PR DESCRIPTION
## Summary

Added a new Reviews tab in the detail screen, next to More like this.
Implemented TMDB review fetching (movie/{id}/reviews, tv/{id}/reviews) and mapped results into a new domain model (MetaReview).
Wired reviews into detail state/viewmodel with loading and error handling.
Added a dedicated ReviewsSection UI for TV:
Horizontal review cards
Auto-scroll for long review text
OK button toggles pause/resume of scrolling
Added new strings for reviews tab and states.

## Why

Issue #602 asked for IMDb-style reviews in the detail page.
This implementation uses TMDB reviews instead of IMDb reviews because:

IMDb does not provide a straightforward public/free reviews API for this use case.
TMDB is already integrated in this project (same metadata pipeline), so it is more reliable and maintainable.
TMDB provides official review endpoints with localization support, avoiding scraping-based or brittle solutions.

## Testing

Manually validated:
Reviews tab appears in detail page.
Reviews load and render correctly.
Long text auto-scrolls after delay.
Pressing OK pauses scroll; pressing OK again resumes.
No regressions observed in existing detail tabs.

## Screenshots / Video (UI changes only)
https://github.com/user-attachments/assets/28097624-7cb0-4d88-9bd5-f3c097430daa


## Breaking changes

None.

## Linked issues

#602 - Address IMDb reviews request via TMDB reviews integration (chosen due to IMDb API availability/reliability constraints).


