### PR TITLE
fix infinite buffering after audio track switch

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -55,6 +55,10 @@ internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {
                             .buildUpon()
                             .setOverrideForType(override)
                             .build()
+                        // Nudge the player to avoid infinite buffering after audio track switch
+                        // where the new track requires a different segment.
+                        val pos = player.currentPosition
+                        if (pos > 0) player.seekTo((pos - 1).coerceAtLeast(0))
                         return
                     }
                     currentAudioIndex++


### PR DESCRIPTION
## Summary

Fix infinite buffering after switching audio track during playback. After changing the audio track on some HLS/DASH streams, ExoPlayer gets stuck in `STATE_BUFFERING` indefinitely. A 1ms seek-back after the track override forces the player to re-fetch the current segment with the new audio track.

## PR type

- Bug fix

## Why

Users reported that switching audio tracks (e.g. from English to Japanese) causes the player to show an infinite loading spinner. The only workaround was to manually seek forward or backward. This happened because ExoPlayer's `setOverrideForType` changes the track selection but doesn't always trigger a segment re-fetch on HLS/DASH streams where the new audio track lives in a different segment variant.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified audio track switch no longer causes infinite buffering 
- Manual: verified playback continues seamlessly after switch (no visible skip or stutter from the 1ms seek).

## Screenshots / Video (UI changes only)

No changes

## Breaking changes

Nothing should break 

## Linked issues

Saw this mentioned few times on discord, and was happening regularly on my tv
