### PR TITLE
feat(L10n): add 52 French strings and modify 8 strings for consistency

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -53,7 +53,7 @@
     <string name="cw_new_episode">Nouvel Épisode</string>
     <string name="cw_new_season">Nouvelle Saison</string>
     <string name="cw_resume">Reprendre</string>
-    <string name="cw_percent_watched">%1$d%% regardé</string>
+    <string name="cw_percent_watched">%1$d%% visionné</string>
     <string name="cw_hours_min_left">%1$dh %2$dm restantes</string>
     <string name="cw_min_left">%1$dm restantes</string>
     <string name="cw_almost_done">Presque terminé</string>
@@ -124,6 +124,8 @@
     <string name="cast_role_writer">Scénariste</string>
     <string name="detail_tab_ratings">Notes</string>
     <string name="detail_tab_more_like_this">Similaires</string>
+    <string name="detail_more_like_this_powered_by_tmdb">Propulsé par TMDB</string>
+    <string name="detail_more_like_this_powered_by_trakt">Propulsé par Trakt</string>
     <string name="detail_comments_title">Commentaires</string>
     <string name="detail_comments_subtitle">Critiques de Trakt</string>
     <string name="detail_section_network">Chaîne</string>
@@ -807,6 +809,26 @@
     <string name="player_more_aspect_ratio">Format d\'image</string>
     <string name="player_more_open_external">Ouvrir dans un lecteur externe</string>
 
+    <!-- StreamInfoOverlay -->
+    <string name="stream_info_section_source">SOURCE</string>
+    <string name="stream_info_section_file">FICHIER</string>
+    <string name="stream_info_section_video">VIDÉO</string>
+    <string name="stream_info_section_audio">AUDIO</string>
+    <string name="stream_info_section_subtitle">SOUS-TITRE</string>
+    <string name="stream_info_filename">Nom du fichier</string>
+    <string name="stream_info_size">Taille</string>
+    <string name="stream_info_codec">Codec</string>
+    <string name="stream_info_resolution">Résolution</string>
+    <string name="stream_info_frame_rate">Fréquence d\'images</string>
+    <string name="stream_info_bitrate">Débit binaire</string>
+    <string name="stream_info_channels">Canaux</string>
+    <string name="stream_info_sample_rate">Fréquence d\'échantillonnage</string>
+    <string name="stream_info_language">Language</string>
+    <string name="stream_info_name">Nom</string>
+    <string name="stream_info_source">Source</string>
+    <string name="stream_info_subtitle_source_addon">Addon</string>
+    <string name="stream_info_subtitle_source_embedded">Intégré</string>
+
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Sources</string>
     <string name="sources_reload">Recharger</string>
@@ -896,7 +918,7 @@
     <string name="skip_ending">Passer les crédits</string>
     <string name="skip_recap">Passer le résumé</string>
     <string name="skip_generic">Passer</string>
-    <string name="display_mode_refresh">Fréquence d\'image</string>
+    <string name="display_mode_refresh">Rafraîchissement</string>
     <string name="display_mode_resolution">Resolution</string>
 
 
@@ -917,6 +939,37 @@
     <string name="library_filter_list">Liste</string>
     <string name="library_filter_type">Type</string>
     <string name="library_filter_sort">Tri</string>
+    <string name="library_filter_genre">Genre</string>
+    <string name="library_filter_year">Année</string>
+    <!-- Genre names (from TMDB movie + TV) -->
+    <string name="genre_action">Action</string>
+    <string name="genre_adventure">Aventure</string>
+    <string name="genre_animation">Animation</string>
+    <string name="genre_comedy">Comédie</string>
+    <string name="genre_crime">Policier</string>
+    <string name="genre_documentary">Documentaire</string>
+    <string name="genre_drama">Drame</string>
+    <string name="genre_family">Famille</string>
+    <string name="genre_fantasy">Fantastique</string>
+    <string name="genre_history">Histoire</string>
+    <string name="genre_horror">Horreur</string>
+    <string name="genre_music">Musique</string>
+    <string name="genre_mystery">Mystère</string>
+    <string name="genre_romance">Romance</string>
+    <string name="genre_science_fiction">Science-fiction</string>
+    <string name="genre_tv_movie">Téléfilm</string>
+    <string name="genre_thriller">Thriller</string>
+    <string name="genre_war">Guerre</string>
+    <string name="genre_western">Western</string>
+    <!-- TV-specific genres -->
+    <string name="genre_action_adventure">Action et Aventure</string>
+    <string name="genre_kids">Jeunesse</string>
+    <string name="genre_news">Information</string>
+    <string name="genre_reality">Téléréalité</string>
+    <string name="genre_sci_fi_fantasy">SF et Fantastique</string>
+    <string name="genre_soap">Soap</string>
+    <string name="genre_talk">Talk-show</string>
+    <string name="genre_war_politics">Guerre et Politique</string>
     <string name="library_sort_trakt_order">Ordre Trakt</string>
     <string name="library_sort_added_desc">Ajoutés ↓</string>
     <string name="library_sort_added_asc">Ajoutés ↑</string>
@@ -938,6 +991,9 @@
     <string name="library_delete_subtitle">Cela supprime la liste et tous ses éléments de Trakt.</string>
     <string name="library_delete_confirm">Supprimer</string>
     <string name="library_source_local">LOCAL</string>
+    <string name="library_source_nuvio">NUVIO</string>
+    <string name="library_source_trakt">TRAKT</string>
+    <string name="library_syncing_library">Synchronisation de la bibliothèque\u2026</string>
     <string name="library_type_all">Tout</string>
     <string name="library_type_items">éléments</string>
     <string name="library_empty_local_title">Aucun %1$s pour le moment</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -118,7 +118,7 @@
     <string name="detail_btn_play_episode">Lire S%1$dE%2$d</string>
     <string name="detail_btn_resume_episode">Reprendre S%1$dE%2$d</string>
     <string name="detail_btn_next_episode">Suivant S%1$dE%2$d</string>
-    <string name="detail_tab_cast">Créateur et casting</string>
+    <string name="detail_tab_cast">Créateur et distribution</string>
     <string name="cast_role_creator">Créateur</string>
     <string name="cast_role_director">Réalisateur</string>
     <string name="cast_role_writer">Scénariste</string>
@@ -248,7 +248,7 @@
 
     <!-- SupportersContributorsScreen -->
     <string name="supporters_contributors_title">Soutiens et contributeurs</string>
-    <string name="supporters_contributors_subtitle">Les personnes qui soutiennent Nuvio et les contributeurs qui le construisent sur TV et mobile.</string>
+    <string name="supporters_contributors_subtitle">Les personnes qui soutiennent Nuvio et les contributeurs qui le développent sur TV et mobile.</string>
     <string name="supporters_contributors_supporters_copy">Les soutiens et les donateurs permettent au projet de continuer à avancer, de financer l\'infrastructure et de laisser la place à des fonctionnalités ambitieuses.</string>
     <string name="supporters_contributors_donate_copy">Nuvio restera gratuit et open source. Si vous souhaitez soutenir le projet, vous pouvez aider à couvrir le temps et l\'infrastructure nécessaires à son développement.</string>
     <string name="supporters_contributors_donate_button">Faire un don à Nuvio</string>
@@ -568,7 +568,7 @@
     <string name="tmdb_details_title">Détails</string>
     <string name="tmdb_details_subtitle">Durée, date de sortie, pays et langue depuis TMDB</string>
     <string name="tmdb_credits_title">Crédits</string>
-    <string name="tmdb_credits_subtitle">Casting avec photos, réalisateur et scénariste depuis TMDB</string>
+    <string name="tmdb_credits_subtitle">Distribution avec photos, réalisateur et scénariste depuis TMDB</string>
     <string name="tmdb_productions_title">Productions</string>
     <string name="tmdb_productions_subtitle">Sociétés de production depuis TMDB</string>
     <string name="tmdb_networks_title">Chaînes</string>
@@ -903,7 +903,7 @@
 
     <!-- PauseOverlay -->
     <string name="pause_you_are_watching">Vous regardez</string>
-    <string name="pause_cast_label">Casting</string>
+    <string name="pause_cast_label">Distribution</string>
     <string name="pause_back_to_details">Retour aux détails</string>
     <string name="pause_as_character">dans le rôle de %1$s</string>
 
@@ -914,7 +914,7 @@
     <string name="next_episode_play">Lire</string>
     <string name="next_episode_unaired">Non diffusé</string>
     <string name="next_episode_not_aired_yet">L\'épisode suivant n\'est pas encore diffusé</string>
-    <string name="skip_intro">Passer le générique</string>
+    <string name="skip_intro">Passer l\'intro</string>
     <string name="skip_ending">Passer les crédits</string>
     <string name="skip_recap">Passer le résumé</string>
     <string name="skip_generic">Passer</string>
@@ -1117,7 +1117,7 @@
     <string name="update_unknown_sources">Autorisez l\'installation depuis des sources inconnues pour continuer.</string>
     <!-- AccountScreen -->
     <string name="account_title">Compte</string>
-    <string name="account_sign_in_description">Connectez-vous pour synchroniser votre bibliothèque, votre progression, vos addons et plugins entre vos appareils. La synchronisation de la bibliothèque et de la progression ne fonctionne que lorsque Trakt n\'est pas connecté.</string>
+    <string name="account_sign_in_description">Connectez-vous pour synchroniser votre bibliothèque, votre progression, vos addons et plugins entre vos appareils. La synchronisation de la bibliothèque utilise Nuvio Sync quand Trakt n\'est pas connecté, et la progression peut utiliser Trakt ou Nuvio Sync.</string>
     <string name="account_sync_code_title">Code de synchronisation</string>
     <string name="account_sync_code_description">Synchroniser entre appareils sans créer de compte.</string>
     <string name="account_linked_devices">Appareils liés (%1$d)</string>


### PR DESCRIPTION
## Summary
Added 52 missing strings to the French strings.xml file. As with previous updates, I maintained a perfect mirror of the default values/strings.xml to ensure total parity and simplify long-term maintenance.
Also updated 2 existing strings: replaced "regardé" with "visionné" and "Fréquence d'image" with "Rafraîchissement".

## PR type
- Translation update

## Why
Ensuring the French localization stays in sync with recent changes in the default strings file.

## Policy check
- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.

## Testing
Manual verification in Android Studio. I compared values-fr/strings.xml with the default values/strings.xml to ensure all 52 new strings are correctly mapped and translated without XML errors.

## Breaking changes
None.

## Linked issues
None.