### PR TITLE
Fixes #1114/Add start from beginning button to player controls

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.filled.ClosedCaption
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.SwapHoriz
@@ -1192,6 +1193,15 @@ private fun PlayerControlsOverlay(
                         contentDescription = if (uiState.isPlaying) "Pause" else "Play",
                         onClick = onPlayPause,
                         focusRequester = playPauseFocusRequester,
+                        upFocusRequester = progressBarFocusRequester,
+                        onDownKey = onHideControls,
+                        onFocused = onResetHideTimer
+                    )
+
+                    ControlButton(
+                        icon = Icons.Default.Replay,
+                        contentDescription = stringResource(R.string.player_start_from_beginning),
+                        onClick = { onSeekTo(0L) },
                         upFocusRequester = progressBarFocusRequester,
                         onDownKey = onHideControls,
                         onFocused = onResetHideTimer

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -736,6 +736,7 @@
 
     <!-- PlayerScreen -->
     <string name="player_no_external_player">Harici oynatıcı bulunamadı</string>
+    <string name="player_start_from_beginning">Baştan başlat</string>
 
     <!-- ParentalGuideOverlay -->
     <string name="parental_nudity">Çıplaklık</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -788,6 +788,7 @@
 
     <!-- PlayerScreen -->
     <string name="player_no_external_player">No external player found</string>
+    <string name="player_start_from_beginning">Start from beginning</string>
 
     <!-- ParentalGuideOverlay -->
     <string name="parental_nudity">Nudity</string>


### PR DESCRIPTION
## Summary
- Added a "Start from Beginning" button to player controls.
- Re-used existing `ControlButton` component with `Icons.Default.Replay`.
- Implemented `onSeekTo(0L)` functionality for the new button.
- Added localization strings for English and Turkish.

## PR type
- Small maintenance improvement

## Why
- Enhances user experience by providing a quick way to restart playback from the beginning, similar to features in other media players (Issue #1114).

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
- Verified button placement in `PlayerControlsOverlay`.
- Tested the seek functionality resets playback to the start.
- Confirmed focus management works correctly with other player controls.

## Screenshots / Video (UI changes only)
- 
![photo_5924641655665397464_w](https://github.com/user-attachments/assets/85c91181-a693-40c8-afc2-3b4fe6b46bfb)

## Breaking changes
- None

## Linked issues
- Fixes #1114



