### PR TITLE
Increase subtitle addon timeout to 15s

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -24,7 +24,7 @@ class SubtitleRepositoryImpl @Inject constructor(
 
     companion object {
         private const val TAG = "SubtitleRepository"
-        private const val PER_ADDON_TIMEOUT_MS = 8_000L
+        private const val PER_ADDON_TIMEOUT_MS = 15_000L
     }
 
     override suspend fun getSubtitles(


### PR DESCRIPTION
## Summary

Increased the per-addon timeout for fetching subtitles from 8 seconds to 15 seconds.

## PR type

- Small maintenance improvement

## Why

[Submaker](https://submaker.elfhosted.com), by default, uses 12 seconds of timeout. This is reasonable, since they hit a lot of APIs to aggregate subtitles into one addon.

I tested the same addon setup on both Stremio and Nuvio. Stremio worked and Nuvio didn't. 

<img width="794" height="266" alt="image" src="https://github.com/user-attachments/assets/982f9821-e720-4a5c-b661-e57c4c6b94d6" />

Some subtitle addons can be slow to respond depending on network conditions or provider latency. The previous 8-second timeout was causing the app to prematurely abandon requests that would have otherwise returned valid subtitles. Increasing this to 15 seconds improves the success rate of finding subtitles from slower sources.

Logcat:

```
2026-03-14 14:05:08.014 okhttp.OkHttpClient      I  <-- 200 https://submaker.elfhosted.com/addon/b079dad25ebe645aed4035886913c26f/v1.4.72/manifest.json (416ms, unknown-length body)
2026-03-14 14:05:08.017 AddonRepository          D  Background manifest refresh completed
2026-03-14 14:05:15.608 okhttp.OkHttpClient      I  <-- HTTP FAILED: java.io.IOException: Canceled
2026-03-14 14:05:15.610 SubtitleRepository       E  Failed to fetch subtitles from SubMaker | ElfHosted: Timed out waiting for 8000 ms
2026-03-14 14:05:15.611 SubtitleRepository       W  Subtitle fetch timed out for addon=SubMaker | ElfHosted after 8000ms
2026-03-14 14:05:15.612 SubtitleRepository       D  Subtitle fetch completed total=0 fromAddons=2 in 8024ms
```

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Logcat

```
2026-03-14 14:19:16.992 okhttp.OkHttpClient      I  <-- 200 https://submaker.elfhosted.com/addon/b079dad25ebe645aed4035886913c26f/v1.4.72/subtitles/series/kitsu:48363:4/videoSize=1239039028&filename=Jujutsu.Kaisen.S03E04.Perfect.Preparation.1080p.NF.WEB-DL.JPN.AAC2.0.H.264.MSubs-ToonsHub.mkv.json (10436ms, unknown-length body)
2026-03-14 14:19:16.996 SubtitleRepository       D  Got 1 subtitles from SubMaker | ElfHosted
2026-03-14 14:19:16.996 SubtitleRepository       D  Subtitle fetch done for addon=SubMaker | ElfHosted count=1 in 10442ms
2026-03-14 14:19:16.997 SubtitleRepository       D  Subtitle fetch completed total=1 fromAddons=2 in 10452ms
2026-03-14 14:19:16.999 PlayerViewModel          D  AUTO_SUB eval: targets=[pt-br, pt], scannedText=false, internalCount=7, selectedInternal=-1, addonCount=1, selectedAddon=null
2026-03-14 14:19:17.001 PlayerViewModel          D  AUTO_SUB defer addon fallback: text tracks not scanned yet
2026-03-14 14:19:17.034 okhttp.OkHttpClient      I  <-- 200 https://submaker.elfhosted.com/addon/b079dad25ebe645aed4035886913c26f/v1.4.72/subtitles/series/kitsu:48363:4/videoSize=1239039028&filename=Jujutsu.Kaisen.S03E04.Perfect.Preparation.1080p.NF.WEB-DL.JPN.AAC2.0.H.264.MSubs-ToonsHub.mkv.json (8562ms, unknown-length body)
2026-03-14 14:19:17.036 SubtitleRepository       D  Got 1 subtitles from SubMaker | ElfHosted
2026-03-14 14:19:17.036 SubtitleRepository       D  Subtitle fetch done for addon=SubMaker | ElfHosted count=1 in 8569ms
2026-03-14 14:19:17.037 SubtitleRepository       D  Subtitle fetch completed total=1 fromAddons=2 in 8580ms
```

## Screenshots / Video (UI changes only)

| Before | After |
|---|---|
| <img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/d1ff0a08-3836-42df-ad52-489df912ca7f" />  | <img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/53360128-4d7f-453b-bda7-1b1ec6dc6e81" /> |

## Breaking changes

None

## Linked issues
https://discord.com/channels/1379902184207941732/1479098447406829690
