### PR TITLE
fix: update modal dialog layout broken on small screens

### DIFF
--- a/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
@@ -65,6 +65,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -114,7 +115,10 @@ fun UpdatePromptDialog(
         }
     }
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
         var isVisible by remember { mutableStateOf(false) }
         LaunchedEffect(Unit) {
             isVisible = true
@@ -133,16 +137,20 @@ fun UpdatePromptDialog(
 
         val shape = RoundedCornerShape(16.dp)
         Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+        Box(
             modifier = Modifier
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
                     this.alpha = alpha
                 }
-                .fillMaxWidth(0.9f)
+                .fillMaxWidth(0.85f)
                 .background(NuvioColors.BackgroundCard, shape)
                 .border(BorderStroke(2.dp, NuvioColors.FocusRing), shape)
-                .padding(32.dp)
+                .padding(28.dp)
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -243,7 +251,7 @@ fun UpdatePromptDialog(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(max = 220.dp)
+                            .heightIn(max = 160.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .drawBehind {
                                 drawRect(textContainerBg.value)
@@ -493,6 +501,7 @@ fun UpdatePromptDialog(
                 }
             }
         }
+        } // end centering Box
     }
 
     LaunchedEffect(state.showDialog, hasPrimaryAction, state.downloadedApkPath, state.showUnknownSourcesDialog, state.isUpdateAvailable, state.update?.notes) {


### PR DESCRIPTION
## Summary

Fix the app update modal displaying incorrectly on 1366×768 TVs, the dialog was very narrow, not centered vertically, and the release notes scroll area caused content to overflow off-screen.

## PR type

- Bug fix

## Why

On 1366×768 screens the update prompt dialog had three issues:
1. The card was extremely narrow because Android's `Dialog` enforces a platform default max width (~280–330dp) that overrode the intended `fillMaxWidth` sizing.
2. The dialog would randomly appear off-center / shifted downward rather than staying centered on screen.
3. The release notes scroll area + card padding pushed the total modal height beyond the screen bounds at 768px.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manually verified on a 1366×768 Android TV device:
- Dialog now fills ~85% of screen width as intended
- Dialog remains vertically centered in all states (checking, update available, downloading, install ready)
- Release notes area scrolls correctly without overflowing the screen

## Screenshots / Video (UI changes only)

None

## Breaking changes

None

## Linked issues

None