### PR TITLE
Fix Continue Watching focus not landing on the first item

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -14,6 +14,7 @@ import com.nuvio.tv.domain.model.WatchProgress
 data class HomeUiState(
     val catalogRows: List<CatalogRow> = emptyList(),
     val continueWatchingItems: List<ContinueWatchingItem> = emptyList(),
+    val cwIsLoading: Boolean = true,
     val isLoading: Boolean = true,
     val error: String? = null,
     val selectedItemId: String? = null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -198,11 +198,13 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 debug.markPhase("render-in-progress")
                 if (inProgressOnly.isNotEmpty()) {
                     val initialItems = inProgressOnly.map { it as ContinueWatchingItem }
-                    _uiState.update { state ->
-                        if (state.continueWatchingItems == initialItems) {
-                            state
-                        } else {
-                            state.copy(continueWatchingItems = initialItems)
+                    // Only do intermediate renders after the first full cycle has completed
+                    // (cwIsLoading=false). During initial load, hold off until normalItems
+                    // so focus lands on the correct first item.
+                    if (!_uiState.value.cwIsLoading) {
+                        _uiState.update { state ->
+                            if (state.continueWatchingItems == initialItems) state
+                            else state.copy(continueWatchingItems = initialItems)
                         }
                     }
                     debug.recordInitialRendered(
@@ -231,11 +233,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                     inProgressItems = inProgressOnly,
                                     nextUpItems = partialNextUpItems
                                 )
-                                _uiState.update { state ->
-                                    if (state.continueWatchingItems == partialItems) {
-                                        state
-                                    } else {
-                                        state.copy(continueWatchingItems = partialItems)
+                                // Same as above: skip partial renders during initial load
+                                if (!_uiState.value.cwIsLoading) {
+                                    _uiState.update { state ->
+                                        if (state.continueWatchingItems == partialItems) state
+                                        else state.copy(continueWatchingItems = partialItems)
                                     }
                                 }
                                 debug.recordPartialRendered(
@@ -257,12 +259,13 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     nextUpItems = nextUpItems
                 )
 
+                // Atomically publish normalItems and clear cwIsLoading in one update
+                // so focus always lands on the correct first item.
                 _uiState.update { state ->
-                    if (state.continueWatchingItems == normalItems) {
-                        state
-                    } else {
-                        state.copy(continueWatchingItems = normalItems)
-                    }
+                    val itemsChanged = state.continueWatchingItems != normalItems
+                    val loadingChanged = state.cwIsLoading
+                    if (!itemsChanged && !loadingChanged) state
+                    else state.copy(continueWatchingItems = normalItems, cwIsLoading = false)
                 }
                 debug.recordLightweightRendered(
                     count = normalItems.size,
@@ -288,6 +291,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     changed = changed
                 )
                 debug.markPhase("completed")
+                // Safety net: if normalItems was empty, cwIsLoading was never cleared above
+                if (_uiState.value.cwIsLoading) {
+                    _uiState.update { it.copy(cwIsLoading = false) }
+                }
                 debug.logSummary()
             } catch (cancelled: CancellationException) {
                 debug.logSummary(cancelled = true)


### PR DESCRIPTION
## Summary

On app startup, the CW pipeline emits data in multiple intermediate batches before the final sorted list is ready (`inProgressOnly`, partial Next Up items). Each intermediate render was immediately pushed to the UI, on cold start causing focus to land on whichever item appeared first - not necessarily the most recently watched one.

The fix suppresses all intermediate CW renders during the initial pipeline cycle. Only `normalItems` (the final merged and sorted list from the `merge-lightweight` phase) triggers the first render, atomically clearing `cwIsLoading` at the same time. Subsequent pipeline cycles (e.g. after a data change) are unaffected.

Key changes:
- `cwIsLoading: Boolean` added to `HomeUiState` (true until the first full pipeline cycle completes)
- Intermediate renders (`inProgressOnly`, partial Next Up) are skipped when `cwIsLoading` is true
- `normalItems` atomically sets `continueWatchingItems` and clears `cwIsLoading` in a single `update` call

## PR type

- Bug fix

## Why

When using Nuvio Sync, CW data arrives in batches. The pipeline was publishing each intermediate batch immediately, so the CW row could appear multiple times with a different item order before settling. Focus would land on the first item that appeared and stay there, even if the final sorted list put a different item first.

https://github.com/user-attachments/assets/9ca9c6a8-0a49-413a-aac8-bdfcc479fb6a

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Reproduced by force-stopping the app and relaunching with Nuvio Sync enabled. Tested across all three display modes (Modern, Classic, Grid) with the same Continue Watching list (on both regular 0.5.0-beta and with my fix)

- [x] Modern - focus lands on correct first CW item on cold start
- [x] Classic - same
- [x] Grid - same

## Screenshots / Video (UI changes only)

Nothing changed



## Breaking changes

Nothing should break 

## Linked issues

No one reported the issue yet 
