### PR TITLE
fix(player): resolve subtitle delay on HLS streams

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -256,6 +256,8 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                             }
                             // Re-evaluate subtitle auto-selection once player is ready.
                             tryAutoSelectPreferredSubtitleFromAvailableTracks()
+
+                            trackSelectionParameters = trackSelectionParameters.buildUpon().build()
                         }
                     
                         

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -316,6 +316,13 @@ internal fun PlayerRuntimeController.adjustSubtitleDelay(deltaMs: Int) {
             showSubtitleDelayOverlay = true
         )
     }
+
+    _exoPlayer?.let { player ->
+        player.trackSelectionParameters = player.trackSelectionParameters
+            .buildUpon()
+            .build()
+    }
+    
     scheduleHideSubtitleDelayOverlay()
 }
 


### PR DESCRIPTION
## Summary

Correcting an issue where the subtitle delay (offset) was reset or not applied immediately during HLS (HTTP Live Streaming) playback caused by loading new stream segments resetting the subtitle delay setting.

Added invalidation of `trackSelectionParameters` within `Player.STATE_READY` in the `onPlaybackStateChanged` receiver.

Also added an immediate update of the track selection within the `adjustSubtitleDelay` function.

This forces the `SubtitleOffsetRenderer` to resynchronize with the updated value of `subtitleDelayUs`, triggering an invalidation in the pipeline that updates the value instantaneously.

## Why

In HLS streams, the player frequently switches between media segments (.ts). Because ExoPlayer buffers and pre-renders subtitles, changes to the `AtomicLong` offset were not always reflected until the next segment was loaded.
In addition, certain HLS transitions caused the `ForwardingRenderer` to lose track of the manual offset. By rebuilding the track selection parameters (`trackSelectionParameters`), the MediaCodec and rendering pipeline are signaled to clear the subtitle cache and reread the offset. This happens instantly and corrects the problem correctly in theory.

## Testing

**Manual Test**: I played an M3U8 and verified that clicking the delay buttons (+/-) results in an immediate change of the subtitle text on the screen, and in tests compared to the previous experience, the delay setting is now maintained throughout the video (it was tested with exactly 6 minutes watched in an M3U8 stream and the delay settings remained).

## Screenshots / Video (UI changes only)

**None**.

<!-- If UI changed, add before/after screenshots or a short clip. -->

## Breaking changes

**None**.

## Linked issues

I myself detected this problem while using the application with m3u8 streams.

