### PR TITLE
Batch of small bug fixes (#1045, #1050, #1025, #958)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -692,6 +692,7 @@ fun NuvioNavHost(
                                         year = args?.getString("year"),
                                         contentId = contentId.takeIf { it.isNotBlank() },
                                         contentName = args?.getString("contentName"),
+                                        manualSelection = true,
                                         returnToDetailOnBack = returnToDetailOnBack,
                                         returnToHomeOnBack = returnToHomeOnBack
                                     )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -229,7 +229,8 @@ fun EpisodesRow(
     restoreFocusToken: Int = 0,
     onRestoreFocusHandled: () -> Unit = {},
     onEpisodeFocused: (episodeId: String) -> Unit = {},
-    scrollToEpisodeId: String? = null
+    scrollToEpisodeId: String? = null,
+    onScrollToEpisodeHandled: () -> Unit = {}
 ) {
     val dedupedEpisodes = remember(episodes) { episodes.distinctBy { it.id } }
     val restoreTargetRequester = restoreEpisodeId?.let { episodeFocusRequesters[it] }
@@ -269,6 +270,7 @@ fun EpisodesRow(
         if (index < 0) return@LaunchedEffect
         val offsetPx = with(density) { (cardMetrics.cardWidth * 2f / 3f - cardMetrics.itemSpacing).roundToPx() }
         lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
+        onScrollToEpisodeHandled()
     }
 
     LazyRow(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -992,6 +992,10 @@ private fun MetaDetailsContent(
     var activePeopleTab by rememberSaveable(meta.id) { mutableStateOf(initialPeopleTab) }
     var seasonOptionsDialogSeason by remember { mutableStateOf<Int?>(null) }
     val lastFocusedEpisodeIdBySeason = remember(meta.id) { mutableStateMapOf<Int, String>() }
+    // Tracks whether the initial auto-scroll to the "next to play" episode has fired
+    // for each season.  Until it fires we must keep passing scrollToEpisodeId even if
+    // the user already focused an episode (which sets lastFocusedEpisodeIdBySeason).
+    val nextToWatchScrolledSeasons = remember(meta.id) { mutableStateMapOf<Int, Boolean>() }
     val episodeFocusRequestersBySeason = remember(meta.id) { mutableMapOf<Int, MutableMap<String, FocusRequester>>() }
     val seasonEpisodeFocusRequesters = remember(selectedSeason, episodesForSeason) {
         val byEpisodeId = episodeFocusRequestersBySeason.getOrPut(selectedSeason) { mutableMapOf() }
@@ -1310,11 +1314,26 @@ private fun MetaDetailsContent(
                             onEpisodeFocused = { episodeId ->
                                 lastFocusedEpisodeIdBySeason[selectedSeason] = episodeId
                             },
-                            scrollToEpisodeId = if (lastFocusedEpisodeIdBySeason[selectedSeason] == null && pendingRestoreType != RestoreTarget.EPISODE) {
-                                nextToWatch?.nextVideoId
+                            scrollToEpisodeId = if (nextToWatchScrolledSeasons[selectedSeason] != true && pendingRestoreType != RestoreTarget.EPISODE) {
+                                val ntwId = nextToWatch?.nextVideoId
                                     ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
-                                    ?: defaultSeriesVideo?.id?.takeIf { defaultId -> episodesForSeason.any { it.id == defaultId } }
-                            } else null
+                                if (ntwId != null) {
+                                    ntwId
+                                } else if (nextToWatch != null) {
+                                    // nextToWatch resolved but target is in a different season — mark done and fall through.
+                                    nextToWatchScrolledSeasons[selectedSeason] = true
+                                    defaultSeriesVideo?.id?.takeIf { defaultId -> episodesForSeason.any { it.id == defaultId } }
+                                } else {
+                                    // nextToWatch not yet calculated — emit null so LaunchedEffect waits.
+                                    null
+                                }
+                            } else if (lastFocusedEpisodeIdBySeason[selectedSeason] == null && pendingRestoreType != RestoreTarget.EPISODE) {
+                                // nextToWatch scroll already done; fall back to default only if user hasn't focused anything yet.
+                                defaultSeriesVideo?.id?.takeIf { defaultId -> episodesForSeason.any { it.id == defaultId } }
+                            } else null,
+                            onScrollToEpisodeHandled = {
+                                nextToWatchScrolledSeasons[selectedSeason] = true
+                            }
                         )
                     }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -108,6 +108,12 @@ class MetaDetailsViewModel @Inject constructor(
     private var traktCommentsEnabled = false
     private var traktAuthenticated = false
 
+    /** Content ID used for watch-progress and watched-items lookups.
+     *  Starts as the navigation [itemId] (which may be "tmdb:123") and is
+     *  updated to [Meta.id] once meta loads (typically an IMDB ID like "tt0396375").
+     *  This ensures progress is read from the same key it was written under. */
+    private val _effectiveContentId = MutableStateFlow(itemId)
+
     init {
         observeMetaViewSettings()
         observeTrailerAutoplaySettings()
@@ -336,7 +342,9 @@ class MetaDetailsViewModel @Inject constructor(
     private fun observeWatchProgress() {
         if (itemType.lowercase() == "movie") return
         viewModelScope.launch {
-            watchProgressRepository.getAllEpisodeProgress(itemId)
+            _effectiveContentId.flatMapLatest { cid ->
+                watchProgressRepository.getAllEpisodeProgress(cid)
+            }
                 .distinctUntilChanged()
                 .collectLatest { progressMap ->
                 _uiState.update { state ->
@@ -355,7 +363,9 @@ class MetaDetailsViewModel @Inject constructor(
     private fun observeWatchedEpisodes() {
         if (itemType.lowercase() == "movie") return
         viewModelScope.launch {
-            watchedItemsPreferences.getWatchedEpisodesForContent(itemId)
+            _effectiveContentId.flatMapLatest { cid ->
+                watchedItemsPreferences.getWatchedEpisodesForContent(cid)
+            }
                 .distinctUntilChanged()
                 .collectLatest { watchedSet ->
                 _uiState.update { state ->
@@ -374,11 +384,13 @@ class MetaDetailsViewModel @Inject constructor(
     private fun observeMovieWatched() {
         if (itemType.lowercase() != "movie") return
         viewModelScope.launch {
-            _uiState.map { it.meta?.imdbId?.takeIf { id -> id != itemId && id.isNotBlank() } }
-                .distinctUntilChanged()
-                .flatMapLatest { videoId ->
-                    watchProgressRepository.isWatched(itemId, videoId = videoId)
-                }
+            _effectiveContentId.flatMapLatest { cid ->
+                _uiState.map { it.meta?.imdbId?.takeIf { id -> id != cid && id.isNotBlank() } }
+                    .distinctUntilChanged()
+                    .flatMapLatest { videoId ->
+                        watchProgressRepository.isWatched(cid, videoId = videoId)
+                    }
+            }
                 .distinctUntilChanged()
                 .collectLatest { watched ->
                 _uiState.update { state ->
@@ -436,6 +448,11 @@ class MetaDetailsViewModel @Inject constructor(
             }
 
             val metaLookupId = resolveMetaLookupId(itemId = itemId, itemType = itemType)
+            // Update effective content ID as early as possible so watch-progress
+            // observers use the canonical (usually IMDB) ID, not the navigation ID.
+            if (metaLookupId != itemId) {
+                _effectiveContentId.value = metaLookupId
+            }
             val preferExternal = layoutPreferenceDataStore.preferExternalMetaAddonDetail.first()
 
             if (preferExternal) {
@@ -511,6 +528,15 @@ class MetaDetailsViewModel @Inject constructor(
     }
 
     private fun applyMeta(meta: Meta) {
+        // Update the effective content ID so watch-progress observers pick up
+        // the canonical ID (e.g. IMDB "tt0396375") instead of the navigation ID
+        // (which may be "tmdb:13836").  This also covers the reverse: if the user
+        // arrived via an IMDB catalog but progress was stored under a tmdb: key,
+        // we still try both.
+        if (meta.id.isNotBlank() && meta.id != itemId) {
+            _effectiveContentId.value = meta.id
+        }
+
         val seasons = meta.videos
             .mapNotNull { it.season }
             .distinct()
@@ -1006,7 +1032,7 @@ class MetaDetailsViewModel @Inject constructor(
         nextToWatchJob = viewModelScope.launch {
             if (!isSeries) {
                 // For movies, check if there's an in-progress watch
-                val progress = watchProgressRepository.getProgress(itemId).first()
+                val progress = watchProgressRepository.getProgress(_effectiveContentId.value).first()
                 val nextToWatch = if (progress != null && shouldResumeProgress(progress)) {
                     NextToWatch(
                         watchProgress = progress,
@@ -1325,7 +1351,7 @@ class MetaDetailsViewModel @Inject constructor(
             _uiState.update { it.copy(isMovieWatchedPending = true) }
             runCatching {
                 if (_uiState.value.isMovieWatched) {
-                    watchProgressRepository.removeFromHistory(itemId, videoId = resolveFallbackVideoId())
+                    watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = resolveFallbackVideoId())
                     showMessage(context.getString(R.string.detail_movie_marked_unwatched))
                 } else {
                     watchProgressRepository.markAsCompleted(buildCompletedMovieProgress(meta))
@@ -1357,7 +1383,7 @@ class MetaDetailsViewModel @Inject constructor(
                 || _uiState.value.watchedEpisodes.contains(season to episode)
             runCatching {
                 if (isWatched) {
-                    watchProgressRepository.removeFromHistory(itemId, videoId = resolveFallbackVideoId(), season = season, episode = episode)
+                    watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = resolveFallbackVideoId(), season = season, episode = episode)
                     showMessage(context.getString(R.string.detail_episode_marked_unwatched))
                 } else {
                     watchProgressRepository.markAsCompleted(buildCompletedEpisodeProgress(meta, video))
@@ -1452,7 +1478,7 @@ class MetaDetailsViewModel @Inject constructor(
             for (video in watched) {
                 val key = episodePendingKey(video)
                 runCatching {
-                    watchProgressRepository.removeFromHistory(itemId, videoId = resolveFallbackVideoId(), season = video.season!!, episode = video.episode!!)
+                    watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = resolveFallbackVideoId(), season = video.season!!, episode = video.episode!!)
                     unmarked++
                 }.onFailure { error ->
                     Log.w(TAG, "Failed to unmark S${video.season}E${video.episode}: ${error.message}")
@@ -1517,7 +1543,7 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun buildCompletedMovieProgress(meta: Meta): WatchProgress {
         return WatchProgress(
-            contentId = itemId,
+            contentId = _effectiveContentId.value,
             contentType = meta.apiType,
             name = meta.name,
             poster = meta.poster,
@@ -1537,7 +1563,7 @@ class MetaDetailsViewModel @Inject constructor(
     private fun buildCompletedEpisodeProgress(meta: Meta, video: Video): WatchProgress {
         val runtimeMs = video.runtime?.toLong()?.times(60_000L) ?: 1L
         return WatchProgress(
-            contentId = itemId,
+            contentId = _effectiveContentId.value,
             contentType = meta.apiType,
             name = meta.name,
             poster = meta.poster,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -268,7 +268,8 @@ fun ModernHomeContent(
                                     occurrence = occurrence,
                                     strTypeMovie = strTypeMovie,
                                     strTypeSeries = strTypeSeries,
-                                    showFullReleaseDate = showFullReleaseDate
+                                    showFullReleaseDate = showFullReleaseDate,
+                                    previousCachedItem = cachedItem?.carouselItem
                                 )
                                 rowItemCache[cacheKey] = CachedCarouselItem(
                                     source = item,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -230,7 +230,7 @@ private fun HeroTitleContent(
     trailerPlaying: Boolean = false
 ) {
     if (preview == null) return
-    val descriptionMaxLines = if (portraitMode) 4 else 5
+    val descriptionMaxLines = 4
     val descriptionScale = if (portraitMode) 0.90f else 1f
     val titleScale = if (portraitMode) 0.92f else 1f
     val metaScale = 1f

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -47,7 +47,13 @@ internal data class HeroPreview(
     val genres: List<String>,
     val poster: String?,
     val backdrop: String?,
-    val imageUrl: String?
+    val imageUrl: String?,
+    /** Snapshot of the backdrop URL captured before TMDB enrichment.
+     *  Survives cache rebuilds so landscape cards keep their original art
+     *  even after navigation away and back. */
+    val frozenBackdropUrl: String? = null,
+    /** Same idea for the logo URL. */
+    val frozenLogoUrl: String? = null
 )
 
 @Immutable
@@ -336,8 +342,24 @@ internal fun buildCatalogItem(
     occurrence: Int,
     strTypeMovie: String = "",
     strTypeSeries: String = "",
-    showFullReleaseDate: Boolean = true
+    showFullReleaseDate: Boolean = true,
+    previousCachedItem: ModernCarouselItem? = null
 ): ModernCarouselItem {
+    // Carry forward the frozen URLs from the previous cache entry so that
+    // TMDB enrichment never changes the image shown on landscape cards,
+    // even after the composable remember-state is lost (e.g. navigation).
+    val carriedBackdrop = previousCachedItem?.heroPreview?.frozenBackdropUrl
+    val carriedLogo = previousCachedItem?.heroPreview?.frozenLogoUrl
+
+    val currentBackdrop = item.backdropUrl
+    val currentLogo = item.logo
+
+    // First non-blank value wins and is never replaced.
+    val frozenBackdrop = carriedBackdrop?.takeIf { it.isNotBlank() }
+        ?: currentBackdrop
+    val frozenLogo = carriedLogo?.takeIf { it.isNotBlank() }
+        ?: currentLogo
+
     val heroPreview = HeroPreview(
         title = item.name,
         logo = item.logo,
@@ -362,7 +384,9 @@ internal fun buildCatalogItem(
             item.backdropUrl ?: item.poster
         } else {
             item.poster ?: item.backdropUrl
-        }
+        },
+        frozenBackdropUrl = frozenBackdrop,
+        frozenLogoUrl = frozenLogo
     )
 
     return ModernCarouselItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -683,13 +683,17 @@ private fun ModernCarouselCard(
     val animatedCardWidth by animatedCardWidthState
     // Freeze the logo URL for row cards - enrichment updates must not cause flickering.
     // The first non-blank value wins and is never replaced.
-    val frozenLogoUrl = remember(item.key) { mutableStateOf(item.heroPreview.logo) }
+    // Primary source of truth is the data-layer frozen value (survives navigation);
+    // the remember-state acts as a secondary guard within the same composition.
+    val dataFrozenLogo = item.heroPreview.frozenLogoUrl
+    val frozenLogoUrl = remember(item.key) { mutableStateOf(dataFrozenLogo ?: item.heroPreview.logo) }
     if (frozenLogoUrl.value.isNullOrBlank() && !item.heroPreview.logo.isNullOrBlank()) {
         frozenLogoUrl.value = item.heroPreview.logo
     }
     val effectiveLogoUrl = frozenLogoUrl.value
     // Freeze the backdrop URL for landscape cards - prevents image reload when enrichment updates backdrop.
-    val frozenBackdropUrl = remember(item.key) { mutableStateOf(item.heroPreview.backdrop) }
+    val dataFrozenBackdrop = item.heroPreview.frozenBackdropUrl
+    val frozenBackdropUrl = remember(item.key) { mutableStateOf(dataFrozenBackdrop ?: item.heroPreview.backdrop) }
     if (frozenBackdropUrl.value.isNullOrBlank() && !item.heroPreview.backdrop.isNullOrBlank()) {
         frozenBackdropUrl.value = item.heroPreview.backdrop
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
 import androidx.media3.common.Player
+import com.nuvio.tv.R
 import com.nuvio.tv.data.local.SubtitleStyleSettings
 import com.nuvio.tv.data.repository.TraktScrobbleItem
 import com.nuvio.tv.data.repository.extractYear
@@ -874,8 +875,8 @@ internal fun PlayerRuntimeController.buildStreamInfoData(): StreamInfoData {
         subtitleCodec = selectedSubtitle?.codec,
         subtitleLanguage = selectedSubtitle?.language ?: addonSub?.lang,
         subtitleSource = when {
-            addonSub != null -> "Addon"
-            selectedSubtitle != null -> "Embedded"
+            addonSub != null -> context.getString(R.string.stream_info_subtitle_source_addon)
+            selectedSubtitle != null -> context.getString(R.string.stream_info_subtitle_source_embedded)
             else -> null
         }
     )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -598,6 +598,20 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         targets = targets
     )
     if (internalIndex >= 0) {
+        // Determine which target position this internal match satisfies
+        val matchedTargetPosition = targets.indexOfFirst { target ->
+            PlayerSubtitleUtils.matchesLanguageCode(state.subtitleTracks[internalIndex].language, target)
+        }
+        // If the match is only for a secondary (non-primary) target and addon subtitles haven't
+        // loaded yet, defer - a primary addon subtitle may still arrive.
+        val addonSubtitlesLoaded = !state.isLoadingAddonSubtitles
+        if (matchedTargetPosition > 0 && !addonSubtitlesLoaded) {
+            Log.d(
+                PlayerRuntimeController.TAG,
+                "AUTO_SUB defer: internal match is secondary target pos=$matchedTargetPosition, addons still loading"
+            )
+            return
+        }
         autoSubtitleSelected = true
         val currentInternal = state.selectedSubtitleTrackIndex
         val currentAddon = state.selectedAddonSubtitle

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.nuvio.tv.R
 import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.ui.util.languageCodeToName
 
@@ -57,7 +59,7 @@ private fun StreamInfoContent(data: StreamInfoData) {
     // SOURCE section
     val hasSourceInfo = data.addonName != null || data.streamName != null
     if (hasSourceInfo) {
-        SectionLabel("SOURCE")
+        SectionLabel(stringResource(R.string.stream_info_section_source))
         Spacer(modifier = Modifier.height(4.dp))
         Row(verticalAlignment = Alignment.CenterVertically) {
             if (!data.addonLogo.isNullOrBlank()) {
@@ -87,7 +89,7 @@ private fun StreamInfoContent(data: StreamInfoData) {
                 }
                 if (data.streamName != null && data.streamName != data.addonName) {
                     Text(
-                        text = data.streamName,
+                        text = data.streamName.replace("\n", " · "),
                         style = MaterialTheme.typography.bodyLarge,
                         color = NuvioColors.TextSecondary,
                         maxLines = 1,
@@ -98,7 +100,7 @@ private fun StreamInfoContent(data: StreamInfoData) {
         }
         if (!data.streamDescription.isNullOrBlank()) {
             Text(
-                text = data.streamDescription,
+                text = data.streamDescription.replace("\n", " · "),
                 style = MaterialTheme.typography.bodyMedium,
                 color = NuvioColors.TextSecondary,
                 maxLines = 1,
@@ -112,11 +114,11 @@ private fun StreamInfoContent(data: StreamInfoData) {
     // FILE section
     val hasFileInfo = data.filename != null || data.fileSize != null
     if (hasFileInfo) {
-        SectionLabel("FILE")
+        SectionLabel(stringResource(R.string.stream_info_section_file))
         Spacer(modifier = Modifier.height(4.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(36.dp)) {
-            InfoItem(label = "Filename", value = data.filename)
-            InfoItem(label = "Size", value = data.fileSize?.let { formatFileSize(it) })
+            InfoItem(label = stringResource(R.string.stream_info_filename), value = data.filename, modifier = Modifier.weight(1f))
+            InfoItem(label = stringResource(R.string.stream_info_size), value = data.fileSize?.let { formatFileSize(it) })
         }
         Spacer(modifier = Modifier.height(16.dp))
     }
@@ -124,22 +126,22 @@ private fun StreamInfoContent(data: StreamInfoData) {
     // VIDEO section
     val hasVideoInfo = data.videoCodec != null || data.videoWidth != null || data.videoFrameRate != null || data.videoBitrate != null
     if (hasVideoInfo) {
-        SectionLabel("VIDEO")
+        SectionLabel(stringResource(R.string.stream_info_section_video))
         Spacer(modifier = Modifier.height(4.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(36.dp)) {
-            InfoItem(label = "Codec", value = data.videoCodec)
+            InfoItem(label = stringResource(R.string.stream_info_codec), value = data.videoCodec)
             InfoItem(
-                label = "Resolution",
+                label = stringResource(R.string.stream_info_resolution),
                 value = if (data.videoWidth != null && data.videoHeight != null) {
                     formatResolution(data.videoWidth, data.videoHeight)
                 } else null
             )
             InfoItem(
-                label = "Frame Rate",
+                label = stringResource(R.string.stream_info_frame_rate),
                 value = data.videoFrameRate?.let { "%.3f fps".format(it) }
             )
             InfoItem(
-                label = "Bitrate",
+                label = stringResource(R.string.stream_info_bitrate),
                 value = data.videoBitrate?.let { formatBitrate(it) }
             )
         }
@@ -149,17 +151,17 @@ private fun StreamInfoContent(data: StreamInfoData) {
     // AUDIO section
     val hasAudioInfo = data.audioCodec != null || data.audioChannels != null || data.audioLanguage != null || data.audioSampleRate != null
     if (hasAudioInfo) {
-        SectionLabel("AUDIO")
+        SectionLabel(stringResource(R.string.stream_info_section_audio))
         Spacer(modifier = Modifier.height(4.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(36.dp)) {
-            InfoItem(label = "Codec", value = data.audioCodec)
-            InfoItem(label = "Channels", value = data.audioChannels)
+            InfoItem(label = stringResource(R.string.stream_info_codec), value = data.audioCodec)
+            InfoItem(label = stringResource(R.string.stream_info_channels), value = data.audioChannels)
             InfoItem(
-                label = "Sample Rate",
+                label = stringResource(R.string.stream_info_sample_rate),
                 value = data.audioSampleRate?.let { "${it / 1000} kHz" }
             )
             InfoItem(
-                label = "Language",
+                label = stringResource(R.string.stream_info_language),
                 value = data.audioLanguage?.let { languageCodeToName(it) }
             )
         }
@@ -169,16 +171,16 @@ private fun StreamInfoContent(data: StreamInfoData) {
     // SUBTITLE section
     val hasSubtitleInfo = data.subtitleName != null || data.subtitleCodec != null || data.subtitleLanguage != null
     if (hasSubtitleInfo) {
-        SectionLabel("SUBTITLE")
+        SectionLabel(stringResource(R.string.stream_info_section_subtitle))
         Spacer(modifier = Modifier.height(4.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(36.dp)) {
-            InfoItem(label = "Name", value = data.subtitleName)
-            InfoItem(label = "Codec", value = data.subtitleCodec)
+            InfoItem(label = stringResource(R.string.stream_info_name), value = data.subtitleName)
+            InfoItem(label = stringResource(R.string.stream_info_codec), value = data.subtitleCodec)
             InfoItem(
-                label = "Language",
+                label = stringResource(R.string.stream_info_language),
                 value = data.subtitleLanguage?.let { languageCodeToName(it) }
             )
-            InfoItem(label = "Source", value = data.subtitleSource)
+            InfoItem(label = stringResource(R.string.stream_info_source), value = data.subtitleSource)
         }
     }
 }
@@ -194,9 +196,9 @@ private fun SectionLabel(text: String) {
 }
 
 @Composable
-private fun InfoItem(label: String, value: String?) {
+private fun InfoItem(label: String, value: String?, modifier: Modifier = Modifier) {
     if (value == null) return
-    Column {
+    Column(modifier = modifier) {
         Text(
             text = label,
             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -639,6 +639,26 @@
     <string name="player_more_aspect_ratio">Proporcje obrazu</string>
     <string name="player_more_open_external">Otwórz w zewnętrznym odtwarzaczu</string>
 
+    <!-- StreamInfoOverlay -->
+    <string name="stream_info_section_source">ŹRÓDŁO</string>
+    <string name="stream_info_section_file">PLIK</string>
+    <string name="stream_info_section_video">WIDEO</string>
+    <string name="stream_info_section_audio">AUDIO</string>
+    <string name="stream_info_section_subtitle">NAPISY</string>
+    <string name="stream_info_filename">Nazwa pliku</string>
+    <string name="stream_info_size">Rozmiar</string>
+    <string name="stream_info_codec">Kodek</string>
+    <string name="stream_info_resolution">Rozdzielczość</string>
+    <string name="stream_info_frame_rate">Klatki/s</string>
+    <string name="stream_info_bitrate">Bitrate</string>
+    <string name="stream_info_channels">Kanały</string>
+    <string name="stream_info_sample_rate">Próbkowanie</string>
+    <string name="stream_info_language">Język</string>
+    <string name="stream_info_name">Nazwa</string>
+    <string name="stream_info_source">Źródło</string>
+    <string name="stream_info_subtitle_source_addon">Dodatek</string>
+    <string name="stream_info_subtitle_source_embedded">Wbudowane</string>
+
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Źródła</string>
     <string name="sources_reload">Odśwież</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -807,6 +807,26 @@
     <string name="player_more_aspect_ratio">Aspect Ratio</string>
     <string name="player_more_open_external">Open in External Player</string>
 
+    <!-- StreamInfoOverlay -->
+    <string name="stream_info_section_source">SOURCE</string>
+    <string name="stream_info_section_file">FILE</string>
+    <string name="stream_info_section_video">VIDEO</string>
+    <string name="stream_info_section_audio">AUDIO</string>
+    <string name="stream_info_section_subtitle">SUBTITLE</string>
+    <string name="stream_info_filename">Filename</string>
+    <string name="stream_info_size">Size</string>
+    <string name="stream_info_codec">Codec</string>
+    <string name="stream_info_resolution">Resolution</string>
+    <string name="stream_info_frame_rate">Frame Rate</string>
+    <string name="stream_info_bitrate">Bitrate</string>
+    <string name="stream_info_channels">Channels</string>
+    <string name="stream_info_sample_rate">Sample Rate</string>
+    <string name="stream_info_language">Language</string>
+    <string name="stream_info_name">Name</string>
+    <string name="stream_info_source">Source</string>
+    <string name="stream_info_subtitle_source_addon">Addon</string>
+    <string name="stream_info_subtitle_source_embedded">Embedded</string>
+
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Sources</string>
     <string name="sources_reload">Reload</string>


### PR DESCRIPTION
## Summary

- Fixed landscape poster flickering after navigating to detail page and back - the frozen backdrop/logo URLs are now persisted in the data layer cache so they survive composition loss during navigation #1045
- Fixed "Next to play" episode not being scrolled to when entering a series detail page - a race condition between async `nextToWatch` calculation and user focus caused the auto-scroll to be skipped #1050
- Fixed stream info overlay truncating stream name and description - addon stream data contains newlines which caused `maxLines=1` to show only the first line; newlines are now replaced with inline separators #1025
- Extracted all hardcoded strings from stream info overlay to string resources and added Polish translations
- Fixed hero description using 5 lines in landscape mode causing IMDB rating/release date/genre overflow - now always 4 lines #981
- Fixed back navigation loop when "Reuse Last Link" + manual stream selection + auto-play next episode were all enabled (reported on Discord)
- Fixed secondary subtitle language being selected before addon subtitles finished loading #958
- Fixed watch progress not syncing when browsing TMDB networks - content accessed via TMDB entity browse used `tmdb:` IDs for progress lookups while the player saved under IMDB IDs, causing watched episodes to not appear as watched. Also affected addons using TMDB IDs. (reported on Discord)

## PR type

- Bug fix
- Small maintenance improvement
- Translation update

## Why

Several independent bugs reported via GitHub issues and Discord. Grouped into one PR to reduce noise.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Verified landscape posters remain stable after navigating to detail page and back with TMDB enrichment enabled
- Verified "Next to play" episode is scrolled to even when `nextToWatch` resolves after initial render
- Verified stream info overlay shows full stream name/description with newline-separated addon data
- Verified stream info file section shows both filename and size without truncation
- Verified hero description stays at 4 lines in both portrait and landscape poster modes
- Verified pressing back from the player no longer loops back into the player when "Reuse Last Link" is enabled with manual stream selection
- Verified Polish translations display correctly in stream info overlay
- Verified secondary subtitle language selection waits for addon subtitles to load
- Verified watch progress is correctly shown when browsing TMDB networks after watching episodes via catalog addons, and vice versa

## Screenshots / Video (UI changes only)

Nothing

## Breaking changes

Nothing should break

## Linked issues

Fixes #1045
Fixes #1050
Fixes #1025
Fixes #981
Fixes #958
