### PR TITLE
Fixes navigation lag on Stream Screen.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -238,6 +238,7 @@ internal fun AddonFilterChips(
     }
 
     var chipRowHasFocus by remember { mutableStateOf(false) }
+    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
 
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -246,6 +247,14 @@ internal fun AddonFilterChips(
             .onFocusChanged { chipRowHasFocus = it.hasFocus }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
+
+                // Throttle rapid key repeats (long-press)
+                if (event.nativeKeyEvent.repeatCount > 0) {
+                    val now = android.os.SystemClock.uptimeMillis()
+                    if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
+                    lastKeyRepeatDispatchRef.set(now)
+                }
+
                 val allOptions = listOf<String?>(null) + orderedNames
                 val currentIdx = allOptions.indexOf(selectedAddon)
                 when (event.key) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -190,6 +190,8 @@ internal fun StreamSourcesSidePanel(
                     val initialFocusStream = uiState.sourceFilteredStreams.getOrNull(currentStreamIndex)
                         ?: uiState.sourceFilteredStreams.firstOrNull()
 
+                    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
+
                     LazyColumn(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = PaddingValues(
@@ -202,6 +204,14 @@ internal fun StreamSourcesSidePanel(
                             .fillMaxHeight()
                             .onKeyEvent { event ->
                                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
+
+                                // Throttle rapid key repeats (long-press)
+                                if (event.nativeKeyEvent.repeatCount > 0) {
+                                    val now = android.os.SystemClock.uptimeMillis()
+                                    if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
+                                    lastKeyRepeatDispatchRef.set(now)
+                                }
+
                                 val addons = uiState.sourceAvailableAddons
                                 if (addons.isEmpty()) return@onKeyEvent false
                                 val allOptions = listOf<String?>(null) + addons

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -622,6 +622,7 @@ private fun AddonFilterChips(
 ) {
     val chipMap = sourceChips.associateBy { it.name }
     var chipRowHasFocus by remember { mutableStateOf(false) }
+    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
@@ -629,6 +630,14 @@ private fun AddonFilterChips(
             .onFocusChanged { chipRowHasFocus = it.hasFocus }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
+
+                // Throttle rapid key repeats (long-press)
+                if (event.nativeKeyEvent.repeatCount > 0) {
+                    val now = android.os.SystemClock.uptimeMillis()
+                    if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
+                    lastKeyRepeatDispatchRef.set(now)
+                }
+
                 val allOptions = listOf<String?>(null) + orderedNames
                 val currentIdx = allOptions.indexOf(selectedAddon)
                 when (event.key) {
@@ -775,6 +784,7 @@ private fun StreamsList(
     onFocusChanged: (Boolean) -> Unit = {}
 ) {
     val firstCardFocusRequester = remember { FocusRequester() }
+    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     val restoreFocusRequester = remember { FocusRequester() }
     val firstStreamKey = streams.firstOrNull()?.let { first ->
         "${first.addonName}_${first.url ?: first.infoHash ?: first.ytId ?: "unknown"}"
@@ -811,6 +821,13 @@ private fun StreamsList(
             .onFocusChanged { onFocusChanged(it.hasFocus) }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
+
+                // Throttle rapid key repeats (long-press)
+                if (event.nativeKeyEvent.repeatCount > 0) {
+                    val now = android.os.SystemClock.uptimeMillis()
+                    if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
+                    lastKeyRepeatDispatchRef.set(now)
+                }
                 if (availableAddons.isEmpty()) return@onKeyEvent false
                 val allOptions = listOf<String?>(null) + availableAddons
                 val currentIdx = allOptions.indexOf(selectedAddonFilter)


### PR DESCRIPTION
## Summary
- Added DPAD repeat throttling (112ms) to Stream Selection Screen and Player Source Side Panel to enhance UI responsiveness.
- Improved focus navigation feel across main stream list and player sources overlay.
- Applying a 112ms throttle ensures smooth navigation consistent with modern TV app standards.

## PR type
- Small maintenance improvement

## Why
- Long-pressing DPAD buttons caused significant navigation stuttering due to rapid focus updates.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
- Verified manually: 112ms delay on repeats prevents lag on Addon filters and Stream lists in both Stream Screen and Player Side Panel.

## Screenshots / Video (UI changes only)
- Smooths out UI focus transitions during long-press/key repeat.

## Breaking changes
-None .

## Linked issues
- Fixes navigation lag on Stream Screen and Player Side Panel.
