### PR TITLE
fix: clear stale More actions state when hiding controls

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -402,7 +402,7 @@ fun PlayerRuntimeController.onUserInteraction() {
 
 fun PlayerRuntimeController.hideControls() {
     hideControlsJob?.cancel()
-    _uiState.update { it.copy(showControls = false, showSeekOverlay = false) }
+    _uiState.update { it.copy(showControls = false, showSeekOverlay = false, showMoreDialog = false) }
 }
 
 fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
@@ -572,8 +572,15 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             if (_uiState.value.showSubtitleDelayOverlay) {
                 hideSubtitleDelayOverlay()
             }
-            _uiState.update { it.copy(showControls = !it.showControls) }
-            if (_uiState.value.showControls) {
+            val shouldShowControls = !_uiState.value.showControls
+            _uiState.update {
+                it.copy(
+                    showControls = shouldShowControls,
+                    showSeekOverlay = false,
+                    showMoreDialog = if (shouldShowControls) it.showMoreDialog else false
+                )
+            }
+            if (shouldShowControls) {
                 scheduleHideControls()
             }
         }


### PR DESCRIPTION
## Summary

- Clear stale `showMoreDialog` state when player controls are hidden.
- Reset related control state when toggling controls off so hidden UI does not keep affecting focus/navigation.
- Fix the broken seek / remote navigation flow after pressing `DPAD Down` while `More actions` is open.

## PR type

- Bug fix

## Why

Issue #873 reports that pressing `DPAD Down` while `More actions` is open hides the controls visually, but leaves part of the player control state behind. That desync can make the player behave as if an invisible menu is still active, which interferes with seek and remote navigation.

This change ensures the `More actions` state is cleared when controls are dismissed, so the player returns cleanly to its normal playback state.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Reproduced the issue in the internal player flow where `More actions` is open and `DPAD Down` hides the controls.
- Verified the control state is cleared when controls are dismissed, so hidden UI no longer interferes with input.
- Ran `./gradlew.bat :app:compileDebugKotlin` successfully.

## Screenshots / Video (UI changes only)

- No visual redesign in this PR. This is a player state/focus handling fix, so the behavior is better verified through the reproduction steps from #873 than through screenshots.

## Breaking changes

- No breaking changes are expected. This only adjusts internal player overlay/control state cleanup when the controls are hidden.

## Linked issues

- Fixes #873