### PR TITLE
Hotfix: Revert HLS chunkless preparation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -81,7 +81,6 @@ internal class PlayerMediaSourceFactory {
 
         return when {
             isHls && !forceDefaultFactory -> HlsMediaSource.Factory(httpDataSourceFactory)
-                .setAllowChunklessPreparation(true)
                 .createMediaSource(mediaItem)
             isDash && !forceDefaultFactory -> DashMediaSource.Factory(httpDataSourceFactory)
                 .createMediaSource(mediaItem)


### PR DESCRIPTION
## Summary

- Bug fix
- Reverts the HLS chunkless preparation change introduced in [`192f3fb`](https://github.com/NuvioMedia/NuvioTV/commit/192f3fb7b056627b554600bcc002999742780d04).
- Removes `.setAllowChunklessPreparation(true)` from `app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt:84`.

## PR Type

- Bug fix

## Why

This PR aims to fix one specific problem: on some devices, HLS playback starts normally, runs for 2-3 seconds, and then the player crashes.

The change that introduced this risk came from commit [`192f3fb`](https://github.com/NuvioMedia/NuvioTV/commit/192f3fb7b056627b554600bcc002999742780d04), where this was enabled for HLS:

```kotlin
.setAllowChunklessPreparation(true)
```

In theory, this setting makes sense. It can make some streams start faster. The problem is that Media3's own issue and commit history shows that this approach is not reliable across all devices and all HLS structures.

Simply put, chunkless mode tries to prepare tracks early from the playlist before enough real segment data is read. If the stream and the device behave nicely, this works and the startup feels faster. But if the device incorrectly reports codec support, the manifest is a bit messy, or the variant matching is not clear, the player can find itself on the wrong path. This aligns well with what users are seeing here: playback starts, looks fine for a moment, and then the codec side crashes.

There are a few Media3 references to support this:

- [androidx/media#323](https://github.com/androidx/media/issues/323)
  - chunkless preparation can cause startup freezes or failures on certain HLS setups.
- [androidx/media#379](https://github.com/androidx/media/issues/379)
  - especially with device-specific codec issues, the device reports support but still fails later inside `MediaCodec` during playback.
- [androidx/media#1656](https://github.com/androidx/media/issues/1656)
  - unsupported variant / fallback usage can still break HLS playback.

Related Media3 commits also support the same idea:

- [androidx/media@546d9f5](https://github.com/androidx/media/commit/546d9f592b3f9b5afbfdbc34b99a905e59d58033)
  - chunkless preparation was enabled by default, but with clear warnings; it was never really a "safe everywhere" feature.
- [androidx/media@da663aa](https://github.com/androidx/media/commit/da663aa0812f346d68b172ba6f7c59caa00b3523)
  - Media3 added a fix to avoid chunkless preparation when the codec mapping is ambiguous.
- [androidx/media@9221eeb](https://github.com/androidx/media/commit/9221eeb2d87f049c668a056f7fd7901b91dd51e3)
  - Media3 had to fix a playback freeze caused by HLS chunkless preparation.

## Testing

- Verified with `git blame` which commit introduced this setting into `app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt`.
- Cross-checked the Media3 issue and commit history regarding chunkless HLS and codec-related playback crashes.

## Screenshots / Video (UI changes only)

None.

## Breaking changes

None. The only expected behavior change is that HLS startup may be slightly slower in some cases, in exchange for safer playback.

## Linked issues

- Regression introduced by commit [`192f3fb`](https://github.com/NuvioMedia/NuvioTV/commit/192f3fb7b056627b554600bcc002999742780d04)
- Upstream references:
  - [androidx/media#323](https://github.com/androidx/media/issues/323)
  - [androidx/media#379](https://github.com/androidx/media/issues/379)
  - [androidx/media#1656](https://github.com/androidx/media/issues/1656)
  - [androidx/media@546d9f5](https://github.com/androidx/media/commit/546d9f592b3f9b5afbfdbc34b99a905e59d58033)
  - [androidx/media@da663aa](https://github.com/androidx/media/commit/da663aa0812f346d68b172ba6f7c59caa00b3523)
  - [androidx/media@9221eeb](https://github.com/androidx/media/commit/9221eeb2d87f049c668a056f7fd7901b91dd51e3)
