### PR TITLE
Use iso_3166_1 country code to correctly distinguish regional logo variants

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -551,15 +551,25 @@ class TmdbMetadataService @Inject constructor(
     ): String? {
         if (images.isEmpty()) return null
         val languageCode = normalizedLanguage.substringBefore("-")
+        val regionCode = normalizedLanguage.substringAfter("-", "").uppercase(Locale.US).takeIf { it.length == 2 }
+            ?: DEFAULT_LANGUAGE_REGIONS[languageCode]
         return images
             .sortedWith(
-                compareByDescending<TmdbImage> { it.iso6391 == normalizedLanguage }
+                compareByDescending<TmdbImage> { it.iso6391 == languageCode && it.iso31661 == regionCode }
+                    .thenByDescending { it.iso6391 == languageCode && it.iso31661 == null }
                     .thenByDescending { it.iso6391 == languageCode }
                     .thenByDescending { it.iso6391 == "en" }
                     .thenByDescending { it.iso6391 == null }
             )
             .firstOrNull()
             ?.filePath
+    }
+
+    companion object {
+        private val DEFAULT_LANGUAGE_REGIONS = mapOf(
+            "pt" to "PT",
+            "es" to "ES"
+        )
     }
 
     suspend fun fetchPersonDetail(

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -294,7 +294,8 @@ data class TmdbTvContentRatingItem(
 @JsonClass(generateAdapter = true)
 data class TmdbImage(
     @Json(name = "file_path") val filePath: String? = null,
-    @Json(name = "iso_639_1") val iso6391: String? = null
+    @Json(name = "iso_639_1") val iso6391: String? = null,
+    @Json(name = "iso_3166_1") val iso31661: String? = null
 )
 
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
## Summary

TMDB image objects include `iso_3166_1` (region code) alongside `iso_639_1` (language code), but we weren't parsing it. This made it impossible to distinguish regional logo variants like `pt-BR` vs `pt-PT` since both share `iso_639_1: "pt"`.

This PR adds `iso_3166_1` to `TmdbImage` and uses it in logo selection.

## PR type

- Bug fix

## Why

Users with **Portuguese (Brazil)** selected in TMDB settings were getting Portuguese (Portugal) logos instead.

PR #944 tried to fix it (#942) by sorting on `normalizedLanguage` (e.g. `pt-BR`), but it didn't work - the [TMDB images API docs](https://developer.themoviedb.org/reference/movie-images) don't mention `iso_3166_1`, so I didn't know it existed. TMDB always returns `iso_639_1` as a plain 2-letter code (`pt`), with the region carried separately in the undocumented `iso_3166_1` field.

Fix:
- Add `iso_3166_1` to `TmdbImage`
- Match on `iso_639_1` + `iso_3166_1` together as primary criterion
- Add `DEFAULT_LANGUAGE_REGIONS` fallback so plain `pt` prefers `PT` logos and plain `es` prefers `ES`

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Verified via TMDB API - Brazilian Portuguese logos have `iso_3166_1: "BR"`, European Portuguese have `iso_3166_1: "PT"`, both with `iso_639_1: "pt"`. Confirmed correct logo is selected for both `pt-BR` and plain `pt`.

## Screenshots / Video (UI changes only)

Nothing changes

## Breaking changes

Nothing should break

## Linked issues

Fixes #942, supersedes #944
