### PR TITLE
feat(player): PCM amplification in audio 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -165,6 +165,8 @@ data class PlayerSettings(
     val decoderPriority: Int = 1, // EXTENSION_RENDERER_MODE_ON (0=off, 1=on, 2=prefer)
     val tunnelingEnabled: Boolean = false,
     val skipSilence: Boolean = false,
+    val audioAmplificationDb: Int = 0,
+    val persistAudioAmplification: Boolean = false,
     val preferredAudioLanguage: String = AudioLanguageOption.DEVICE,
     val secondaryPreferredAudioLanguage: String? = null,
     val loadingOverlayEnabled: Boolean = true,
@@ -255,6 +257,8 @@ class PlayerSettingsDataStore @Inject constructor(
 ) {
     companion object {
         private const val FEATURE = "player_settings"
+        private const val AUDIO_AMPLIFICATION_DB_MIN = 0
+        private const val AUDIO_AMPLIFICATION_DB_MAX = 10
     }
 
     private fun store(profileId: Int = profileManager.activeProfileId.value) =
@@ -273,6 +277,8 @@ class PlayerSettingsDataStore @Inject constructor(
     private val decoderPriorityKey = intPreferencesKey("decoder_priority")
     private val tunnelingEnabledKey = booleanPreferencesKey("tunneling_enabled")
     private val skipSilenceKey = booleanPreferencesKey("skip_silence")
+    private val audioAmplificationDbKey = intPreferencesKey("audio_amplification_db")
+    private val persistAudioAmplificationKey = booleanPreferencesKey("persist_audio_amplification")
     private val preferredAudioLanguageKey = stringPreferencesKey("preferred_audio_language")
     private val secondaryPreferredAudioLanguageKey = stringPreferencesKey("secondary_preferred_audio_language")
     private val loadingOverlayEnabledKey = booleanPreferencesKey("loading_overlay_enabled")
@@ -409,6 +415,11 @@ class PlayerSettingsDataStore @Inject constructor(
                 decoderPriority = prefs[decoderPriorityKey] ?: 1,
                 tunnelingEnabled = prefs[tunnelingEnabledKey] ?: false,
                 skipSilence = prefs[skipSilenceKey] ?: false,
+                audioAmplificationDb = (prefs[audioAmplificationDbKey] ?: 0).coerceIn(
+                    AUDIO_AMPLIFICATION_DB_MIN,
+                    AUDIO_AMPLIFICATION_DB_MAX
+                ),
+                persistAudioAmplification = prefs[persistAudioAmplificationKey] ?: false,
                 preferredAudioLanguage = normalizeSelectableLanguageCode(
                     prefs[preferredAudioLanguageKey] ?: AudioLanguageOption.DEVICE
                 ),
@@ -535,6 +546,27 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setSkipSilence(enabled: Boolean) {
         store().edit { prefs ->
             prefs[skipSilenceKey] = enabled
+        }
+    }
+
+    suspend fun setAudioAmplificationDb(db: Int) {
+        store().edit { prefs ->
+            prefs[audioAmplificationDbKey] = db.coerceIn(
+                AUDIO_AMPLIFICATION_DB_MIN,
+                AUDIO_AMPLIFICATION_DB_MAX
+            )
+        }
+    }
+
+    suspend fun setPersistAudioAmplification(enabled: Boolean, dbToPersist: Int? = null) {
+        store().edit { prefs ->
+            prefs[persistAudioAmplificationKey] = enabled
+            if (enabled && dbToPersist != null) {
+                prefs[audioAmplificationDbKey] = dbToPersist.coerceIn(
+                    AUDIO_AMPLIFICATION_DB_MIN,
+                    AUDIO_AMPLIFICATION_DB_MAX
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -16,24 +17,27 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
-import androidx.tv.material3.Card
+import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Border
+import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
@@ -49,13 +53,41 @@ internal fun AudioSelectionOverlay(
     visible: Boolean,
     tracks: List<TrackInfo>,
     selectedIndex: Int,
+    audioAmplificationDb: Int,
+    isAmplificationAvailable: Boolean,
+    persistAmplification: Boolean,
     onTrackSelected: (Int) -> Unit,
+    onAmplificationChange: (Int) -> Unit,
+    onPersistAmplificationChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val initialFocusRequester = remember { FocusRequester() }
-    var lastFocusedAudioIndex by rememberSaveable { mutableStateOf<Int?>(null) }
+    val tracksFocusRequester = remember { FocusRequester() }
+    val minusFocusRequester = remember { FocusRequester() }
+    val plusFocusRequester = remember { FocusRequester() }
+    val persistFocusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
+
+    var lastFocusedAudioIndex by rememberSaveable { mutableStateOf<Int?>(null) }
+
+    LaunchedEffect(visible, tracks, selectedIndex) {
+        if (!visible) return@LaunchedEffect
+
+        if (tracks.isNotEmpty()) {
+            val targetIndex = lastFocusedAudioIndex
+                ?.let { idx -> tracks.indexOfFirst { it.index == idx } }
+                ?.takeIf { it >= 0 }
+                ?: tracks.indexOfFirst { it.index == selectedIndex }
+                    .takeIf { it >= 0 }
+                ?: 0
+            listState.scrollToItem(targetIndex)
+            delay(120)
+            runCatching { tracksFocusRequester.requestFocus() }
+        } else {
+            delay(120)
+            runCatching { minusFocusRequester.requestFocus() }
+        }
+    }
 
     PlayerOverlayScaffold(
         visible = visible,
@@ -64,23 +96,9 @@ internal fun AudioSelectionOverlay(
         captureKeys = false,
         contentPadding = PaddingValues(start = 52.dp, end = 52.dp, top = 36.dp, bottom = 88.dp)
     ) {
-        LaunchedEffect(visible, tracks, selectedIndex) {
-            if (visible && tracks.isNotEmpty()) {
-                val targetIndex = lastFocusedAudioIndex
-                    ?.let { idx -> tracks.indexOfFirst { it.index == idx } }
-                    ?.takeIf { it >= 0 }
-                    ?: tracks.indexOfFirst { it.index == selectedIndex }
-                        .takeIf { it >= 0 }
-                    ?: 0
-                listState.scrollToItem(targetIndex)
-                delay(120)
-                runCatching { initialFocusRequester.requestFocus() }
-            }
-        }
-
         Column(
             modifier = Modifier
-                .width(440.dp)
+                .width(760.dp)
                 .align(Alignment.BottomStart)
                 .fillMaxHeight(),
             verticalArrangement = Arrangement.Bottom
@@ -92,38 +110,83 @@ internal fun AudioSelectionOverlay(
                 modifier = Modifier.padding(bottom = 12.dp)
             )
 
-            if (tracks.isEmpty()) {
-                Text(
-                    text = stringResource(R.string.audio_lang_default),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = Color.White.copy(alpha = 0.7f)
-                )
-            } else {
-                LazyColumn(
-                    state = listState,
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                    contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp),
-                    modifier = Modifier.weight(1f, fill = false)
-                ) {
-                    items(items = tracks, key = { track -> track.index }) { track ->
-                        AudioTrackCard(
-                            track = track,
-                            isSelected = track.index == selectedIndex,
-                            onFocused = { lastFocusedAudioIndex = track.index },
-                            onClick = { onTrackSelected(track.index) },
-                            focusRequester = if (
-                                track.index == lastFocusedAudioIndex ||
-                                (lastFocusedAudioIndex == null && track.index == selectedIndex) ||
-                                (lastFocusedAudioIndex == null && selectedIndex < 0 && track == tracks.firstOrNull())
-                            ) {
-                                initialFocusRequester
-                            } else {
-                                null
-                            }
-                        )
-                    }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                verticalAlignment = Alignment.Bottom,
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Column(modifier = Modifier.width(460.dp)) {
+                    AudioTracksContent(
+                        tracks = tracks,
+                        selectedIndex = selectedIndex,
+                        listState = listState,
+                        initialFocusRequester = tracksFocusRequester,
+                        rightFocusRequester = minusFocusRequester,
+                        onTrackFocused = { lastFocusedAudioIndex = it },
+                        onTrackSelected = onTrackSelected
+                    )
+                }
+                Column(modifier = Modifier.width(286.dp)) {
+                    AudioMixContent(
+                        audioAmplificationDb = audioAmplificationDb,
+                        isAmplificationAvailable = isAmplificationAvailable,
+                        persistAmplification = persistAmplification,
+                        minusFocusRequester = minusFocusRequester,
+                        plusFocusRequester = plusFocusRequester,
+                        persistFocusRequester = persistFocusRequester,
+                        leftFocusRequester = tracksFocusRequester,
+                        onAmplificationChange = onAmplificationChange,
+                        onPersistAmplificationChange = onPersistAmplificationChange
+                    )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AudioTracksContent(
+    tracks: List<TrackInfo>,
+    selectedIndex: Int,
+    listState: androidx.compose.foundation.lazy.LazyListState,
+    initialFocusRequester: FocusRequester,
+    rightFocusRequester: FocusRequester,
+    onTrackFocused: (Int) -> Unit,
+    onTrackSelected: (Int) -> Unit
+) {
+    if (tracks.isEmpty()) {
+        Text(
+            text = stringResource(R.string.audio_lang_default),
+            style = MaterialTheme.typography.bodyLarge,
+            color = Color.White.copy(alpha = 0.7f),
+            modifier = Modifier.padding(top = 8.dp, bottom = 12.dp)
+        )
+        return
+    }
+
+    LazyColumn(
+        state = listState,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp),
+        modifier = Modifier
+            .heightIn(max = 620.dp)
+            .fillMaxWidth()
+    ) {
+        items(items = tracks, key = { track -> track.index }) { track ->
+            AudioTrackCard(
+                track = track,
+                isSelected = track.index == selectedIndex,
+                onFocused = { onTrackFocused(track.index) },
+                onClick = { onTrackSelected(track.index) },
+                rightFocusRequester = rightFocusRequester,
+                focusRequester = if (
+                    track.index == selectedIndex || (selectedIndex < 0 && track == tracks.firstOrNull())
+                ) {
+                    initialFocusRequester
+                } else {
+                    null
+                }
+            )
         }
     }
 }
@@ -134,22 +197,22 @@ private fun AudioTrackCard(
     isSelected: Boolean,
     onFocused: () -> Unit,
     onClick: () -> Unit,
+    rightFocusRequester: FocusRequester,
     focusRequester: FocusRequester?
 ) {
     val metadata = listOfNotNull(
         track.codec,
         track.channelCount?.let { "$it ch" },
         track.sampleRate?.let { "${it / 1000} kHz" }
-    ).joinToString(" • ")
+    ).joinToString(" | ")
 
     Card(
         onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-            .onFocusChanged {
-                if (it.isFocused) onFocused()
-            },
+            .focusProperties { right = rightFocusRequester }
+            .onFocusChanged { if (it.isFocused) onFocused() },
         colors = CardDefaults.colors(
             containerColor = if (isSelected) NuvioColors.Secondary else Color.Transparent,
             focusedContainerColor = if (isSelected) NuvioColors.Secondary else Color.Transparent
@@ -218,6 +281,171 @@ private fun AudioTrackCard(
                     tint = NuvioColors.OnSecondary
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun AudioMixContent(
+    audioAmplificationDb: Int,
+    isAmplificationAvailable: Boolean,
+    persistAmplification: Boolean,
+    minusFocusRequester: FocusRequester,
+    plusFocusRequester: FocusRequester,
+    persistFocusRequester: FocusRequester,
+    leftFocusRequester: FocusRequester,
+    onAmplificationChange: (Int) -> Unit,
+    onPersistAmplificationChange: (Boolean) -> Unit
+) {
+    val currentDb = audioAmplificationDb.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+    val canDecrease = isAmplificationAvailable && currentDb > AUDIO_AMPLIFICATION_MIN_DB
+    val canIncrease = isAmplificationAvailable && currentDb < AUDIO_AMPLIFICATION_MAX_DB
+    val helperText = when {
+        !isAmplificationAvailable -> stringResource(R.string.audio_mix_unavailable)
+        persistAmplification -> stringResource(
+            R.string.audio_mix_range_saved,
+            AUDIO_AMPLIFICATION_MIN_DB,
+            AUDIO_AMPLIFICATION_MAX_DB
+        )
+        else -> stringResource(
+            R.string.audio_mix_range,
+            AUDIO_AMPLIFICATION_MIN_DB,
+            AUDIO_AMPLIFICATION_MAX_DB
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, bottom = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.audio_mix_label),
+            style = MaterialTheme.typography.titleMedium,
+            color = Color.White.copy(alpha = 0.92f)
+        )
+
+        Text(
+            text = stringResource(R.string.audio_mix_value_db, currentDb),
+            style = MaterialTheme.typography.headlineSmall,
+            color = Color.White
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            MixStepCard(
+                icon = Icons.Default.Remove,
+                enabled = canDecrease,
+                focusRequester = minusFocusRequester,
+                leftFocusRequester = leftFocusRequester,
+                rightFocusRequester = plusFocusRequester,
+                onClick = { onAmplificationChange(currentDb - 1) }
+            )
+            MixStepCard(
+                icon = Icons.Default.Add,
+                enabled = canIncrease,
+                focusRequester = plusFocusRequester,
+                leftFocusRequester = minusFocusRequester,
+                rightFocusRequester = persistFocusRequester,
+                onClick = { onAmplificationChange(currentDb + 1) }
+            )
+        }
+
+        Card(
+            onClick = { onPersistAmplificationChange(!persistAmplification) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(persistFocusRequester)
+                .focusProperties { left = plusFocusRequester },
+            colors = CardDefaults.colors(
+                containerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent,
+                focusedContainerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent
+            ),
+            shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+            border = CardDefaults.border(
+                border = Border(
+                    border = BorderStroke(2.dp, Color.Transparent),
+                    shape = RoundedCornerShape(12.dp)
+                ),
+                focusedBorder = Border(
+                    border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                    shape = RoundedCornerShape(12.dp)
+                )
+            ),
+            scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+        ) {
+            Text(
+                text = if (persistAmplification) {
+                    stringResource(R.string.audio_mix_persist_on)
+                } else {
+                    stringResource(R.string.audio_mix_persist_off)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (persistAmplification) NuvioColors.OnSecondary else Color.White,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+            )
+        }
+
+        Text(
+            text = helperText,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.White.copy(alpha = 0.66f)
+        )
+    }
+}
+
+@Composable
+private fun MixStepCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    enabled: Boolean,
+    focusRequester: FocusRequester,
+    leftFocusRequester: FocusRequester,
+    rightFocusRequester: FocusRequester = FocusRequester.Default,
+    onClick: () -> Unit
+) {
+    Card(
+        onClick = {
+            if (enabled) {
+                onClick()
+            }
+        },
+        modifier = Modifier
+            .width(78.dp)
+            .focusRequester(focusRequester)
+            .focusProperties {
+                left = leftFocusRequester
+                right = rightFocusRequester
+            },
+        colors = CardDefaults.colors(
+            containerColor = if (enabled) Color.Transparent else Color.White.copy(alpha = 0.06f),
+            focusedContainerColor = if (enabled) Color.Transparent else Color.White.copy(alpha = 0.06f)
+        ),
+        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        border = CardDefaults.border(
+            border = Border(
+                border = BorderStroke(2.dp, if (enabled) Color.White.copy(alpha = 0.18f) else Color.Transparent),
+                shape = RoundedCornerShape(12.dp)
+            ),
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, if (enabled) NuvioColors.FocusRing else Color.Transparent),
+                shape = RoundedCornerShape(12.dp)
+            )
+        ),
+        scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (enabled) Color.White else Color.White.copy(alpha = 0.35f)
+            )
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -99,9 +98,7 @@ internal fun AudioSelectionOverlay(
         Column(
             modifier = Modifier
                 .width(760.dp)
-                .align(Alignment.BottomStart)
-                .fillMaxHeight(),
-            verticalArrangement = Arrangement.Bottom
+                .align(Alignment.TopStart)
         ) {
             Text(
                 text = stringResource(R.string.audio_dialog_title),
@@ -112,7 +109,7 @@ internal fun AudioSelectionOverlay(
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(14.dp),
-                verticalAlignment = Alignment.Bottom,
+                verticalAlignment = Alignment.Top,
                 modifier = Modifier.padding(bottom = 8.dp)
             ) {
                 Column(modifier = Modifier.width(460.dp)) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -98,7 +99,9 @@ internal fun AudioSelectionOverlay(
         Column(
             modifier = Modifier
                 .width(760.dp)
-                .align(Alignment.TopStart)
+                .align(Alignment.BottomStart)
+                .fillMaxHeight(),
+            verticalArrangement = Arrangement.Bottom
         ) {
             Text(
                 text = stringResource(R.string.audio_dialog_title),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
@@ -1,0 +1,91 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+internal class GainAudioProcessor : BaseAudioProcessor() {
+
+    @Volatile
+    private var gainDb: Int = AUDIO_AMPLIFICATION_MIN_DB
+
+    @Volatile
+    private var gainScale: Float = 1f
+
+    fun setGainDb(db: Int) {
+        val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+        gainDb = clampedDb
+        gainScale = gainToLinearScale(clampedDb)
+    }
+
+    override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        return when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT,
+            C.ENCODING_PCM_FLOAT -> inputAudioFormat
+            else -> AudioProcessor.AudioFormat.NOT_SET
+        }
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        if (!inputBuffer.hasRemaining()) return
+
+        val inputSize = inputBuffer.remaining()
+        val outputBuffer = replaceOutputBuffer(inputSize)
+        val scale = gainScale
+
+        if (scale == 1f) {
+            outputBuffer.put(inputBuffer)
+            outputBuffer.flip()
+            return
+        }
+
+        when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT -> processPcm16(inputBuffer, outputBuffer, scale)
+            C.ENCODING_PCM_FLOAT -> processPcmFloat(inputBuffer, outputBuffer, scale)
+            else -> outputBuffer.put(inputBuffer)
+        }
+
+        outputBuffer.flip()
+    }
+
+    private fun processPcm16(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer, scale: Float) {
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+
+        while (inputBuffer.remaining() >= 2) {
+            val sample = inputBuffer.short.toInt()
+            val amplified = (sample * scale)
+                .roundToInt()
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            outputBuffer.putShort(amplified.toShort())
+        }
+
+        if (inputBuffer.hasRemaining()) {
+            outputBuffer.put(inputBuffer)
+        }
+    }
+
+    private fun processPcmFloat(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer, scale: Float) {
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+
+        while (inputBuffer.remaining() >= 4) {
+            val sample = inputBuffer.float
+            val amplified = (sample * scale).coerceIn(-1f, 1f)
+            outputBuffer.putFloat(amplified)
+        }
+
+        if (inputBuffer.hasRemaining()) {
+            outputBuffer.put(inputBuffer)
+        }
+    }
+
+    private fun gainToLinearScale(db: Int): Float {
+        if (db == 0) return 1f
+        return 10.0.pow(db / 20.0).toFloat()
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -2,7 +2,6 @@ package com.nuvio.tv.ui.screens.player
 
 import android.app.Activity
 import android.content.Context
-import android.media.audiofx.LoudnessEnhancer
 import androidx.lifecycle.SavedStateHandle
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -223,10 +222,11 @@ class PlayerRuntimeController(
     internal var nextEpisodeThresholdMinutesBeforeEndSetting: Float = 2f
     internal var currentStreamBingeGroup: String? = navigationArgs.bingeGroup
     internal var hasAppliedRememberedAudioSelection: Boolean = false
+    internal var hasInitializedAudioAmplificationForSession: Boolean = false
 
     internal var lastBufferLogTimeMs: Long = 0L
     
-    internal var loudnessEnhancer: LoudnessEnhancer? = null
+    internal val gainAudioProcessor = GainAudioProcessor()
     internal var trackSelector: DefaultTrackSelector? = null
     internal var currentMediaSession: MediaSession? = null
     internal var pauseOverlayJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -2,7 +2,6 @@ package com.nuvio.tv.ui.screens.player
 
 import android.content.Context
 import android.content.res.Resources
-import android.media.audiofx.LoudnessEnhancer
 import android.os.Build
 import android.util.Log
 import android.view.accessibility.CaptioningManager
@@ -17,6 +16,8 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.ForwardingRenderer
 import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.text.TextOutput
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -166,7 +167,8 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
             subtitleDelayUs.set(_uiState.value.subtitleDelayMs.toLong() * 1000L)
             val renderersFactory = SubtitleOffsetRenderersFactory(
                 context = context,
-                subtitleDelayUsProvider = subtitleDelayUs::get
+                subtitleDelayUsProvider = subtitleDelayUs::get,
+                gainAudioProcessor = gainAudioProcessor
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc)
 
@@ -227,12 +229,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     e.printStackTrace()
                 }
 
-                try {
-                    loudnessEnhancer?.release()
-                    loudnessEnhancer = LoudnessEnhancer(audioSessionId)
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
+                applyAudioAmplification(_uiState.value.audioAmplificationDb)
 
                 
                 notifyAudioSessionUpdate(true)
@@ -564,8 +561,21 @@ internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
 
 private class SubtitleOffsetRenderersFactory(
     context: Context,
-    private val subtitleDelayUsProvider: () -> Long
+    private val subtitleDelayUsProvider: () -> Long,
+    private val gainAudioProcessor: GainAudioProcessor
 ) : DefaultRenderersFactory(context) {
+
+    override fun buildAudioSink(
+        context: Context,
+        enableFloatOutput: Boolean,
+        enableAudioTrackPlaybackParams: Boolean
+    ): AudioSink {
+        return DefaultAudioSink.Builder(context)
+            .setEnableFloatOutput(enableFloatOutput)
+            .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+            .setAudioProcessors(arrayOf(gainAudioProcessor))
+            .build()
+    }
 
     override fun buildTextRenderers(
         context: Context,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -15,12 +15,6 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     notifyAudioSessionUpdate(false)
 
     try {
-        loudnessEnhancer?.release()
-        loudnessEnhancer = null
-    } catch (e: Exception) {
-        e.printStackTrace()
-    }
-    try {
         currentMediaSession?.release()
         currentMediaSession = null
     } catch (e: Exception) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -149,6 +149,20 @@ internal fun PlayerRuntimeController.observeEpisodeWatchProgress() {
 internal fun PlayerRuntimeController.observeSubtitleSettings() {
     scope.launch {
         playerSettingsDataStore.playerSettings.collect { settings ->
+            val currentState = _uiState.value
+            val resolvedAudioAmplificationDb = when {
+                !hasInitializedAudioAmplificationForSession -> {
+                    hasInitializedAudioAmplificationForSession = true
+                    if (settings.persistAudioAmplification) {
+                        settings.audioAmplificationDb
+                    } else {
+                        AUDIO_AMPLIFICATION_MIN_DB
+                    }
+                }
+                settings.persistAudioAmplification -> settings.audioAmplificationDb
+                else -> currentState.audioAmplificationDb
+            }
+
             _uiState.update { state ->
                 val shouldShowOverlay = if (settings.loadingOverlayEnabled && !hasRenderedFirstFrame) {
                     true
@@ -164,9 +178,16 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     showLoadingOverlay = shouldShowOverlay,
                     pauseOverlayEnabled = settings.pauseOverlayEnabled,
                     osdClockEnabled = settings.osdClockEnabled,
-                    frameRateMatchingMode = settings.frameRateMatchingMode
+                    frameRateMatchingMode = settings.frameRateMatchingMode,
+                    persistAudioAmplification = settings.persistAudioAmplification,
+                    audioAmplificationDb = resolvedAudioAmplificationDb
                 )
             }
+
+            if (resolvedAudioAmplificationDb != currentState.audioAmplificationDb) {
+                applyAudioAmplification(resolvedAudioAmplificationDb)
+            }
+
             if (settings.frameRateMatchingMode == FrameRateMatchingMode.OFF) {
                 frameRateProbeJob?.cancel()
                 _uiState.update {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -13,6 +13,20 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+internal const val AUDIO_AMPLIFICATION_MIN_DB = 0
+internal const val AUDIO_AMPLIFICATION_MAX_DB = 10
+
+internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
+    val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+    gainAudioProcessor.setGainDb(clampedDb)
+    _uiState.update {
+        it.copy(
+            audioAmplificationDb = clampedDb,
+            isAudioAmplificationAvailable = true
+        )
+    }
+}
+
 internal fun PlayerRuntimeController.startProgressUpdates() {
     progressJob?.cancel()
     progressJob = scope.launch {
@@ -476,6 +490,25 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             rememberSameSeriesAudioSelection(event.index)
             selectAudioTrack(event.index)
             _uiState.update { it.copy(showAudioOverlay = false, showSubtitleDelayOverlay = false) }
+        }
+        is PlayerEvent.OnSetAudioAmplificationDb -> {
+            val clampedDb = event.db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+            applyAudioAmplification(clampedDb)
+            if (_uiState.value.persistAudioAmplification) {
+                scope.launch {
+                    playerSettingsDataStore.setAudioAmplificationDb(clampedDb)
+                }
+            }
+        }
+        is PlayerEvent.OnSetPersistAudioAmplification -> {
+            val currentDb = _uiState.value.audioAmplificationDb
+            _uiState.update { it.copy(persistAudioAmplification = event.enabled) }
+            scope.launch {
+                playerSettingsDataStore.setPersistAudioAmplification(
+                    enabled = event.enabled,
+                    dbToPersist = if (event.enabled) currentDb else null
+                )
+            }
         }
         is PlayerEvent.OnSelectSubtitleTrack -> {
             autoSubtitleSelected = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -959,7 +959,14 @@ fun PlayerScreen(
             visible = uiState.showAudioOverlay,
             tracks = uiState.audioTracks,
             selectedIndex = uiState.selectedAudioTrackIndex,
+            audioAmplificationDb = uiState.audioAmplificationDb,
+            isAmplificationAvailable = uiState.isAudioAmplificationAvailable,
+            persistAmplification = uiState.persistAudioAmplification,
             onTrackSelected = { viewModel.onEvent(PlayerEvent.OnSelectAudioTrack(it)) },
+            onAmplificationChange = { viewModel.onEvent(PlayerEvent.OnSetAudioAmplificationDb(it)) },
+            onPersistAmplificationChange = {
+                viewModel.onEvent(PlayerEvent.OnSetPersistAudioAmplification(it))
+            },
             onDismiss = { viewModel.onEvent(PlayerEvent.OnDismissTransientOverlay) },
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -43,6 +43,9 @@ data class PlayerUiState(
     val subtitleTracks: List<TrackInfo> = emptyList(),
     val selectedAudioTrackIndex: Int = -1,
     val selectedSubtitleTrackIndex: Int = -1,
+    val audioAmplificationDb: Int = 0,
+    val isAudioAmplificationAvailable: Boolean = true,
+    val persistAudioAmplification: Boolean = false,
     val showAudioOverlay: Boolean = false,
     val showSubtitleOverlay: Boolean = false,
     val showSubtitleStylePanel: Boolean = false,
@@ -162,6 +165,8 @@ sealed class PlayerEvent {
     data object OnCommitPreviewSeek : PlayerEvent()
     data class OnSeekTo(val position: Long) : PlayerEvent()
     data class OnSelectAudioTrack(val index: Int) : PlayerEvent()
+    data class OnSetAudioAmplificationDb(val db: Int) : PlayerEvent()
+    data class OnSetPersistAudioAmplification(val enabled: Boolean) : PlayerEvent()
     data class OnSelectSubtitleTrack(val index: Int) : PlayerEvent()
     data object OnDisableSubtitles : PlayerEvent()
     data class OnSelectAddonSubtitle(val subtitle: Subtitle) : PlayerEvent()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,6 +729,15 @@
 
     <!-- AudioDialog -->
     <string name="audio_dialog_title">Audio</string>
+    <string name="audio_dialog_tab_tracks">Audio</string>
+    <string name="audio_dialog_tab_mix">Mix</string>
+    <string name="audio_mix_label">Amplification (PCM)</string>
+    <string name="audio_mix_value_db">%1$d dB</string>
+    <string name="audio_mix_persist_on">Persist between sessions: ON</string>
+    <string name="audio_mix_persist_off">Persist between sessions: OFF</string>
+    <string name="audio_mix_range">Range: %1$d dB to %2$d dB</string>
+    <string name="audio_mix_range_saved">Range: %1$d dB to %2$d dB (saved)</string>
+    <string name="audio_mix_unavailable">Amplification is not available on this device</string>
 
     <!-- SubtitleDialog / SubtitleStyleSidePanel -->
     <string name="subtitle_dialog_title">Subtitles</string>


### PR DESCRIPTION
## Summary

- Adds a new PCM amplification feature in the player audio overlay.
- Shows `Amplification (PCM)` controls next to audio track selection.
- Allows real-time gain control with `- / +` buttons (range: `0 dB` to `10 dB`).
- Adds `Persist between sessions` toggle to save/load the selected gain.
- Stores settings in `PlayerSettingsDataStore`.
- Applies gain through `GainAudioProcessor` only for PCM audio (`ENCODING_PCM_16BIT` and `ENCODING_PCM_FLOAT`).
- Passthrough/bitstream audio is not modified.

## PR type

- Small maintenance improvement

## Why

Some streams play with low PCM volume.  
Also downmixing for people with stereo speakers, the sound is lowered. And stays too low. No need to switch to Kodi to watch some streams.
This adds direct in-player PCM gain control while keeping passthrough audio unchanged.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [] If this is a larger or directional change, I linked the issue where it was approved. 

## Testing

- Manual:
  - Open player audio overlay.
  - Select audio track and confirm normal behavior.
  - Change amplification with `- / +` and confirm value updates.
  - Toggle `Persist between sessions`, reopen playback, confirm saved behavior.

## Screenshots / Video (UI changes only)

<img width="1292" height="581" alt="image" src="https://github.com/user-attachments/assets/ea10fd63-108e-4738-bc00-f4bbf796a6e0" />

<img width="1474" height="622" alt="image" src="https://github.com/user-attachments/assets/826d7856-f934-4a13-81f4-edf65a9615f9" />

## Breaking changes

None,

## Linked issues

None.
