### PR TITLE
Show watched badge for series & badges on all screens

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -1,0 +1,21 @@
+package com.nuvio.tv.data.local
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Shared holder for fully-watched series IDs derived from the CW pipeline.
+ * Updated by HomeViewModel, observed by any screen that needs series watched badges.
+ */
+@Singleton
+class WatchedSeriesStateHolder @Inject constructor() {
+    private val _fullyWatchedSeriesIds = MutableStateFlow<Set<String>>(emptySet())
+    val fullyWatchedSeriesIds: StateFlow<Set<String>> = _fullyWatchedSeriesIds.asStateFlow()
+
+    fun update(ids: Set<String>) {
+        _fullyWatchedSeriesIds.value = ids
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -672,7 +672,21 @@ class TraktProgressService @Inject constructor(
                 watched = false
             )
         } else {
-            invalidateEpisodeProgressCache(contentId)
+            // Optimistically remove just this episode from the cache instead of
+            // invalidating the entire series cache (which causes all episodes to
+            // briefly appear unwatched until the next Trakt fetch completes).
+            val cacheKey = canonicalLookupKey(contentId.trim())
+            if (season != null && episode != null) {
+                episodeProgressState.update { current ->
+                    val entry = current[cacheKey] ?: return@update current
+                    val updatedProgress = entry.progress.toMutableMap().apply {
+                        remove(season to episode)
+                    }
+                    current + (cacheKey to entry.copy(progress = updatedProgress))
+                }
+            } else {
+                invalidateEpisodeProgressCache(contentId)
+            }
         }
         refreshNow()
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -450,7 +450,9 @@ class TraktProgressService @Inject constructor(
             }
             result as Set<String>
         }
-            .onStart { getWatchedMoviesSnapshot(forceRefresh = false) }
+            .onStart {
+                scope.launch { getWatchedMoviesSnapshot(forceRefresh = false) }
+            }
             .distinctUntilChanged()
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -449,7 +449,9 @@ class TraktProgressService @Inject constructor(
                 }
             }
             result as Set<String>
-        }.distinctUntilChanged()
+        }
+            .onStart { getWatchedMoviesSnapshot(forceRefresh = false) }
+            .distinctUntilChanged()
     }
 
     suspend fun markAsWatched(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -190,10 +190,14 @@ fun CatalogSeeAllScreen(
                         items = catalogRow.items,
                         key = { index, item -> "${catalogRow.catalogId}_${item.id}_$index" }
                     ) { index, item ->
+                        val isWatched = uiState.movieWatchedStatus[
+                            com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
+                        ] == true
                         GridContentCard(
                             item = item,
                             posterCardStyle = posterCardStyle,
                             showLabel = uiState.posterLabelsEnabled,
+                            isWatched = isWatched,
                             focusRequester = if (index == focusedItemIndex) restoreFocusRequester else null,
                             onFocused = {
                                 focusedItemIndex = index

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1236,7 +1236,13 @@ class MetaDetailsViewModel @Inject constructor(
 
             val nonSpecialEpisodes = allEpisodes.filter { (it.season ?: 0) > 0 }
             val episodePool = if (nonSpecialEpisodes.isNotEmpty()) nonSpecialEpisodes else allEpisodes
-            val latestSeriesProgress = progressMap.values.maxByOrNull { it.lastWatched }
+            val latestSeriesProgress = progressMap.values
+                .sortedWith(
+                    compareByDescending<WatchProgress> { it.lastWatched }
+                        .thenByDescending { it.season ?: 0 }
+                        .thenByDescending { it.episode ?: 0 }
+                )
+                .firstOrNull()
             val defaultEpisode = findPreferredDefaultEpisode(meta)?.takeIf { preferred ->
                 episodePool.any { it.id == preferred.id }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -132,6 +132,7 @@ class HomeViewModel @Inject constructor(
     internal val cwMetaCache = Collections.synchronizedMap(mutableMapOf<String, Meta?>())
     internal val cwTmdbIdCache = Collections.synchronizedMap(mutableMapOf<String, String?>())
     internal val cwNextUpResolutionCache = Collections.synchronizedMap(mutableMapOf<String, NextUpResolution?>())
+    internal val fullyWatchedSeriesIds = MutableStateFlow<Set<String>>(emptySet())
     internal var tmdbEnrichFocusJob: Job? = null
     internal var pendingTmdbEnrichItemId: String? = null
     internal var adjacentItemPrefetchJob: Job? = null
@@ -140,6 +141,7 @@ class HomeViewModel @Inject constructor(
     internal val movieWatchedObserverJobs = mutableMapOf<String, Job>()
     internal var movieWatchedBatchJob: Job? = null
     internal var lastMovieWatchedItemKeys: Set<String> = emptySet()
+    internal var seriesWatchedObserverJob: Job? = null
     internal var libraryTabsObserverJob: Job? = null
     internal var activePosterListPickerInput: LibraryEntryInput? = null
     internal var posterStatusObservationEnabled: Boolean = false
@@ -386,6 +388,7 @@ class HomeViewModel @Inject constructor(
         startupAuthNoticeJob?.cancel()
         posterStatusReconcileJob?.cancel()
         movieWatchedBatchJob?.cancel()
+        seriesWatchedObserverJob?.cancel()
         cancelInFlightCatalogLoads()
         posterLibraryObserverJobs.values.forEach { it.cancel() }
         movieWatchedObserverJobs.values.forEach { it.cancel() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -57,7 +57,8 @@ class HomeViewModel @Inject constructor(
     internal val tmdbService: TmdbService,
     internal val tmdbMetadataService: TmdbMetadataService,
     internal val trailerService: TrailerService,
-    internal val watchedItemsPreferences: WatchedItemsPreferences
+    internal val watchedItemsPreferences: WatchedItemsPreferences,
+    internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
@@ -132,7 +133,7 @@ class HomeViewModel @Inject constructor(
     internal val cwMetaCache = Collections.synchronizedMap(mutableMapOf<String, Meta?>())
     internal val cwTmdbIdCache = Collections.synchronizedMap(mutableMapOf<String, String?>())
     internal val cwNextUpResolutionCache = Collections.synchronizedMap(mutableMapOf<String, NextUpResolution?>())
-    internal val fullyWatchedSeriesIds = MutableStateFlow<Set<String>>(emptySet())
+    internal val fullyWatchedSeriesIds get() = watchedSeriesStateHolder
     internal var tmdbEnrichFocusJob: Job? = null
     internal var pendingTmdbEnrichItemId: String? = null
     internal var adjacentItemPrefetchJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -615,7 +615,7 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
     if (allSeriesItemsByKey.isNotEmpty()) {
         seriesWatchedObserverJob?.cancel()
         seriesWatchedObserverJob = viewModelScope.launch {
-            fullyWatchedSeriesIds.collectLatest { fullyWatched ->
+            fullyWatchedSeriesIds.fullyWatchedSeriesIds.collectLatest { fullyWatched ->
                 val seriesStatus = buildMap {
                     allSeriesItemsByKey.forEach { (statusKey, contentId) ->
                         put(statusKey, contentId in fullyWatched)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -540,6 +540,17 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
         }
     val desiredMovieKeys = allMovieItemsByKey.keys
 
+    val allSeriesItemsByKey = linkedMapOf<String, String>()
+    rows.asSequence()
+        .flatMap { row -> row.items.asSequence() }
+        .filter { it.apiType.equals("series", ignoreCase = true) || it.apiType.equals("tv", ignoreCase = true) }
+        .forEach { item ->
+            val key = homeItemStatusKey(item.id, item.apiType)
+            if (key !in allSeriesItemsByKey) {
+                allSeriesItemsByKey[key] = item.id
+            }
+        }
+
     posterLibraryObserverJobs.keys
         .filterNot { it in desiredLibraryKeys }
         .forEach { staleKey ->
@@ -596,11 +607,35 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
         }
     }
 
+    // Update series watched status from CW pipeline's fully-watched resolution.
+    // This piggybacks on the meta lookups CW already performs — no extra network calls.
+    if (allSeriesItemsByKey.isNotEmpty()) {
+        seriesWatchedObserverJob?.cancel()
+        seriesWatchedObserverJob = viewModelScope.launch {
+            fullyWatchedSeriesIds.collectLatest { fullyWatched ->
+                val seriesStatus = buildMap {
+                    allSeriesItemsByKey.forEach { (statusKey, contentId) ->
+                        put(statusKey, contentId in fullyWatched)
+                    }
+                }
+                _uiState.update { state ->
+                    val merged = state.movieWatchedStatus + seriesStatus
+                    if (state.movieWatchedStatus == merged) state
+                    else state.copy(movieWatchedStatus = merged)
+                }
+            }
+        }
+    } else {
+        seriesWatchedObserverJob?.cancel()
+        seriesWatchedObserverJob = null
+    }
+
     _uiState.update { state ->
+        val allWatchedKeys = desiredMovieKeys + allSeriesItemsByKey.keys
         val trimmedLibraryMembership =
             state.posterLibraryMembership.filterKeys { it in desiredLibraryKeys }
         val trimmedMovieWatchedStatus =
-            state.movieWatchedStatus.filterKeys { it in desiredMovieKeys }
+            state.movieWatchedStatus.filterKeys { it in allWatchedKeys }
         val trimmedLibraryPending =
             state.posterLibraryPending.filterTo(linkedSetOf()) { it in desiredLibraryKeys }
         val trimmedMovieWatchedPending =

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -636,11 +636,8 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
     }
 
     _uiState.update { state ->
-        val allWatchedKeys = desiredMovieKeys + allSeriesItemsByKey.keys
         val trimmedLibraryMembership =
             state.posterLibraryMembership.filterKeys { it in desiredLibraryKeys }
-        val trimmedMovieWatchedStatus =
-            state.movieWatchedStatus.filterKeys { it in allWatchedKeys }
         val trimmedLibraryPending =
             state.posterLibraryPending.filterTo(linkedSetOf()) { it in desiredLibraryKeys }
         val trimmedMovieWatchedPending =
@@ -648,7 +645,6 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
 
         if (
             trimmedLibraryMembership == state.posterLibraryMembership &&
-            trimmedMovieWatchedStatus == state.movieWatchedStatus &&
             trimmedLibraryPending == state.posterLibraryPending &&
             trimmedMovieWatchedPending == state.movieWatchedPending
         ) {
@@ -656,7 +652,6 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
         } else {
             state.copy(
                 posterLibraryMembership = trimmedLibraryMembership,
-                movieWatchedStatus = trimmedMovieWatchedStatus,
                 posterLibraryPending = trimmedLibraryPending,
                 movieWatchedPending = trimmedMovieWatchedPending
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -591,15 +591,18 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
                 watchProgressRepository.observeWatchedMovieIds()
                     .collectLatest { watchedIds ->
                         _uiState.update { state ->
-                            val newStatus = buildMap {
+                            val movieStatus = buildMap {
                                 allMovieItemsByKey.forEach { (statusKey, contentId) ->
                                     put(statusKey, contentId in watchedIds)
                                 }
                             }
-                            if (state.movieWatchedStatus == newStatus) {
+                            // Merge with existing status to preserve series entries.
+                            val merged = state.movieWatchedStatus
+                                .filterKeys { it !in desiredMovieKeys } + movieStatus
+                            if (state.movieWatchedStatus == merged) {
                                 state
                             } else {
-                                state.copy(movieWatchedStatus = newStatus)
+                                state.copy(movieWatchedStatus = merged)
                             }
                         }
                     }
@@ -619,7 +622,9 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
                     }
                 }
                 _uiState.update { state ->
-                    val merged = state.movieWatchedStatus + seriesStatus
+                    // Merge with existing status to preserve movie entries.
+                    val merged = state.movieWatchedStatus
+                        .filterKeys { it !in allSeriesItemsByKey.keys } + seriesStatus
                     if (state.movieWatchedStatus == merged) state
                     else state.copy(movieWatchedStatus = merged)
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -282,8 +282,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     }
                 }.toSet()
                 val newFullyWatched = allSeedContentIds - nextUpContentIds - olderSeedsWithNextUp - inProgressContentIds
-                if (fullyWatchedSeriesIds.value != newFullyWatched) {
-                    fullyWatchedSeriesIds.value = newFullyWatched
+                if (fullyWatchedSeriesIds.fullyWatchedSeriesIds.value != newFullyWatched) {
+                    fullyWatchedSeriesIds.update(newFullyWatched)
                 }
 
                 // For older seeds not yet in the resolution cache, resolve async.
@@ -324,8 +324,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 }
                             }.toSet()
                             val updatedFullyWatched = allSeedContentIds - nextUpContentIds - updatedOlderWithNextUp - inProgressContentIds
-                            if (fullyWatchedSeriesIds.value != updatedFullyWatched) {
-                                fullyWatchedSeriesIds.value = updatedFullyWatched
+                            if (fullyWatchedSeriesIds.fullyWatchedSeriesIds.value != updatedFullyWatched) {
+                                fullyWatchedSeriesIds.update(updatedFullyWatched)
                             }
 
                             // Inject discovered next-up items into CW (e.g. new season alerts).

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -303,18 +303,18 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     if (uncachedSeeds.isNotEmpty()) {
                         launch(Dispatchers.IO) {
                             val lookupSemaphore = Semaphore(CW_MAX_NEXT_UP_CONCURRENCY)
-                            uncachedSeeds.map { seed ->
+                            val discoveredNextUpItems = uncachedSeeds.map { seed ->
                                 async {
                                     lookupSemaphore.withPermit {
-                                        findNextUpEpisodeFromMetaSeed(
+                                        buildNextUpItem(
                                             progress = seed,
                                             showUnairedNextUp = showUnairedNextUp
                                         )
                                     }
-                                    seed.contentId
                                 }
-                            }.awaitAll()
-                            // Re-evaluate after cache is populated.
+                            }.awaitAll().filterNotNull()
+
+                            // Re-evaluate watched badge after cache is populated.
                             val updatedOlderWithNextUp = olderSeedContentIds.filter { contentId ->
                                 synchronized(cwNextUpResolutionCache) {
                                     cwNextUpResolutionCache.entries.any { (key, value) ->
@@ -325,6 +325,18 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             val updatedFullyWatched = allSeedContentIds - nextUpContentIds - updatedOlderWithNextUp - inProgressContentIds
                             if (fullyWatchedSeriesIds.value != updatedFullyWatched) {
                                 fullyWatchedSeriesIds.value = updatedFullyWatched
+                            }
+
+                            // Inject discovered next-up items into CW (e.g. new season alerts).
+                            if (discoveredNextUpItems.isNotEmpty()) {
+                                val updatedItems = mergeContinueWatchingItems(
+                                    inProgressItems = inProgressOnly,
+                                    nextUpItems = nextUpItems + discoveredNextUpItems
+                                )
+                                _uiState.update { state ->
+                                    if (state.continueWatchingItems == updatedItems) state
+                                    else state.copy(continueWatchingItems = updatedItems)
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -252,6 +252,84 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     elapsedMs = SystemClock.elapsedRealtime() - nextUpStartMs
                 )
 
+                // Derive fully-watched series: seeds that have completed episodes
+                // but no next-up episode (CW already resolved this via meta).
+                // Use the FULL (uncapped) nextUpSeeds so the badge persists regardless
+                // of the Continue Watching days-cap setting.
+                val nextUpContentIds = nextUpItems.map { it.info.contentId }.toSet()
+                val inProgressContentIds = inProgressOnly
+                    .map { it.progress }
+                    .filter { isSeriesTypeCW(it.contentType) }
+                    .map { it.contentId }
+                    .toSet()
+                val allSeedContentIds = nextUpSeeds
+                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
+                    .map { it.contentId }
+                    .toSet()
+                // Seeds within the CW window were already resolved by buildLightweightNextUpItems.
+                // For seeds outside the window, check the resolution cache (populated by prior runs).
+                val recentSeedContentIds = recentNextUpSeeds
+                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
+                    .map { it.contentId }
+                    .toSet()
+                val olderSeedContentIds = allSeedContentIds - recentSeedContentIds
+                val olderSeedsWithNextUp = olderSeedContentIds.filter { contentId ->
+                    // If the cache has a non-null resolution, the series has a next episode.
+                    synchronized(cwNextUpResolutionCache) {
+                        cwNextUpResolutionCache.entries.any { (key, value) ->
+                            key.startsWith("$contentId|") && value != null
+                        }
+                    }
+                }.toSet()
+                val newFullyWatched = allSeedContentIds - nextUpContentIds - olderSeedsWithNextUp - inProgressContentIds
+                if (fullyWatchedSeriesIds.value != newFullyWatched) {
+                    fullyWatchedSeriesIds.value = newFullyWatched
+                }
+
+                // For older seeds not yet in the resolution cache, resolve async.
+                // The badge will appear with a slight delay — that's fine.
+                val uncachedOlderSeedIds = olderSeedContentIds.filter { contentId ->
+                    synchronized(cwNextUpResolutionCache) {
+                        cwNextUpResolutionCache.keys.none { it.startsWith("$contentId|") }
+                    }
+                }.toSet()
+                if (uncachedOlderSeedIds.isNotEmpty()) {
+                    val uncachedSeeds = nextUpSeeds
+                        .filter { it.contentId in uncachedOlderSeedIds }
+                        .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null && it.season != 0 }
+                        .filter { shouldUseAsCompletedSeed(it) }
+                        .groupBy { it.contentId }
+                        .mapNotNull { (_, items) -> choosePreferredNextUpSeed(items) }
+                    if (uncachedSeeds.isNotEmpty()) {
+                        launch(Dispatchers.IO) {
+                            val lookupSemaphore = Semaphore(CW_MAX_NEXT_UP_CONCURRENCY)
+                            uncachedSeeds.map { seed ->
+                                async {
+                                    lookupSemaphore.withPermit {
+                                        findNextUpEpisodeFromMetaSeed(
+                                            progress = seed,
+                                            showUnairedNextUp = showUnairedNextUp
+                                        )
+                                    }
+                                    seed.contentId
+                                }
+                            }.awaitAll()
+                            // Re-evaluate after cache is populated.
+                            val updatedOlderWithNextUp = olderSeedContentIds.filter { contentId ->
+                                synchronized(cwNextUpResolutionCache) {
+                                    cwNextUpResolutionCache.entries.any { (key, value) ->
+                                        key.startsWith("$contentId|") && value != null
+                                    }
+                                }
+                            }.toSet()
+                            val updatedFullyWatched = allSeedContentIds - nextUpContentIds - updatedOlderWithNextUp - inProgressContentIds
+                            if (fullyWatchedSeriesIds.value != updatedFullyWatched) {
+                                fullyWatchedSeriesIds.value = updatedFullyWatched
+                            }
+                        }
+                    }
+                }
+
                 debug.markPhase("merge-lightweight")
                 val normalItems = mergeContinueWatchingItems(
                     inProgressItems = inProgressOnly,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -281,28 +281,24 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         }
                     }
                 }.toSet()
-                val newFullyWatched = (allSeedContentIds - nextUpContentIds - olderSeedsWithNextUp - inProgressContentIds)
+                val newFullyWatched = allSeedContentIds
                     .filter { contentId ->
-                        // Verify against meta: a series is only "fully watched" when ALL
-                        // known episodes (including scheduled/unaired) are completed.
+                        // Verify against watched items: the series is only "fully watched"
+                        // when every episode in meta is marked as watched.
                         val cacheKey = "series:$contentId"
                         val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
                             ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                        if (meta == null) return@filter false // no meta cached → don't badge
+                        if (meta == null) return@filter false
 
-                        val airedEpisodes = meta.videos.filter { video ->
-                            video.season != null && video.episode != null && video.season != 0
-                        }
-                        if (airedEpisodes.isEmpty()) return@filter false
+                        val episodes = meta.videos
+                            .filter { it.season != null && it.episode != null && it.season != 0 }
+                        if (episodes.isEmpty()) return@filter false
 
-                        // All episodes from meta must have a completed seed
-                        val completedEpisodes = nextUpSeeds
-                            .filter { it.contentId == contentId && it.season != null && it.episode != null }
-                            .filter { shouldUseAsCompletedSeed(it) }
-                            .map { it.season!! to it.episode!! }
-                            .toSet()
-                        airedEpisodes.all { video ->
-                            (video.season!! to video.episode!!) in completedEpisodes
+                        val watchedEpisodes = watchedItemsPreferences
+                            .getWatchedEpisodesForContent(contentId)
+                            .first()
+                        episodes.all { video ->
+                            (video.season!! to video.episode!!) in watchedEpisodes
                         }
                     }
                     .toSet()
@@ -347,25 +343,22 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                     }
                                 }
                             }.toSet()
-                            val updatedFullyWatched = (allSeedContentIds - nextUpContentIds - updatedOlderWithNextUp - inProgressContentIds)
+                            val updatedFullyWatched = allSeedContentIds
                                 .filter { contentId ->
                                     val cacheKey = "series:$contentId"
                                     val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
                                         ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
                                     if (meta == null) return@filter false
 
-                                    val airedEpisodes = meta.videos.filter { video ->
-                                        video.season != null && video.episode != null && video.season != 0
-                                    }
-                                    if (airedEpisodes.isEmpty()) return@filter false
+                                    val episodes = meta.videos
+                                        .filter { it.season != null && it.episode != null && it.season != 0 }
+                                    if (episodes.isEmpty()) return@filter false
 
-                                    val completedEpisodes = nextUpSeeds
-                                        .filter { it.contentId == contentId && it.season != null && it.episode != null }
-                                        .filter { shouldUseAsCompletedSeed(it) }
-                                        .map { it.season!! to it.episode!! }
-                                        .toSet()
-                                    airedEpisodes.all { video ->
-                                        (video.season!! to video.episode!!) in completedEpisodes
+                                    val watchedEpisodes = watchedItemsPreferences
+                                        .getWatchedEpisodesForContent(contentId)
+                                        .first()
+                                    episodes.all { video ->
+                                        (video.season!! to video.episode!!) in watchedEpisodes
                                     }
                                 }
                                 .toSet()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -300,6 +300,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         .filter { shouldUseAsCompletedSeed(it) }
                         .groupBy { it.contentId }
                         .mapNotNull { (_, items) -> choosePreferredNextUpSeed(items) }
+                        .take(CW_MAX_NEXT_UP_LOOKUPS)
                     if (uncachedSeeds.isNotEmpty()) {
                         launch(Dispatchers.IO) {
                             val lookupSemaphore = Semaphore(CW_MAX_NEXT_UP_CONCURRENCY)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -281,7 +281,31 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         }
                     }
                 }.toSet()
-                val newFullyWatched = allSeedContentIds - nextUpContentIds - olderSeedsWithNextUp - inProgressContentIds
+                val newFullyWatched = (allSeedContentIds - nextUpContentIds - olderSeedsWithNextUp - inProgressContentIds)
+                    .filter { contentId ->
+                        // Verify against meta: a series is only "fully watched" when ALL
+                        // known episodes (including scheduled/unaired) are completed.
+                        val cacheKey = "series:$contentId"
+                        val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
+                            ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
+                        if (meta == null) return@filter false // no meta cached → don't badge
+
+                        val airedEpisodes = meta.videos.filter { video ->
+                            video.season != null && video.episode != null && video.season != 0
+                        }
+                        if (airedEpisodes.isEmpty()) return@filter false
+
+                        // All episodes from meta must have a completed seed
+                        val completedEpisodes = nextUpSeeds
+                            .filter { it.contentId == contentId && it.season != null && it.episode != null }
+                            .filter { shouldUseAsCompletedSeed(it) }
+                            .map { it.season!! to it.episode!! }
+                            .toSet()
+                        airedEpisodes.all { video ->
+                            (video.season!! to video.episode!!) in completedEpisodes
+                        }
+                    }
+                    .toSet()
                 if (fullyWatchedSeriesIds.fullyWatchedSeriesIds.value != newFullyWatched) {
                     fullyWatchedSeriesIds.update(newFullyWatched)
                 }
@@ -323,7 +347,28 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                     }
                                 }
                             }.toSet()
-                            val updatedFullyWatched = allSeedContentIds - nextUpContentIds - updatedOlderWithNextUp - inProgressContentIds
+                            val updatedFullyWatched = (allSeedContentIds - nextUpContentIds - updatedOlderWithNextUp - inProgressContentIds)
+                                .filter { contentId ->
+                                    val cacheKey = "series:$contentId"
+                                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
+                                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
+                                    if (meta == null) return@filter false
+
+                                    val airedEpisodes = meta.videos.filter { video ->
+                                        video.season != null && video.episode != null && video.season != 0
+                                    }
+                                    if (airedEpisodes.isEmpty()) return@filter false
+
+                                    val completedEpisodes = nextUpSeeds
+                                        .filter { it.contentId == contentId && it.season != null && it.episode != null }
+                                        .filter { shouldUseAsCompletedSeed(it) }
+                                        .map { it.season!! to it.episode!! }
+                                        .toSet()
+                                    airedEpisodes.all { video ->
+                                        (video.season!! to video.episode!!) in completedEpisodes
+                                    }
+                                }
+                                .toSet()
                             if (fullyWatchedSeriesIds.fullyWatchedSeriesIds.value != updatedFullyWatched) {
                                 fullyWatchedSeriesIds.update(updatedFullyWatched)
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -101,6 +101,7 @@ fun LibraryScreen(
     onNavigateToDetail: (String, String, String?) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val watchedContentIds by viewModel.watchedContentIds.collectAsState()
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var expandedPicker by remember { mutableStateOf<String?>(null) }
     val primaryFocusRequester = remember { FocusRequester() }
@@ -307,6 +308,7 @@ fun LibraryScreen(
             GridContentCard(
                 item = item.toMetaPreview().copy(posterShape = PosterShape.POSTER),
                 posterCardStyle = posterCardStyle,
+                isWatched = item.id in watchedContentIds,
                 focusRequester = posterFocusRequesters[focusKey],
                 showLabel = true,
                 onFocused = {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -102,7 +102,8 @@ fun LibraryScreen(
     onNavigateToDetail: (String, String, String?) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val watchedContentIds by viewModel.watchedContentIds.collectAsState()
+    val watchedMovieIds by viewModel.watchedMovieIds.collectAsState()
+    val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsState()
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var expandedPicker by remember { mutableStateOf<String?>(null) }
     val primaryFocusRequester = remember { FocusRequester() }
@@ -322,10 +323,11 @@ fun LibraryScreen(
 
         items(uiState.visibleItems, key = { "${it.type}:${it.id}" }) { item ->
             val focusKey = "${item.type}:${item.id}"
+            val isSeries = item.type.equals("series", ignoreCase = true) || item.type.equals("tv", ignoreCase = true)
             GridContentCard(
                 item = item.toMetaPreview().copy(posterShape = PosterShape.POSTER),
                 posterCardStyle = posterCardStyle,
-                isWatched = item.id in watchedContentIds,
+                isWatched = if (isSeries) item.id in watchedSeriesIds else item.id in watchedMovieIds,
                 focusRequester = posterFocusRequesters[focusKey],
                 showLabel = true,
                 onFocused = {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -88,17 +88,29 @@ data class LibraryUiState(
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
-    private val layoutPreferenceDataStore: LayoutPreferenceDataStore
+    private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
+    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LibraryUiState())
     val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
+
+    private val _watchedContentIds = MutableStateFlow<Set<String>>(emptySet())
+    val watchedContentIds: StateFlow<Set<String>> = _watchedContentIds.asStateFlow()
 
     private var messageClearJob: Job? = null
 
     init {
         observeLayoutPreferences()
         observeLibraryData()
+        viewModelScope.launch {
+            kotlinx.coroutines.flow.combine(
+                watchProgressRepository.observeWatchedMovieIds(),
+                watchedSeriesStateHolder.fullyWatchedSeriesIds
+            ) { movieIds, seriesIds -> movieIds + seriesIds }
+                .collect { ids -> _watchedContentIds.value = ids }
+        }
     }
 
     fun onSelectTypeTab(tab: LibraryTypeTab) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -112,8 +112,9 @@ class LibraryViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LibraryUiState())
     val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
 
-    private val _watchedContentIds = MutableStateFlow<Set<String>>(emptySet())
-    val watchedContentIds: StateFlow<Set<String>> = _watchedContentIds.asStateFlow()
+    private val _watchedMovieIds = MutableStateFlow<Set<String>>(emptySet())
+    val watchedMovieIds: StateFlow<Set<String>> = _watchedMovieIds.asStateFlow()
+    val watchedSeriesIds: StateFlow<Set<String>> = watchedSeriesStateHolder.fullyWatchedSeriesIds
 
     private var messageClearJob: Job? = null
 
@@ -121,11 +122,8 @@ class LibraryViewModel @Inject constructor(
         observeLayoutPreferences()
         observeLibraryData()
         viewModelScope.launch {
-            kotlinx.coroutines.flow.combine(
-                watchProgressRepository.observeWatchedMovieIds(),
-                watchedSeriesStateHolder.fullyWatchedSeriesIds
-            ) { movieIds, seriesIds -> movieIds + seriesIds }
-                .collect { ids -> _watchedContentIds.value = ids }
+            watchProgressRepository.observeWatchedMovieIds()
+                .collect { ids -> _watchedMovieIds.value = ids }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -34,6 +34,7 @@ fun DiscoverScreen(
     onNavigateToDetail: (String, String, String) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val watchedContentIds by viewModel.watchedContentIds.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
     val discoverFirstItemFocusRequester = remember { FocusRequester() }
     var discoverFocusedItemIndex by rememberSaveable { mutableStateOf(0) }
@@ -77,6 +78,7 @@ fun DiscoverScreen(
             DiscoverSection(
                 uiState = uiState,
                 posterCardStyle = posterCardStyle,
+                watchedContentIds = watchedContentIds,
                 focusResults = false,
                 firstItemFocusRequester = discoverFirstItemFocusRequester,
                 focusedItemIndex = discoverFocusedItemIndex,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -34,7 +34,8 @@ fun DiscoverScreen(
     onNavigateToDetail: (String, String, String) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val watchedContentIds by viewModel.watchedContentIds.collectAsState()
+    val watchedMovieIds by viewModel.watchedMovieIds.collectAsState()
+    val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
     val discoverFirstItemFocusRequester = remember { FocusRequester() }
     var discoverFocusedItemIndex by rememberSaveable { mutableStateOf(0) }
@@ -78,7 +79,8 @@ fun DiscoverScreen(
             DiscoverSection(
                 uiState = uiState,
                 posterCardStyle = posterCardStyle,
-                watchedContentIds = watchedContentIds,
+                watchedMovieIds = watchedMovieIds,
+                watchedSeriesIds = watchedSeriesIds,
                 focusResults = false,
                 firstItemFocusRequester = discoverFirstItemFocusRequester,
                 focusedItemIndex = discoverFocusedItemIndex,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -69,6 +69,7 @@ import com.nuvio.tv.ui.util.formatAddonTypeLabel
 internal fun DiscoverSection(
     uiState: SearchUiState,
     posterCardStyle: PosterCardStyle,
+    watchedContentIds: Set<String> = emptySet(),
     focusResults: Boolean,
     firstItemFocusRequester: FocusRequester,
     focusedItemIndex: Int,
@@ -206,6 +207,7 @@ internal fun DiscoverSection(
                 DiscoverGrid(
                     items = uiState.discoverResults,
                     posterCardStyle = posterCardStyle,
+                    watchedContentIds = watchedContentIds,
                     focusResults = focusResults,
                     firstItemFocusRequester = firstItemFocusRequester,
                     focusedItemIndex = focusedItemIndex,
@@ -396,6 +398,7 @@ private data class DiscoverOption(
 internal fun DiscoverGrid(
     items: List<MetaPreview>,
     posterCardStyle: PosterCardStyle,
+    watchedContentIds: Set<String> = emptySet(),
     focusResults: Boolean,
     firstItemFocusRequester: FocusRequester,
     focusedItemIndex: Int,
@@ -494,6 +497,7 @@ internal fun DiscoverGrid(
                 item = item,
                 onClick = { onItemClick(index, item) },
                 posterCardStyle = adaptiveStyle,
+                isWatched = item.id in watchedContentIds,
                 modifier = Modifier.width(adaptiveStyle.width),
                 focusRequester = focusReq,
                 onFocused = { onItemFocused(index) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -70,7 +70,8 @@ import com.nuvio.tv.ui.util.localizedGenreLabel
 internal fun DiscoverSection(
     uiState: SearchUiState,
     posterCardStyle: PosterCardStyle,
-    watchedContentIds: Set<String> = emptySet(),
+    watchedMovieIds: Set<String> = emptySet(),
+    watchedSeriesIds: Set<String> = emptySet(),
     focusResults: Boolean,
     firstItemFocusRequester: FocusRequester,
     focusedItemIndex: Int,
@@ -208,7 +209,8 @@ internal fun DiscoverSection(
                 DiscoverGrid(
                     items = uiState.discoverResults,
                     posterCardStyle = posterCardStyle,
-                    watchedContentIds = watchedContentIds,
+                    watchedMovieIds = watchedMovieIds,
+                    watchedSeriesIds = watchedSeriesIds,
                     focusResults = focusResults,
                     firstItemFocusRequester = firstItemFocusRequester,
                     focusedItemIndex = focusedItemIndex,
@@ -399,7 +401,8 @@ private data class DiscoverOption(
 internal fun DiscoverGrid(
     items: List<MetaPreview>,
     posterCardStyle: PosterCardStyle,
-    watchedContentIds: Set<String> = emptySet(),
+    watchedMovieIds: Set<String> = emptySet(),
+    watchedSeriesIds: Set<String> = emptySet(),
     focusResults: Boolean,
     firstItemFocusRequester: FocusRequester,
     focusedItemIndex: Int,
@@ -498,7 +501,10 @@ internal fun DiscoverGrid(
                 item = item,
                 onClick = { onItemClick(index, item) },
                 posterCardStyle = adaptiveStyle,
-                isWatched = item.id in watchedContentIds,
+                isWatched = run {
+                    val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)
+                    if (isSeries) item.id in watchedSeriesIds else item.id in watchedMovieIds
+                },
                 modifier = Modifier.width(adaptiveStyle.width),
                 focusRequester = focusReq,
                 onFocused = { onItemFocused(index) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -93,6 +93,7 @@ fun SearchScreen(
     onOpenDiscover: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val watchedContentIds by viewModel.watchedContentIds.collectAsState()
     val context = LocalContext.current
     val view = LocalView.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -529,6 +530,7 @@ fun SearchScreen(
                                 showAddonName = uiState.catalogAddonNameEnabled,
                                 showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,
                                 enableRowFocusRestorer = false,
+                                isItemWatched = { item -> item.id in watchedContentIds },
                                 focusedItemIndex = if (focusResults && index == 0) 0 else -1,
                                 onItemFocused = {
                                     if (focusResults) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -93,7 +93,8 @@ fun SearchScreen(
     onOpenDiscover: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val watchedContentIds by viewModel.watchedContentIds.collectAsState()
+    val watchedMovieIds by viewModel.watchedMovieIds.collectAsState()
+    val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsState()
     val context = LocalContext.current
     val view = LocalView.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -530,7 +531,10 @@ fun SearchScreen(
                                 showAddonName = uiState.catalogAddonNameEnabled,
                                 showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,
                                 enableRowFocusRestorer = false,
-                                isItemWatched = { item -> item.id in watchedContentIds },
+                                isItemWatched = { item ->
+                                    val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)
+                                    if (isSeries) item.id in watchedSeriesIds else item.id in watchedMovieIds
+                                },
                                 focusedItemIndex = if (focusResults && index == 0) 0 else -1,
                                 onItemFocused = {
                                     if (focusResults) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -31,11 +31,16 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     private val addonRepository: AddonRepository,
     private val catalogRepository: CatalogRepository,
-    private val layoutPreferenceDataStore: LayoutPreferenceDataStore
+    private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
+    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
+
+    private val _watchedContentIds = MutableStateFlow<Set<String>>(emptySet())
+    val watchedContentIds: StateFlow<Set<String>> = _watchedContentIds.asStateFlow()
 
     private val catalogsMap = linkedMapOf<String, CatalogRow>()
     private val catalogOrder = mutableListOf<String>()
@@ -57,6 +62,13 @@ class SearchViewModel @Inject constructor(
     }
 
     init {
+        viewModelScope.launch {
+            kotlinx.coroutines.flow.combine(
+                watchProgressRepository.observeWatchedMovieIds(),
+                watchedSeriesStateHolder.fullyWatchedSeriesIds
+            ) { movieIds, seriesIds -> movieIds + seriesIds }
+                .collect { ids -> _watchedContentIds.value = ids }
+        }
         viewModelScope.launch {
             layoutPreferenceDataStore.searchDiscoverEnabled.collectLatest { enabled ->
                 _uiState.update { it.copy(discoverEnabled = enabled) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -39,8 +39,9 @@ class SearchViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
-    private val _watchedContentIds = MutableStateFlow<Set<String>>(emptySet())
-    val watchedContentIds: StateFlow<Set<String>> = _watchedContentIds.asStateFlow()
+    private val _watchedMovieIds = MutableStateFlow<Set<String>>(emptySet())
+    val watchedMovieIds: StateFlow<Set<String>> = _watchedMovieIds.asStateFlow()
+    val watchedSeriesIds: StateFlow<Set<String>> = watchedSeriesStateHolder.fullyWatchedSeriesIds
 
     private val catalogsMap = linkedMapOf<String, CatalogRow>()
     private val catalogOrder = mutableListOf<String>()
@@ -63,11 +64,8 @@ class SearchViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            kotlinx.coroutines.flow.combine(
-                watchProgressRepository.observeWatchedMovieIds(),
-                watchedSeriesStateHolder.fullyWatchedSeriesIds
-            ) { movieIds, seriesIds -> movieIds + seriesIds }
-                .collect { ids -> _watchedContentIds.value = ids }
+            watchProgressRepository.observeWatchedMovieIds()
+                .collect { ids -> _watchedMovieIds.value = ids }
         }
         viewModelScope.launch {
             layoutPreferenceDataStore.searchDiscoverEnabled.collectLatest { enabled ->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1154,4 +1154,40 @@
     <string name="update_checking">Sprawdzanie aktualizacji…</string>
     <string name="update_download_complete">Pobieranie zakończone. Gotowe do instalacji.</string>
     <string name="update_up_to_date">System jest aktualny. Ostatnie zmiany:</string>
+
+    <string name="detail_more_like_this_powered_by_tmdb">Na podstawie danych TMDB</string>
+    <string name="detail_more_like_this_powered_by_trakt">Na podstawie danych Trakt</string>
+    <string name="library_filter_genre">Gatunek</string>
+    <string name="library_filter_year">Rok</string>
+    <string name="library_source_nuvio">NUVIO</string>
+    <string name="library_source_trakt">TRAKT</string>
+    <string name="library_syncing_library">Synchronizacja biblioteki\u2026</string>
+
+    <string name="genre_action">Akcja</string>
+    <string name="genre_action_adventure">Akcja i przygoda</string>
+    <string name="genre_adventure">Przygodowy</string>
+    <string name="genre_animation">Animacja</string>
+    <string name="genre_comedy">Komedia</string>
+    <string name="genre_crime">Kryminał</string>
+    <string name="genre_documentary">Dokumentalny</string>
+    <string name="genre_drama">Dramat</string>
+    <string name="genre_family">Familijny</string>
+    <string name="genre_fantasy">Fantasy</string>
+    <string name="genre_history">Historyczny</string>
+    <string name="genre_horror">Horror</string>
+    <string name="genre_kids">Dla dzieci</string>
+    <string name="genre_music">Muzyczny</string>
+    <string name="genre_mystery">Tajemnica</string>
+    <string name="genre_news">Wiadomości</string>
+    <string name="genre_reality">Reality</string>
+    <string name="genre_romance">Romans</string>
+    <string name="genre_science_fiction">Sci-Fi</string>
+    <string name="genre_sci_fi_fantasy">Sci-Fi i fantasy</string>
+    <string name="genre_soap">Telenowela</string>
+    <string name="genre_talk">Talk-show</string>
+    <string name="genre_thriller">Thriller</string>
+    <string name="genre_tv_movie">Film TV</string>
+    <string name="genre_war">Wojenny</string>
+    <string name="genre_war_politics">Wojna i polityka</string>
+    <string name="genre_western">Western</string>
 </resources>


### PR DESCRIPTION
## Summary

Two related improvements to series tracking on the home screen:

1. Show the "watched" badge (checkmark) on series posters when all known episodes are completed.
2. Surface old series with new episodes/seasons in Continue Watching, even if they fall outside the days-cap window.

Additionally:
- Watched badges now appear on all screens: Home, Discover, Library, Search results, and Catalog See All grid.
- Fixed unmarking a single episode on Trakt briefly showing the entire season as unwatched.
- Fixed "next to watch" showing wrong episode when all episodes were bulk-marked as watched on the same date.

## PR type

- Bug fix
- Small maintenance improvement

## Why

The watched badge pipeline on home (`movieWatchedStatus`) was hardcoded to filter only `apiType == "movie"`. Series never received a badge, even when fully watched.

Additionally, series completed longer ago than the CW days-cap (e.g. 30 days) were invisible - if a new season dropped, the user had no way to know from the home screen.

Watched badges were also missing from Discover, Library, Search, and Catalog See All screens entirely.

### How it works

**Watched badge:** After the CW pipeline resolves next-up episodes, we check each series with completed seeds against `watchedItemsPreferences` and meta from `cwMetaCache`. A series is "fully watched" when every non-special episode in meta is present in `watchedItemsPreferences`. This is independent of CW next-up resolution - it doesn't matter if CW thinks there's a next episode due to timestamp quirks or rewatching a show

**Cross-screen sharing:** Movie watched status comes from `WatchProgressRepository.observeWatchedMovieIds()` (available to all ViewModels). Series watched status comes from `WatchedSeriesStateHolder` (a `@Singleton` populated by HomeViewModel's CW pipeline). Each ViewModel combines both flows.

**Async resolution for older seeds:** Seeds within the CW days-cap window are already resolved by the normal CW cycle. For older seeds:

1. **Cache hit** - if a prior CW cycle already resolved the seed, meta lives in `cwMetaCache`. Badge is applied immediately.
2. **Cache miss** - an async meta lookup fires in the background using `buildNextUpItem` (capped at 15 per cycle). If a next-up IS found (e.g. new season), the item is injected into the CW row with existing New Season / New Episode badges.
3. **Subsequent loads** - cache is warm, everything is instant.

This means a user who finished a series 6 months ago will see:
- A watched badge on the poster if no new episodes exist
- The series reappearing in CW with a "New Season" badge if new episodes dropped

**Trakt cold start fix:** `TraktProgressService.observeAllWatchedMovieIds()` now triggers an initial fetch via `onStart` in a non-cancellable scope, so watched movie data is available immediately on app launch.

**Badge stability fix:** Removed `movieWatchedStatus` trimming from catalog reconciliation and switched movie/series batch jobs to merge-based updates, preventing the two from overwriting each other.

**Trakt episode unmark fix:** `removeFromHistory` now optimistically removes only the target episode from the episode progress cache instead of invalidating the entire series cache, which caused all episodes to briefly appear unwatched.

**Bulk-watched next-to-watch fix:** `calculateNextToWatch` now uses season/episode as tiebreaker when multiple episodes share the same `lastWatched` timestamp, so the last episode in order is correctly identified.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified badge appears on series poster after completing all episodes.
- Manual: verified badge persists when rewatching an episode (in-progress rewatch does not remove badge).
- Manual: verified badge disappears when unmarking any episode as unwatched.
- Manual: verified badge reappears when re-marking the episode as watched.
- Manual: verified badge persists for series watched longer ago than the CW days-cap setting.
- Manual: verified series in progress (not all episodes aired yet) do not get badge.
- Manual: verified marking a single episode as watched does not badge the entire series.
- Manual: verified older series with a new season appear in CW with "New Season" badge after async resolution.
- Manual: verified movie badge behavior is unchanged.
- Manual: verified badges appear on Discover, Library, Search results, and Catalog See All screens.
- Manual: verified Trakt users see movie badges immediately on cold start without visiting detail page.
- Manual: verified badges do not flicker when navigating between home and detail screens.
- Manual: verified unmarking a single episode on Trakt does not briefly show entire season as unwatched.
- Manual: verified "next to watch" shows correct episode after bulk-marking all episodes as watched.
- Tested with Trakt users with large libraries via test builds.
- Tested with Nuvio Sync users with large libraries via test builds.

## Screenshots / Video (UI changes only)

Uses existing CheckCircle badge for watched, existing New Season / New Episode badges for CW items.

## Breaking changes

Nothing should break

## Linked issues

Surprisingly, no one reported missing watched checkmark. I saw some mentions here and there on discord though
