### PR TITLE
resolve back stack issues in autoplay navigation flow

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -581,17 +581,25 @@ fun NuvioNavHost(
                         episodeChangedInPlace && autoPlayEnabled -> {
                             // autoplay moved to next episode — skip Stream, go to detail
                             if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
-                                navController.navigate(
-                                    Screen.Detail.createRoute(
-                                        itemId = contentId,
-                                        itemType = contentType,
-                                        addonBaseUrl = null,
-                                        returnFocusSeason = focusSeason,
-                                        returnFocusEpisode = focusEpisode
-                                    )
-                                ) {
-                                    popUpTo(Screen.Stream.route) { inclusive = true }
-                                    launchSingleTop = true
+                                val detailOnStack = navController.previousBackStackEntry
+                                    ?.destination?.route?.startsWith("detail/") == true
+                                if (detailOnStack) {
+                                    navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusSeason", focusSeason)
+                                    navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusEpisode", focusEpisode)
+                                    navController.popBackStack()
+                                } else {
+                                    navController.navigate(
+                                        Screen.Detail.createRoute(
+                                            itemId = contentId,
+                                            itemType = contentType,
+                                            addonBaseUrl = null,
+                                            returnFocusSeason = focusSeason,
+                                            returnFocusEpisode = focusEpisode
+                                        )
+                                    ) {
+                                        popUpTo(Screen.Player.route) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
                                 }
                             } else {
                                 navController.popBackStack()
@@ -629,17 +637,25 @@ fun NuvioNavHost(
                             val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
                             if (!returnedToStream) {
                                 if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
-                                    navController.navigate(
-                                        Screen.Detail.createRoute(
-                                            itemId = contentId,
-                                            itemType = contentType,
-                                            addonBaseUrl = null,
-                                            returnFocusSeason = focusSeason,
-                                            returnFocusEpisode = focusEpisode
-                                        )
-                                    ) {
-                                        popUpTo(Screen.Stream.route) { inclusive = true }
-                                        launchSingleTop = true
+                                    val detailOnStack = navController.previousBackStackEntry
+                                        ?.destination?.route?.startsWith("detail/") == true
+                                    if (detailOnStack) {
+                                        navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusSeason", focusSeason)
+                                        navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusEpisode", focusEpisode)
+                                        navController.popBackStack()
+                                    } else {
+                                        navController.navigate(
+                                            Screen.Detail.createRoute(
+                                                itemId = contentId,
+                                                itemType = contentType,
+                                                addonBaseUrl = null,
+                                                returnFocusSeason = focusSeason,
+                                                returnFocusEpisode = focusEpisode
+                                            )
+                                        ) {
+                                            popUpTo(Screen.Player.route) { inclusive = true }
+                                            launchSingleTop = true
+                                        }
                                     }
                                 } else {
                                     navController.popBackStack()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -934,9 +934,13 @@ private fun MetaDetailsContent(
         byEpisodeId.keys.retainAll(episodesForSeason.map { it.id }.toSet())
         byEpisodeId
     }
-    val seasonDownFocusRequester = remember(selectedSeason, episodesForSeason, seasonEpisodeFocusRequesters, lastFocusedEpisodeIdBySeason[selectedSeason], nextToWatch) {
-        val nextEpisodeId = nextToWatch?.nextVideoId
-            ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
+    val seasonDownFocusRequester = remember(selectedSeason, episodesForSeason, seasonEpisodeFocusRequesters, lastFocusedEpisodeIdBySeason[selectedSeason], nextToWatch, pendingRestoreType, pendingRestoreEpisodeId) {
+        val nextEpisodeId = if (pendingRestoreType == RestoreTarget.EPISODE) {
+            null
+        } else {
+            nextToWatch?.nextVideoId
+                ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
+        }
         val preferredEpisodeId = lastFocusedEpisodeIdBySeason[selectedSeason]
             ?: nextEpisodeId?.takeIf { episodesForSeason.any { ep -> ep.id == it } }
         (preferredEpisodeId?.let { seasonEpisodeFocusRequesters[it] })
@@ -1225,7 +1229,7 @@ private fun MetaDetailsContent(
                             onEpisodeFocused = { episodeId ->
                                 lastFocusedEpisodeIdBySeason[selectedSeason] = episodeId
                             },
-                            scrollToEpisodeId = if (lastFocusedEpisodeIdBySeason[selectedSeason] == null) {
+                            scrollToEpisodeId = if (lastFocusedEpisodeIdBySeason[selectedSeason] == null && pendingRestoreType != RestoreTarget.EPISODE) {
                                 nextToWatch?.nextVideoId
                                     ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
                             } else null


### PR DESCRIPTION
## Summary
Fixed back navigation getting stuck in a loop when autoplay is enabled
and the Stream screen is removed from the back stack. Also suppressed
incorrect next-to-watch focus when returning to detail from player.


## PR type

- Bug fix

## Why
When autoplay resolves a stream directly (skipping the Stream screen via
popUpTo(Stream) { inclusive = true }), pressing back from the player
caused a navigation loop or landed on a duplicate Detail screen.
Additionally, returning to the detail screen after watching an episode
incorrectly scrolled/focused the next-to-watch episode instead of the
one that was just played.


## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manually tested the following back navigation paths with autoplay enabled:

- Episode → back → Detail → back → Home (no loop)
- Episode → autoplay advances to next episode → back → Detail
  (correct episode focused) → back → Home
- Episode → back → Detail → back → player reappears (fixed)


## Breaking changes

Nothing should break 

## Linked issues
Reported on discord
