### PR TITLE
Split regional subtitle variants into separate language tabs (pt, es)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -57,12 +57,6 @@ class PlayerRuntimeController(
         internal const val TAG = "PlayerViewModel"
         internal const val TRACK_FRAME_RATE_GRACE_MS = 1500L
         internal const val ADDON_SUBTITLE_TRACK_ID_PREFIX = "nuvio-addon-sub:"
-        internal val PORTUGUESE_BRAZILIAN_TAGS = listOf(
-            "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil"
-        )
-        internal val PORTUGUESE_EUROPEAN_TAGS = listOf(
-            "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu"
-        )
     }
 
     internal data class PendingAudioSelection(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -800,9 +800,18 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
     val selectedAddonMatchesTarget = state.selectedAddonSubtitle != null &&
         targets.any { target -> PlayerSubtitleUtils.matchesLanguageCode(state.selectedAddonSubtitle.lang, target) }
     if (selectedAddonMatchesTarget) {
-        autoSubtitleSelected = true
-        Log.d(PlayerRuntimeController.TAG, "AUTO_SUB stop: matching addon already selected (no internal match)")
-        return
+        val selectedMatchesPrimary = PlayerSubtitleUtils.matchesLanguageCode(
+            state.selectedAddonSubtitle!!.lang, targets.first()
+        )
+        if (selectedMatchesPrimary) {
+            autoSubtitleSelected = true
+            Log.d(PlayerRuntimeController.TAG, "AUTO_SUB stop: matching addon already selected (primary match)")
+            return
+        }
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "AUTO_SUB: selected addon ${state.selectedAddonSubtitle.lang} matches secondary target, checking for primary addon"
+        )
     }
 
     // Wait until we have at least one full text-track scan to avoid choosing addon too early.
@@ -823,7 +832,14 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
             val match = state.addonSubtitles.firstOrNull { subtitle ->
                 PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, target)
             }
-            if (match != null) return@run match
+            if (match != null) {
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "AUTO_SUB addon fallback: target=$target matched addon lang=${match.lang} id=${match.id} " +
+                        "(addons=${state.addonSubtitles.size}, targets=$targets)"
+                )
+                return@run match
+            }
         }
         null
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -347,12 +347,32 @@ internal fun PlayerRuntimeController.findMatchingTrackIndex(
     if (nameContainsIndex >= 0) return nameContainsIndex
 
     return if (!targetLang.isNullOrBlank()) {
-        tracks.indexOfFirst { track ->
-            val trackLang = normalizeTrackMatchValue(track.language)
+        // Detect the regional variant from the remembered selection's name/language
+        val targetVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+            language = target.language,
+            name = target.name,
+            trackId = target.trackId
+        )
+        val langCandidates = tracks.indices.filter { index ->
+            val trackLang = normalizeTrackMatchValue(tracks[index].language)
             !trackLang.isNullOrBlank() &&
                 (trackLang == targetLang ||
                     trackLang.startsWith("$targetLang-") ||
                     trackLang.startsWith("${targetLang}_"))
+        }
+        if (langCandidates.size <= 1) {
+            langCandidates.firstOrNull() ?: -1
+        } else {
+            // Multiple tracks with the same base language — prefer the one
+            // whose detected variant matches the remembered selection.
+            langCandidates.firstOrNull { index ->
+                val trackVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+                    language = tracks[index].language,
+                    name = tracks[index].name,
+                    trackId = tracks[index].trackId
+                )
+                trackVariant == targetVariant
+            } ?: langCandidates.first()
         }
     } else {
         -1
@@ -427,8 +447,31 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                         updatedPending = updatedPending.copy(subtitle = null)
                     }
                 } else {
-                    Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle no match, clearing")
-                    updatedPending = updatedPending.copy(subtitle = null)
+                    // No internal track matches — try addon fallback with the same language variant.
+                    val resolvedVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+                        language = subtitleSelection.track.language,
+                        name = subtitleSelection.track.name,
+                        trackId = subtitleSelection.track.trackId
+                    )
+                    val state = _uiState.value
+                    val addonFallback = state.addonSubtitles.firstOrNull { subtitle ->
+                        PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, resolvedVariant)
+                    }
+                    if (addonFallback != null) {
+                        Log.d(
+                            PlayerRuntimeController.TAG,
+                            "TRACK_PREF restore: internal no match, falling back to addon lang=${addonFallback.lang} variant=$resolvedVariant"
+                        )
+                        autoSubtitleSelected = true
+                        subtitleAddonRestoredByPersistedPreference = true
+                        pendingRestoredAddonSubtitle = addonFallback
+                        selectAddonSubtitle(addonFallback)
+                        updatedAddonSubtitle = addonFallback
+                        updatedPending = updatedPending.copy(subtitle = null)
+                    } else {
+                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle no match, no addon fallback for variant=$resolvedVariant, clearing")
+                        updatedPending = updatedPending.copy(subtitle = null)
+                    }
                 }
             }
         }
@@ -499,8 +542,19 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
                     )
                     return brazilianFromGenericPt
                 }
-                // Specific PT-BR rule:
-                // generic "pt" tracks without brazilian tags are not accepted as PT-BR.
+                if (targetPosition == 0) {
+                    return -1
+                }
+            }
+            if (normalizedTarget == "es-419") {
+                val latinoFromGenericEs = findLatinoSpanishInGenericEsTracks(subtitleTracks)
+                if (latinoFromGenericEs >= 0) {
+                    Log.d(
+                        PlayerRuntimeController.TAG,
+                        "AUTO_SUB pick internal es-419 via generic-es tags index=$latinoFromGenericEs"
+                    )
+                    return latinoFromGenericEs
+                }
                 if (targetPosition == 0) {
                     return -1
                 }
@@ -511,6 +565,14 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
 
         if (normalizedTarget == "pt" || normalizedTarget == "pt-br") {
             val tieBroken = breakPortugueseSubtitleTie(
+                subtitleTracks = subtitleTracks,
+                candidateIndexes = candidateIndexes,
+                normalizedTarget = normalizedTarget
+            )
+            if (tieBroken >= 0) return tieBroken
+        }
+        if (normalizedTarget == "es" || normalizedTarget == "es-419") {
+            val tieBroken = breakSpanishSubtitleTie(
                 subtitleTracks = subtitleTracks,
                 candidateIndexes = candidateIndexes,
                 normalizedTarget = normalizedTarget
@@ -536,11 +598,18 @@ internal fun PlayerRuntimeController.findBrazilianPortugueseInGenericPtTracks(
     }
     if (genericPtIndexes.isEmpty()) return -1
 
+    val brazilianNonForced = genericPtIndexes.filter { index ->
+        !subtitleTracks[index].isForced &&
+            subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
+            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
+    }
+    if (brazilianNonForced.isNotEmpty()) return brazilianNonForced.first()
+
     return genericPtIndexes.firstOrNull { index ->
-        subtitleHasAnyTag(subtitleTracks[index], PlayerRuntimeController.PORTUGUESE_BRAZILIAN_TAGS) &&
-            !subtitleHasAnyTag(subtitleTracks[index], PlayerRuntimeController.PORTUGUESE_EUROPEAN_TAGS)
+        subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
+            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
     } ?: genericPtIndexes.firstOrNull { index ->
-        subtitleHasAnyTag(subtitleTracks[index], PlayerRuntimeController.PORTUGUESE_BRAZILIAN_TAGS)
+        subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS)
     } ?: -1
 }
 
@@ -550,11 +619,11 @@ internal fun PlayerRuntimeController.breakPortugueseSubtitleTie(
     normalizedTarget: String
 ): Int {
     fun hasBrazilianTags(index: Int): Boolean {
-        return subtitleHasAnyTag(subtitleTracks[index], PlayerRuntimeController.PORTUGUESE_BRAZILIAN_TAGS)
+        return subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS)
     }
 
     fun hasEuropeanTags(index: Int): Boolean {
-        return subtitleHasAnyTag(subtitleTracks[index], PlayerRuntimeController.PORTUGUESE_EUROPEAN_TAGS)
+        return subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
     }
 
     return if (normalizedTarget == "pt-br") {
@@ -565,6 +634,55 @@ internal fun PlayerRuntimeController.breakPortugueseSubtitleTie(
         candidateIndexes.firstOrNull { hasEuropeanTags(it) && !hasBrazilianTags(it) }
             ?: candidateIndexes.firstOrNull { hasEuropeanTags(it) }
             ?: candidateIndexes.firstOrNull { !hasBrazilianTags(it) }
+            ?: candidateIndexes.first()
+    }
+}
+
+internal fun PlayerRuntimeController.findLatinoSpanishInGenericEsTracks(
+    subtitleTracks: List<TrackInfo>
+): Int {
+    val genericEsIndexes = subtitleTracks.indices.filter { index ->
+        val trackLanguage = subtitleTracks[index].language ?: return@filter false
+        PlayerSubtitleUtils.normalizeLanguageCode(trackLanguage) == "es"
+    }
+    if (genericEsIndexes.isEmpty()) return -1
+
+    val latinoNonForced = genericEsIndexes.filter { index ->
+        !subtitleTracks[index].isForced &&
+            subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
+            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
+    }
+    if (latinoNonForced.isNotEmpty()) return latinoNonForced.first()
+
+    return genericEsIndexes.firstOrNull { index ->
+        subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
+            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
+    } ?: genericEsIndexes.firstOrNull { index ->
+        subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS)
+    } ?: -1
+}
+
+internal fun PlayerRuntimeController.breakSpanishSubtitleTie(
+    subtitleTracks: List<TrackInfo>,
+    candidateIndexes: List<Int>,
+    normalizedTarget: String
+): Int {
+    fun hasLatinoTags(index: Int): Boolean {
+        return subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS)
+    }
+
+    fun hasCastilianTags(index: Int): Boolean {
+        return subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
+    }
+
+    return if (normalizedTarget == "es-419") {
+        candidateIndexes.firstOrNull { hasLatinoTags(it) && !hasCastilianTags(it) }
+            ?: candidateIndexes.firstOrNull { hasLatinoTags(it) }
+            ?: candidateIndexes.first()
+    } else {
+        candidateIndexes.firstOrNull { hasCastilianTags(it) && !hasLatinoTags(it) }
+            ?: candidateIndexes.firstOrNull { hasCastilianTags(it) }
+            ?: candidateIndexes.firstOrNull { !hasLatinoTags(it) }
             ?: candidateIndexes.first()
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -561,7 +561,25 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
             }
             continue
         }
-        if (candidateIndexes.size == 1) return candidateIndexes.first()
+        if (candidateIndexes.size == 1) {
+            // For regional targets, verify the single candidate is actually the right variant.
+            // A track with language="por" matches both "pt" and "pt-br" by language code,
+            // but may be the wrong accent based on its name tags.
+            if (normalizedTarget == "pt" || normalizedTarget == "es") {
+                val track = subtitleTracks[candidateIndexes.first()]
+                val variant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+                    language = track.language,
+                    name = track.name,
+                    trackId = track.trackId
+                )
+                if (variant != normalizedTarget && variant != track.language?.lowercase()) {
+                    // Single candidate is a different variant (e.g. PT-BR when we want PT).
+                    // Skip it so the search can continue to secondary target or addon fallback.
+                    continue
+                }
+            }
+            return candidateIndexes.first()
+        }
 
         if (normalizedTarget == "pt" || normalizedTarget == "pt-br") {
             val tieBroken = breakPortugueseSubtitleTie(
@@ -716,9 +734,19 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         targets = targets
     )
     if (internalIndex >= 0) {
-        // Determine which target position this internal match satisfies
+        // Determine which target position this internal match satisfies,
+        // taking regional variant into account so that e.g. a PT-BR track
+        // is not treated as a primary match when the user wants PT.
+        val matchedTrack = state.subtitleTracks[internalIndex]
+        val trackVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+            language = matchedTrack.language,
+            name = matchedTrack.name,
+            trackId = matchedTrack.trackId
+        )
         val matchedTargetPosition = targets.indexOfFirst { target ->
-            PlayerSubtitleUtils.matchesLanguageCode(state.subtitleTracks[internalIndex].language, target)
+            val normalizedTarget = PlayerSubtitleUtils.normalizeLanguageCode(target)
+            trackVariant == normalizedTarget ||
+                PlayerSubtitleUtils.matchesLanguageCode(trackVariant, target)
         }
         // If the match is only for a secondary (non-primary) target and addon subtitles haven't
         // loaded yet, defer - a primary addon subtitle may still arrive.
@@ -729,6 +757,22 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
                 "AUTO_SUB defer: internal match is secondary target pos=$matchedTargetPosition, addons still loading"
             )
             return
+        }
+        // If internal match is secondary and a primary addon match exists, prefer the addon.
+        if (matchedTargetPosition > 0 && addonSubtitlesLoaded) {
+            val primaryTarget = targets.first()
+            val primaryAddonMatch = state.addonSubtitles.firstOrNull { subtitle ->
+                PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, primaryTarget)
+            }
+            if (primaryAddonMatch != null) {
+                autoSubtitleSelected = true
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "AUTO_SUB pick addon (primary) over internal (secondary): addon lang=${primaryAddonMatch.lang} vs internal variant=$trackVariant"
+                )
+                selectAddonSubtitle(primaryAddonMatch)
+                return
+            }
         }
         autoSubtitleSelected = true
         val currentInternal = state.selectedSubtitleTrackIndex

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -733,7 +733,7 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         subtitleTracks = state.subtitleTracks,
         targets = targets
     )
-    if (internalIndex >= 0) {
+    if (internalIndex >= 0 && hasScannedTextTracksOnce) {
         // Determine which target position this internal match satisfies,
         // taking regional variant into account so that e.g. a PT-BR track
         // is not treated as a primary match when the user wants PT.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -817,8 +817,15 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         return
     }
 
-    val addonMatch = state.addonSubtitles.firstOrNull { subtitle ->
-        targets.any { target -> PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, target) }
+    val addonMatch = run {
+        // Try each target in priority order so primary language is preferred over secondary.
+        for (target in targets) {
+            val match = state.addonSubtitles.firstOrNull { subtitle ->
+                PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, target)
+            }
+            if (match != null) return@run match
+        }
+        null
     }
     if (addonMatch != null) {
         autoSubtitleSelected = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1137,7 +1137,7 @@ private fun PlayerControlsOverlay(
                                 exit = fadeOut(animationSpec = tween(durationMillis = 180))
                             ) {
                                 Text(
-                                    text = stringResource(R.string.player_via, uiState.currentStreamName ?: ""),
+                                    text = stringResource(R.string.player_via, (uiState.currentStreamName ?: "").replace("\n", " · ")),
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = Color.White.copy(alpha = 0.68f),
                                     maxLines = 2,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -30,6 +30,13 @@ internal object PlayerSubtitleUtils {
             return "pt"
         }
 
+        if (containsAny("spanish", "espanol", "español", "castellano")) {
+            if (containsAny("latin", "latino", "latinoamerica", "latinoamericano", "lat am", "latam", "es 419", "es419", "la")) {
+                return "es-419"
+            }
+            return "es"
+        }
+
         // LANGUAGE_OVERRIDES uses pt-BR (mixed case) — normalize to lowercase for consistency
         return LANGUAGE_OVERRIDES[code]?.lowercase() ?: normalizedCode
     }
@@ -64,13 +71,64 @@ internal object PlayerSubtitleUtils {
         normalizedLanguage: String,
         normalizedTarget: String
     ): Boolean {
+        // Exact regional targets: "pt" should not match "pt-br", "es" should not match "es-419"
         if (normalizedTarget == "pt") {
             return normalizedLanguage == "pt"
+        }
+        if (normalizedTarget == "es") {
+            return normalizedLanguage == "es"
         }
         return normalizedLanguage == normalizedTarget ||
             normalizedLanguage.startsWith("$normalizedTarget-") ||
             normalizedLanguage.startsWith("${normalizedTarget}_")
     }
+
+    /**
+     * Detects the regional variant of an embedded subtitle track by inspecting
+     * its name, language, and trackId fields. Returns a normalized language key
+     * that preserves the accent (e.g. "pt-br", "es-419") when detectable,
+     * or falls back to the base language code.
+     */
+    fun detectTrackLanguageVariant(language: String?, name: String?, trackId: String?): String {
+        val baseLang = normalizeLanguageCode(language ?: "")
+        val haystack = listOfNotNull(name, language, trackId)
+            .joinToString(" ")
+            .lowercase()
+
+        // Portuguese: detect Brazilian vs European from tags
+        if (baseLang == "pt" || baseLang == "por") {
+            val hasBrazilian = BRAZILIAN_TAGS.any { haystack.contains(it) }
+            val hasEuropean = EUROPEAN_PT_TAGS.any { haystack.contains(it) }
+            if (hasBrazilian && !hasEuropean) return "pt-br"
+            if (hasEuropean && !hasBrazilian) return "pt"
+            return baseLang
+        }
+
+        // Spanish: detect Latin American from tags
+        if (baseLang == "es" || baseLang == "spa") {
+            val hasLatino = LATINO_TAGS.any { haystack.contains(it) }
+            val hasCastilian = CASTILIAN_TAGS.any { haystack.contains(it) }
+            if (hasLatino && !hasCastilian) return "es-419"
+            if (hasCastilian && !hasLatino) return "es"
+            return baseLang
+        }
+
+        return baseLang
+    }
+
+    internal val BRAZILIAN_TAGS = listOf(
+        "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil", "brasileiro"
+    )
+    internal val EUROPEAN_PT_TAGS = listOf(
+        "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu"
+    )
+    internal val LATINO_TAGS = listOf(
+        "es-419", "es_419", "es-la", "es-lat", "latino", "latinoamerica",
+        "latinoamericano", "latam", "lat am", "latin america"
+    )
+    internal val CASTILIAN_TAGS = listOf(
+        "es-es", "es_es", "castilian", "castellano", "spain", "españa", "espana", "iberian"
+    )
 
     fun mimeTypeFromUrl(url: String): String {
         val normalizedPath = url

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -651,9 +651,13 @@ private fun SubtitleLanguageCard(
             Text(
                 text = item.label,
                 style = MaterialTheme.typography.bodyLarge,
-                color = textColor
+                color = textColor,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false)
             )
             if (item.count > 0) {
+                androidx.compose.foundation.layout.Spacer(modifier = Modifier.width(6.dp))
                 CountBadge(count = item.count, selected = isSelected)
             }
         }
@@ -1156,7 +1160,7 @@ private fun buildSubtitleLanguageRailItems(
 ): List<SubtitleLanguageRailItem> {
     val counts = linkedMapOf<String, Int>()
     internalTracks.forEach { track ->
-        val key = normalizeOverlayLanguageKey(track.language)
+        val key = normalizeOverlayLanguageKeyForTrack(track)
         counts[key] = (counts[key] ?: 0) + 1
     }
     addonSubtitles.forEach { subtitle ->
@@ -1226,7 +1230,7 @@ private fun buildSubtitleOptionRailItems(
 
     val addonOrderMap = installedAddonOrder.withIndex().associate { (index, name) -> name to index }
     val internalItems = internalTracks
-        .filter { normalizeOverlayLanguageKey(it.language) == selectedLanguageKey }
+        .filter { normalizeOverlayLanguageKeyForTrack(it) == selectedLanguageKey }
         .map { track ->
             SubtitleOptionRailItem(
                 id = "internal:${track.index}",
@@ -1277,11 +1281,9 @@ private fun selectedSubtitleLanguageKey(
 
     val selectedInternalKey = internalTracks
         .firstOrNull { it.index == selectedInternalIndex }
-        ?.language
-        ?.let(::normalizeOverlayLanguageKey)
+        ?.let { normalizeOverlayLanguageKeyForTrack(it) }
         ?: internalTracks.firstOrNull { it.isSelected }
-            ?.language
-        ?.let(::normalizeOverlayLanguageKey)
+            ?.let { normalizeOverlayLanguageKeyForTrack(it) }
     if (selectedInternalKey != null) return selectedInternalKey
 
     return SubtitleOffLanguageKey
@@ -1289,9 +1291,30 @@ private fun selectedSubtitleLanguageKey(
 
 private fun normalizeOverlayLanguageKey(language: String?): String {
     if (language.isNullOrBlank()) return SubtitleUnknownLanguageKey
-    return when (PlayerSubtitleUtils.normalizeLanguageCode(language)) {
-        "pt-br" -> "pt-br"
-        else -> PlayerSubtitleUtils.normalizeLanguageCode(language)
+    val normalized = PlayerSubtitleUtils.normalizeLanguageCode(language)
+    return when (normalized) {
+        "pt-br", "es-419" -> normalized
+        else -> normalized
+            .substringBefore('-')
+            .substringBefore('_')
+            .ifBlank { SubtitleUnknownLanguageKey }
+    }
+}
+
+/**
+ * Variant-aware language key for embedded tracks. Inspects name/label/trackId
+ * to detect regional accents (e.g. Brazilian Portuguese, Latin American Spanish)
+ * even when the language field is generic ("por", "spa").
+ */
+private fun normalizeOverlayLanguageKeyForTrack(track: TrackInfo): String {
+    val variant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+        language = track.language,
+        name = track.name,
+        trackId = track.trackId
+    )
+    return when (variant) {
+        "pt-br", "es-419" -> variant
+        else -> variant
             .substringBefore('-')
             .substringBefore('_')
             .ifBlank { SubtitleUnknownLanguageKey }


### PR DESCRIPTION
## Summary

Split regional subtitle variants (Brazilian Portuguese, European Portuguese, Latin American Spanish, Castilian Spanish) into separate language tabs in the subtitle selection overlay. Previously with embed subtitles all variants were merged under one generic tab, causing wrong auto-selection and making it hard to find the right accent.

Based in part on PR #758 by @kernexshadow.

## PR type

- Bug fix

## Why

Embedded subtitle tracks typically report a generic language code (`por`, `spa`) regardless of regional variant. This caused:
- Brazilian and European Portuguese merged into one "Portuguese" tab
- Latin American and Castilian Spanish merged into one "Spanish" tab
- Auto-selection picking the wrong variant (e.g. Brazilian when user wants European, simply because it was first in the list)
- Persisted track restore falling back to the wrong variant on episode switch

The fix detects regional accents from track name/label tags (e.g. "Brazil", "Latino", "Portugal", "Castilian") and groups them into separate tabs. Addon subtitles already return proper language codes (`pob`, `es-419`) so they were already grouped correctly - now embedded tracks match.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified PT-BR and PT tracks split into separate tabs when embedded tracks have accent tags in name/label
- Manual: verified ES-419 and ES tracks split into separate tabs
- Manual: verified auto-selection picks correct variant (PT-BR user gets Brazilian, PT user gets European)
- Manual: verified auto-selection prefers non-forced tracks over forced when multiple Brazilian tracks exist
- Manual: verified persisted track restore falls back to addon with matching variant when internal track is missing on episode switch
- Manual: verified PT user does not get Brazilian subtitles by accident (neither via auto-select nor via persisted restore)
- Provided test builds to user using PT and PT-BR

## Screenshots / Video (UI changes only)

![IMG20260326130348](https://github.com/user-attachments/assets/31b65eef-0ee5-4ef7-b737-9e1e07caf1fb)
![IMG20260326130315](https://github.com/user-attachments/assets/87020979-1744-4de8-8b08-9e6ef7a94556)


## Breaking changes

Nothing should break - changes are only for Spanish and Portuguese subtitles 

## Linked issues

Fixes #692
