### PR TITLE
Detect subtitle format via HEAD probe for extension-less URLs

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/SubtitleFormatUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/SubtitleFormatUtils.kt
@@ -1,0 +1,46 @@
+package com.nuvio.tv.core.player
+
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import javax.inject.Inject
+
+class SubtitleFormatUtils @Inject constructor(private val okHttpClient: OkHttpClient) {
+
+    fun resolveFormat(url: String, hintFormat: String? = null): String? =
+        hintFormat ?: formatFromUrl(url) ?: probeFormatFromHead(url)
+
+    private fun probeFormatFromHead(url: String): String? {
+        return try {
+            val request = Request.Builder().url(url).head().build()
+            okHttpClient.newCall(request).execute().use { response ->
+                val contentType = response.header("Content-Type") ?: return null
+                when {
+                    contentType.contains("x-ssa") || contentType.contains("ass") -> "ass"
+                    contentType.contains("subrip") || contentType.contains("x-srt") -> "srt"
+                    contentType.contains("vtt") || contentType.contains("webvtt") -> "vtt"
+                    contentType.contains("ttml") -> "ttml"
+                    else -> null
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "HEAD probe failed for $url: ${e.message}")
+            null
+        }
+    }
+
+    companion object {
+        private const val TAG = "SubtitleFormatUtils"
+
+        fun formatFromUrl(url: String): String? {
+            val path = url.substringBefore('?').substringBefore('#').trimEnd('/').lowercase()
+            return when {
+                path.endsWith(".ass") || path.endsWith(".ssa") -> "ass"
+                path.endsWith(".srt") -> "srt"
+                path.endsWith(".vtt") || path.endsWith(".webvtt") -> "vtt"
+                path.endsWith(".ttml") || path.endsWith(".dfxp") -> "ttml"
+                else -> null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/SubtitleResponseDto.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/SubtitleResponseDto.kt
@@ -12,5 +12,6 @@ data class SubtitleResponseDto(
 data class SubtitleItemDto(
     @Json(name = "id") val id: String? = null,
     @Json(name = "url") val url: String,
-    @Json(name = "lang") val lang: String
+    @Json(name = "lang") val lang: String,
+    @Json(name = "format") val format: String? = null
 )

--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -15,11 +15,13 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.withContext
+import com.nuvio.tv.core.player.SubtitleFormatUtils
 import javax.inject.Inject
 
 class SubtitleRepositoryImpl @Inject constructor(
     private val api: AddonApi,
-    private val addonRepository: AddonRepositoryImpl
+    private val addonRepository: AddonRepositoryImpl,
+    private val subtitleFormatUtils: SubtitleFormatUtils
 ) : SubtitleRepository {
 
     companion object {
@@ -149,12 +151,14 @@ class SubtitleRepositoryImpl @Inject constructor(
             when (val result = safeApiCall { api.getSubtitles(subtitleUrl) }) {
                 is NetworkResult.Success -> {
                     val subtitles = result.data.subtitles?.mapNotNull { dto ->
+                        val resolvedFormat = subtitleFormatUtils.resolveFormat(dto.url, dto.format)
                         Subtitle(
                             id = dto.id ?: "${dto.lang}-${dto.url.hashCode()}",
                             url = dto.url,
                             lang = dto.lang,
                             addonName = addon.displayName,
-                            addonLogo = addon.logo
+                            addonLogo = addon.logo,
+                            format = resolvedFormat
                         )
                     } ?: emptyList()
                     

--- a/app/src/main/java/com/nuvio/tv/domain/model/Subtitle.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Subtitle.kt
@@ -9,7 +9,8 @@ data class Subtitle(
     val url: String,
     val lang: String,
     val addonName: String,
-    val addonLogo: String?
+    val addonLogo: String?,
+    val format: String? = null
 ) {
     fun getDisplayLanguage(): String = languageCodeToName(lang)
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -228,7 +228,7 @@ internal fun PlayerRuntimeController.addonSubtitleKey(subtitle: Subtitle): Strin
 
 internal fun PlayerRuntimeController.toSubtitleConfiguration(subtitle: Subtitle): MediaItem.SubtitleConfiguration {
     val normalizedLang = PlayerSubtitleUtils.normalizeLanguageCode(subtitle.lang)
-    val subtitleMimeType = PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url)
+    val subtitleMimeType = PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url, subtitle.format)
     val addonTrackId = buildAddonSubtitleTrackId(subtitle)
 
     return MediaItem.SubtitleConfiguration.Builder(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -72,19 +72,17 @@ internal object PlayerSubtitleUtils {
             normalizedLanguage.startsWith("${normalizedTarget}_")
     }
 
-    fun mimeTypeFromUrl(url: String): String {
-        val normalizedPath = url
-            .substringBefore('#')
-            .substringBefore('?')
-            .trimEnd('/')
-            .lowercase()
-
-        return when {
-            normalizedPath.endsWith(".srt") -> MimeTypes.APPLICATION_SUBRIP
-            normalizedPath.endsWith(".vtt") || normalizedPath.endsWith(".webvtt") -> MimeTypes.TEXT_VTT
-            normalizedPath.endsWith(".ass") || normalizedPath.endsWith(".ssa") -> MimeTypes.TEXT_SSA
-            normalizedPath.endsWith(".ttml") || normalizedPath.endsWith(".dfxp") -> MimeTypes.APPLICATION_TTML
-            else -> MimeTypes.APPLICATION_SUBRIP
+    fun mimeTypeFromUrl(url: String, format: String? = null): String {
+        val resolvedFormat = format
+        if (!resolvedFormat.isNullOrBlank()) {
+            return when (resolvedFormat.trim().lowercase()) {
+                "ass", "ssa", "text/x-ssa" -> MimeTypes.TEXT_SSA
+                "srt", "application/x-subrip" -> MimeTypes.APPLICATION_SUBRIP
+                "vtt", "webvtt", "text/vtt" -> MimeTypes.TEXT_VTT
+                "ttml", "dfxp" -> MimeTypes.APPLICATION_TTML
+                else -> MimeTypes.APPLICATION_SUBRIP
+            }
         }
+        return MimeTypes.APPLICATION_SUBRIP
     }
 }


### PR DESCRIPTION
## Summary

Added subtitle format detection via HTTP HEAD probe for extension-less URLs.
Previously, subtitle URLs without a file extension (for exampel from SubMaker addon) were always treated as SRT, causing ASS/SSA subtitles to be parsed incorrectly and not displayed at all (regardless if libass was used or not)

## PR type

- Bug fix

## Why

Some addons serve subtitle files via URLs without a file extension. The app was defaulting to `application/x-subrip` (SRT) MIME type for all such URLs, which broke rendering for addons that return non SRT content.

SubMaker recently added ASS passthrough support (https://github.com/xtremexq/StremioSubMaker/issues/91), meaning it now returns proper ASS subtitles - but the app was still treating them as SRT, so libass never got involved and subtitles were not displayed.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Opened an episode with SubMaker addon providing Polish translated subtitles
- Confirmed `Content-Type: text/x-ssa` is returned by HEAD request to SubMaker URL
- Verified subtitles are now correctly rendered via libass after the fix
- Tested with different formats from other addons (extension-based detection unchanged)

## Screenshots / Video (UI changes only)
Nothing changed

## Breaking changes

Nothing should break. For subtitles for which url ends with an extension, everything still

## Linked issues

Nothing, although I saw few people mentioned similar issues (selected subtitles not displayed) on discord - probably the same case