### PR TITLE
Update Portuguese (Portugal) strings.xml - added 300+ missing strings

### DIFF
--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,32 +1,74 @@
 <resources>
+    <string name="app_name">Nuvio</string>
     <string name="type_movie">Filme</string>
     <string name="type_series">Série</string>
+    <string name="type_unknown">Desconhecido</string>g>
 
     <!-- HomeScreen -->
-    <string name="home_no_addons">Sem complementos instalados. Adicione um para começar.</string>
-    <string name="home_no_catalog_addons">Sem complementos de catálogo instalados. Instale um complemento de catálogo para ver conteúdo.</string>
+    <string name="home_no_addons">Nenhum addon instalado. Adiciona um para começar.</string>
+    <string name="home_no_catalog_addons">Nenhum addon de catálogo instalado. Instala um para ver conteúdo.</string>
+    <string name="auth_notice_nuvio_logged_out">A tua sessão no Nuvio terminou. Por favor, inicia sessão novamente.</string>
+    <string name="auth_notice_trakt_logged_out">A tua sessão no Trakt terminou. Por favor, volta a ligar.</string>
     <string name="error_generic">Ocorreu um erro</string>
 
     <!-- ErrorState -->
     <string name="action_retry">Tentar novamente</string>
+    <string name="error_state_generic_issue">Algo correu mal.</string>
+    <string name="error_state_possible_fix">Correção possível: %1$s</string>
+    <string name="error_state_fix_retry_soon">tenta novamente daqui a pouco.</string>
+    <string name="error_state_issue_no_metadata_any_addon">Este ID não conseguiu carregar detalhes porque nenhum dos addons instalados retornou metadados.</string>
+    <string name="error_state_fix_no_metadata_any_addon">tenta outro addon, desativa \"Preferir addon de meta externo\" nas definições de Layout, ou confirma se um addon instalado suporta este ID.</string>
+    <string name="error_state_prefix_no_supported_metadata">Nenhum addon instalado suporta metadados para </string>
+    <string name="error_state_prefix_no_addon_for_id">Nenhum addon instalado pôde fornecer metadados para id=</string>
+    <string name="error_state_fix_no_supported_metadata">instala ou atualiza um addon que suporte este tipo de conteúdo e tenta novamente.</string>
+    <string name="error_state_prefix_tried_meta_addons">Addons de meta testados:</string>
+    <string name="error_state_fix_tried_meta_addons">instala um addon que suporte este ID, ou reconfigura/atualiza o addon e tenta novamente.</string>
+    <string name="error_state_issue_missing_metadata_for_id">não tem metadados para este ID</string>
+    <string name="error_state_fix_missing_metadata_for_id">abre este ID de um addon diferente, desativa \"Preferir addon de meta externo\", ou verifica se o addon suporta este ID.</string>
+    <string name="error_state_issue_addon_unreachable">não foi possível alcançar</string>
+    <string name="error_state_fix_addon_unreachable">verifica a tua ligação à internet, verifica se o URL do addon ainda funciona e tenta novamente.</string>
+    <string name="error_state_issue_addon_connection_failed">rejeitou a ligação</string>
+    <string name="error_state_fix_addon_connection_failed">certifica-te de que o servidor do addon está online e contactável, depois tenta novamente.</string>
+    <string name="error_state_issue_addon_timeout">demorou demasiado tempo a responder</string>
+    <string name="error_state_fix_addon_timeout">tenta novamente daqui a pouco, ou tenta outro addon se isto continuar a acontecer.</string>
+    <string name="error_state_issue_addon_cleartext">utiliza uma ligação HTTP insegura que o Android bloqueou</string>
+    <string name="error_state_fix_addon_cleartext">muda o URL do addon para HTTPS ou atualiza a configuração do addon.</string>
+    <string name="error_state_fix_addon_generic">tenta novamente, atualiza ou reinstala o addon, ou tenta um addon diferente.</string>
+    <string name="error_state_addon_issue_template">%1$s: %2$s.</string>
+    <string name="error_meta_not_found">Metadados não encontrados</string>
+    <string name="error_meta_no_supported_addon">Nenhum addon instalado suporta metadados para \"%1$s\".</string>
+    <string name="error_meta_no_addon_for_id">Nenhum addon instalado pôde fornecer metadados para id=%1$s (tipo=%2$s).</string>
+    <string name="error_meta_tried_none">Addons de meta testados: %1$s. Nenhum forneceu metadados para id=%2$s (tipo=%3$s).</string>
+    <string name="error_meta_tried_generic">Addons de meta testados: %1$s. Não foi possível carregar metadados para id=%2$s (tipo=%3$s).</string>
+    <string name="error_meta_tried_issues">Addons de meta testados: %1$s. Não foi possível carregar metadados para id=%2$s (tipo=%3$s). Problemas: %4$s.</string>
+    <string name="error_stream_no_supported_addon">Nenhum addon instalado suporta transmissões para \"%1$s\".</string>
+    <string name="error_stream_tried_none">Addons de transmissão testados: %1$s. Nenhum retornou transmissões para id=%2$s (tipo=%3$s).</string>
+    <string name="error_stream_tried_generic">Addons de transmissão testados: %1$s. Não foi possível carregar as transmissões para id=%2$s (tipo=%3$s).</string>
+    <string name="error_stream_tried_issues">Addons de transmissão testados: %1$s. Não foi possível carregar as transmissões para id=%2$s (tipo=%3$s). Problemas: %4$s.</string>
 
     <!-- ContinueWatchingSection -->
-    <string name="continue_watching">Continuar a ver</string>
-    <string name="cw_upcoming">Em breve</string>
-    <string name="cw_next_up">A seguir</string>
+    <string name="continue_watching">Continuar a Ver</string>
+    <string name="cw_upcoming">Próximos</string>
+    <string name="cw_next_up">Seguinte</string>
     <string name="cw_resume">Retomar</string>
-    <string name="cw_airs_date">Estreia a %1$s</string>
+    <string name="cw_percent_watched">%1$d%% visto</string>
+    <string name="cw_hours_min_left">restam %1$dh %2$dm</string>
+    <string name="cw_min_left">restam %1$dm</string>
+    <string name="cw_almost_done">Quase a terminar</string>
+    <string name="cw_airs_date">Emite a %1$s</string>
     <string name="cw_action_go_to_details">Ir para detalhes</string>
+    <string name="cw_action_start_from_beginning">Começar do início</string>
     <string name="cw_action_remove">Remover</string>
-    <string name="cw_dialog_subtitle">Escolha o que pretende fazer com este item.</string>
-
+    <string name="cw_dialog_subtitle">Escolhe o que queres fazer com este item.</string>
+    <string name="home_poster_dialog_subtitle">Ações do título</string>
+    
     <!-- CatalogRowSection -->
     <string name="catalog_from_addon">de %1$s</string>
-    <string name="action_see_all">Ver tudo</string>
-
+    <string name="action_see_all">Ver Tudo</string>
+    
     <!-- HeroSection -->
-    <string name="hero_creator">Autor: %1$s</string>
-    <string name="hero_director">Realizador: %1$s</string>
+    <string name="hero_creator">Criador: %1$s</string>
+    <string name="hero_director">Diretor: %1$s</string>
     <string name="hero_writer">Argumentista: %1$s</string>
     <string name="hero_play">Reproduzir</string>
     <string name="hero_play_episode">Reproduzir T%1$d, E%2$d</string>
@@ -34,10 +76,10 @@
     <string name="hero_remove_from_library">Remover da biblioteca</string>
     <string name="hero_mark_watched">Marcar como visto</string>
     <string name="hero_mark_unwatched">Marcar como não visto</string>
-    <string name="hero_play_trailer">Reproduzir trailer</string>
-    <string name="hero_press_back_trailer">Prima voltar para sair do trailer</string>
+    <string name="hero_play_trailer">Ver trailer</string>
+    <string name="hero_press_back_trailer">Prime \"voltar\" para sair do trailer</string>
     <string name="cd_rating">Classificação</string>
-
+    
     <!-- EpisodesSection -->
     <string name="episodes_season">Temporada %1$d</string>
     <string name="episodes_specials">Especiais</string>
@@ -50,90 +92,182 @@
     <string name="episodes_mark_season_unwatched">Marcar temporada como não vista</string>
     <string name="episodes_mark_previous_watched">Marcar anteriores desta temporada como vistos</string>
     <string name="episodes_play">Reproduzir</string>
+    <string name="play_manually">Reproduzir manualmente</string>
     <string name="episodes_season_actions">Ações da temporada</string>
 
+    <!-- MetaDetailsViewModel -->
+    <string name="detail_added_to_library">Adicionado à biblioteca</string>
+    <string name="detail_removed_from_library">Removido da biblioteca</string>
+    <string name="detail_episode_marked_watched">Episódio marcado como visto</string>
+    <string name="detail_episode_marked_unwatched">Episódio marcado como não visto</string>
+    <string name="detail_lists_updated">Listas atualizadas</string>
+    <string name="detail_movie_marked_watched">Marcado como visto</string>
+    <string name="detail_movie_marked_unwatched">Marcado como não visto</string>
+    <string name="detail_all_episodes_watched">Todos os episódios já foram vistos</string>
+    <string name="detail_no_watched_episodes">Nenhum episódio visto nesta temporada</string>
+    <string name="detail_all_previous_watched">Todos os episódios anteriores já foram vistos</string>
+    <string name="detail_marked_episodes_watched">Episódios marcados como vistos: %1$d</string>
+    <string name="detail_marked_episodes_unwatched">Episódios marcados como não vistos: %1$d</string>
+    <string name="detail_marked_previous_watched">Episódios anteriores marcados como vistos: %1$d</string>
+
     <!-- MetaDetailsScreen -->
-    <string name="detail_tab_cast">Autor e elenco</string>
+    <string name="detail_btn_play">Reproduzir</string>
+    <string name="detail_btn_resume">Retomar</string>
+    <string name="detail_btn_play_episode">Reproduzir T%1$dE%2$d</string>
+    <string name="detail_btn_resume_episode">Retomar T%1$dE%2$d</string>
+    <string name="detail_btn_next_episode">Seguinte T%1$dE%2$d</string>
+    <string name="detail_tab_cast">Criador e Elenco</string>
+    <string name="cast_role_creator">Criador</string>
+    <string name="cast_role_director">Diretor</string>
+    <string name="cast_role_writer">Argumentista</string>
     <string name="detail_tab_ratings">Classificações</string>
     <string name="detail_tab_more_like_this">Mais como este</string>
-    <string name="detail_section_network">Canal</string>
+    <string name="detail_section_network">Rede/Canal</string>
     <string name="detail_section_production">Produção</string>
+    <string name="episodes_unavailable">Indisponível</string>
+    <string name="series_status_ended">Terminada</string>
+    <string name="series_status_continuing">Em curso</string>
+    <string name="series_status_current">Atual</string>
+    <string name="series_status_cancelled">Cancelada</string>
+    <string name="series_status_released">Lançada</string>
+    <string name="series_status_planned">Planeada</string>
+    <string name="series_status_rumored">Rumores</string>
+    <string name="series_status_in_production">Em Produção</string>
+    <string name="series_status_post_production">Pós-Produção</string>
     <string name="detail_lists_fallback">Listas</string>
-    <string name="detail_lists_subtitle">Selecione as listas que devem incluir este título.</string>
+    <string name="detail_lists_subtitle">Seleciona quais as listas que devem incluir este título.</string>
     <string name="action_save">Guardar</string>
     <string name="action_saving">A guardar…</string>
 
     <!-- AppLanguage -->
-    <string name="appearance_language">Idioma da aplicação</string>
+    <string name="appearance_language">Idioma da App</string>
     <string name="appearance_language_subtitle">Substituir idioma do sistema</string>
-    <string name="appearance_language_system">Predefinição do sistema</string>
-    <string name="appearance_language_dialog_title">Escolher idioma</string>
-    <string name="appearance_language_restart_hint">Reinicie a aplicação para aplicar a alteração de idioma.</string>
-
+    <string name="appearance_language_system">Padrão do sistema</string>
+    <string name="appearance_language_dialog_title">Escolher Idioma</string>
+    <string name="appearance_language_restart_hint">Reinicia a app para aplicar a alteração de idioma.</string>
+    
+    <!-- Font -->
+    <string name="appearance_font">Tipo de letra</string>
+    <string name="appearance_font_subtitle">Escolhe o teu tipo de letra preferido</string>
+    <string name="appearance_font_dialog_title">Escolher tipo de letra</string>
+    
     <!-- ThemeSettingsScreen -->
-    <string name="appearance_title">Aspeto</string>
-    <string name="appearance_subtitle">Escolha o tema de cores e o idioma</string>
+    <string name="appearance_title">Aparência</string>
+    <string name="appearance_subtitle">Escolhe o tema de cores, letra e idioma</string>
     <string name="cd_selected">Selecionado</string>
-
+    
     <!-- AboutScreen -->
     <string name="about_title">Sobre</string>
-    <string name="about_subtitle">Informações da app, atualizações e hiperligações legais</string>
-    <string name="about_made_with_love">Feito com ❤️ pelo Tapframe e amigos</string>
+    <string name="about_subtitle">Informações da app, atualizações e links legais</string>
+    <string name="about_made_with_love">Feito com ❤️ pela Tapframe e amigos</string>
     <string name="about_version">Versão %1$s</string>
     <string name="about_check_updates">Procurar atualizações</string>
-    <string name="about_check_updates_subtitle">Transferir versão mais recente</string>
-    <string name="about_privacy_policy">Política de privacidade</string>
+    <string name="about_check_updates_subtitle">Descarregar a versão mais recente</string>
+    <string name="about_privacy_policy">Política de Privacidade</string>
     <string name="about_privacy_policy_subtitle">Ver a nossa política de privacidade</string>
+    <string name="about_supporters_contributors">Apoiantes e Colaboradores</string>
+    <string name="about_supporters_contributors_subtitle">Reconhecimento aberto e créditos do projeto</string>
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Conta</string>
-    <string name="settings_account_subtitle">Conta e estado de sincronização.</string>
+    <string name="settings_account_subtitle">Estado da conta e sincronização.</string>
     <string name="settings_profiles">Perfis</string>
     <string name="settings_profiles_subtitle">Gerir perfis de utilizador.</string>
-    <string name="settings_layout">Disposição</string>
-    <string name="settings_layout_subtitle">Estrutura da página inicial e estilos dos posters.</string>
-    <string name="settings_plugins">Extensões</string>
+    <string name="settings_layout">Layout</string>
+    <string name="settings_layout_subtitle">Estrutura do ecrã inicial e estilos de póster.</string>
+    <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Repositórios e fornecedores.</string>
     <string name="settings_integration">Integração</string>
     <string name="settings_playback">Reprodução</string>
-    <string name="settings_playback_subtitle">Leitor, legendas e reprodução automática.</string>
+    <string name="settings_playback_subtitle">Reprodutor, legendas e reprodução automática.</string>
     <string name="settings_trakt_subtitle">Abrir ecrã de ligação ao Trakt.</string>
     <string name="settings_about_subtitle">Versão e políticas.</string>
-    <string name="settings_debug">Depuração</string>
-    <string name="settings_debug_subtitle">Ferramentas de programador e indicadores de funcionalidade.</string>
-    <string name="settings_plugins_section_subtitle">Gerir repositórios, fornecedores e estados das extensões.</string>
+    <string name="settings_network">Velocidade da rede</string>
+    <string name="settings_network_subtitle">Diagnósticos de latência e download</string>
+    <string name="settings_advanced">Avançado</string>
+    <string name="settings_advanced_subtitle">Executar diagnóstico de velocidade de rede</string>
+    <string name="network_speed_test_run">Executar Teste de Velocidade</string>
+    <string name="network_speed_test_running">A executar Teste de Velocidade</string>
+    <string name="network_speed_test_subtitle">Medir velocidade de download e latência</string>
+    <string name="network_testing_latency">A medir latência</string>
+    <string name="network_testing_download">A medir velocidade de download</string>
+    <string name="network_results_title">Resultados</string>
+    <string name="network_latency_label">Latência</string>
+    <string name="network_download_label">Download</string>
+    <string name="network_error_prefix">Erro: %1$s</string>
+    <string name="network_powered_by_fast">Powered by fast.com</string>
+    <string name="network_connection_wifi">Wi-Fi</string>
+    <string name="network_connection_ethernet">Ethernet</string>
+    <string name="network_connection_offline">Offline</string>
+    <string name="settings_debug">Debug</string>
+    <string name="settings_debug_subtitle">Ferramentas de programador e feature flags.</string>
+    <string name="settings_plugins_section_subtitle">Gerir repositórios, fornecedores e estado dos plugins.</string>
     <string name="settings_account_section_subtitle">Estado da conta e sincronização.</string>
+    <string name="account_stat_addons">addons</string>
+    <string name="account_stat_plugins">plugins</string>
+    <string name="account_stat_library">biblioteca</string>
+    <string name="account_stat_progress">progresso</string>
+    <string name="account_stat_watched">vistos</string>
     <string name="settings_integrations_section">Integrações</string>
-    <string name="settings_integrations_section_subtitle">Escolha definições TMDB ou MDBList</string>
+    <string name="settings_integrations_section_subtitle">Escolher TMDB ou MDBList</string>
     <string name="settings_tmdb_subtitle">Controlos de enriquecimento de metadados</string>
     <string name="settings_mdblist_subtitle">Fornecedores externos de classificações</string>
+    <string name="settings_animeskip_subtitle">Tempos de salto para intros/outros de Anime</string>
 
     <!-- PlaybackSettingsScreen -->
-    <string name="playback_title">Definições de reprodução</string>
-    <string name="playback_subtitle">Configurar opções de reprodução de vídeo e legendas</string>
+    <string name="playback_title">Definições de Reprodução</string>
+    <string name="playback_subtitle">Configurar reprodução de vídeo e opções de legendas</string>
     <string name="cd_decrease">Diminuir</string>
     <string name="cd_increase">Aumentar</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_none">Nenhum</string>
+    <string name="action_close">Fechar</string>
+
+    <!-- SupportersContributorsScreen -->
+    <string name="supporters_contributors_title">Apoiantes e Colaboradores</string>
+    <string name="supporters_contributors_subtitle">As pessoas que apoiam o Nuvio e os colaboradores que o constroem para TV e dispositivos móveis.</string>
+    <string name="supporters_contributors_supporters_copy">Os apoiantes e doadores ajudam a manter o projeto em movimento, financiam a infraestrutura e abrem espaço para funcionalidades ambiciosas.</string>
+    <string name="supporters_contributors_donate_copy">O Nuvio continuará a ser gratuito e de código aberto. Se quiseres apoiar o projeto, podes ajudar a cobrir o tempo e a infraestrutura por trás dele.</string>
+    <string name="supporters_contributors_donate_button">Doar ao Nuvio</string>
+    <string name="supporters_contributors_qr_title">Digitaliza para doar</string>
+    <string name="supporters_contributors_qr_subtitle">Abre o link no teu telemóvel e apoia o Nuvio através do Ko-fi.</string>
+    <string name="supporters_contributors_qr_hint">Aponta a tua câmara para o código QR ou usa o botão abaixo.</string>
+    <string name="supporters_contributors_back_button">Voltar aos detalhes</string>
+    <string name="supporters_tab">Apoiantes</string>
+    <string name="contributors_tab">Colaboradores</string>
+    <string name="supporters_loading">A carregar apoiantes…</string>
+    <string name="supporters_empty">Ainda não foram encontrados apoiantes.</string>
+    <string name="supporters_error_title">Não foi possível carregar os apoiantes</string>
+    <string name="supporters_no_message">Nenhuma mensagem partilhada.</string>
+    <string name="supporters_open_donations">Abrir página de doações</string>
+    <string name="contributors_loading">A carregar colaboradores do GitHub…</string>
+    <string name="contributors_empty">Ainda não foram encontrados colaboradores.</string>
+    <string name="contributors_error_title">Não foi possível carregar os colaboradores</string>
+    <string name="contributors_total_contributions">%1$d contribuições no total</string>
+    <string name="contributors_open_github">Abrir Perfil do GitHub</string>
+    <string name="contributors_show_kofi_qr">Mostrar QR do Ko-fi</string>
+    <string name="contributors_hide_kofi_qr">Ocultar QR do Ko-fi</string>
+    <string name="contributors_profile_unavailable">Link do perfil do GitHub indisponível.</string>
 
     <!-- PlaybackSettingsSections -->
     <string name="playback_section_general">Geral</string>
-    <string name="playback_section_general_desc">Comportamento base da reprodução.</string>
-    <string name="playback_loading_overlay">Sobreposição de carregamento</string>
-    <string name="playback_loading_overlay_sub">Mostrar ecrã de carregamento até aparecer o primeiro frame de vídeo.</string>
-    <string name="playback_pause_overlay">Sobreposição de pausa</string>
-    <string name="playback_pause_overlay_sub">Mostrar sobreposição de detalhes após 5 segundos em pausa.</string>
-    <string name="playback_show_clock_sub">Mostrar hora atual e hora de fim enquanto os controlos estão visíveis.</string>
-    <string name="playback_skip_intro">Saltar intro</string>
-    <string name="playback_skip_intro_sub">Usar introdb.app para detetar intros e recaps.</string>
-    <string name="playback_auto_frame_rate">Taxa de frames automática</string>
-    <string name="playback_section_player">Leitor e seleção de transmissão</string>
-    <string name="playback_section_player_desc">Preferência de leitor, reprodução automática e filtragem de fontes.</string>
-    <string name="playback_player">Leitor</string>
+    <string name="playback_section_general_desc">Comportamento principal de reprodução.</string>
+    <string name="playback_loading_overlay">Sobreposição de Carregamento</string>
+    <string name="playback_loading_overlay_sub">Mostrar ecrã de carregamento até aparecer o primeiro frame do vídeo.</string>
+    <string name="playback_pause_overlay">Sobreposição em Pausa</string>
+    <string name="playback_pause_overlay_sub">Mostrar detalhes após 5 segundos em pausa.</string>
+    <string name="playback_show_clock_sub">Mostrar hora atual e hora de término quando os controlos estão visíveis.</string>
+    <string name="playback_osd_clock">Relógio no OSD</string>
+    <string name="playback_skip_intro">Saltar Intro</string>
+    <string name="playback_skip_intro_sub">Usar introdb.app para detetar intros e resumos.</string>
+    <string name="playback_auto_frame_rate">Taxa de Frames Automática</string>
+    <string name="playback_section_player">Reprodutor e Seleção de Transmissão</string>
+    <string name="playback_section_player_desc">Preferência de reprodutor, reprodução automática e filtragem de fontes.</string>
+    <string name="playback_player">Reprodutor</string>
     <string name="playback_player_internal">Interno</string>
     <string name="playback_player_external">Externo</string>
     <string name="playback_player_ask">Perguntar sempre</string>
-    <string name="playback_section_audio">Áudio e trailer</string>
+    <string name="playback_section_audio">Áudio e Trailer</string>
     <string name="playback_section_audio_desc">Comportamento do trailer e controlos de áudio.</string>
     <string name="playback_section_subtitles">Legendas</string>
     <string name="playback_section_subtitles_desc">Idioma, estilo e modo de renderização.</string>
@@ -141,276 +275,324 @@
     <string name="playback_afr_closed">Fechado</string>
     <string name="playback_afr_off">Desligado</string>
     <string name="playback_afr_off_sub">Não alterar a taxa de atualização do ecrã.</string>
-    <string name="playback_afr_on_start">Ao iniciar</string>
-    <string name="playback_afr_on_start_sub">Mudar quando a reprodução começar.</string>
-    <string name="playback_afr_on_start_stop">Ao iniciar/parar</string>
+    <string name="playback_afr_on_start">No início</string>
+    <string name="playback_afr_on_start_sub">Mudar quando a reprodução começa.</string>
+    <string name="playback_afr_on_start_stop">No início/fim</string>
     <string name="playback_afr_on_start_stop_sub">Mudar no início e restaurar ao parar.</string>
-    <string name="playback_player_external_desc">Abrir sempre transmissões numa app externa</string>
-    <string name="playback_player_ask_desc">Escolher o leitor de cada vez</string>
+    <string name="playback_resolution_matching">Ajuste de resolução</string>
+    <string name="playback_resolution_matching_sub">Permitir alterações no modo de exibição para corresponder à resolução do vídeo.</string>
+    <string name="playback_player_external_desc">Abrir sempre as transmissões numa app externa</string>
+    <string name="playback_player_ask_desc">Escolher o reprodutor de cada vez</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_trailer_section">Trailer</string>
-    <string name="audio_autoplay_trailers">Reprodução automática de trailers</string>
+    <string name="audio_autoplay_trailers">Reprodução Automática de Trailers</string>
     <string name="audio_autoplay_trailers_sub">Reproduzir trailers automaticamente no ecrã de detalhes após um período de inatividade</string>
-    <string name="audio_trailer_delay">Atraso do trailer</string>
+    <string name="audio_trailer_delay">Atraso do Trailer</string>
     <string name="audio_section">Áudio</string>
-    <string name="audio_lang_default">Predefinido (ficheiro multimédia)</string>
+    <string name="audio_lang_default">Predefinido (ficheiro media)</string>
     <string name="audio_lang_device">Idioma do dispositivo</string>
-    <string name="audio_preferred_lang">Idioma de áudio preferido</string>
-    <string name="audio_skip_silence">Saltar silêncio</string>
+    <string name="audio_preferred_lang">Idioma de Áudio Preferido</string>
+    <string name="audio_skip_silence">Saltar Silêncio</string>
     <string name="audio_skip_silence_sub">Saltar partes silenciosas do áudio durante a reprodução</string>
-    <string name="audio_advanced_section">Áudio avançado</string>
-    <string name="audio_advanced_warning">Estas definições podem causar problemas em alguns dispositivos. Altere apenas se souber o que está a fazer.</string>
+    <string name="audio_advanced_section">Áudio Avançado</string>
+    <string name="audio_advanced_warning">Estas definições podem causar problemas em alguns dispositivos. Altera apenas se souberes o que estás a fazer.</string>
     <string name="audio_decoder_device_only">Apenas descodificadores do dispositivo</string>
     <string name="audio_decoder_prefer_device">Preferir descodificadores do dispositivo</string>
     <string name="audio_decoder_prefer_app">Preferir descodificadores da app (FFmpeg)</string>
-    <string name="audio_decoder_priority">Prioridade do descodificador</string>
-    <string name="audio_tunneled">Reprodução em túnel</string>
+    <string name="audio_decoder_priority">Prioridade do Descodificador</string>
+    <string name="audio_tunneled">Reprodução com Túnel (Tunneled)</string>
     <string name="audio_tunneled_sub">Sincronização áudio/vídeo ao nível do hardware. Pode melhorar a reprodução em alguns dispositivos Android TV</string>
-    <string name="audio_dv_sub">Mapear Dolby Vision Perfil 7 para HEVC padrão em dispositivos sem suporte de hardware DV</string>
+    <string name="audio_dv_sub">Mapear Dolby Vision Perfil 7 para HEVC padrão para dispositivos sem suporte de hardware DV</string>
     <string name="audio_decoder_device_only_desc">Usar apenas descodificadores de hardware integrados. Mais compatível, mas pode não suportar todos os formatos.</string>
-    <string name="audio_decoder_prefer_device_desc">Usar descodificadores de hardware quando disponíveis, com plano alternativo para FFmpeg. Recomendado para a maioria dos dispositivos.</string>
-    <string name="audio_decoder_prefer_app_desc">Usar descodificadores FFmpeg quando disponíveis. Melhor suporte de formatos, mas maior utilização de CPU.</string>
-    <string name="audio_decoder_controls">Controla se são usados descodificadores de hardware ou software (FFmpeg) para áudio e vídeo</string>
+    <string name="audio_decoder_prefer_device_desc">Usar descodificadores de hardware quando disponíveis, caso contrário usar FFmpeg. Recomendado para a maioria dos dispositivos.</string>
+    <string name="audio_decoder_prefer_app_desc">Usar descodificadores FFmpeg quando disponíveis. Melhor suporte de formatos, mas maior uso de CPU.</string>
+    <string name="audio_decoder_controls">Controla se descodificadores de hardware ou software (FFmpeg) são usados para áudio e vídeo</string>
 
     <!-- PlaybackSubtitleSettings -->
     <string name="sub_section">Legendas</string>
     <string name="sub_not_set">Não definido</string>
-    <string name="sub_preferred_lang">Idioma preferido</string>
-    <string name="sub_secondary_lang">Segundo idioma preferido</string>
-    <string name="sub_organization">Organização das legendas</string>
+    <string name="sub_forced_lang">Forçadas</string>
+    <string name="sub_preferred_lang">Idioma Preferido</string>
+    <string name="sub_secondary_lang">Segundo Idioma Preferido</string>
+    <string name="sub_organization">Organização das Legendas</string>
     <string name="sub_size">Tamanho</string>
-    <string name="sub_vertical_offset">Deslocamento vertical</string>
+    <string name="sub_vertical_offset">Desvio Vertical</string>
     <string name="sub_bold">Negrito</string>
-    <string name="sub_bold_sub">Usar peso de letra a negrito para as legendas</string>
-    <string name="sub_text_color">Cor do texto</string>
-    <string name="sub_bg_color">Cor de fundo</string>
+    <string name="sub_bold_sub">Usar negrito nas legendas</string>
+    <string name="sub_text_color">Cor do Texto</string>
+    <string name="sub_bg_color">Cor de Fundo</string>
     <string name="sub_outline">Contorno</string>
     <string name="sub_outline_sub">Adicionar contorno ao texto das legendas para melhor visibilidade</string>
-    <string name="sub_outline_color">Cor do contorno</string>
-    <string name="sub_advanced_section">Renderização avançada de legendas</string>
+    <string name="sub_outline_color">Cor do Contorno</string>
+    <string name="sub_advanced_section">Renderização de Legendas Avançada</string>
     <string name="sub_libass">Usar libass para legendas ASS/SSA</string>
-    <string name="sub_libass_sub">Temporariamente desativado para manutenção</string>
-    <string name="sub_libass_mode">Modo de renderização libass</string>
+    <string name="sub_libass_sub">Experimental: renderização ASS/SSA avançada (estilos, posicionamento, animações)</string>
+    <string name="sub_libass_mode">Modo de Renderização Libass</string>
     <string name="sub_mode_overlay_gl">Sobreposição OpenGL (Recomendado)</string>
-    <string name="sub_mode_overlay_gl_sub">Melhor qualidade com suporte HDR. Renderiza legendas numa linha de execução separada.</string>
+    <string name="sub_mode_overlay_gl_sub">Melhor qualidade com suporte HDR. Renderiza legendas numa thread separada.</string>
     <string name="sub_mode_overlay_canvas">Sobreposição Canvas</string>
     <string name="sub_mode_effects_gl">Efeitos OpenGL</string>
-    <string name="sub_mode_effects_gl_sub">Suporte de animação com efeitos Media3. Mais rápido que Canvas.</string>
+    <string name="sub_mode_effects_gl_sub">Suporte para animações usando efeitos Media3. Mais rápido que Canvas.</string>
     <string name="sub_mode_effects_canvas">Efeitos Canvas</string>
-    <string name="sub_mode_effects_canvas_sub">Suporte de animação com efeitos Media3 e renderização Canvas.</string>
-    <string name="sub_mode_standard">Legendas padrão</string>
-    <string name="sub_mode_standard_sub">Renderização básica de legendas sem suporte de animação. Mais compatível.</string>
+    <string name="sub_mode_effects_canvas_sub">Suporte para animações usando efeitos Media3 com renderização Canvas.</string>
+    <string name="sub_mode_standard">Cues Padrão</string>
+    <string name="sub_mode_standard_sub">Renderização de legendas básica sem suporte para animações. Mais compatível.</string>
     <string name="sub_org_none">Nenhuma (ordem predefinida)</string>
     <string name="sub_org_by_lang">Por idioma</string>
-    <string name="sub_org_by_addon">Por complemento</string>
-    <string name="sub_org_none_desc">Mostrar legendas pela ordem predefinida dos resultados do complemento.</string>
+    <string name="sub_org_by_addon">Por addon</string>
+    <string name="sub_org_none_desc">Mostrar legendas na ordem predefinida do addon.</string>
     <string name="sub_org_by_lang_desc">Agrupar legendas por idioma.</string>
-    <string name="sub_org_by_addon_desc">Agrupar legendas por fonte do complemento.</string>
+    <string name="sub_org_by_addon_desc">Agrupar legendas pela fonte (addon).</string>
+    <string name="sub_startup_mode_title">Carregamento de Legendas de Addons</string>
+    <string name="sub_startup_mode_fast">Início rápido</string>
+    <string name="sub_startup_mode_preferred">Idiomas preferidos</string>
+    <string name="sub_startup_mode_all">Todas as legendas de addons</string>
+    <string name="sub_startup_mode_fast_desc">Inicia a reprodução imediatamente. Selecionar legendas de addons pode recarregar o reprodutor uma vez.</string>
+    <string name="sub_startup_mode_preferred_desc">Pré-carrega legendas de addons antes da reprodução e anexa as faixas dos idiomas preferidos.</string>
+    <string name="sub_startup_mode_all_desc">Pré-carrega e anexa todas as legendas de addons antes da reprodução. Início mais lento.</string>
 
     <!-- PlaybackAutoPlaySettings -->
-    <string name="autoplay_reuse_last_link">Reutilizar último link</string>
-    <string name="autoplay_reuse_last_link_sub">Reproduzir automaticamente a última transmissão funcional deste mesmo filme/episódio quando a cache ainda for válida</string>
-    <string name="autoplay_last_link_cache">Duração da cache do último link</string>
-    <string name="autoplay_mode_manual">Manual (escolher transmissão)</string>
-    <string name="autoplay_mode_first">Reprodução automática da primeira fonte</string>
-    <string name="autoplay_mode_regex">Reprodução automática por expressão regular</string>
-    <string name="autoplay_stream_selection">Seleção automática de transmissão</string>
-    <string name="autoplay_next_episode">Reproduzir automaticamente próximo episódio</string>
-    <string name="autoplay_next_episode_sub">Iniciar automaticamente o próximo episódio quando surgir o aviso.</string>
+    <string name="autoplay_reuse_last_link">Reutilizar Último Link</string>
+    <string name="autoplay_reuse_last_link_sub">Reproduzir automaticamente o último link funcional para o mesmo filme/episódio enquanto a cache for válida</string>
+    <string name="autoplay_last_link_cache">Duração da Cache do Último Link</string>
+    <string name="autoplay_mode_manual">Manual (escolher stream)</string>
+    <string name="autoplay_mode_first">Auto-reproduzir primeira fonte</string>
+    <string name="autoplay_mode_regex">Auto-reproduzir via Regex</string>
+    <string name="autoplay_stream_selection">Seleção Automática de Stream</string>
+    <string name="autoplay_next_episode">Auto-reproduzir Próximo Episódio</string>
+    <string name="autoplay_next_episode_sub">Iniciar o próximo episódio automaticamente quando o aviso aparecer.</string>
+    <string name="autoplay_prefer_binge_group">Preferir Grupo Binge (Próximo Episódio)</string>
+    <string name="autoplay_prefer_binge_group_sub">Tentar primeiro o mesmo perfil de fonte (mesmo addon/grupo de qualidade) antes das regras normais.</string>
     <string name="autoplay_threshold_pct">Percentagem</string>
     <string name="autoplay_threshold_min">Minutos antes do fim</string>
-    <string name="autoplay_threshold_mode">Modo de limite do próximo episódio</string>
-    <string name="autoplay_threshold_pct_title">Percentagem limite</string>
-    <string name="autoplay_threshold_pct_sub">Recurso alternativo quando não existe nenhum outro registo temporal.</string>
-    <string name="autoplay_threshold_min_title">Minutos limite</string>
-    <string name="autoplay_threshold_min_sub">Recurso alternativo quando não existe registo temporal do final.</string>
+    <string name="autoplay_threshold_mode">Modo de Limite para Próximo Episódio</string>
+    <string name="autoplay_threshold_pct_title">Percentagem de Limite</string>
+    <string name="autoplay_threshold_pct_sub">Alternativa quando não existe timestamp de fim.</string>
+    <string name="autoplay_threshold_min_title">Minutos de Limite</string>
+    <string name="autoplay_threshold_min_sub">Alternativa quando não existe timestamp de fim.</string>
     <string name="autoplay_scope_all">Todas as fontes</string>
-    <string name="autoplay_scope_addons">Apenas complementos instalados</string>
-    <string name="autoplay_scope_plugins">Apenas extensões ativas</string>
-    <string name="autoplay_scope">Âmbito da fonte para reprodução automática</string>
-    <string name="autoplay_allowed_addons">Complementos permitidos</string>
-    <string name="autoplay_all_addons">Todos os complementos instalados</string>
-    <string name="autoplay_allowed_plugins">Extensões permitidas</string>
-    <string name="autoplay_all_plugins">Todas as extensões ativas</string>
-    <string name="autoplay_regex_placeholder">Nenhum padrão definido. Exemplo: 4K|2160p|Remux</string>
-    <string name="autoplay_regex_title">Padrão de expressão regular</string>
+    <string name="autoplay_scope_addons">Apenas addons instalados</string>
+    <string name="autoplay_scope_plugins">Apenas plugins ativos</string>
+    <string name="autoplay_scope">Âmbito da Auto-reprodução</string>
+    <string name="autoplay_timeout_title">Tempo Limite de Seleção de Stream</string>
+    <string name="autoplay_timeout_sub">Tempo de espera pelos addons antes de selecionar.</string>
+    <string name="autoplay_timeout_instant">Instantâneo</string>
+    <string name="autoplay_timeout_unlimited">Ilimitado</string>
+    <string name="autoplay_allowed_addons">Addons Permitidos</string>
+    <string name="autoplay_all_addons">Todos os addons instalados</string>
+    <string name="autoplay_allowed_plugins">Plugins Permitidos</string>
+    <string name="autoplay_all_plugins">Todos os plugins ativos</string>
+    <string name="autoplay_regex_placeholder">Nenhum padrão definido. Ex: 4K|2160p|Remux</string>
+    <string name="autoplay_regex_title">Padrão Regex</string>
     <string name="autoplay_no_items">Nenhum item disponível</string>
-    <string name="autoplay_mode_manual_desc">Mostrar sempre a lista de fontes e deixar-me escolher.</string>
-    <string name="autoplay_mode_first_desc">Reproduzir automaticamente a primeira fonte disponível.</string>
-    <string name="autoplay_mode_regex_desc">Reproduzir a primeira fonte cujo texto corresponda ao padrão de expressão regular.</string>
-    <string name="autoplay_scope_all_desc">A reprodução automática pode usar complementos instalados e extensões ativas.</string>
-    <string name="autoplay_scope_addons_desc">A reprodução automática considera apenas transmissões de complementos instalados.</string>
-    <string name="autoplay_scope_plugins_desc">A reprodução automática considera apenas transmissões de extensões ativas.</string>
-    <string name="autoplay_threshold_pct_desc">Mostrar por percentagem de reprodução quando não houver registo temporal do final.</string>
-    <string name="autoplay_threshold_min_desc">Mostrar este número de minutos antes do fim do episódio quando não houver registo temporal do final.</string>
-    <string name="autoplay_regex_matches">Corresponde ao nome/título/descrição/complemento/url da transmissão. Exemplo: 4K|2160p|Remux</string>
+    <string name="autoplay_mode_manual_desc">Mostrar sempre a lista de fontes para eu escolher.</string>
+    <string name="autoplay_mode_first_desc">Reproduzir a primeira fonte disponível automaticamente.</string>
+    <string name="autoplay_mode_regex_desc">Reproduzir a primeira fonte cujo texto corresponda ao teu padrão regex.</string>
+    <string name="autoplay_scope_all_desc">Pode usar tanto addons instalados como plugins ativos.</string>
+    <string name="autoplay_scope_addons_desc">Considera apenas streams provenientes dos teus addons instalados.</string>
+    <string name="autoplay_scope_plugins_desc">Considera apenas streams provenientes de plugins ativos.</string>
+    <string name="autoplay_threshold_pct_desc">Mostrar por percentagem de reprodução quando não há timestamp de fim.</string>
+    <string name="autoplay_threshold_min_desc">Mostrar x minutos antes do fim do episódio quando não há timestamp de fim.</string>
+    <string name="autoplay_regex_matches">Compara com o nome/título/descrição/addon/URL. Ex: 4K|2160p|Remux</string>
     <string name="autoplay_regex_presets">Predefinições</string>
-    <string name="autoplay_invalid_regex">Padrão de expressão regular inválido</string>
+    <string name="autoplay_invalid_regex">Padrão regex inválido</string>
 
     <!-- LayoutSettingsScreen -->
-    <string name="layout_title">Definições de disposição</string>
-    <string name="layout_subtitle">Ajustar disposição da página inicial, visibilidade de conteúdo e comportamento dos posters</string>
-    <string name="layout_classic">Vista clássica</string>
-    <string name="layout_grid">Vista em grelha</string>
-    <string name="layout_modern">Vista moderna</string>
-    <string name="layout_classic_desc">Percorrer categorias horizontalmente</string>
-    <string name="layout_grid_desc">Navegar em tudo numa grelha vertical com secção de destaque</string>
-    <string name="layout_modern_desc">Destaque fixo com uma única linha ativa para navegação mais rápida</string>
-    <string name="layout_section_home">Disposição da página inicial</string>
-    <string name="layout_section_home_desc">Escolha a estrutura e a fonte do destaque.</string>
-    <string name="layout_landscape_posters">Posters em paisagem</string>
-    <string name="layout_landscape_posters_sub">Alternar entre cartões em retrato e paisagem na vista moderna.</string>
-    <string name="layout_preview_row">Mostrar linha de pré-visualização</string>
-    <string name="layout_preview_row_sub">Mostrar uma pré-visualização parcial da linha seguinte na disposição moderna da página inicial.</string>
-    <string name="layout_hero_catalogs">Catálogos de destaque</string>
-    <string name="layout_hero_catalogs_sub">Selecione um ou mais catálogos para conteúdo de destaque.</string>
-    <string name="layout_section_content">Conteúdo da página inicial</string>
-    <string name="layout_section_content_desc">Controlar o que aparece na página inicial e na pesquisa.</string>
-    <string name="layout_collapse_sidebar">Recolher barra lateral</string>
-    <string name="layout_collapse_sidebar_sub">Ocultar barra lateral por predefinição; mostrar quando focada.</string>
-    <string name="layout_modern_sidebar">Barra lateral moderna</string>
-    <string name="layout_modern_sidebar_sub">Ativar navegação com barra lateral flutuante.</string>
-    <string name="layout_modern_sidebar_blur">Desfoque da barra lateral moderna</string>
-    <string name="layout_modern_sidebar_blur_sub">Ativar/desativar efeito de desfoque nas superfícies da barra lateral moderna.</string>
-    <string name="layout_show_hero">Mostrar secção de destaque</string>
-    <string name="layout_show_hero_sub">Mostrar carrossel de destaque no topo da página inicial.</string>
-    <string name="layout_show_discover">Mostrar Descobrir na pesquisa</string>
-    <string name="layout_show_discover_sub">Mostrar secção de exploração quando a pesquisa está vazia.</string>
-    <string name="layout_poster_labels">Mostrar etiquetas dos posters</string>
-    <string name="layout_poster_labels_sub">Mostrar títulos por baixo dos posters em linhas, grelha e ver-tudo.</string>
-    <string name="layout_addon_name">Mostrar nome do complemento</string>
-    <string name="layout_addon_name_sub">Mostrar nome da fonte por baixo dos títulos de catálogo.</string>
-    <string name="layout_catalog_type">Mostrar tipo de catálogo</string>
-    <string name="layout_catalog_type_sub">Mostrar sufixo de tipo junto ao nome do catálogo (Filme/Série).</string>
-    <string name="layout_section_detail">Página de detalhes</string>
-    <string name="layout_section_detail_desc">Definições dos ecrãs de detalhes e episódios.</string>
-    <string name="layout_blur_unwatched">Desfocar episódios não vistos</string>
+    <string name="layout_title">Definições de Layout</string>
+    <string name="layout_subtitle">Ajusta o layout inicial, visibilidade de conteúdo e posters</string>
+    <string name="layout_classic">Vista Clássica</string>
+    <string name="layout_grid">Vista em Grelha</string>
+    <string name="layout_modern">Vista Moderna</string>
+    <string name="layout_classic_desc">Navega pelas categorias horizontalmente</string>
+    <string name="layout_grid_desc">Navega por tudo numa grelha vertical com uma secção de destaque</string>
+    <string name="layout_modern_desc">Destaque fixo com uma única linha ativa para navegação rápida</string>
+    <string name="layout_section_home">Layout do Ecrã Principal</string>
+    <string name="layout_section_home_desc">Escolhe a estrutura e a fonte do destaque.</string>
+    <string name="layout_landscape_posters">Posters em Paisagem</string>
+    <string name="layout_landscape_posters_sub">Alternar entre cartões verticais e horizontais na Vista Moderna.</string>
+    <string name="layout_preview_row">Mostrar Linha de Pré-visualização</string>
+    <string name="layout_preview_row_sub">Mostrar uma pré-visualização parcial da linha seguinte no Layout Moderno.</string>
+    <string name="layout_hero_catalogs">Catálogos de Destaque</string>
+    <string name="layout_hero_catalogs_sub">Seleciona um ou mais catálogos para o conteúdo de destaque.</string>
+    <string name="layout_section_content">Conteúdo do Ecrã Principal</string>
+    <string name="layout_section_content_desc">Controla o que aparece no ecrã principal e na pesquisa.</string>
+    <string name="layout_collapse_sidebar">Recolher Barra Lateral</string>
+    <string name="layout_collapse_sidebar_sub">Ocultar barra lateral por defeito; mostrar quando focada.</string>
+    <string name="layout_modern_sidebar">Barra Lateral Moderna</string>
+    <string name="layout_modern_sidebar_sub">Ativar navegação em barra lateral flutuante.</string>
+    <string name="layout_modern_sidebar_blur">Desfocagem da Barra Lateral Moderna</string>
+    <string name="layout_modern_sidebar_blur_sub">Alternar efeito de desfocagem para superfícies da barra lateral moderna.</string>
+    <string name="layout_show_hero">Mostrar Secção de Destaque</string>
+    <string name="layout_show_hero_sub">Exibir carrossel de destaque no topo do ecrã principal.</string>
+    <string name="layout_show_discover">Mostrar \"Descobrir\" na Pesquisa</string>
+    <string name="layout_show_discover_sub">Mostrar secção de navegação quando a pesquisa está vazia.</string>
+    <string name="layout_poster_labels">Mostrar Etiquetas nos Posters</string>
+    <string name="layout_poster_labels_sub">Mostrar títulos por baixo dos posters em linhas, grelha e \"ver tudo\".</string>
+    <string name="layout_addon_name">Mostrar Nome do Addon</string>
+    <string name="layout_addon_name_sub">Mostrar nome da fonte por baixo dos títulos dos catálogos.</string>
+    <string name="layout_catalog_type">Mostrar Tipo de Catálogo</string>
+    <string name="layout_catalog_type_sub">Mostrar sufixo do tipo ao lado do nome do catálogo (Filme/Série).</string>
+    <string name="layout_hide_unreleased">Ocultar Conteúdo Não Lançado</string>
+    <string name="layout_hide_unreleased_sub">Ocultar filmes e séries que ainda não estrearam.</string>
+    <string name="layout_section_detail">Página de Detalhes</string>
+    <string name="layout_section_detail_desc">Definições para os ecrãs de detalhes e episódios.</string>
+    <string name="layout_blur_unwatched">Desfocar Episódios Não Vistos</string>
     <string name="layout_blur_unwatched_sub">Desfocar miniaturas de episódios até serem vistos para evitar spoilers.</string>
-    <string name="layout_trailer_button">Mostrar botão de trailer</string>
-    <string name="layout_trailer_button_sub">Mostrar botão de trailer na página de detalhes (apenas quando houver trailer).</string>
-    <string name="layout_prefer_external_meta">Preferir metadados de complemento externo</string>
-    <string name="layout_prefer_external_meta_sub">Usar metadados de complemento externo em vez de complemento de catálogo.</string>
-    <string name="layout_section_focused">Poster focado</string>
-    <string name="layout_section_focused_desc">Comportamento avançado para cartões de poster focados.</string>
-    <string name="layout_expand_poster">Expandir poster focado para pano de fundo</string>
-    <string name="layout_expand_poster_sub">Expandir poster focado após atraso de inatividade.</string>
-    <string name="layout_expand_delay">Atraso de expansão do pano de fundo</string>
-    <string name="layout_expand_delay_sub">Quanto tempo aguardar antes de expandir cartões focados.</string>
-    <string name="layout_autoplay_trailer">Reprodução automática de trailer</string>
-    <string name="layout_autoplay_trailer_expanded">Reprodução automática de trailer em cartão expandido</string>
-    <string name="layout_autoplay_trailer_sub">Reproduzir pré-visualização de trailer para conteúdo focado quando disponível.</string>
-    <string name="layout_autoplay_trailer_expanded_sub">Reproduzir trailer dentro do pano de fundo expandido quando disponível.</string>
-    <string name="layout_trailer_muted">Reproduzir trailer sem som</string>
-    <string name="layout_trailer_muted_sub_preview">Silenciar áudio do trailer durante pré-visualização automática.</string>
-    <string name="layout_trailer_muted_sub_expanded">Silenciar áudio do trailer em cartões expandidos.</string>
-    <string name="layout_section_card_style">Estilo do cartão de poster</string>
-    <string name="layout_section_card_style_desc">Ajustar largura do cartão e raio dos cantos.</string>
+    <string name="layout_trailer_button">Mostrar Botão de Trailer</string>
+    <string name="layout_trailer_button_sub">Mostrar botão de trailer na página de detalhes (apenas quando disponível).</string>
+    <string name="layout_prefer_external_meta">Preferir metadados de addon externo</string>
+    <string name="layout_prefer_external_meta_sub">Usar metadados de addon externo em vez do addon do catálogo.</string>
+    <string name="layout_section_focused">Poster Focado</string>
+    <string name="layout_section_focused_desc">Comportamento avançado para cartões de posters focados.</string>
+    <string name="layout_expand_poster">Expandir Poster Focado para Fundo</string>
+    <string name="layout_expand_poster_sub">Expandir o poster focado após um atraso de inatividade.</string>
+    <string name="layout_expand_delay">Atraso de Expansão de Fundo</string>
+    <string name="layout_expand_delay_sub">Quanto tempo esperar antes de expandir cartões focados.</string>
+    <string name="layout_autoplay_trailer">Auto-reproduzir Trailer</string>
+    <string name="layout_autoplay_trailer_expanded">Auto-reproduzir Trailer em Cartão Expandido</string>
+    <string name="layout_autoplay_trailer_sub">Reproduzir antevisão do trailer para conteúdo focado quando disponível.</string>
+    <string name="layout_autoplay_trailer_expanded_sub">Reproduzir trailer dentro do fundo expandido quando disponível.</string>
+    <string name="layout_trailer_muted">Reproduzir Trailer sem Som</string>
+    <string name="layout_trailer_muted_sub_preview">Silenciar o áudio do trailer durante a antevisão automática.</string>
+    <string name="layout_trailer_muted_sub_expanded">Silenciar o áudio do trailer em cartões expandidos.</string>
+    <string name="layout_section_card_style">Estilo do Cartão de Poster</string>
+    <string name="layout_section_card_style_desc">Ajustar largura e raio dos cantos do cartão.</string>
     <string name="layout_open">Aberto</string>
     <string name="layout_closed">Fechado</string>
-    <string name="layout_trailer_location">Local de reprodução do trailer no moderno</string>
-    <string name="layout_trailer_location_sub">Escolha onde a pré-visualização do trailer é reproduzida na página inicial moderna.</string>
-    <string name="layout_trailer_expanded_card">Cartão expandido</string>
-    <string name="layout_trailer_hero_media">Multimédia de destaque</string>
+    <string name="layout_trailer_location">Localização de Reprodução de Trailer (Moderno)</string>
+    <string name="layout_trailer_location_sub">Escolher onde a antevisão do trailer é reproduzida no Ecrã Principal Moderno.</string>
+    <string name="layout_trailer_expanded_card">Cartão Expandido</string>
+    <string name="layout_trailer_hero_media">Media de Destaque</string>
     <string name="layout_preset_compact">Compacto</string>
     <string name="layout_preset_dense">Denso</string>
     <string name="layout_preset_standard">Padrão</string>
     <string name="layout_preset_balanced">Equilibrado</string>
     <string name="layout_preset_comfort">Conforto</string>
     <string name="layout_preset_large">Grande</string>
-    <string name="layout_preset_sharp">Nítido</string>
-    <string name="layout_preset_subtle">Suave</string>
+    <string name="layout_preset_sharp">Acentuado</string>
+    <string name="layout_preset_subtle">Subtil</string>
     <string name="layout_preset_classic">Clássico</string>
     <string name="layout_preset_rounded">Arredondado</string>
     <string name="layout_preset_pill">Pílula</string>
     <string name="layout_card_width">Largura</string>
-    <string name="layout_card_radius">Raio do canto</string>
-    <string name="layout_reset_default">Repor predefinições</string>
+    <string name="layout_card_radius">Raio dos Cantos</string>
+    <string name="layout_reset_default">Repor Predefinições</string>
     <string name="layout_custom">Personalizado</string>
 
 
     <!-- MDBListSettingsScreen -->
     <string name="mdblist_title">Classificações MDBList</string>
-    <string name="mdblist_subtitle">Configurar classificações externas mostradas na secção de destaque dos detalhes</string>
-    <string name="mdblist_enable_title">Ativar classificações MDBList</string>
-    <string name="mdblist_enable_subtitle">Obter classificações de fornecedores externos no ecrã de detalhes dos metadados</string>
+    <string name="mdblist_subtitle">Configurar classificações externas mostradas no destaque</string>
+    <string name="mdblist_enable_title">Ativar Classificações MDBList</string>
+    <string name="mdblist_enable_subtitle">Obter classificações de fornecedores externos no ecrã de detalhes</string>
     <string name="mdblist_api_key_title">Chave API</string>
     <string name="mdblist_api_key_subtitle">Necessária para obter classificações do MDBList</string>
     <string name="mdblist_trakt_title">Trakt</string>
-    <string name="mdblist_trakt_subtitle">Mostrar classificação Trakt</string>
+    <string name="mdblist_trakt_subtitle">Mostrar pontuação do Trakt</string>
     <string name="mdblist_imdb_title">IMDb</string>
-    <string name="mdblist_imdb_subtitle">Mostrar classificação IMDb (e ocultar linha IMDb predefinida quando disponível)</string>
+    <string name="mdblist_imdb_subtitle">Mostrar pontuação IMDb (e ocultar a linha IMDb padrão)</string>
     <string name="mdblist_tmdb_title">TMDB</string>
-    <string name="mdblist_tmdb_subtitle">Mostrar classificação TMDB</string>
+    <string name="mdblist_tmdb_subtitle">Mostrar pontuação TMDB</string>
     <string name="mdblist_letterboxd_title">Letterboxd</string>
-    <string name="mdblist_letterboxd_subtitle">Mostrar classificação Letterboxd</string>
+    <string name="mdblist_letterboxd_subtitle">Mostrar pontuação Letterboxd</string>
     <string name="mdblist_tomatoes_title">Rotten Tomatoes</string>
-    <string name="mdblist_tomatoes_subtitle">Mostrar classificação dos críticos</string>
-    <string name="mdblist_audience_title">Classificação do público</string>
-    <string name="mdblist_audience_subtitle">Mostrar classificação do público</string>
+    <string name="mdblist_tomatoes_subtitle">Mostrar pontuação da crítica</string>
+    <string name="mdblist_audience_title">Pontuação do Público</string>
+    <string name="mdblist_audience_subtitle">Mostrar pontuação do público</string>
     <string name="mdblist_metacritic_title">Metacritic</string>
-    <string name="mdblist_metacritic_subtitle">Mostrar classificação Metacritic</string>
+    <string name="mdblist_metacritic_subtitle">Mostrar pontuação Metacritic</string>
     <string name="mdblist_dialog_title">Chave API MDBList</string>
-    <string name="mdblist_dialog_subtitle">Introduza a sua chave API para obter classificações externas</string>
-    <string name="mdblist_dialog_placeholder">Introduza a chave API MDBList</string>
+    <string name="mdblist_dialog_subtitle">Introduz a tua chave API para obter classificações externas</string>
+    <string name="mdblist_dialog_placeholder">Introduzir chave API MDBList</string>
     <string name="mdblist_not_set">Não definido</string>
+    <string name="mdblist_invalid_api_key">Chave API MDBList inválida</string>
+
+    <!-- Anime-Skip -->
+    <string name="animeskip_title">Anime Skip</string>
+    <string name="animeskip_subtitle">Configura o teu Client ID do Anime Skip para saltar intros/outros</string>
+    <string name="animeskip_enable_title">Ativar Anime Skip</string>
+    <string name="animeskip_enable_subtitle">Obter timestamps de salto de anime-skip.com</string>
+    <string name="animeskip_client_id_title">Client ID</string>
+    <string name="animeskip_client_id_subtitle">Necessário para obter timestamps de salto de anime-skip.com</string>
+    <string name="animeskip_dialog_title">Client ID do Anime Skip</string>
+    <string name="animeskip_dialog_subtitle">Cria o teu próprio Client ID em anime-skip.com/account/settings</string>
+    <string name="animeskip_dialog_placeholder">Introduzir Client ID</string>
+    <string name="animeskip_invalid_client_id">Client ID inválido</string>
     <string name="action_clear">Limpar</string>
 
     <!-- TmdbSettingsScreen -->
     <string name="tmdb_title">Enriquecimento TMDB</string>
-    <string name="tmdb_subtitle">Escolha quais os campos de metadados que devem vir do TMDB</string>
-    <string name="tmdb_enable_title">Ativar enriquecimento TMDB</string>
-    <string name="tmdb_enable_subtitle">Usar TMDB como fonte de metadados para enriquecer dados dos complementos</string>
+    <string name="tmdb_subtitle">Escolhe quais campos de metadados devem vir do TMDB</string>
+    <string name="tmdb_enable_title">Ativar Enriquecimento TMDB</string>
+    <string name="tmdb_enable_subtitle">Usar o TMDB como fonte de metadados para melhorar os dados dos addons</string>
     <string name="tmdb_language_title">Idioma</string>
-    <string name="tmdb_language_subtitle">Idioma dos metadados TMDB para título, logótipo e campos ativados</string>
-    <string name="tmdb_artwork_title">Arte</string>
-    <string name="tmdb_artwork_subtitle">Logótipo e imagens de pano de fundo do TMDB</string>
-    <string name="tmdb_basic_info_title">Informação básica</string>
+    <string name="tmdb_language_subtitle">Idioma dos metadados TMDB para título, logótipo e campos ativos</string>
+    <string name="tmdb_artwork_title">Arte Visual</string>
+    <string name="tmdb_artwork_subtitle">Logótipos e imagens de fundo do TMDB</string>
+    <string name="tmdb_basic_info_title">Informação Básica</string>
     <string name="tmdb_basic_info_subtitle">Descrição, géneros e classificação do TMDB</string>
     <string name="tmdb_details_title">Detalhes</string>
     <string name="tmdb_details_subtitle">Duração, data de lançamento, país e idioma do TMDB</string>
     <string name="tmdb_credits_title">Créditos</string>
     <string name="tmdb_credits_subtitle">Elenco com fotos, realizador e argumentista do TMDB</string>
     <string name="tmdb_productions_title">Produções</string>
-    <string name="tmdb_productions_subtitle">Produtoras do TMDB</string>
-    <string name="tmdb_networks_title">Canais</string>
+    <string name="tmdb_productions_subtitle">Empresas de produção do TMDB</string>
+    <string name="tmdb_networks_title">Canais/Redes</string>
     <string name="tmdb_networks_subtitle">Canais com logótipos do TMDB</string>
     <string name="tmdb_episodes_title">Episódios</string>
-    <string name="tmdb_episodes_subtitle">Títulos de episódios, sinopses, miniaturas e duração do TMDB</string>
-    <string name="tmdb_more_like_this_title">Mais como este</string>
-    <string name="tmdb_more_like_this_subtitle">Panos de fundo de recomendações TMDB na página de detalhes</string>
+    <string name="tmdb_episodes_subtitle">Títulos, resumos, miniaturas e duração dos episódios do TMDB</string>
+    <string name="tmdb_more_like_this_title">Mais Semelhantes</string>
+    <string name="tmdb_more_like_this_subtitle">Fundos de recomendações TMDB na página de detalhes</string>
+    <string name="tmdb_collections_title">Coleções</string>
+    <string name="tmdb_collections_subtitle">Coleções de filmes TMDB por ordem de lançamento</string>
+    
     <string name="tmdb_language_dialog_title">Idioma TMDB</string>
 
     <!-- TraktScreen -->
-    <string name="trakt_description">Sincronize a sua watchlist, progresso de visualização, continuar a ver, scrobbles e listas pessoais com o Trakt.</string>
+    <string name="trakt_description">Sincroniza a tua lista de interesses, progresso, continuar a ver, scrobbles e listas pessoais com o Trakt.</string>
     <string name="trakt_connected_as">Ligado como %1$s</string>
-    <string name="trakt_account_login">Início de sessão da conta</string>
-    <string name="trakt_awaiting_instruction">Vá a trakt.tv/activate e introduza este código:</string>
+    <string name="trakt_account_login">Login na Conta</string>
+    <string name="trakt_awaiting_instruction">Vai a trakt.tv/activate e introduz este código:</string>
+    <string name="trakt_waiting_approval">A aguardar aprovação…</string>
+    <string name="qr_login_approved">Login aprovado. A terminar sessão…</string>
+    <string name="qr_login_pending">A aguardar aprovação no teu telemóvel…</string>
+    <string name="qr_login_expired">O login por QR expirou. Gera um novo código.</string>
     <string name="trakt_code_expires">O código expira em %1$s</string>
-    <string name="trakt_token_refreshes">O token de acesso Trakt é renovado em %1$s</string>
-    <string name="trakt_login_instruction">Prima Iniciar sessão para começar a autenticação do dispositivo Trakt. Um código QR aparecerá aqui.</string>
-    <string name="trakt_missing_credentials">Falta TRAKT_CLIENT_ID / TRAKT_CLIENT_SECRET em local.properties.</string>
-    <string name="trakt_continue_watching_window">Janela de Continuar a ver</string>
-    <string name="trakt_continue_watching_subtitle">Histórico Trakt considerado para Continuar a ver</string>
-    <string name="trakt_unaired_next_up">Próximos episódios não emitidos</string>
-    <string name="trakt_unaired_next_up_subtitle">Mostrar episódios futuros antes de irem para o ar</string>
-    <string name="trakt_unaired_shown">Mostrado</string>
-    <string name="trakt_unaired_hidden">Oculto</string>
+    <string name="trakt_token_refreshes">O token do Trakt renova-se em %1$s</string>
+    <string name="trakt_login_instruction">Prime Login para iniciar a autenticação de dispositivo Trakt. Aparecerá um código QR aqui.</string>
+    <string name="trakt_missing_credentials">Faltam TRAKT_CLIENT_ID / TRAKT_CLIENT_SECRET em local.properties.</string>
+    <string name="trakt_watch_progress_title">Progresso de Visualização</string>
+    <string name="trakt_watch_progress_subtitle">Escolhe qual fonte de progresso alimenta o retomar e o continuar a ver</string>
+    <string name="trakt_watch_progress_dialog_title">Progresso de Visualização</string>
+    <string name="trakt_watch_progress_dialog_subtitle">Escolhe se o progresso deve usar o Trakt ou o Nuvio Sync (o scrobbling do Trakt permanece ativo).</string>
+    <string name="trakt_watch_progress_source_trakt">Trakt</string>
+    <string name="trakt_watch_progress_source_nuvio">Nuvio Sync</string>
+    <string name="trakt_watch_progress_trakt_selected">Fonte de progresso definida para Trakt</string>
+    <string name="trakt_watch_progress_nuvio_selected">Fonte de progresso definida para Nuvio Sync</string>
+    <string name="trakt_continue_watching_window">Janela do Continuar a Ver</string>
+    <string name="trakt_continue_watching_subtitle">Histórico do Trakt considerado para o continuar a ver</string>
+    <string name="trakt_unaired_next_up">Próximos Episódios Não Emitidos</string>
+    <string name="trakt_unaired_next_up_subtitle">Mostrar episódios futuros antes de estrearem</string>
+    <string name="trakt_unaired_shown">Visíveis</string>
+    <string name="trakt_unaired_hidden">Ocultos</string>
+    <string name="trakt_unaired_now_shown">Episódios não emitidos estão agora visíveis</string>
+    <string name="trakt_unaired_now_hidden">Episódios não emitidos estão agora ocultos</string>
     <string name="trakt_cached_label">Em cache</string>
     <string name="trakt_stat_movies">Filmes</string>
     <string name="trakt_stat_shows">Séries</string>
     <string name="trakt_stat_episodes">Episódios</string>
-    <string name="trakt_stat_watched_hours">Horas vistas</string>
+    <string name="trakt_stat_watched_hours">Horas Vistas</string>
     <string name="trakt_disconnect">Desligar</string>
     <string name="trakt_disconnect_title">Desligar Trakt?</string>
-    <string name="trakt_disconnect_subtitle">Isto vai desligar a sua conta Trakt do Nuvio.</string>
-    <string name="trakt_login">Iniciar sessão</string>
-    <string name="trakt_retry">Tentar novamente</string>
+    <string name="trakt_disconnect_subtitle">Isto irá desligar a tua conta Trakt do Nuvio.</string>
+    <string name="trakt_login">Login</string>
+    <string name="trakt_retry">Repetir</string>
     <string name="trakt_back">Voltar</string>
-    <string name="trakt_cw_window_title">Janela de Continuar a ver</string>
-    <string name="trakt_cw_window_subtitle">Escolha quanta atividade Trakt deve aparecer em Continuar a ver.</string>
-    <string name="trakt_unaired_dialog_title">Próximos episódios não emitidos</string>
-    <string name="trakt_unaired_dialog_subtitle">Escolha se Continuar a ver deve incluir episódios futuros antes da estreia.</string>
+    <string name="trakt_cw_window_title">Janela do Continuar a Ver</string>
+    <string name="trakt_cw_window_subtitle">Escolhe quanto histórico do Trakt deve aparecer no continuar a ver.</string>
+    <string name="trakt_unaired_dialog_title">Próximos Episódios Não Emitidos</string>
+    <string name="trakt_unaired_dialog_subtitle">Escolhe se o Continuar a Ver deve incluir episódios futuros antes do lançamento.</string>
     <string name="trakt_show_unaired">Mostrar episódios não emitidos</string>
     <string name="trakt_hide_unaired">Ocultar episódios não emitidos</string>
     <string name="trakt_all_history">Todo o histórico</string>
@@ -418,281 +600,406 @@
 
     <!-- DebugSettingsScreen -->
     <string name="debug_title">Depuração</string>
-    <string name="debug_subtitle">Ferramentas de programador e indicadores de funcionalidade (apenas compilações de depuração)</string>
-    <string name="debug_section_popup">Testes de janela popup / diálogo</string>
-    <string name="debug_playback_error_title">Ecrã de erro de reprodução</string>
-    <string name="debug_playback_error_subtitle">Mostrar uma janela popup de erro de reprodução simulado</string>
-    <string name="debug_section_features">Alternadores de funcionalidades</string>
+    <string name="debug_subtitle">Ferramentas de programador e sinalizadores (apenas versões debug)</string>
+    <string name="debug_section_popup">Teste de Popups / Diálogos</string>
+    <string name="debug_playback_error_title">Ecrã de Erro de Reprodução</string>
+    <string name="debug_playback_error_subtitle">Mostrar um popup simulado de erro de reprodução</string>
+    <string name="debug_section_features">Alternadores de Funcionalidades</string>
     <string name="debug_account_tab_title">Separador Conta</string>
     <string name="debug_account_tab_subtitle">Mostrar o separador Conta na navegação das Definições</string>
-    <string name="debug_sync_code_title">Funcionalidades de código de sincronização</string>
-    <string name="debug_sync_code_subtitle">Mostrar botões Gerar/Introduzir código de sincronização nas definições da conta</string>
+    <string name="debug_sync_code_title">Funcionalidades de Código de Sync</string>
+    <string name="debug_sync_code_subtitle">Mostrar botões de Gerar/Introduzir Código nas definições de Conta</string>
     <string name="debug_section_account">Conta</string>
-    <string name="debug_manual_signin_title">Início de sessão manual</string>
-    <string name="debug_manual_signin_subtitle">Iniciar sessão com email e palavra-passe (auth Supabase)</string>
-    <string name="debug_email_placeholder">Email</string>
+    <string name="debug_manual_signin_title">Login Manual</string>
+    <string name="debug_manual_signin_subtitle">Iniciar sessão com e-mail e palavra-passe (Supabase auth)</string>
+    <string name="debug_email_placeholder">E-mail</string>
     <string name="debug_password_placeholder">Palavra-passe</string>
     <string name="debug_signing_in">A iniciar sessão\u2026</string>
-    <string name="debug_sign_in">Iniciar sessão</string>
-    <string name="debug_error_dialog_title">Erro de reprodução</string>
-    <string name="debug_error_dialog_subtitle">Ocorreu um erro durante a reprodução.\n\nErro: erro simulado de teste - isto não é uma falha real. A fonte devolveu HTTP 503 (Serviço Indisponível).</string>
-    <string name="debug_dismiss">Fechar</string>
+    <string name="debug_sign_in">Iniciar Sessão</string>
+    <string name="debug_error_dialog_title">Erro de Reprodução</string>
+    <string name="debug_error_dialog_subtitle">Ocorreu um erro durante a reprodução.\n\nErro: Erro de teste simulado. A fonte devolveu HTTP 503 (Serviço Indisponível).</string>
+    <string name="debug_dismiss">Ignorar</string>
+    <string name="debug_section_library">Biblioteca</string>
+    <string name="debug_generate_library_title">Gerar Itens de Biblioteca</string>
+    <string name="debug_generate_library_subtitle">Adicionar filmes/séries aleatórios para testes</string>
+    <string name="debug_generate_library_placeholder">Número de itens</string>
+    <string name="debug_generate_library_button">Gerar</string>
+    <string name="debug_generating_library">A gerar\u2026</string>
 
     <!-- ProfileSettingsContent -->
     <string name="profile_title">Perfis</string>
-    <string name="profile_subtitle">Gerir perfis de utilizador para esta conta.</string>
+    <string name="profile_subtitle">Gere os perfis de utilizador para esta conta.</string>
+    <string name="profile_manage_button">Gerir Perfis</string>
+    <string name="profile_manage_title">Gerir Perfis</string>
+    <string name="profile_manage_subtitle">Seleciona um perfil para editar, mudar ou criar um novo</string>
+    <string name="profile_manage_hint">Seleciona um perfil para gerir</string>
     <string name="profile_primary_label">Principal</string>
     <string name="profile_shares_primary">Partilha %1$s do perfil principal</string>
     <string name="profile_edit_label">Editar</string>
-    <string name="profile_add">Adicionar perfil</string>
-    <string name="profile_create_title">Criar perfil</string>
-    <string name="profile_edit_title">Editar perfil %1$s</string>
+    <string name="profile_add">Adicionar Perfil</string>
+    <string name="profile_create_title">Criar Perfil</string>
+    <string name="profile_edit_title">Editar Perfil %1$s</string>
     <string name="profile_name_placeholder">Nome do perfil</string>
-    <string name="profile_avatar_color">Cor do avatar</string>
-    <string name="profile_use_primary_addons">Usar complementos do perfil principal</string>
-    <string name="profile_use_primary_plugins">Usar extensões do perfil principal</string>
+    <string name="profile_avatar_color">Cor do Avatar</string>
+    <string name="profile_use_primary_addons">Usar addons do perfil principal</string>
+    <string name="profile_use_primary_plugins">Usar plugins do perfil principal</string>
     <string name="profile_creating">A criar\u2026</string>
     <string name="profile_create_btn">Criar</string>
     <string name="profile_confirm">Confirmar</string>
     <string name="profile_delete">Eliminar</string>
-    <string name="profile_addons">complementos</string>
-    <string name="profile_plugins">extensões</string>
+    <string name="profile_addons">addons</string>
+    <string name="profile_plugins">plugins</string>
+    <string name="profile_choose_avatar">Escolher Avatar</string>
+    <string name="profile_avatar_none_selected">Nenhum avatar selecionado</string>
+    <string name="profile_avatar_focus_hint">Foca num avatar para ver o nome</string>
+    <string name="profile_avatar_category_all">Todos</string>
+    <string name="profile_avatar_category_anime">Anime</string>
+    <string name="profile_avatar_category_animation">Animação</string>
+    <string name="profile_avatar_category_movie">Filme</string>
+    <string name="profile_avatar_category_tv">TV</string>
+    <string name="profile_avatar_category_gaming">Jogos</string>
+    <string name="profile_add_new">Adicionar Perfil</string>
+    <string name="profile_cancel">Cancelar</string>
+    <string name="profile_save">Guardar</string>
 
 
     <!-- AddonManagerScreen -->
-    <string name="addon_title">Complementos</string>
-    <string name="addon_readonly_notice">A usar complementos do perfil principal e não pode ser alterado</string>
-    <string name="addon_install_title">Instalar complemento</string>
-    <string name="addon_install_placeholder">https://example.com</string>
+    <string name="addon_title">Addons</string>
+    <string name="addon_readonly_notice">A usar addons do perfil principal (não podem ser alterados)</string>
+    <string name="addon_install_title">Instalar addon</string>
+    <string name="addon_install_placeholder">https://exemplo.com</string>
     <string name="addon_installing">A instalar</string>
     <string name="addon_install_btn">Instalar</string>
+    <string name="addon_install_success">Instalado: %1$s</string>
+    <string name="addon_error_invalid_url">Introduz um URL de addon válido</string>
+    <string name="addon_error_invalid_scheme">O URL do addon deve começar por http ou https</string>
     <string name="addon_installed_section">Instalados</string>
-    <string name="addon_empty">Sem complementos instalados. Adicione um para começar.</string>
+    <string name="addon_empty">Nenhum addon instalado. Adiciona um para começar.</string>
     <string name="addon_remove">Remover</string>
     <string name="addon_manage_from_phone_title">Gerir pelo telemóvel</string>
-    <string name="addon_manage_from_phone_subtitle">Leia um código QR para gerir complementos e catálogos da página inicial no telemóvel</string>
-    <string name="addon_reorder_title">Reordenar catálogos da página inicial</string>
-    <string name="addon_reorder_subtitle">Controla a ordem das linhas de catálogo na página inicial (Clássico + Moderno + Grelha)</string>
-    <string name="addon_qr_scan_instruction">Leia com o telemóvel para gerir complementos e catálogos</string>
+    <string name="addon_manage_from_phone_subtitle">Digitaliza um código QR para gerir addons e catálogos pelo telemóvel</string>
+    <string name="addon_reorder_title">Reordenar catálogos</string>
+    <string name="addon_reorder_subtitle">Controla a ordem das linhas no ecrã principal</string>
+    <string name="addon_qr_scan_instruction">Digitaliza com o telemóvel para gerir addons e catálogos</string>
     <string name="addon_qr_close">Fechar</string>
-    <string name="addon_confirm_title">Confirmar alterações de complemento e catálogo</string>
-    <string name="addon_confirm_subtitle">Foram feitas as seguintes alterações a partir do seu telemóvel:</string>
+    <string name="addon_confirm_title">Confirmar alterações</string>
+    <string name="addon_confirm_subtitle">Foram feitas as seguintes alterações pelo telemóvel:</string>
     <string name="addon_confirm_added">Adicionado:</string>
     <string name="addon_confirm_removed">Removido:</string>
     <string name="addon_confirm_catalog_reordered">A ordem dos catálogos foi alterada</string>
-    <string name="addon_confirm_catalogs_disabled">Catálogos desativados na página inicial:</string>
-    <string name="addon_confirm_catalogs_enabled">Catálogos ativados na página inicial:</string>
-    <string name="addon_confirm_no_changes">Não foram detetadas alterações visíveis</string>
+    <string name="addon_confirm_catalogs_disabled">Catálogos desativados no Ecrã Principal:</string>
+    <string name="addon_confirm_catalogs_enabled">Catálogos ativados no Ecrã Principal:</string>
+    <string name="addon_confirm_no_changes">Nenhuma alteração detetada</string>
     <string name="addon_confirm_reject">Rejeitar</string>
     <string name="addon_confirm_confirm">Confirmar</string>
 
     <!-- CatalogOrderScreen -->
-    <string name="catalog_order_title">Reordenar catálogos da página inicial</string>
-    <string name="catalog_order_subtitle">Isto controla a ordem das linhas de catálogo na página inicial (Clássico + Moderno + Grelha).</string>
-    <string name="catalog_order_empty">Ainda não há catálogos disponíveis na página inicial.</string>
-    <string name="catalog_order_disabled_on_home">Desativado na página inicial</string>
+    <string name="catalog_order_title">Reordenar Catálogos</string>
+    <string name="catalog_order_subtitle">Isto controla a ordem das linhas no ecrã principal.</string>
+    <string name="catalog_order_empty">Ainda não existem catálogos disponíveis.</string>
+    <string name="catalog_order_disabled_on_home">Desativado no Ecrã Principal</string>
     <string name="catalog_order_enable">Ativar</string>
     <string name="catalog_order_disable">Desativar</string>
 
 
     <!-- StreamScreen -->
-    <string name="stream_retry">Tentar novamente</string>
-    <string name="stream_no_streams">Nenhuma transmissão encontrada</string>
-    <string name="stream_no_streams_hint">Tente instalar mais complementos para encontrar transmissões</string>
-    <string name="stream_finding_source">A encontrar fonte de transmissão</string>
+    <string name="stream_retry">Repetir</string>
+    <string name="stream_no_streams">Nenhuma stream encontrada</string>
+    <string name="stream_no_streams_hint">Tenta instalar mais addons para encontrar streams</string>
+    <string name="stream_finding_source">A procurar fonte da stream</string>
     <string name="stream_type_torrent">Torrent</string>
     <string name="stream_type_youtube">YouTube</string>
     <string name="stream_type_external">Externo</string>
-    <string name="stream_player_picker_title">Que leitor deve ser usado?</string>
+    <string name="stream_player_picker_title">Qual reprodutor deve ser usado?</string>
     <string name="stream_player_internal">Interno</string>
     <string name="stream_player_external">Externo</string>
 
     <!-- PlayerScreen -->
-    <string name="player_ends_at">Termina às: %1$s</string>
+    <string name="player_no_external_player">Nenhum reprodutor externo encontrado</string>
+
+    <!-- ParentalGuideOverlay -->
+    <string name="parental_nudity">Nudez</string>
+    <string name="parental_violence">Violência</string>
+    <string name="parental_profanity">Linguagem Forte</string>
+    <string name="parental_alcohol">Álcool/Drogas</string>
+    <string name="parental_frightening">Assustador</string>
+    <string name="parental_severity_severe">Grave</string>
+    <string name="parental_severity_moderate">Moderado</string>
+    <string name="parental_severity_mild">Ligeiro</string>
+    <string name="player_ends_at">Termina às %1$s</string>
     <string name="player_via">via %1$s</string>
-    <string name="player_subtitle_delay">Atraso das legendas</string>
-    <string name="player_error_title">Erro de reprodução</string>
+    <string name="player_subtitle_delay">Atraso das Legendas</string>
+    <string name="player_error_title">Erro de Reprodução</string>
     <string name="player_go_back">Voltar</string>
-    <string name="player_speed_title">Velocidade de reprodução</string>
-    <string name="player_more_actions_title">Mais ações</string>
-    <string name="player_more_speed">Velocidade de reprodução</string>
-    <string name="player_more_aspect_ratio">Rácio de aspeto</string>
-    <string name="player_more_open_external">Abrir no leitor externo</string>
+    <string name="player_speed_title">Velocidade de Reprodução</string>
+    <string name="player_more_actions_title">Mais Ações</string>
+    <string name="player_more_speed">Velocidade</string>
+    <string name="player_more_aspect_ratio">Proporção do Ecrã</string>
+    <string name="player_more_open_external">Abrir em Reprodutor Externo</string>
 
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Fontes</string>
     <string name="sources_reload">Recarregar</string>
     <string name="sources_close">Fechar</string>
-    <string name="sources_no_streams">Nenhuma transmissão encontrada</string>
-
+    <string name="sources_playing">A reproduzir</string>
+    <string name="sources_no_streams">Nenhuma stream encontrada</string>
+    
     <!-- EpisodesSidePanel -->
     <string name="episodes_panel_close">Fechar</string>
     <string name="episodes_panel_back">Voltar</string>
     <string name="episodes_panel_reload">Recarregar</string>
-    <string name="episodes_panel_no_streams">Nenhuma transmissão encontrada</string>
-    <string name="episodes_panel_no_episodes">Sem episódios disponíveis</string>
+    <string name="episodes_panel_no_streams">Nenhuma stream encontrada</string>
+    <string name="episodes_panel_no_episodes">Nenhum episódio disponível</string>
+    <string name="episodes_panel_title">Episódios</string>
+    <string name="episodes_panel_streams_title">Streams</string>
+    <string name="player_speed_normal">Normal</string>
+    <string name="player_aspect_fit">Ajustar (Original)</string>
+    <string name="player_aspect_stretch">Esticar</string>
+    <string name="player_aspect_fit_width">Ajustar à Largura</string>
+    <string name="player_aspect_fit_height">Ajustar à Altura</string>
+    <string name="player_aspect_crop">Recortar</string>
 
     <!-- AudioDialog -->
     <string name="audio_dialog_title">Áudio</string>
-
+    <string name="audio_dialog_tab_tracks">Áudio</string>
+    <string name="audio_dialog_tab_mix">Mistura</string>
+    <string name="audio_mix_label">Amplificação (PCM)</string>
+    <string name="audio_mix_value_db">%1$d dB</string>
+    <string name="audio_mix_persist_on">Persistir entre sessões: LIGADO</string>
+    <string name="audio_mix_persist_off">Persistir entre sessões: DESLIGADO</string>
+    <string name="audio_mix_range">Intervalo: %1$d dB a %2$d dB</string>
+    <string name="audio_mix_range_saved">Intervalo: %1$d dB a %2$d dB (guardado)</string>
+    <string name="audio_mix_unavailable">Amplificação não disponível neste dispositivo</string>
+    
     <!-- SubtitleDialog / SubtitleStyleSidePanel -->
     <string name="subtitle_dialog_title">Legendas</string>
-    <string name="subtitle_no_builtin">Sem legendas incorporadas disponíveis</string>
-    <string name="subtitle_loading_addon">A carregar legendas dos complementos\u2026</string>
-    <string name="subtitle_no_addon">Sem legendas de complementos disponíveis</string>
-    <string name="subtitle_text_color">Cor do texto</string>
-    <string name="subtitle_outline_color">Cor do contorno</string>
-    <string name="subtitle_reset_defaults">Repor predefinições</string>
-    <string name="subtitle_style_title">Estilo das legendas</string>
+    <string name="subtitle_no_builtin">Nenhuma legenda integrada disponível</string>
+    <string name="subtitle_loading_addon">A carregar legendas de addons\u2026</string>
+    <string name="subtitle_no_addon">Nenhuma legenda de addon disponível</string>
+    <string name="subtitle_text_color">Cor do Texto</string>
+    <string name="subtitle_outline_color">Cor do Contorno</string>
+    <string name="subtitle_reset_defaults">Repor Predefinições</string>
+    <string name="subtitle_tab_builtin">Integradas</string>
+    <string name="subtitle_tab_addons">Addons</string>
+    <string name="subtitle_tab_languages">Idiomas</string>
+    <string name="subtitle_tab_style">Estilo</string>
+    <string name="subtitle_tab_delay">Atraso</string>
+    <string name="subtitle_none">Nenhum</string>
+    <string name="subtitle_all">Todos</string>
+    <string name="subtitle_section_core">Principal</string>
+    <string name="subtitle_section_advanced">Avançado</string>
+    <string name="subtitle_font_size">Tamanho da Fonte</string>
+    <string name="subtitle_bold">Negrito</string>
+    <string name="subtitle_outline">Contorno</string>
+    <string name="subtitle_bottom_offset">Margem Inferior</string>
+    <string name="subtitle_on">Ligado</string>
+    <string name="subtitle_off">Desligado</string>
+    <string name="subtitle_style_title">Estilo das Legendas</string>
+    <string name="subtitle_style_customize">Personalizar</string>
     <string name="subtitle_style_color">Cor</string>
     <string name="subtitle_style_reset">Repor</string>
+    <string name="subtitle_style_font_size">Tamanho da Fonte</string>
+    <string name="subtitle_style_bold">Negrito</string>
+    <string name="subtitle_style_text_color">Cor do Texto</string>
+    <string name="subtitle_style_outline">Contorno</string>
+    <string name="subtitle_style_bottom_offset">Margem Inferior</string>
+    <string name="subtitle_style_defaults">Predefinições</string>
+    <string name="subtitle_style_on">Ligado</string>
+    <string name="subtitle_style_off">Desligado</string>
+    <string name="panel_failed_load_streams">Falha ao carregar streams</string>
+    <string name="panel_failed_load_episodes">Falha ao carregar episódios</string>
 
     <!-- PauseOverlay -->
-    <string name="pause_you_are_watching">Está a ver</string>
+    <string name="pause_you_are_watching">Estás a ver</string>
     <string name="pause_cast_label">Elenco</string>
     <string name="pause_back_to_details">Voltar aos detalhes</string>
     <string name="pause_as_character">como %1$s</string>
 
     <!-- NextEpisodeCardOverlay -->
-    <string name="next_episode_label">Próximo episódio</string>
-
+    <string name="next_episode_label">Próximo Episódio</string>
+    <string name="next_episode_finding_source">A procurar fonte…</string>
+    <string name="next_episode_playing_via">A reproduzir via %1$s em %2$ds</string>
+    <string name="next_episode_play">Reproduzir</string>
+    <string name="next_episode_unaired">Não emitido</string>
+    <string name="next_episode_not_aired_yet">O próximo episódio ainda não estreou</string>
+    <string name="skip_intro">Saltar Intro</string>
+    <string name="skip_ending">Saltar Fim</string>
+    <string name="skip_recap">Saltar Resumo</string>
+    <string name="skip_generic">Saltar</string>
+    <string name="display_mode_refresh">Taxa de Atualização</string>
+    <string name="display_mode_resolution">Resolução</string>
+    
 
     <!-- SearchScreen -->
-    <string name="search_keyboard_hint">Prima Concluir no teclado para pesquisar</string>
+    <string name="search_keyboard_hint">Prime \"Concluído\" no teclado para pesquisar</string>
     <string name="search_placeholder">Pesquisar filmes e séries</string>
-
+    <string name="search_start_title">Começar Pesquisa</string>
+    <string name="search_start_subtitle">Introduz pelo menos 2 caracteres</string>
+    <string name="search_start_subtitle_no_discover">Descobrir desativado. Introduz pelo menos 2 caracteres</string>
+    <string name="search_voice_no_speech">Nenhuma voz detetada. Tenta novamente.</string>
+    <string name="search_voice_mic_permission">É necessária permissão de microfone para pesquisa por voz.</string>
+    <string name="search_voice_failed">Falha no reconhecimento de voz. Tenta novamente.</string>
+    <string name="search_voice_unavailable">Pesquisa por voz indisponível neste dispositivo.</string>
+    
     <!-- LibraryScreen -->
     <string name="library_syncing">A sincronizar biblioteca Trakt\u2026</string>
     <string name="library_title">Biblioteca</string>
     <string name="library_filter_list">Lista</string>
     <string name="library_filter_type">Tipo</string>
     <string name="library_filter_sort">Ordenar</string>
-    <string name="library_manage_lists">Gerir listas</string>
-    <string name="library_manage_trakt_lists">Gerir listas Trakt</string>
-    <string name="library_no_lists">Ainda não existem listas pessoais.</string>
+    <string name="library_sort_trakt_order">Ordem Trakt</string>
+    <string name="library_sort_added_desc">Adicionado ↓</string>
+    <string name="library_sort_added_asc">Adicionado ↑</string>
+    <string name="library_sort_title_asc">Título A-Z</string>
+    <string name="library_sort_title_desc">Título Z-A</string>
+    <string name="library_manage_lists">Gerir Listas</string>
+    <string name="library_manage_trakt_lists">Gerir Listas Trakt</string>
+    <string name="library_no_lists">Ainda sem listas pessoais.</string>
     <string name="library_list_create">Criar</string>
     <string name="library_list_edit">Editar</string>
-    <string name="library_list_move_up">Mover para cima</string>
-    <string name="library_list_move_down">Mover para baixo</string>
+    <string name="library_list_move_up">Mover para Cima</string>
+    <string name="library_list_move_down">Mover para Baixo</string>
     <string name="library_list_delete">Eliminar</string>
     <string name="library_list_close">Fechar</string>
     <string name="library_list_name_label">Nome</string>
     <string name="library_list_description_label">Descrição</string>
     <string name="library_list_privacy">Privacidade</string>
     <string name="library_delete_title">Eliminar esta lista?</string>
-    <string name="library_delete_subtitle">Isto remove a lista e todos os seus itens no Trakt.</string>
+    <string name="library_delete_subtitle">Isto remove a lista e todos os itens do Trakt.</string>
     <string name="library_delete_confirm">Eliminar</string>
     <string name="library_source_local">LOCAL</string>
-    <string name="library_type_all">Todos</string>
+    <string name="library_type_all">Tudo</string>
     <string name="library_type_items">itens</string>
-    <string name="library_empty_local_title">Ainda sem %1$s</string>
+    <string name="library_empty_local_title">Sem %1$s ainda</string>
     <string name="library_empty_trakt_title">Sem %1$s nesta lista</string>
-    <string name="library_empty_local_subtitle">Comece a guardar os seus favoritos para os ver aqui</string>
-    <string name="library_empty_trakt_subtitle">Use + nos detalhes para adicionar itens à watchlist ou listas</string>
-
+    <string name="library_empty_local_subtitle">Começa a guardar favoritos para os veres aqui</string>
+    <string name="library_empty_trakt_subtitle">Usa o botão + nos detalhes para adicionar itens à lista de interesses ou listas pessoais</string>
+    
     <!-- AccountSettingsContent -->
     <string name="account_loading">A carregar\u2026</string>
-    <string name="account_sync_description">Sincronize a sua biblioteca, progresso de visualização, complementos e extensões entre dispositivos.</string>
-    <string name="account_signin_qr_title">Iniciar sessão com QR</string>
-    <string name="account_signin_qr_subtitle">Leia um código QR e conclua o início de sessão por email no telemóvel</string>
+    <string name="account_sync_description">Sincroniza biblioteca, progresso e addons entre dispositivos.</string>
+    <string name="account_sync_restart_note">A sincronização não é em tempo real. Reinicia este dispositivo para aplicar alterações feitas noutro local.</string>
+    <string name="account_signin_qr_title">Login com QR</string>
+    <string name="account_signin_qr_subtitle">Digitaliza o código e completa o login no telemóvel</string>
     <string name="account_signed_in_label">Sessão iniciada</string>
     <string name="account_total_label">Total</string>
     <string name="account_loading_sync">A carregar dados de sincronização\u2026</string>
-    <string name="account_sign_out">Terminar sessão</string>
+    <string name="account_sign_out">Terminar Sessão</string>
 
     <!-- AuthSignInScreen -->
-    <string name="auth_signin_title">Iniciar sessão</string>
-    <string name="auth_signin_tv_disabled">A introdução de email/palavra-passe na TV está desativada. Continue com início de sessão por QR.</string>
+    <string name="auth_signin_title">Iniciar Sessão</string>
+    <string name="auth_signin_tv_disabled">A introdução de e-mail/palavra-passe na TV está desativada. Continua com o login por QR.</string>
     <string name="auth_signin_qr_btn">Continuar com QR</string>
 
     <!-- AuthQrSignInScreen -->
-    <string name="auth_qr_title">Iniciar sessão com QR</string>
-    <string name="auth_qr_account_login">Início de sessão da conta</string>
-    <string name="auth_qr_finishing">A concluir início de sessão\u2026</string>
+    <string name="auth_qr_title">Iniciar Sessão com QR</string>
+    <string name="auth_qr_account_login">Login na Conta</string>
+    <string name="auth_qr_finishing">A terminar sessão\u2026</string>
     <string name="auth_qr_code_label">Código: %1$s</string>
     <string name="auth_qr_expires">Expira em %1$s</string>
+    <string name="auth_qr_phone_hint">Usa o telemóvel para o login. A TV usa apenas QR para maior rapidez.</string>
+    <string name="auth_qr_scan_instruction">Digitaliza o QR, aprova no navegador e regressa aqui.</string>
+    <string name="auth_qr_code_display">Código: %1$s</string>
+    <string name="auth_qr_refresh">Atualizar QR</string>
+    <string name="auth_qr_continue_without_account">Continuar sem conta</string>
+    <string name="auth_qr_connected">A tua conta está ligada nesta TV.</string>
+    <string name="auth_qr_synced_data">Os teus dados sincronizados</string>
+    <string name="auth_qr_generating">A gerar QR\u2026</string>
+    <string name="auth_qr_unavailable">QR indisponível. Atualiza para tentar novamente.</string>
+    <string name="auth_qr_please_wait">Por favor, aguarda\u2026</string>
+    <string name="auth_qr_continue">Continuar</string>
+    <string name="auth_qr_back">Voltar</string>
 
     <!-- SyncCodeGenerateScreen -->
-    <string name="sync_generate_title">Gerar código de sincronização</string>
-    <string name="sync_generate_subtitle">Crie um PIN para proteger o seu código de sincronização. Partilhe o código com os seus outros dispositivos.</string>
-    <string name="sync_generate_code_label">O seu código de sincronização</string>
-    <string name="sync_generate_instruction">Introduza este código e o seu PIN no outro dispositivo para os ligar.</string>
-    <string name="sync_generate_done">Concluir</string>
-    <string name="sync_generate_pin_label">Escolha um PIN (4-8 caracteres)</string>
-    <string name="sync_generate_pin_placeholder">Introduza PIN</string>
+    <string name="sync_generate_title">Gerar Código de Sync</string>
+    <string name="sync_generate_subtitle">Cria um PIN para proteger o teu código. Partilha o código com outros dispositivos.</string>
+    <string name="sync_generate_code_label">O teu Código de Sync</string>
+    <string name="sync_generate_instruction">Introduz este código e o teu PIN no outro dispositivo para os ligar.</string>
+    <string name="sync_generate_done">Concluído</string>
+    <string name="sync_generate_pin_label">Escolhe um PIN (4-8 caracteres)</string>
+    <string name="sync_generate_pin_placeholder">Introduzir PIN</string>
 
     <!-- SyncCodeClaimScreen -->
-    <string name="sync_claim_title">Ligar dispositivo</string>
-    <string name="sync_claim_subtitle">Introduza o código de sincronização e o PIN do outro dispositivo para ligar este dispositivo.</string>
-    <string name="sync_claim_success">Dispositivo ligado com sucesso! Os seus complementos e extensões serão agora sincronizados.</string>
-    <string name="sync_claim_done">Concluir</string>
-    <string name="sync_claim_code_label">Código de sincronização</string>
+    <string name="sync_claim_title">Ligar Dispositivo</string>
+    <string name="sync_claim_subtitle">Introduz o código de sync e o PIN do outro dispositivo para ligar este.</string>
+    <string name="sync_claim_success">Dispositivo ligado com sucesso! Os teus addons e plugins serão agora sincronizados.</string>
+    <string name="sync_claim_done">Concluído</string>
+    <string name="sync_claim_code_label">Código de Sync</string>
     <string name="sync_claim_code_placeholder">XXXX-XXXX-XXXX-XXXX-XXXX</string>
     <string name="sync_claim_pin_label">PIN</string>
-    <string name="sync_claim_pin_placeholder">Introduza PIN</string>
+    <string name="sync_claim_pin_placeholder">Introduzir PIN</string>
 
     <!-- PluginScreen -->
-    <string name="plugin_readonly_notice">A usar extensões do perfil principal e não pode ser alterado</string>
+    <string name="plugin_readonly_notice">A usar plugins do perfil principal (não podem ser alterados)</string>
     <string name="plugin_repositories_section">Repositórios (%1$d)</string>
     <string name="plugin_providers_section">Fornecedores (%1$d)</string>
-    <string name="plugin_title">Extensões</string>
+    <string name="plugin_title">Plugins</string>
     <string name="plugin_subtitle">Gerir scrapers e fornecedores locais</string>
     <string name="plugin_add_repository">Adicionar repositório</string>
     <string name="plugin_add_btn">Adicionar</string>
     <string name="plugin_manage_from_phone_title">Gerir pelo telemóvel</string>
-    <string name="plugin_manage_from_phone_subtitle">Leia um código QR para adicionar ou remover repositórios a partir do telemóvel</string>
-    <string name="plugin_qr_instruction">Leia com o telemóvel para gerir repositórios</string>
+    <string name="plugin_manage_from_phone_subtitle">Digitaliza um código QR para gerir repositórios pelo telemóvel</string>
+    <string name="plugin_qr_instruction">Digitaliza com o telemóvel para gerir repositórios</string>
     <string name="plugin_qr_close">Fechar</string>
     <string name="plugin_confirm_title">Confirmar alterações de repositório</string>
-    <string name="plugin_confirm_subtitle">Foram feitas as seguintes alterações a partir do seu telemóvel:</string>
+    <string name="plugin_confirm_subtitle">Foram feitas as seguintes alterações pelo telemóvel:</string>
     <string name="plugin_confirm_added">Adicionado:</string>
     <string name="plugin_confirm_removed">Removido:</string>
-    <string name="plugin_confirm_no_changes">Não foram detetadas alterações</string>
+    <string name="plugin_confirm_no_changes">Nenhuma alteração detetada</string>
     <string name="plugin_confirm_total">Total de repositórios: %1$d</string>
     <string name="plugin_confirm_reject">Rejeitar</string>
     <string name="plugin_confirm_confirm">Confirmar</string>
     <string name="plugin_updated_format">Atualizado: %1$s</string>
     <string name="plugin_test_btn">Testar</string>
-    <string name="plugin_test_results">Resultados do teste (%1$d transmissões)</string>
+    <string name="plugin_test_results">Resultados do Teste (%1$d streams)</string>
 
     <!-- ProfileSelectionScreen -->
     <string name="profile_selection_title">Quem está a ver?</string>
-    <string name="profile_selection_subtitle">Selecione um perfil para continuar</string>
-    <string name="profile_selection_hint">Use o D-pad para escolher um perfil</string>
+    <string name="profile_selection_subtitle">Seleciona um perfil para continuar</string>
+    <string name="profile_selection_hint">Prime longamente para gerir o perfil</string>
     <string name="profile_selection_empty">Nenhum perfil encontrado</string>
     <string name="profile_selection_primary_badge">PRINCIPAL</string>
+    <string name="profile_selection_options_title">Opções de Perfil</string>
+    <string name="profile_delete_confirm_title">Eliminar Perfil?</string>
+    <string name="profile_delete_confirm_subtitle">Isto eliminará permanentemente este perfil e todos os seus dados (biblioteca, histórico e addons). Não pode ser anulado.</string>
+    <string name="profile_delete_btn">Eliminar Perfil</string>
+    <string name="profile_saving">A guardar\u2026</string>
 
     <!-- CastDetailScreen -->
     <string name="cast_detail_error">Algo correu mal</string>
-    <string name="cast_detail_retry">Tentar novamente</string>
+    <string name="cast_detail_retry">Repetir</string>
     <string name="cast_detail_filmography">Filmografia</string>
-
+    
     <!-- CatalogSeeAllScreen -->
     <string name="catalog_see_all_from">de %1$s</string>
-    <string name="catalog_see_all_empty_title">Nenhum item disponível</string>
-    <string name="catalog_see_all_empty_subtitle">Experimente outro catálogo ou volte mais tarde</string>
+    <string name="catalog_see_all_empty_title">Sem itens disponíveis</string>
+    <string name="catalog_see_all_empty_subtitle">Tenta outro catálogo ou volta mais tarde</string>
 
     <!-- LayoutSelectionScreen -->
     <string name="layout_selection_welcome">Bem-vindo ao Nuvio</string>
-    <string name="layout_selection_subtitle">Escolha a disposição do seu ecrã inicial</string>
+    <string name="layout_selection_subtitle">Escolhe o layout do teu ecrã principal</string>
     <string name="layout_selection_continue">Continuar</string>
 
     <!-- UpdatePromptDialog -->
-    <string name="update_title">Atualização da app</string>
-    <string name="update_downloading">A transferir atualização</string>
-    <string name="update_unknown_sources">Permita instalações de fontes desconhecidas para continuar.</string>
+    <string name="update_title">Atualização da App</string>
+    <string name="update_downloading">A descarregar atualização</string>
+    <string name="update_download">Descarregar</string>
+    <string name="update_downloading_ellipsis">A descarregar…</string>
+    <string name="update_unknown_sources">Permite a instalação de fontes desconhecidas para continuar.</string>
+    
     <!-- AccountScreen -->
     <string name="account_title">Conta</string>
-    <string name="account_sign_in_description">Inicie sessão para sincronizar a sua biblioteca, progresso de visualização, complementos e extensões entre dispositivos. A sincronização da biblioteca e do progresso só acontece quando o Trakt não está ligado.</string>
-    <string name="account_sync_code_title">Código de sincronização</string>
-    <string name="account_sync_code_description">Sincronize entre dispositivos sem criar uma conta.</string>
-    <string name="account_linked_devices">Dispositivos ligados (%1$d)</string>
-    <string name="account_no_linked_devices">Sem dispositivos ligados</string>
+    <string name="account_sign_in_description">Inicia sessão para sincronizar tudo entre dispositivos. A sincronização da biblioteca usa Nuvio Sync se o Trakt não estiver ligado.</string>
+    <string name="account_sync_code_title">Código de Sync</string>
+    <string name="account_sync_code_description">Sincroniza entre dispositivos sem criar uma conta.</string>
+    <string name="account_linked_devices">Dispositivos Ligados (%1$d)</string>
+    <string name="account_no_linked_devices">Nenhum dispositivo ligado</string>
     <string name="account_unlink">Desligar</string>
 
     <!-- EpisodeRatingsSection -->
     <string name="ratings_loading">A carregar classificações dos episódios...</string>
-    <string name="ratings_unavailable">As classificações dos episódios não estão disponíveis.</string>
+    <string name="ratings_unavailable">Classificações indisponíveis.</string>
+    <string name="ratings_load_error">Não foi possível carregar as classificações.</string>
     <string name="ratings_season_summary">Temporada %1$d - %2$d episódios</string>
 
     <!-- SearchDiscoverSection -->
@@ -704,13 +1011,13 @@
     <string name="discover_filter_genre">Género</string>
     <string name="discover_select_catalog">Selecionar</string>
     <string name="discover_genre_default">Predefinido</string>
-    <string name="discover_empty_no_catalog_title">Selecione um catálogo</string>
-    <string name="discover_empty_no_catalog_subtitle">Escolha um catálogo de descoberta para explorar</string>
+    <string name="discover_empty_no_catalog_title">Seleciona um catálogo</string>
+    <string name="discover_empty_no_catalog_subtitle">Escolhe um catálogo para navegar</string>
     <string name="discover_empty_no_content_title">Nenhum conteúdo encontrado</string>
-    <string name="discover_empty_no_content_subtitle">Experimente outro género ou catálogo</string>
+    <string name="discover_empty_no_content_subtitle">Tenta um género ou catálogo diferente</string>
 
     <!-- AddonManagerScreen -->
-    <string name="addon_confirm_total_addons">Total de complementos: %1$d</string>
+    <string name="addon_confirm_total_addons">Total de addons: %1$d</string>
     <string name="addon_confirm_total_catalogs">Total de catálogos: %1$d</string>
     <string name="addon_catalogs_types">Catálogos: %1$d - Tipos: %2$s</string>
 
@@ -719,26 +1026,32 @@
     <string name="plugin_providers_count">%1$d fornecedores</string>
     <string name="plugin_enabled">Ativado</string>
     <string name="plugin_disabled">Desativado</string>
-    <string name="plugin_no_repos">Ainda não foram adicionados repositórios.\nAdicione um repositório para começar.</string>
+    <string name="plugin_no_repos">Nenhum repositório adicionado.\nAdiciona um para começar.</string>
 
     <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Editar perfil %1$d</string>
+    <string name="profile_edit_title_id">Editar Perfil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
-    <string name="audio_passthrough_info">A passagem direta de áudio (TrueHD, DTS, AC-3, etc.) é automática. Quando ligado via HDMI a um recetor AV ou a uma barra de som compatível, o áudio sem perdas é enviado tal como está, sem descodificação.</string>
-    <string name="audio_dv_title">DV7 - Plano alternativo HEVC</string>
+    <string name="audio_passthrough_info">O passthrough de áudio (TrueHD, DTS, AC-3, etc.) é automático. Quando ligado a um recetor AV ou soundbar compatível via HDMI, o áudio lossless é enviado sem descodificação.</string>
+    <string name="audio_dv_title">DV7 - HEVC Fallback</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Início</string>
     <string name="nav_discover">Descobrir</string>
     <string name="nav_search">Pesquisar</string>
     <string name="nav_library">Biblioteca</string>
-    <string name="nav_addons">Complementos</string>
+    <string name="nav_addons">Addons</string>
     <string name="nav_settings">Definições</string>
+    <string name="settings_rounded_ui">Interface Arredondada</string>
     <string name="cd_expand_sidebar">Expandir barra lateral</string>
 
+    <string name="update_checking">A procurar atualizações…</string>
+    <string name="update_download_complete">Download concluído. Pronto para instalar.</string>
+    <string name="update_up_to_date">O sistema está atualizado. Últimas alterações:</string>
     <string name="update_close">Fechar</string>
-    <string name="update_open_settings">Abrir definições</string>
+    <string name="update_open_settings">Abrir Definições</string>
     <string name="update_install">Instalar</string>
     <string name="update_ignore">Ignorar</string>
+    <string name="watchlist_added">Adicionado à lista de interesses</string>
+    <string name="watchlist_removed">Removido da lista de interesses</string>
 </resources>


### PR DESCRIPTION
Update Portuguese - Portugal translation for NuvioTV. Added and fixed translations for newly added keys to keep the localization up to date - added +300 missing strings.

## Summary

Update Portuguese - Portugal translation for NuvioTV. Added and fixed translations for newly added keys to keep the localization up to date - added +300 missing strings.

## PR type

<!-- Pick one and delete the others -->
- Translation update


## Why

New strings were added to the app and portuguese (Portugal) translations needed to be updated and fixed to keep the localization current.

## Policy check

<!-- Confirm these before requesting review -->
 - [x ] This PR is not cosmetic-only, unless it is a translation PR.
- [ x] This PR does not add a new major feature without prior approval.
- [ x] This PR is small in scope and focused on one problem.
- [ x] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

Checked the strings in the XML file.

## Screenshots / Video (UI changes only)

None. Not applicable for this change.

## Breaking changes

There are no breaking changes in this pull request. All modifications are additive or involve string refinements.

## Linked issues

<!-- Example: Fixes #123 -->
