### PR TITLE
ui: improve dropdown highlight and selection visibility

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -416,6 +416,7 @@ private fun LibrarySelectorsRow(
                     .focusRequester(primaryFocusRequester),
                 title = stringResource(R.string.library_filter_list),
                 value = selectedListLabel,
+                selectedValue = selectedListKey,
                 expanded = expandedPicker == "list",
                 options = listTabs.map { LibraryOption(it.title, it.key) },
                 onExpandedChange = { onExpandedChange("list", it) },
@@ -433,6 +434,7 @@ private fun LibrarySelectorsRow(
             },
             title = stringResource(R.string.library_filter_type),
             value = selectedTypeLabel,
+            selectedValue = selectedTypeTab?.key,
             expanded = expandedPicker == "type",
             options = typeTabs.map { LibraryOption(localizedTypeLabel(it.key), it.key) },
             onExpandedChange = { onExpandedChange("type", it) },
@@ -447,6 +449,7 @@ private fun LibrarySelectorsRow(
                     .weight(1f),
                 title = stringResource(R.string.library_filter_sort),
                 value = selectedSortLabel,
+                selectedValue = selectedSortOption.key,
                 expanded = expandedPicker == "sort",
                 options = sortOptions.map { LibraryOption(stringResource(it.labelResId), it.key) },
                 onExpandedChange = { onExpandedChange("sort", it) },
@@ -464,6 +467,7 @@ private fun LibraryDropdownPicker(
     modifier: Modifier = Modifier,
     title: String,
     value: String,
+    selectedValue: String?,
     expanded: Boolean,
     options: List<LibraryOption>,
     onExpandedChange: (Boolean) -> Unit,
@@ -471,6 +475,7 @@ private fun LibraryDropdownPicker(
 ) {
     var isFocused by remember { mutableStateOf(false) }
     var anchorSize by remember { mutableStateOf(IntSize.Zero) }
+    var focusedOptionValue by remember(expanded) { mutableStateOf<String?>(null) }
 
     Box(modifier = modifier) {
         Card(
@@ -533,7 +538,10 @@ private fun LibraryDropdownPicker(
 
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { onExpandedChange(false) },
+            onDismissRequest = {
+                focusedOptionValue = null
+                onExpandedChange(false)
+            },
             modifier = Modifier
                 .width(with(LocalDensity.current) { anchorSize.width.toDp() })
                 .heightIn(max = 320.dp),
@@ -544,18 +552,45 @@ private fun LibraryDropdownPicker(
             border = BorderStroke(1.dp, NuvioColors.Border)
         ) {
             options.forEach { option ->
+                val isSelected = option.value == selectedValue
+                val isOptionFocused = option.value == focusedOptionValue
+                val itemTextColor = when {
+                    isOptionFocused -> NuvioColors.OnSecondary
+                    isSelected -> NuvioColors.TextPrimary
+                    else -> NuvioColors.TextPrimary
+                }
+                val itemBackgroundColor = when {
+                    isOptionFocused -> NuvioColors.Secondary
+                    isSelected -> NuvioColors.FocusBackground
+                    else -> Color.Transparent
+                }
+
                 DropdownMenuItem(
+                    modifier = Modifier
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                        .background(
+                            color = itemBackgroundColor,
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .onFocusChanged { state ->
+                            val hasFocus = state.isFocused || state.hasFocus
+                            focusedOptionValue = when {
+                                hasFocus -> option.value
+                                focusedOptionValue == option.value -> null
+                                else -> focusedOptionValue
+                            }
+                        },
                     text = {
                         Text(
                             text = option.label,
-                            color = NuvioColors.TextPrimary,
+                            color = itemTextColor,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                     },
                     onClick = { onSelect(option) },
                     colors = MenuDefaults.itemColors(
-                        textColor = NuvioColors.TextPrimary,
+                        textColor = itemTextColor,
                         disabledTextColor = NuvioColors.TextDisabled
                     )
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.search
 
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -120,6 +122,7 @@ internal fun DiscoverSection(
                 modifier = Modifier.weight(1f),
                 title = stringResource(R.string.discover_filter_type),
                 value = selectedTypeLabel,
+                selectedValue = uiState.selectedDiscoverType,
                 expanded = expandedPicker == "type",
                 options = availableTypes.map { type ->
                     val label = localizedTypeLabel(type)
@@ -138,6 +141,7 @@ internal fun DiscoverSection(
                 modifier = Modifier.weight(1f),
                 title = stringResource(R.string.discover_filter_catalog),
                 value = selectedCatalogLabel,
+                selectedValue = uiState.selectedDiscoverCatalogKey,
                 expanded = expandedPicker == "catalog",
                 options = filteredCatalogs.map { DiscoverOption(it.catalogName, it.key) },
                 onExpandedChange = { shouldExpand ->
@@ -153,6 +157,7 @@ internal fun DiscoverSection(
                 modifier = Modifier.weight(1f),
                 title = stringResource(R.string.discover_filter_genre),
                 value = selectedGenreLabel,
+                selectedValue = uiState.selectedDiscoverGenre ?: "__default__",
                 expanded = expandedPicker == "genre",
                 options = buildList {
                     add(DiscoverOption(stringResource(R.string.discover_genre_default), "__default__"))
@@ -247,6 +252,7 @@ private fun DiscoverDropdownPicker(
     modifier: Modifier = Modifier,
     title: String,
     value: String,
+    selectedValue: String?,
     expanded: Boolean,
     options: List<DiscoverOption>,
     onExpandedChange: (Boolean) -> Unit,
@@ -254,6 +260,7 @@ private fun DiscoverDropdownPicker(
 ) {
     var isFocused by remember { mutableStateOf(false) }
     var anchorSize by remember { mutableStateOf(IntSize.Zero) }
+    var focusedOptionValue by remember(expanded) { mutableStateOf<String?>(null) }
 
     Box(modifier = modifier) {
         Card(
@@ -319,7 +326,10 @@ private fun DiscoverDropdownPicker(
 
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { onExpandedChange(false) },
+            onDismissRequest = {
+                focusedOptionValue = null
+                onExpandedChange(false)
+            },
             modifier = Modifier
                 .width(with(LocalDensity.current) { anchorSize.width.toDp() })
                 .heightIn(max = 320.dp),
@@ -330,18 +340,45 @@ private fun DiscoverDropdownPicker(
             border = BorderStroke(1.dp, NuvioColors.Border)
         ) {
             options.forEach { option ->
+                val isSelected = option.value == selectedValue
+                val isOptionFocused = option.value == focusedOptionValue
+                val itemTextColor = when {
+                    isOptionFocused -> NuvioColors.OnSecondary
+                    isSelected -> NuvioColors.TextPrimary
+                    else -> NuvioColors.TextPrimary
+                }
+                val itemBackgroundColor = when {
+                    isOptionFocused -> NuvioColors.Secondary
+                    isSelected -> NuvioColors.FocusBackground
+                    else -> Color.Transparent
+                }
+
                 DropdownMenuItem(
+                    modifier = Modifier
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                        .background(
+                            color = itemBackgroundColor,
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .onFocusChanged { state ->
+                            val hasFocus = state.isFocused || state.hasFocus
+                            focusedOptionValue = when {
+                                hasFocus -> option.value
+                                focusedOptionValue == option.value -> null
+                                else -> focusedOptionValue
+                            }
+                        },
                     text = {
                         Text(
                             text = option.label,
-                            color = NuvioColors.TextPrimary,
+                            color = itemTextColor,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                     },
                     onClick = { onSelect(option) },
                     colors = MenuDefaults.itemColors(
-                        textColor = NuvioColors.TextPrimary,
+                        textColor = itemTextColor,
                         disabledTextColor = NuvioColors.TextDisabled
                     )
                 )


### PR DESCRIPTION
## Summary

I've updated the dropdown menus in the Library and Search/Discover sections to improve D-Pad navigation. The changes provide clearer visual feedback by distinguishing between focused and selected states.

**Note on scope:** While the issue specifically mentioned the Library section, I've applied these changes to both Library and Search/Discover screens since they share the same architecture and requirements for focus management.

Key changes:
- Updated `LibraryDropdownPicker` and `DiscoverDropdownPicker` to track and display the `selectedValue`.
- Implemented a focus highlight using `NuvioColors.Secondary` to show the current item target during navigation.
- Refined the menu item styling with 10dp rounded corners and adjusted padding to align with the overall design system.

## PR type

- Bug fix

## Why

The current dropdown implementation doesn't provide enough visual feedback during D-Pad navigation, making it difficult to identify which item is focused versus which one is currently selected. This PR addresses #471 to ensure consistent navigation behavior on TV devices.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Verified on both emulator and physical TV device:
1. Tested all filters in Library and Discover sections.
2. Confirmed that the focus highlight accurately follows D-Pad input.
3. Verified that selection states update correctly and focus states are cleared when the menu is dismissed.

## Screenshots / Video (UI changes only)
- before

https://github.com/user-attachments/assets/d323f185-1f31-4c3d-ae68-b6905eb56e05

- after 

https://github.com/user-attachments/assets/fae0dac7-0b6f-49bd-a005-8248c4d52b28



## Breaking changes

No breaking changes

## Linked issues

Fixes #471
