### PR TITLE
Fix for Back button loop from source selection #736

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -366,12 +366,10 @@ fun NuvioNavHost(
                     val season = streamArgs?.getString("season")?.toIntOrNull()
                     val episode = streamArgs?.getString("episode")?.toIntOrNull()
                     if (streamContentType.equals("series", ignoreCase = true) && streamContentId.isNotBlank()) {
-                        val detailOnStack = navController.backQueue.any {
-                            it.destination.route == Screen.Detail.route
-                        }
-                        if (detailOnStack) {
-                            navController.getBackStackEntry(Screen.Detail.route).savedStateHandle.set("returnFocusSeason", season)
-                            navController.getBackStackEntry(Screen.Detail.route).savedStateHandle.set("returnFocusEpisode", episode)
+                        val detailEntry = runCatching { navController.getBackStackEntry(Screen.Detail.route) }.getOrNull()
+                        if (detailEntry != null) {
+                            detailEntry.savedStateHandle["returnFocusSeason"] = season
+                            detailEntry.savedStateHandle["returnFocusEpisode"] = episode
                             navController.popBackStack(Screen.Detail.route, inclusive = false)
                         } else {
                             navController.navigate(


### PR DESCRIPTION
## Summary

When auto-play is enabled and the next episode's streams fail to load, pressing back from the stream selection screen now always navigates to the detail screen instead of looping back to stream selection.

## PR type

- Bug fix

## Why

Fixes #736. When a source failed to load before an episode ended with auto-play enabled, the back stack contained the player entry with `playbackEnded = true`. Pressing back from the stream screen returned to the player, which immediately re-triggered navigation to stream selection, creating an unbreakable loop.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manually reproduced the loop: enabled auto-play, let an episode end, blocked stream loading for the next episode, confirmed back now exits to detail correctly
- Verified normal back navigation from stream screen still works as expected

## Breaking changes

Nothing should break

## Linked issues

Fixes #736
