### PR TITLE
Feature/trailer youtube player fallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -234,6 +234,7 @@ dependencies {
     implementation("androidx.tv:tv-material:1.0.1")
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation("androidx.activity:activity-compose:1.11.0")
+    implementation("com.pierfrancescosoffritti.androidyoutubeplayer:core:13.0.0")
 
     // Hilt
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -153,8 +153,10 @@ class TrailerService @Inject constructor(
         title: String? = null,
         year: String? = null
     ): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
+        var youtubeKey: String? = null
         try {
-            val youtubeKey = extractYouTubeVideoId(youtubeUrl)
+            youtubeKey = extractYouTubeVideoId(youtubeUrl)
+            val iframeFallbackSource = youtubeKey?.let(::youtubeIframeFallbackSource)
             if (!youtubeKey.isNullOrBlank()) {
                 youtubeSourceCache[youtubeKey]?.let { cached ->
                     Log.d(TAG, "YouTube session cache hit for key=${obfuscateYoutubeKey(youtubeKey)}")
@@ -181,20 +183,31 @@ class TrailerService @Inject constructor(
             val response = trailerApi.getTrailer(youtubeUrl = youtubeUrl, title = title, year = year)
             if (!response.isSuccessful) {
                 Log.w(TAG, "Backend trailer fallback failed (${response.code()}) for ${summarizeUrl(youtubeUrl)}")
-                return@withContext null
+                return@withContext fallbackToYouTubeIframeSource(youtubeKey, iframeFallbackSource, youtubeUrl)
             }
 
-            val fallbackUrl = response.body()?.url ?: return@withContext null
-            if (!isValidUrl(fallbackUrl)) return@withContext null
+            val fallbackUrl = response.body()?.url
+            if (!isValidUrl(fallbackUrl)) {
+                return@withContext fallbackToYouTubeIframeSource(youtubeKey, iframeFallbackSource, youtubeUrl)
+            }
+            val validatedFallbackUrl = fallbackUrl ?: return@withContext fallbackToYouTubeIframeSource(
+                youtubeKey,
+                iframeFallbackSource,
+                youtubeUrl
+            )
 
             if (!youtubeKey.isNullOrBlank()) {
-                youtubeSourceCache[youtubeKey] = TrailerPlaybackSource(videoUrl = fallbackUrl)
+                youtubeSourceCache[youtubeKey] = TrailerPlaybackSource(videoUrl = validatedFallbackUrl)
             }
             Log.d(TAG, "Using backend fallback source for ${summarizeUrl(youtubeUrl)}")
-            TrailerPlaybackSource(videoUrl = fallbackUrl)
+            TrailerPlaybackSource(videoUrl = validatedFallbackUrl)
         } catch (e: Exception) {
             Log.e(TAG, "Error getting trailer from YouTube: ${e.message}", e)
-            null
+            fallbackToYouTubeIframeSource(
+                youtubeKey = youtubeKey,
+                fallbackSource = youtubeKey?.let(::youtubeIframeFallbackSource),
+                youtubeUrl = youtubeUrl
+            )
         }
     }
 
@@ -291,6 +304,21 @@ class TrailerService @Inject constructor(
     private fun obfuscateYoutubeKey(key: String): String {
         if (key.length <= 4) return "****"
         return "***${key.takeLast(4)}"
+    }
+
+    private fun youtubeIframeFallbackSource(youtubeKey: String): TrailerPlaybackSource {
+        return TrailerPlaybackSource(videoUrl = "https://www.youtube.com/watch?v=$youtubeKey")
+    }
+
+    private fun fallbackToYouTubeIframeSource(
+        youtubeKey: String?,
+        fallbackSource: TrailerPlaybackSource?,
+        youtubeUrl: String
+    ): TrailerPlaybackSource? {
+        if (youtubeKey.isNullOrBlank() || fallbackSource == null) return null
+        youtubeSourceCache[youtubeKey] = fallbackSource
+        Log.d(TAG, "Using YouTube iframe fallback for ${summarizeUrl(youtubeUrl)}")
+        return fallbackSource
     }
 
     fun clearCache() {

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -1,5 +1,8 @@
 package com.nuvio.tv.ui.components
 
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -11,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -19,10 +23,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -30,17 +34,85 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
-import com.nuvio.tv.data.trailer.YoutubeChunkedDataSourceFactory
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
-import android.view.LayoutInflater
 import com.nuvio.tv.R
+import com.nuvio.tv.data.trailer.YoutubeChunkedDataSourceFactory
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.PlayerConstants
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.options.IFramePlayerOptions
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.roundToLong
 import kotlinx.coroutines.delay
+
+private val TRAILER_YOUTUBE_VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
 fun TrailerPlayer(
+    trailerUrl: String?,
+    trailerAudioUrl: String? = null,
+    isPlaying: Boolean,
+    onEnded: () -> Unit,
+    onFirstFrameRendered: () -> Unit = {},
+    muted: Boolean = false,
+    seekRequestToken: Int = 0,
+    seekDeltaMs: Long = 0L,
+    onProgressChanged: (positionMs: Long, durationMs: Long) -> Unit = { _, _ -> },
+    onRemoteKey: (keyCode: Int, action: Int, repeatCount: Int) -> Boolean = { _, _, _ -> false },
+    cropToFill: Boolean = false,
+    overscanZoom: Float = 1f,
+    modifier: Modifier = Modifier,
+    enter: EnterTransition = fadeIn(animationSpec = tween(800)),
+    exit: ExitTransition = fadeOut(animationSpec = tween(500))
+) {
+    val youtubeVideoId = remember(trailerUrl, trailerAudioUrl) {
+        if (trailerAudioUrl.isNullOrBlank()) trailerUrl?.let(::extractYouTubeVideoIdForFallback) else null
+    }
+
+    if (youtubeVideoId != null) {
+        YouTubeFallbackTrailerPlayer(
+            youtubeVideoId = youtubeVideoId,
+            isPlaying = isPlaying,
+            onEnded = onEnded,
+            onFirstFrameRendered = onFirstFrameRendered,
+            muted = muted,
+            seekRequestToken = seekRequestToken,
+            seekDeltaMs = seekDeltaMs,
+            onProgressChanged = onProgressChanged,
+            onRemoteKey = onRemoteKey,
+            cropToFill = cropToFill,
+            overscanZoom = overscanZoom,
+            modifier = modifier,
+            enter = enter,
+            exit = exit
+        )
+    } else {
+        ExoTrailerPlayer(
+            trailerUrl = trailerUrl,
+            trailerAudioUrl = trailerAudioUrl,
+            isPlaying = isPlaying,
+            onEnded = onEnded,
+            onFirstFrameRendered = onFirstFrameRendered,
+            muted = muted,
+            seekRequestToken = seekRequestToken,
+            seekDeltaMs = seekDeltaMs,
+            onProgressChanged = onProgressChanged,
+            onRemoteKey = onRemoteKey,
+            cropToFill = cropToFill,
+            overscanZoom = overscanZoom,
+            modifier = modifier,
+            enter = enter,
+            exit = exit
+        )
+    }
+}
+
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@Composable
+private fun ExoTrailerPlayer(
     trailerUrl: String?,
     trailerAudioUrl: String? = null,
     isPlaying: Boolean,
@@ -187,6 +259,7 @@ fun TrailerPlayer(
                         player.playWhenReady = true
                     }
                 }
+
                 Lifecycle.Event.ON_PAUSE,
                 Lifecycle.Event.ON_STOP -> {
                     player.playWhenReady = false
@@ -194,6 +267,7 @@ fun TrailerPlayer(
                     player.stop()
                     player.clearMediaItems()
                 }
+
                 Lifecycle.Event.ON_DESTROY -> {
                     if (releaseCalled.compareAndSet(false, true)) {
                         runCatching { player.stop() }
@@ -201,6 +275,7 @@ fun TrailerPlayer(
                         runCatching { player.release() }
                     }
                 }
+
                 else -> Unit
             }
         }
@@ -257,4 +332,207 @@ fun TrailerPlayer(
             )
         }
     }
+}
+
+@Composable
+private fun YouTubeFallbackTrailerPlayer(
+    youtubeVideoId: String,
+    isPlaying: Boolean,
+    onEnded: () -> Unit,
+    onFirstFrameRendered: () -> Unit = {},
+    muted: Boolean = false,
+    seekRequestToken: Int = 0,
+    seekDeltaMs: Long = 0L,
+    onProgressChanged: (positionMs: Long, durationMs: Long) -> Unit = { _, _ -> },
+    onRemoteKey: (keyCode: Int, action: Int, repeatCount: Int) -> Boolean = { _, _, _ -> false },
+    cropToFill: Boolean = false,
+    overscanZoom: Float = 1f,
+    modifier: Modifier = Modifier,
+    enter: EnterTransition = fadeIn(animationSpec = tween(800)),
+    exit: ExitTransition = fadeOut(animationSpec = tween(500))
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val activityLifecycleOwner = remember(context) { context as? androidx.lifecycle.LifecycleOwner ?: lifecycleOwner }
+    val currentOnEnded by rememberUpdatedState(onEnded)
+    val currentOnFirstFrameRendered by rememberUpdatedState(onFirstFrameRendered)
+    val currentOnProgressChanged by rememberUpdatedState(onProgressChanged)
+    val currentOnRemoteKey by rememberUpdatedState(onRemoteKey)
+    val zoomScale = if (cropToFill) overscanZoom.coerceAtLeast(1f) else 1f
+    var hasRenderedFirstFrame by remember(youtubeVideoId) { mutableStateOf(false) }
+    var youtubePlayer by remember(youtubeVideoId) { mutableStateOf<YouTubePlayer?>(null) }
+    var currentSecond by remember(youtubeVideoId) { mutableFloatStateOf(0f) }
+    var durationSeconds by remember(youtubeVideoId) { mutableFloatStateOf(0f) }
+    val playerAlphaState = animateFloatAsState(
+        targetValue = if (isPlaying && hasRenderedFirstFrame) 1f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "trailerYouTubeFirstFrameAlpha"
+    )
+
+    val youTubePlayerView = remember(youtubeVideoId) {
+        val options = IFramePlayerOptions.Builder(context)
+            .controls(0)
+            .fullscreen(0)
+            .rel(0)
+            .ivLoadPolicy(3)
+            .ccLoadPolicy(1)
+            .build()
+
+        YouTubePlayerView(context).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            enableAutomaticInitialization = false
+            isFocusable = true
+            isFocusableInTouchMode = true
+            keepScreenOn = true
+            setOnKeyListener { _, keyCode, event ->
+                currentOnRemoteKey(keyCode, event.action, event.repeatCount)
+            }
+            initialize(
+                object : AbstractYouTubePlayerListener() {
+                    override fun onReady(player: YouTubePlayer) {
+                        youtubePlayer = player
+                        runCatching {
+                            if (muted) player.mute() else player.unMute()
+                        }
+                    }
+
+                    override fun onStateChange(player: YouTubePlayer, state: PlayerConstants.PlayerState) {
+                        when (state) {
+                            PlayerConstants.PlayerState.PLAYING -> {
+                                if (!hasRenderedFirstFrame) {
+                                    hasRenderedFirstFrame = true
+                                    currentOnFirstFrameRendered()
+                                }
+                            }
+
+                            PlayerConstants.PlayerState.ENDED -> currentOnEnded()
+                            else -> Unit
+                        }
+                    }
+
+                    override fun onCurrentSecond(player: YouTubePlayer, second: Float) {
+                        currentSecond = second
+                        currentOnProgressChanged(
+                            (second * 1_000f).roundToLong(),
+                            (durationSeconds * 1_000f).roundToLong()
+                        )
+                    }
+
+                    override fun onVideoDuration(player: YouTubePlayer, duration: Float) {
+                        durationSeconds = duration
+                        currentOnProgressChanged(
+                            (currentSecond * 1_000f).roundToLong(),
+                            (duration * 1_000f).roundToLong()
+                        )
+                    }
+                },
+                true,
+                options
+            )
+        }
+    }
+
+    DisposableEffect(activityLifecycleOwner, youTubePlayerView) {
+        activityLifecycleOwner.lifecycle.addObserver(youTubePlayerView)
+        onDispose {
+            runCatching { activityLifecycleOwner.lifecycle.removeObserver(youTubePlayerView) }
+            runCatching { youTubePlayerView.release() }
+        }
+    }
+
+    LaunchedEffect(youtubePlayer, youtubeVideoId, isPlaying) {
+        val player = youtubePlayer ?: return@LaunchedEffect
+        if (isPlaying) {
+            hasRenderedFirstFrame = false
+            currentSecond = 0f
+            currentOnProgressChanged(0L, 0L)
+            player.loadVideo(youtubeVideoId, 0f)
+        } else {
+            hasRenderedFirstFrame = false
+            currentSecond = 0f
+            durationSeconds = 0f
+            currentOnProgressChanged(0L, 0L)
+            runCatching { player.pause() }
+            runCatching { player.seekTo(0f) }
+        }
+    }
+
+    LaunchedEffect(youtubePlayer, muted) {
+        val player = youtubePlayer ?: return@LaunchedEffect
+        runCatching {
+            if (muted) player.mute() else player.unMute()
+        }
+    }
+
+    LaunchedEffect(seekRequestToken, seekDeltaMs, youtubePlayer, currentSecond, durationSeconds) {
+        val player = youtubePlayer ?: return@LaunchedEffect
+        if (seekRequestToken <= 0) return@LaunchedEffect
+        val durationMs = (durationSeconds * 1_000f).roundToLong().coerceAtLeast(0L)
+        val currentMs = (currentSecond * 1_000f).roundToLong().coerceAtLeast(0L)
+        val targetMs = (currentMs + seekDeltaMs).coerceIn(0L, durationMs)
+        player.seekTo(targetMs / 1_000f)
+    }
+
+    AnimatedVisibility(
+        visible = isPlaying,
+        enter = enter,
+        exit = exit
+    ) {
+        AndroidView(
+            factory = { youTubePlayerView },
+            update = { view ->
+                view.keepScreenOn = isPlaying
+                view.setOnKeyListener { _, keyCode, event ->
+                    currentOnRemoteKey(keyCode, event.action, event.repeatCount)
+                }
+            },
+            modifier = modifier
+                .clipToBounds()
+                .graphicsLayer {
+                    alpha = playerAlphaState.value
+                    scaleX = zoomScale
+                    scaleY = zoomScale
+                }
+        )
+    }
+}
+
+private fun extractYouTubeVideoIdForFallback(input: String): String? {
+    val trimmed = input.trim()
+    if (TRAILER_YOUTUBE_VIDEO_ID_REGEX.matches(trimmed)) return trimmed
+
+    return runCatching {
+        val normalized = if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            trimmed
+        } else {
+            "https://$trimmed"
+        }
+        val uri = Uri.parse(normalized)
+        val host = uri.host?.lowercase()?.removePrefix("www.") ?: return@runCatching null
+
+        when {
+            host == "youtu.be" -> {
+                uri.pathSegments.firstOrNull()?.takeIf { TRAILER_YOUTUBE_VIDEO_ID_REGEX.matches(it) }
+            }
+
+            host == "youtube.com" || host.endsWith(".youtube.com") -> {
+                val queryId = uri.getQueryParameter("v")
+                if (!queryId.isNullOrBlank() && TRAILER_YOUTUBE_VIDEO_ID_REGEX.matches(queryId)) {
+                    queryId
+                } else {
+                    val segments = uri.pathSegments
+                    val candidate = when (segments.firstOrNull()?.lowercase()) {
+                        "embed", "shorts", "live" -> segments.getOrNull(1)
+                        else -> null
+                    }
+                    candidate?.takeIf { TRAILER_YOUTUBE_VIDEO_ID_REGEX.matches(it) }
+                }
+            }
+
+            else -> null
+        }
+    }.getOrNull()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -48,6 +48,7 @@ import kotlin.math.roundToLong
 import kotlinx.coroutines.delay
 
 private val TRAILER_YOUTUBE_VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
+private const val TRAILER_YOUTUBE_STARTUP_UNMUTE_DELAY_MS = 200L
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
@@ -394,20 +395,11 @@ private fun YouTubeFallbackTrailerPlayer(
                 object : AbstractYouTubePlayerListener() {
                     override fun onReady(player: YouTubePlayer) {
                         youtubePlayer = player
-                        runCatching {
-                            if (muted) player.mute() else player.unMute()
-                        }
+                        runCatching { player.mute() }
                     }
 
                     override fun onStateChange(player: YouTubePlayer, state: PlayerConstants.PlayerState) {
                         when (state) {
-                            PlayerConstants.PlayerState.PLAYING -> {
-                                if (!hasRenderedFirstFrame) {
-                                    hasRenderedFirstFrame = true
-                                    currentOnFirstFrameRendered()
-                                }
-                            }
-
                             PlayerConstants.PlayerState.ENDED -> currentOnEnded()
                             else -> Unit
                         }
@@ -415,6 +407,10 @@ private fun YouTubeFallbackTrailerPlayer(
 
                     override fun onCurrentSecond(player: YouTubePlayer, second: Float) {
                         currentSecond = second
+                        if (!hasRenderedFirstFrame) {
+                            hasRenderedFirstFrame = true
+                            currentOnFirstFrameRendered()
+                        }
                         currentOnProgressChanged(
                             (second * 1_000f).roundToLong(),
                             (durationSeconds * 1_000f).roundToLong()
@@ -448,7 +444,9 @@ private fun YouTubeFallbackTrailerPlayer(
         if (isPlaying) {
             hasRenderedFirstFrame = false
             currentSecond = 0f
+            durationSeconds = 0f
             currentOnProgressChanged(0L, 0L)
+            runCatching { player.mute() }
             player.loadVideo(youtubeVideoId, 0f)
         } else {
             hasRenderedFirstFrame = false
@@ -460,11 +458,18 @@ private fun YouTubeFallbackTrailerPlayer(
         }
     }
 
-    LaunchedEffect(youtubePlayer, muted) {
+    LaunchedEffect(youtubePlayer, isPlaying, muted, hasRenderedFirstFrame) {
         val player = youtubePlayer ?: return@LaunchedEffect
-        runCatching {
-            if (muted) player.mute() else player.unMute()
+        if (!isPlaying || muted) {
+            runCatching { player.mute() }
+            return@LaunchedEffect
         }
+
+        runCatching { player.mute() }
+        if (!hasRenderedFirstFrame) return@LaunchedEffect
+
+        delay(TRAILER_YOUTUBE_STARTUP_UNMUTE_DELAY_MS)
+        runCatching { player.unMute() }
     }
 
     LaunchedEffect(seekRequestToken, seekDeltaMs, youtubePlayer, currentSecond, durationSeconds) {

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceYouTubeSessionCacheTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceYouTubeSessionCacheTest.kt
@@ -64,7 +64,7 @@ class TrailerServiceYouTubeSessionCacheTest {
     }
 
     @Test
-    fun `failed youtube extraction is not cached for same key`() = runTest {
+    fun `falls back to youtube iframe source when extraction and backend fallback fail`() = runTest {
         val trailerApi = mockk<TrailerApi>()
         val tmdbApi = mockk<TmdbApi>()
         val extractor = mockk<InAppYouTubeExtractor>()
@@ -83,9 +83,10 @@ class TrailerServiceYouTubeSessionCacheTest {
         val first = service.getTrailerPlaybackSourceFromYouTubeUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
         val second = service.getTrailerPlaybackSourceFromYouTubeUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 
-        assertNull(first)
-        assertEquals("https://cdn.example/video-after-retry.mp4", second?.videoUrl)
-        coVerify(exactly = 2) { extractor.extractPlaybackSource("https://www.youtube.com/watch?v=dQw4w9WgXcQ") }
+        assertEquals("https://www.youtube.com/watch?v=dQw4w9WgXcQ", first?.videoUrl)
+        assertEquals("https://www.youtube.com/watch?v=dQw4w9WgXcQ", second?.videoUrl)
+        assertNull(first?.audioUrl)
+        coVerify(exactly = 1) { extractor.extractPlaybackSource("https://www.youtube.com/watch?v=dQw4w9WgXcQ") }
         coVerify(exactly = 1) { trailerApi.getTrailer(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary

- add a YouTube iframe fallback for trailers when the current extraction flow hits rate limits or fails
- use `android-youtube-player` as the fallback player source: `https://github.com/PierfrancescoSoffritti/android-youtube-player`
- keep the existing trailer flow and UI unchanged, only switching to fallback when needed
- improve fallback startup sync by delaying unmute until the first playback progress signal arrives

## PR type

- Bug fix

## Why

- the current trailer system can fail after many trailer plays because YouTube-backed extraction starts hitting rate limits
- I have seen this problem mentioned many times in Discord, so this change addresses a recurring playback complaint from users
- this uses `android-youtube-player` as a safer fallback path for affected YouTube trailers
- the goal is to recover playback without changing the normal trailer experience

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- passed `:app:testDebugUnitTest --tests "com.nuvio.tv.data.trailer.TrailerServiceYouTubeSessionCacheTest"`
- passed `:app:compileDebugKotlin`
- passed `:app:assembleDebug`
- manually tested trailer playback flow and confirmed the fallback still opens without changing the existing UI path
- manually tested the fallback startup behavior to verify audio/video startup feels more aligned after the delayed unmute change

## Screenshots / Video (UI changes only)

- None

## Breaking changes

- None

## Linked issues


- context only: this issue has been discussed repeatedly in Discord by users hitting trailer playback/rate-limit problems
