### PR TITLE
Update Pt-Br Fullscreen strings.xml

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -444,6 +444,8 @@
     <string name="layout_modern_sidebar_sub">Ativar navegação lateral flutuante.</string>
     <string name="layout_modern_sidebar_blur">Desfoque no menu lateral</string>
     <string name="layout_modern_sidebar_blur_sub">Ativar efeito de desfoque (blur) no menu.</string>
+    <string name="layout_fullscreen_hero_backdrop">Plano de Fundo Moderno em Tela Cheia</string>
+    <string name="layout_fullscreen_hero_backdrop_sub">Expandir o fundo do visual Moderno para preencher toda a tela</string>
     <string name="layout_show_hero">Mostrar Destaque</string>
     <string name="layout_show_hero_sub">Exibir Destaque de topo na home.</string>
     <string name="layout_show_discover">Mostrar Descobrir na busca</string>


### PR DESCRIPTION
## Summary
Added missing translations in strings.xml (pt-rBR) for the fullscreen hero backdrop layout settings.

## PR type
- Translation update

## Why
The strings for fullscreen hero backdrop were present in the source file but missing in the Brazilian Portuguese localization.

## Policy check
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Manual verification of XML tags and translation accuracy in the Android resource files.

## Screenshots / Video (UI changes only)
N/A

## Breaking changes
There are no breaking changes in this translation update.

## Linked issues
No linked issues for this translation update.

---

### New translations included:

<string name="layout_fullscreen_hero_backdrop">Backdrop do Herói em Tela Cheia</string>
<string name="layout_fullscreen_hero_backdrop_sub">Expande o backdrop do herói para preencher toda a tela.</string>
