### PR TITLE
feat: DNS over HTTPS support with in-memory caching

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,6 +206,7 @@ dependencies {
     implementation(libs.retrofit.moshi)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
+    implementation(libs.okhttp.dnsoverhttps)
     implementation(libs.moshi)
     ksp(libs.moshi.codegen)
 

--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -17,6 +17,14 @@ import com.nuvio.tv.data.remote.api.MDBListApi
 import com.nuvio.tv.data.remote.api.ParentalGuideApi
 import com.nuvio.tv.data.remote.api.SeriesGraphApi
 import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.core.network.addAdGuardDns
+import com.nuvio.tv.core.network.addCanadianShieldDns
+import com.nuvio.tv.core.network.addCloudFlareDns
+import com.nuvio.tv.core.network.addDNSWatchDns
+import com.nuvio.tv.core.network.addDnsSbDns
+import com.nuvio.tv.core.network.addGoogleDns
+import com.nuvio.tv.core.network.addQuad9Dns
+import kotlinx.coroutines.flow.first
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -52,15 +60,45 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(@ApplicationContext context: Context): OkHttpClient = OkHttpClient.Builder()
-        .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .addInterceptor(HttpLoggingInterceptor().apply {
-            level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
-                    else HttpLoggingInterceptor.Level.NONE
-        })
-        .build()
+    fun provideOkHttpClient(
+        @ApplicationContext context: Context,
+        networkSettingsDataStore: com.nuvio.tv.data.local.NetworkSettingsDataStore
+    ): OkHttpClient {
+        val dns = kotlinx.coroutines.runBlocking { networkSettingsDataStore.dnsProvider.first() }
+        var builder = OkHttpClient.Builder()
+            .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
+                        else HttpLoggingInterceptor.Level.NONE
+            })
+            .eventListenerFactory(object : okhttp3.EventListener.Factory {
+                override fun create(call: okhttp3.Call): okhttp3.EventListener {
+                    return object : okhttp3.EventListener() {
+                        override fun dnsStart(call: okhttp3.Call, domainName: String) {
+                            Log.d("NuvioDNS", "DNS Resolving: $domainName")
+                        }
+                        override fun dnsEnd(call: okhttp3.Call, domainName: String, inetAddressList: List<java.net.InetAddress>) {
+                            Log.d("NuvioDNS", "DNS Resolved: $domainName -> ${inetAddressList.joinToString { it.hostAddress ?: "" }}")
+                        }
+                    }
+                }
+            })
+            
+        builder = when (dns) {
+            1 -> builder.addGoogleDns()
+            2 -> builder.addCloudFlareDns()
+            4 -> builder.addAdGuardDns()
+            5 -> builder.addDNSWatchDns()
+            6 -> builder.addQuad9Dns()
+            7 -> builder.addDnsSbDns()
+            8 -> builder.addCanadianShieldDns()
+            else -> builder
+        }
+            
+        return builder.build()
+    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/nuvio/tv/core/network/DohProviders.kt
+++ b/app/src/main/java/com/nuvio/tv/core/network/DohProviders.kt
@@ -1,0 +1,86 @@
+package com.nuvio.tv.core.network
+
+import okhttp3.Dns
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import java.net.InetAddress
+import java.util.concurrent.ConcurrentHashMap
+
+class CachedDns(private val delegate: Dns) : Dns {
+    private val cache = ConcurrentHashMap<String, CachedRecord>()
+
+    private data class CachedRecord(
+        val ips: List<InetAddress>,
+        val expiresAt: Long
+    )
+
+    override fun lookup(hostname: String): List<InetAddress> {
+        val now = System.currentTimeMillis()
+        val cached = cache[hostname]
+        if (cached != null && cached.expiresAt > now) {
+            return cached.ips
+        }
+
+        // Prevent multiple threads from resolving the same hostname concurrently
+        synchronized(this) {
+            val syncCached = cache[hostname]
+            if (syncCached != null && syncCached.expiresAt > now) {
+                return syncCached.ips
+            }
+            
+            val ips = delegate.lookup(hostname)
+            // Cache DNS lookup for 10 minutes to significantly speed up API requests
+            cache[hostname] = CachedRecord(ips, System.currentTimeMillis() + 10 * 60 * 1000L) 
+            return ips
+        }
+    }
+}
+
+fun OkHttpClient.Builder.addGenericDns(url: String, ips: List<String>) = dns(
+    CachedDns(
+        DnsOverHttps
+            .Builder()
+            .client(build())
+            .url(url.toHttpUrl())
+            .bootstrapDnsHosts(
+                ips.map { InetAddress.getByName(it) }
+            )
+            .build()
+    )
+)
+
+fun OkHttpClient.Builder.addGoogleDns() = addGenericDns(
+    "https://dns.google/dns-query",
+    listOf("8.8.4.4", "8.8.8.8")
+)
+
+fun OkHttpClient.Builder.addCloudFlareDns() = addGenericDns(
+    "https://cloudflare-dns.com/dns-query",
+    listOf("1.1.1.1", "1.0.0.1", "2606:4700:4700::1111", "2606:4700:4700::1001")
+)
+
+fun OkHttpClient.Builder.addAdGuardDns() = addGenericDns(
+    "https://dns.adguard.com/dns-query",
+    listOf("94.140.14.140", "94.140.14.141")
+)
+
+fun OkHttpClient.Builder.addDNSWatchDns() = addGenericDns(
+    "https://resolver2.dns.watch/dns-query",
+    listOf("84.200.69.80", "84.200.70.40")
+)
+
+fun OkHttpClient.Builder.addQuad9Dns() = addGenericDns(
+    "https://dns.quad9.net/dns-query",
+    listOf("9.9.9.9", "149.112.112.112")
+)
+
+fun OkHttpClient.Builder.addDnsSbDns() = addGenericDns(
+    "https://doh.dns.sb/dns-query",
+    listOf("185.222.222.222", "45.11.45.11")
+)
+
+fun OkHttpClient.Builder.addCanadianShieldDns() = addGenericDns(
+    "https://private.canadianshield.cira.ca/dns-query",
+    listOf("149.112.121.10", "149.112.122.10")
+)

--- a/app/src/main/java/com/nuvio/tv/data/local/NetworkSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/NetworkSettingsDataStore.kt
@@ -1,0 +1,34 @@
+package com.nuvio.tv.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.networkDataStore: DataStore<Preferences> by preferencesDataStore(name = "network_settings")
+
+@Singleton
+class NetworkSettingsDataStore @Inject constructor(
+    @ApplicationContext val context: Context
+) {
+    val dataStore = context.networkDataStore
+
+    private val dnsProviderKey = intPreferencesKey("dns_provider")
+
+    val dnsProvider: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[dnsProviderKey] ?: 0
+    }
+
+    suspend fun setDnsProvider(provider: Int) {
+        dataStore.edit { prefs ->
+            prefs[dnsProviderKey] = provider
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsViewModel.kt
@@ -1,0 +1,29 @@
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.data.local.NetworkSettingsDataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NetworkSettingsViewModel @Inject constructor(
+    private val networkSettingsDataStore: NetworkSettingsDataStore
+) : ViewModel() {
+
+    val dnsProvider: StateFlow<Int> = networkSettingsDataStore.dnsProvider.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = 0
+    )
+
+    fun setDnsProvider(provider: Int) {
+        viewModelScope.launch {
+            networkSettingsDataStore.setDnsProvider(provider)
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -133,6 +133,10 @@ fun PlaybackSettingsContent(
     val trailerSettings by viewModel.trailerSettings.collectAsStateWithLifecycle(initialValue = TrailerSettings())
     val installedAddonNames by viewModel.installedAddonNames.collectAsStateWithLifecycle(initialValue = emptyList())
     val enabledPluginNames by viewModel.enabledPluginNames.collectAsStateWithLifecycle(initialValue = emptyList())
+    
+    val networkViewModel: com.nuvio.tv.ui.screens.settings.NetworkSettingsViewModel = hiltViewModel()
+    val dnsProvider by networkViewModel.dnsProvider.collectAsStateWithLifecycle()
+    
     val coroutineScope = rememberCoroutineScope()
 
     // Dialog states
@@ -250,7 +254,9 @@ fun PlaybackSettingsContent(
                 onSetSubtitleBold = { bold -> coroutineScope.launch { viewModel.setSubtitleBold(bold) } },
                 onSetSubtitleOutlineEnabled = { enabled -> coroutineScope.launch { viewModel.setSubtitleOutlineEnabled(enabled) } },
                 onSetUseLibass = { enabled -> coroutineScope.launch { viewModel.setUseLibass(enabled) } },
-                onSetLibassRenderType = { renderType -> coroutineScope.launch { viewModel.setLibassRenderType(renderType) } }
+                onSetLibassRenderType = { renderType -> coroutineScope.launch { viewModel.setLibassRenderType(renderType) } },
+                dnsProvider = dnsProvider,
+                onSetDnsProvider = { provider -> coroutineScope.launch { networkViewModel.setDnsProvider(provider) } }
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -65,7 +65,8 @@ private enum class PlaybackSection {
     GENERAL,
     STREAM_SELECTION,
     AUDIO_TRAILER,
-    SUBTITLES
+    SUBTITLES,
+    NETWORK
 }
 
 private data class PlaybackGeneralUi(
@@ -129,19 +130,23 @@ internal fun PlaybackSettingsSections(
     onSetSubtitleBold: (Boolean) -> Unit,
     onSetSubtitleOutlineEnabled: (Boolean) -> Unit,
     onSetUseLibass: (Boolean) -> Unit,
-    onSetLibassRenderType: (com.nuvio.tv.data.local.LibassRenderType) -> Unit
+    onSetLibassRenderType: (com.nuvio.tv.data.local.LibassRenderType) -> Unit,
+    dnsProvider: Int,
+    onSetDnsProvider: (Int) -> Unit
 ) {
     var generalExpanded by rememberSaveable { mutableStateOf(false) }
     var afrExpanded by rememberSaveable { mutableStateOf(false) }
     var streamExpanded by rememberSaveable { mutableStateOf(false) }
     var audioTrailerExpanded by rememberSaveable { mutableStateOf(false) }
     var subtitlesExpanded by rememberSaveable { mutableStateOf(false) }
+    var networkExpanded by rememberSaveable { mutableStateOf(false) }
 
     val defaultGeneralHeaderFocus = remember { FocusRequester() }
     val afrHeaderFocus = remember { FocusRequester() }
     val streamHeaderFocus = remember { FocusRequester() }
     val audioTrailerHeaderFocus = remember { FocusRequester() }
     val subtitlesHeaderFocus = remember { FocusRequester() }
+    val networkHeaderFocus = remember { FocusRequester() }
     val generalHeaderFocus = initialFocusRequester ?: defaultGeneralHeaderFocus
 
     var focusedSection by remember { mutableStateOf<PlaybackSection?>(null) }
@@ -157,6 +162,8 @@ internal fun PlaybackSettingsSections(
     val strSectionAudioDesc = stringResource(R.string.playback_section_audio_desc)
     val strSectionSubtitles = stringResource(R.string.playback_section_subtitles)
     val strSectionSubtitlesDesc = stringResource(R.string.playback_section_subtitles_desc)
+    val strSectionNetwork = stringResource(R.string.settings_network)
+    val strSectionNetworkDesc = stringResource(R.string.settings_network_subtitle)
     val generalUi = PlaybackGeneralUi(
         isExternalPlayer = playerSettings.playerPreference == PlayerPreference.EXTERNAL,
         frameRateMatchingLabel = frameRateMatchingModeLabel(
@@ -192,6 +199,11 @@ internal fun PlaybackSettingsSections(
     LaunchedEffect(subtitlesExpanded, focusedSection) {
         if (!subtitlesExpanded && focusedSection == PlaybackSection.SUBTITLES) {
             subtitlesHeaderFocus.requestFocus()
+        }
+    }
+    LaunchedEffect(networkExpanded, focusedSection) {
+        if (!networkExpanded && focusedSection == PlaybackSection.NETWORK) {
+            networkHeaderFocus.requestFocus()
         }
     }
 
@@ -373,6 +385,25 @@ internal fun PlaybackSettingsSections(
                 enabled = !generalUi.isExternalPlayer
             )
         }
+
+        playbackCollapsibleSection(
+            keyPrefix = "network",
+            title = strSectionNetwork,
+            description = strSectionNetworkDesc,
+            expanded = networkExpanded,
+            onToggle = { networkExpanded = !networkExpanded },
+            focusRequester = networkHeaderFocus,
+            onHeaderFocused = { focusedSection = PlaybackSection.NETWORK }
+        ) {
+            item(key = "network_options") {
+                NetworkDnsOptions(
+                    selectedDns = dnsProvider,
+                    onSelect = onSetDnsProvider,
+                    onFocused = { focusedSection = PlaybackSection.NETWORK },
+                    enabled = true
+                )
+            }
+        }
     }
 }
 
@@ -487,6 +518,44 @@ private fun FrameRateMatchingModeOptions(
             onFocused = onFocused,
             enabled = enabled
         )
+    }
+}
+
+@Composable
+private fun NetworkDnsOptions(
+    selectedDns: Int,
+    onSelect: (Int) -> Unit,
+    onFocused: () -> Unit,
+    enabled: Boolean
+) {
+    val options = listOf(
+        0 to stringResource(R.string.settings_network_system_default),
+        1 to "Google DNS",
+        2 to "Cloudflare",
+        4 to "AdGuard DNS",
+        5 to "DNS.Watch",
+        6 to "Quad9",
+        7 to "DNS.SB",
+        8 to "Canadian Shield"
+    )
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, pair ->
+            val value = pair.first
+            val name = pair.second
+            RenderTypeSettingsItem(
+                title = name,
+                subtitle = if (value == 0) stringResource(R.string.settings_network_system_default_desc) else stringResource(R.string.settings_network_doh_desc, name),
+                isSelected = selectedDns == value,
+                onClick = { onSelect(value) },
+                onFocused = onFocused,
+                enabled = enabled
+            )
+            
+            if (index < options.lastIndex) {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -147,6 +148,7 @@ private fun rememberSettingsSectionSpecs() = listOf(
         subtitle = stringResource(R.string.settings_playback_subtitle),
         destination = SettingsSectionDestination.Inline
     ),
+
     SettingsSectionSpec(
         category = SettingsCategory.TRAKT,
         title = "Trakt",

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -867,4 +867,12 @@
     <string name="update_open_settings">Ayarları Aç</string>
     <string name="update_install">Yükle</string>
     <string name="update_ignore">Atla</string>
+
+    <!-- Network Settings -->
+    <string name="settings_network">Ağ</string>
+    <string name="settings_network_subtitle">DNS ve Güvenli Bağlantı (DoH)</string>
+    <string name="settings_dns_provider">DNS Sağlayıcısı</string>
+    <string name="settings_network_system_default">Sistem Varsayılanı</string>
+    <string name="settings_network_system_default_desc">Yerel cihaz DNS\'i kullanılır</string>
+    <string name="settings_network_doh_desc">%1$s DoH sunucuları</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -983,4 +983,11 @@
     <string name="update_open_settings">Open Settings</string>
     <string name="update_install">Install</string>
     <string name="update_ignore">Ignore</string>
+    <!-- Network Settings -->
+    <string name="settings_network">Network</string>
+    <string name="settings_network_subtitle">DNS and Secure Connection (DoH)</string>
+    <string name="settings_dns_provider">DNS Provider</string>
+    <string name="settings_network_system_default">System Default</string>
+    <string name="settings_network_system_default_desc">Uses local device DNS</string>
+    <string name="settings_network_doh_desc">%1$s DoH servers</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 retrofit-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+okhttp-dnsoverhttps = { group = "com.squareup.okhttp3", name = "okhttp-dnsoverhttps", version.ref = "okhttp" }
 moshi = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 moshi-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 


### PR DESCRIPTION
## Summary

Adds DNS over HTTPS (DoH) support to the playback settings, giving users a way to use secure providers like Cloudflare, Google, or AdGuard. To make sure metadata and posters still load fast, I've also added a simple in-memory DNS cache so we're not constantly hitting the DoH servers for every single image/request.

## PR type

- Small maintenance improvement

## Why

Sometimes local DNS causes ISP blocks or just slows down metadata for TMDB/Stremio add-ons. Adding DoH helps fix that by increasing privacy and bypassing simple DNS restrictions, so metadata/posters load more reliably.

## Policy check

 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual test: Switched DNS to AdGuard in Settings -> Playback -> Network.
- Verified via logcat (`NuvioDNS` tag) that it's hitting `dns.adguard.com` over HTTPS instead of standard port 53.
- Confirmed that images and metadata load quickly with the new `CachedDns` wrapper; it avoids the DoH handshake overhead for repeated requests.
- Verified build/install with `assembleDebug` and `installDebug`.

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

None. The default option is `0` (System Default), so the app's behavior stays exactly the same unless a user manually changes it.

## Linked issues

Improves metadata reliability. No specific issue was linked for this.
