### PR TITLE
fix: Inconsistent vertical offset between built-in and some external addon subtitles

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -7,9 +7,12 @@ import android.util.Log
 import android.view.accessibility.CaptioningManager
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import androidx.media3.common.text.Cue
+import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
@@ -172,6 +175,11 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
             val renderersFactory = SubtitleOffsetRenderersFactory(
                 context = context,
                 subtitleDelayUsProvider = subtitleDelayUs::get,
+                shouldNormalizeCuePositionProvider = {
+                    val selectedAddonSubtitle = _uiState.value.selectedAddonSubtitle
+                    selectedAddonSubtitle != null &&
+                        PlayerSubtitleUtils.mimeTypeFromUrl(selectedAddonSubtitle.url) == MimeTypes.TEXT_VTT
+                },
                 gainAudioProcessor = gainAudioProcessor
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc)
@@ -566,6 +574,7 @@ internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
 private class SubtitleOffsetRenderersFactory(
     context: Context,
     private val subtitleDelayUsProvider: () -> Long,
+    private val shouldNormalizeCuePositionProvider: () -> Boolean,
     private val gainAudioProcessor: GainAudioProcessor
 ) : DefaultRenderersFactory(context) {
 
@@ -589,11 +598,48 @@ private class SubtitleOffsetRenderersFactory(
         extensionRendererMode: Int,
         out: ArrayList<Renderer>
     ) {
+        val normalizingOutput = CueNormalizingTextOutput(
+            delegate = output,
+            shouldNormalizeCuePositionProvider = shouldNormalizeCuePositionProvider
+        )
         val startIndex = out.size
-        super.buildTextRenderers(context, output, outputLooper, extensionRendererMode, out)
+        super.buildTextRenderers(context, normalizingOutput, outputLooper, extensionRendererMode, out)
         for (index in startIndex until out.size) {
             out[index] = SubtitleOffsetRenderer(out[index], subtitleDelayUsProvider)
         }
+    }
+}
+
+private class CueNormalizingTextOutput(
+    private val delegate: TextOutput,
+    private val shouldNormalizeCuePositionProvider: () -> Boolean
+) : TextOutput {
+
+    override fun onCues(cueGroup: CueGroup) {
+        if (!shouldNormalizeCuePositionProvider()) {
+            delegate.onCues(cueGroup)
+            return
+        }
+        delegate.onCues(CueGroup(cueGroup.cues.map(::normalizeCuePosition), cueGroup.presentationTimeUs))
+    }
+
+    @Deprecated("Uses the deprecated Media3 callback for text outputs.")
+    override fun onCues(cues: List<Cue>) {
+        if (!shouldNormalizeCuePositionProvider()) {
+            delegate.onCues(cues)
+            return
+        }
+        delegate.onCues(cues.map(::normalizeCuePosition))
+    }
+
+    private fun normalizeCuePosition(cue: Cue): Cue {
+        if (cue.bitmap != null || cue.verticalType != Cue.TYPE_UNSET || cue.line == Cue.DIMEN_UNSET) {
+            return cue
+        }
+        return cue.buildUpon()
+            .setLine(Cue.DIMEN_UNSET, Cue.TYPE_UNSET)
+            .setLineAnchor(Cue.TYPE_UNSET)
+            .build()
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -241,7 +241,7 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         Log.d(
             PlayerRuntimeController.TAG,
             "Selecting ADDON subtitle addon=${subtitle.addonName} lang=${subtitle.lang} normalizedLang=$normalizedLang " +
-                "id=${subtitle.id} inferredMime=$inferredMime ext=${PlayerSubtitleUtils.fileExtensionFromUrl(subtitle.url)} " +
+                "id=${subtitle.id} inferredMime=$inferredMime " +
                 "url=${subtitle.url}"
         )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -92,7 +92,11 @@ internal fun PlayerRuntimeController.applyAddonSubtitleOverride(addonTrackId: St
                     .setOverrideForType(override)
                     .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
                     .build()
-                Log.d(PlayerRuntimeController.TAG, "applyAddonSubtitleOverride: found id=${format.id} at group/track $i")
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "applyAddonSubtitleOverride: found id=${format.id} at group/track $i " +
+                        "mime=${format.sampleMimeType} codecs=${format.codecs} label=${format.label} lang=${format.language}"
+                )
                 return true
             }
         }
@@ -232,9 +236,15 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         if (currentlySelected?.id == subtitle.id && currentlySelected.url == subtitle.url) {
             return@let
         }
-        Log.d(PlayerRuntimeController.TAG, "Selecting ADDON subtitle lang=${subtitle.lang} id=${subtitle.id}")
-
         val normalizedLang = PlayerSubtitleUtils.normalizeLanguageCode(subtitle.lang)
+        val inferredMime = PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url)
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "Selecting ADDON subtitle addon=${subtitle.addonName} lang=${subtitle.lang} normalizedLang=$normalizedLang " +
+                "id=${subtitle.id} inferredMime=$inferredMime ext=${PlayerSubtitleUtils.fileExtensionFromUrl(subtitle.url)} " +
+                "url=${subtitle.url}"
+        )
+
         val addonTrackId = buildAddonSubtitleTrackId(subtitle)
         val preAttachedByStartup = attachedAddonSubtitleKeys.contains(addonSubtitleKey(subtitle))
         val appliedWithoutReload = applyAddonSubtitleOverride(addonTrackId) ||
@@ -243,7 +253,8 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         if (appliedWithoutReload) {
             Log.d(
                 PlayerRuntimeController.TAG,
-                "Switching ADDON subtitle without media reload id=${subtitle.id}"
+                "Switching ADDON subtitle without media reload addon=${subtitle.addonName} id=${subtitle.id} " +
+                    "trackId=$addonTrackId"
             )
             pendingAddonSubtitleLanguage = null
             pendingAddonSubtitleTrackId = null
@@ -265,6 +276,11 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         val subtitleConfigurations = (_uiState.value.addonSubtitles + subtitle)
             .distinctBy { "${it.id}|${it.url}" }
             .map(::toSubtitleConfiguration)
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "Selecting ADDON subtitle with media refresh addon=${subtitle.addonName} id=${subtitle.id} " +
+                "attachedConfigs=${subtitleConfigurations.size}"
+        )
         attachedAddonSubtitleKeys = (_uiState.value.addonSubtitles + subtitle)
             .distinctBy { addonSubtitleKey(it) }
             .map(::addonSubtitleKey)
@@ -301,6 +317,7 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         }
     }
 }
+
 
 internal fun PlayerRuntimeController.rememberAddonSubtitleSelection(subtitle: Subtitle) {
     persistedTrackPreference = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -87,7 +87,6 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.media3.common.MimeTypes
 import androidx.media3.ui.PlayerView
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -491,27 +490,6 @@ fun PlayerScreen(
         viewModel.exoPlayer?.let { player ->
             val subtitleStyle = uiState.subtitleStyle
             val resizeMode = uiState.resizeMode
-            val selectedAddonSubtitle = uiState.selectedAddonSubtitle
-            val selectedAddonSubtitleMimeType = selectedAddonSubtitle?.let { subtitle ->
-                PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url)
-            }
-            val shouldApplyExternalWebVttCompensation =
-                selectedAddonSubtitle != null && selectedAddonSubtitleMimeType == MimeTypes.TEXT_VTT
-
-            LaunchedEffect(
-                selectedAddonSubtitle?.id,
-                selectedAddonSubtitleMimeType,
-                shouldApplyExternalWebVttCompensation
-            ) {
-                selectedAddonSubtitle?.let { subtitle ->
-                    Log.d(
-                        "PlayerScreen",
-                        "Subtitle compensation check: id=${subtitle.id} " +
-                            "mime=$selectedAddonSubtitleMimeType " +
-                            "applyWebVttCompensation=$shouldApplyExternalWebVttCompensation"
-                    )
-                }
-            }
             
             AndroidView(
                 factory = { context ->
@@ -563,27 +541,11 @@ fun PlayerScreen(
                         
                         // Apply vertical offset (-20 = very bottom, 0 = default, 50 = middle)
                         // Convert percentage to fraction for bottom padding
-                        val webVttCompensationFraction = if (shouldApplyExternalWebVttCompensation) 0.06f else 0f
                         val bottomPaddingFraction = (
                             0.06f +
-                                (subtitleStyle.verticalOffset / 250f) +
-                                webVttCompensationFraction
+                                (subtitleStyle.verticalOffset / 250f)
                             ).coerceIn(0f, 0.4f)
                         setBottomPaddingFraction(bottomPaddingFraction)
-
-                        // Also apply explicit bottom padding based on view height for stronger offset effect
-                        post {
-                            val webVttCompensationPadding = if (shouldApplyExternalWebVttCompensation) {
-                                (height * 0.06f).toInt()
-                            } else {
-                                0
-                            }
-                            val extraPadding = (
-                                (height * (subtitleStyle.verticalOffset / 400f)).toInt() +
-                                    webVttCompensationPadding
-                                ).coerceAtLeast(0)
-                            setPadding(paddingLeft, paddingTop, paddingRight, extraPadding)
-                        }
                     }
                 },
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -563,7 +563,7 @@ fun PlayerScreen(
                         
                         // Apply vertical offset (-20 = very bottom, 0 = default, 50 = middle)
                         // Convert percentage to fraction for bottom padding
-                        val webVttCompensationFraction = if (shouldApplyExternalWebVttCompensation) 0.08f else 0f
+                        val webVttCompensationFraction = if (shouldApplyExternalWebVttCompensation) 0.06f else 0f
                         val bottomPaddingFraction = (
                             0.06f +
                                 (subtitleStyle.verticalOffset / 250f) +
@@ -574,7 +574,7 @@ fun PlayerScreen(
                         // Also apply explicit bottom padding based on view height for stronger offset effect
                         post {
                             val webVttCompensationPadding = if (shouldApplyExternalWebVttCompensation) {
-                                (height * 0.08f).toInt()
+                                (height * 0.06f).toInt()
                             } else {
                                 0
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.common.MimeTypes
 import androidx.media3.ui.PlayerView
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -490,6 +491,27 @@ fun PlayerScreen(
         viewModel.exoPlayer?.let { player ->
             val subtitleStyle = uiState.subtitleStyle
             val resizeMode = uiState.resizeMode
+            val selectedAddonSubtitle = uiState.selectedAddonSubtitle
+            val selectedAddonSubtitleMimeType = selectedAddonSubtitle?.let { subtitle ->
+                PlayerSubtitleUtils.mimeTypeFromUrl(subtitle.url)
+            }
+            val shouldApplyExternalWebVttCompensation =
+                selectedAddonSubtitle != null && selectedAddonSubtitleMimeType == MimeTypes.TEXT_VTT
+
+            LaunchedEffect(
+                selectedAddonSubtitle?.id,
+                selectedAddonSubtitleMimeType,
+                shouldApplyExternalWebVttCompensation
+            ) {
+                selectedAddonSubtitle?.let { subtitle ->
+                    Log.d(
+                        "PlayerScreen",
+                        "Subtitle compensation check: id=${subtitle.id} " +
+                            "mime=$selectedAddonSubtitleMimeType " +
+                            "applyWebVttCompensation=$shouldApplyExternalWebVttCompensation"
+                    )
+                }
+            }
             
             AndroidView(
                 factory = { context ->
@@ -541,12 +563,25 @@ fun PlayerScreen(
                         
                         // Apply vertical offset (-20 = very bottom, 0 = default, 50 = middle)
                         // Convert percentage to fraction for bottom padding
-                        val bottomPaddingFraction = (0.06f + (subtitleStyle.verticalOffset / 250f)).coerceIn(0f, 0.4f)
+                        val webVttCompensationFraction = if (shouldApplyExternalWebVttCompensation) 0.08f else 0f
+                        val bottomPaddingFraction = (
+                            0.06f +
+                                (subtitleStyle.verticalOffset / 250f) +
+                                webVttCompensationFraction
+                            ).coerceIn(0f, 0.4f)
                         setBottomPaddingFraction(bottomPaddingFraction)
 
                         // Also apply explicit bottom padding based on view height for stronger offset effect
                         post {
-                            val extraPadding = (height * (subtitleStyle.verticalOffset / 400f)).toInt().coerceAtLeast(0)
+                            val webVttCompensationPadding = if (shouldApplyExternalWebVttCompensation) {
+                                (height * 0.08f).toInt()
+                            } else {
+                                0
+                            }
+                            val extraPadding = (
+                                (height * (subtitleStyle.verticalOffset / 400f)).toInt() +
+                                    webVttCompensationPadding
+                                ).coerceAtLeast(0)
                             setPadding(paddingLeft, paddingTop, paddingRight, extraPadding)
                         }
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -87,16 +87,4 @@ internal object PlayerSubtitleUtils {
             else -> MimeTypes.APPLICATION_SUBRIP
         }
     }
-
-    fun fileExtensionFromUrl(url: String): String? {
-        val normalizedPath = url
-            .substringBefore('#')
-            .substringBefore('?')
-            .trimEnd('/')
-        val lastSegment = normalizedPath.substringAfterLast('/', missingDelimiterValue = normalizedPath)
-        val extension = lastSegment.substringAfterLast('.', missingDelimiterValue = "")
-            .trim()
-            .lowercase()
-        return extension.takeIf { it.isNotEmpty() }
-    }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -87,4 +87,16 @@ internal object PlayerSubtitleUtils {
             else -> MimeTypes.APPLICATION_SUBRIP
         }
     }
+
+    fun fileExtensionFromUrl(url: String): String? {
+        val normalizedPath = url
+            .substringBefore('#')
+            .substringBefore('?')
+            .trimEnd('/')
+        val lastSegment = normalizedPath.substringAfterLast('/', missingDelimiterValue = normalizedPath)
+        val extension = lastSegment.substringAfterLast('.', missingDelimiterValue = "")
+            .trim()
+            .lowercase()
+        return extension.takeIf { it.isNotEmpty() }
+    }
 }


### PR DESCRIPTION
## Summary
This PR fixes inconsistent vertical positioning for some external addon subtitles by normalizing externally loaded WebVTT cue positioning before rendering.

The player now clears embedded vertical cue positioning for external addon WebVTT tracks so they follow the same subtitle offset behavior as the rest of the player.

## PR type
Bug fix

## Why
This change is needed because users reported inconsistent subtitle placement between built-in subtitles and addon subtitles.

Some addons, such as OpenSubtitles Pro, could provide subtitles as external WebVTT tracks whose cue positioning caused them to render noticeably lower than built-in subtitles or other external subtitle formats.

Context:

[Bug]: Inconsistent vertical offset between built-in and addon subtitles #983

During investigation, the issue was narrowed down to WebVTT cue positioning itself:

built-in subtitles and external SubRip/SRT subtitles were aligned correctly
some external addon subtitles delivered as WebVTT carried cue line positioning that caused them to render lower
the previous approach compensated this in the UI, but that made manual subtitle offset behavior inconsistent
The latest PR implementation fixes the issue at the subtitle rendering path instead of adding a visual compensation layer.

Behavior change
For external addon WebVTT subtitles, embedded vertical cue positioning is normalized before cues reach SubtitleView.

This means:

external addon WebVTT subtitles now follow the same player offset behavior as other subtitle types
the manual subtitle vertical offset setting remains predictable
the previous WebVTT-specific UI compensation is no longer needed
Policy check
[X] This PR is not cosmetic-only, unless it is a translation PR.
[X] This PR does not add a new major feature without prior approval.
[X] This PR is small in scope and focused on one problem.
[ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Manual:

Compared built-in subtitles against external addon WebVTT subtitles in the player
Verified that external addon WebVTT subtitles now follow the normal subtitle offset path
Verified that built-in subtitles and external SubRip/SRT subtitles were unchanged
Verified that switching between subtitle sources during playback still worked correctly
Build:

:app:assembleDebug
Screenshots / Video (UI changes only)
None.

## Breaking changes
None expected, but external addon WebVTT subtitles that rely on embedded vertical cue positioning will now follow the player’s standard subtitle positioning behavior.

## Linked issues
Fixes #983