### PR TITLE
Fix Stabilize libass pipeline switching with Fast startup subtitles and ASS/SSA

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -230,6 +230,7 @@ class PlayerRuntimeController(
     internal var libassPipelineOverrideForCurrentStream: Boolean? = null
     internal var activePlayerUsesLibass: Boolean = false
     internal var libassPipelineSwitchInFlight: Boolean = false
+    internal var hasDetectedAssSsaTrackForCurrentStream: Boolean = false
     internal var libassPipelineDecisionStreamUrl: String? = null
     internal var episodeStreamsJob: Job? = null
     internal var episodeStreamsCacheRequestKey: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -492,6 +492,7 @@ internal suspend fun PlayerRuntimeController.prepareStreamStartSubtitles(
         libassPipelineDecisionStreamUrl = currentStreamUrl
         libassPipelineOverrideForCurrentStream = null
         libassPipelineSwitchInFlight = false
+        hasDetectedAssSsaTrackForCurrentStream = false
     }
     resetAddonSubtitleStateForNewStream()
     return prepareStartupSubtitles(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -173,7 +173,14 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
 internal fun PlayerRuntimeController.maybeAdjustLibassPipelineForTracks(tracks: Tracks) {
     if (libassPipelineSwitchInFlight) return
 
-    val desiredUseLibass = requestedUseLibassByUser && tracks.hasAssSsaTextTrack()
+    val hasAssSsaTrack = tracks.hasAssSsaTextTrack()
+    if (hasAssSsaTrack) {
+        hasDetectedAssSsaTrackForCurrentStream = true
+    }
+    // Keep libass sticky only after we have actually detected ASS/SSA for this stream.
+    // This avoids startup ping-pong but does not keep libass on for streams that never
+    // expose ASS/SSA tracks.
+    val desiredUseLibass = requestedUseLibassByUser && hasDetectedAssSsaTrackForCurrentStream
     if (desiredUseLibass == activePlayerUsesLibass) return
 
     val player = _exoPlayer ?: return


### PR DESCRIPTION
## Summary
Fixed a reload loop when Addon Subtitle Loading = Fast startup and ASS/SSA addon subtitles are auto-selected.
Updated libass pipeline switching to become sticky only after ASS/SSA is actually detected for the current stream.
Reset ASS/SSA detection on stream change, preventing washed-out colors on content without ASS/SSA subtitles.

## PR type
Bug fix
## Why
Fast startup loads addon subtitles asynchronously. In ASS/SSA cases, this could trigger repeated pipeline switching/re-initialization and cause continuous reload behavior.
The previous mitigation could keep libass active on streams without ASS/SSA, which caused washed-out colors on some devices/content.
This change keeps the anti-loop behavior while avoiding the color regression.

## Policy check
[X] This PR is not cosmetic-only, unless it is a translation PR.
[X]  This PR does not add a new major feature without prior approval.
[X]  This PR is small in scope and focused on one problem.
[] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manual:
Fast startup + ASS/SSA addon subtitles: verified no infinite reload loop.
Streams without ASS/SSA subtitles: verified colors are not washed out.
Stream switch: verified ASS/SSA detection resets correctly for the new stream.

## Screenshots / Video (UI changes only)
None (no UI changes).

## Breaking changes
None.

## Linked issues
Reddit Report.