### PR TITLE
fix(profile): localize hardcoded edit title and cleanup unused strings

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -1374,7 +1374,7 @@ private fun EditProfileOverlay(
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
-                        text = "Edit Profile",
+                        text = stringResource(R.string.profile_edit_title),
                         color = NuvioColors.TextSecondary,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.SemiBold

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -671,7 +671,7 @@
     <string name="profile_edit_label">Editar</string>
     <string name="profile_add">Agregar perfil</string>
     <string name="profile_create_title">Crear perfil</string>
-    <string name="profile_edit_title">Editar perfil %1$s</string>
+    <string name="profile_edit_title">Editar perfil</string>
     <string name="profile_name_placeholder">Nombre del perfil</string>
     <string name="profile_avatar_color">Color del avatar</string>
     <string name="profile_use_primary_addons">Usar los addons del perfil principal</string>
@@ -1093,9 +1093,6 @@
     <string name="plugin_enabled">Habilitado</string>
     <string name="plugin_disabled">Deshabilitado</string>
     <string name="plugin_no_repos">No se han añadido repositorios aún.\nAñade un repositorio para empezar.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Editar Perfil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">El passthrough de audio (TrueHD, DTS, AC-3, etc.) es automático. Al conectarlo a un receptor AV o barra de sonido compatible mediante HDMI, el audio sin pérdida se envía tal cual sin decodificarse.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -582,7 +582,7 @@
     <string name="profile_edit_label">Upravit</string>
     <string name="profile_add">Přidat profil</string>
     <string name="profile_create_title">Vytvořit profil</string>
-    <string name="profile_edit_title">Upravit profil %1$s</string>
+    <string name="profile_edit_title">Upravit profil</string>
     <string name="profile_name_placeholder">Název profilu</string>
     <string name="profile_avatar_color">Barva avatara</string>
     <string name="profile_use_primary_addons">Použít doplňky primárního profilu</string>
@@ -927,8 +927,6 @@
     <string name="plugin_enabled">Povoleno</string>
     <string name="plugin_disabled">Zakázáno</string>
     <string name="plugin_no_repos">Zatím nebyly přidány žádné repozitáře.\nPřidejte repozitář pro začátek.</string>
-
-    <string name="profile_edit_title_id">Upravit profil %1$d</string>
 
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3 atd.) je automatický. Při připojení ke kompatibilnímu AV přijímači nebo soundbaru přes HDMI se bezztrátové audio odesílá bez dekódování.</string>
     <string name="audio_dv_title">DV7 - HEVC Fallback</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -611,7 +611,7 @@
     <string name="profile_edit_label">Bearbeiten</string>
     <string name="profile_add">Profil hinzufügen</string>
     <string name="profile_create_title">Profil erstellen</string>
-    <string name="profile_edit_title">Profil bearbeiten %1$s</string>
+    <string name="profile_edit_title">Profil bearbeiten</string>
     <string name="profile_name_placeholder">Profilname</string>
     <string name="profile_avatar_color">Avatar-Farbe</string>
     <string name="profile_use_primary_addons">Add-ons des primären Profils verwenden</string>
@@ -987,9 +987,6 @@
     <string name="plugin_enabled">Aktiviert</string>
     <string name="plugin_disabled">Deaktiviert</string>
     <string name="plugin_no_repos">Es wurden noch keine Repositorys hinzugefügt.\nFügen Sie ein Repository hinzu, um zu beginnen.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Profil bearbeiten %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio-Passthrough (TrueHD, DTS, AC-3 usw.) erfolgt automatisch. Bei Anschluss an einen kompatiblen AV-Receiver oder eine Soundbar über HDMI wird verlustfreies Audio ohne Dekodierung und unverändert übertragen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -488,7 +488,7 @@
     <string name="profile_edit_label">Editar</string>
     <string name="profile_add">Añadir perfil</string>
     <string name="profile_create_title">Crear perfil</string>
-    <string name="profile_edit_title">Editar perfil %1$s</string>
+    <string name="profile_edit_title">Editar perfil</string>
     <string name="profile_name_placeholder">Nombre del perfil</string>
     <string name="profile_avatar_color">Color del avatar</string>
     <string name="profile_use_primary_addons">Usar complementos del perfil principal</string>
@@ -821,9 +821,6 @@
     <string name="plugin_enabled">Habilitado</string>
     <string name="plugin_disabled">Deshabilitado</string>
     <string name="plugin_no_repos">Sin repositorios añadidos aún.\nAñade un repositorio para empezar.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Editar perfil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">El audio pasthrough (TrueHD, DTS, AC-3, etc.) es automático. Cuando está conectado a un receptor AV o barra de sonido compatible vía HDMI, el audio sin pérdida se envía tal cual sin decodificación.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -677,7 +677,7 @@
     <string name="profile_edit_label">Modifier</string>
     <string name="profile_add">Ajouter un profil</string>
     <string name="profile_create_title">Créer un profil</string>
-    <string name="profile_edit_title">Modifier le profil %1$s</string>
+    <string name="profile_edit_title">Modifier le profil</string>
     <string name="profile_name_placeholder">Nom du profil</string>
     <string name="profile_avatar_color">Couleur de l\'avatar</string>
     <string name="profile_use_primary_addons">Utiliser les addons du profil principal</string>
@@ -1099,9 +1099,6 @@
     <string name="plugin_enabled">Activé</string>
     <string name="plugin_disabled">Désactivé</string>
     <string name="plugin_no_repos">Aucun dépôt ajouté pour le moment.\nAjoutez un dépôt pour commencer.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Modifier le profil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Le passthrough audio (TrueHD, DTS, AC-3, etc.) est automatique. Lorsqu\'il est connecté à un récepteur AV ou une barre de son compatible via HDMI, l\'audio sans perte est envoyé tel quel sans décodage.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -601,7 +601,7 @@
     <string name="profile_edit_label">संपादित करें</string>
     <string name="profile_add">प्रोफाइल जोड़ें</string>
     <string name="profile_create_title">प्रोफाइल बनाएँ</string>
-    <string name="profile_edit_title">प्रोफाइल संपादित करें %1$s</string>
+    <string name="profile_edit_title">प्रोफाइल संपादित करें</string>
     <string name="profile_name_placeholder">प्रोफाइल नाम</string>
     <string name="profile_avatar_color">अवतार रंग</string>
     <string name="profile_use_primary_addons">प्राइमरी प्रोफाइल के ऐडऑन उपयोग करें</string>
@@ -976,9 +976,6 @@
     <string name="plugin_enabled">सक्षम</string>
     <string name="plugin_disabled">अक्षम</string>
     <string name="plugin_no_repos">अभी तक कोई रिपॉजिटरी नहीं जोड़ी गई।\nशुरू करने के लिए एक रिपॉजिटरी जोड़ें।</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">प्रोफाइल संपादित करें %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">ऑडियो पासथ्रू (TrueHD, DTS, AC-3 आदि) स्वचालित है। HDMI के माध्यम से संगत AV रिसीवर या साउंडबार से जुड़ने पर लॉसलेस ऑडियो बिना डिकोड किए सीधे भेजा जाता है।</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -638,7 +638,7 @@
     <string name="profile_edit_label">Szerkesztés</string>
     <string name="profile_add">Profil hozzáadása</string>
     <string name="profile_create_title">Profil létrehozása</string>
-    <string name="profile_edit_title">%1$s profil szerkesztése</string>
+    <string name="profile_edit_title">Profil szerkesztése</string>
     <string name="profile_name_placeholder">Profil neve</string>
     <string name="profile_avatar_color">Avatar színe</string>
     <string name="profile_use_primary_addons">Elsődleges profil bővítményeinek használata</string>
@@ -1029,9 +1029,6 @@
     <string name="plugin_enabled">Engedélyezve</string>
     <string name="plugin_disabled">Letiltva</string>
     <string name="plugin_no_repos">Nincsenek hozzáadott adattárak.\nAdj hozzá egyet a kezdéshez.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">%1$d. profil szerkesztése</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">A hangátvitel (passthrough – TrueHD, DTS, AC-3 stb.) automatikus. Kompatibilis erősítőhöz vagy soundbarhoz HDMI-n csatlakozva a veszteségmentes hang dekódolás nélkül továbbítódik.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -669,7 +669,7 @@
     <string name="profile_edit_label">Modifica</string>
     <string name="profile_add">Aggiungi profilo</string>
     <string name="profile_create_title">Crea profilo</string>
-    <string name="profile_edit_title">Modifica profilo %1$s</string>
+    <string name="profile_edit_title">Modifica profilo</string>
     <string name="profile_name_placeholder">Nome profilo</string>
     <string name="profile_avatar_color">Colore avatar</string>
     <string name="profile_use_primary_addons">Usa gli addon del profilo principale</string>
@@ -1090,11 +1090,8 @@
     <string name="plugin_enabled">Abilitato</string>
     <string name="plugin_disabled">Disabilitato</string>
     <string name="plugin_no_repos">Nessuna repository ancora aggiunta.\nAggiungi una repository per iniziare.</string>
-    
-    <!-- ProfileSettingsContent -->
-   <string name="profile_edit_title_id">Modifica profilo %1$d</string>
 
-    <!-- PlaybackAudioSettings -->
+ <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Il passthrough audio (TrueHD, DTS, AC-3, ecc.) è automatico. Se collegato a un ricevitore AV o soundbar compatibile tramite HDMI, l\'audio lossless viene inviato così com\'è senza decodifica.</string>
     <string name="audio_dv_title">DV7 - HEVC Fallback</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -615,7 +615,7 @@
     <string name="profile_edit_label">編集</string>
     <string name="profile_add">プロフィールを追加</string>
     <string name="profile_create_title">プロフィールを作成</string>
-    <string name="profile_edit_title">プロフィール%1$sを編集</string>
+    <string name="profile_edit_title">プロフィールを編集</string>
     <string name="profile_name_placeholder">プロフィール名</string>
     <string name="profile_avatar_color">アバターカラー</string>
     <string name="profile_use_primary_addons">プライマリプロフィールのアドオンを使用</string>
@@ -1001,9 +1001,6 @@
     <string name="plugin_enabled">有効</string>
     <string name="plugin_disabled">無効</string>
     <string name="plugin_no_repos">リポジトリはまだ追加されていません。\nリポジトリを追加して始めましょう</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">プロフィール%1$dを編集</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">音声パススルー（TrueHD、DTS、AC-3など）は自動です。HDMI経由で対応するAVレシーバーやサウンドバーに接続している場合、ロスレスオーディオはデコードされずにそのまま送信されます</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -611,7 +611,7 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="profile_edit_label">Redaguoti</string>
     <string name="profile_add">Pridėti profilį</string>
     <string name="profile_create_title">Sukurti profilį</string>
-    <string name="profile_edit_title">Redaguoti profilį %1$s</string>
+    <string name="profile_edit_title">Redaguoti profilį</string>
     <string name="profile_name_placeholder">Profilio pavadinimas</string>
     <string name="profile_avatar_color">Avataro spalva</string>
     <string name="profile_use_primary_addons">Naudoti pagrindinio profilio priedus</string>
@@ -987,9 +987,6 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="plugin_enabled">Įjungta</string>
     <string name="plugin_disabled">Išjungta</string>
     <string name="plugin_no_repos">Repozitorijų nerasta</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Redaguoti profilį #%1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Garso pralaidumas tiesiogiai į jūsų garso sistemą</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -517,7 +517,7 @@
 <string name="profile_edit_label">Bewerken</string>
 <string name="profile_add">Profiel toevoegen</string>
 <string name="profile_create_title">Profiel aanmaken</string>
-<string name="profile_edit_title">Profiel %1$s bewerken</string>
+<string name="profile_edit_title">Profiel bewerken</string>
 <string name="profile_name_placeholder">Profielnaam</string>
 <string name="profile_avatar_color">Avatarkleur</string>
 <string name="profile_use_primary_addons">Addons van het primaire profiel gebruiken</string>
@@ -849,10 +849,7 @@
 <string name="plugin_disabled">Uitgeschakeld</string>
 <string name="plugin_no_repos">Nog geen repositories toegevoegd.\nVoeg een repository toe om te beginnen.</string>
 
-<!-- ProfileSettingsContent -->
-<string name="profile_edit_title_id">Profiel %1$d bewerken</string>
-
-<!-- PlaybackAudioSettings -->
+    <!-- PlaybackAudioSettings -->
 <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, enz.) is automatisch. Wanneer aangesloten op een compatibele AV-receiver of soundbar via HDMI, wordt lossless audio direct doorgestuurd zonder decodering.</string>
 <string name="audio_dv_title">DV7 - HEVC fallback</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -534,7 +534,7 @@
     <string name="profile_edit_label">Edytuj</string>
     <string name="profile_add">Dodaj profil</string>
     <string name="profile_create_title">Utwórz profil</string>
-    <string name="profile_edit_title">Edytuj profil %1$s</string>
+    <string name="profile_edit_title">Edytuj profil</string>
     <string name="profile_name_placeholder">Nazwa profilu</string>
     <string name="profile_avatar_color">Kolor awatara</string>
     <string name="profile_use_primary_addons">Używaj dodatków profilu głównego</string>
@@ -936,9 +936,6 @@
     <string name="plugin_enabled">Wlaczone</string>
     <string name="plugin_disabled">Wylaczone</string>
     <string name="plugin_no_repos">Nie dodano zadnych repozytoriow.\nDodaj repozytorium, aby zaczac.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Edytuj profil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Przepuszczanie audio (TrueHD, DTS, AC-3 itp.) jest automatyczne. Po podlaczeniu do kompatybilnego amplitunera lub soundbara przez HDMI, bezstratne audio jest przesylane bez dekodowania.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -679,7 +679,7 @@
     <string name="profile_edit_label">Editar</string>
     <string name="profile_add">Adicionar Perfil</string>
     <string name="profile_create_title">Criar Perfil</string>
-    <string name="profile_edit_title">Editar Perfil %1$s</string>
+    <string name="profile_edit_title">Editar Perfil</string>
     <string name="profile_name_placeholder">Nome do perfil</string>
     <string name="profile_avatar_color">Cor do Avatar</string>
     <string name="profile_use_primary_addons">Usar addons do perfil principal</string>
@@ -1101,11 +1101,8 @@
     <string name="plugin_enabled">Ativado</string>
     <string name="plugin_disabled">Desativado</string>
     <string name="plugin_no_repos">Nenhum repositório adicionado.\nAdicione um para começar.</string>
-    
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Editar Perfil %1$d</string>
 
-    <!-- PlaybackAudioSettings -->
+      <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">A passagem direta de áudio (passthrough) para TrueHD, DTS e AC-3 é automática. Se sua Soundbar/Receiver for compatível via HDMI, o áudio será enviado sem perdas e sem decodificação prévia.</string>
     <string name="audio_dv_title">DV7 - Modo HEVC Alternativo</string>
 

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -642,7 +642,7 @@
     <string name="profile_edit_label">Editar</string>
     <string name="profile_add">Adicionar Perfil</string>
     <string name="profile_create_title">Criar Perfil</string>
-    <string name="profile_edit_title">Editar Perfil %1$s</string>
+    <string name="profile_edit_title">Editar Perfil</string>
     <string name="profile_name_placeholder">Nome do perfil</string>
     <string name="profile_avatar_color">Cor do Avatar</string>
     <string name="profile_use_primary_addons">Usar addons do perfil principal</string>
@@ -1031,9 +1031,6 @@
     <string name="plugin_enabled">Ativado</string>
     <string name="plugin_disabled">Desativado</string>
     <string name="plugin_no_repos">Nenhum repositório adicionado.\nAdiciona um para começar.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Editar Perfil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">O passthrough de áudio (TrueHD, DTS, AC-3, etc.) é automático. Quando ligado a um recetor AV ou soundbar compatível via HDMI, o áudio lossless é enviado sem descodificação.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -488,7 +488,7 @@
     <string name="profile_edit_label">Editează</string>
     <string name="profile_add">Adaugă profil</string>
     <string name="profile_create_title">Creează profil</string>
-    <string name="profile_edit_title">Editează profilul %1$s</string>
+    <string name="profile_edit_title">Editează profilul</string>
     <string name="profile_name_placeholder">Nume profil</string>
     <string name="profile_avatar_color">Culoare avatar</string>
     <string name="profile_use_primary_addons">Folosește suplimentele profilului principal</string>
@@ -821,9 +821,6 @@
     <string name="plugin_enabled">Activat</string>
     <string name="plugin_disabled">Dezactivat</string>
     <string name="plugin_no_repos">Nu au fost adăugate încă depozite.\nAdăugați un depozit pentru a începe.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Editați profilul %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Passthrough audio (TrueHD, DTS, AC-3, etc.) este automat. Când este conectat la un receptor AV compatibil sau soundbar prin HDMI, audio lossless este trimis așa cum este, fără decodare.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -446,7 +446,7 @@
     <string name="profile_edit_label">Upraviť</string>
     <string name="profile_add">Pridať profil</string>
     <string name="profile_create_title">Vytvoriť profil</string>
-    <string name="profile_edit_title">Upraviť profil %1$s</string>
+    <string name="profile_edit_title">Upraviť profil</string>
     <string name="profile_name_placeholder">Názov profilu</string>
     <string name="profile_avatar_color">Farba avatara</string>
     <string name="profile_use_primary_addons">Použiť doplnky primárneho profilu</string>
@@ -718,9 +718,6 @@
     <string name="plugin_enabled">Povolené</string>
     <string name="plugin_disabled">Zakázané</string>
     <string name="plugin_no_repos">Zatiaľ neboli pridané žiadne repozitáre.\nPridajte repozitár pre začiatok.</string>
-
-    <!-- ProfileSettingsContent (extra) -->
-    <string name="profile_edit_title_id">Upraviť profil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3 atď.) je automatický. Pri pripojení k kompatibilnému AV prijímaču alebo soundbaru cez HDMI sa bezstratové audio odosiela bez dekódovania.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -638,7 +638,7 @@
     <string name="profile_edit_label">Uredi</string>
     <string name="profile_add">Dodaj profil</string>
     <string name="profile_create_title">Ustvari profil</string>
-    <string name="profile_edit_title">Uredi profil %1$s</string>
+    <string name="profile_edit_title">Uredi profil</string>
     <string name="profile_name_placeholder">Ime profila</string>
     <string name="profile_avatar_color">Barva avatarja</string>
     <string name="profile_use_primary_addons">Uporabi dodatke glavnega profila</string>
@@ -1033,9 +1033,6 @@
     <string name="plugin_enabled">Omogočeno</string>
     <string name="plugin_disabled">Onemogočeno</string>
     <string name="plugin_no_repos">Ni še dodanih repozitorijev.\nDodajte repozitorij za začetek.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Uredi profil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Prehod zvoka (TrueHD, DTS, AC-3 itd.) je samodejen. Ob povezavi z združljivim AV sprejemnikom ali zvočno vrstico prek HDMI se zvok brez izgub pošlje nespremenjen, brez dekodiranja.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -608,7 +608,7 @@
     <string name="profile_edit_label">Redigera</string>
     <string name="profile_add">Lägg till profil</string>
     <string name="profile_create_title">Skapa profil</string>
-    <string name="profile_edit_title">Redigera profil %1$s</string>
+    <string name="profile_edit_title">Redigera profil</string>
     <string name="profile_name_placeholder">Profilnamn</string>
     <string name="profile_avatar_color">Avatarfärg</string>
     <string name="profile_use_primary_addons">Använd primärprofilens tillägg</string>
@@ -993,9 +993,6 @@
     <string name="plugin_enabled">Aktiverad</string>
     <string name="plugin_disabled">Inaktiverad</string>
     <string name="plugin_no_repos">Inga arkiv tillagda ännu.\nLägg till ett arkiv för att komma igång.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Redigera profil %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Ljudgenomströmning (TrueHD, DTS, AC-3, etc.) är automatisk. När enheten är ansluten till en kompatibel AV-receiver eller soundbar via HDMI skickas förlustfritt ljud som det är utan avkodning.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -658,7 +658,7 @@
     <string name="profile_edit_label">Düzenle</string>
     <string name="profile_add">Profil Ekle</string>
     <string name="profile_create_title">Profil Oluştur</string>
-    <string name="profile_edit_title">Profili Düzenle: %1$s</string>
+    <string name="profile_edit_title">Profili Düzenle</string>
     <string name="profile_name_placeholder">Profil Adı</string>
     <string name="profile_avatar_color">Avatar Rengi</string>
     <string name="profile_use_primary_addons">Birincil profilin eklentilerini kullan</string>
@@ -1049,9 +1049,6 @@
     <string name="plugin_enabled">Etkin</string>
     <string name="plugin_disabled">Devre Dışı</string>
     <string name="plugin_no_repos">Henüz depo eklenmedi.\nBaşlamak için bir depo ekleyin.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Profili Düzenle: %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Yüksek kaliteli ses geçidi (TrueHD, DTS, AC-3) desteklenen HDMI veya uyumlu ses alıcı / arayüz bar donanımlarına bağlanıldığında yazılımın çözümüne bırakılmadan direkt doğrudan iletilir.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -522,7 +522,7 @@
     <string name="profile_edit_label">Chỉnh sửa</string>
     <string name="profile_add">Thêm hồ sơ</string>
     <string name="profile_create_title">Tạo hồ sơ</string>
-    <string name="profile_edit_title">Chỉnh sửa hồ sơ %1$s</string>
+    <string name="profile_edit_title">Chỉnh sửa hồ sơ</string>
     <string name="profile_name_placeholder">Tên hồ sơ</string>
     <string name="profile_avatar_color">Màu avatar</string>
     <string name="profile_use_primary_addons">Dùng addon của hồ sơ chính</string>
@@ -869,9 +869,6 @@
     <string name="plugin_enabled">Đã bật</string>
     <string name="plugin_disabled">Đã tắt</string>
     <string name="plugin_no_repos">Chưa thêm kho lưu trữ nào.\nThêm kho lưu trữ để bắt đầu.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Chỉnh sửa hồ sơ %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3...) là tự động. Khi kết nối với bộ khuếch đại AV hoặc soundbar tương thích qua HDMI, âm thanh lossless được truyền nguyên vẹn mà không giải mã.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,7 +679,7 @@
     <string name="profile_edit_label">Edit</string>
     <string name="profile_add">Add Profile</string>
     <string name="profile_create_title">Create Profile</string>
-    <string name="profile_edit_title">Edit Profile %1$s</string>
+    <string name="profile_edit_title">Edit Profile</string>
     <string name="profile_name_placeholder">Profile name</string>
     <string name="profile_avatar_color">Avatar Color</string>
     <string name="profile_use_primary_addons">Use primary profile\'s addons</string>
@@ -1121,9 +1121,6 @@
     <string name="plugin_enabled">Enabled</string>
     <string name="plugin_disabled">Disabled</string>
     <string name="plugin_no_repos">No repositories added yet.\nAdd a repository to get started.</string>
-
-    <!-- ProfileSettingsContent -->
-    <string name="profile_edit_title_id">Edit Profile %1$d</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, etc.) is automatic. When connected to a compatible AV receiver or soundbar via HDMI, lossless audio is sent as-is without decoding.</string>


### PR DESCRIPTION
## Summary
The profile modification screen was displaying a hardcoded title in the code. This PR fixes the localization by using an existing but unreferenced string resource and performs a thorough cleanup of XML files across all languages.

## PR type
- Bug fix
- Small maintenance improvement
- Translation update

## Why
The title was previously locked in English because it was not linked to the Android resource system. This change allows the title to be displayed in the user's system language.

## Policy check
- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.

## Testing
Manual Test: Verified on-device using Android Studio Debug mode; the title now correctly follows the system language.

Reference Check: Manually searched the codebase and confirmed that neither profile_edit_title_id nor the section header were referenced before this PR.

## Screenshots / Video (UI changes only)
<img width="1920" height="1080" alt="Before" src="https://github.com/user-attachments/assets/e00db9fd-0b9a-4773-8042-0d36101503c1" />
<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/dd1ed85c-d2e3-4606-9779-5118b936373c" />

## Breaking changes
None.

## Linked issues
None.