### PR TITLE
Improve Smart player close navigation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -557,33 +557,87 @@ fun NuvioNavHost(
             )
         ) { backStackEntry ->
             PlayerScreen(
-                onBackPress = {
-                    val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
-                    if (!returnedToStream) {
-                        val args = backStackEntry.arguments
-                        val returnToDetailOnBack = args?.getString("returnToDetailOnBack")
-                            ?.toBooleanStrictOrNull() == true
-                        val contentType = args?.getString("contentType").orEmpty()
-                        val contentId = args?.getString("contentId").orEmpty()
-                        if (
-                            returnToDetailOnBack &&
-                            contentType.equals("series", ignoreCase = true) &&
-                            contentId.isNotBlank()
-                        ) {
-                            navController.navigate(
-                                Screen.Detail.createRoute(
-                                    itemId = contentId,
-                                    itemType = contentType,
-                                    addonBaseUrl = null,
-                                    returnFocusSeason = args?.getString("season")?.toIntOrNull(),
-                                    returnFocusEpisode = args?.getString("episode")?.toIntOrNull()
-                                )
-                            ) {
-                                popUpTo(Screen.Player.route) { inclusive = true }
-                                launchSingleTop = true
+                onBackPress = { currentSeason, currentEpisode, autoPlayEnabled ->
+                    val args = backStackEntry.arguments
+                    val initialSeason = args?.getString("season")?.toIntOrNull()
+                    val initialEpisode = args?.getString("episode")?.toIntOrNull()
+                    val episodeChangedInPlace = (currentSeason != null || currentEpisode != null) &&
+                        (currentSeason != initialSeason || currentEpisode != initialEpisode)
+                    val returnToDetailOnBack = args?.getString("returnToDetailOnBack")
+                        ?.toBooleanStrictOrNull() == true
+                    val contentType = args?.getString("contentType").orEmpty()
+                    val contentId = args?.getString("contentId").orEmpty()
+                    val focusSeason = currentSeason ?: initialSeason
+                    val focusEpisode = currentEpisode ?: initialEpisode
+
+                    when {
+                        episodeChangedInPlace && autoPlayEnabled -> {
+                            // autoplay moved to next episode — skip Stream, go to detail
+                            if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
+                                navController.navigate(
+                                    Screen.Detail.createRoute(
+                                        itemId = contentId,
+                                        itemType = contentType,
+                                        addonBaseUrl = null,
+                                        returnFocusSeason = focusSeason,
+                                        returnFocusEpisode = focusEpisode
+                                    )
+                                ) {
+                                    popUpTo(Screen.Player.route) { inclusive = true }
+                                    launchSingleTop = true
+                                }
+                            } else {
+                                navController.popBackStack()
                             }
-                        } else {
-                            navController.popBackStack()
+                        }
+                        episodeChangedInPlace && !autoPlayEnabled -> {
+                            // manual stream switch to next episode — go to Stream of current episode
+                            val videoId = args?.getString("videoId").orEmpty()
+                            if (videoId.isNotBlank() && contentType.isNotBlank()) {
+                                navController.navigate(
+                                    Screen.Stream.createRoute(
+                                        videoId = videoId,
+                                        contentType = contentType,
+                                        title = args?.getString("title").orEmpty(),
+                                        poster = args?.getString("poster"),
+                                        backdrop = args?.getString("backdrop"),
+                                        logo = args?.getString("logo"),
+                                        season = focusSeason,
+                                        episode = focusEpisode,
+                                        year = args?.getString("year"),
+                                        contentId = contentId.takeIf { it.isNotBlank() },
+                                        contentName = args?.getString("contentName"),
+                                        returnToDetailOnBack = returnToDetailOnBack
+                                    )
+                                ) {
+                                    popUpTo(Screen.Player.route) { inclusive = true }
+                                    launchSingleTop = true
+                                }
+                            } else {
+                                navController.popBackStack()
+                            }
+                        }
+                        else -> {
+                            // normal back — try returning to Stream of this episode
+                            val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
+                            if (!returnedToStream) {
+                                if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
+                                    navController.navigate(
+                                        Screen.Detail.createRoute(
+                                            itemId = contentId,
+                                            itemType = contentType,
+                                            addonBaseUrl = null,
+                                            returnFocusSeason = focusSeason,
+                                            returnFocusEpisode = focusEpisode
+                                        )
+                                    ) {
+                                        popUpTo(Screen.Player.route) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                } else {
+                                    navController.popBackStack()
+                                }
+                            }
                         }
                     }
                 },
@@ -612,7 +666,7 @@ fun NuvioNavHost(
                             returnToDetailOnBack = returnToDetailOnBack
                         )
                         navController.navigate(route) {
-                            popUpTo(Screen.Stream.route) { inclusive = true }
+                            popUpTo(Screen.Player.route) { inclusive = true }
                             launchSingleTop = true
                         }
                     } else if (contentId.isNotBlank() && contentType.isNotBlank()) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -182,6 +182,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             }
             streamReuseLastLinkEnabled = settings.streamReuseLastLinkEnabled
             streamAutoPlayModeSetting = settings.streamAutoPlayMode
+            _uiState.update { it.copy(streamAutoPlayMode = settings.streamAutoPlayMode) }
             streamAutoPlayNextEpisodeEnabledSetting = settings.streamAutoPlayNextEpisodeEnabled
             streamAutoPlayPreferBingeGroupForNextEpisodeSetting =
                 settings.streamAutoPlayPreferBingeGroupForNextEpisode

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -103,6 +103,7 @@ import coil.request.ImageRequest
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
 import com.nuvio.tv.core.player.ExternalPlayerLauncher
+import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.theme.NuvioColors
 import android.text.format.DateFormat
@@ -114,8 +115,8 @@ import kotlinx.coroutines.delay
 @Composable
 fun PlayerScreen(
     viewModel: PlayerViewModel = hiltViewModel(),
-    onBackPress: () -> Unit,
-    onPlaybackErrorBack: () -> Unit = onBackPress,
+    onBackPress: (currentSeason: Int?, currentEpisode: Int?, autoPlayEnabled: Boolean) -> Unit,
+    onPlaybackErrorBack: () -> Unit = { onBackPress(null, null, false) },
     onPlaybackEnded: ((nextVideoId: String?, nextSeason: Int?, nextEpisode: Int?) -> Unit)? = null
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -131,7 +132,7 @@ fun PlayerScreen(
     val nextEpisodeFocusRequester = remember { FocusRequester() }
     val exitPlayer: () -> Unit = {
         viewModel.stopAndRelease()
-        onBackPress()
+        onBackPress(uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL)
     }
     val exitPlayerFromError: () -> Unit = {
         viewModel.stopAndRelease()
@@ -184,7 +185,7 @@ fun PlayerScreen(
             if (onPlaybackEnded != null) {
                 onPlaybackEnded(next?.videoId, next?.season, next?.episode)
             } else {
-                onBackPress()
+                onBackPress(uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL)
             }
         }
     }
@@ -743,7 +744,7 @@ fun PlayerScreen(
                     val title = uiState.title
                     val headers = viewModel.getCurrentHeaders()
                     viewModel.stopAndRelease()
-                    onBackPress()
+                    onBackPress(uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL)
                     ExternalPlayerLauncher.launch(
                         context = context,
                         url = url,
@@ -753,7 +754,7 @@ fun PlayerScreen(
                 },
                 onResetHideTimer = { viewModel.scheduleHideControls(); viewModel.onUserInteraction() },
                 onHideControls = { viewModel.hideControls() },
-                onBack = onBackPress,
+                onBack = { exitPlayer() },
                 skipButtonVisible = skipButtonActuallyVisible
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -4,6 +4,7 @@ import androidx.media3.common.C
 import androidx.media3.common.TrackGroup
 import androidx.media3.ui.AspectRatioFrameLayout
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.SubtitleOrganizationMode
 import com.nuvio.tv.data.local.SubtitleStyleSettings
 import com.nuvio.tv.data.repository.SkipInterval
@@ -108,6 +109,7 @@ data class PlayerUiState(
     val nextEpisodeAutoPlaySearching: Boolean = false,
     val nextEpisodeAutoPlaySourceName: String? = null,
     val nextEpisodeAutoPlayCountdownSec: Int? = null,
+    val streamAutoPlayMode: StreamAutoPlayMode = StreamAutoPlayMode.MANUAL,
     // Stream source badge
     val showStreamSourceIndicator: Boolean = false,
     val streamSourceIndicatorText: String = "",


### PR DESCRIPTION
## Summary

- Pressing back after watching an episode that was reached via binge group or autoplay now correctly returns to the show detail screen instead of the previous episode's stream selection
- When autoplay is enabled and the episode changed in-place (`switchToEpisodeStream`), back skips the Stream screen and navigates directly to detail with focus on the current episode
- When autoplay is disabled and the episode changed in-place (manual stream switch from panel), back navigates to the Stream screen of the current episode
- Normal back (no episode change) retains existing behavior - returns to Stream screen if available, otherwise to detail
- `returnFocusSeason`/`returnFocusEpisode` now reflect the actually played episode, not the initial navigation argument

## Why

Bug introduced in #567 - not all back navigation paths were considered when implementing the next-episode stream display. When `switchToEpisodeStream` changed the episode in-place, the back stack still contained `Stream(ep1)`, causing back to return there instead of detail.

## Testing
- Watch episode 1, let it finish, autoplay enabled to episode 2 -> press back -> goes to detail with focus on episode 2 
- Watch episode 1, manually select episode 2 stream -> press back -> goes to Stream screen of episode 2 
- Watch episode 1, press back manually (no episode change, no autoplay enabled) -> goes back to Stream 
- Watch episode 1, press back manually (no episode change, autoplay enabled) -> goes back to Details 

## Screenshots / Video (UI changes only)

None

## Breaking changes

Should not break anything

## Linked issues

Should fix #622