### PR TITLE
Avoid OLED burn-in when the player is paused

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -496,11 +496,13 @@ fun PlayerScreen(
                     PlayerView(context).apply {
                         this.player = player
                         useController = false
-                        keepScreenOn = true
+                        keepScreenOn = false
                         setShowBuffering(PlayerView.SHOW_BUFFERING_NEVER)
                     }
                 },
                 update = { playerView ->
+                    // Keep device awake only while playback is active (or buffering), not when paused.
+                    playerView.keepScreenOn = uiState.isPlaying || uiState.isBuffering
                     Log.d("PlayerScreen", "Applying resizeMode: $resizeMode")
                     playerView.resizeMode = resizeMode
                     playerView.subtitleView?.apply {


### PR DESCRIPTION
## Summary
Adjusted player screen wake behavior so it only keeps the TV awake during active playback/buffering. In `PlayerScreen.kt`, `PlayerView.keepScreenOn` is now driven by `uiState.isPlaying || uiState.isBuffering` instead of always true.

This prevents paused playback from indefinitely blocking Android TV Daydream/screensaver.

## PR type

- Bug fix

## Why

Paused playback on the player screen could keep the display awake indefinitely, increasing risk of static-image retention/burn-in and preventing expected Android TV Daydream/screensaver behavior.

This change scopes wake behavior to actual playback activity only.

## Policy check

 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

For testing purposes, I made the code like this locally:

```kt
                update = { playerView ->
                    val shouldKeepOn = uiState.isPlaying || uiState.isBuffering
                    if (playerView.keepScreenOn != shouldKeepOn) {
                        Log.d("PlayerScreen", "keepScreenOn changed to: $shouldKeepOn")
                        playerView.keepScreenOn = shouldKeepOn
                    }
                    ...
```

With this, I could see in the Logcat that, when I started playing, it was showing:

```
2026-03-14 16:28:39.231 PlayerScreen             D  keepScreenOn changed to: true
```

But when I paused, it was showing:

```
2026-03-14 16:28:52.796 PlayerScreen             D  keepScreenOn changed to: false
```

## Screenshots / Video (UI changes only)

Not needed (no visible UI change).

## Breaking changes

None.

## Linked issues

None.