### PR TITLE
Fix forced subtitle selection logic (match by audio language + label)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -174,6 +174,8 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
         audioTracks = audioTracks,
         subtitleTracks = subtitleTracks
     )
+    // Forced subtitle autoselect (runs before normal auto-sub)
+    trySelectForcedSubtitleIfRequested()
     tryAutoSelectPreferredSubtitleFromAvailableTracks()
     maybeAdjustLibassPipelineForTracks(tracks)
 }
@@ -769,3 +771,85 @@ internal fun PlayerRuntimeController.applySubtitlePreferences(preferred: String,
         player.trackSelectionParameters = builder.build()
     }
 }
+
+internal fun PlayerRuntimeController.trySelectForcedSubtitleIfRequested() {
+    val preferred = _uiState.value.subtitleStyle.preferredLanguage.lowercase()
+    if (preferred != SUBTITLE_LANGUAGE_FORCED) return
+    if (autoSubtitleSelected) return
+
+    val state = _uiState.value
+    val tracks = state.subtitleTracks
+    if (tracks.isEmpty()) return
+
+
+    val audioLangCode = state.audioTracks
+        .getOrNull(state.selectedAudioTrackIndex)
+        ?.language
+        ?.lowercase()
+
+    if (audioLangCode.isNullOrBlank()) {
+
+        autoSubtitleSelected = true
+        disableSubtitles()
+        _uiState.update {
+            it.copy(
+                selectedSubtitleTrackIndex = -1,
+                selectedAddonSubtitle = null
+            )
+        }
+        return
+    }
+
+
+    val audioLangName = languageCodeToName(audioLangCode)?.lowercase()
+
+    fun matchesAudioLanguage(track: TrackInfo): Boolean {
+        val trackLangCode = track.language?.lowercase()
+        val trackName = track.name.lowercase()
+
+        // Match by language code if present
+        if (!trackLangCode.isNullOrBlank()) {
+            if (PlayerSubtitleUtils.matchesLanguageCode(trackLangCode, audioLangCode)) {
+                return true
+            }
+        }
+
+        // Match by human-readable language name in the track name, e.g. "English [Forced]"
+        if (!audioLangName.isNullOrBlank() && trackName.contains(audioLangName)) {
+            return true
+        }
+
+        return false
+    }
+
+    // 3. Find a forced subtitle that matches the audio language
+    val matchingForcedIndex = tracks.indexOfFirst { track ->
+        track.isForced && matchesAudioLanguage(track)
+    }
+
+    if (matchingForcedIndex >= 0) {
+        autoSubtitleSelected = true
+        selectSubtitleTrack(matchingForcedIndex)
+        _uiState.update {
+            it.copy(
+                selectedSubtitleTrackIndex = matchingForcedIndex,
+                selectedAddonSubtitle = null
+            )
+        }
+        return
+    }
+
+    // 4. No matching forced subtitle → disable subtitles
+    autoSubtitleSelected = true
+    disableSubtitles()
+    _uiState.update {
+        it.copy(
+            selectedSubtitleTrackIndex = -1,
+            selectedAddonSubtitle = null
+        )
+    }
+}
+
+
+
+


### PR DESCRIPTION
## Summary

A forced subtitle is selected only if:

It is marked as forced (isForced = true), and

It matches the audio language by:

language code (e.g., "en"), or

language name inside the label (e.g., "English [Forced]")

## PR type

- Bug fix

## Why

The previous implementation relied on the generic auto‑subtitle pipeline, which:

Always tries to pick something

Falls back to the first forced track

Does not consider audio language when selecting forced subtitles

## Policy check

<!-- Confirm these before requesting review -->
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

Scenarios:

1.Audio: JA, Forced: JA + EN → selects Forced JA

2.Audio: JA, Forced: EN only → selects none

3.Audio: JA, no forced tracks → selects none

4.Audio: JA, Forced: JA → selects Forced JA

5.Audio: EN, Forced: ES only → selects none

## Screenshots / Video (UI changes only)



## Breaking changes

No Breaking changes

## Linked issues

Fixes #662
Fixes #1200 
