### PR TITLE
Remove release signing and minification flags from debug build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,10 +78,6 @@ android {
 
     buildTypes {
         debug {
-            signingConfig = signingConfigs.getByName("release")
-            isDebuggable = false
-            isMinifyEnabled = false
-
             buildConfigField("boolean", "IS_DEBUG_BUILD", "true")
 
             // Dev environment (from local.dev.properties)


### PR DESCRIPTION
## Summary

Fixing the debug build to improve contributors first experience.

Before my change, the debug build was using the `release` signing keys, which is not openly available - thus making debug build fail. Also, it was using `isDebuggable = false` which is not recommended for debug builds - it should be debuggable to help seeing the logs and attach debugger.

I'm also removing the `isMinifyEnabled = false` since it is also default `false` for `debug` variant.

## PR type

- Small maintenance improvement

## Why

When I first tried to do my first contribution, build were failing in this task:

```
> Task :app:validateSigningDebug FAILED
Execution failed for task ':app:validateSigningDebug'.
> Keystore file 'D:\Projects\NuvioTV\nuviotv.jks' not found for signing config 'release'.

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```

I tried both the green Play button from AS and also the Gradle task from README: `./gradlew build`. Both attempts failed for the same reason.

## Policy check

 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

After the change, I tested both with `./gradlew assembleDebug` and hitting the green Play button on Android Studio.

```
BUILD SUCCESSFUL in 1m 31s
43 actionable tasks: 21 executed, 22 up-to-date
```

## Breaking changes

None.

## Linked issues

None.
