### PR TITLE
Update Pt-Br News strings to Nuvio 0.5.2

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -123,7 +123,9 @@
     <string name="cast_role_director">Direção</string>
     <string name="cast_role_writer">Roteiro</string>
     <string name="detail_tab_ratings">Avaliações</string>
-    <string name="detail_tab_more_like_this">Títulos similares</string>
+    <string name="detail_tab_more_like_this">Recomendações</string>
+    <string name="detail_more_like_this_powered_by_tmdb">Fonte: TMDB</string>
+    <string name="detail_more_like_this_powered_by_trakt">Fonte: Trakt</string>
     <string name="detail_comments_title">Comentários</string>
     <string name="detail_comments_subtitle">Avaliações do Trakt</string>
     <string name="detail_section_network">Rede e Emissora</string>
@@ -462,6 +464,8 @@
     <string name="layout_section_detail_desc">Opções para as telas de títulos e episódios.</string>
     <string name="layout_blur_unwatched">Desfocar episódios não assistidos</string>
     <string name="layout_blur_unwatched_sub">Desfoca a imagem para evitar spoilers.</string>
+    <string name="layout_blur_cw_next_up">Desfocar não assistidos no Continuar Assistindo</string>
+    <string name="layout_blur_cw_next_up_sub">Desfocar próximos episódios no Continuar Assistindo para evitar spoilers.</string>
     <string name="layout_trailer_button">Botão de Trailer</string>
     <string name="layout_trailer_button_sub">Mostrar botão em detalhes, se existir.</string>
     <string name="layout_prefer_external_meta">Priorizar metadados externos</string>
@@ -553,6 +557,8 @@
     <string name="tmdb_enable_subtitle">Usa o TMDB para aprimorar os dados dos addons</string>
     <string name="tmdb_modern_home_title">Ativar no Visual Moderno</string>
     <string name="tmdb_modern_home_subtitle">Aplicar enriquecimento do TMDB no Visual Moderno</string>
+    <string name="tmdb_enrich_continue_watching_title">Aprimorar Continuar Assistindo</string>
+    <string name="tmdb_enrich_continue_watching_subtitle">Aplicar metadados do TMDB aos itens do Continuar Assistindo</string>
     <string name="tmdb_language_title">Idioma</string>
     <string name="tmdb_language_subtitle">Idioma dos títulos, logos e metadados</string>
     <string name="tmdb_artwork_title">Imagens e Logos</string>


### PR DESCRIPTION
## Summary

Updated and added Portuguese (pt-BR) translations for streaming-related features, including metadata enrichment from TMDB/Trakt and anti-spoiler UI settings (blur unwatched thumbnails).

## PR type

- Translation update

## Why

To provide better localization for Brazilian users, ensuring terms like "Continue Watching" and "Metadata Enrichment" follow the industry standard (Netflix/HBO/Disney+) and providing clear descriptions for the new "Blur Unwatched" feature.

## Policy check

 - [x] This PR is not cosmetic-only, unless it is a translation PR.
 - [x] This PR does not add a new major feature without prior approval.
 - [x] This PR is small in scope and focused on one problem.

## Testing

Manual verification of the `strings.xml` file to ensure XML tags are correctly closed and string names match the source.

## Screenshots / Video (UI changes only)

No UI structural changes, only text localization.

## Breaking changes

There are no breaking changes in this pull request as it only updates string resources.

## Linked issues

This pull request is a standalone translation update and is not linked to a specific existing issue.