### PR TITLE
Update Latin American Spanish (es-419) translations – added new strin…

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -7,49 +7,58 @@
     <!-- HomeScreen -->
     <string name="home_no_addons">No hay addons instalados. Agrega uno para empezar.</string>
     <string name="home_no_catalog_addons">No hay addons de catálogo instalados. Instala un addon de catálogo para ver contenido.</string>
+    <string name="auth_notice_nuvio_logged_out">Se cerró tu sesión de Nuvio. Por favor, vuelve a iniciar sesión.</string>
+    <string name="auth_notice_trakt_logged_out">Se cerró tu sesión de Trakt. Por favor, vuelve a conectarla.</string>
     <string name="error_generic">Ocurrió un error</string>
 
     <!-- ErrorState -->
     <string name="action_retry">Reintentar</string>
     <string name="error_state_generic_issue">Algo salió mal.</string>
     <string name="error_state_possible_fix">Posible solución: %1$s</string>
-    <string name="error_state_fix_retry_soon">reintenta en un momento.</string>
-    <string name="error_state_issue_no_metadata_any_addon">Este id no pudo cargar detalles porque ninguno de los addons instalados devolvió metadatos.</string>
-    <string name="error_state_fix_no_metadata_any_addon">prueba otro addon, desactiva \"Prefer external meta addon\" en la configuración de Layout, o confirma que algún addon instalado soporte este id.</string>
-    <string name="error_state_prefix_no_supported_metadata">Ningún addon instalado admite metadatos para </string>
-    <string name="error_state_prefix_no_addon_for_id">Ningún addon instalado pudo proporcionar metadatos para id=</string>
-    <string name="error_state_fix_no_supported_metadata">instala o actualiza un addon que admita este tipo de contenido y luego vuelve a intentarlo.</string>
-    <string name="error_state_prefix_tried_meta_addons">Addons de metadatos probados:</string>
-    <string name="error_state_fix_tried_meta_addons">instala un addon que admita este id, o reconfigura/actualiza el addon y vuelve a intentarlo.</string>
+    <string name="error_state_fix_retry_soon">intenta de nuevo en un momento.</string>
+    <string name="error_state_issue_no_metadata_any_addon">Este id no pudo cargar los detalles porque ninguno de los addons instalados devolvió metadatos.</string>
+    <string name="error_state_fix_no_metadata_any_addon">intenta con otro addon, desactiva \"Preferir addon de meta externo\" en los ajustes de Diseño, o confirma que un addon instalado soporta este id.</string>
+    <string name="error_state_prefix_no_supported_metadata">Ningún addon instalado soporta metadatos para </string>
+    <string name="error_state_prefix_no_addon_for_id">Ningún addon instalado pudo proporcionar metadatos para el id=</string>
+    <string name="error_state_fix_no_supported_metadata">instala o actualiza un addon que soporte este tipo de contenido, y luego reintenta.</string>
+    <string name="error_state_prefix_tried_meta_addons">Addons de meta probados:</string>
+    <string name="error_state_fix_tried_meta_addons">instala un addon que soporte este id, o reconfigura/actualiza el addon y reintenta.</string>
     <string name="error_state_issue_missing_metadata_for_id">no tiene metadatos para este id</string>
-    <string name="error_state_fix_missing_metadata_for_id">abre este id desde otro addon, desactiva \"Prefer external meta addon\" o verifica que el addon admita este id.</string>
+    <string name="error_state_fix_missing_metadata_for_id">abre este id desde un addon diferente, desactiva \"Preferir addon de meta externo\", o verifica que el addon soporte este id.</string>
     <string name="error_state_issue_addon_unreachable">no se pudo alcanzar</string>
-    <string name="error_state_fix_addon_unreachable">verifica tu conexión a internet, confirma que la URL del addon aún funcione y luego vuelve a intentarlo.</string>
+    <string name="error_state_fix_addon_unreachable">revisa tu conexión a internet, verifica que la URL del addon siga funcionando, y luego reintenta.</string>
     <string name="error_state_issue_addon_connection_failed">rechazó la conexión</string>
-    <string name="error_state_fix_addon_connection_failed">asegúrate de que el servidor del addon esté en línea y accesible, luego vuelve a intentarlo.</string>
+    <string name="error_state_fix_addon_connection_failed">asegúrate de que el servidor del addon esté en línea y accesible, y luego reintenta.</string>
     <string name="error_state_issue_addon_timeout">tardó demasiado en responder</string>
-    <string name="error_state_fix_addon_timeout">reintenta en un momento, o prueba con otro addon si esto sigue ocurriendo.</string>
+    <string name="error_state_fix_addon_timeout">reintenta en un momento, o intenta con un addon diferente si esto sigue pasando.</string>
     <string name="error_state_issue_addon_cleartext">usa una conexión HTTP insegura que Android bloqueó</string>
     <string name="error_state_fix_addon_cleartext">cambia la URL del addon a HTTPS o actualiza la configuración del addon.</string>
-    <string name="error_state_fix_addon_generic">reintenta, actualiza o reinstala el addon, o prueba con otro addon.</string>
+    <string name="error_state_fix_addon_generic">reintenta, actualiza o reinstala el addon, o intenta con un addon diferente.</string>
     <string name="error_state_addon_issue_template">%1$s: %2$s.</string>
-    <string name="error_meta_not_found">Metadatos no encontrados</string>
-    <string name="error_meta_no_supported_addon">Ningún addon instalado admite metadatos para \"%1$s\".</string>
-    <string name="error_meta_no_addon_for_id">Ningún addon instalado pudo proporcionar metadatos para id=%1$s (tipo=%2$s).</string>
-    <string name="error_meta_tried_none">Addons de metadatos probados: %1$s. Ninguno proporcionó metadatos para id=%2$s (tipo=%3$s).</string>
-    <string name="error_meta_tried_generic">Addons de metadatos probados: %1$s. No se pudieron cargar los metadatos para id=%2$s (tipo=%3$s).</string>
-    <string name="error_meta_tried_issues">Addons de metadatos probados: %1$s. No se pudieron cargar los metadatos para id=%2$s (tipo=%3$s). Problemas: %4$s.</string>
-
+    <string name="error_meta_not_found">Meta no encontrado</string>
+    <string name="error_meta_no_supported_addon">Ningún addon instalado soporta metadatos para \"%1$s\".</string>
+    <string name="error_meta_no_addon_for_id">Ningún addon instalado pudo proporcionar metadatos para el id=%1$s (tipo=%2$s).</string>
+    <string name="error_meta_tried_none">Addons de meta probados: %1$s. Ninguno de ellos proporcionó metadatos para el id=%2$s (tipo=%3$s).</string>
+    <string name="error_meta_tried_generic">Addons de meta probados: %1$s. No se pudieron cargar los metadatos para el id=%2$s (tipo=%3$s).</string>
+    <string name="error_meta_tried_issues">Addons de meta probados: %1$s. No se pudieron cargar los metadatos para el id=%2$s (tipo=%3$s). Problemas: %4$s.</string>
+    <string name="error_stream_no_supported_addon">Ningún addon instalado soporta streams para \"%1$s\".</string>
+    <string name="error_stream_tried_none">Addons de stream probados: %1$s. Ninguno de ellos devolvió streams para el id=%2$s (tipo=%3$s).</string>
+    <string name="error_stream_tried_generic">Addons de stream probados: %1$s. No se pudieron cargar los streams para el id=%2$s (tipo=%3$s).</string>
+    <string name="error_stream_tried_issues">Addons de stream probados: %1$s. No se pudieron cargar los streams para el id=%2$s (tipo=%3$s). Problemas: %4$s.</string>
+    
     <!-- ContinueWatchingSection -->
-    <string name="continue_watching">Continuar viendo</string>
-    <string name="cw_upcoming">Próximamente</string>
-    <string name="cw_next_up">A continuación</string>
+    <string name="continue_watching">Seguir Viendo</string>
+    <string name="cw_upcoming">Próximos</string>
+    <string name="cw_next_up">Siguiente</string>
+    <string name="cw_new_episode">Nuevo episodio</string>
+    <string name="cw_new_season">Nueva temporada</string>
     <string name="cw_resume">Reanudar</string>
-    <string name="cw_hours_min_left">Faltan %1$dh %2$dm</string>
-    <string name="cw_min_left">Faltan %1$dm</string>
-    <string name="cw_almost_done">Casi terminado</string>
+    <string name="cw_percent_watched">%1$d%% visto</string>
+    <string name="cw_hours_min_left">faltan %1$dh %2$dm</string>
+    <string name="cw_min_left">faltan %1$dm</string>
+    <string name="cw_almost_done">Casi termina</string>
     <string name="cw_airs_date">Se emite el %1$s</string>
-    <string name="cw_action_go_to_details">Ir a detalles</string>
+    <string name="cw_action_go_to_details">Ir a los detalles</string>
     <string name="cw_action_start_from_beginning">Empezar desde el principio</string>
     <string name="cw_action_remove">Eliminar</string>
     <string name="cw_dialog_subtitle">Elige qué quieres hacer con este elemento.</string>
@@ -115,9 +124,37 @@
     <string name="cast_role_writer">Escritor</string>
     <string name="detail_tab_ratings">Calificaciones</string>
     <string name="detail_tab_more_like_this">Similares</string>
+    <string name="detail_comments_title">Comentarios</string>
+    <string name="detail_comments_subtitle">Reseñas de Trakt</string>
     <string name="detail_section_network">Cadena</string>
     <string name="detail_section_production">Producción</string>
+    <string name="detail_comments_empty">Aún no hay reseñas en Trakt.</string>
+    <string name="detail_comments_error">No se pudieron cargar las reseñas de Trakt en este momento.</string>
+    <string name="detail_comments_spoiler_hidden">Reseña con spoiler. Presiona OK para mostrarla.</string>
+    <string name="detail_comments_reveal_spoiler">Mostrar spoiler</string>
+    <string name="detail_comments_reveal_spoiler_hint">Presiona OK para mostrar el spoiler.</string>
+    <string name="detail_comments_back_hint">Pulsa atrás para cerrar</string>
+    <string name="detail_comments_badge_review">Reseña</string>
+    <string name="detail_comments_badge_spoiler">Spoiler</string>
+    <string name="detail_comments_badge_rating">%1$d/10</string>
+    <string name="detail_comments_likes">%1$d Me gusta</string>
+    <string name="tmdb_entity_kind_company">Productora</string>
+    <string name="tmdb_entity_kind_network">Cadena</string>
+    <string name="tmdb_entity_rail_popular">Popular</string>
+    <string name="tmdb_entity_rail_top_rated">Mejor valoradas</string>
+    <string name="tmdb_entity_rail_recent">Recientes</string>
+    <string name="tmdb_entity_empty_title">No se encontraron títulos</string>
+    <string name="tmdb_entity_empty_subtitle">TMDB no tiene títulos disponibles para explorar en esta selección actualmente.</string>
     <string name="episodes_unavailable">No disponible</string>
+    <string name="series_status_ended">Finalizada</string>
+    <string name="series_status_continuing">En emisión</string>
+    <string name="series_status_current">Actual</string>
+    <string name="series_status_cancelled">Cancelada</string>
+    <string name="series_status_released">Estrenada</string>
+    <string name="series_status_planned">Planeada</string>
+    <string name="series_status_rumored">Rumoreada</string>
+    <string name="series_status_in_production">En producción</string>
+    <string name="series_status_post_production">Postproducción</string>
     <string name="detail_lists_fallback">Listas</string>
     <string name="detail_lists_subtitle">Selecciona en qué listas incluir este título.</string>
     <string name="action_save">Guardar</string>
@@ -166,6 +203,23 @@
     <string name="settings_playback_subtitle">Reproductor, subtítulos y auto-reproducción.</string>
     <string name="settings_trakt_subtitle">Abrir pantalla de conexión con Trakt.</string>
     <string name="settings_about_subtitle">Versión y políticas.</string>
+    <string name="settings_network">Velocidad de red</string>
+    <string name="settings_network_subtitle">Diagnóstico de latencia y descarga</string>
+    <string name="settings_advanced">Avanzado</string>
+    <string name="settings_advanced_subtitle">Ejecutar diagnóstico de velocidad de red</string>
+    <string name="network_speed_test_run">Ejecutar prueba de velocidad</string>
+    <string name="network_speed_test_running">Ejecutando prueba de velocidad</string>
+    <string name="network_speed_test_subtitle">Medir velocidad de descarga y latencia</string>
+    <string name="network_testing_latency">Midiendo latencia</string>
+    <string name="network_testing_download">Midiendo velocidad de descarga</string>
+    <string name="network_results_title">Resultados</string>
+    <string name="network_latency_label">Latencia</string>
+    <string name="network_download_label">Descarga</string>
+    <string name="network_error_prefix">Error: %1$s</string>
+    <string name="network_powered_by_fast">Con tecnología de fast.com</string>
+    <string name="network_connection_wifi">Wi-Fi</string>
+    <string name="network_connection_ethernet">Ethernet</string>
+    <string name="network_connection_offline">Sin conexión</string>
     <string name="settings_debug">Depuración</string>
     <string name="settings_debug_subtitle">Herramientas de desarrollador y funciones experimentales.</string>
     <string name="settings_plugins_section_subtitle">Administrar repositorios, proveedores y estado de los plugins.</string>
@@ -342,6 +396,10 @@
     <string name="autoplay_scope_addons">Solo addons instalados</string>
     <string name="autoplay_scope_plugins">Solo plugins habilitados</string>
     <string name="autoplay_scope">Alcance de Fuentes para Auto-reproducción</string>
+    <string name="autoplay_timeout_title">Tiempo de espera de transmisión</string>
+    <string name="autoplay_timeout_sub">Tiempo de espera para los Addons antes de seleccionar.</string>
+    <string name="autoplay_timeout_instant">Instantáneo</string>
+    <string name="autoplay_timeout_unlimited">Ilimitado</string>
     <string name="autoplay_allowed_addons">Addons Permitidos</string>
     <string name="autoplay_all_addons">Todos los addons instalados</string>
     <string name="autoplay_allowed_plugins">Plugins Permitidos</string>
@@ -406,6 +464,8 @@
     <string name="layout_trailer_button_sub">Mostrar el botón de tráiler en la página de detalles (solo si está disponible).</string>
     <string name="layout_prefer_external_meta">Preferir metadatos de addon externo</string>
     <string name="layout_prefer_external_meta_sub">Usar metadatos del addon externo en lugar del addon del catálogo.</string>
+    <string name="layout_show_full_release_date">Mostrar fecha de estreno completa</string>
+    <string name="layout_show_full_release_date_sub">Para películas, muestra la fecha de estreno completa en lugar de solo el año.</string>
     <string name="layout_section_focused">Póster en Foco</string>
     <string name="layout_section_focused_desc">Comportamiento avanzado para tarjetas de póster seleccionadas.</string>
     <string name="layout_expand_poster">Expandir Póster al Fondo (Backdrop)</string>
@@ -489,6 +549,8 @@
     <string name="tmdb_subtitle">Elige qué campos de metadatos deben provenir de TMDB</string>
     <string name="tmdb_enable_title">Habilitar Enriquecimiento de TMDB</string>
     <string name="tmdb_enable_subtitle">Usar TMDB como fuente de metadatos para mejorar los datos de los addons</string>
+    <string name="tmdb_modern_home_title">Activar en Inicio Moderno</string>
+    <string name="tmdb_modern_home_subtitle">Aplicar también el enriquecimiento de TMDB al banner principal y a las tarjetas enfocadas en Inicio Moderno</string>
     <string name="tmdb_language_title">Idioma</string>
     <string name="tmdb_language_subtitle">Idioma de los metadatos de TMDB para el título, logo y campos habilitados</string>
     <string name="tmdb_artwork_title">Arte</string>
@@ -525,14 +587,30 @@
     <string name="trakt_token_refreshes">El token de acceso de Trakt se actualiza en %1$s</string>
     <string name="trakt_login_instruction">Presiona Iniciar Sesión para comenzar la autenticación del dispositivo con Trakt. Aquí aparecerá un código QR.</string>
     <string name="trakt_missing_credentials">Faltan TRAKT_CLIENT_ID / TRAKT_CLIENT_SECRET en local.properties.</string>
-    <string name="trakt_continue_watching_window">Ventana de Continuar Viendo</string>
+    <string name="trakt_watch_progress_title">Progreso de reproducción</string>
+    <string name="trakt_watch_progress_subtitle">Elige qué fuente de progreso se usa para reanudar y continuar viendo</string>
+    <string name="trakt_watch_progress_dialog_title">Progreso de reproducción</string>
+    <string name="trakt_watch_progress_dialog_subtitle">Elige si reanudar y continuar viendo deben usar Trakt o Nuvio Sync mientras el scrobbling de Trakt sigue activo.</string>
+    <string name="trakt_watch_progress_source_trakt">Trakt</string>
+    <string name="trakt_watch_progress_source_nuvio">Nuvio Sync</string>
+    <string name="trakt_setting_on">Activado</string>
+    <string name="trakt_setting_off">Desactivado</string>
+    <string name="trakt_watch_progress_trakt_selected">Fuente de progreso de reproducción establecida en Trakt</string>
+    <string name="trakt_watch_progress_nuvio_selected">Fuente de progreso de reproducción establecida en Nuvio Sync</string>
+    <string name="trakt_continue_watching_window">Ventana de continuar viendo</string>
     <string name="trakt_continue_watching_subtitle">Historial de Trakt considerado para continuar viendo</string>
-    <string name="trakt_unaired_next_up">Próximos Episodios Sin Emitir</string>
+    <string name="trakt_unaired_next_up">Incluir próximos episodios no emitidos</string>
     <string name="trakt_unaired_next_up_subtitle">Mostrar los próximos episodios antes de su emisión</string>
     <string name="trakt_unaired_shown">Mostrados</string>
     <string name="trakt_unaired_hidden">Ocultos</string>
     <string name="trakt_unaired_now_shown">Los episodios no emitidos ahora se muestran</string>
-    <string name="trakt_unaired_now_hidden">Los episodios no emitidos ahora están ocultos</string>
+    <string name="trakt_unaired_now_hidden">Los episodios “Siguiente” no emitidos ahora están ocultos</string>
+    <string name="trakt_comments_title">Comentarios</string>
+    <string name="trakt_comments_subtitle">Mostrar reseñas de Trakt en las páginas de metadatos</string>
+    <string name="trakt_comments_dialog_title">Comentarios</string>
+    <string name="trakt_comments_dialog_subtitle">Elige si las páginas de metadatos deben mostrar reseñas de Trakt cuando tu cuenta esté conectada.</string>
+    <string name="trakt_comments_now_shown">Las reseñas de Trakt en las páginas de metadatos ahora se muestran</string>
+    <string name="trakt_comments_now_hidden">Las reseñas de Trakt en las páginas de metadatos ahora están ocultas</string>
     <string name="trakt_cached_label">En caché</string>
     <string name="trakt_stat_movies">Películas</string>
     <string name="trakt_stat_shows">Series</string>
@@ -573,7 +651,13 @@
     <string name="debug_sign_in">Iniciar Sesión</string>
     <string name="debug_error_dialog_title">Error de Reproducción</string>
     <string name="debug_error_dialog_subtitle">Ocurrió un error durante la reproducción.\n\nError: Error simulado de prueba - esto no es un fallo real. La fuente devolvió HTTP 503 (Servicio no disponible).</string>
-    <string name="debug_dismiss">Descartar</string>
+    <string name="debug_dismiss">Cerrar</string>
+    <string name="debug_section_library">Biblioteca</string>
+    <string name="debug_generate_library_title">Generar elementos de la biblioteca</string>
+    <string name="debug_generate_library_subtitle">Agregar películas/series aleatorias a la biblioteca para pruebas</string>
+    <string name="debug_generate_library_placeholder">Número de elementos</string>
+    <string name="debug_generate_library_button">Generar</string>
+    <string name="debug_generating_library">Generando\u2026</string>
 
     <!-- ProfileSettingsContent -->
     <string name="profile_title">Perfiles</string>
@@ -610,6 +694,37 @@
     <string name="profile_add_new">Agregar perfil</string>
     <string name="profile_cancel">Cancelar</string>
     <string name="profile_save">Guardar</string>
+    <string name="profile_pin_title">Bloqueo con PIN del perfil</string>
+    <string name="profile_pin_enabled_subtitle">Este perfil requiere un PIN de 4 dígitos antes de cambiar.</string>
+    <string name="profile_pin_disabled_subtitle">Establece un PIN de 4 dígitos para bloquear este perfil.</string>
+    <string name="profile_pin_set">Establecer PIN</string>
+    <string name="profile_pin_change">Cambiar PIN</string>
+    <string name="profile_pin_remove">Eliminar PIN</string>
+    <string name="profile_pin_set_title">Establecer PIN del perfil</string>
+    <string name="profile_pin_set_subtitle">Ingresa un PIN de 4 dígitos y confírmalo.</string>
+    <string name="profile_pin_enter">Ingresa el PIN de 4 dígitos</string>
+    <string name="profile_pin_confirm">Confirma el PIN de 4 dígitos</string>
+    <string name="profile_pin_mismatch">Los PIN no coinciden.</string>
+    <string name="profile_pin_save">Guardar PIN</string>
+    <string name="profile_pin_unlock_title">Desbloquear %1$s</string>
+    <string name="profile_pin_unlock_subtitle">Ingresa el PIN de 4 dígitos para continuar.</string>
+    <string name="profile_pin_verifying">Verificando…</string>
+    <string name="profile_pin_unlock_action">Desbloquear</string>
+    <string name="profile_pin_overlay_unlock_heading">Ingresa tu PIN para acceder a %1$s.</string>
+    <string name="profile_pin_overlay_set_heading">Crea un PIN de 4 dígitos para %1$s.</string>
+    <string name="profile_pin_overlay_confirm_heading">Confirma tu nuevo PIN.</string>
+    <string name="profile_pin_overlay_unlock_support">Usa tu control remoto o teclado para ingresar 4 dígitos.</string>
+    <string name="profile_pin_overlay_change_verify_kicker">Se requiere verificación de seguridad.</string>
+    <string name="profile_pin_overlay_change_verify_heading">Ingresa el PIN actual para cambiar el PIN de %1$s.</string>
+    <string name="profile_pin_overlay_change_verify_support">Ingresa el PIN actual de 4 dígitos antes de establecer uno nuevo.</string>
+    <string name="profile_pin_overlay_remove_verify_kicker">Se requiere verificación de seguridad.</string>
+    <string name="profile_pin_overlay_remove_verify_heading">Ingresa el PIN actual para eliminar el bloqueo de %1$s.</string>
+    <string name="profile_pin_overlay_remove_verify_support">Ingresa el PIN actual de 4 dígitos para eliminar este bloqueo.</string>
+    <string name="profile_pin_overlay_set_support">Este PIN será requerido antes de abrir este perfil.</string>
+    <string name="profile_pin_overlay_confirm_support">Vuelve a ingresar los mismos 4 dígitos para finalizar la configuración.</string>
+    <string name="profile_pin_overlay_mismatch">Los PIN no coinciden. Ingresa uno nuevo nuevamente.</string>
+    <string name="profile_pin_overlay_forgot_hint">¿Olvidaste el PIN? Restablécelo desde tu cuenta de Nuvio en el sitio web de Nuvio.</string>
+    <string name="profile_pin_overlay_back_hint">Presiona atrás para cancelar</string>
 
 
     <!-- AddonManagerScreen -->
@@ -619,6 +734,9 @@
     <string name="addon_install_placeholder">https://ejemplo.com</string>
     <string name="addon_installing">Instalando</string>
     <string name="addon_install_btn">Instalar</string>
+    <string name="addon_install_success">Se instaló %1$s</string>
+    <string name="addon_error_invalid_url">Ingresa una URL de addon válida</string>
+    <string name="addon_error_invalid_scheme">La URL del addon debe comenzar con http o https</string>
     <string name="addon_installed_section">Instalados</string>
     <string name="addon_empty">No hay addons instalados. Agrega uno para empezar.</string>
     <string name="addon_remove">Eliminar</string>
@@ -707,6 +825,15 @@
 
     <!-- AudioDialog -->
     <string name="audio_dialog_title">Audio</string>
+    <string name="audio_dialog_tab_tracks">Audio</string>
+    <string name="audio_dialog_tab_mix">Mezcla</string>
+    <string name="audio_mix_label">Amplificación (PCM)</string>
+    <string name="audio_mix_value_db">%1$d dB</string>
+    <string name="audio_mix_persist_on">Persistir entre sesiones: ACTIVADO</string>
+    <string name="audio_mix_persist_off">Persistir entre sesiones: DESACTIVADO</string>
+    <string name="audio_mix_range">Rango: %1$d dB a %2$d dB</string>
+    <string name="audio_mix_range_saved">Rango: %1$d dB a %2$d dB (guardado)</string>
+    <string name="audio_mix_unavailable">La amplificación no está disponible en este dispositivo</string>
 
     <!-- SubtitleDialog / SubtitleStyleSidePanel -->
     <string name="subtitle_dialog_title">Subtítulos</string>
@@ -732,6 +859,7 @@
     <string name="subtitle_on">Activado</string>
     <string name="subtitle_off">Desactivado</string>
     <string name="subtitle_style_title">Estilo de Subtítulos</string>
+    <string name="subtitle_style_customize">Personalizar</string>
     <string name="subtitle_style_color">Color</string>
     <string name="subtitle_style_reset">Restablecer</string>
     <string name="subtitle_style_font_size">Tamaño de Fuente</string>
@@ -899,12 +1027,15 @@
     <string name="profile_delete_confirm_title">¿Eliminar perfil?</string>
     <string name="profile_delete_confirm_subtitle">Esto eliminará permanentemente este perfil y todos sus datos, incluyendo biblioteca, historial de reproducción y configuraciones de addons. Esta acción no se puede deshacer.</string>
     <string name="profile_delete_btn">Eliminar perfil</string>
-    <string name="profile_saving">Guardando…</string>
+    <string name="profile_saving">Guardando\u2026</string>
 
     <!-- CastDetailScreen -->
     <string name="cast_detail_error">Algo salió mal</string>
     <string name="cast_detail_retry">Reintentar</string>
     <string name="cast_detail_filmography">Filmografía</string>
+    <string name="cast_detail_born">Nacimiento: %1$s</string>
+    <string name="cast_detail_born_died">Nacimiento: %1$s — †%2$s</string>
+    <string name="cast_detail_age">%1$d años</string>
 
     <!-- CatalogSeeAllScreen -->
     <string name="catalog_see_all_from">de %1$s</string>
@@ -980,8 +1111,13 @@
     <string name="settings_rounded_ui">Interfaz Redondeada</string>
     <string name="cd_expand_sidebar">Expandir barra lateral</string>
 
+    <string name="update_checking">Buscando actualizaciones…</string>
+    <string name="update_download_complete">Descarga completada. Listo para instalar.</string>
+    <string name="update_up_to_date">El sistema está actualizado. Últimos cambios:</string>
     <string name="update_close">Cerrar</string>
     <string name="update_open_settings">Abrir Ajustes</string>
     <string name="update_install">Instalar</string>
     <string name="update_ignore">Ignorar</string>
+    <string name="watchlist_added">Añadido a la lista para ver</string>
+    <string name="watchlist_removed">Eliminado de la lista para ver</string>
 </resources>


### PR DESCRIPTION
## Summary
- Added Latin American Spanish (es-419) translations for newly introduced strings (profile, autoplay, and related features)
- Refined existing translations for better consistency and clarity
- Minor wording and formatting improvements across the locale

## PR type
- Translation update

## Why
To keep the Latin American Spanish (es-419) locale up to date with recently added strings and improve overall translation quality and consistency across the app.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
- Verified all new strings are correctly translated and displayed
- Checked for formatting issues and placeholder consistency (e.g. %1$s, %1$d)
- No functional changes introduced

## Screenshots / Video (UI changes only)
N/A

## Breaking changes
- No breaking changes. Existing functionality remains unaffected.

## Linked issues
- No breaking changes.