### PR TITLE
 home screen watched checkmark not updating until refocus

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -92,7 +92,7 @@ fun HomeScreen(
     // downstream recomposition when uiState changes.
     val latestMovieWatchedStatus by rememberUpdatedState(uiState.movieWatchedStatus)
     val latestPosterOptionsTarget by rememberUpdatedState(posterOptionsTarget)
-    val isCatalogItemWatched: (MetaPreview) -> Boolean = remember(Unit) {
+    val isCatalogItemWatched: (MetaPreview) -> Boolean = remember(uiState.movieWatchedStatus) {
         { item -> latestMovieWatchedStatus[homeItemStatusKey(item.id, item.apiType)] == true }
     }
     val onCatalogItemLongPress: (MetaPreview, String) -> Unit = remember(Unit) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -525,7 +525,7 @@ internal fun ModernRowSection(
                         is ModernPayload.Catalog -> {
                             val nextCatalogItem = row.items.getOrNull(index + 1)?.metaPreview
                             val metaPreview = item.metaPreview ?: return@itemsIndexed
-                            val isWatched = remember(metaPreview) { isCatalogItemWatched(metaPreview) }
+                            val isWatched = isCatalogItemWatched(metaPreview)
                             val onLongPress: () -> Unit = remember(metaPreview, payload.addonBaseUrl) {
                                 {
                                     onCatalogItemLongPress(metaPreview, payload.addonBaseUrl)


### PR DESCRIPTION
## Summary

Fix checkmark not appearing on home screen after marking content as watched until refocus.

## PR type

- Bug fix

## Why

The watched status result was being cached per item, so when a movie was marked as watched the home screen cards didn't reflect the change until something triggered a refocus.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manually verified: 
- mark a movie as watched from the detail screen, return to home screen 
- mark a movie as watched from home screen using the long press

For both scenarios check mark was shown without need to refocus

## Screenshots / Video (UI changes only)

checkmark visibility fix, no layout change.

## Breaking changes

Nothing should break

## Linked issues

Nothing yet
