### PR TITLE
Changes for fullscreen gradients

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -138,25 +138,46 @@ internal fun ModernHeroGradientLayer(
     Box(
         modifier = modifier
             .drawWithCache {
-                val horizontalFadeEndX = size.width * if (isFullScreen) 0.55f else 0.45f
+                val horizontalFadeEndX = size.width * if (isFullScreen) 0.65f else 0.45f
                 val horizontalGradient = Brush.horizontalGradient(
-                    colorStops = arrayOf(
-                        0.0f to bgColor,
-                        0.22f to bgColor.copy(alpha = 0.86f),
-                        0.46f to bgColor.copy(alpha = 0.56f),
-                        0.76f to bgColor.copy(alpha = 0.16f),
-                        1.0f to Color.Transparent
-                    ),
+                    colorStops = if (isFullScreen) {
+                        arrayOf(
+                            0.0f to bgColor,
+                            0.22f to bgColor.copy(alpha = 0.90f),
+                            0.46f to bgColor.copy(alpha = 0.80f),
+                            0.76f to bgColor.copy(alpha = 0.42f),
+                            1.0f to Color.Transparent
+                        )
+                    } else {
+                        arrayOf(
+                            0.0f to bgColor,
+                            0.22f to bgColor.copy(alpha = 0.86f),
+                            0.46f to bgColor.copy(alpha = 0.56f),
+                            0.76f to bgColor.copy(alpha = 0.16f),
+                            1.0f to Color.Transparent
+                        )
+                    },
                     startX = 0f,
                     endX = horizontalFadeEndX
                 )
 
-                val bottomStripStartY = size.height * 0.82f
+                val bottomStripStartY = size.height * if (isFullScreen) 0.64f else 0.82f
                 val verticalGradient = Brush.verticalGradient(
-                    0.0f to Color.Transparent,
-                    0.40f to bgColor.copy(alpha = 0.25f),
-                    0.75f to bgColor.copy(alpha = 0.65f),
-                    1.0f to bgColor,
+                    colorStops = if (isFullScreen) {
+                        arrayOf(
+                            0.0f to Color.Transparent,
+                            0.30f to bgColor.copy(alpha = 0.35f),
+                            0.60f to bgColor.copy(alpha = 0.75f),
+                            1.0f to bgColor
+                        )
+                    } else {
+                        arrayOf(
+                            0.0f to Color.Transparent,
+                            0.40f to bgColor.copy(alpha = 0.25f),
+                            0.75f to bgColor.copy(alpha = 0.65f),
+                            1.0f to bgColor
+                        )
+                    },
                     startY = bottomStripStartY,
                     endY = size.height
                 )


### PR DESCRIPTION
## Summary

Updated horizontal and vertical gradients in the hero section to better fit the fullscreen backdrop mode. Gradients are now stronger and cover more area when fullscreen backdrop is enabled, improving readability of overlaid UI elements. Standard mode is unchanged.

## PR type

- Small maintenance improvement

## Why

The existing gradients didn't look right with fullscreen backdrop enabled - hero section description lacked sufficient contrast against hero images.  Especially with light backdrop images. Same situation with posters cards.

Addresses #1033

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manual testing on Android TV - verified gradient appearance in both fullscreen and standard backdrop modes across different hero images.

## Screenshots / Video (UI changes only)
Before
![IMG20260325063726](https://github.com/user-attachments/assets/aba6d45c-cb39-4d02-a133-9da3f64f3091)

After
![IMG20260325063710](https://github.com/user-attachments/assets/2a95e60b-f10c-4904-b40c-065c0ff35293)


## Breaking changes

Nothing should break

## Linked issues

Fixes #1033
