### PR TITLE
More persistent watched badges - improvements for #1074

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
@@ -104,6 +104,18 @@ class TraktSettingsDataStore @Inject constructor(
         }
     }
 
+    suspend fun removeDismissedNextUpKeysForContent(contentId: String) {
+        if (contentId.isBlank()) return
+        val prefix = "${contentId.trim()}|"
+        store().edit { prefs ->
+            val current = prefs[dismissedNextUpKeysKey] ?: emptySet()
+            val filtered = current.filterNot { it.startsWith(prefix) }
+            if (filtered.size != current.size) {
+                prefs[dismissedNextUpKeysKey] = filtered.toSet()
+            }
+        }
+    }
+
     suspend fun setShowUnairedNextUp(enabled: Boolean) {
         store().edit { prefs ->
             prefs[showUnairedNextUpKey] = enabled

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -1,21 +1,57 @@
 package com.nuvio.tv.data.local
 
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import com.nuvio.tv.core.profile.ProfileManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
  * Shared holder for fully-watched series IDs derived from the CW pipeline.
  * Updated by HomeViewModel, observed by any screen that needs series watched badges.
+ * Persisted per profile so badges appear instantly on cold start.
  */
 @Singleton
-class WatchedSeriesStateHolder @Inject constructor() {
+class WatchedSeriesStateHolder @Inject constructor(
+    private val factory: ProfileDataStoreFactory,
+    private val profileManager: ProfileManager
+) {
+    companion object {
+        private const val FEATURE = "watched_series_cache"
+        private val KEY = stringSetPreferencesKey("fully_watched_ids")
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val _fullyWatchedSeriesIds = MutableStateFlow<Set<String>>(emptySet())
     val fullyWatchedSeriesIds: StateFlow<Set<String>> = _fullyWatchedSeriesIds.asStateFlow()
 
+    private var loaded = false
+
+    private fun store() = factory.get(profileManager.activeProfileId.value, FEATURE)
+
+    fun loadFromDisk() {
+        if (loaded) return
+        scope.launch {
+            val persisted = store().data.first()[KEY] ?: emptySet()
+            if (_fullyWatchedSeriesIds.value.isEmpty() && persisted.isNotEmpty()) {
+                _fullyWatchedSeriesIds.value = persisted
+            }
+            loaded = true
+        }
+    }
+
     fun update(ids: Set<String>) {
         _fullyWatchedSeriesIds.value = ids
+        scope.launch {
+            store().edit { prefs -> prefs[KEY] = ids }
+        }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -504,6 +504,11 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveProgress(progress: WatchProgress, syncRemote: Boolean) {
+        // Clear any CW dismiss keys for this series so it reappears in Continue Watching.
+        if (progress.contentType.equals("series", ignoreCase = true) ||
+            progress.contentType.equals("tv", ignoreCase = true)) {
+            traktSettingsDataStore.removeDismissedNextUpKeysForContent(progress.contentId)
+        }
         if (shouldUseTraktProgress()) {
             traktProgressService.applyOptimisticProgress(progress)
             watchProgressPreferences.saveProgress(progress)
@@ -623,6 +628,11 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markAsCompleted(progress: WatchProgress) {
+        // Clear any CW dismiss keys for this series so it reappears in Continue Watching.
+        if (progress.contentType.equals("series", ignoreCase = true) ||
+            progress.contentType.equals("tv", ignoreCase = true)) {
+            traktSettingsDataStore.removeDismissedNextUpKeysForContent(progress.contentId)
+        }
         val useTraktProgress = shouldUseTraktProgress()
         val hasEffectiveTraktConnection = hasEffectiveTraktConnection()
         if (useTraktProgress && hasEffectiveTraktConnection) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -81,6 +81,7 @@ class MetaDetailsViewModel @Inject constructor(
     private val traktSettingsDataStore: TraktSettingsDataStore,
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
     private val playerSettingsDataStore: PlayerSettingsDataStore,
+    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private val itemId: String = savedStateHandle["itemId"] ?: ""
@@ -388,6 +389,7 @@ class MetaDetailsViewModel @Inject constructor(
                         state.copy(watchedEpisodes = watchedSet)
                     }
                 }
+                reevaluateSeriesWatchedBadge()
                 calculateNextToWatch()
             }
         }
@@ -581,6 +583,7 @@ class MetaDetailsViewModel @Inject constructor(
         }
 
         // Calculate next to watch after meta is loaded
+        reevaluateSeriesWatchedBadge()
         calculateNextToWatch()
 
         // Start fetching trailer after meta is loaded
@@ -1180,6 +1183,30 @@ class MetaDetailsViewModel @Inject constructor(
         return videos
             .filter { it.season == season }
             .sortedBy { it.episode }
+    }
+
+    private fun reevaluateSeriesWatchedBadge() {
+        val contentId = _effectiveContentId.value
+        val meta = _uiState.value.meta ?: return
+        val isSeries = meta.apiType.equals("series", ignoreCase = true) ||
+            meta.apiType.equals("tv", ignoreCase = true)
+        if (!isSeries) return
+
+        val episodes = meta.videos.filter {
+            it.season != null && it.episode != null && (it.season ?: 0) > 0
+        }
+        if (episodes.isEmpty()) return
+
+        val watchedEpisodes = _uiState.value.watchedEpisodes
+        val allWatched = episodes.all { video ->
+            (video.season!! to video.episode!!) in watchedEpisodes
+        }
+
+        val current = watchedSeriesStateHolder.fullyWatchedSeriesIds.value
+        val updated = if (allWatched) current + contentId else current - contentId
+        if (updated != current) {
+            watchedSeriesStateHolder.update(updated)
+        }
     }
 
     private fun calculateNextToWatch() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1193,7 +1193,8 @@ class MetaDetailsViewModel @Inject constructor(
         if (!isSeries) return
 
         val episodes = meta.videos.filter {
-            it.season != null && it.episode != null && (it.season ?: 0) > 0
+            it.season != null && it.episode != null && (it.season ?: 0) > 0 &&
+                (it.available != false || !it.released.isNullOrBlank())
         }
         if (episodes.isEmpty()) return
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -158,6 +158,7 @@ class HomeViewModel @Inject constructor(
         get() = trailerPreviewAudioUrlsState
 
     init {
+        watchedSeriesStateHolder.loadFromDisk()
         observeLayoutPreferences()
         observeExternalMetaPrefetchPreference()
         loadHomeCatalogOrderPreference()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -252,39 +252,17 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     elapsedMs = SystemClock.elapsedRealtime() - nextUpStartMs
                 )
 
-                // Derive fully-watched series: seeds that have completed episodes
-                // but no next-up episode (CW already resolved this via meta).
-                // Use the FULL (uncapped) nextUpSeeds so the badge persists regardless
-                // of the Continue Watching days-cap setting.
-                val nextUpContentIds = nextUpItems.map { it.info.contentId }.toSet()
-                val inProgressContentIds = inProgressOnly
-                    .map { it.progress }
-                    .filter { isSeriesTypeCW(it.contentType) }
+                // Derive fully-watched series from watchedItemsPreferences.
+                // Any series with at least one watched episode is a candidate.
+                // We then verify against meta (from cwMetaCache) that ALL episodes are watched.
+                val allWatchedItems = watchedItemsPreferences.allItems.first()
+                val seriesCandidateIds = allWatchedItems
+                    .filter { it.season != null && it.episode != null }
                     .map { it.contentId }
                     .toSet()
-                val allSeedContentIds = nextUpSeeds
-                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
-                    .map { it.contentId }
-                    .toSet()
-                // Seeds within the CW window were already resolved by buildLightweightNextUpItems.
-                // For seeds outside the window, check the resolution cache (populated by prior runs).
-                val recentSeedContentIds = recentNextUpSeeds
-                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
-                    .map { it.contentId }
-                    .toSet()
-                val olderSeedContentIds = allSeedContentIds - recentSeedContentIds
-                val olderSeedsWithNextUp = olderSeedContentIds.filter { contentId ->
-                    // If the cache has a non-null resolution, the series has a next episode.
-                    synchronized(cwNextUpResolutionCache) {
-                        cwNextUpResolutionCache.entries.any { (key, value) ->
-                            key.startsWith("$contentId|") && value != null
-                        }
-                    }
-                }.toSet()
-                val newFullyWatched = allSeedContentIds
+
+                val newFullyWatched = seriesCandidateIds
                     .filter { contentId ->
-                        // Verify against watched items: the series is only "fully watched"
-                        // when every episode in meta is marked as watched.
                         val cacheKey = "series:$contentId"
                         val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
                             ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
@@ -294,9 +272,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             .filter { it.season != null && it.episode != null && it.season != 0 }
                         if (episodes.isEmpty()) return@filter false
 
-                        val watchedEpisodes = watchedItemsPreferences
-                            .getWatchedEpisodesForContent(contentId)
-                            .first()
+                        val watchedEpisodes = allWatchedItems
+                            .filter { it.contentId == contentId && it.season != null && it.episode != null }
+                            .map { it.season!! to it.episode!! }
+                            .toSet()
                         episodes.all { video ->
                             (video.season!! to video.episode!!) in watchedEpisodes
                         }
@@ -306,18 +285,61 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     fullyWatchedSeriesIds.update(newFullyWatched)
                 }
 
-                // For older seeds not yet in the resolution cache, resolve async.
-                // The badge will appear with a slight delay — that's fine.
-                val uncachedOlderSeedIds = olderSeedContentIds.filter { contentId ->
+                // For series without meta in cache, resolve async when CW discovers them.
+                val nextUpContentIds = nextUpItems.map { it.info.contentId }.toSet()
+                val recentSeedContentIds = recentNextUpSeeds
+                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
+                    .map { it.contentId }
+                    .toSet()
+                val allSeedContentIds = nextUpSeeds
+                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
+                    .map { it.contentId }
+                    .toSet()
+                val olderSeedContentIds = allSeedContentIds - recentSeedContentIds
+                // Also include series from watchedItems that have no meta cached yet.
+                val uncachedWatchedSeriesIds = seriesCandidateIds.filter { contentId ->
+                    val cacheKey = "series:$contentId"
+                    synchronized(cwMetaCache) {
+                        cwMetaCache[cacheKey] == null && cwMetaCache["tv:$contentId"] == null
+                    }
+                }.toSet()
+                val uncachedOlderSeedIds = (olderSeedContentIds + uncachedWatchedSeriesIds).filter { contentId ->
                     synchronized(cwNextUpResolutionCache) {
                         cwNextUpResolutionCache.keys.none { it.startsWith("$contentId|") }
                     }
                 }.toSet()
                 if (uncachedOlderSeedIds.isNotEmpty()) {
-                    val uncachedSeeds = nextUpSeeds
+                    // Build seeds from nextUpSeeds where available, otherwise create
+                    // lightweight seeds from watchedItems for meta resolution.
+                    val seedsFromNextUp = nextUpSeeds
                         .filter { it.contentId in uncachedOlderSeedIds }
                         .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null && it.season != 0 }
                         .filter { shouldUseAsCompletedSeed(it) }
+                    val seedsFromWatchedItems = uncachedOlderSeedIds
+                        .filter { contentId -> seedsFromNextUp.none { it.contentId == contentId } }
+                        .mapNotNull { contentId ->
+                            val latestEpisode = allWatchedItems
+                                .filter { it.contentId == contentId && it.season != null && it.episode != null }
+                                .maxWithOrNull(compareBy({ it.season }, { it.episode }))
+                                ?: return@mapNotNull null
+                            com.nuvio.tv.domain.model.WatchProgress(
+                                contentId = contentId,
+                                contentType = "series",
+                                name = latestEpisode.title,
+                                poster = null,
+                                backdrop = null,
+                                logo = null,
+                                videoId = contentId,
+                                season = latestEpisode.season,
+                                episode = latestEpisode.episode,
+                                episodeTitle = null,
+                                position = 1L,
+                                duration = 1L,
+                                lastWatched = latestEpisode.watchedAt,
+                                progressPercent = 100f
+                            )
+                        }
+                    val uncachedSeeds = (seedsFromNextUp + seedsFromWatchedItems)
                         .groupBy { it.contentId }
                         .mapNotNull { (_, items) -> choosePreferredNextUpSeed(items) }
                         .take(CW_MAX_NEXT_UP_LOOKUPS)
@@ -335,15 +357,13 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 }
                             }.awaitAll().filterNotNull()
 
-                            // Re-evaluate watched badge after cache is populated.
-                            val updatedOlderWithNextUp = olderSeedContentIds.filter { contentId ->
-                                synchronized(cwNextUpResolutionCache) {
-                                    cwNextUpResolutionCache.entries.any { (key, value) ->
-                                        key.startsWith("$contentId|") && value != null
-                                    }
-                                }
-                            }.toSet()
-                            val updatedFullyWatched = allSeedContentIds
+                            // Re-evaluate watched badge after meta cache is populated.
+                            val updatedWatchedItems = watchedItemsPreferences.allItems.first()
+                            val updatedCandidateIds = updatedWatchedItems
+                                .filter { it.season != null && it.episode != null }
+                                .map { it.contentId }
+                                .toSet()
+                            val updatedFullyWatched = updatedCandidateIds
                                 .filter { contentId ->
                                     val cacheKey = "series:$contentId"
                                     val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
@@ -354,9 +374,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                         .filter { it.season != null && it.episode != null && it.season != 0 }
                                     if (episodes.isEmpty()) return@filter false
 
-                                    val watchedEpisodes = watchedItemsPreferences
-                                        .getWatchedEpisodesForContent(contentId)
-                                        .first()
+                                    val watchedEpisodes = updatedWatchedItems
+                                        .filter { it.contentId == contentId && it.season != null && it.episode != null }
+                                        .map { it.season!! to it.episode!! }
+                                        .toSet()
                                     episodes.all { video ->
                                         (video.season!! to video.episode!!) in watchedEpisodes
                                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -270,6 +270,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
 
                         val episodes = meta.videos
                             .filter { it.season != null && it.episode != null && it.season != 0 }
+                            .filter { it.available != false || !it.released.isNullOrBlank() }
                         if (episodes.isEmpty()) return@filter false
 
                         val watchedEpisodes = allWatchedItems
@@ -372,6 +373,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
 
                                     val episodes = meta.videos
                                         .filter { it.season != null && it.episode != null && it.season != 0 }
+                                        .filter { it.available != false || !it.released.isNullOrBlank() }
                                     if (episodes.isEmpty()) return@filter false
 
                                     val watchedEpisodes = updatedWatchedItems

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -21,7 +21,7 @@ internal object PlayerSubtitleUtils {
         }
 
         if (containsAny("portuguese", "portugues")) {
-            if (containsAny("brazil", "brasil", "brazilian", "brasileiro", "pt br", "ptbr", "pob")) {
+            if (containsAny("brazil", "brasil", "brazilian", "brasileiro", "pt br", "ptbr", "pob", "(br)")) {
                 return "pt-br"
             }
             if (containsAny("portugal", "european", "europeu", "iberian", "pt pt", "ptpt")) {
@@ -31,7 +31,7 @@ internal object PlayerSubtitleUtils {
         }
 
         if (containsAny("spanish", "espanol", "español", "castellano")) {
-            if (containsAny("latin", "latino", "latinoamerica", "latinoamericano", "lat am", "latam", "es 419", "es419", "la")) {
+            if (containsAny("latin", "latino", "latinoamerica", "latinoamericano", "lat am", "latam", "es 419", "es419", "la", "(419)")) {
                 return "es-419"
             }
             return "es"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/ThemeSettingsScreen.kt
@@ -93,7 +93,7 @@ fun ThemeSettingsContent(
     val strLanguageSystem = stringResource(R.string.appearance_language_system)
     val supportedLocales = remember(strLanguageSystem) {
         val tags = listOf(
-            "en", "de", "es", "es-419", "hu", "fr", "it", "pl",
+            "en", "de", "el", "es", "es-419", "hu", "fr", "it", "no", "pl",
             "pt-PT", "pt-BR", "tr", "cs", "sk", "sl", "sv", "ro", "ja",
             "nl", "vi", "hi", "lt"
         )


### PR DESCRIPTION
## Summary

Follow-up to #1074. After testing with a user with a large library (~200 watched series), several edge cases surfaced that required changes to how the series watched badge is determined and delivered.

Key changes:
- Persist watched series cache to disk per profile for instant badges on cold start
- Use `watchedItemsPreferences.allItems` as badge candidate source instead of CW seeds
- Re-evaluate badge directly in MetaDetailsViewModel when entering a series detail page
- Async-resolve meta for watched series not in `cwMetaCache` (including series without CW seeds)

## PR type

- Bug fix

## Why

#1074 relied on CW pipeline seeds to determine badge candidates. This missed series outside the CW days-cap window or without a progress entry.

Testing revealed:
- Series fully watched on Trakt but not in CW never got a badge (no meta loaded)
- Library showed every series as watched because `observeWatchedMovieIds()` leaked series IDs
- Cold start showed no series badges until CW pipeline completed (several seconds)
- Entering detail of a fully-watched series didn't trigger the badge despite having all data


## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified series badges appear instantly on cold start from persisted cache.
- Manual: verified badges update after CW pipeline re-validates with fresh data.
- Manual: verified entering detail of a fully-watched series triggers badge immediately.
- Manual: verified unmarking an episode removes the badge reactively.
- Manual: verified re-marking restores the badge.
- Manual: verified series in progress (not all episodes aired) do not get badge.
- Tested with user with large library via test builds.

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

Nothing should break

## Linked issues

Follow-up to #1074
