### PR TITLE
Profile creation focus fix

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -40,9 +40,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -54,9 +57,11 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -1221,6 +1226,7 @@ private fun ProfileNameField(
     modifier: Modifier = Modifier
 ) {
     var isFocused by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
     val borderColor by animateColorAsState(
         targetValue = if (isFocused) NuvioColors.FocusRing else NuvioColors.Border,
         animationSpec = tween(120),
@@ -1268,6 +1274,12 @@ private fun ProfileNameField(
                 fontSize = 16.sp
             ),
             singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.moveFocus(FocusDirection.Down)
+                }
+            ),
             cursorBrush = SolidColor(NuvioColors.FocusRing)
         )
     }


### PR DESCRIPTION
## Summary

This PR fixes a focus "trap" issue in the profile creation screen on Android TV (specifically tested on XGIMI MoGo 2). It ensures that when a user finishes typing a profile name, the focus correctly releases from the BasicTextField and moves to the action buttons.

Key changes:

- Added ImeAction.Done to the BasicTextField.
- Implemented KeyboardActions to trigger focusManager.moveFocus(FocusDirection.Down) upon clicking "Submit" on the software keyboard.
- Ensured the D-pad navigation flow is not blocked by the active text input state.


## PR type
- Bug fix

## Why

On Android TV devices using a remote/D-pad, the BasicTextField was retaining focus even after the user finished typing. This prevented users from navigating to the "Create" or "Cancel" buttons using the remote, effectively soft-locking the UI.

## Policy check

<!-- Confirm these before requesting review -->
 - [ Y] This PR is not cosmetic-only, unless it is a translation PR.
- [ Y] This PR does not add a new major feature without prior approval.
- [Y ] This PR is small in scope and focused on one problem.
- [Y ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manual Testing:

- Tested on XGIMI MoGo 2 (Android TV).
- Steps: Opened "Add Profile," typed a name using the on-screen keyboard, clicked the "Done/Checkmark" button on the keyboard.
- Result: Keyboard dismissed and focus automatically moved to the "Create" button.
- Verified that D-pad "Down" now successfully exits the text field.

## Screenshots / Video (UI changes only)
N/A

## Breaking changes
None

## Linked issues
N/A
