### PR TITLE
Fix Trakt continue watching shows not supposed to appear & Improve performance at cold start when Trakt is enabled

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
@@ -28,6 +28,7 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktUserEpisodeHistoryItemDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktUserSettingsResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktUserStatsResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktWatchedMovieItemDto
+import com.nuvio.tv.data.remote.dto.trakt.TraktWatchedShowItemDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -103,6 +104,12 @@ interface TraktApi {
         @Path("type") type: String,
         @Query("extended") extended: String? = null
     ): Response<List<TraktWatchedMovieItemDto>>
+
+    @GET("sync/watched/shows")
+    suspend fun getWatchedShows(
+        @Header("Authorization") authorization: String,
+        @Query("extended") extended: String? = null
+    ): Response<List<TraktWatchedShowItemDto>>
 
     @GET("sync/history/episodes")
     suspend fun getEpisodeHistory(

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/trakt/TraktSyncDtos.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/trakt/TraktSyncDtos.kt
@@ -36,6 +36,28 @@ data class TraktWatchedMovieItemDto(
 )
 
 @JsonClass(generateAdapter = true)
+data class TraktWatchedShowItemDto(
+    @Json(name = "plays") val plays: Int? = null,
+    @Json(name = "last_watched_at") val lastWatchedAt: String? = null,
+    @Json(name = "last_updated_at") val lastUpdatedAt: String? = null,
+    @Json(name = "show") val show: TraktShowDto? = null,
+    @Json(name = "seasons") val seasons: List<TraktWatchedShowSeasonDto>? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class TraktWatchedShowSeasonDto(
+    @Json(name = "number") val number: Int? = null,
+    @Json(name = "episodes") val episodes: List<TraktWatchedShowEpisodeDto>? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class TraktWatchedShowEpisodeDto(
+    @Json(name = "number") val number: Int? = null,
+    @Json(name = "plays") val plays: Int? = null,
+    @Json(name = "last_watched_at") val lastWatchedAt: String? = null
+)
+
+@JsonClass(generateAdapter = true)
 data class TraktUserEpisodeHistoryItemDto(
     @Json(name = "id") val id: Long? = null,
     @Json(name = "watched_at") val watchedAt: String? = null,

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.repository
 
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.core.network.NetworkResult
@@ -21,6 +22,7 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktIdsDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktPlaybackItemDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktShowSeasonProgressDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktUserEpisodeHistoryItemDto
+import com.nuvio.tv.data.remote.dto.trakt.TraktWatchedShowItemDto
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.repository.MetaRepository
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -48,6 +50,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
+import retrofit2.Response
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -91,6 +94,7 @@ class TraktProgressService @Inject constructor(
 
     private data class EpisodeProgressCacheEntry(
         val progress: Map<Pair<Int, Int>, WatchProgress>,
+        val airedEpisodes: List<Pair<Int, Int>>,
         val updatedAtMs: Long,
         val activityVersion: Long,
         val hasCompletedSnapshot: Boolean
@@ -98,7 +102,20 @@ class TraktProgressService @Inject constructor(
 
     private data class EpisodeProgressFetchResult(
         val progress: Map<Pair<Int, Int>, WatchProgress>,
+        val airedEpisodes: List<Pair<Int, Int>>,
         val hasCompletedSnapshot: Boolean
+    )
+
+    private data class EpisodeHistoryAddAttempt(
+        val response: Response<TraktHistoryAddResponseDto>,
+        val remappedEpisode: EpisodeMappingEntry? = null
+    )
+
+    private data class WatchedShowSeedsSnapshot(
+        val seeds: List<WatchProgress>,
+        val updatedAtMs: Long,
+        val hasLoaded: Boolean,
+        val stale: Boolean
     )
 
     private data class OptimisticProgressEntry(
@@ -129,15 +146,18 @@ class TraktProgressService @Inject constructor(
     private val optimisticProgress = MutableStateFlow<Map<String, OptimisticProgressEntry>>(emptyMap())
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
     private val watchedMoviesState = MutableStateFlow<Set<String>>(emptySet())
+    private val watchedShowSeedsState = MutableStateFlow<List<WatchProgress>>(emptyList())
     private val episodeProgressState = MutableStateFlow<Map<String, EpisodeProgressCacheEntry>>(emptyMap())
     private val hasLoadedRemoteProgress = MutableStateFlow(false)
     private val cacheMutex = Mutex()
     private val metadataMutex = Mutex()
     private val watchedMoviesMutex = Mutex()
+    private val watchedShowSeedsMutex = Mutex()
     private val episodeProgressMutex = Mutex()
     private val inFlightMetadataKeys = mutableSetOf<String>()
     private val inFlightEpisodeProgressKeys = mutableSetOf<String>()
     private val episodeProgressLastAttemptAtMs = mutableMapOf<String, Long>()
+    private val serviceStartedAtMs = SystemClock.elapsedRealtime()
     private var cachedMoviesPlayback: TimedCache<List<TraktPlaybackItemDto>>? = null
     private var cachedEpisodesPlayback: TimedCache<List<TraktPlaybackItemDto>>? = null
     private var cachedUserStats: TimedCache<TraktCachedStats>? = null
@@ -146,6 +166,10 @@ class TraktProgressService @Inject constructor(
     private var watchedMoviesLastAttemptAtMs: Long = 0L
     private var hasLoadedWatchedMovies: Boolean = false
     private var watchedMoviesStale: Boolean = true
+    private var watchedShowSeedsUpdatedAtMs: Long = 0L
+    private var watchedShowSeedsLastAttemptAtMs: Long = 0L
+    private var hasLoadedWatchedShowSeeds: Boolean = false
+    private var watchedShowSeedsStale: Boolean = true
     @Volatile
     private var lastFastSyncRequestMs: Long = 0L
     @Volatile
@@ -156,6 +180,8 @@ class TraktProgressService @Inject constructor(
     private var lastKnownEpisodeActivityFingerprint: String? = null
     @Volatile
     private var lastManualRefreshSignalMs: Long = 0L
+    @Volatile
+    private var metadataWarmupScheduled: Boolean = false
     private val episodeProgressActivityVersion = AtomicLong(0L)
 
     private val playbackCacheTtlMs = 30_000L
@@ -165,6 +191,7 @@ class TraktProgressService @Inject constructor(
     private val episodeProgressCacheTtlMs = 5 * 60_000L
     private val episodeProgressFetchThrottleMs = 15_000L
     private val optimisticTtlMs = 3 * 60_000L
+    private val initialMetadataHydrationDelayMs = 3_000L
     private val maxRecentEpisodeHistoryEntries = 300
     private val metadataHydrationLimit = 110
     private val metadataFetchSemaphore = Semaphore(5)
@@ -325,6 +352,14 @@ class TraktProgressService @Inject constructor(
         return hasLoadedRemoteProgress
     }
 
+    fun observeWatchedShowSeeds(): Flow<List<WatchProgress>> {
+        return watchedShowSeedsState
+            .onStart {
+                emit(getWatchedShowSeedsSnapshot(forceRefresh = false))
+            }
+            .distinctUntilChanged()
+    }
+
     fun observeEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> {
         val cacheKey = canonicalLookupKey(contentId)
         return combine(episodeProgressState, optimisticProgress) { state, optimistic ->
@@ -346,6 +381,18 @@ class TraktProgressService @Inject constructor(
                 }
             merged as Map<Pair<Int, Int>, WatchProgress>
         }
+            .onStart {
+                scope.launch {
+                    ensureEpisodeProgressSnapshot(contentId = cacheKey, forceRefresh = false)
+                }
+            }
+            .distinctUntilChanged()
+    }
+
+    fun observeAiredEpisodes(contentId: String): Flow<List<Pair<Int, Int>>> {
+        val cacheKey = canonicalLookupKey(contentId)
+        return episodeProgressState
+            .map { state -> state[cacheKey]?.airedEpisodes.orEmpty() }
             .onStart {
                 scope.launch {
                     ensureEpisodeProgressSnapshot(contentId = cacheKey, forceRefresh = false)
@@ -417,15 +464,30 @@ class TraktProgressService @Inject constructor(
         val body = buildHistoryAddRequest(progress, title, year)
             ?: throw IllegalStateException("Insufficient Trakt IDs to mark watched")
 
+        val isSeriesEpisode = isSeriesEpisodeProgress(progress)
+        val watchedShowSeedsSnapshot = if (isSeriesEpisode) {
+            snapshotWatchedShowSeeds()
+                .also { updateWatchedShowSeedOptimistically(progress) }
+        } else {
+            null
+        }
+
         Log.d(TAG, "markAsWatched REQUEST: shows=${body.shows?.map { show ->
             "ids=${show.ids} title=${show.title} year=${show.year} seasons=${show.seasons?.map { s ->
                 "number=${s.number} episodes=${s.episodes?.map { e -> "number=${e.number} watchedAt=${e.watchedAt}" }}"
             }}"
         }} movies=${body.movies?.map { m -> "ids=${m.ids} title=${m.title}" }}")
 
-        val response = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
-            traktApi.addHistory(authHeader, body)
-        } ?: throw IllegalStateException("Trakt request failed")
+        val response = try {
+            traktAuthService.executeAuthorizedWriteRequest { authHeader ->
+                traktApi.addHistory(authHeader, body)
+            } ?: throw IllegalStateException("Trakt request failed")
+        } catch (error: Throwable) {
+            if (watchedShowSeedsSnapshot != null) {
+                restoreWatchedShowSeeds(watchedShowSeedsSnapshot)
+            }
+            throw error
+        }
 
         var responseBody = response.body()
         val initialFailure = !response.isSuccessful || hasHistoryAddNotFound(responseBody)
@@ -437,30 +499,40 @@ class TraktProgressService @Inject constructor(
             "shows=${responseBody?.notFound?.shows?.map { it.ids }} " +
             "episodes=${responseBody?.notFound?.episodes?.map { "s=${it.season} e=${it.number} ids=${it.ids}" }}]")
 
-        val isSeriesEpisode = isSeriesEpisodeProgress(progress)
         val shouldRetryRemap = isSeriesEpisode && (
             !response.isSuccessful ||
                 hasHistoryAddNotFound(responseBody) ||
                 !hasSuccessfulHistoryAdd(responseBody)
-            )
+        )
         var recoveredByRemap = false
+        var effectiveProgress = progress
         if (shouldRetryRemap) {
-            val remappedResponse = attemptEpisodeRemapHistoryAdd(
+            val remappedAttempt = attemptEpisodeRemapHistoryAdd(
                 progress = progress,
                 title = title,
                 year = year
             )
-            if (remappedResponse != null) {
-                responseBody = remappedResponse.body()
-                effectiveResponseCode = remappedResponse.code()
+            if (remappedAttempt != null) {
+                responseBody = remappedAttempt.response.body()
+                effectiveResponseCode = remappedAttempt.response.code()
                 recoveredByRemap =
-                    remappedResponse.isSuccessful &&
+                    remappedAttempt.response.isSuccessful &&
                     !hasHistoryAddNotFound(responseBody) &&
                     hasSuccessfulHistoryAdd(responseBody)
+                if (recoveredByRemap && remappedAttempt.remappedEpisode != null) {
+                    effectiveProgress = progress.copy(
+                        season = remappedAttempt.remappedEpisode.season,
+                        episode = remappedAttempt.remappedEpisode.episode,
+                        videoId = remappedAttempt.remappedEpisode.videoId ?: progress.videoId
+                    )
+                }
             }
         }
 
         if (initialFailure && !recoveredByRemap) {
+            if (watchedShowSeedsSnapshot != null) {
+                restoreWatchedShowSeeds(watchedShowSeedsSnapshot)
+            }
             throw IllegalStateException("Failed to mark watched on Trakt ($effectiveResponseCode)")
         }
         if (!hasSuccessfulHistoryAdd(responseBody)) {
@@ -474,6 +546,7 @@ class TraktProgressService @Inject constructor(
             progress.contentType.equals("tv", ignoreCase = true)
         ) {
             invalidateEpisodeProgressCache(progress.contentId)
+            updateWatchedShowSeedOptimistically(effectiveProgress)
         }
         refreshNow()
     }
@@ -652,6 +725,11 @@ class TraktProgressService @Inject constructor(
         hasLoadedRemoteProgress.value = true
         reconcileOptimistic(snapshot)
         hydrateMetadata(snapshot)
+        if (watchedShowSeedsStale && hasLoadedWatchedShowSeeds) {
+            scope.launch {
+                getWatchedShowSeedsSnapshot(forceRefresh = true)
+            }
+        }
     }
 
     private suspend fun hasActivityChanged(): Boolean {
@@ -673,6 +751,7 @@ class TraktProgressService @Inject constructor(
         ).joinToString("|")
         if (episodeFingerprint != lastKnownEpisodeActivityFingerprint) {
             lastKnownEpisodeActivityFingerprint = episodeFingerprint
+            watchedShowSeedsStale = true
             val version = episodeProgressActivityVersion.incrementAndGet()
             trace("last_activities: episodes changed -> show-progress cache version=$version")
         }
@@ -758,6 +837,7 @@ class TraktProgressService @Inject constructor(
                 current + (
                     cacheKey to EpisodeProgressCacheEntry(
                         progress = result.progress,
+                        airedEpisodes = result.airedEpisodes,
                         updatedAtMs = fetchedAt,
                         activityVersion = activityVersion,
                         hasCompletedSnapshot = result.hasCompletedSnapshot
@@ -835,6 +915,182 @@ class TraktProgressService @Inject constructor(
         }
     }
 
+    private suspend fun getWatchedShowSeedsSnapshot(forceRefresh: Boolean): List<WatchProgress> {
+        val now = System.currentTimeMillis()
+        return watchedShowSeedsMutex.withLock {
+            val hasFreshCache = hasLoadedWatchedShowSeeds &&
+                !watchedShowSeedsStale &&
+                now - watchedShowSeedsUpdatedAtMs <= watchedMoviesCacheTtlMs
+            if (!forceRefresh && hasFreshCache) {
+                trace("watched-shows cache hit: size=${watchedShowSeedsState.value.size}")
+                return@withLock watchedShowSeedsState.value
+            }
+            if (!forceRefresh && now - watchedShowSeedsLastAttemptAtMs < watchedMoviesFetchThrottleMs) {
+                trace("watched-shows fetch throttled: ${now - watchedShowSeedsLastAttemptAtMs}ms since last attempt")
+                return@withLock watchedShowSeedsState.value
+            }
+
+            watchedShowSeedsLastAttemptAtMs = now
+            trace("watched-shows fetch: requesting /sync/watched/shows")
+            val response = traktAuthService.executeAuthorizedRequest { authHeader ->
+                traktApi.getWatchedShows(
+                    authorization = authHeader
+                )
+            } ?: run {
+                trace("watched-shows fetch: request returned null (network/auth failure)")
+                return@withLock watchedShowSeedsState.value
+            }
+
+            if (!response.isSuccessful) {
+                trace("watched-shows fetch: non-success code=${response.code()}")
+                return@withLock watchedShowSeedsState.value
+            }
+
+            val watchedShowSeeds = response.body().orEmpty()
+                .mapNotNull(::mapWatchedShowSeed)
+                .sortedByDescending { it.lastWatched }
+
+            watchedShowSeedsState.value = watchedShowSeeds
+            watchedShowSeedsUpdatedAtMs = System.currentTimeMillis()
+            hasLoadedWatchedShowSeeds = true
+            watchedShowSeedsStale = false
+            trace("watched-shows cache refreshed: size=${watchedShowSeeds.size}")
+            watchedShowSeeds
+        }
+    }
+
+    private fun mapWatchedShowSeed(item: TraktWatchedShowItemDto): WatchProgress? {
+        val show = item.show ?: return null
+        val contentId = normalizeContentId(show.ids)
+        if (contentId.isBlank()) return null
+
+        val furthestEpisode = item.seasons.orEmpty()
+            .asSequence()
+            .filter { season -> (season.number ?: 0) > 0 }
+            .flatMap { season ->
+                val seasonNumber = season.number ?: return@flatMap emptySequence()
+                season.episodes.orEmpty()
+                    .asSequence()
+                    .filter { episode -> (episode.number ?: 0) > 0 && (episode.plays ?: 1) > 0 }
+                    .mapNotNull { episode ->
+                        val episodeNumber = episode.number ?: return@mapNotNull null
+                        Triple(
+                            seasonNumber,
+                            episodeNumber,
+                            parseIsoToMillis(episode.lastWatchedAt)
+                        )
+                    }
+            }
+            .maxWithOrNull(
+                compareBy<Triple<Int, Int, Long>>(
+                    { it.first },
+                    { it.second },
+                    { it.third }
+                )
+            ) ?: return null
+
+        val season = furthestEpisode.first
+        val episode = furthestEpisode.second
+        val lastWatched = furthestEpisode.third.takeIf { it > 0L }
+            ?: parseIsoToMillis(item.lastWatchedAt)
+
+        return WatchProgress(
+            contentId = contentId,
+            contentType = "series",
+            name = show.title ?: contentId,
+            poster = null,
+            backdrop = null,
+            logo = null,
+            videoId = buildLightweightEpisodeVideoId(contentId, season, episode),
+            season = season,
+            episode = episode,
+            episodeTitle = null,
+            position = 1L,
+            duration = 1L,
+            lastWatched = lastWatched,
+            progressPercent = 100f,
+            source = WatchProgress.SOURCE_TRAKT_SHOW_PROGRESS,
+            traktShowId = show.ids?.trakt
+        )
+    }
+
+    private fun updateWatchedShowSeedOptimistically(progress: WatchProgress) {
+        if (!isSeriesEpisodeProgress(progress)) return
+        val season = progress.season ?: return
+        val episode = progress.episode ?: return
+        val contentId = canonicalLookupKey(progress.contentId)
+        if (contentId.isBlank()) return
+
+        val now = System.currentTimeMillis()
+        val candidate = WatchProgress(
+            contentId = contentId,
+            contentType = "series",
+            name = progress.name.takeIf { it.isNotBlank() } ?: contentId,
+            poster = progress.poster,
+            backdrop = progress.backdrop,
+            logo = progress.logo,
+            videoId = progress.videoId.takeIf { it.isNotBlank() }
+                ?: buildLightweightEpisodeVideoId(contentId, season, episode),
+            season = season,
+            episode = episode,
+            episodeTitle = progress.episodeTitle,
+            position = 1L,
+            duration = 1L,
+            lastWatched = progress.lastWatched.takeIf { it > 0L } ?: now,
+            progressPercent = 100f,
+            source = WatchProgress.SOURCE_TRAKT_SHOW_PROGRESS,
+            traktShowId = progress.traktShowId,
+            traktEpisodeId = progress.traktEpisodeId
+        )
+
+        watchedShowSeedsState.update { current ->
+            val updated = current.toMutableList()
+            val existingIndex = updated.indexOfFirst { canonicalLookupKey(it.contentId) == contentId }
+            if (existingIndex >= 0) {
+                val existing = updated[existingIndex]
+                val shouldReplace =
+                    (candidate.season ?: -1) > (existing.season ?: -1) ||
+                        (
+                            candidate.season == existing.season &&
+                                (
+                                    (candidate.episode ?: -1) > (existing.episode ?: -1) ||
+                                        (
+                                            candidate.episode == existing.episode &&
+                                                candidate.lastWatched >= existing.lastWatched
+                                            )
+                                    )
+                            )
+                if (!shouldReplace) {
+                    return@update current
+                }
+                updated[existingIndex] = candidate
+            } else {
+                updated.add(candidate)
+            }
+            updated.sortedByDescending { it.lastWatched }
+        }
+        watchedShowSeedsUpdatedAtMs = now
+        hasLoadedWatchedShowSeeds = true
+        watchedShowSeedsStale = true
+        trace("watched-shows optimistic update: contentId=$contentId s=$season e=$episode")
+    }
+
+    private fun snapshotWatchedShowSeeds(): WatchedShowSeedsSnapshot {
+        return WatchedShowSeedsSnapshot(
+            seeds = watchedShowSeedsState.value,
+            updatedAtMs = watchedShowSeedsUpdatedAtMs,
+            hasLoaded = hasLoadedWatchedShowSeeds,
+            stale = watchedShowSeedsStale
+        )
+    }
+
+    private fun restoreWatchedShowSeeds(snapshot: WatchedShowSeedsSnapshot) {
+        watchedShowSeedsState.value = snapshot.seeds
+        watchedShowSeedsUpdatedAtMs = snapshot.updatedAtMs
+        hasLoadedWatchedShowSeeds = snapshot.hasLoaded
+        watchedShowSeedsStale = snapshot.stale
+    }
+
     private suspend fun setMovieWatchedInCache(contentId: String, watched: Boolean) {
         val rawKey = contentId.trim()
         if (rawKey.isBlank()) return
@@ -859,6 +1115,10 @@ class TraktProgressService @Inject constructor(
         val parsed = parseContentIds(contentId)
         val canonical = normalizeContentId(toTraktIds(parsed))
         return if (canonical.isNotBlank()) canonical else contentId.trim()
+    }
+
+    private fun buildLightweightEpisodeVideoId(contentId: String, season: Int, episode: Int): String {
+        return "$contentId:$season:$episode"
     }
 
     private fun watchedMovieLookupKeys(ids: TraktIdsDto?): List<String> {
@@ -1001,6 +1261,7 @@ class TraktProgressService @Inject constructor(
     ): EpisodeProgressFetchResult {
         val pathId = toTraktPathId(contentId)
         val completed = mutableMapOf<Pair<Int, Int>, WatchProgress>()
+        var airedEpisodes = emptyList<Pair<Int, Int>>()
         var hasCompletedSnapshot = false
 
         val response = traktAuthService.executeAuthorizedRequest { authHeader ->
@@ -1013,6 +1274,19 @@ class TraktProgressService @Inject constructor(
         if (response?.isSuccessful == true) {
             hasCompletedSnapshot = true
             val seasons = response.body()?.seasons.orEmpty()
+            airedEpisodes = seasons
+                .asSequence()
+                .filter { (it.number ?: 0) > 0 }
+                .sortedBy { it.number }
+                .flatMap { season ->
+                    val seasonNumber = season.number ?: return@flatMap emptySequence()
+                    season.episodes.orEmpty().asSequence()
+                        .mapNotNull { episode ->
+                            val episodeNumber = episode.number ?: return@mapNotNull null
+                            seasonNumber to episodeNumber
+                        }
+                }
+                .toList()
             for (season in seasons) {
                 mapSeasonProgress(contentId, season).forEach { progress ->
                     val seasonNum = progress.season ?: return@forEach
@@ -1036,6 +1310,7 @@ class TraktProgressService @Inject constructor(
 
         return EpisodeProgressFetchResult(
             progress = completed,
+            airedEpisodes = airedEpisodes,
             hasCompletedSnapshot = hasCompletedSnapshot
         )
     }
@@ -1221,6 +1496,9 @@ class TraktProgressService @Inject constructor(
         season: Int,
         episode: Int
     ): String {
+        if (!hasLoadedRemoteProgress.value) {
+            return "$contentId:$season:$episode"
+        }
         val key = "$contentId:$season:$episode"
         episodeVideoIdCache[key]?.let { return it }
 
@@ -1340,7 +1618,7 @@ class TraktProgressService @Inject constructor(
         progress: WatchProgress,
         title: String?,
         year: Int?
-    ) = runCatching {
+    ): EpisodeHistoryAddAttempt? = runCatching {
         val remapped = resolveCanonicalEpisodeMapping(progress) ?: return@runCatching null
         val currentSeason = progress.season
         val currentEpisode = progress.episode
@@ -1376,7 +1654,10 @@ class TraktProgressService @Inject constructor(
                 "shows=${retryBody?.notFound?.shows?.map { it.ids }} " +
                 "episodes=${retryBody?.notFound?.episodes?.map { "s=${it.season} e=${it.number} ids=${it.ids}" }}]"
         )
-        retryResponse
+        EpisodeHistoryAddAttempt(
+            response = retryResponse,
+            remappedEpisode = remapped
+        )
     }.getOrElse { error ->
         Log.w(TAG, "markAsWatched: episode remap fallback failed", error)
         null
@@ -1455,7 +1736,27 @@ class TraktProgressService @Inject constructor(
         refreshSignals.tryEmit(Unit)
     }
 
+    private fun remainingMetadataWarmupDelayMs(): Long {
+        val elapsed = SystemClock.elapsedRealtime() - serviceStartedAtMs
+        return (initialMetadataHydrationDelayMs - elapsed).coerceAtLeast(0L)
+    }
+
+    private fun shouldDelayMetadataHydration(): Boolean {
+        val remainingDelayMs = remainingMetadataWarmupDelayMs()
+        if (remainingDelayMs <= 0L) return false
+        if (metadataWarmupScheduled) return true
+        metadataWarmupScheduled = true
+        scope.launch {
+            delay(remainingDelayMs)
+            metadataWarmupScheduled = false
+            hydrateMetadata(remoteProgress.value)
+        }
+        return true
+    }
+
     private fun hydrateMetadata(progressList: List<WatchProgress>) {
+        if (progressList.isEmpty()) return
+        if (shouldDelayMetadataHydration()) return
         val sorted = progressList.sortedByDescending { it.lastWatched }
         val uniqueByContent = linkedMapOf<String, WatchProgress>()
         sorted.forEach { progress ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.combine
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
@@ -53,6 +55,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
 ) : WatchProgressRepository {
     companion object {
         private const val TAG = "WatchProgressRepo"
+        private const val OPTIMISTIC_NEXT_UP_SEED_WINDOW_MS = 3 * 60_000L
     }
 
     private data class EpisodeMetadata(
@@ -76,6 +79,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
     var hasCompletedInitialWatchedItemsPull = false
 
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
+    private val optimisticContinueWatchingUpdates = MutableSharedFlow<WatchProgress>(
+        replay = 1,
+        extraBufferCapacity = 16
+    )
     private val metadataMutex = Mutex()
     private val inFlightMetadataKeys = mutableSetOf<String>()
     private val metadataHydrationLimit = 30
@@ -233,16 +240,11 @@ class WatchProgressRepositoryImpl @Inject constructor(
         traktAuthDataStore.isEffectivelyAuthenticated.first()
 
     private fun traktAllProgressFlow(): Flow<List<WatchProgress>> {
-        return combine(
-            traktProgressService.observeAllProgress()
-                .onStart {
-                    emit(emptyList())
-                },
-            metadataState
-        ) { remoteItems, metadataMap ->
-            hydrateMetadata(remoteItems)
-            remoteItems.map { enrichWithMetadata(it, metadataMap) }
-        }.distinctUntilChanged()
+        return traktProgressService.observeAllProgress()
+            .onStart {
+                emit(emptyList())
+            }
+            .distinctUntilChanged()
     }
 
     override val allProgress: Flow<List<WatchProgress>>
@@ -251,13 +253,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 if (useTraktProgress) {
                     traktAllProgressFlow()
                 } else {
-                    combine(
-                        watchProgressPreferences.allProgress,
-                        metadataState
-                    ) { items, metadataMap ->
-                        hydrateMetadata(items)
-                        items.map { enrichWithMetadata(it, metadataMap) }
-                    }
+                    watchProgressPreferences.allProgress
                 }
             }
 
@@ -317,6 +313,110 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     watchProgressPreferences.getAllEpisodeProgress(contentId)
                 }
             }
+    }
+
+    override fun getAiredEpisodeOrder(contentId: String): Flow<List<Pair<Int, Int>>> {
+        return useTraktProgressFlow()
+            .flatMapLatest { useTraktProgress ->
+                if (useTraktProgress) {
+                    traktProgressService.observeAiredEpisodes(contentId)
+                } else {
+                    flowOf(emptyList())
+                }
+            }
+            .distinctUntilChanged()
+    }
+
+    override fun observeNextUpSeeds(): Flow<List<WatchProgress>> {
+        return useTraktProgressFlow()
+            .flatMapLatest { useTraktProgress ->
+                if (useTraktProgress) {
+                    combine(
+                        traktProgressService.observeWatchedShowSeeds(),
+                        traktProgressService.observeAllProgress()
+                            .map { items ->
+                                val nowMs = System.currentTimeMillis()
+                                items.filter { progress ->
+                                    isOptimisticNextUpSeedCandidate(progress, nowMs)
+                                }
+                            }
+                            .onStart { emit(emptyList()) }
+                    ) { canonicalSeeds, optimisticSeeds ->
+                        mergeNextUpSeeds(canonicalSeeds, optimisticSeeds)
+                    }
+                } else {
+                    watchProgressPreferences.allProgress.map { items ->
+                        items.filter { progress ->
+                            progress.isCompleted() &&
+                                progress.contentType.equals("series", ignoreCase = true) &&
+                                progress.season != null &&
+                                progress.episode != null &&
+                                progress.season != 0
+                        }
+                    }
+                }
+            }
+            .distinctUntilChanged()
+    }
+
+    private fun isOptimisticNextUpSeedCandidate(
+        progress: WatchProgress,
+        nowMs: Long
+    ): Boolean {
+        if (!progress.contentType.equals("series", ignoreCase = true)) return false
+        if (!progress.isCompleted()) return false
+        if (progress.source != WatchProgress.SOURCE_TRAKT_PLAYBACK) return false
+        if (progress.season == null || progress.episode == null || progress.season == 0) return false
+        val ageMs = nowMs - progress.lastWatched
+        return ageMs in 0..OPTIMISTIC_NEXT_UP_SEED_WINDOW_MS
+    }
+
+    private fun mergeNextUpSeeds(
+        canonicalSeeds: List<WatchProgress>,
+        optimisticSeeds: List<WatchProgress>
+    ): List<WatchProgress> {
+        val merged = linkedMapOf<String, WatchProgress>()
+        canonicalSeeds.forEach { seed ->
+            merged[nextUpSeedKey(seed)] = seed
+        }
+        optimisticSeeds.forEach { seed ->
+            val key = nextUpSeedKey(seed)
+            val existing = merged[key]
+            if (existing == null || shouldReplaceNextUpSeed(existing, seed)) {
+                merged[key] = seed
+            }
+        }
+        return merged.values.sortedByDescending { it.lastWatched }
+    }
+
+    private fun nextUpSeedKey(progress: WatchProgress): String {
+        return progress.traktShowId?.let { "trakt_show:$it" }
+            ?: progress.contentId.trim()
+    }
+
+    private fun shouldReplaceNextUpSeed(
+        existing: WatchProgress,
+        candidate: WatchProgress
+    ): Boolean {
+        val candidateSeason = candidate.season ?: -1
+        val candidateEpisode = candidate.episode ?: -1
+        val existingSeason = existing.season ?: -1
+        val existingEpisode = existing.episode ?: -1
+        return candidateSeason > existingSeason ||
+            (
+                candidateSeason == existingSeason &&
+                    (
+                        candidateEpisode > existingEpisode ||
+                            (
+                                candidateEpisode == existingEpisode &&
+                                    candidate.lastWatched >= existing.lastWatched
+                                )
+                        )
+                )
+    }
+
+    override fun observeOptimisticContinueWatchingUpdates(): Flow<WatchProgress> {
+        return optimisticContinueWatchingUpdates
     }
 
     @OptIn(FlowPreview::class)
@@ -484,6 +584,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 progressPercent = 100f,
                 lastWatched = now
             )
+            optimisticContinueWatchingUpdates.tryEmit(completed)
             traktProgressService.applyOptimisticProgress(completed)
             runCatching {
                 traktProgressService.markAsWatched(
@@ -532,6 +633,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 progressPercent = 100f,
                 lastWatched = now
             )
+            optimisticContinueWatchingUpdates.tryEmit(completed)
             runCatching {
                 traktProgressService.markAsWatched(
                     progress = completed,

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -33,6 +33,22 @@ interface WatchProgressRepository {
      */
     fun getAllEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>>
 
+    /**
+     * Get the aired episode order for a series when available from the current progress backend.
+     */
+    fun getAiredEpisodeOrder(contentId: String): Flow<List<Pair<Int, Int>>>
+
+    /**
+     * Get completed series episode seeds suitable for building a lightweight "Next Up".
+     */
+    fun observeNextUpSeeds(): Flow<List<WatchProgress>>
+
+    /**
+     * Emits immediate optimistic updates that should patch Continue Watching
+     * without waiting for the regular progress flows to settle.
+     */
+    fun observeOptimisticContinueWatchingUpdates(): Flow<WatchProgress>
+
 
     /**
      * Returns whether the item is marked as watched/completed.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -87,7 +87,9 @@ data class NextUpInfo(
     val lastWatched: Long,
     val imdbRating: Float? = null,
     val genres: List<String> = emptyList(),
-    val releaseInfo: String? = null
+    val releaseInfo: String? = null,
+    val seedSeason: Int? = null,
+    val seedEpisode: Int? = null
 )
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.ui.screens.home
 
+import android.os.SystemClock
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -60,6 +61,8 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
+        internal const val STARTUP_GRACE_PERIOD_MS = 3_000L
+        internal const val CONTINUE_WATCHING_ENRICHMENT_GRACE_PERIOD_MS = 10_000L
         private const val CONTINUE_WATCHING_WINDOW_MS = 30L * 24 * 60 * 60 * 1000
         private const val MAX_RECENT_PROGRESS_ITEMS = 300
         private const val MAX_NEXT_UP_LOOKUPS = 24
@@ -135,9 +138,12 @@ class HomeViewModel @Inject constructor(
     internal val movieWatchedObserverJobs = mutableMapOf<String, Job>()
     internal var movieWatchedBatchJob: Job? = null
     internal var lastMovieWatchedItemKeys: Set<String> = emptySet()
+    internal var libraryTabsObserverJob: Job? = null
     internal var activePosterListPickerInput: LibraryEntryInput? = null
+    internal var posterStatusObservationEnabled: Boolean = false
     @Volatile
     internal var externalMetaPrefetchEnabled: Boolean = false
+    internal val startupStartedAtMs: Long = SystemClock.elapsedRealtime()
     @Volatile
     internal var startupGracePeriodActive: Boolean = true
     internal var startupAuthNoticeJob: Job? = null
@@ -157,9 +163,21 @@ class HomeViewModel @Inject constructor(
         loadContinueWatching()
         observeInstalledAddons()
         viewModelScope.launch {
-            delay(3000)
+            delay(STARTUP_GRACE_PERIOD_MS)
             startupGracePeriodActive = false
         }
+    }
+
+    internal fun remainingStartupGraceMs(nowMs: Long = SystemClock.elapsedRealtime()): Long {
+        if (!startupGracePeriodActive) return 0L
+        return (STARTUP_GRACE_PERIOD_MS - (nowMs - startupStartedAtMs)).coerceAtLeast(0L)
+    }
+
+    internal fun remainingContinueWatchingEnrichmentGraceMs(
+        nowMs: Long = SystemClock.elapsedRealtime()
+    ): Long {
+        return (CONTINUE_WATCHING_ENRICHMENT_GRACE_PERIOD_MS - (nowMs - startupStartedAtMs))
+            .coerceAtLeast(0L)
     }
 
     private fun observeLayoutPreferences() = observeLayoutPreferencesPipeline()
@@ -231,7 +249,9 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun loadContinueWatching() = loadContinueWatchingPipeline()
+    private fun loadContinueWatching() {
+        loadContinueWatchingPipeline()
+    }
 
     private fun removeContinueWatching(
         contentId: String,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1,6 +1,5 @@
 package com.nuvio.tv.ui.screens.home
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.TraktSettingsDataStore
@@ -11,11 +10,11 @@ import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -30,15 +29,18 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 private const val CW_MAX_RECENT_PROGRESS_ITEMS = 300
 private const val CW_MAX_NEXT_UP_LOOKUPS = 24
-private const val CW_MAX_NEXT_UP_CONCURRENCY = 4
+private const val CW_MAX_NEXT_UP_CONCURRENCY = 2
 private const val CW_PROGRESS_DEBOUNCE_MS = 500L
+private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7L
 
 private data class ContinueWatchingSettingsSnapshot(
     val items: List<WatchProgress>,
+    val nextUpSeeds: List<WatchProgress>,
     val daysCap: Int,
     val dismissedNextUp: Set<String>,
     val showUnairedNextUp: Boolean
@@ -57,26 +59,46 @@ private data class NextUpTmdbData(
 )
 
 private data class NextUpResolution(
-    val episode: Video,
+    val season: Int,
+    val episode: Int,
+    val videoId: String,
+    val episodeTitle: String?,
+    val released: String?,
+    val hasAired: Boolean,
+    val airDateLabel: String?,
     val lastWatched: Long
 )
 
+@OptIn(kotlinx.coroutines.FlowPreview::class)
 internal fun HomeViewModel.loadContinueWatchingPipeline() {
     viewModelScope.launch {
         combine(
-            watchProgressRepository.allProgress,
-            traktSettingsDataStore.continueWatchingDaysCap,
-            traktSettingsDataStore.dismissedNextUpKeys,
-            traktSettingsDataStore.showUnairedNextUp
-        ) { items, daysCap, dismissedNextUp, showUnairedNextUp ->
+            combine(
+                watchProgressRepository.allProgress,
+                watchProgressRepository.observeNextUpSeeds()
+            ) { items, nextUpSeeds ->
+                items to nextUpSeeds
+            },
+            combine(
+                traktSettingsDataStore.continueWatchingDaysCap,
+                traktSettingsDataStore.dismissedNextUpKeys,
+                traktSettingsDataStore.showUnairedNextUp
+            ) { daysCap, dismissedNextUp, showUnairedNextUp ->
+                Triple(daysCap, dismissedNextUp, showUnairedNextUp)
+            }
+        ) { progressSnapshot, settingsSnapshot ->
+            val (items, nextUpSeeds) = progressSnapshot
+            val (daysCap, dismissedNextUp, showUnairedNextUp) = settingsSnapshot
             ContinueWatchingSettingsSnapshot(
                 items = items,
+                nextUpSeeds = nextUpSeeds,
                 daysCap = daysCap,
                 dismissedNextUp = dismissedNextUp,
                 showUnairedNextUp = showUnairedNextUp
             )
         }.debounce(CW_PROGRESS_DEBOUNCE_MS).collectLatest { snapshot ->
             val items = snapshot.items
+            val nextUpSeeds = snapshot.nextUpSeeds
             val daysCap = snapshot.daysCap
             val dismissedNextUp = snapshot.dismissedNextUp
             val showUnairedNextUp = snapshot.showUnairedNextUp
@@ -92,8 +114,12 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 .sortedByDescending { it.lastWatched }
                 .take(CW_MAX_RECENT_PROGRESS_ITEMS)
                 .toList()
-
-            Log.d("HomeViewModel", "allProgress emitted=${items.size} recentWindow=${recentItems.size}")
+            val recentNextUpSeeds = nextUpSeeds
+                .asSequence()
+                .filter { progress -> cutoffMs == null || progress.lastWatched >= cutoffMs }
+                .sortedByDescending { it.lastWatched }
+                .take(CW_MAX_RECENT_PROGRESS_ITEMS)
+                .toList()
 
             val inProgressOnly = buildList {
                 deduplicateInProgress(
@@ -107,34 +133,32 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 }
             }
 
-            Log.d("HomeViewModel", "inProgressOnly: ${inProgressOnly.size} items after filter+dedup")
-
-            _uiState.update { state ->
-                val immediateItems = if (inProgressOnly.isNotEmpty()) {
-                    inProgressOnly
-                } else {
-                    val existingNextUp = state.continueWatchingItems
-                        .filterIsInstance<ContinueWatchingItem.NextUp>()
-                    mergeContinueWatchingItems(
-                        inProgressItems = inProgressOnly,
-                        nextUpItems = existingNextUp
-                    )
-                }
-                if (state.continueWatchingItems == immediateItems) {
-                    state
-                } else {
-                    state.copy(continueWatchingItems = immediateItems)
-                }
-            }
-
-            // Then enrich Next Up and item details in background.
-            enrichContinueWatchingProgressively(
+            val nextUpItems = buildLightweightNextUpItems(
                 allProgress = recentItems,
+                nextUpSeeds = recentNextUpSeeds,
                 inProgressItems = inProgressOnly,
                 dismissedNextUp = dismissedNextUp,
                 showUnairedNextUp = showUnairedNextUp
             )
-            enrichInProgressEpisodeDetailsProgressively(inProgressOnly)
+            val normalItems = mergeContinueWatchingItems(
+                inProgressItems = inProgressOnly,
+                nextUpItems = nextUpItems
+            )
+
+            _uiState.update { state ->
+                if (state.continueWatchingItems == normalItems) {
+                    state
+                } else {
+                    state.copy(continueWatchingItems = normalItems)
+                }
+            }
+
+            // Rich metadata only runs after the final lightweight CW list is visible.
+            val enrichmentDelayMs = remainingContinueWatchingEnrichmentGraceMs()
+            if (enrichmentDelayMs > 0L) {
+                delay(enrichmentDelayMs)
+            }
+            enrichVisibleContinueWatchingItems(normalItems)
         }
     }
 }
@@ -173,6 +197,57 @@ private fun shouldTreatAsActiveInProgressForNextUpSuppression(
     if (!shouldTreatAsInProgressForContinueWatching(progress)) return false
     if (latestCompletedAt == null || latestCompletedAt == Long.MIN_VALUE) return true
     return progress.lastWatched >= latestCompletedAt
+}
+
+private fun logNextUpDecision(message: String) {
+    Unit
+}
+
+private fun shouldTraceNextUpSeries(progress: WatchProgress): Boolean = false
+
+private fun WatchProgress.toNextUpTraceString(): String {
+    return buildString {
+        append(name)
+        append("(")
+        append(contentId)
+        append(") s=")
+        append(season)
+        append(" e=")
+        append(episode)
+        append(" src=")
+        append(source)
+        append(" last=")
+        append(lastWatched)
+        append(" pct=")
+        append(progressPercent)
+        append(" videoId=")
+        append(videoId)
+    }
+}
+
+private fun nextUpSeedSourceRank(progress: WatchProgress): Int {
+    return when (progress.source) {
+        WatchProgress.SOURCE_TRAKT_PLAYBACK -> 0
+        WatchProgress.SOURCE_TRAKT_SHOW_PROGRESS -> 0
+        WatchProgress.SOURCE_TRAKT_HISTORY -> 1
+        WatchProgress.SOURCE_LOCAL -> 2
+        else -> 4
+    }
+}
+
+private fun choosePreferredNextUpSeed(items: List<WatchProgress>): WatchProgress? {
+    if (items.isEmpty()) return null
+    val bestRank = items.minOf(::nextUpSeedSourceRank)
+    return items
+        .asSequence()
+        .filter { nextUpSeedSourceRank(it) == bestRank }
+        .maxWithOrNull(
+            compareBy<WatchProgress>(
+                { it.season ?: -1 },
+                { it.episode ?: -1 },
+                { it.lastWatched }
+            )
+        )
 }
 
 private suspend fun HomeViewModel.resolveCurrentEpisodeDescription(
@@ -241,12 +316,13 @@ private fun resolveVideoForProgress(progress: WatchProgress, meta: Meta): Video?
     return null
 }
 
-private suspend fun HomeViewModel.enrichContinueWatchingProgressively(
+private suspend fun HomeViewModel.buildLightweightNextUpItems(
     allProgress: List<WatchProgress>,
+    nextUpSeeds: List<WatchProgress>,
     inProgressItems: List<ContinueWatchingItem.InProgress>,
     dismissedNextUp: Set<String>,
     showUnairedNextUp: Boolean
-) = coroutineScope {
+): List<ContinueWatchingItem.NextUp> = coroutineScope {
     val latestCompletedByContent = allProgress
         .asSequence()
         .filter { isSeriesTypeCW(it.contentType) }
@@ -268,7 +344,7 @@ private suspend fun HomeViewModel.enrichContinueWatchingProgressively(
         .map { it.contentId }
         .toSet()
 
-    val latestCompletedBySeries = allProgress
+    val latestCompletedBySeries = nextUpSeeds
         .filter { progress ->
             isSeriesTypeCW(progress.contentType) &&
                 progress.season != null &&
@@ -278,151 +354,88 @@ private suspend fun HomeViewModel.enrichContinueWatchingProgressively(
         }
         .groupBy { it.contentId }
         .mapNotNull { (_, items) ->
-            items.maxWithOrNull(
-                compareBy<WatchProgress>(
-                    { it.lastWatched },
-                    { it.season ?: -1 },
-                    { it.episode ?: -1 }
+            if (items.any(::shouldTraceNextUpSeries)) {
+                val candidates = items
+                    .sortedWith(
+                        compareBy<WatchProgress> { nextUpSeedSourceRank(it) }
+                            .thenByDescending { it.season ?: -1 }
+                            .thenByDescending { it.episode ?: -1 }
+                            .thenByDescending { it.lastWatched }
+                    )
+                    .joinToString(" || ") { it.toNextUpTraceString() }
+                logNextUpDecision("seed-group contentId=${items.first().contentId} candidates=$candidates")
+            }
+            val chosen = choosePreferredNextUpSeed(items)
+            if (chosen != null && shouldTraceNextUpSeries(chosen)) {
+                logNextUpDecision(
+                    "seed-picked ${chosen.toNextUpTraceString()} rank=${nextUpSeedSourceRank(chosen)}"
                 )
-            )
+            }
+            chosen
         }
         .filter { it.contentId !in inProgressIds }
         .filter { progress -> nextUpDismissKey(progress.contentId) !in dismissedNextUp }
         .sortedByDescending { it.lastWatched }
         .take(CW_MAX_NEXT_UP_LOOKUPS)
 
+    logNextUpDecision(
+        "seed candidates=${latestCompletedBySeries.joinToString { "${it.name}(${it.contentId}) s=${it.season} e=${it.episode}" }} " +
+            "suppressedInProgress=${inProgressIds.joinToString()}"
+    )
+
     if (latestCompletedBySeries.isEmpty()) {
-        _uiState.update { state ->
-            val mergedItems = mergeContinueWatchingItems(
-                inProgressItems = inProgressItems,
-                nextUpItems = emptyList()
-            )
-            if (state.continueWatchingItems == mergedItems) {
-                state
-            } else {
-                state.copy(continueWatchingItems = mergedItems)
-            }
-        }
-        return@coroutineScope
+        return@coroutineScope emptyList()
     }
 
     val lookupSemaphore = Semaphore(CW_MAX_NEXT_UP_CONCURRENCY)
     val mergeMutex = Mutex()
     val nextUpByContent = linkedMapOf<String, ContinueWatchingItem.NextUp>()
-    val metaCache = cwMetaCache
-    var lastEmittedNextUpCount = 0
 
     val jobs = latestCompletedBySeries.map { progress ->
         launch(Dispatchers.IO) {
             lookupSemaphore.withPermit {
                 val nextUp = buildNextUpItem(
                     progress = progress,
-                    metaCache = metaCache,
                     showUnairedNextUp = showUnairedNextUp
-                ) ?: return@withPermit
+                ) ?: run {
+                    logNextUpDecision("drop contentId=${progress.contentId} name=${progress.name} reason=buildNextUpItem-null")
+                    return@withPermit
+                }
                 mergeMutex.withLock {
                     nextUpByContent[progress.contentId] = nextUp
-                    if (nextUpByContent.size - lastEmittedNextUpCount >= 2) {
-                        val nextUpItems = nextUpByContent.values.toList()
-                        _uiState.update {
-                            val mergedItems = mergeContinueWatchingItems(
-                                inProgressItems = inProgressItems,
-                                nextUpItems = nextUpItems
-                            )
-                            if (it.continueWatchingItems == mergedItems) {
-                                it
-                            } else {
-                                it.copy(continueWatchingItems = mergedItems)
-                            }
-                        }
-                        lastEmittedNextUpCount = nextUpByContent.size
-                    }
                 }
             }
         }
     }
     jobs.joinAll()
 
-    mergeMutex.withLock {
-        if (nextUpByContent.size != lastEmittedNextUpCount) {
-            val nextUpItems = nextUpByContent.values.toList()
-            _uiState.update {
-                val mergedItems = mergeContinueWatchingItems(
-                    inProgressItems = inProgressItems,
-                    nextUpItems = nextUpItems
-                )
-                if (it.continueWatchingItems == mergedItems) {
-                    it
-                } else {
-                    it.copy(continueWatchingItems = mergedItems)
-                }
-            }
-        }
-    }
+    nextUpByContent.values.toList()
 }
 
-private suspend fun HomeViewModel.enrichInProgressEpisodeDetailsProgressively(
-    inProgressItems: List<ContinueWatchingItem.InProgress>
+private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
+    finalItems: List<ContinueWatchingItem>
 ) = coroutineScope {
-    if (inProgressItems.isEmpty()) return@coroutineScope
+    if (finalItems.isEmpty()) return@coroutineScope
 
     val metaCache = cwMetaCache
-    val enrichedByProgress = linkedMapOf<WatchProgress, ContinueWatchingItem.InProgress>()
-    var lastAppliedCount = 0
-
-    for (item in inProgressItems) {
-        val description = resolveCurrentEpisodeDescription(item.progress, metaCache)
-        val thumbnail = resolveCurrentEpisodeThumbnail(item.progress, metaCache)
-        val imdbRating = resolveCurrentEpisodeImdbRating(item.progress, metaCache)
-        val genres = resolveCurrentGenres(item.progress, metaCache)
-        val releaseInfo = resolveCurrentReleaseInfo(item.progress, metaCache)
-        val enrichedItem = item.copy(
-            episodeDescription = description,
-            episodeThumbnail = thumbnail,
-            episodeImdbRating = imdbRating,
-            genres = genres,
-            releaseInfo = releaseInfo
-        )
-
-        if (enrichedItem != item) {
-            enrichedByProgress[item.progress] = enrichedItem
-            if (enrichedByProgress.size - lastAppliedCount >= 2) {
-                applyInProgressEpisodeDetailEnrichment(enrichedByProgress)
-                lastAppliedCount = enrichedByProgress.size
-            }
+    val enrichedItems = buildList(finalItems.size) {
+        finalItems.forEach { item ->
+            add(
+                when (item) {
+                    is ContinueWatchingItem.InProgress -> enrichInProgressItem(item, metaCache)
+                    is ContinueWatchingItem.NextUp -> enrichNextUpItem(item, metaCache)
+                }
+            )
         }
     }
 
-    if (enrichedByProgress.isNotEmpty() && enrichedByProgress.size != lastAppliedCount) {
-        applyInProgressEpisodeDetailEnrichment(enrichedByProgress)
-    }
-}
-
-private fun HomeViewModel.applyInProgressEpisodeDetailEnrichment(
-    replacements: Map<WatchProgress, ContinueWatchingItem.InProgress>
-) {
-    if (replacements.isEmpty()) return
+    if (enrichedItems == finalItems) return@coroutineScope
 
     _uiState.update { state ->
-        var changed = false
-        val updatedItems = state.continueWatchingItems.map { item ->
-            if (item is ContinueWatchingItem.InProgress) {
-                val replacement = replacements[item.progress]
-                if (replacement != null && replacement != item) {
-                    changed = true
-                    replacement
-                } else {
-                    item
-                }
-            } else {
-                item
-            }
-        }
-
-        if (changed) {
-            state.copy(continueWatchingItems = updatedItems)
-        } else {
+        if (state.continueWatchingItems == enrichedItems) {
             state
+        } else {
+            state.copy(continueWatchingItems = enrichedItems)
         }
     }
 }
@@ -454,212 +467,244 @@ private fun mergeContinueWatchingItems(
 
 private suspend fun HomeViewModel.buildNextUpItem(
     progress: WatchProgress,
-    metaCache: MutableMap<String, Meta?>,
     showUnairedNextUp: Boolean
 ): ContinueWatchingItem.NextUp? {
-    val meta = resolveMetaForProgress(progress, metaCache) ?: return null
-    val nextUp = findNextUpEpisodeFromProgressMap(
-        contentId = progress.contentId,
-        meta = meta,
-        showUnairedNextUp = showUnairedNextUp
-    ) ?: findNextUpEpisodeFromLatestProgress(
+    if (shouldTraceNextUpSeries(progress)) {
+        logNextUpDecision(
+            "build-start ${progress.toNextUpTraceString()} showUnaired=$showUnairedNextUp"
+        )
+    }
+    val nextUp = findNextUpEpisodeFromMetaSeed(
         progress = progress,
-        meta = meta,
         showUnairedNextUp = showUnairedNextUp
     ) ?: return null
-    val video = nextUp.episode
-    val nextSeason = requireNotNull(video.season)
-    val nextEpisodeNumber = requireNotNull(video.episode)
 
-    val existingPoster = meta.poster.normalizeImageUrl()
-    val existingBackdrop = meta.backdropUrl.normalizeImageUrl()
-    val existingLogo = meta.logo.normalizeImageUrl()
-    val existingThumbnail = video.thumbnail.normalizeImageUrl()
-    val tmdbData = resolveNextUpTmdbData(
-            progress = progress,
-            meta = meta,
-            season = nextSeason,
-            episode = nextEpisodeNumber
-        )
-    val released = video.released?.trim()?.takeIf { it.isNotEmpty() }
-        ?: tmdbData?.airDate
-    val releaseDate = parseEpisodeReleaseDate(released)
-    val todayLocal = LocalDate.now(ZoneId.systemDefault())
-    val hasAired = releaseDate?.let { !it.isAfter(todayLocal) } ?: true
+    val name = progress.name.trim().takeIf { it.isNotEmpty() }
+        ?: progress.contentId
     val info = NextUpInfo(
         contentId = progress.contentId,
         contentType = progress.contentType,
-        name = tmdbData?.name ?: meta.name,
-        poster = existingPoster ?: tmdbData?.poster,
-        backdrop = existingBackdrop ?: tmdbData?.backdrop,
-        logo = tmdbData?.logo ?: existingLogo,
-        videoId = video.id,
-        season = nextSeason,
-        episode = nextEpisodeNumber,
-        episodeTitle = tmdbData?.episodeTitle ?: video.title,
-        episodeDescription = tmdbData?.overview ?: video.overview?.takeIf { it.isNotBlank() },
-        thumbnail = existingThumbnail ?: tmdbData?.thumbnail,
-        released = released,
-        hasAired = hasAired,
-        airDateLabel = if (hasAired) {
-            null
-        } else {
-            formatEpisodeAirDateLabel(releaseDate)
-        },
+        name = name,
+        poster = progress.poster.normalizeImageUrl(),
+        backdrop = progress.backdrop.normalizeImageUrl(),
+        logo = progress.logo.normalizeImageUrl(),
+        videoId = nextUp.videoId,
+        season = nextUp.season,
+        episode = nextUp.episode,
+        episodeTitle = nextUp.episodeTitle,
+        episodeDescription = null,
+        thumbnail = null,
+        released = nextUp.released,
+        hasAired = nextUp.hasAired,
+        airDateLabel = nextUp.airDateLabel,
         lastWatched = nextUp.lastWatched,
-        imdbRating = meta.imdbRating,
-        genres = meta.genres.take(3),
-        releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() }
+        imdbRating = null,
+        genres = emptyList(),
+        releaseInfo = null,
+        seedSeason = progress.season,
+        seedEpisode = progress.episode
+    )
+    logNextUpDecision(
+        "built contentId=${progress.contentId} name=${progress.name} next=${nextUp.season}x${nextUp.episode} " +
+            "videoId=${nextUp.videoId} lastWatched=${nextUp.lastWatched}"
     )
     return ContinueWatchingItem.NextUp(info)
 }
 
-private suspend fun HomeViewModel.findNextUpEpisodeFromProgressMap(
-    contentId: String,
-    meta: Meta,
-    showUnairedNextUp: Boolean
-): NextUpResolution? {
-    val episodes = meta.videos
-        .filter { it.season != null && it.episode != null && it.season != 0 }
-        .sortedWith(compareBy<Video> { it.season }.thenBy { it.episode })
-    if (episodes.isEmpty()) return null
-
-    val progressMap = runCatching {
-        withTimeoutOrNull(2_500L) {
-            watchProgressRepository.getAllEpisodeProgress(contentId)
-                .first { it.isNotEmpty() }
-        } ?: watchProgressRepository.getAllEpisodeProgress(contentId).firstOrNull().orEmpty()
-    }.getOrElse {
-        Log.w(HomeViewModel.TAG, "findNextUpEpisodeFromProgressMap failed for $contentId: ${it.message}")
-        emptyMap()
-    }
-    if (progressMap.isEmpty()) return null
-
-    val watchedEpisodesMap = runCatching {
-        watchedItemsPreferences.getWatchedEpisodesWithTimestamps(contentId).first()
-    }.getOrElse { emptyMap() }
-    val watchedEpisodes = watchedEpisodesMap.keys
-
-    val completedProgress = progressMap.values
-        .filter {
-            val season = it.season
-            val episode = it.episode
-            season != null &&
-                episode != null &&
-                season != 0 &&
-                it.isCompleted()
-        }
-
-    val latestWatchedSeason = watchedEpisodes.maxByOrNull { (s, e) -> s * 10000 + e }
-    val completedSeasonEpisode = completedProgress.maxWithOrNull(
-        compareBy<WatchProgress>({ it.season ?: -1 }, { it.episode ?: -1 }, { it.lastWatched })
-    )
-
-    val furthestSeason: Int
-    val furthestEpisode: Int
-    val furthestLastWatched: Long
-
-    if (completedSeasonEpisode != null && latestWatchedSeason != null) {
-        val progKey = (completedSeasonEpisode.season ?: 0) * 10000 + (completedSeasonEpisode.episode ?: 0)
-        val watchedKey = latestWatchedSeason.first * 10000 + latestWatchedSeason.second
-        if (watchedKey > progKey) {
-            furthestSeason = latestWatchedSeason.first
-            furthestEpisode = latestWatchedSeason.second
-            furthestLastWatched = watchedEpisodesMap[latestWatchedSeason] ?: completedSeasonEpisode.lastWatched
-        } else {
-            furthestSeason = completedSeasonEpisode.season ?: return null
-            furthestEpisode = completedSeasonEpisode.episode ?: return null
-            furthestLastWatched = maxOf(
-                completedSeasonEpisode.lastWatched,
-                watchedEpisodesMap.values.maxOrNull() ?: 0L
-            )
-        }
-    } else if (latestWatchedSeason != null) {
-        furthestSeason = latestWatchedSeason.first
-        furthestEpisode = latestWatchedSeason.second
-        furthestLastWatched = watchedEpisodesMap[latestWatchedSeason] ?: System.currentTimeMillis()
-    } else if (completedSeasonEpisode != null) {
-        furthestSeason = completedSeasonEpisode.season ?: return null
-        furthestEpisode = completedSeasonEpisode.episode ?: return null
-        furthestLastWatched = completedSeasonEpisode.lastWatched
-    } else {
-        return null
-    }
-
-    val furthestIndex = episodes.indexOfFirst {
-        it.season == furthestSeason && it.episode == furthestEpisode
-    }
-    if (furthestIndex < 0) return null
-
-    val nextEpisode = episodes
-        .drop(furthestIndex + 1)
-        .firstOrNull { candidate ->
-            val season = candidate.season ?: return@firstOrNull false
-            val episode = candidate.episode ?: return@firstOrNull false
-            val candidateProgress = progressMap[season to episode]
-            candidateProgress?.isCompleted() != true &&
-                (season to episode) !in watchedEpisodes
-        }
-        ?: return null
-
-    val nextSeason = nextEpisode.season ?: return null
-    val nextEpisodeNumber = nextEpisode.episode ?: return null
-    val nextEpisodeProgress = progressMap[nextSeason to nextEpisodeNumber]
-    if (nextEpisodeProgress != null && shouldTreatAsInProgressForContinueWatching(nextEpisodeProgress)) {
-        return null
-    }
-    if (!shouldIncludeNextUpEpisode(nextEpisode, showUnairedNextUp)) return null
-
-    val lastWatched = maxOf(
-        completedProgress.maxOfOrNull { it.lastWatched } ?: 0L,
-        furthestLastWatched,
-        watchedEpisodesMap.values.maxOrNull() ?: 0L
-    )
-    return NextUpResolution(
-        episode = nextEpisode,
-        lastWatched = lastWatched
+private suspend fun HomeViewModel.enrichInProgressItem(
+    item: ContinueWatchingItem.InProgress,
+    metaCache: MutableMap<String, Meta?>
+): ContinueWatchingItem.InProgress {
+    val description = resolveCurrentEpisodeDescription(item.progress, metaCache)
+    val thumbnail = resolveCurrentEpisodeThumbnail(item.progress, metaCache)
+    val imdbRating = resolveCurrentEpisodeImdbRating(item.progress, metaCache)
+    val genres = resolveCurrentGenres(item.progress, metaCache)
+    val releaseInfo = resolveCurrentReleaseInfo(item.progress, metaCache)
+    return item.copy(
+        episodeDescription = description,
+        episodeThumbnail = thumbnail,
+        episodeImdbRating = imdbRating,
+        genres = genres,
+        releaseInfo = releaseInfo
     )
 }
 
-private suspend fun HomeViewModel.findNextUpEpisodeFromLatestProgress(
+private suspend fun HomeViewModel.enrichNextUpItem(
+    item: ContinueWatchingItem.NextUp,
+    metaCache: MutableMap<String, Meta?>
+): ContinueWatchingItem.NextUp {
+    val progressSeed = item.info.toProgressSeed()
+    val meta = resolveMetaForProgress(progressSeed, metaCache) ?: return item
+    val video = resolveNextUpVideoFromMeta(progressSeed, meta)
+    val tmdbData = resolveNextUpTmdbData(
+        progress = progressSeed,
+        meta = meta,
+        season = video?.season ?: item.info.season,
+        episode = video?.episode ?: item.info.episode
+    )
+    val released = video?.released?.trim()?.takeIf { it.isNotEmpty() }
+        ?: tmdbData?.airDate
+        ?: item.info.released
+    val releaseDate = parseEpisodeReleaseDate(released)
+    val todayLocal = LocalDate.now(ZoneId.systemDefault())
+    val hasAired = releaseDate?.let { !it.isAfter(todayLocal) } ?: item.info.hasAired
+
+    val enrichedInfo = item.info.copy(
+        name = tmdbData?.name ?: meta.name,
+        poster = item.info.poster ?: meta.poster.normalizeImageUrl() ?: tmdbData?.poster,
+        backdrop = item.info.backdrop ?: meta.backdropUrl.normalizeImageUrl() ?: tmdbData?.backdrop,
+        logo = item.info.logo ?: meta.logo.normalizeImageUrl() ?: tmdbData?.logo,
+        season = video?.season ?: item.info.season,
+        episode = video?.episode ?: item.info.episode,
+        videoId = video?.id?.takeIf { it.isNotBlank() } ?: item.info.videoId,
+        episodeTitle = tmdbData?.episodeTitle
+            ?: video?.title?.takeIf { it.isNotBlank() }
+            ?: item.info.episodeTitle,
+        episodeDescription = tmdbData?.overview
+            ?: video?.overview?.takeIf { it.isNotBlank() }
+            ?: item.info.episodeDescription,
+        thumbnail = item.info.thumbnail ?: video?.thumbnail.normalizeImageUrl() ?: tmdbData?.thumbnail,
+        released = released,
+        hasAired = hasAired,
+        airDateLabel = if (hasAired || releaseDate == null) null else formatEpisodeAirDateLabel(releaseDate),
+        imdbRating = meta.imdbRating ?: item.info.imdbRating,
+        genres = meta.genres.take(3).ifEmpty { item.info.genres },
+        releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: item.info.releaseInfo
+    )
+    if (shouldTraceNextUpSeries(progressSeed)) {
+        logNextUpDecision(
+            "enrich-result contentId=${item.info.contentId} seed=${item.info.seedSeason}x${item.info.seedEpisode} " +
+                "initial=${item.info.season}x${item.info.episode} final=${enrichedInfo.season}x${enrichedInfo.episode} " +
+                "released=${enrichedInfo.released} hasAired=${enrichedInfo.hasAired} title=${enrichedInfo.episodeTitle}"
+        )
+    }
+    return item.copy(info = enrichedInfo)
+}
+
+private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
+    progress: WatchProgress,
+    showUnairedNextUp: Boolean
+): NextUpResolution? {
+    val contentId = progress.contentId
+    val season = progress.season
+    val episode = progress.episode
+    if (season == null || episode == null || season == 0) {
+        logNextUpDecision(
+            "drop contentId=$contentId name=${progress.name} reason=missing-seed-season-episode " +
+                "seed=${progress.season}x${progress.episode}"
+        )
+        return null
+    }
+
+    val meta = resolveMetaForProgress(progress, cwMetaCache) ?: run {
+        logNextUpDecision("drop contentId=$contentId name=${progress.name} reason=no-meta-for-seed")
+        return null
+    }
+    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp) ?: return null
+    if (shouldTraceNextUpSeries(progress)) {
+        logNextUpDecision(
+            "next-video contentId=$contentId name=${progress.name} seed=${season}x${episode} src=${progress.source} " +
+                "showUnaired=$showUnairedNextUp next=${nextVideo.season}x${nextVideo.episode} released=${nextVideo.released} title=${nextVideo.title}"
+        )
+    }
+
+    return NextUpResolution(
+        season = nextVideo.season ?: return null,
+        episode = nextVideo.episode ?: return null,
+        videoId = nextVideo.id.takeIf { it.isNotBlank() }
+            ?: buildLightweightEpisodeVideoId(
+                contentId,
+                nextVideo.season ?: return null,
+                nextVideo.episode ?: return null
+            ),
+        episodeTitle = nextVideo.title.takeIf { it.isNotBlank() },
+        released = nextVideo.released?.trim()?.takeIf { it.isNotBlank() },
+        hasAired = nextVideo.released?.let(::parseEpisodeReleaseDate)?.let { !it.isAfter(LocalDate.now(ZoneId.systemDefault())) } ?: true,
+        airDateLabel = nextVideo.released?.let(::parseEpisodeReleaseDate)?.takeIf { it.isAfter(LocalDate.now(ZoneId.systemDefault())) }?.let(::formatEpisodeAirDateLabel),
+        lastWatched = progress.lastWatched
+    )
+}
+
+private fun resolveNextUpVideoFromMeta(
+    progress: WatchProgress,
+    meta: Meta
+): Video? = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp = true)
+
+private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: Meta,
     showUnairedNextUp: Boolean
-): NextUpResolution? {
+): Video? {
     val episodes = meta.videos
-        .filter { it.season != null && it.episode != null && it.season != 0 }
-        .sortedWith(compareBy<Video> { it.season }.thenBy { it.episode })
+        .filter { video ->
+            val season = video.season
+            val episode = video.episode
+            season != null && episode != null && season != 0
+        }
+        .sortedWith(compareBy<Video>({ it.season ?: Int.MAX_VALUE }, { it.episode ?: Int.MAX_VALUE }))
+
     if (episodes.isEmpty()) return null
 
-    val currentSeason = progress.season ?: return null
-    val currentEpisode = progress.episode ?: return null
+    val seedSeason = progress.season
+    val seedEpisode = progress.episode
+    if (seedSeason == null || seedEpisode == null) return null
 
-    val watchedEpisodesMap = runCatching {
-        watchedItemsPreferences.getWatchedEpisodesWithTimestamps(progress.contentId).first()
-    }.getOrElse { emptyMap() }
-    val watchedEpisodes = watchedEpisodesMap.keys
-
-    val currentIndex = episodes.indexOfFirst {
-        it.season == currentSeason && it.episode == currentEpisode
+    val watchedIndex = episodes.indexOfFirst { it.season == seedSeason && it.episode == seedEpisode }
+    if (watchedIndex < 0) {
+        logNextUpDecision(
+            "drop contentId=${progress.contentId} name=${progress.name} reason=seed-not-found-in-meta seed=${seedSeason}x${seedEpisode}"
+        )
+        return null
     }
-    if (currentIndex < 0) return null
 
-    val nextEpisode = episodes
-        .drop(currentIndex + 1)
-        .firstOrNull { candidate ->
-            val s = candidate.season ?: return@firstOrNull false
-            val e = candidate.episode ?: return@firstOrNull false
-            (s to e) !in watchedEpisodes
+    val todayLocal = LocalDate.now(ZoneId.systemDefault())
+    val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
+        val releaseDate = parseEpisodeReleaseDate(video.released)
+        val isSeasonRollover = video.season != seedSeason
+        if (isSeasonRollover) {
+            if (releaseDate == null) {
+                logNextUpDecision(
+                    "skip contentId=${progress.contentId} name=${progress.name} reason=unaired-next-season-missing-date " +
+                        "seed=${seedSeason}x${seedEpisode} next=${video.season}x${video.episode}"
+                )
+                return@firstOrNull false
+            }
+            if (!releaseDate.isAfter(todayLocal)) {
+                return@firstOrNull true
+            }
+            if (!showUnairedNextUp) {
+                return@firstOrNull false
+            }
+
+            val daysUntilRelease = ChronoUnit.DAYS.between(todayLocal, releaseDate)
+            val withinWindow = daysUntilRelease <= CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS
+            if (!withinWindow) {
+                logNextUpDecision(
+                    "skip contentId=${progress.contentId} name=${progress.name} reason=unaired-next-season-too-far " +
+                        "seed=${seedSeason}x${seedEpisode} next=${video.season}x${video.episode} daysUntil=$daysUntilRelease"
+                )
+            }
+            return@firstOrNull withinWindow
         }
-        ?: return null
 
-    if (!shouldIncludeNextUpEpisode(nextEpisode, showUnairedNextUp)) return null
+        val isUnaired = releaseDate?.isAfter(todayLocal) == true
+        if (!isUnaired) {
+            return@firstOrNull true
+        }
+        if (!showUnairedNextUp) {
+            return@firstOrNull false
+        }
+        true
+    }
 
-    val latestWatchedAt = watchedEpisodesMap.values.maxOrNull() ?: 0L
-    return NextUpResolution(
-        episode = nextEpisode,
-        lastWatched = maxOf(progress.lastWatched, latestWatchedAt)
-    )
+    if (nextVideo == null) {
+        logNextUpDecision(
+            "drop contentId=${progress.contentId} name=${progress.name} reason=no-next-video-after-seed seed=${seedSeason}x${seedEpisode} showUnaired=$showUnairedNextUp"
+        )
+        return null
+    }
+
+    return nextVideo
 }
 
 private suspend fun HomeViewModel.resolveMetaForProgress(
@@ -684,13 +729,13 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
         var meta: Meta? = null
         for (type in typeCandidates) {
             for (candidateId in idCandidates) {
-                val result = withTimeoutOrNull(2500) {
+                val result = withTimeoutOrNull(2_500L) {
                     metaRepository.getMetaFromPrimaryAddon(
                         type = type,
                         id = candidateId
                     ).first { it !is NetworkResult.Loading }
                 } ?: continue
-                meta = (result as? NetworkResult.Success)?.data
+                meta = (result as? NetworkResult.Success<*>)?.data as? Meta
                 if (meta != null) break
             }
             if (meta != null) break
@@ -704,19 +749,32 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
     return resolved
 }
 
-private fun isSeriesTypeCW(type: String?): Boolean {
-    return type.equals("series", ignoreCase = true) || type.equals("tv", ignoreCase = true)
+private fun buildLightweightEpisodeVideoId(
+    contentId: String,
+    season: Int,
+    episode: Int
+): String = "$contentId:$season:$episode"
+
+private fun NextUpInfo.toProgressSeed(): WatchProgress {
+    return WatchProgress(
+        contentId = contentId,
+        contentType = contentType,
+        name = name,
+        poster = poster,
+        backdrop = backdrop,
+        logo = logo,
+        videoId = videoId,
+        season = seedSeason ?: season,
+        episode = seedEpisode ?: episode,
+        episodeTitle = episodeTitle,
+        position = 1L,
+        duration = 1L,
+        lastWatched = lastWatched
+    )
 }
 
-private fun shouldIncludeNextUpEpisode(
-    nextEpisode: Video,
-    showUnairedNextUp: Boolean
-): Boolean {
-    if (showUnairedNextUp) return true
-    val releaseDate = parseEpisodeReleaseDate(nextEpisode.released)
-        ?: return true
-    val todayLocal = LocalDate.now(ZoneId.systemDefault())
-    return !releaseDate.isAfter(todayLocal)
+private fun isSeriesTypeCW(type: String?): Boolean {
+    return type.equals("series", ignoreCase = true) || type.equals("tv", ignoreCase = true)
 }
 
 private fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
@@ -857,10 +915,6 @@ internal fun HomeViewModel.removeContinueWatchingPipeline(
     viewModelScope.launch {
         val targetSeason = if (isNextUp) season else null
         val targetEpisode = if (isNextUp) episode else null
-        Log.d(
-            HomeViewModel.TAG,
-            "removeContinueWatching requested contentId=$contentId season=$season episode=$episode isNextUp=$isNextUp targetSeason=$targetSeason targetEpisode=$targetEpisode"
-        )
         watchProgressRepository.removeProgress(
             contentId = contentId,
             season = targetSeason,


### PR DESCRIPTION
## Summary

This PR refactors the Trakt-backed Continue Watching / Next Up pipeline to reduce startup cost and make episode progression accurate.

Main changes:

Keep In Progress driven by allProgress
Stop using allProgress as the primary seed for Next Up
Add a dedicated Trakt seed flow for Next Up based on sync/watched/shows
Rebuild Continue Watching from lightweight In Progress and lightweight Next Up seeds, then dedupe/merge first and enrich after
This is primarily a Trakt / progress bug fix, but it also improves home startup performance by removing expensive Next Up derivation from the hot startup path.

## PR type

- Bug fix
- Small maintenance improvement

## Why

Bug Fixing: Fixes https://github.com/NuvioMedia/NuvioTV/issues/784
I was having the same problem. 

From a performance point: When Trakt is enabled, home startup was doing too much work in the Continue Watching pipeline.

The main problems were:

allProgress was being used for both In Progress and Next Up
that caused repeated metadata work during startup
Next Up seeds could be stale or incorrect because they came from a mixed progress pipeline
From a performance point of view, using allProgress for Next Up made startup heavier because every emission of that broad flow could trigger Continue Watching recomputation and downstream metadata work. Since allProgress can emit multiple times quickly during startup, especially with Trakt enabled, it amplified the amount of work done on the home screen. That made the pipeline both noisy and expensive.



This PR separates responsibilities:

allProgress still powers In Progress
Next Up now uses a dedicated Trakt watched-shows source
enrichment happens after the final Continue Watching list is decided, which reduces unnecessary startup work

The result is:

faster and lighter home startup with Trakt enabled
more accurate Next Up

## Policy check

<!-- Confirm these before requesting review -->
 - [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Cold-started the app on a slow Mi Box with Trakt enabled
Verified home startup behavior and Continue Watching responsiveness
Checked Next Up correctness against Trakt data


## Screenshots / Video (UI changes only)

Nuvio version showing wrong shows:

https://github.com/user-attachments/assets/1b509d2b-3296-45c8-88a5-5707db91cea7

Shows like Wednesday, Alien: Earth, Walking Dead: Daryl and The Last of Us were appearing in Continue Watching even though those suggested episodes had already been watched and later episodes had already been seen as well.

Debug Version showing the correct shows:


https://github.com/user-attachments/assets/d1303889-9c8a-40db-8ca1-25e0fc0db0fd


It's possible also  to see in the 2 videos above, that going up to continue watching the debug version is faster. CW appears much faster. I am pressing up, in both cases.

8 seconds Vs 2 seconds from thumbnails appearing   to continue Watching (while pressing up key) 

Nuvio cold startup:
 
https://github.com/user-attachments/assets/bac94b1a-ed21-4249-aa82-d3635a5cff4b

Debug cold startup:

https://github.com/user-attachments/assets/6af757c8-d58e-4b79-8655-a40d9ef1de40

Debug version is not perfect on my old xiaomi box s, but still more responsive, and a little less laggy.

There are still margin for further performance Trakt startup, that I decided to leave for now. 

As part of the startup performance investigation, it was also identified a second group of issues outside the Trakt Continue Watching / Next Up pipeline that could be addressed in a separate follow-up fix.

The main findings were on the home screen side:

libraryRepository.listTabs as a good candidate for lazy loading instead of being observed during home startup.

This shown as one of the strongest non-CW contributors to startup cost.
It appears more appropriate to fetch only when the user actually opens a list-related action or picker.

lazy-loading listTabs
delaying poster watch-status / library-membership observation until after startup
reducing Trakt library metadata work triggered from home initialization


Meta request deduplication remains a valid infrastructure-level improvement.
This is broader than the Trakt/CW fix in this PR.
It could reduce redundant concurrent metadata fetches across multiple paths.

This was intentionally left out of the current PR so the Trakt Continue Watching / Next Up fix could remain focused and easier to review.


## Breaking changes
None.

## Linked issues
Fixes #784 
