### PR TITLE
wip: integrate libmpv internal engine (mvplayer) with existing player UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -253,8 +253,8 @@ dependencies {
 
     // libass-android for ASS/SSA subtitle support (from Maven Central)
     implementation("io.github.peerless2012:ass-media:0.4.0-beta01")
-    implementation("io.github.anilbeesetti:nextlib-mediainfo:1.9.1-0.11.0")
-    implementation("io.github.anilbeesetti:nextlib-media3ext:1.9.1-0.11.0")
+    // Local nextlib-mediainfo fork (static FFmpeg; no libav*.so in final AAR)
+    implementation(files("libs/nextlib-mediainfo-local.aar"))
     implementation("io.github.abdallahmehiz:mpv-android-lib:0.1.12")
     implementation("dev.chrisbanes.haze:haze-android:0.7.3") {
         exclude(group = "org.jetbrains.compose.ui")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,9 @@ android {
             pickFirsts += listOf(
                 "lib/*/libc++_shared.so",
                 "lib/*/libavcodec.so",
+                "lib/*/libavdevice.so",
+                "lib/*/libavfilter.so",
+                "lib/*/libavformat.so",
                 "lib/*/libavutil.so",
                 "lib/*/libswscale.so",
                 "lib/*/libswresample.so"
@@ -242,6 +245,7 @@ dependencies {
     implementation("io.github.peerless2012:ass-media:0.4.0-beta01")
     implementation("io.github.anilbeesetti:nextlib-mediainfo:1.9.1-0.11.0")
     implementation("io.github.anilbeesetti:nextlib-media3ext:1.9.1-0.11.0")
+    implementation("io.github.abdallahmehiz:mpv-android-lib:0.1.12")
     implementation("dev.chrisbanes.haze:haze-android:0.7.3") {
         exclude(group = "org.jetbrains.compose.ui")
         exclude(group = "org.jetbrains.compose.foundation")

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -118,6 +118,7 @@ object AudioLanguageOption {
  */
 data class PlayerSettings(
     val playerPreference: PlayerPreference = PlayerPreference.INTERNAL,
+    val internalPlayerEngine: InternalPlayerEngine = InternalPlayerEngine.EXOPLAYER,
     val useLibass: Boolean = false,
     val libassRenderType: LibassRenderType = LibassRenderType.OVERLAY_OPEN_GL,
     val subtitleStyle: SubtitleStyleSettings = SubtitleStyleSettings(),
@@ -195,6 +196,11 @@ enum class PlayerPreference {
     ASK_EVERY_TIME
 }
 
+enum class InternalPlayerEngine {
+    EXOPLAYER,
+    MVP_PLAYER
+}
+
 /**
  * Enum representing the different libass render types
  * Maps to io.github.peerless2012.ass.media.type.AssRenderType
@@ -223,6 +229,7 @@ class PlayerSettingsDataStore @Inject constructor(
 
     // Player preference key
     private val playerPreferenceKey = stringPreferencesKey("player_preference")
+    private val internalPlayerEngineKey = stringPreferencesKey("internal_player_engine")
 
     // Libass settings keys
     private val useLibassKey = booleanPreferencesKey("use_libass")
@@ -359,6 +366,9 @@ class PlayerSettingsDataStore @Inject constructor(
                 playerPreference = prefs[playerPreferenceKey]?.let {
                     runCatching { PlayerPreference.valueOf(it) }.getOrDefault(PlayerPreference.INTERNAL)
                 } ?: PlayerPreference.INTERNAL,
+                internalPlayerEngine = prefs[internalPlayerEngineKey]?.let {
+                    runCatching { InternalPlayerEngine.valueOf(it) }.getOrDefault(InternalPlayerEngine.EXOPLAYER)
+                } ?: InternalPlayerEngine.EXOPLAYER,
                 useLibass = prefs[useLibassKey] ?: false,
                 libassRenderType = prefs[libassRenderTypeKey]?.let {
                     try { LibassRenderType.valueOf(it) } catch (e: Exception) { LibassRenderType.OVERLAY_OPEN_GL }
@@ -470,6 +480,12 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setPlayerPreference(preference: PlayerPreference) {
         store().edit { prefs ->
             prefs[playerPreferenceKey] = preference.name
+        }
+    }
+
+    suspend fun setInternalPlayerEngine(engine: InternalPlayerEngine) {
+        store().edit { prefs ->
+            prefs[internalPlayerEngineKey] = engine.name
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
 import `is`.xyz.mpv.BaseMPVView
-import `is`.xyz.mpv.MPVNode
 import `is`.xyz.mpv.Utils
 import kotlin.math.roundToLong
 
@@ -53,6 +52,16 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     fun isPlayingNow(): Boolean {
         if (!initialized) return false
         return mpv.getPropertyBoolean("pause") == false
+    }
+
+    fun isPausedForCacheNow(): Boolean {
+        if (!initialized) return false
+        return mpv.getPropertyBoolean("paused-for-cache") == true
+    }
+
+    fun isCoreIdleNow(): Boolean {
+        if (!initialized) return false
+        return mpv.getPropertyBoolean("core-idle") == true
     }
 
     fun seekToMs(positionMs: Long) {
@@ -115,11 +124,25 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         }
     }
 
-    fun addAndSelectExternalSubtitle(url: String): Boolean {
+    fun addAndSelectExternalSubtitle(
+        url: String,
+        title: String? = null,
+        language: String? = null
+    ): Boolean {
         if (!initialized) return false
         if (url.isBlank()) return false
         return runCatching {
-            mpv.command("sub-add", url, "select")
+            // "cached" avoids duplicate re-loads for the same external subtitle.
+            val safeTitle = title?.takeIf { it.isNotBlank() }
+            val safeLanguage = language?.takeIf { it.isNotBlank() }
+            when {
+                safeTitle != null && safeLanguage != null ->
+                    mpv.command("sub-add", url, "cached", safeTitle, safeLanguage)
+                safeTitle != null ->
+                    mpv.command("sub-add", url, "cached", safeTitle)
+                else ->
+                    mpv.command("sub-add", url, "cached")
+            }
             mpv.setPropertyBoolean("sub-visibility", true)
             true
         }.getOrElse {
@@ -144,30 +167,33 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     fun readTrackSnapshot(): MpvTrackSnapshot {
         if (!initialized) return MpvTrackSnapshot(emptyList(), emptyList())
-        val trackNodes = runCatching { mpv.getPropertyNode("track-list")?.asArray() }
-            .getOrNull()
-            .orEmpty()
-
-        if (trackNodes.isEmpty()) {
+        val trackCount = runCatching { mpv.getPropertyInt("track-list/count") ?: 0 }
+            .getOrDefault(0)
+        if (trackCount <= 0) {
             return MpvTrackSnapshot(emptyList(), emptyList())
         }
 
         val audioTracks = mutableListOf<MpvTrack>()
         val subtitleTracks = mutableListOf<MpvTrack>()
 
-        trackNodes.forEach { node ->
-            val map = node.asMap() ?: return@forEach
-            val type = map.string("type")?.lowercase() ?: return@forEach
-            val id = map.int("id") ?: return@forEach
-            val language = map.string("lang")
-            val title = map.string("title")
-            val codec = map.string("codec")
-            val selected = map.bool("selected")
-            val external = map.bool("external")
-            val channelCount = map.int("demux-channel-count")
-                ?: map.int("audio-channels")
-                ?: map.int("channels")
-            val forced = map.bool("forced") || listOfNotNull(title, language).any {
+        for (i in 0 until trackCount) {
+            val type = mpv.getPropertyString("track-list/$i/type")?.lowercase() ?: continue
+            val id = mpv.getPropertyInt("track-list/$i/id") ?: continue
+            val language = mpv.getPropertyString("track-list/$i/lang")
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+            val title = mpv.getPropertyString("track-list/$i/title")
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+            val codec = mpv.getPropertyString("track-list/$i/codec")
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+            val selected = mpv.getPropertyBoolean("track-list/$i/selected") == true
+            val external = mpv.getPropertyBoolean("track-list/$i/external") == true
+            val channelCount = mpv.getPropertyInt("track-list/$i/demux-channel-count")
+                ?: mpv.getPropertyInt("track-list/$i/audio-channels")
+                ?: mpv.getPropertyInt("track-list/$i/channels")
+            val forced = (mpv.getPropertyBoolean("track-list/$i/forced") == true) || listOfNotNull(title, language).any {
                 it.contains("forced", ignoreCase = true)
             }
 
@@ -223,7 +249,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         mpv.setOptionString("opengl-es", "yes")
         mpv.setOptionString("hwdec", "mediacodec,mediacodec-copy")
         mpv.setOptionString("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
-        mpv.setOptionString("ao", "audiotrack,aaudio,opensles")
+        mpv.setOptionString("ao", "audiotrack,opensles")
         mpv.setOptionString("audio-set-media-role", "yes")
         mpv.setOptionString("tls-verify", "yes")
         mpv.setOptionString("tls-ca-file", "${context.filesDir.path}/cacert.pem")
@@ -269,15 +295,3 @@ data class MpvTrack(
     val isForced: Boolean,
     val isExternal: Boolean
 )
-
-private fun Map<String, MPVNode>.string(key: String): String? {
-    return this[key]?.asString()?.trim()?.takeIf { it.isNotBlank() }
-}
-
-private fun Map<String, MPVNode>.int(key: String): Int? {
-    return this[key]?.asInt()?.toInt()
-}
-
-private fun Map<String, MPVNode>.bool(key: String): Boolean {
-    return this[key]?.asBoolean() == true
-}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
 import `is`.xyz.mpv.BaseMPVView
+import `is`.xyz.mpv.MPVNode
 import `is`.xyz.mpv.Utils
 import kotlin.math.roundToLong
 
@@ -33,6 +34,14 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         } else {
             playFile(url)
             hasQueuedInitialMedia = true
+        }
+        runCatching {
+            // Let mpv choose the default streams for every new media load.
+            mpv.setPropertyString("aid", "auto")
+            mpv.setPropertyString("sid", "auto")
+            mpv.setPropertyBoolean("sub-visibility", true)
+        }.onFailure {
+            Log.w(TAG, "Failed to reset default A/V track selection: ${it.message}")
         }
     }
 
@@ -71,6 +80,134 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         mpv.setPropertyDouble("speed", speed.toDouble())
     }
 
+    fun selectAudioTrackById(trackId: Int): Boolean {
+        if (!initialized) return false
+        return runCatching {
+            mpv.setPropertyInt("aid", trackId)
+            true
+        }.getOrElse {
+            Log.w(TAG, "Failed to select audio track id=$trackId: ${it.message}")
+            false
+        }
+    }
+
+    fun selectSubtitleTrackById(trackId: Int): Boolean {
+        if (!initialized) return false
+        return runCatching {
+            mpv.setPropertyBoolean("sub-visibility", true)
+            mpv.setPropertyInt("sid", trackId)
+            true
+        }.getOrElse {
+            Log.w(TAG, "Failed to select subtitle track id=$trackId: ${it.message}")
+            false
+        }
+    }
+
+    fun disableSubtitles(): Boolean {
+        if (!initialized) return false
+        return runCatching {
+            mpv.setPropertyString("sid", "no")
+            mpv.setPropertyBoolean("sub-visibility", false)
+            true
+        }.getOrElse {
+            Log.w(TAG, "Failed to disable subtitles: ${it.message}")
+            false
+        }
+    }
+
+    fun addAndSelectExternalSubtitle(url: String): Boolean {
+        if (!initialized) return false
+        if (url.isBlank()) return false
+        return runCatching {
+            mpv.command("sub-add", url, "select")
+            mpv.setPropertyBoolean("sub-visibility", true)
+            true
+        }.getOrElse {
+            Log.w(TAG, "Failed to add external subtitle: ${it.message}")
+            false
+        }
+    }
+
+    fun applySubtitleLanguagePreferences(preferred: String, secondary: String?) {
+        if (!initialized) return
+        val languages = listOfNotNull(
+            preferred.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) },
+            secondary?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+        )
+        if (languages.isEmpty()) return
+        runCatching {
+            mpv.setPropertyString("slang", languages.joinToString(","))
+        }.onFailure {
+            Log.w(TAG, "Failed to set subtitle language preference: ${it.message}")
+        }
+    }
+
+    fun readTrackSnapshot(): MpvTrackSnapshot {
+        if (!initialized) return MpvTrackSnapshot(emptyList(), emptyList())
+        val trackNodes = runCatching { mpv.getPropertyNode("track-list")?.asArray() }
+            .getOrNull()
+            .orEmpty()
+
+        if (trackNodes.isEmpty()) {
+            return MpvTrackSnapshot(emptyList(), emptyList())
+        }
+
+        val audioTracks = mutableListOf<MpvTrack>()
+        val subtitleTracks = mutableListOf<MpvTrack>()
+
+        trackNodes.forEach { node ->
+            val map = node.asMap() ?: return@forEach
+            val type = map.string("type")?.lowercase() ?: return@forEach
+            val id = map.int("id") ?: return@forEach
+            val language = map.string("lang")
+            val title = map.string("title")
+            val codec = map.string("codec")
+            val selected = map.bool("selected")
+            val external = map.bool("external")
+            val channelCount = map.int("demux-channel-count")
+                ?: map.int("audio-channels")
+                ?: map.int("channels")
+            val forced = map.bool("forced") || listOfNotNull(title, language).any {
+                it.contains("forced", ignoreCase = true)
+            }
+
+            when (type) {
+                "audio" -> {
+                    audioTracks += MpvTrack(
+                        id = id,
+                        type = type,
+                        name = title ?: language ?: "Audio $id",
+                        language = language,
+                        codec = codec,
+                        channelCount = channelCount,
+                        isSelected = selected,
+                        isForced = false,
+                        isExternal = external
+                    )
+                }
+
+                "sub" -> {
+                    subtitleTracks += MpvTrack(
+                        id = id,
+                        type = type,
+                        name = title ?: language ?: "Subtitle $id",
+                        language = language,
+                        codec = codec,
+                        channelCount = null,
+                        isSelected = selected,
+                        isForced = forced,
+                        isExternal = external
+                    )
+                }
+            }
+        }
+
+        return MpvTrackSnapshot(
+            audioTracks = audioTracks,
+            subtitleTracks = subtitleTracks
+        )
+    }
+
     fun releasePlayer() {
         if (!initialized) return
         runCatching { destroy() }
@@ -86,7 +223,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         mpv.setOptionString("opengl-es", "yes")
         mpv.setOptionString("hwdec", "mediacodec,mediacodec-copy")
         mpv.setOptionString("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
-        mpv.setOptionString("ao", "audiotrack,opensles")
+        mpv.setOptionString("ao", "audiotrack,aaudio,opensles")
         mpv.setOptionString("audio-set-media-role", "yes")
         mpv.setOptionString("tls-verify", "yes")
         mpv.setOptionString("tls-ca-file", "${context.filesDir.path}/cacert.pem")
@@ -114,4 +251,33 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     companion object {
         private const val TAG = "NuvioMpvSurfaceView"
     }
+}
+
+data class MpvTrackSnapshot(
+    val audioTracks: List<MpvTrack>,
+    val subtitleTracks: List<MpvTrack>
+)
+
+data class MpvTrack(
+    val id: Int,
+    val type: String,
+    val name: String,
+    val language: String?,
+    val codec: String?,
+    val channelCount: Int?,
+    val isSelected: Boolean,
+    val isForced: Boolean,
+    val isExternal: Boolean
+)
+
+private fun Map<String, MPVNode>.string(key: String): String? {
+    return this[key]?.asString()?.trim()?.takeIf { it.isNotBlank() }
+}
+
+private fun Map<String, MPVNode>.int(key: String): Int? {
+    return this[key]?.asInt()?.toInt()
+}
+
+private fun Map<String, MPVNode>.bool(key: String): Boolean {
+    return this[key]?.asBoolean() == true
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -16,6 +16,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     private var initialized = false
     private var hasQueuedInitialMedia = false
+    private var lastMediaRequestKey: String? = null
 
     fun ensureInitialized() {
         if (initialized) return
@@ -29,6 +30,10 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     fun setMedia(url: String, headers: Map<String, String>) {
         ensureInitialized()
+        val requestKey = buildMediaRequestKey(url = url, headers = headers)
+        if (hasQueuedInitialMedia && requestKey == lastMediaRequestKey) {
+            return
+        }
         applyHeaders(headers)
         if (hasQueuedInitialMedia) {
             mpv.command("loadfile", url, "replace")
@@ -36,6 +41,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             playFile(url)
             hasQueuedInitialMedia = true
         }
+        lastMediaRequestKey = requestKey
         runCatching {
             // Let mpv choose the default streams for every new media load.
             mpv.setPropertyString("aid", "auto")
@@ -229,6 +235,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             return MpvTrackSnapshot(emptyList(), emptyList())
         }
 
+        val selectedAudioTrackId = mpv.getPropertyString("aid")?.toIntOrNull()
+            ?: mpv.getPropertyInt("current-tracks/audio/id")
+        val selectedSubtitleTrackId = mpv.getPropertyString("sid")?.toIntOrNull()
+            ?: mpv.getPropertyInt("current-tracks/sub/id")
+
         val audioTracks = mutableListOf<MpvTrack>()
         val subtitleTracks = mutableListOf<MpvTrack>()
 
@@ -244,13 +255,18 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             val codec = mpv.getPropertyString("track-list/$i/codec")
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
-            val selected = mpv.getPropertyBoolean("track-list/$i/selected") == true
+            val selectedByFlag = mpv.getPropertyBoolean("track-list/$i/selected") == true
             val external = mpv.getPropertyBoolean("track-list/$i/external") == true
             val channelCount = mpv.getPropertyInt("track-list/$i/demux-channel-count")
                 ?: mpv.getPropertyInt("track-list/$i/audio-channels")
                 ?: mpv.getPropertyInt("track-list/$i/channels")
             val forced = (mpv.getPropertyBoolean("track-list/$i/forced") == true) || listOfNotNull(title, language).any {
                 it.contains("forced", ignoreCase = true)
+            }
+            val selected = when (type) {
+                "audio" -> (selectedAudioTrackId != null && selectedAudioTrackId == id) || selectedByFlag
+                "sub" -> (selectedSubtitleTrackId != null && selectedSubtitleTrackId == id) || selectedByFlag
+                else -> selectedByFlag
             }
 
             when (type) {
@@ -296,6 +312,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             .onFailure { Log.w(TAG, "Failed to destroy libmpv view cleanly: ${it.message}") }
         initialized = false
         hasQueuedInitialMedia = false
+        lastMediaRequestKey = null
     }
 
     override fun initOptions() {
@@ -328,8 +345,17 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     private fun applyHeaders(headers: Map<String, String>) {
         val raw = headers.entries
             .filter { it.key.isNotBlank() && it.value.isNotBlank() }
+            .sortedWith(compareBy({ it.key.lowercase(Locale.ROOT) }, { it.value }))
             .joinToString(separator = ",") { "${it.key}: ${it.value}" }
         mpv.setPropertyString("http-header-fields", raw)
+    }
+
+    private fun buildMediaRequestKey(url: String, headers: Map<String, String>): String {
+        val normalizedHeaders = headers.entries
+            .filter { it.key.isNotBlank() && it.value.isNotBlank() }
+            .sortedWith(compareBy({ it.key.lowercase(Locale.ROOT) }, { it.value }))
+            .joinToString(separator = "|") { "${it.key.trim()}:${it.value.trim()}" }
+        return "$url#$normalizedHeaders"
     }
 
     private fun toMpvColor(color: Int): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -127,7 +127,9 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         if (!initialized) return
         runCatching {
             val scale = (style.size / 100.0).coerceIn(0.5, 3.0)
-            val normalizedOffset = ((style.verticalOffset + 20).coerceIn(0, 70)) / 70.0
+            // Keep the user-facing offset unchanged while lowering the MPV baseline.
+            val effectiveVerticalOffset = style.verticalOffset - MPV_SUBTITLE_VERTICAL_OFFSET_BASELINE_SHIFT
+            val normalizedOffset = ((effectiveVerticalOffset + 20).coerceIn(0, 70)) / 70.0
             val subPos = (95.0 - (normalizedOffset * 25.0)).coerceIn(65.0, 100.0)
             val outlineSize = if (style.outlineEnabled) {
                 style.outlineWidth.coerceIn(1, 6).toDouble()
@@ -364,6 +366,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "NuvioMpvSurfaceView"
+        private const val MPV_SUBTITLE_VERTICAL_OFFSET_BASELINE_SHIFT = 24
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.nuvio.tv.data.local.SubtitleStyleSettings
 import `is`.xyz.mpv.BaseMPVView
 import `is`.xyz.mpv.Utils
+import java.util.Locale
 import kotlin.math.roundToLong
 
 class NuvioMpvSurfaceView @JvmOverloads constructor(
@@ -96,16 +97,23 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             val scale = (style.size / 100.0).coerceIn(0.5, 3.0)
             val normalizedOffset = ((style.verticalOffset + 20).coerceIn(0, 70)) / 70.0
             val subPos = (95.0 - (normalizedOffset * 25.0)).coerceIn(65.0, 100.0)
-            val borderSize = if (style.outlineEnabled) {
+            val outlineSize = if (style.outlineEnabled) {
                 style.outlineWidth.coerceIn(1, 6).toDouble()
             } else {
                 0.0
             }
+            val backgroundAlpha = (style.backgroundColor ushr 24) and 0xFF
+            val borderStyle = if (backgroundAlpha > 0) "opaque-box" else "outline-and-shadow"
 
             mpv.setPropertyDouble("sub-scale", scale)
             mpv.setPropertyBoolean("sub-bold", style.bold)
-            mpv.setPropertyDouble("sub-border-size", borderSize)
+            mpv.setPropertyDouble("sub-outline-size", outlineSize)
             mpv.setPropertyDouble("sub-pos", subPos)
+            mpv.setPropertyDouble("sub-shadow-offset", 0.0)
+            mpv.setPropertyString("sub-border-style", borderStyle)
+            mpv.setPropertyString("sub-color", toMpvColor(style.textColor))
+            mpv.setPropertyString("sub-back-color", toMpvColor(style.backgroundColor))
+            mpv.setPropertyString("sub-outline-color", toMpvColor(style.outlineColor))
         }.onFailure {
             Log.w(TAG, "Failed to apply subtitle style on mpv: ${it.message}")
         }
@@ -269,6 +277,8 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         setVo("gpu")
         mpv.setOptionString("gpu-context", "android")
         mpv.setOptionString("opengl-es", "yes")
+        // Keep style controls consistent with Exo by overriding embedded ASS styling.
+        mpv.setOptionString("sub-ass-override", "force")
         mpv.setOptionString("hwdec", "mediacodec,mediacodec-copy")
         mpv.setOptionString("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
         mpv.setOptionString("ao", "audiotrack,opensles")
@@ -294,6 +304,10 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             .filter { it.key.isNotBlank() && it.value.isNotBlank() }
             .joinToString(separator = ",") { "${it.key}: ${it.value}" }
         mpv.setPropertyString("http-header-fields", raw)
+    }
+
+    private fun toMpvColor(color: Int): String {
+        return String.format(Locale.US, "#%08X", color)
     }
 
     companion object {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -91,6 +91,15 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         mpv.setPropertyDouble("speed", speed.toDouble())
     }
 
+    fun setSubtitleDelayMs(delayMs: Int) {
+        if (!initialized) return
+        runCatching {
+            mpv.setPropertyDouble("sub-delay", delayMs / 1000.0)
+        }.onFailure {
+            Log.w(TAG, "Failed to set subtitle delay on mpv: ${it.message}")
+        }
+    }
+
     fun applySubtitleStyle(style: SubtitleStyleSettings) {
         if (!initialized) return
         runCatching {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
+import com.nuvio.tv.data.local.SubtitleStyleSettings
 import `is`.xyz.mpv.BaseMPVView
 import `is`.xyz.mpv.Utils
 import kotlin.math.roundToLong
@@ -87,6 +88,27 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     fun setPlaybackSpeed(speed: Float) {
         if (!initialized) return
         mpv.setPropertyDouble("speed", speed.toDouble())
+    }
+
+    fun applySubtitleStyle(style: SubtitleStyleSettings) {
+        if (!initialized) return
+        runCatching {
+            val scale = (style.size / 100.0).coerceIn(0.5, 3.0)
+            val normalizedOffset = ((style.verticalOffset + 20).coerceIn(0, 70)) / 70.0
+            val subPos = (95.0 - (normalizedOffset * 25.0)).coerceIn(65.0, 100.0)
+            val borderSize = if (style.outlineEnabled) {
+                style.outlineWidth.coerceIn(1, 6).toDouble()
+            } else {
+                0.0
+            }
+
+            mpv.setPropertyDouble("sub-scale", scale)
+            mpv.setPropertyBoolean("sub-bold", style.bold)
+            mpv.setPropertyDouble("sub-border-size", borderSize)
+            mpv.setPropertyDouble("sub-pos", subPos)
+        }.onFailure {
+            Log.w(TAG, "Failed to apply subtitle style on mpv: ${it.message}")
+        }
     }
 
     fun selectAudioTrackById(trackId: Int): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -91,6 +91,23 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         mpv.setPropertyDouble("speed", speed.toDouble())
     }
 
+    fun applyAudioLanguagePreferences(languages: List<String>) {
+        if (!initialized) return
+        val normalized = languages
+            .mapNotNull { language ->
+                language.trim().takeIf { it.isNotBlank() }
+            }
+            .distinct()
+        runCatching {
+            // Empty value resets language preference back to default behavior.
+            mpv.setPropertyString("alang", normalized.joinToString(","))
+            // Re-run automatic audio selection with the latest preferences.
+            mpv.setPropertyString("aid", "auto")
+        }.onFailure {
+            Log.w(TAG, "Failed to set audio language preference: ${it.message}")
+        }
+    }
+
     fun setSubtitleDelayMs(delayMs: Int) {
         if (!initialized) return
         runCatching {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -1,0 +1,117 @@
+package com.nuvio.tv.ui.screens.player
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import `is`.xyz.mpv.BaseMPVView
+import `is`.xyz.mpv.Utils
+import kotlin.math.roundToLong
+
+class NuvioMpvSurfaceView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : BaseMPVView(context, attrs) {
+
+    private var initialized = false
+    private var hasQueuedInitialMedia = false
+
+    fun ensureInitialized() {
+        if (initialized) return
+        Utils.copyAssets(context)
+        initialize(
+            configDir = context.filesDir.path,
+            cacheDir = context.cacheDir.path
+        )
+        initialized = true
+    }
+
+    fun setMedia(url: String, headers: Map<String, String>) {
+        ensureInitialized()
+        applyHeaders(headers)
+        if (hasQueuedInitialMedia) {
+            mpv.command("loadfile", url, "replace")
+        } else {
+            playFile(url)
+            hasQueuedInitialMedia = true
+        }
+    }
+
+    fun setPaused(paused: Boolean) {
+        if (!initialized) return
+        mpv.setPropertyBoolean("pause", paused)
+    }
+
+    fun isPlayingNow(): Boolean {
+        if (!initialized) return false
+        return mpv.getPropertyBoolean("pause") == false
+    }
+
+    fun seekToMs(positionMs: Long) {
+        if (!initialized) return
+        val seconds = (positionMs.coerceAtLeast(0L) / 1000.0)
+        mpv.setPropertyDouble("time-pos", seconds)
+    }
+
+    fun currentPositionMs(): Long {
+        if (!initialized) return 0L
+        val seconds = mpv.getPropertyDouble("time-pos/full")
+            ?: mpv.getPropertyDouble("time-pos")
+            ?: 0.0
+        return (seconds * 1000.0).roundToLong().coerceAtLeast(0L)
+    }
+
+    fun durationMs(): Long {
+        if (!initialized) return 0L
+        val seconds = mpv.getPropertyDouble("duration/full") ?: 0.0
+        return (seconds * 1000.0).roundToLong().coerceAtLeast(0L)
+    }
+
+    fun setPlaybackSpeed(speed: Float) {
+        if (!initialized) return
+        mpv.setPropertyDouble("speed", speed.toDouble())
+    }
+
+    fun releasePlayer() {
+        if (!initialized) return
+        runCatching { destroy() }
+            .onFailure { Log.w(TAG, "Failed to destroy libmpv view cleanly: ${it.message}") }
+        initialized = false
+        hasQueuedInitialMedia = false
+    }
+
+    override fun initOptions() {
+        mpv.setOptionString("profile", "fast")
+        setVo("gpu")
+        mpv.setOptionString("gpu-context", "android")
+        mpv.setOptionString("opengl-es", "yes")
+        mpv.setOptionString("hwdec", "mediacodec,mediacodec-copy")
+        mpv.setOptionString("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
+        mpv.setOptionString("ao", "audiotrack,opensles")
+        mpv.setOptionString("audio-set-media-role", "yes")
+        mpv.setOptionString("tls-verify", "yes")
+        mpv.setOptionString("tls-ca-file", "${context.filesDir.path}/cacert.pem")
+        mpv.setOptionString("input-default-bindings", "yes")
+        mpv.setOptionString("demuxer-max-bytes", "${64 * 1024 * 1024}")
+        mpv.setOptionString("demuxer-max-back-bytes", "${64 * 1024 * 1024}")
+        mpv.setOptionString("keep-open", "yes")
+    }
+
+    override fun postInitOptions() {
+        mpv.setOptionString("save-position-on-quit", "no")
+    }
+
+    override fun observeProperties() {
+        // Progress is polled by PlayerRuntimeController.
+    }
+
+    private fun applyHeaders(headers: Map<String, String>) {
+        val raw = headers.entries
+            .filter { it.key.isNotBlank() && it.value.isNotBlank() }
+            .joinToString(separator = ",") { "${it.key}: ${it.value}" }
+        mpv.setPropertyString("http-header-fields", raw)
+    }
+
+    companion object {
+        private const val TAG = "NuvioMpvSurfaceView"
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -193,6 +193,7 @@ class PlayerRuntimeController(
     internal var trackSelector: DefaultTrackSelector? = null
     internal var currentMediaSession: MediaSession? = null
     internal var mpvView: NuvioMpvSurfaceView? = null
+    internal var mpvInitializationInProgress: Boolean = false
     internal var pauseOverlayJob: Job? = null
     internal val pauseOverlayDelayMs = 5000L
     internal val seekProgressSyncDebounceMs = 700L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -183,6 +183,7 @@ class PlayerRuntimeController(
     internal var nextEpisodeThresholdModeSetting: NextEpisodeThresholdMode = NextEpisodeThresholdMode.PERCENTAGE
     internal var nextEpisodeThresholdPercentSetting: Float = 98f
     internal var nextEpisodeThresholdMinutesBeforeEndSetting: Float = 2f
+    internal var mpvPreferredAudioLanguages: List<String> = emptyList()
     internal var currentStreamBingeGroup: String? = navigationArgs.bingeGroup
     internal var hasAppliedRememberedAudioSelection: Boolean = false
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import com.nuvio.tv.core.plugin.PluginManager
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.StreamLinkCacheDataStore
@@ -175,6 +176,7 @@ class PlayerRuntimeController(
     internal var attachedAddonSubtitleKeys: Set<String> = emptySet()
     internal var hasScannedTextTracksOnce: Boolean = false
     internal var streamReuseLastLinkEnabled: Boolean = false
+    internal var currentInternalPlayerEngine: InternalPlayerEngine = InternalPlayerEngine.EXOPLAYER
     internal var streamAutoPlayModeSetting: StreamAutoPlayMode = StreamAutoPlayMode.MANUAL
     internal var streamAutoPlayNextEpisodeEnabledSetting: Boolean = false
     internal var streamAutoPlayPreferBingeGroupForNextEpisodeSetting: Boolean = false
@@ -189,6 +191,7 @@ class PlayerRuntimeController(
     internal var loudnessEnhancer: LoudnessEnhancer? = null
     internal var trackSelector: DefaultTrackSelector? = null
     internal var currentMediaSession: MediaSession? = null
+    internal var mpvView: NuvioMpvSurfaceView? = null
     internal var pauseOverlayJob: Job? = null
     internal val pauseOverlayDelayMs = 5000L
     internal val seekProgressSyncDebounceMs = 700L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -65,7 +65,16 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                 )
             }
             if (playerSettings.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
+                runAfrPreflightIfEnabled(
+                    url = url,
+                    headers = headers,
+                    frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                    resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                )
                 initializeMpvPlayer(url = url, headers = headers)
+                // Keep addon subtitle discovery available on the mpv path too.
+                // Exo does this later in this method, but this branch returns early.
+                fetchAddonSubtitles()
                 return@launch
             }
             runAfrPreflightIfEnabled(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -71,18 +71,24 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                 )
             }
             if (playerSettings.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
-                runAfrPreflightIfEnabled(
-                    url = url,
-                    headers = headers,
-                    frameRateMatchingMode = playerSettings.frameRateMatchingMode,
-                    resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
-                )
-                initializeMpvPlayer(url = url, headers = headers)
-                // Keep addon subtitle discovery available on the mpv path too.
-                // Exo does this later in this method, but this branch returns early.
-                fetchAddonSubtitles()
+                mpvInitializationInProgress = true
+                try {
+                    runAfrPreflightIfEnabled(
+                        url = url,
+                        headers = headers,
+                        frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                        resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                    )
+                    initializeMpvPlayer(url = url, headers = headers)
+                    // Keep addon subtitle discovery available on the mpv path too.
+                    // Exo does this later in this method, but this branch returns early.
+                    fetchAddonSubtitles()
+                } finally {
+                    mpvInitializationInProgress = false
+                }
                 return@launch
             }
+            mpvInitializationInProgress = false
             runAfrPreflightIfEnabled(
                 url = url,
                 headers = headers,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -57,6 +57,12 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
             hasScannedTextTracksOnce = false
             resetLoadingOverlayForNewStream()
             val playerSettings = playerSettingsDataStore.playerSettings.first()
+            val preferredAudioLanguages = resolvePreferredAudioLanguages(
+                preferredAudioLanguage = playerSettings.preferredAudioLanguage,
+                secondaryPreferredAudioLanguage = playerSettings.secondaryPreferredAudioLanguage,
+                deviceLanguages = resolveDeviceAudioLanguages()
+            )
+            mpvPreferredAudioLanguages = preferredAudioLanguages
             currentInternalPlayerEngine = playerSettings.internalPlayerEngine
             _uiState.update {
                 it.copy(
@@ -104,17 +110,6 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     )
                 }
 
-                val deviceLanguages = if (Build.VERSION.SDK_INT >= 24) {
-                    val localeList = Resources.getSystem().configuration.locales
-                    List(localeList.size()) { localeList[it].isO3Language }
-                } else {
-                    listOf(Resources.getSystem().configuration.locale.isO3Language)
-                }
-                val preferredAudioLanguages = resolvePreferredAudioLanguages(
-                    preferredAudioLanguage = playerSettings.preferredAudioLanguage,
-                    secondaryPreferredAudioLanguage = playerSettings.secondaryPreferredAudioLanguage,
-                    deviceLanguages = deviceLanguages
-                )
                 if (preferredAudioLanguages.isNotEmpty()) {
                     setParameters(
                         buildUponParameters().setPreferredAudioLanguages(*preferredAudioLanguages.toTypedArray())
@@ -399,6 +394,15 @@ internal fun resolvePreferredAudioLanguages(
             normalize(preferredAudioLanguage),
             normalize(secondaryPreferredAudioLanguage)
         ).distinct()
+    }
+}
+
+internal fun resolveDeviceAudioLanguages(): List<String> {
+    return if (Build.VERSION.SDK_INT >= 24) {
+        val localeList = Resources.getSystem().configuration.locales
+        List(localeList.size()) { localeList[it].isO3Language }
+    } else {
+        listOf(Resources.getSystem().configuration.locale.isO3Language)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -27,6 +27,7 @@ import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioLanguageOption
 import com.nuvio.tv.data.local.SUBTITLE_LANGUAGE_FORCED
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.domain.model.Subtitle
 import io.github.peerless2012.ass.media.kt.buildWithAssSupport
 import kotlinx.coroutines.flow.first
@@ -56,10 +57,16 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
             hasScannedTextTracksOnce = false
             resetLoadingOverlayForNewStream()
             val playerSettings = playerSettingsDataStore.playerSettings.first()
+            currentInternalPlayerEngine = playerSettings.internalPlayerEngine
             _uiState.update {
                 it.copy(
+                    internalPlayerEngine = playerSettings.internalPlayerEngine,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode
                 )
+            }
+            if (playerSettings.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
+                initializeMpvPlayer(url = url, headers = headers)
+                return@launch
             }
             runAfrPreflightIfEnabled(
                 url = url,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -29,6 +29,7 @@ internal fun PlayerRuntimeController.releasePlayer() {
     hideSubtitleDelayOverlayJob?.cancel()
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null
+    releaseMpvPlayer()
     _exoPlayer?.release()
     _exoPlayer = null
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -15,6 +15,10 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
     runCatching {
         view.setMedia(currentStreamUrl, currentHeaders)
         view.setPlaybackSpeed(_uiState.value.playbackSpeed)
+        view.applySubtitleLanguagePreferences(
+            preferred = _uiState.value.subtitleStyle.preferredLanguage,
+            secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
+        )
         view.setPaused(false)
         val pendingSeek = _uiState.value.pendingSeekPosition
             ?: pendingResumeProgress?.position
@@ -35,6 +39,8 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         cancelPauseOverlay()
         startProgressUpdates()
         startWatchProgressSaving()
+        updateMpvAvailableTracks()
+        tryAutoSelectPreferredSubtitleFromAvailableTracks()
         scheduleHideControls()
         emitScrobbleStart()
     }.onFailure {
@@ -79,6 +85,10 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: M
     runCatching {
         view.setMedia(url, headers)
         view.setPlaybackSpeed(_uiState.value.playbackSpeed)
+        view.applySubtitleLanguagePreferences(
+            preferred = _uiState.value.subtitleStyle.preferredLanguage,
+            secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
+        )
         view.setPaused(false)
         val pendingSeek = _uiState.value.pendingSeekPosition
             ?: pendingResumeProgress?.position
@@ -104,6 +114,8 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: M
         cancelPauseOverlay()
         startProgressUpdates()
         startWatchProgressSaving()
+        updateMpvAvailableTracks()
+        tryAutoSelectPreferredSubtitleFromAvailableTracks()
         scheduleHideControls()
         emitScrobbleStart()
     }.onFailure { error ->
@@ -131,6 +143,82 @@ internal fun PlayerRuntimeController.pauseForLifecycle() {
         return
     }
     _exoPlayer?.pause()
+}
+
+internal fun PlayerRuntimeController.updateMpvAvailableTracks() {
+    if (!isUsingMpvEngine()) return
+    val snapshot = mpvView?.readTrackSnapshot() ?: return
+
+    val audioTracks = snapshot.audioTracks
+        .mapIndexed { index, track ->
+            val codecSuffix = buildList {
+                track.codec?.takeIf { it.isNotBlank() }?.let { add(it) }
+                track.channelCount?.takeIf { it > 0 }?.let { add("${it}ch") }
+            }.joinToString(" ")
+            val displayName = if (codecSuffix.isBlank()) {
+                track.name
+            } else {
+                "${track.name} ($codecSuffix)"
+            }
+            TrackInfo(
+                index = index,
+                name = displayName,
+                language = track.language,
+                trackId = track.id.toString(),
+                codec = track.codec,
+                channelCount = track.channelCount,
+                isSelected = track.isSelected
+            )
+        }
+
+    val internalSubtitleTracks = snapshot.subtitleTracks
+        .filterNot { it.isExternal }
+        .mapIndexed { index, track ->
+            TrackInfo(
+                index = index,
+                name = track.name,
+                language = track.language,
+                trackId = track.id.toString(),
+                codec = track.codec,
+                isForced = track.isForced,
+                isSelected = track.isSelected
+            )
+        }
+
+    val selectedAudioIndex = audioTracks.indexOfFirst { it.isSelected }
+    val selectedSubtitleIndex = internalSubtitleTracks.indexOfFirst { it.isSelected }
+    val selectedExternalSubtitle = snapshot.subtitleTracks.any { it.isExternal && it.isSelected }
+
+    hasScannedTextTracksOnce = true
+    maybeApplyRememberedAudioSelection(audioTracks)
+    maybeRestorePendingAudioSelectionAfterSubtitleRefresh(audioTracks)
+
+    _uiState.update { state ->
+        val addonSelection = if (!selectedExternalSubtitle) null else state.selectedAddonSubtitle
+        val normalizedSelectedSubtitleIndex = if (selectedExternalSubtitle) {
+            -1
+        } else {
+            selectedSubtitleIndex
+        }
+
+        if (
+            state.audioTracks == audioTracks &&
+            state.subtitleTracks == internalSubtitleTracks &&
+            state.selectedAudioTrackIndex == selectedAudioIndex &&
+            state.selectedSubtitleTrackIndex == normalizedSelectedSubtitleIndex &&
+            state.selectedAddonSubtitle == addonSelection
+        ) {
+            state
+        } else {
+            state.copy(
+                audioTracks = audioTracks,
+                subtitleTracks = internalSubtitleTracks,
+                selectedAudioTrackIndex = selectedAudioIndex,
+                selectedSubtitleTrackIndex = normalizedSelectedSubtitleIndex,
+                selectedAddonSubtitle = addonSelection
+            )
+        }
+    }
 }
 
 internal fun PlayerRuntimeController.isUsingMpvEngine(): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -2,7 +2,9 @@ package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
 import com.nuvio.tv.data.local.InternalPlayerEngine
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
     if (mpvView === view) return
@@ -272,6 +274,28 @@ internal fun PlayerRuntimeController.setPlaybackPaused(paused: Boolean) {
     } else {
         _exoPlayer?.let { player ->
             if (paused) player.pause() else player.play()
+        }
+    }
+}
+
+internal fun PlayerRuntimeController.keepMpvPlayingIfNeeded(wasPlaying: Boolean) {
+    if (!wasPlaying || !isUsingMpvEngine()) return
+    scope.launch {
+        // If track switch forces a pause, nudge playback back only when needed.
+        repeat(6) {
+            if (!isUsingMpvEngine()) return@launch
+            val view = mpvView ?: return@launch
+            val pausedByCache = view.isPausedForCacheNow()
+            val coreIdle = view.isCoreIdleNow()
+            if (view.isPlayingNow() && !pausedByCache && !coreIdle) {
+                _uiState.update { state ->
+                    if (state.isPlaying) state else state.copy(isPlaying = true, isBuffering = false)
+                }
+                return@launch
+            }
+            view.setPaused(false)
+            _uiState.update { it.copy(isPlaying = true, isBuffering = false) }
+            delay(120L)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -22,6 +22,7 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
             secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
         )
         view.applySubtitleStyle(_uiState.value.subtitleStyle)
+        view.setSubtitleDelayMs(_uiState.value.subtitleDelayMs)
         view.setPaused(false)
         val pendingSeek = _uiState.value.pendingSeekPosition
             ?: pendingResumeProgress?.position
@@ -93,6 +94,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: M
             secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
         )
         view.applySubtitleStyle(_uiState.value.subtitleStyle)
+        view.setSubtitleDelayMs(_uiState.value.subtitleDelayMs)
         view.setPaused(false)
         val pendingSeek = _uiState.value.pendingSeekPosition
             ?: pendingResumeProgress?.position
@@ -255,7 +257,11 @@ internal fun PlayerRuntimeController.isPlaybackCurrentlyPlaying(): Boolean {
 
 internal fun PlayerRuntimeController.seekPlaybackTo(positionMs: Long) {
     if (isUsingMpvEngine()) {
-        mpvView?.seekToMs(positionMs)
+        mpvView?.let { view ->
+            view.seekToMs(positionMs)
+            // Keep subtitle delay sticky during FF/RW seeks.
+            view.setSubtitleDelayMs(_uiState.value.subtitleDelayMs)
+        }
     } else {
         _exoPlayer?.seekTo(positionMs)
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -31,12 +31,12 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
             _uiState.update { it.copy(pendingSeekPosition = null) }
             pendingResumeProgress = null
         }
-        hasRenderedFirstFrame = true
+        hasRenderedFirstFrame = false
         _uiState.update {
             it.copy(
-                isBuffering = false,
-                isPlaying = true,
-                showLoadingOverlay = false,
+                isBuffering = true,
+                isPlaying = view.isPlayingNow(),
+                showLoadingOverlay = it.loadingOverlayEnabled,
                 error = null
             )
         }
@@ -104,12 +104,12 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: M
             pendingResumeProgress = null
         }
 
-        hasRenderedFirstFrame = true
+        hasRenderedFirstFrame = false
         _uiState.update {
             it.copy(
-                isBuffering = false,
-                isPlaying = true,
-                showLoadingOverlay = false,
+                isBuffering = true,
+                isPlaying = view.isPlayingNow(),
+                showLoadingOverlay = it.loadingOverlayEnabled,
                 error = null,
                 audioTracks = emptyList(),
                 subtitleTracks = emptyList(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -13,6 +13,7 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
     if (view == null) return
     if (!isUsingMpvEngine()) return
     if (currentStreamUrl.isBlank()) return
+    if (mpvInitializationInProgress) return
 
     runCatching {
         view.setMedia(currentStreamUrl, currentHeaders)
@@ -195,14 +196,26 @@ internal fun PlayerRuntimeController.updateMpvAvailableTracks() {
 
     val selectedAudioIndex = audioTracks.indexOfFirst { it.isSelected }
     val selectedSubtitleIndex = internalSubtitleTracks.indexOfFirst { it.isSelected }
-    val selectedExternalSubtitle = snapshot.subtitleTracks.any { it.isExternal && it.isSelected }
+    val selectedExternalSubtitleTrack = snapshot.subtitleTracks.firstOrNull { it.isExternal && it.isSelected }
+    val selectedExternalSubtitle = selectedExternalSubtitleTrack != null
 
     hasScannedTextTracksOnce = true
     maybeApplyRememberedAudioSelection(audioTracks)
     maybeRestorePendingAudioSelectionAfterSubtitleRefresh(audioTracks)
 
     _uiState.update { state ->
-        val addonSelection = if (!selectedExternalSubtitle) null else state.selectedAddonSubtitle
+        val selectedAddonFromMpvTrack = selectedExternalSubtitleTrack?.let { track ->
+            state.addonSubtitles.firstOrNull { subtitle ->
+                buildAddonSubtitleTrackId(subtitle).equals(track.name, ignoreCase = true)
+            }
+        }
+
+        val addonSelection = when {
+            selectedAddonFromMpvTrack != null -> selectedAddonFromMpvTrack
+            selectedExternalSubtitle -> null
+            selectedSubtitleIndex >= 0 -> null
+            else -> state.selectedAddonSubtitle
+        }
         val normalizedSelectedSubtitleIndex = if (selectedExternalSubtitle) {
             -1
         } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -21,6 +21,7 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
             preferred = _uiState.value.subtitleStyle.preferredLanguage,
             secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
         )
+        view.applySubtitleStyle(_uiState.value.subtitleStyle)
         view.setPaused(false)
         val pendingSeek = _uiState.value.pendingSeekPosition
             ?: pendingResumeProgress?.position
@@ -91,6 +92,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: M
             preferred = _uiState.value.subtitleStyle.preferredLanguage,
             secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
         )
+        view.applySubtitleStyle(_uiState.value.subtitleStyle)
         view.setPaused(false)
         val pendingSeek = _uiState.value.pendingSeekPosition
             ?: pendingResumeProgress?.position

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -17,6 +17,7 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
     runCatching {
         view.setMedia(currentStreamUrl, currentHeaders)
         view.setPlaybackSpeed(_uiState.value.playbackSpeed)
+        view.applyAudioLanguagePreferences(mpvPreferredAudioLanguages)
         view.applySubtitleLanguagePreferences(
             preferred = _uiState.value.subtitleStyle.preferredLanguage,
             secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage
@@ -89,6 +90,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: M
     runCatching {
         view.setMedia(url, headers)
         view.setPlaybackSpeed(_uiState.value.playbackSpeed)
+        view.applyAudioLanguagePreferences(mpvPreferredAudioLanguages)
         view.applySubtitleLanguagePreferences(
             preferred = _uiState.value.subtitleStyle.preferredLanguage,
             secondary = _uiState.value.subtitleStyle.secondaryPreferredLanguage

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -1,0 +1,189 @@
+package com.nuvio.tv.ui.screens.player
+
+import android.util.Log
+import com.nuvio.tv.data.local.InternalPlayerEngine
+import kotlinx.coroutines.flow.update
+
+internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
+    if (mpvView === view) return
+    mpvView = view
+
+    if (view == null) return
+    if (!isUsingMpvEngine()) return
+    if (currentStreamUrl.isBlank()) return
+
+    runCatching {
+        view.setMedia(currentStreamUrl, currentHeaders)
+        view.setPlaybackSpeed(_uiState.value.playbackSpeed)
+        view.setPaused(false)
+        val pendingSeek = _uiState.value.pendingSeekPosition
+            ?: pendingResumeProgress?.position
+        if (pendingSeek != null && pendingSeek > 0L) {
+            view.seekToMs(pendingSeek)
+            _uiState.update { it.copy(pendingSeekPosition = null) }
+            pendingResumeProgress = null
+        }
+        hasRenderedFirstFrame = true
+        _uiState.update {
+            it.copy(
+                isBuffering = false,
+                isPlaying = true,
+                showLoadingOverlay = false,
+                error = null
+            )
+        }
+        cancelPauseOverlay()
+        startProgressUpdates()
+        startWatchProgressSaving()
+        scheduleHideControls()
+        emitScrobbleStart()
+    }.onFailure {
+        _uiState.update { state ->
+            state.copy(
+                error = it.message ?: "Failed to initialize libmpv surface",
+                showLoadingOverlay = false
+            )
+        }
+    }
+}
+
+internal fun PlayerRuntimeController.initializeMpvPlayer(url: String, headers: Map<String, String>) {
+    _exoPlayer?.release()
+    _exoPlayer = null
+    trackSelector = null
+    try {
+        loudnessEnhancer?.release()
+    } catch (_: Exception) {
+    }
+    loudnessEnhancer = null
+    try {
+        currentMediaSession?.release()
+    } catch (_: Exception) {
+    }
+    currentMediaSession = null
+    notifyAudioSessionUpdate(false)
+
+    val view = mpvView
+    if (view == null) {
+        _uiState.update {
+            it.copy(
+                isBuffering = true,
+                isPlaying = false,
+                showLoadingOverlay = it.loadingOverlayEnabled,
+                error = null
+            )
+        }
+        return
+    }
+
+    runCatching {
+        view.setMedia(url, headers)
+        view.setPlaybackSpeed(_uiState.value.playbackSpeed)
+        view.setPaused(false)
+        val pendingSeek = _uiState.value.pendingSeekPosition
+            ?: pendingResumeProgress?.position
+        if (pendingSeek != null && pendingSeek > 0L) {
+            view.seekToMs(pendingSeek)
+            _uiState.update { it.copy(pendingSeekPosition = null) }
+            pendingResumeProgress = null
+        }
+
+        hasRenderedFirstFrame = true
+        _uiState.update {
+            it.copy(
+                isBuffering = false,
+                isPlaying = true,
+                showLoadingOverlay = false,
+                error = null,
+                audioTracks = emptyList(),
+                subtitleTracks = emptyList(),
+                selectedAudioTrackIndex = -1,
+                selectedSubtitleTrackIndex = -1
+            )
+        }
+        cancelPauseOverlay()
+        startProgressUpdates()
+        startWatchProgressSaving()
+        scheduleHideControls()
+        emitScrobbleStart()
+    }.onFailure { error ->
+        Log.e(PlayerRuntimeController.TAG, "libmpv initialize failed: ${error.message}", error)
+        _uiState.update {
+            it.copy(
+                error = error.message ?: "Failed to initialize libmpv playback",
+                showLoadingOverlay = false,
+                isBuffering = false
+            )
+        }
+    }
+}
+
+internal fun PlayerRuntimeController.releaseMpvPlayer() {
+    runCatching { mpvView?.releasePlayer() }
+}
+
+internal fun PlayerRuntimeController.pauseForLifecycle() {
+    if (isUsingMpvEngine()) {
+        mpvView?.setPaused(true)
+        stopWatchProgressSaving()
+        stopProgressUpdates()
+        _uiState.update { it.copy(isPlaying = false) }
+        return
+    }
+    _exoPlayer?.pause()
+}
+
+internal fun PlayerRuntimeController.isUsingMpvEngine(): Boolean {
+    return currentInternalPlayerEngine == InternalPlayerEngine.MVP_PLAYER
+}
+
+internal fun PlayerRuntimeController.currentPlaybackPositionMs(): Long? {
+    return if (isUsingMpvEngine()) {
+        mpvView?.currentPositionMs()
+    } else {
+        _exoPlayer?.currentPosition
+    }
+}
+
+internal fun PlayerRuntimeController.currentPlaybackDurationMs(): Long {
+    return if (isUsingMpvEngine()) {
+        mpvView?.durationMs() ?: 0L
+    } else {
+        _exoPlayer?.duration ?: 0L
+    }
+}
+
+internal fun PlayerRuntimeController.isPlaybackCurrentlyPlaying(): Boolean {
+    return if (isUsingMpvEngine()) {
+        mpvView?.isPlayingNow() == true
+    } else {
+        _exoPlayer?.isPlaying == true
+    }
+}
+
+internal fun PlayerRuntimeController.seekPlaybackTo(positionMs: Long) {
+    if (isUsingMpvEngine()) {
+        mpvView?.seekToMs(positionMs)
+    } else {
+        _exoPlayer?.seekTo(positionMs)
+    }
+}
+
+internal fun PlayerRuntimeController.setPlaybackSpeedInternal(speed: Float) {
+    if (isUsingMpvEngine()) {
+        mpvView?.setPlaybackSpeed(speed)
+    } else {
+        _exoPlayer?.setPlaybackSpeed(speed)
+    }
+}
+
+internal fun PlayerRuntimeController.setPlaybackPaused(paused: Boolean) {
+    if (isUsingMpvEngine()) {
+        mpvView?.setPaused(paused)
+        _uiState.update { it.copy(isPlaying = !paused) }
+    } else {
+        _exoPlayer?.let { player ->
+            if (paused) player.pause() else player.play()
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -191,6 +191,19 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             nextEpisodeThresholdPercentSetting = settings.nextEpisodeThresholdPercent
             nextEpisodeThresholdMinutesBeforeEndSetting = settings.nextEpisodeThresholdMinutesBeforeEnd
 
+            val resolvedAudioLanguages = resolvePreferredAudioLanguages(
+                preferredAudioLanguage = settings.preferredAudioLanguage,
+                secondaryPreferredAudioLanguage = settings.secondaryPreferredAudioLanguage,
+                deviceLanguages = resolveDeviceAudioLanguages()
+            )
+            if (resolvedAudioLanguages != mpvPreferredAudioLanguages) {
+                mpvPreferredAudioLanguages = resolvedAudioLanguages
+                if (isUsingMpvEngine()) {
+                    mpvView?.applyAudioLanguagePreferences(resolvedAudioLanguages)
+                    updateMpvAvailableTracks()
+                }
+            }
+
             applySubtitlePreferences(
                 settings.subtitleStyle.preferredLanguage,
                 settings.subtitleStyle.secondaryPreferredLanguage

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -157,6 +157,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     showLoadingOverlay = shouldShowOverlay,
                     pauseOverlayEnabled = settings.pauseOverlayEnabled,
                     osdClockEnabled = settings.osdClockEnabled,
+                    internalPlayerEngine = settings.internalPlayerEngine,
                     frameRateMatchingMode = settings.frameRateMatchingMode
                 )
             }
@@ -181,6 +182,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                 schedulePauseOverlay()
             }
             streamReuseLastLinkEnabled = settings.streamReuseLastLinkEnabled
+            currentInternalPlayerEngine = settings.internalPlayerEngine
             streamAutoPlayModeSetting = settings.streamAutoPlayMode
             streamAutoPlayNextEpisodeEnabledSetting = settings.streamAutoPlayNextEpisodeEnabled
             streamAutoPlayPreferBingeGroupForNextEpisodeSetting =
@@ -236,9 +238,22 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
             
             if (saved.isInProgress()) {
                 pendingResumeProgress = saved
-                _exoPlayer?.let { player ->
-                    if (player.playbackState == Player.STATE_READY) {
-                        tryApplyPendingResumeProgress(player)
+                if (isUsingMpvEngine()) {
+                    val target = saved.position.coerceAtLeast(0L)
+                    if (target > 0L) {
+                        if (mpvView != null) {
+                            seekPlaybackTo(target)
+                            _uiState.update { it.copy(pendingSeekPosition = null) }
+                            pendingResumeProgress = null
+                        } else {
+                            _uiState.update { it.copy(pendingSeekPosition = target) }
+                        }
+                    }
+                } else {
+                    _exoPlayer?.let { player ->
+                        if (player.playbackState == Player.STATE_READY) {
+                            tryApplyPendingResumeProgress(player)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -37,6 +37,8 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                             playbackEnded = ended
                         )
                     }
+                    updateMpvAvailableTracks()
+                    tryAutoSelectPreferredSubtitleFromAvailableTracks()
                     updateActiveSkipInterval(pos)
                     evaluateNextEpisodeCardVisibility(
                         positionMs = pos,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -22,18 +22,28 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                 if (view != null) {
                     val pos = view.currentPositionMs().coerceAtLeast(0L)
                     val playerDuration = view.durationMs().coerceAtLeast(0L)
+                    val playingNow = view.isPlayingNow()
+                    val cacheBuffering = view.isPausedForCacheNow() || view.isCoreIdleNow()
+                    var firstFrameReady = hasRenderedFirstFrame
+                    if (!firstFrameReady) {
+                        firstFrameReady = pos > 0L || (playingNow && !cacheBuffering && playerDuration > 0L)
+                        if (firstFrameReady) {
+                            hasRenderedFirstFrame = true
+                        }
+                    }
                     if (playerDuration > lastKnownDuration) {
                         lastKnownDuration = playerDuration
                     }
                     val displayPosition = pendingPreviewSeekPosition ?: pos
                     val ended = playerDuration > 0L && pos >= (playerDuration - 500L)
                     val wasEnded = _uiState.value.playbackEnded
-                    _uiState.update {
-                        it.copy(
+                    _uiState.update { state ->
+                        state.copy(
                             currentPosition = displayPosition,
                             duration = playerDuration,
-                            isPlaying = view.isPlayingNow(),
-                            isBuffering = false,
+                            isPlaying = playingNow,
+                            isBuffering = !firstFrameReady || cacheBuffering,
+                            showLoadingOverlay = if (state.loadingOverlayEnabled) !firstFrameReady else false,
                             playbackEnded = ended
                         )
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -349,6 +349,9 @@ internal fun PlayerRuntimeController.adjustSubtitleDelay(deltaMs: Int) {
     )
 
     subtitleDelayUs.set(newDelayMs.toLong() * 1000L)
+    if (isUsingMpvEngine()) {
+        mpvView?.setSubtitleDelayMs(newDelayMs)
+    }
     _uiState.update {
         it.copy(
             subtitleDelayMs = newDelayMs,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -17,6 +17,41 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
     progressJob?.cancel()
     progressJob = scope.launch {
         while (isActive) {
+            if (isUsingMpvEngine()) {
+                val view = mpvView
+                if (view != null) {
+                    val pos = view.currentPositionMs().coerceAtLeast(0L)
+                    val playerDuration = view.durationMs().coerceAtLeast(0L)
+                    if (playerDuration > lastKnownDuration) {
+                        lastKnownDuration = playerDuration
+                    }
+                    val displayPosition = pendingPreviewSeekPosition ?: pos
+                    val ended = playerDuration > 0L && pos >= (playerDuration - 500L)
+                    val wasEnded = _uiState.value.playbackEnded
+                    _uiState.update {
+                        it.copy(
+                            currentPosition = displayPosition,
+                            duration = playerDuration,
+                            isPlaying = view.isPlayingNow(),
+                            isBuffering = false,
+                            playbackEnded = ended
+                        )
+                    }
+                    updateActiveSkipInterval(pos)
+                    evaluateNextEpisodeCardVisibility(
+                        positionMs = pos,
+                        durationMs = playerDuration
+                    )
+                    if (ended && !wasEnded) {
+                        emitCompletionScrobbleStop(progressPercent = 99.5f)
+                        saveWatchProgress()
+                        resetNextEpisodeCardState(clearEpisode = false)
+                    }
+                }
+                delay(500)
+                continue
+            }
+
             _exoPlayer?.let { player ->
                 val pos = player.currentPosition.coerceAtLeast(0L)
                 val playerDuration = player.duration
@@ -36,7 +71,6 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     durationMs = playerDuration.coerceAtLeast(0L)
                 )
 
-                
                 if (player.isPlaying) {
                     val now = System.currentTimeMillis()
                     if (now - lastBufferLogTimeMs >= 10_000) {
@@ -77,7 +111,7 @@ internal fun PlayerRuntimeController.stopWatchProgressSaving() {
 
 internal fun PlayerRuntimeController.saveWatchProgressIfNeeded() {
     if (!hasRenderedFirstFrame) return
-    val currentPosition = _exoPlayer?.currentPosition ?: return
+    val currentPosition = currentPlaybackPositionMs() ?: return
     val duration = getEffectiveDuration(currentPosition)
     
     
@@ -89,17 +123,21 @@ internal fun PlayerRuntimeController.saveWatchProgressIfNeeded() {
 
 internal fun PlayerRuntimeController.saveWatchProgress() {
     if (!hasRenderedFirstFrame) return
-    val currentPosition = _exoPlayer?.currentPosition ?: return
+    val currentPosition = currentPlaybackPositionMs() ?: return
     val duration = getEffectiveDuration(currentPosition)
     saveWatchProgressInternal(currentPosition, duration)
 }
 
 internal fun PlayerRuntimeController.getEffectiveDuration(position: Long): Long {
-    val playerDuration = _exoPlayer?.duration ?: 0L
+    val playerDuration = currentPlaybackDurationMs()
     val effectiveDuration = maxOf(playerDuration, lastKnownDuration)
     if (effectiveDuration <= 0L) return 0L
 
-    val isEnded = _exoPlayer?.playbackState == Player.STATE_ENDED
+    val isEnded = if (isUsingMpvEngine()) {
+        position >= (effectiveDuration - 500L)
+    } else {
+        _exoPlayer?.playbackState == Player.STATE_ENDED
+    }
     if (!isEnded && effectiveDuration < position) return 0L
 
     return effectiveDuration
@@ -137,10 +175,10 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, d
 
 internal fun PlayerRuntimeController.currentPlaybackProgressPercent(): Float {
     if (!hasRenderedFirstFrame) return 0f
-    val player = _exoPlayer ?: return 0f
-    val duration = player.duration.takeIf { it > 0 } ?: lastKnownDuration
+    val position = currentPlaybackPositionMs() ?: return 0f
+    val duration = currentPlaybackDurationMs().takeIf { it > 0 } ?: lastKnownDuration
     if (duration <= 0L) return 0f
-    return ((player.currentPosition.toFloat() / duration.toFloat()) * 100f).coerceIn(0f, 100f)
+    return ((position.toFloat() / duration.toFloat()) * 100f).coerceIn(0f, 100f)
 }
 
 internal fun PlayerRuntimeController.refreshScrobbleItem() {
@@ -260,7 +298,7 @@ internal fun PlayerRuntimeController.scheduleProgressSyncAfterSeek() {
         val progressPercent = currentPlaybackProgressPercent()
         emitPauseScrobbleStop(progressPercent = progressPercent)
 
-        if (_exoPlayer?.isPlaying == true && progressPercent >= 1f && progressPercent < 80f) {
+        if (isPlaybackCurrentlyPlaying() && progressPercent >= 1f && progressPercent < 80f) {
             emitScrobbleStart()
         }
     }
@@ -372,15 +410,35 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
     onUserInteraction()
     when (event) {
         PlayerEvent.OnPlayPause -> {
-            _exoPlayer?.let { player ->
-                if (player.isPlaying) {
+            if (isUsingMpvEngine()) {
+                val playing = isPlaybackCurrentlyPlaying()
+                if (playing) {
                     userPausedManually = true
-                    player.pause()
+                    setPlaybackPaused(true)
+                    stopProgressUpdates()
+                    stopWatchProgressSaving()
+                    emitStopScrobbleForCurrentProgress()
                     schedulePauseOverlay()
                 } else {
                     userPausedManually = false
                     cancelPauseOverlay()
-                    player.play()
+                    setPlaybackPaused(false)
+                    startProgressUpdates()
+                    startWatchProgressSaving()
+                    scheduleHideControls()
+                    emitScrobbleStart()
+                }
+            } else {
+                _exoPlayer?.let { player ->
+                    if (player.isPlaying) {
+                        userPausedManually = true
+                        player.pause()
+                        schedulePauseOverlay()
+                    } else {
+                        userPausedManually = false
+                        cancelPauseOverlay()
+                        player.play()
+                    }
                 }
             }
             showControlsTemporarily()
@@ -393,15 +451,14 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         is PlayerEvent.OnSeekBy -> {
             pendingPreviewSeekPosition = null
-            _exoPlayer?.let { player ->
-                val maxDuration = player.duration.takeIf { it >= 0 } ?: Long.MAX_VALUE
-                val target = (player.currentPosition + event.deltaMs)
-                    .coerceAtLeast(0L)
-                    .coerceAtMost(maxDuration)
-                player.seekTo(target)
-                _uiState.update { it.copy(currentPosition = target) }
-                scheduleProgressSyncAfterSeek()
-            }
+            val current = currentPlaybackPositionMs() ?: 0L
+            val maxDuration = currentPlaybackDurationMs().takeIf { it >= 0 } ?: Long.MAX_VALUE
+            val target = (current + event.deltaMs)
+                .coerceAtLeast(0L)
+                .coerceAtMost(maxDuration)
+            seekPlaybackTo(target)
+            _uiState.update { it.copy(currentPosition = target) }
+            scheduleProgressSyncAfterSeek()
             if (_uiState.value.showControls) {
                 showControlsTemporarily()
             } else {
@@ -409,15 +466,13 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnPreviewSeekBy -> {
-            _exoPlayer?.let { player ->
-                val maxDuration = player.duration.takeIf { it >= 0 } ?: Long.MAX_VALUE
-                val basePosition = pendingPreviewSeekPosition ?: player.currentPosition.coerceAtLeast(0L)
-                val target = (basePosition + event.deltaMs)
-                    .coerceAtLeast(0L)
-                    .coerceAtMost(maxDuration)
-                pendingPreviewSeekPosition = target
-                _uiState.update { it.copy(currentPosition = target) }
-            }
+            val maxDuration = currentPlaybackDurationMs().takeIf { it >= 0 } ?: Long.MAX_VALUE
+            val basePosition = pendingPreviewSeekPosition ?: currentPlaybackPositionMs()?.coerceAtLeast(0L) ?: 0L
+            val target = (basePosition + event.deltaMs)
+                .coerceAtLeast(0L)
+                .coerceAtMost(maxDuration)
+            pendingPreviewSeekPosition = target
+            _uiState.update { it.copy(currentPosition = target) }
             if (_uiState.value.showControls) {
                 showControlsTemporarily()
             } else {
@@ -427,7 +482,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         PlayerEvent.OnCommitPreviewSeek -> {
             val target = pendingPreviewSeekPosition
             if (target != null) {
-                _exoPlayer?.seekTo(target)
+                seekPlaybackTo(target)
                 _uiState.update { it.copy(currentPosition = target) }
                 pendingPreviewSeekPosition = null
                 scheduleProgressSyncAfterSeek()
@@ -440,7 +495,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         is PlayerEvent.OnSeekTo -> {
             pendingPreviewSeekPosition = null
-            _exoPlayer?.seekTo(event.position)
+            seekPlaybackTo(event.position)
             _uiState.update { it.copy(currentPosition = event.position) }
             scheduleProgressSyncAfterSeek()
             if (_uiState.value.showControls) {
@@ -496,7 +551,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSetPlaybackSpeed -> {
-            _exoPlayer?.setPlaybackSpeed(event.speed)
+            setPlaybackSpeedInternal(event.speed)
             _uiState.update { 
                 it.copy(
                     playbackSpeed = event.speed,
@@ -678,10 +733,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         PlayerEvent.OnSkipIntro -> {
             _uiState.value.activeSkipInterval?.let { interval ->
-                val duration = _exoPlayer?.duration?.takeIf { it > 0 } ?: Long.MAX_VALUE
+                val duration = currentPlaybackDurationMs().takeIf { it > 0 } ?: Long.MAX_VALUE
                 val seekMs = if (interval.endTime == Double.MAX_VALUE) duration
                              else (interval.endTime * 1000).toLong()
-                _exoPlayer?.seekTo(seekMs.coerceAtMost(duration))
+                seekPlaybackTo(seekMs.coerceAtMost(duration))
                 scheduleProgressSyncAfterSeek()
                 _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = true) }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -42,6 +42,16 @@ internal fun PlayerRuntimeController.showSeekOverlayTemporarily() {
 }
 
 internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {
+    if (isUsingMpvEngine()) {
+        val track = _uiState.value.audioTracks.getOrNull(trackIndex)
+        val trackId = track?.trackId?.toIntOrNull()
+        val changed = trackId != null && mpvView?.selectAudioTrackById(trackId) == true
+        if (changed) {
+            persistRememberedLinkAudioSelection(trackIndex)
+        }
+        return
+    }
+
     _exoPlayer?.let { player ->
         val tracks = player.currentTracks
         var currentAudioIndex = 0
@@ -145,6 +155,20 @@ internal fun PlayerRuntimeController.applyAddonSubtitleOverrideByLanguage(
 }
 
 internal fun PlayerRuntimeController.selectSubtitleTrack(trackIndex: Int) {
+    if (isUsingMpvEngine()) {
+        Log.d(PlayerRuntimeController.TAG, "Selecting INTERNAL subtitle trackIndex=$trackIndex (mpv)")
+        val track = _uiState.value.subtitleTracks.getOrNull(trackIndex)
+        val trackId = track?.trackId?.toIntOrNull()
+        val changed = trackId != null && mpvView?.selectSubtitleTrackById(trackId) == true
+        if (changed) {
+            pendingAddonSubtitleLanguage = null
+            pendingAddonSubtitleTrackId = null
+            pendingAudioSelectionAfterSubtitleRefresh = null
+            updateMpvAvailableTracks()
+        }
+        return
+    }
+
     _exoPlayer?.let { player ->
         Log.d(PlayerRuntimeController.TAG, "Selecting INTERNAL subtitle trackIndex=$trackIndex")
         val tracks = player.currentTracks
@@ -172,6 +196,22 @@ internal fun PlayerRuntimeController.selectSubtitleTrack(trackIndex: Int) {
 }
 
 internal fun PlayerRuntimeController.disableSubtitles() {
+    if (isUsingMpvEngine()) {
+        if (mpvView?.disableSubtitles() == true) {
+            pendingAddonSubtitleLanguage = null
+            pendingAddonSubtitleTrackId = null
+            pendingAudioSelectionAfterSubtitleRefresh = null
+            _uiState.update {
+                it.copy(
+                    selectedAddonSubtitle = null,
+                    selectedSubtitleTrackIndex = -1
+                )
+            }
+            updateMpvAvailableTracks()
+        }
+        return
+    }
+
     _exoPlayer?.let { player ->
         player.trackSelectionParameters = player.trackSelectionParameters
             .buildUpon()
@@ -205,6 +245,28 @@ internal fun PlayerRuntimeController.toSubtitleConfiguration(subtitle: Subtitle)
 }
 
 internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
+    if (isUsingMpvEngine()) {
+        val currentlySelected = _uiState.value.selectedAddonSubtitle
+        if (currentlySelected?.id == subtitle.id && currentlySelected.url == subtitle.url) {
+            return
+        }
+        Log.d(PlayerRuntimeController.TAG, "Selecting ADDON subtitle lang=${subtitle.lang} id=${subtitle.id} (mpv)")
+        val added = mpvView?.addAndSelectExternalSubtitle(subtitle.url) == true
+        if (!added) return
+
+        pendingAddonSubtitleLanguage = null
+        pendingAddonSubtitleTrackId = null
+        pendingAudioSelectionAfterSubtitleRefresh = null
+        _uiState.update {
+            it.copy(
+                selectedAddonSubtitle = subtitle,
+                selectedSubtitleTrackIndex = -1
+            )
+        }
+        updateMpvAvailableTracks()
+        return
+    }
+
     _exoPlayer?.let { player ->
         val currentlySelected = _uiState.value.selectedAddonSubtitle
         if (currentlySelected?.id == subtitle.id && currentlySelected.url == subtitle.url) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -43,11 +43,13 @@ internal fun PlayerRuntimeController.showSeekOverlayTemporarily() {
 
 internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {
     if (isUsingMpvEngine()) {
+        val wasPlaying = isPlaybackCurrentlyPlaying()
         val track = _uiState.value.audioTracks.getOrNull(trackIndex)
         val trackId = track?.trackId?.toIntOrNull()
         val changed = trackId != null && mpvView?.selectAudioTrackById(trackId) == true
         if (changed) {
             persistRememberedLinkAudioSelection(trackIndex)
+            keepMpvPlayingIfNeeded(wasPlaying)
         }
         return
     }
@@ -157,6 +159,7 @@ internal fun PlayerRuntimeController.applyAddonSubtitleOverrideByLanguage(
 internal fun PlayerRuntimeController.selectSubtitleTrack(trackIndex: Int) {
     if (isUsingMpvEngine()) {
         Log.d(PlayerRuntimeController.TAG, "Selecting INTERNAL subtitle trackIndex=$trackIndex (mpv)")
+        val shouldKeepPlaying = !userPausedManually && !_uiState.value.playbackEnded
         val track = _uiState.value.subtitleTracks.getOrNull(trackIndex)
         val trackId = track?.trackId?.toIntOrNull()
         val changed = trackId != null && mpvView?.selectSubtitleTrackById(trackId) == true
@@ -165,6 +168,7 @@ internal fun PlayerRuntimeController.selectSubtitleTrack(trackIndex: Int) {
             pendingAddonSubtitleTrackId = null
             pendingAudioSelectionAfterSubtitleRefresh = null
             updateMpvAvailableTracks()
+            keepMpvPlayingIfNeeded(shouldKeepPlaying)
         }
         return
     }
@@ -251,7 +255,14 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
             return
         }
         Log.d(PlayerRuntimeController.TAG, "Selecting ADDON subtitle lang=${subtitle.lang} id=${subtitle.id} (mpv)")
-        val added = mpvView?.addAndSelectExternalSubtitle(subtitle.url) == true
+        val wasPlaying = isPlaybackCurrentlyPlaying()
+        val normalizedLang = PlayerSubtitleUtils.normalizeLanguageCode(subtitle.lang)
+        val trackTitle = buildAddonSubtitleTrackId(subtitle)
+        val added = mpvView?.addAndSelectExternalSubtitle(
+            url = subtitle.url,
+            title = trackTitle,
+            language = normalizedLang
+        ) == true
         if (!added) return
 
         pendingAddonSubtitleLanguage = null
@@ -264,6 +275,7 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
             )
         }
         updateMpvAvailableTracks()
+        keepMpvPlayingIfNeeded(wasPlaying)
         return
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -434,7 +434,11 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         return
     }
 
-    val playerReady = _exoPlayer?.playbackState == Player.STATE_READY
+    val playerReady = if (isUsingMpvEngine()) {
+        mpvView != null
+    } else {
+        _exoPlayer?.playbackState == Player.STATE_READY
+    }
     if (!playerReady) {
         Log.d(PlayerRuntimeController.TAG, "AUTO_SUB defer addon fallback: player not ready")
         return
@@ -531,6 +535,20 @@ internal fun PlayerRuntimeController.startFrameRateProbe(
 }
 
 internal fun PlayerRuntimeController.applySubtitlePreferences(preferred: String, secondary: String?) {
+    if (isUsingMpvEngine()) {
+        mpvView?.applySubtitleLanguagePreferences(preferred, secondary)
+        if (preferred == "none") {
+            mpvView?.disableSubtitles()
+            _uiState.update {
+                it.copy(
+                    selectedSubtitleTrackIndex = -1,
+                    selectedAddonSubtitle = null
+                )
+            }
+        }
+        return
+    }
+
     _exoPlayer?.let { player ->
         val builder = player.trackSelectionParameters.buildUpon()
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -485,6 +485,7 @@ fun PlayerScreen(
                 },
                 update = { view ->
                     viewModel.attachMpvView(view)
+                    view.applySubtitleStyle(uiState.subtitleStyle)
                 },
                 modifier = Modifier.fillMaxSize()
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -103,6 +103,7 @@ import coil.request.ImageRequest
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
 import com.nuvio.tv.core.player.ExternalPlayerLauncher
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.theme.NuvioColors
 import android.text.format.DateFormat
@@ -194,7 +195,7 @@ fun PlayerScreen(
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
                 Lifecycle.Event.ON_PAUSE -> {
-                    viewModel.exoPlayer?.pause()
+                    viewModel.pauseForLifecycle()
                 }
                 Lifecycle.Event.ON_RESUME -> {
                     // Don't auto-resume, let user control
@@ -475,70 +476,89 @@ fun PlayerScreen(
             }
     ) {
         // Video Player
-        viewModel.exoPlayer?.let { player ->
-            val subtitleStyle = uiState.subtitleStyle
-            val resizeMode = uiState.resizeMode
-            
+        if (uiState.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
             AndroidView(
                 factory = { context ->
-                    PlayerView(context).apply {
-                        this.player = player
-                        useController = false
-                        keepScreenOn = true
-                        setShowBuffering(PlayerView.SHOW_BUFFERING_NEVER)
+                    NuvioMpvSurfaceView(context).also { view ->
+                        viewModel.attachMpvView(view)
                     }
                 },
-                update = { playerView ->
-                    Log.d("PlayerScreen", "Applying resizeMode: $resizeMode")
-                    playerView.resizeMode = resizeMode
-                    playerView.subtitleView?.apply {
-                        // Calculate font size based on percentage (100% = 24sp base)
-                        val baseFontSize = 24f
-                        val scaledFontSize = baseFontSize * (subtitleStyle.size / 100f)
-                        setFixedTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, scaledFontSize)
-                        setApplyEmbeddedFontSizes(false)
-                        
-                        // Apply bold style via typeface
-                        val typeface = if (subtitleStyle.bold) {
-                            android.graphics.Typeface.DEFAULT_BOLD
-                        } else {
-                            android.graphics.Typeface.DEFAULT
-                        }
-                        
-                        // Calculate edge type based on outline setting
-                        val edgeType = if (subtitleStyle.outlineEnabled) {
-                            androidx.media3.ui.CaptionStyleCompat.EDGE_TYPE_OUTLINE
-                        } else {
-                            androidx.media3.ui.CaptionStyleCompat.EDGE_TYPE_NONE
-                        }
-                        
-                        setStyle(
-                            androidx.media3.ui.CaptionStyleCompat(
-                                subtitleStyle.textColor,
-                                subtitleStyle.backgroundColor,
-                                android.graphics.Color.TRANSPARENT, // Window color
-                                edgeType,
-                                subtitleStyle.outlineColor,
-                                typeface
-                            )
-                        )
-                        
-                        setApplyEmbeddedStyles(false)
-                        
-                        // Apply vertical offset (-20 = very bottom, 0 = default, 50 = middle)
-                        // Convert percentage to fraction for bottom padding
-                        val bottomPaddingFraction = (0.06f + (subtitleStyle.verticalOffset / 250f)).coerceIn(0f, 0.4f)
-                        setBottomPaddingFraction(bottomPaddingFraction)
-
-                        // Also apply explicit bottom padding based on view height for stronger offset effect
-                        post {
-                            val extraPadding = (height * (subtitleStyle.verticalOffset / 400f)).toInt().coerceAtLeast(0)
-                            setPadding(paddingLeft, paddingTop, paddingRight, extraPadding)
-                        }
-                    }
+                update = { view ->
+                    viewModel.attachMpvView(view)
                 },
                 modifier = Modifier.fillMaxSize()
             )
+            DisposableEffect(Unit) {
+                onDispose {
+                    viewModel.attachMpvView(null)
+                }
+            }
+        } else {
+            viewModel.exoPlayer?.let { player ->
+                val subtitleStyle = uiState.subtitleStyle
+                val resizeMode = uiState.resizeMode
+
+                AndroidView(
+                    factory = { context ->
+                        PlayerView(context).apply {
+                            this.player = player
+                            useController = false
+                            keepScreenOn = true
+                            setShowBuffering(PlayerView.SHOW_BUFFERING_NEVER)
+                        }
+                    },
+                    update = { playerView ->
+                        Log.d("PlayerScreen", "Applying resizeMode: $resizeMode")
+                        playerView.resizeMode = resizeMode
+                        playerView.subtitleView?.apply {
+                            // Calculate font size based on percentage (100% = 24sp base)
+                            val baseFontSize = 24f
+                            val scaledFontSize = baseFontSize * (subtitleStyle.size / 100f)
+                            setFixedTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, scaledFontSize)
+                            setApplyEmbeddedFontSizes(false)
+
+                            // Apply bold style via typeface
+                            val typeface = if (subtitleStyle.bold) {
+                                android.graphics.Typeface.DEFAULT_BOLD
+                            } else {
+                                android.graphics.Typeface.DEFAULT
+                            }
+
+                            // Calculate edge type based on outline setting
+                            val edgeType = if (subtitleStyle.outlineEnabled) {
+                                androidx.media3.ui.CaptionStyleCompat.EDGE_TYPE_OUTLINE
+                            } else {
+                                androidx.media3.ui.CaptionStyleCompat.EDGE_TYPE_NONE
+                            }
+
+                            setStyle(
+                                androidx.media3.ui.CaptionStyleCompat(
+                                    subtitleStyle.textColor,
+                                    subtitleStyle.backgroundColor,
+                                    android.graphics.Color.TRANSPARENT, // Window color
+                                    edgeType,
+                                    subtitleStyle.outlineColor,
+                                    typeface
+                                )
+                            )
+
+                            setApplyEmbeddedStyles(false)
+
+                            // Apply vertical offset (-20 = very bottom, 0 = default, 50 = middle)
+                            // Convert percentage to fraction for bottom padding
+                            val bottomPaddingFraction = (0.06f + (subtitleStyle.verticalOffset / 250f)).coerceIn(0f, 0.4f)
+                            setBottomPaddingFraction(bottomPaddingFraction)
+
+                            // Also apply explicit bottom padding based on view height for stronger offset effect
+                            post {
+                                val extraPadding = (height * (subtitleStyle.verticalOffset / 400f)).toInt().coerceAtLeast(0)
+                                setPadding(paddingLeft, paddingTop, paddingRight, extraPadding)
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
         }
 
         LoadingOverlay(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -4,6 +4,7 @@ import androidx.media3.common.C
 import androidx.media3.common.TrackGroup
 import androidx.media3.ui.AspectRatioFrameLayout
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.SubtitleOrganizationMode
 import com.nuvio.tv.data.local.SubtitleStyleSettings
 import com.nuvio.tv.data.repository.SkipInterval
@@ -116,6 +117,7 @@ data class PlayerUiState(
     val detectedFrameRateSource: FrameRateSource? = null,
     val detectedFrameRate: Float = 0f,
     val afrProbeRunning: Boolean = false,
+    val internalPlayerEngine: InternalPlayerEngine = InternalPlayerEngine.EXOPLAYER,
     val frameRateMatchingMode: FrameRateMatchingMode = FrameRateMatchingMode.OFF,
     val displayModeInfo: DisplayModeInfo? = null,
     val showDisplayModeInfo: Boolean = false,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -88,6 +88,14 @@ class PlayerViewModel @Inject constructor(
         controller.attachHostActivity(activity)
     }
 
+    fun attachMpvView(view: NuvioMpvSurfaceView?) {
+        controller.attachMpvView(view)
+    }
+
+    fun pauseForLifecycle() {
+        controller.pauseForLifecycle()
+    }
+
     fun startInitialPlaybackIfNeeded() {
         controller.startInitialPlaybackIfNeeded()
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -153,6 +153,7 @@ fun PlaybackSettingsContent(
     var showNextEpisodeThresholdModeDialog by remember { mutableStateOf(false) }
     var showReuseLastLinkCacheDialog by remember { mutableStateOf(false) }
     var showPlayerPreferenceDialog by remember { mutableStateOf(false) }
+    var showInternalPlayerEngineDialog by remember { mutableStateOf(false) }
 
     fun dismissAllDialogs() {
         showLanguageDialog = false
@@ -173,6 +174,7 @@ fun PlaybackSettingsContent(
         showNextEpisodeThresholdModeDialog = false
         showReuseLastLinkCacheDialog = false
         showPlayerPreferenceDialog = false
+        showInternalPlayerEngineDialog = false
     }
 
     fun openDialog(setter: () -> Unit) {
@@ -199,6 +201,7 @@ fun PlaybackSettingsContent(
                 playerSettings = playerSettings,
                 trailerSettings = trailerSettings,
                 onShowPlayerPreferenceDialog = { openDialog { showPlayerPreferenceDialog = true } },
+                onShowInternalPlayerEngineDialog = { openDialog { showInternalPlayerEngineDialog = true } },
                 onShowAudioLanguageDialog = { openDialog { showAudioLanguageDialog = true } },
                 onShowSecondaryAudioLanguageDialog = { openDialog { showSecondaryAudioLanguageDialog = true } },
                 onShowDecoderPriorityDialog = { openDialog { showDecoderPriorityDialog = true } },
@@ -259,6 +262,7 @@ fun PlaybackSettingsContent(
         installedAddonNames = installedAddonNames,
         enabledPluginNames = enabledPluginNames,
         showPlayerPreferenceDialog = showPlayerPreferenceDialog,
+        showInternalPlayerEngineDialog = showInternalPlayerEngineDialog,
         showLanguageDialog = showLanguageDialog,
         showSecondaryLanguageDialog = showSecondaryLanguageDialog,
         showSubtitleOrganizationDialog = showSubtitleOrganizationDialog,
@@ -280,6 +284,10 @@ fun PlaybackSettingsContent(
             coroutineScope.launch { viewModel.setPlayerPreference(preference) }
         },
         onDismissPlayerPreferenceDialog = ::dismissAllDialogs,
+        onSetInternalPlayerEngine = { engine ->
+            coroutineScope.launch { viewModel.setInternalPlayerEngine(engine) }
+        },
+        onDismissInternalPlayerEngineDialog = ::dismissAllDialogs,
         onSetSubtitlePreferredLanguage = { language ->
             coroutineScope.launch { viewModel.setSubtitlePreferredLanguage(language ?: "none") }
         },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -55,6 +55,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.TrailerSettings
@@ -74,7 +75,8 @@ private data class PlaybackGeneralUi(
 )
 
 private data class PlaybackStreamSelectionUi(
-    val playerPreferenceLabel: String
+    val playerPreferenceLabel: String,
+    val internalEngineLabel: String
 )
 
 private fun frameRateMatchingModeLabel(mode: FrameRateMatchingMode, off: String, onStart: String, onStartStop: String): String {
@@ -91,6 +93,7 @@ internal fun PlaybackSettingsSections(
     playerSettings: PlayerSettings,
     trailerSettings: TrailerSettings,
     onShowPlayerPreferenceDialog: () -> Unit,
+    onShowInternalPlayerEngineDialog: () -> Unit,
     onShowAudioLanguageDialog: () -> Unit,
     onShowSecondaryAudioLanguageDialog: () -> Unit,
     onShowDecoderPriorityDialog: () -> Unit,
@@ -171,6 +174,10 @@ internal fun PlaybackSettingsSections(
             PlayerPreference.INTERNAL -> stringResource(R.string.playback_player_internal)
             PlayerPreference.EXTERNAL -> stringResource(R.string.playback_player_external)
             PlayerPreference.ASK_EVERY_TIME -> stringResource(R.string.playback_player_ask)
+        },
+        internalEngineLabel = when (playerSettings.internalPlayerEngine) {
+            InternalPlayerEngine.EXOPLAYER -> stringResource(R.string.playback_engine_exoplayer)
+            InternalPlayerEngine.MVP_PLAYER -> stringResource(R.string.playback_engine_mvplayer)
         }
     )
 
@@ -299,6 +306,17 @@ internal fun PlaybackSettingsSections(
                     subtitle = streamSelectionUi.playerPreferenceLabel,
                     onClick = onShowPlayerPreferenceDialog,
                     onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION }
+                )
+            }
+
+            item(key = "stream_internal_player_engine") {
+                NavigationSettingsItem(
+                    icon = Icons.Default.PlayArrow,
+                    title = stringResource(R.string.playback_internal_player_engine),
+                    subtitle = streamSelectionUi.internalEngineLabel,
+                    onClick = onShowInternalPlayerEngineDialog,
+                    onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
+                    enabled = playerSettings.playerPreference != PlayerPreference.EXTERNAL
                 )
             }
 
@@ -496,6 +514,7 @@ internal fun PlaybackSettingsDialogsHost(
     installedAddonNames: List<String>,
     enabledPluginNames: List<String>,
     showPlayerPreferenceDialog: Boolean,
+    showInternalPlayerEngineDialog: Boolean,
     showLanguageDialog: Boolean,
     showSecondaryLanguageDialog: Boolean,
     showSubtitleOrganizationDialog: Boolean,
@@ -515,6 +534,8 @@ internal fun PlaybackSettingsDialogsHost(
     showReuseLastLinkCacheDialog: Boolean,
     onSetPlayerPreference: (PlayerPreference) -> Unit,
     onDismissPlayerPreferenceDialog: () -> Unit,
+    onSetInternalPlayerEngine: (InternalPlayerEngine) -> Unit,
+    onDismissInternalPlayerEngineDialog: () -> Unit,
     onSetSubtitlePreferredLanguage: (String?) -> Unit,
     onSetSubtitleSecondaryLanguage: (String?) -> Unit,
     onSetSubtitleOrganizationMode: (com.nuvio.tv.data.local.SubtitleOrganizationMode) -> Unit,
@@ -558,6 +579,17 @@ internal fun PlaybackSettingsDialogsHost(
                 onDismissPlayerPreferenceDialog()
             },
             onDismiss = onDismissPlayerPreferenceDialog
+        )
+    }
+
+    if (showInternalPlayerEngineDialog) {
+        InternalPlayerEngineDialog(
+            currentEngine = playerSettings.internalPlayerEngine,
+            onEngineSelected = { engine ->
+                onSetInternalPlayerEngine(engine)
+                onDismissInternalPlayerEngineDialog()
+            },
+            onDismiss = onDismissInternalPlayerEngineDialog
         )
     }
 
@@ -671,6 +703,101 @@ private fun PlayerPreferenceDialog(
 
                     Card(
                         onClick = { onPreferenceSelected(preference) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(if (index == 0) Modifier.focusRequester(focusRequester) else Modifier),
+                        colors = CardDefaults.colors(
+                            containerColor = if (isSelected) NuvioColors.FocusBackground else NuvioColors.BackgroundCard,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        shape = CardDefaults.shape(shape = RoundedCornerShape(10.dp)),
+                        scale = CardDefaults.scale(focusedScale = 1f)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = title,
+                                    color = if (isSelected) NuvioColors.Primary else NuvioColors.TextPrimary,
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = description,
+                                    color = NuvioColors.TextSecondary,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                            if (isSelected) {
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = stringResource(R.string.cd_selected),
+                                    tint = NuvioColors.Primary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InternalPlayerEngineDialog(
+    currentEngine: InternalPlayerEngine,
+    onEngineSelected: (InternalPlayerEngine) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    val options = listOf(
+        Triple(
+            InternalPlayerEngine.EXOPLAYER,
+            stringResource(R.string.playback_engine_exoplayer),
+            stringResource(R.string.playback_engine_exoplayer_desc)
+        ),
+        Triple(
+            InternalPlayerEngine.MVP_PLAYER,
+            stringResource(R.string.playback_engine_mvplayer),
+            stringResource(R.string.playback_engine_mvplayer_desc)
+        )
+    )
+
+    NuvioDialog(
+        onDismiss = onDismiss,
+        title = stringResource(R.string.playback_internal_player_engine),
+        width = 420.dp,
+        suppressFirstKeyUp = false
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 320.dp)
+        ) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(vertical = 4.dp)
+            ) {
+                items(
+                    count = options.size,
+                    key = { index -> options[index].first.name }
+                ) { index ->
+                    val (engine, title, description) = options[index]
+                    val isSelected = engine == currentEngine
+
+                    Card(
+                        onClick = { onEngineSelected(engine) },
                         modifier = Modifier
                             .fillMaxWidth()
                             .then(if (index == 0) Modifier.focusRequester(focusRequester) else Modifier),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.settings
 import androidx.lifecycle.ViewModel
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.data.local.LibassRenderType
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.PlayerPreference
@@ -55,6 +56,10 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setPlayerPreference(preference: PlayerPreference) {
         playerSettingsDataStore.setPlayerPreference(preference)
+    }
+
+    suspend fun setInternalPlayerEngine(engine: InternalPlayerEngine) {
+        playerSettingsDataStore.setInternalPlayerEngine(engine)
     }
 
     suspend fun setTrailerEnabled(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,9 @@
     <string name="playback_player_internal">Internal</string>
     <string name="playback_player_external">External</string>
     <string name="playback_player_ask">Ask every time</string>
+    <string name="playback_internal_player_engine">Internal Engine</string>
+    <string name="playback_engine_exoplayer">ExoPlayer</string>
+    <string name="playback_engine_mvplayer">Libmpv (Beta)</string>
     <string name="playback_section_audio">Audio &amp; Trailer</string>
     <string name="playback_section_audio_desc">Trailer behavior and audio controls.</string>
     <string name="playback_section_subtitles">Subtitles</string>
@@ -191,6 +194,8 @@
     <string name="playback_resolution_matching_sub">Allow display mode changes to match video resolution.</string>
     <string name="playback_player_external_desc">Always open streams in an external app</string>
     <string name="playback_player_ask_desc">Choose the player each time</string>
+    <string name="playback_engine_exoplayer_desc">Best compatibility with current Nuvio features.</string>
+    <string name="playback_engine_mvplayer_desc">Uses libmpv with Nuvio OSD controls. Experimental.</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_trailer_section">Trailer</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6144m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError
+# Keep worker concurrency modest to reduce peak memory during APK packaging/splitting.
+org.gradle.workers.max=2
+kotlin.daemon.jvmargs=-Xmx2048m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Summary

Work In Progress

- Added optional `libmpv` internal playback engine while keeping the same in-app UI/OSD.
- Every OSD control working. (subtitles selection, styling, delay, audio change track all working).
- Added new Playback setting: **Internal Engine** (`ExoPlayer` / `Libmpv (Beta)`).
- Implemented mpv surface + runtime integration:
  - `NuvioMpvSurfaceView`
  - `PlayerRuntimeControllerMpv`
  - wiring in `PlayerScreen`, `PlayerViewModel`, and player runtime controller flow.
- Kept ExoPlayer path intact; default internal engine remains `ExoPlayer`.
- Added mpv-android integration and switched to a local nextlib-mediainfo AAR (statically linked FFmpeg) to avoid native libav collisions.

## Why

- Needed to support an alternative internal engine (`libmpv`) for stream compatibility and playback behavior on streams that ExoPlayer fail to open.
- Goal was to let users choose engine without changing the existing player UX (controls, OSD, overlays).
- Full libass support.

## Testing

  Manual runtime testing:
  - Basic validation done. Opens some videos that ExoPlayer fails to open.
  - Full device matrix and long-session playback tests are still pending.

## Screenshots / Video (UI changes only)

- No visual UI layout change (same player UI/OSD.



<img width="630" height="390" alt="image" src="https://github.com/user-attachments/assets/3e5ea2e3-c21f-41b7-9dae-41539789c0c7" />



<img width="1456" height="847" alt="image" src="https://github.com/user-attachments/assets/9b0ddc5e-fe8d-43d4-b4ed-e4ba51fd608d" />



## Breaking changes

- None.
- New setting key introduced for internal engine selection, defaulting to `ExoPlayer` for backward compatibility.

## Linked issues

- mpv is a must since, ExoPlayer fails to open lots of movies.
