### PR TITLE
Auto-retry on transient playback errors

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -27,10 +27,12 @@ internal class PlayerMediaSourceFactory {
     private val playbackHttpClient by lazy {
         OkHttpClient.Builder()
             .dns(IPv4FirstDns())
-            .connectTimeout(8, TimeUnit.SECONDS)
-            .readTimeout(8, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
             .followRedirects(true)
             .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
             .build()
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -238,6 +238,8 @@ class PlayerRuntimeController(
     internal var pendingPreviewSeekPosition: Long? = null
     internal var pendingResumeProgress: WatchProgress? = null
     internal var hasRetriedCurrentStreamAfter416: Boolean = false
+    internal var errorRetryCount: Int = 0
+    internal var errorRetryJob: Job? = null
     internal var currentScrobbleItem: TraktScrobbleItem? = null
     internal var currentTraktEpisodeMapping: EpisodeMappingEntry? = null
     internal var currentTraktEpisodeMappingKey: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -1,0 +1,107 @@
+package com.nuvio.tv.ui.screens.player
+
+import android.util.Log
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.UnstableApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private const val MAX_AUTO_RETRIES = 1
+private const val RETRY_DELAY_MS = 1_500L
+
+/**
+ * Determines whether the given [PlaybackException] is transient and worth retrying.
+ *
+ * Retryable errors include source/IO errors, parsing glitches, and unexpected runtime
+ * exceptions that commonly occur after pause/resume or seek on flaky streams.
+ * Decoder-init and DRM errors are considered fatal.
+ */
+internal fun isRetryablePlaybackError(error: PlaybackException): Boolean {
+    return when (error.errorCode) {
+        // --- Source / IO errors (the 2xxx range) ---
+        PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
+        PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+        PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
+        PlaybackException.ERROR_CODE_IO_NO_PERMISSION,
+        PlaybackException.ERROR_CODE_IO_CLEARTEXT_NOT_PERMITTED,
+        PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE,
+        PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED,
+        PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED,
+        PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED,
+        PlaybackException.ERROR_CODE_PARSING_MANIFEST_UNSUPPORTED -> true
+
+        // --- Behind-the-scenes / unexpected errors (often IllegalStateException / NPE) ---
+        PlaybackException.ERROR_CODE_UNSPECIFIED -> {
+            val cause = error.cause
+            cause is IllegalStateException || cause is NullPointerException
+        }
+
+        else -> false
+    }
+}
+
+/**
+ * Attempts an automatic retry of the current stream, preserving the playback position.
+ *
+ * The player is fully torn down and re-initialised so that internal ExoPlayer state
+ * (extractors, loaders, renderers) is clean - this is the most reliable way to recover
+ * from the class of errors reported by users (corrupt parser state after pause/seek).
+ *
+ * Returns `true` if a retry was scheduled, `false` if the error should be shown to the user.
+ */
+@androidx.annotation.OptIn(UnstableApi::class)
+internal fun PlayerRuntimeController.attemptAutoRetry(
+    error: PlaybackException,
+    detailedError: String
+): Boolean {
+    if (!isRetryablePlaybackError(error)) return false
+    if (errorRetryCount >= MAX_AUTO_RETRIES) return false
+
+    val attempt = errorRetryCount
+    errorRetryCount++
+
+    Log.w(
+        PlayerRuntimeController.TAG,
+        "Auto-retry ${attempt + 1}/$MAX_AUTO_RETRIES after ${RETRY_DELAY_MS}ms for: $detailedError"
+    )
+
+    // Capture the current position so we can resume after re-init.
+    val savedPosition = _exoPlayer?.currentPosition?.takeIf { it > 0L } ?: 0L
+
+    errorRetryJob?.cancel()
+    errorRetryJob = scope.launch {
+        _uiState.update {
+            it.copy(
+                error = null,
+                showLoadingOverlay = it.loadingOverlayEnabled,
+                showPauseOverlay = false
+            )
+        }
+
+        delay(RETRY_DELAY_MS)
+
+        // Full teardown — clears any corrupt internal state.
+        releasePlayer(flushPlaybackState = false)
+
+        // Stash position so initializePlayer's STATE_READY handler will seek to it.
+        if (savedPosition > 0L) {
+            _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
+        }
+
+        initializePlayer(currentStreamUrl, currentHeaders)
+    }
+    return true
+}
+
+/**
+ * Resets the retry counter. Call this whenever playback enters a healthy state
+ * (first frame rendered, or user-initiated retry).
+ */
+internal fun PlayerRuntimeController.resetErrorRetryState() {
+    errorRetryCount = 0
+    errorRetryJob?.cancel()
+    errorRetryJob = null
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -111,7 +111,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
                     70_000,
                     DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-                    DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
+                    5_000
                 )
                 .build()
 
@@ -341,6 +341,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
 
                     override fun onRenderedFirstFrame() {
                         hasRenderedFirstFrame = true
+                        resetErrorRetryState()
                         _uiState.update { it.copy(showLoadingOverlay = false) }
                     }
 
@@ -359,6 +360,10 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                             (error.cause as? androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException)?.responseCode
                         if (responseCode == 416 && !hasRetriedCurrentStreamAfter416) {
                             retryCurrentStreamFromStartAfter416()
+                            return
+                        }
+                        // Attempt automatic recovery for transient errors.
+                        if (attemptAutoRetry(error, detailedError)) {
                             return
                         }
                         _uiState.update {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -31,6 +31,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     playbackPreparationJob = null
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null
+    errorRetryJob?.cancel()
+    errorRetryJob = null
     _exoPlayer?.release()
     _exoPlayer = null
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -722,6 +722,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         PlayerEvent.OnRetry -> {
             hasRenderedFirstFrame = false
             hasRetriedCurrentStreamAfter416 = false
+            resetErrorRetryState()
             resetNextEpisodeCardState(clearEpisode = false)
             _uiState.update { state ->
                 state.copy(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -340,6 +340,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
     )
     persistSelectedStreamForReuse(stream = stream, url = url, headers = newHeaders)
     hasRetriedCurrentStreamAfter416 = false
+    errorRetryCount = 0
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
@@ -615,6 +616,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(stream: Stream, force
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
     hasRetriedCurrentStreamAfter416 = false
+    errorRetryCount = 0
     currentVideoId = targetVideo?.id ?: _uiState.value.episodeStreamsForVideoId ?: currentVideoId
     currentSeason = targetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
     currentEpisode = targetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode


### PR DESCRIPTION
## Summary

Add automatic error recovery for transient ExoPlayer errors during playback. Instead of immediately showing an error screen, the player attempts one automatic retry with full teardown and re-initialization, preserving the playback position. Also increases HTTP timeouts and post-rebuffer buffer duration.

## PR type

- Bug fix

## Why

Users report playback errors that crash the player mid-stream, after pause/resume, and after seeking:
- "source error: Unexpected IllegalStateException: Top bit not zero" [2000]
- "source error: invalid integer size: 85" [3001]
- "source error: null" [2008]
- "source error: unexpected NullPointerException" [2000]

These are transient errors caused by corrupt internal ExoPlayer parser state, not by permanently broken streams. A full player re-init (the same thing the manual retry does) should resolve them in most cases.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- I prepared a test build and gave it on Discord to users that had the most issues with Playback. Apparently it is way better from them now (probably by increased buffer) and the retry mechanism works as expected - player reloads on error and let them watch further without need of any manual action 

## Screenshots / Video (UI changes only)

no UI changes. The loading overlay briefly appears during retry instead of the error screen.

## Breaking changes

Nothing should break as this just adds a retry mechanism 

## Linked issues

Problems mostly reported on discord 
