### PR TITLE
Fix playback HTTP 403 regression by aligning player DNS behavior with IPv4 fallback policy

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -2,7 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
-import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.dash.DashMediaSource
@@ -10,17 +10,29 @@ import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.text.SubtitleParser
+import com.nuvio.tv.core.network.IPv4FirstDns
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLDecoder
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 internal class PlayerMediaSourceFactory {
     private var customExtractorsFactory: ExtractorsFactory? = null
     private var customSubtitleParserFactory: SubtitleParser.Factory? = null
+    private val playbackHttpClient by lazy {
+        OkHttpClient.Builder()
+            .dns(IPv4FirstDns())
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(8, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .build()
+    }
 
     fun configureSubtitleParsing(
         extractorsFactory: ExtractorsFactory?,
@@ -37,10 +49,7 @@ internal class PlayerMediaSourceFactory {
         mimeTypeOverride: String? = null
     ): MediaSource {
         val sanitizedHeaders = sanitizeHeaders(headers)
-        val httpDataSourceFactory = DefaultHttpDataSource.Factory().apply {
-            setConnectTimeoutMs(8000)
-            setReadTimeoutMs(8000)
-            setAllowCrossProtocolRedirects(true)
+        val httpDataSourceFactory = OkHttpDataSource.Factory(playbackHttpClient).apply {
             setDefaultRequestProperties(sanitizedHeaders)
             setUserAgent(DEFAULT_USER_AGENT)
         }


### PR DESCRIPTION
## Summary

This PR fixes a playback regression introduced after 0.4.18-beta. Error playback HTTP 403

## PR type

- Bug fix


## Why

Playback Error for some streams. For instance, AIOStreams Elfhosted instance.
Source error (HTTP 403) [2004]
Repro pattern: worked on Xiaomi box, failed on NVIDIA Shield in 0.4.19-beta (while 0.4.18-beta worked).
Additional signal: disabling IPv6 on Shield made playback work again.

Root cause:

In 0.4.19-beta, stream/addon resolution moved to IPv4FirstDns.
Playback requests were still using DefaultHttpDataSource (different DNS/network path behavior).
This created an inconsistency between stream resolution and segment playback path (IPv4 vs IPv6 route/family), which can break signed/proxied links and lead to HTTP 403 [2004].

What changed:

Switched player HTTP datasource from DefaultHttpDataSource to OkHttpDataSource.
Added an OkHttp client in PlayerMediaSourceFactory configured with IPv4FirstDns.
Kept existing headers/user-agent behavior.

## Policy check

<!-- Confirm these before requesting review -->
 - [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

I tested the new version with patch applied, and no HTTP 403 error occurred.

## Screenshots / Video (UI changes only)

No UI.

## Breaking changes

None.

## Linked issues

Fixes #857

