### PR TITLE
Implement catalog group management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ HOME_UI_OPTIMIZATION_NOTES.local.md
 bugs/
 avatars/
 logs
+PR_MESSAGE.md
+finish_pr.sh

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,8 +185,11 @@ android {
     }
 }
 
-// Removed applicationId override for debug builds to ensure consistent package name.
-
+androidComponents {
+    onVariants(selector().withBuildType("debug")) { variant ->
+        variant.applicationId.set("com.nuviodebug.com")
+    }
+}
 
 composeCompiler {
     // Enable Compose compiler metrics for performance analysis

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,4 @@
-﻿plugins {
+plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
@@ -185,11 +185,8 @@ android {
     }
 }
 
-androidComponents {
-    onVariants(selector().withBuildType("debug")) { variant ->
-        variant.applicationId.set("com.nuviodebug.com")
-    }
-}
+// Removed applicationId override for debug builds to ensure consistent package name.
+
 
 composeCompiler {
     // Enable Compose compiler metrics for performance analysis

--- a/app/src/main/assets/group_web.html
+++ b/app/src/main/assets/group_web.html
@@ -1,0 +1,552 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>NuvioTV - Manage Groups</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  *:focus, *:active { outline: none !important; }
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #000; color: #fff; min-height: 100vh; line-height: 1.5;
+  }
+  .page { max-width: 600px; margin: 0 auto; padding: 0 1.5rem 6rem; }
+  .header { text-align: center; padding: 2rem 0 1.5rem; border-bottom: 1px solid rgba(255, 255, 255, 0.05); }
+  .header-logo { height: 32px; width: auto; margin-bottom: 0.5rem; filter: brightness(0) invert(1); opacity: 0.9; }
+  .header p { font-size: 0.875rem; font-weight: 300; color: rgba(255, 255, 255, 0.4); letter-spacing: 0.02em; }
+  
+  .tabs { display: flex; gap: 1rem; margin-top: 1.5rem; border-bottom: 1px solid rgba(255,255,255,0.1); }
+  .tab { flex: 1; text-align: center; padding: 0.75rem; cursor: pointer; color: rgba(255,255,255,0.5); font-weight: 600; font-size: 0.9rem; border-bottom: 2px solid transparent; }
+  .tab.active { color: #fff; border-bottom-color: #fff; }
+  
+  .btn { display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; background: transparent; border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 100px; padding: 0.75rem 1.25rem; color: #fff; font-family: inherit; font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: all 0.3s ease; }
+  .btn:hover { background: #fff; color: #000; border-color: #fff; }
+  .btn-primary { background: #fff; color: #000; border: none; }
+  .btn-primary:hover { background: #eee; }
+  .btn-block { width: 100%; margin-top: 1rem; padding: 1rem; font-size: 0.95rem; font-weight: 600; }
+  .btn-danger { color: #CF6679; border-color: rgba(207, 102, 121, 0.3); }
+  .btn-danger:hover { background: rgba(207, 102, 121, 0.1); color: #CF6679; border-color: #CF6679; }
+  
+  .input-field { width: 100%; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #fff; padding: 0.875rem 1rem; border-radius: 8px; font-size: 0.95rem; margin-top: 0.25rem; font-family: inherit; }
+  .input-field:focus { border-color: #fff; }
+  .input-label { font-size: 0.75rem; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 1.5rem; display: block; }
+  
+  select.input-field { appearance: none; }
+  
+  .list-view { margin-top: 1rem; }
+  .list-item { border: 1px solid rgba(255,255,255,0.1); border-radius: 8px; padding: 1rem; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 1rem; background: rgba(255,255,255,0.02); }
+  .list-item-content { flex: 1; min-width: 0; cursor: pointer; }
+  .list-item-title { font-weight: 600; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .list-item-subtitle { font-size: 0.75rem; color: rgba(255,255,255,0.4); margin-top: 0.25rem; }
+  
+  .order-controls { display: flex; flex-direction: column; gap: 0.25rem; }
+  .btn-order { background: transparent; border: none; color: rgba(255,255,255,0.3); cursor: pointer; padding: 0.25rem; border-radius: 4px; }
+  .btn-order:hover { background: rgba(255,255,255,0.1); color: #fff; }
+  .btn-order:disabled { opacity: 0.2; pointer-events: none; }
+
+  .empty-state { text-align: center; color: rgba(255, 255, 255, 0.3); padding: 3rem 0; font-size: 0.875rem; }
+  
+  .editor-header { display: flex; align-items: center; gap: 1rem; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 1rem; margin-bottom: 1rem; }
+  .back-btn { background: transparent; border: none; color: #fff; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0.5rem; margin-left: -0.5rem; }
+  .editor-title { font-size: 1.1rem; font-weight: 600; }
+  
+  .catalog-list { margin-top: 1.5rem; }
+  .catalog-item { padding: 0.75rem 0; border-top: 1px solid rgba(255,255,255,0.05); display: flex; align-items: center; gap: 0.75rem; }
+  .catalog-item:last-child { border-bottom: 1px solid rgba(255,255,255,0.05); }
+  
+  .hidden { display: none !important; }
+
+  /* Checkbox styling */
+  .checkbox-wrapper { display: flex; align-items: center; justify-content: center; width: 40px; cursor: pointer; }
+  .checkbox { width: 20px; height: 20px; border: 2px solid rgba(255,255,255,0.5); border-radius: 4px; display: flex; align-items: center; justify-content: center; transition: all 0.2s; }
+  .checkbox.checked { background: #fff; border-color: #fff; }
+  .checkbox.checked::after { content: ''; width: 5px; height: 10px; border-right: 2px solid #000; border-bottom: 2px solid #000; transform: rotate(45deg); margin-bottom: 2px; }
+
+  .view-container { display: none; }
+  .view-container.active { display: block; }
+
+  /* Overlay styles */
+  .status-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.92); backdrop-filter: blur(10px); z-index: 500; display: flex; align-items: center; justify-content: center; opacity: 0; visibility: hidden; transition: all 0.3s; }
+  .status-overlay.visible { opacity: 1; visibility: visible; }
+  .status-content { text-align: center; max-width: 320px; padding: 2rem; }
+  .spinner { width: 40px; height: 40px; border: 2px solid rgba(255,255,255,0.1); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; margin: 0 auto 1.5rem; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .status-title { font-size: 1.25rem; font-weight: 700; margin-bottom: 0.5rem; }
+  .status-message { font-size: 0.875rem; color: rgba(255,255,255,0.5); line-height: 1.5; }
+  .connection-bar { position: fixed; top: 0; left: 0; right: 0; background: rgba(207,102,121,0.2); text-align: center; padding: 0.5rem; font-size: 0.75rem; color: #CF6679; display: none; }
+</style>
+</head>
+<body>
+
+<div class="connection-bar" id="connectionBar">Connection to TV lost / Unauthorized</div>
+
+<div class="page">
+  <div class="header" id="mainHeader">
+    <img src="/logo.png" alt="NuvioTV" class="header-logo">
+    <p>Manage Groups & Layout</p>
+  </div>
+
+  <!-- Main View -->
+  <div id="mainView" class="view-container active">
+    <div class="tabs">
+      <div class="tab active" id="tabSubgroups" onclick="switchTab('subgroups')">Subgroups</div>
+      <div class="tab" id="tabMaingroups" onclick="switchTab('maingroups')">Primary Groups</div>
+    </div>
+
+    <!-- Subgroups List -->
+    <div id="subgroupsListContainer" style="margin-top: 1.5rem;">
+      <button class="btn btn-block" onclick="createSubgroup()">+ Create Subgroup</button>
+      <div id="subgroupsList" class="list-view"></div>
+    </div>
+
+    <!-- Main Groups List -->
+    <div id="maingroupsListContainer" class="hidden" style="margin-top: 1.5rem;">
+      <button class="btn btn-block" onclick="createMainGroup()">+ Create Primary Group</button>
+      <div id="maingroupsList" class="list-view"></div>
+    </div>
+
+    <button class="btn btn-primary btn-block" id="saveAllBtn" onclick="saveAllChanges()" style="margin-top: 3rem;">Sync to TV</button>
+  </div>
+
+  <!-- Editor View -->
+  <div id="editorView" class="view-container">
+    <div class="editor-header">
+      <button class="back-btn" onclick="closeEditor()">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+      </button>
+      <div class="editor-title" id="editorTitle">Edit Group</div>
+    </div>
+
+    <div class="editor-body">
+      <label class="input-label">Name</label>
+      <input type="text" id="editName" class="input-field" autocomplete="off" placeholder="Group Name">
+
+      <label class="input-label">Custom Logo URL (Optional)</label>
+      <input type="text" id="editLogoUrl" class="input-field" autocomplete="off" placeholder="https://...">
+
+      <!-- Main Group Specific -->
+      <div id="maingroupFields" class="hidden">
+        <label class="input-label">Select Subgroups</label>
+        <div id="editorSubgroupList" class="catalog-list"></div>
+      </div>
+
+      <!-- Subgroup Specific -->
+      <div id="subgroupFields" class="hidden">
+        <div class="input-label">Select Catalogs</div>
+        <div id="editorCatalogList" class="catalog-list"></div>
+      </div>
+
+      <button class="btn btn-primary btn-block" onclick="saveEditor()">Apply</button>
+      <button class="btn btn-danger btn-block" style="background: transparent" onclick="deleteEditingItem()">Delete Group</button>
+    </div>
+  </div>
+</div>
+
+<div class="status-overlay" id="statusOverlay">
+  <div class="status-content" id="statusContent"></div>
+</div>
+
+<script>
+let state = {
+  availableCatalogs: [],
+  catalogGroups: [],
+  mainGroups: [],
+  currentTab: 'subgroups',
+  editingMode: null,
+  editingItem: null,
+  editingItemIndex: -1
+};
+
+const urlParams = new URLSearchParams(window.location.search);
+const token = urlParams.get('token') || '';
+
+// UUID Gen
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+function el(id) { return document.getElementById(id); }
+
+async function loadState() {
+  try {
+    let res = await fetch(`/api/state?token=${token}`);
+    if (!res.ok) throw new Error("Unauthorized");
+    let data = await res.json();
+    state.availableCatalogs = data.availableCatalogs || [];
+    state.catalogGroups = data.catalogGroups || [];
+    state.mainGroups = data.mainGroups || [];
+    el('connectionBar').style.display = 'none';
+    renderLists();
+  } catch (e) {
+    el('connectionBar').style.display = 'block';
+  }
+}
+
+async function refreshFromTv() {
+  await loadState();
+}
+
+function switchTab(tab) {
+  state.currentTab = tab;
+  el('tabSubgroups').className = 'tab' + (tab === 'subgroups' ? ' active' : '');
+  el('tabMaingroups').className = 'tab' + (tab === 'maingroups' ? ' active' : '');
+  el('subgroupsListContainer').classList.toggle('hidden', tab !== 'subgroups');
+  el('maingroupsListContainer').classList.toggle('hidden', tab !== 'maingroups');
+}
+
+function renderLists() {
+  let sgHtml = '';
+  if (state.catalogGroups.length === 0) {
+    sgHtml = '<div class="empty-state">No subgroups configured</div>';
+  } else {
+    state.catalogGroups.forEach((sg, i) => {
+      sgHtml += `
+        <div class="list-item">
+          <div class="order-controls">
+            <button class="btn-order" ${i===0?'disabled':''} onclick="moveArrayItem('catalogGroups', ${i}, -1)">▲</button>
+            <button class="btn-order" ${i===state.catalogGroups.length-1?'disabled':''} onclick="moveArrayItem('catalogGroups', ${i}, 1)">▼</button>
+          </div>
+          <div class="list-item-content" onclick="editSubgroup(${i})">
+            <div class="list-item-title">${escapeHtml(sg.name)}</div>
+            <div class="list-item-subtitle">${(sg.catalogKeys||[]).length} catalogs</div>
+          </div>
+          <button class="btn btn-primary" style="padding: 0.5rem 1rem;" onclick="editSubgroup(${i})">Edit</button>
+        </div>
+      `;
+    });
+  }
+  el('subgroupsList').innerHTML = sgHtml;
+
+  let mgHtml = '';
+  if (state.mainGroups.length === 0) {
+    mgHtml = '<div class="empty-state">No primary groups configured</div>';
+  } else {
+    state.mainGroups.forEach((mg, i) => {
+      mgHtml += `
+        <div class="list-item">
+          <div class="order-controls">
+            <button class="btn-order" ${i===0?'disabled':''} onclick="moveArrayItem('mainGroups', ${i}, -1)">▲</button>
+            <button class="btn-order" ${i===state.mainGroups.length-1?'disabled':''} onclick="moveArrayItem('mainGroups', ${i}, 1)">▼</button>
+          </div>
+          <div class="list-item-content" onclick="editMainGroup(${i})">
+            <div class="list-item-title">${escapeHtml(mg.name)}</div>
+            <div class="list-item-subtitle">${(mg.subGroupIds||[]).length} subgroups</div>
+          </div>
+          <button class="btn btn-primary" style="padding: 0.5rem 1rem;" onclick="editMainGroup(${i})">Edit</button>
+        </div>
+      `;
+    });
+  }
+  el('maingroupsList').innerHTML = mgHtml;
+}
+
+function moveArrayItem(arrayName, index, dir) {
+  let arr = state[arrayName];
+  if (index + dir < 0 || index + dir >= arr.length) return;
+  let temp = arr[index];
+  arr[index] = arr[index + dir];
+  arr[index + dir] = temp;
+  renderLists();
+}
+
+// --- Editors ---
+function showEditor() {
+  el('mainView').classList.remove('active');
+  el('editorView').classList.add('active');
+  el('mainHeader').classList.add('hidden');
+}
+function closeEditor() {
+  el('editorView').classList.remove('active');
+  el('mainView').classList.add('active');
+  el('mainHeader').classList.remove('hidden');
+  state.editingMode = null;
+  state.editingItem = null;
+  state.editingItemIndex = -1;
+  renderLists();
+}
+
+function processUrl(url) {
+  if (!url) return null;
+  return url.trim();
+}
+
+function saveEditor() {
+  if (!state.editingMode) return;
+  
+  let name = el('editName').value.trim();
+  if (!name) { alert("Name cannot be empty"); return; }
+  
+  state.editingItem.name = name;
+  state.editingItem.logoUrl = processUrl(el('editLogoUrl').value);
+  
+  if (state.editingMode === 'subgroup') {
+    if (state.editingItemIndex === -1) state.catalogGroups.push(state.editingItem);
+    else state.catalogGroups[state.editingItemIndex] = state.editingItem;
+  } else if (state.editingMode === 'maingroup') {
+    state.editingItem.posterType = "Square";
+    state.editingItem.posterSize = "Default";
+    if (state.editingItemIndex === -1) state.mainGroups.push(state.editingItem);
+    else state.mainGroups[state.editingItemIndex] = state.editingItem;
+  }
+  
+  closeEditor();
+}
+
+function deleteEditingItem() {
+  if (!confirm("Are you sure you want to delete this group?")) return;
+  
+  if (state.editingMode === 'subgroup' && state.editingItemIndex !== -1) {
+    state.catalogGroups.splice(state.editingItemIndex, 1);
+    let id = state.editingItem.id;
+    state.mainGroups.forEach(mg => {
+      mg.subGroupIds = mg.subGroupIds.filter(sid => sid !== id);
+    });
+  } else if (state.editingMode === 'maingroup' && state.editingItemIndex !== -1) {
+    state.mainGroups.splice(state.editingItemIndex, 1);
+  }
+  closeEditor();
+}
+
+function editSubgroup(index) {
+  state.editingMode = 'subgroup';
+  state.editingItemIndex = index;
+  state.editingItem = index === -1 ? { id: uuidv4(), name: '', catalogKeys: [] } : JSON.parse(JSON.stringify(state.catalogGroups[index]));
+  
+  el('editorTitle').innerText = index === -1 ? 'New Subgroup' : 'Edit Subgroup';
+  el('editName').value = state.editingItem.name || '';
+  el('editLogoUrl').value = state.editingItem.logoUrl || '';
+  
+  el('subgroupFields').classList.remove('hidden');
+  el('maingroupFields').classList.add('hidden');
+  
+  renderEditorCatalogList();
+  showEditor();
+}
+function createSubgroup() { editSubgroup(-1); }
+
+function renderEditorCatalogList() {
+  let selected = state.editingItem.catalogKeys || [];
+  let combined = [];
+  
+  selected.forEach(k => {
+    let cat = state.availableCatalogs.find(c => c.key === k);
+    if (cat) combined.push({ ...cat, isSelected: true });
+  });
+  
+  state.availableCatalogs.forEach(c => {
+    if (!selected.includes(c.key)) combined.push({ ...c, isSelected: false });
+  });
+  
+  let html = '';
+  combined.forEach((cat, i) => {
+    let cbClass = cat.isSelected ? 'checkbox checked' : 'checkbox';
+    html += `
+      <div class="catalog-item">
+        <div class="order-controls">
+          <button class="btn-order" ${i===0?'disabled':''} onclick="moveEditorCatalog(${i}, -1)">▲</button>
+          <button class="btn-order" ${i===combined.length-1?'disabled':''} onclick="moveEditorCatalog(${i}, 1)">▼</button>
+        </div>
+        <div class="checkbox-wrapper" onclick="toggleEditorCatalog('${cat.key}')">
+          <div class="${cbClass}"></div>
+        </div>
+        <div class="list-item-content" onclick="toggleEditorCatalog('${cat.key}')">
+          <div class="list-item-title">${escapeHtml(cat.catalogName)}</div>
+          <div class="list-item-subtitle">${escapeHtml(cat.addonName)} - ${escapeHtml(cat.type)}</div>
+        </div>
+      </div>
+    `;
+  });
+  el('editorCatalogList').innerHTML = html;
+  state.editingItem.catalogKeys = combined.filter(c => c.isSelected).map(c => c.key);
+}
+
+function toggleEditorCatalog(key) {
+  let idx = state.editingItem.catalogKeys.indexOf(key);
+  if (idx !== -1) state.editingItem.catalogKeys.splice(idx, 1);
+  else state.editingItem.catalogKeys.push(key);
+  renderEditorCatalogList();
+}
+function moveEditorCatalog(currentIndex, dir) {
+  let selected = state.editingItem.catalogKeys || [];
+  let combined = [];
+  selected.forEach(k => { let c = state.availableCatalogs.find(c => c.key === k); if(c) combined.push({key:k, sel:true}); });
+  state.availableCatalogs.forEach(c => { if(!selected.includes(c.key)) combined.push({key:c.key, sel:false}); });
+  
+  let targetIndex = currentIndex + dir;
+  if(targetIndex < 0 || targetIndex >= combined.length) return;
+  
+  let temp = combined[currentIndex];
+  combined[currentIndex] = combined[targetIndex];
+  combined[targetIndex] = temp;
+  
+  let newSelectedKeys = [];
+  combined.forEach(c => { if (c.sel) newSelectedKeys.push(c.key); });
+  state.editingItem.catalogKeys = newSelectedKeys;
+  
+  let sortedAvailable = [];
+  combined.forEach(c => {
+    let cat = state.availableCatalogs.find(av => av.key === c.key);
+    if(cat) sortedAvailable.push(cat);
+  });
+  state.availableCatalogs = sortedAvailable;
+  
+  renderEditorCatalogList();
+}
+
+function editMainGroup(index) {
+  state.editingMode = 'maingroup';
+  state.editingItemIndex = index;
+  state.editingItem = index === -1 ? { id: uuidv4(), name: '', subGroupIds: [] } : JSON.parse(JSON.stringify(state.mainGroups[index]));
+  
+  el('editorTitle').innerText = index === -1 ? 'New Primary Group' : 'Edit Primary Group';
+  el('editName').value = state.editingItem.name || '';
+  el('editLogoUrl').value = state.editingItem.logoUrl || '';
+  
+  el('maingroupFields').classList.remove('hidden');
+  el('subgroupFields').classList.add('hidden');
+  
+  renderEditorSubgroupList();
+  showEditor();
+}
+function createMainGroup() { editMainGroup(-1); }
+
+function renderEditorSubgroupList() {
+  let selected = state.editingItem.subGroupIds || [];
+  let combined = [];
+  selected.forEach(id => {
+    let sg = state.catalogGroups.find(c => c.id === id);
+    if (sg) combined.push({ ...sg, isSelected: true });
+  });
+  state.catalogGroups.forEach(sg => {
+    if (!selected.includes(sg.id)) combined.push({ ...sg, isSelected: false });
+  });
+
+  let html = '';
+  combined.forEach((sg, i) => {
+    let cbClass = sg.isSelected ? 'checkbox checked' : 'checkbox';
+    html += `
+      <div class="catalog-item">
+        <div class="order-controls">
+          <button class="btn-order" ${i===0?'disabled':''} onclick="moveEditorSubgroup(${i}, -1)">▲</button>
+          <button class="btn-order" ${i===combined.length-1?'disabled':''} onclick="moveEditorSubgroup(${i}, 1)">▼</button>
+        </div>
+        <div class="checkbox-wrapper" onclick="toggleEditorSubgroup('${sg.id}')">
+          <div class="${cbClass}"></div>
+        </div>
+        <div class="list-item-content" onclick="toggleEditorSubgroup('${sg.id}')">
+          <div class="list-item-title">${escapeHtml(sg.name)}</div>
+          <div class="list-item-subtitle">${(sg.catalogKeys||[]).length} catalogs</div>
+        </div>
+      </div>
+    `;
+  });
+  el('editorSubgroupList').innerHTML = html;
+  state.editingItem.subGroupIds = combined.filter(c => c.isSelected).map(c => c.id);
+}
+
+function toggleEditorSubgroup(id) {
+  let idx = state.editingItem.subGroupIds.indexOf(id);
+  if (idx !== -1) state.editingItem.subGroupIds.splice(idx, 1);
+  else state.editingItem.subGroupIds.push(id);
+  renderEditorSubgroupList();
+}
+
+function moveEditorSubgroup(currentIndex, dir) {
+  let selected = state.editingItem.subGroupIds || [];
+  let combined = [];
+  selected.forEach(id => { let sg = state.catalogGroups.find(c => c.id === id); if(sg) combined.push({id:id, sel:true}); });
+  state.catalogGroups.forEach(sg => { if(!selected.includes(sg.id)) combined.push({id:sg.id, sel:false}); });
+  
+  let targetIndex = currentIndex + dir;
+  if(targetIndex < 0 || targetIndex >= combined.length) return;
+  
+  let temp = combined[currentIndex];
+  combined[currentIndex] = combined[targetIndex];
+  combined[targetIndex] = temp;
+  
+  let newSelectedIds = [];
+  combined.forEach(c => { if (c.sel) newSelectedIds.push(c.id); });
+  state.editingItem.subGroupIds = newSelectedIds;
+  
+  let sortedCatalogGroups = [];
+  combined.forEach(c => {
+    let sg = state.catalogGroups.find(av => av.id === c.id);
+    if(sg) sortedCatalogGroups.push(sg);
+  });
+  state.catalogGroups = sortedCatalogGroups;
+  
+  renderEditorSubgroupList();
+}
+
+async function saveAllChanges() {
+  el('saveAllBtn').disabled = true;
+  showOverlay('<div class="spinner"></div><div class="status-title">Waiting for TV...</div><div class="status-message">Please confirm the changes on your TV.</div>');
+  
+  try {
+    let res = await fetch(`/api/catalogs?token=${token}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        catalogGroups: state.catalogGroups,
+        mainGroups: state.mainGroups
+      })
+    });
+    if (!res.ok) throw new Error("Unauthorized or Invalid token");
+    let data = await res.json();
+    if (data.status === 'pending_confirmation') {
+      pollStatus(data.id);
+    } else {
+      showOverlayError(data.error || 'Failed to save');
+    }
+  } catch (e) {
+    showOverlayError('Unauthorized or network error.');
+  }
+}
+
+async function pollStatus(changeId) {
+  let timerId = setInterval(async () => {
+    try {
+      let res = await fetch(`/api/status/${changeId}?token=${token}`);
+      if (!res.ok) throw new Error("Unauthorized");
+      let data = await res.json();
+      if (data.status === 'confirmed') {
+        clearInterval(timerId);
+        showOverlay('<div class="status-title" style="color:#4CAF50;">Success!</div><div class="status-message">Changes applied on TV.</div>');
+        setTimeout(() => hideOverlay(), 2000);
+      } else if (data.status === 'rejected') {
+        clearInterval(timerId);
+        showOverlayError('Changes were rejected on the TV.');
+      }
+    } catch (e) {
+      clearInterval(timerId);
+      showOverlayError('Connection lost.');
+    }
+  }, 1500);
+}
+
+function showOverlay(html) {
+  el('statusContent').innerHTML = html;
+  el('statusOverlay').classList.add('visible');
+}
+function hideOverlay() {
+  el('statusOverlay').classList.remove('visible');
+  el('saveAllBtn').disabled = false;
+}
+function showOverlayError(msg) {
+  showOverlay(`<div class="status-title" style="color:#CF6679;">Error</div><div class="status-message">${escapeHtml(msg)}</div><button class="btn btn-primary" style="margin-top:1rem;" onclick="hideOverlay()">Dismiss</button>`);
+}
+function escapeHtml(str) {
+  let div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+loadState();
+</script>
+</body>
+</html>

--- a/app/src/main/assets/group_web.html
+++ b/app/src/main/assets/group_web.html
@@ -123,8 +123,13 @@
       <label class="input-label">Name</label>
       <input type="text" id="editName" class="input-field" autocomplete="off" placeholder="Group Name">
 
-      <label class="input-label">Custom Logo URL (Optional)</label>
-      <input type="text" id="editLogoUrl" class="input-field" autocomplete="off" placeholder="https://...">
+      <div id="logoUrlField">
+        <label class="input-label" style="display:flex; justify-content:space-between; align-items:flex-end;">
+          <span>Custom Logo URL (Optional)</span>
+          <span style="font-size: 0.75rem; color: #888; font-weight: normal;">Must be direct link (.jpg/.png)</span>
+        </label>
+        <input type="text" id="editLogoUrl" class="input-field" autocomplete="off" placeholder="e.g. https://i.ibb.co/XYZ123/image.jpg">
+      </div>
 
       <!-- Main Group Specific -->
       <div id="maingroupFields" class="hidden">
@@ -282,9 +287,9 @@ function saveEditor() {
   if (!name) { alert("Name cannot be empty"); return; }
   
   state.editingItem.name = name;
-  state.editingItem.logoUrl = processUrl(el('editLogoUrl').value);
   
   if (state.editingMode === 'subgroup') {
+    state.editingItem.logoUrl = processUrl(el('editLogoUrl').value);
     if (state.editingItemIndex === -1) state.catalogGroups.push(state.editingItem);
     else state.catalogGroups[state.editingItemIndex] = state.editingItem;
   } else if (state.editingMode === 'maingroup') {
@@ -323,6 +328,7 @@ function editSubgroup(index) {
   
   el('subgroupFields').classList.remove('hidden');
   el('maingroupFields').classList.add('hidden');
+  el('logoUrlField').classList.remove('hidden');
   
   renderEditorCatalogList();
   showEditor();
@@ -409,6 +415,7 @@ function editMainGroup(index) {
   
   el('maingroupFields').classList.remove('hidden');
   el('subgroupFields').classList.add('hidden');
+  el('logoUrlField').classList.add('hidden');
   
   renderEditorSubgroupList();
   showEditor();

--- a/app/src/main/java/com/nuvio/tv/core/server/DeviceIpAddress.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/DeviceIpAddress.kt
@@ -17,7 +17,7 @@ object DeviceIpAddress {
         }
 
         // Fallback: iterate NetworkInterface for Ethernet / other connections
-        return try {
+        val fallbackIp = try {
             NetworkInterface.getNetworkInterfaces()?.toList()
                 ?.flatMap { it.inetAddresses.toList() }
                 ?.firstOrNull { !it.isLoopbackAddress && it is Inet4Address }
@@ -25,6 +25,8 @@ object DeviceIpAddress {
         } catch (e: Exception) {
             null
         }
+
+        return fallbackIp
     }
 
     private fun formatIp(ip: Int): String {

--- a/app/src/main/java/com/nuvio/tv/core/server/GroupConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/GroupConfigServer.kt
@@ -1,0 +1,199 @@
+package com.nuvio.tv.core.server
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import fi.iki.elonen.NanoHTTPD
+import java.io.ByteArrayInputStream
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class GroupConfigServer(
+    private val serverToken: String,
+    private val webPageHtml: String,
+    private val currentPageStateProvider: () -> PageState,
+    private val onChangeProposed: (PendingGroupChange) -> Unit,
+    private val logoProvider: (() -> ByteArray?)? = null,
+    port: Int = 8080
+) : NanoHTTPD(port) {
+
+    data class CatalogInfo(
+        val key: String,
+        val catalogName: String,
+        val addonName: String,
+        val type: String,
+        val isSelected: Boolean
+    )
+
+    data class PageState(
+        val availableCatalogs: List<CatalogInfo>,
+        val catalogGroups: List<com.nuvio.tv.domain.model.CatalogGroup>,
+        val mainGroups: List<com.nuvio.tv.domain.model.MainGroup>
+    )
+
+    data class PendingGroupChange(
+        val id: String = UUID.randomUUID().toString(),
+        val proposedCatalogGroups: List<com.nuvio.tv.domain.model.CatalogGroup>,
+        val proposedMainGroups: List<com.nuvio.tv.domain.model.MainGroup>,
+        var status: ChangeStatus = ChangeStatus.PENDING
+    )
+
+    enum class ChangeStatus { PENDING, CONFIRMED, REJECTED }
+
+    private val gson = Gson()
+    private val pendingChanges = ConcurrentHashMap<String, PendingGroupChange>()
+
+    fun confirmChange(id: String) {
+        pendingChanges[id]?.status = ChangeStatus.CONFIRMED
+    }
+
+    fun rejectChange(id: String) {
+        pendingChanges[id]?.status = ChangeStatus.REJECTED
+    }
+
+    override fun serve(session: IHTTPSession): Response {
+        val uri = session.uri
+        val method = session.method
+        
+        if (uri.startsWith("/api/")) {
+            val reqToken = session.parameters["token"]?.firstOrNull()
+            if (reqToken != serverToken) {
+                return newFixedLengthResponse(Response.Status.UNAUTHORIZED, "application/json", "{\"error\":\"Unauthorized\"}")
+            }
+        }
+
+        return when {
+            method == Method.GET && uri == "/" -> serveWebPage()
+            method == Method.GET && uri == "/logo.png" -> serveLogo()
+            method == Method.GET && uri == "/api/state" -> servePageState()
+            method == Method.POST && uri == "/api/catalogs" -> handleUpdate(session)
+            method == Method.GET && uri.startsWith("/api/status/") -> serveChangeStatus(uri)
+            else -> newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Not found")
+        }
+    }
+
+    private fun serveWebPage(): Response {
+        return newFixedLengthResponse(Response.Status.OK, "text/html", webPageHtml)
+    }
+
+    private fun serveLogo(): Response {
+        val bytes = logoProvider?.invoke()
+        return if (bytes != null) {
+            newFixedLengthResponse(
+                Response.Status.OK,
+                "image/png",
+                ByteArrayInputStream(bytes),
+                bytes.size.toLong()
+            )
+        } else {
+            newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Not found")
+        }
+    }
+
+    private fun servePageState(): Response {
+        val state = currentPageStateProvider()
+        val json = gson.toJson(state)
+        return newFixedLengthResponse(Response.Status.OK, "application/json", json)
+    }
+
+    private fun handleUpdate(session: IHTTPSession): Response {
+        pendingChanges.values
+            .filter { it.status == ChangeStatus.PENDING }
+            .forEach { it.status = ChangeStatus.REJECTED }
+            
+        // Memory limit protection against DoS
+        if (pendingChanges.size > 20) {
+            val oldKeys = pendingChanges.filterValues { it.status != ChangeStatus.PENDING }.keys
+            oldKeys.forEach { pendingChanges.remove(it) }
+        }
+
+        val bodyMap = HashMap<String, String>()
+        session.parseBody(bodyMap)
+        val body = bodyMap["postData"] ?: ""
+
+        val change: PendingGroupChange = try {
+            val parsed = gson.fromJson<Map<String, Any>>(body, object : TypeToken<Map<String, Any>>() {}.type)
+            
+            // Add fallback values for MainGroup so Moshi/Gson doesn't null them out and cause crashes
+            val mainGroupsRaw = (parsed["mainGroups"] as? List<Map<String, Any>>)?.map { mg ->
+                val mgMutable = mg.toMutableMap()
+                if (!mgMutable.containsKey("posterType")) mgMutable["posterType"] = "Square"
+                if (!mgMutable.containsKey("posterSize")) mgMutable["posterSize"] = "Default"
+                mgMutable
+            } ?: emptyList<Map<String, Any>>()
+
+            val catalogGroupsJson = gson.toJson(parsed["catalogGroups"])
+            val mainGroupsJson = gson.toJson(mainGroupsRaw)
+            
+            val cgType = object : TypeToken<List<com.nuvio.tv.domain.model.CatalogGroup>>() {}.type
+            val mgType = object : TypeToken<List<com.nuvio.tv.domain.model.MainGroup>>() {}.type
+            
+            val cgs: List<com.nuvio.tv.domain.model.CatalogGroup> = gson.fromJson(catalogGroupsJson, cgType) ?: emptyList()
+            val mgs: List<com.nuvio.tv.domain.model.MainGroup> = gson.fromJson(mainGroupsJson, mgType) ?: emptyList()
+
+            PendingGroupChange(
+                proposedCatalogGroups = cgs,
+                proposedMainGroups = mgs
+            )
+        } catch (e: Exception) {
+            val error = mapOf("error" to "Invalid request body")
+            return newFixedLengthResponse(
+                Response.Status.BAD_REQUEST,
+                "application/json",
+                gson.toJson(error)
+            )
+        }
+
+        pendingChanges[change.id] = change
+        onChangeProposed(change)
+
+        val response = mapOf("status" to "pending_confirmation", "id" to change.id)
+        return newFixedLengthResponse(Response.Status.OK, "application/json", gson.toJson(response))
+    }
+
+    private fun serveChangeStatus(uri: String): Response {
+        val id = uri.removePrefix("/api/status/")
+        val change = pendingChanges[id]
+        val status = change?.status?.name?.lowercase() ?: "not_found"
+        val response = mapOf("status" to status)
+        return newFixedLengthResponse(Response.Status.OK, "application/json", gson.toJson(response))
+    }
+
+    private fun parseStringList(rawValue: Any?): List<String> {
+        val values = rawValue as? List<*> ?: return emptyList()
+        return values.asSequence()
+            .mapNotNull { (it as? String)?.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .toList()
+    }
+
+    companion object {
+        fun startOnAvailablePort(
+            serverToken: String,
+            webPageHtml: String,
+            currentPageStateProvider: () -> PageState,
+            onChangeProposed: (PendingGroupChange) -> Unit,
+            logoProvider: (() -> ByteArray?)? = null,
+            startPort: Int = 8080,
+            maxAttempts: Int = 10
+        ): GroupConfigServer? {
+            for (port in startPort until startPort + maxAttempts) {
+                try {
+                    val server = GroupConfigServer(
+                        serverToken = serverToken,
+                        webPageHtml = webPageHtml,
+                        currentPageStateProvider = currentPageStateProvider, 
+                        onChangeProposed = onChangeProposed, 
+                        logoProvider = logoProvider, 
+                        port = port
+                    )
+                    server.start(SOCKET_READ_TIMEOUT, false)
+                    return server
+                } catch (e: Exception) {
+                    // Port in use, try next
+                }
+            }
+            return null
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/GroupPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/GroupPreferenceDataStore.kt
@@ -1,0 +1,150 @@
+package com.nuvio.tv.data.local
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.domain.model.CatalogGroup
+import com.nuvio.tv.domain.model.MainGroup
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GroupPreferenceDataStore @Inject constructor(
+    private val factory: ProfileDataStoreFactory,
+    private val profileManager: ProfileManager
+) {
+    companion object {
+        private const val FEATURE = "group_settings"
+    }
+
+    private fun store(profileId: Int = profileManager.activeProfileId.value) =
+        factory.get(profileId, FEATURE)
+
+    private val gson = Gson()
+    
+    private val catalogGroupsKey = stringPreferencesKey("catalog_groups")
+    private val mainGroupsKey = stringPreferencesKey("main_groups")
+
+    private fun <T> profileFlow(extract: (prefs: androidx.datastore.preferences.core.Preferences) -> T): Flow<T> =
+        profileManager.activeProfileId.flatMapLatest { pid ->
+            factory.get(pid, FEATURE).data.map { prefs -> extract(prefs) }
+        }
+
+    val catalogGroups: Flow<List<CatalogGroup>> = profileFlow { prefs ->
+        parseCatalogGroups(prefs[catalogGroupsKey])
+    }
+
+    val mainGroups: Flow<List<MainGroup>> = profileFlow { prefs ->
+        parseMainGroups(prefs[mainGroupsKey])
+    }
+
+    suspend fun setCatalogGroups(groups: List<CatalogGroup>) {
+        store().edit { prefs ->
+            if (groups.isEmpty()) {
+                prefs.remove(catalogGroupsKey)
+            } else {
+                prefs[catalogGroupsKey] = gson.toJson(groups)
+            }
+        }
+    }
+
+    suspend fun setMainGroups(groups: List<MainGroup>) {
+        store().edit { prefs ->
+            if (groups.isEmpty()) {
+                prefs.remove(mainGroupsKey)
+            } else {
+                prefs[mainGroupsKey] = gson.toJson(groups)
+            }
+        }
+    }
+
+    private fun parseCatalogGroups(json: String?): List<CatalogGroup> {
+        if (json.isNullOrBlank()) return emptyList()
+        return try {
+            val type = object : TypeToken<List<CatalogGroup>>() {}.type
+            gson.fromJson(json, type) ?: emptyList()
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun parseMainGroups(json: String?): List<MainGroup> {
+        if (json.isNullOrBlank()) return emptyList()
+        return try {
+            val type = object : TypeToken<List<MainGroup>>() {}.type
+            gson.fromJson(json, type) ?: emptyList()
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    suspend fun updateCatalogGroup(group: CatalogGroup) {
+        store().edit { prefs ->
+            val json = prefs[catalogGroupsKey]
+            val currentGroups = parseCatalogGroups(json).toMutableList()
+            val index = currentGroups.indexOfFirst { it.id == group.id }
+            if (index != -1) {
+                currentGroups[index] = group
+            } else {
+                currentGroups.add(group)
+            }
+            prefs[catalogGroupsKey] = gson.toJson(currentGroups)
+        }
+    }
+
+    suspend fun updateMainGroup(group: MainGroup) {
+        store().edit { prefs ->
+            val json = prefs[mainGroupsKey]
+            val currentGroups = parseMainGroups(json).toMutableList()
+            val index = currentGroups.indexOfFirst { it.id == group.id }
+            if (index != -1) {
+                currentGroups[index] = group
+            } else {
+                currentGroups.add(group)
+            }
+            prefs[mainGroupsKey] = gson.toJson(currentGroups)
+        }
+    }
+
+    suspend fun removeCatalogGroup(id: String) {
+        store().edit { prefs ->
+            val cgJson = prefs[catalogGroupsKey]
+            val currentGroups = parseCatalogGroups(cgJson)
+            val updatedCg = currentGroups.filter { it.id != id }
+            if (updatedCg.isEmpty()) {
+                prefs.remove(catalogGroupsKey)
+            } else {
+                prefs[catalogGroupsKey] = gson.toJson(updatedCg)
+            }
+
+            val mgJson = prefs[mainGroupsKey]
+            val currentMainGroups = parseMainGroups(mgJson)
+            val updatedMain = currentMainGroups.map { main ->
+                main.copy(subGroupIds = main.subGroupIds.filter { it != id })
+            }
+            if (updatedMain.isEmpty()) {
+                prefs.remove(mainGroupsKey)
+            } else {
+                prefs[mainGroupsKey] = gson.toJson(updatedMain)
+            }
+        }
+    }
+
+    suspend fun removeMainGroup(id: String) {
+        store().edit { prefs ->
+            val mgJson = prefs[mainGroupsKey]
+            val currentGroups = parseMainGroups(mgJson)
+            val updatedMg = currentGroups.filter { it.id != id }
+            if (updatedMg.isEmpty()) {
+                prefs.remove(mainGroupsKey)
+            } else {
+                prefs[mainGroupsKey] = gson.toJson(updatedMg)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/domain/model/GroupModels.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/GroupModels.kt
@@ -1,0 +1,22 @@
+package com.nuvio.tv.domain.model
+
+import androidx.annotation.Keep
+import java.util.UUID
+
+@Keep
+data class CatalogGroup(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val logoUrl: String? = null,
+    val catalogKeys: List<String> = emptyList()
+)
+
+@Keep
+data class MainGroup(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val posterType: String = "Square",
+    val posterSize: String = "Default",
+    val logoUrl: String? = null,
+    val subGroupIds: List<String> = emptyList()
+)

--- a/app/src/main/java/com/nuvio/tv/domain/model/GroupModels.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/GroupModels.kt
@@ -17,6 +17,5 @@ data class MainGroup(
     val name: String,
     val posterType: String = "Square",
     val posterSize: String = "Default",
-    val logoUrl: String? = null,
     val subGroupIds: List<String> = emptyList()
 )

--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -59,7 +59,7 @@ fun CatalogRowSection(
     onItemClick: (String, String, String) -> Unit,
     onSeeAll: () -> Unit = {},
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
-    showPosterLabels: Boolean = true,
+    showPosterLabels: Boolean = false,
     showAddonName: Boolean = true,
     showCatalogTypeSuffix: Boolean = true,
     focusedPosterBackdropExpandEnabled: Boolean = false,
@@ -136,9 +136,13 @@ fun CatalogRowSection(
             else -> formatAddonTypeLabel(raw)
         }
     }
-    val catalogTitle = remember(catalogRow.catalogName, typeLabel, showCatalogTypeSuffix) {
+    val catalogTitle = remember(catalogRow.catalogName, typeLabel, showCatalogTypeSuffix, catalogRow.addonId) {
         val formattedName = catalogRow.catalogName.replaceFirstChar { it.uppercase() }
-        if (showCatalogTypeSuffix && typeLabel.isNotEmpty()) "$formattedName - $typeLabel" else formattedName
+        if (showCatalogTypeSuffix && typeLabel.isNotEmpty() && catalogRow.addonId != "maingroup") {
+            "$formattedName - $typeLabel"
+        } else {
+            formattedName
+        }
     }
 
     Column(modifier = modifier.fillMaxWidth()) {
@@ -149,22 +153,18 @@ fun CatalogRowSection(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column {
-                Text(
-                    text = catalogTitle,
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = NuvioColors.TextPrimary,
-                    maxLines = 3,
-                    overflow = TextOverflow.Clip
-                )
-                if (showAddonName) {
-                    Text(
-                        text = stringResource(R.string.catalog_from_addon, catalogRow.addonName),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = NuvioColors.TextTertiary
-                    )
-                }
+            val titleText = if (showAddonName) {
+                "$catalogTitle - ${stringResource(R.string.catalog_from_addon, catalogRow.addonName)}"
+            } else {
+                catalogTitle
             }
+            Text(
+                text = titleText,
+                style = MaterialTheme.typography.titleLarge,
+                color = NuvioColors.TextPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
 
         LazyRow(

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -178,6 +178,8 @@ fun ContentCard(
         emptyList()
     }
 
+    val isMaingroupItem = item.rawType == "maingroup_item"
+
     Column(
         modifier = modifier.width(animatedCardWidth)
     ) {
@@ -190,10 +192,10 @@ fun ContentCard(
             baseCardWidth
         }
         val requestWidthPx = remember(maxRequestCardWidth, density) {
-            with(density) { maxRequestCardWidth.roundToPx() }
+            with(density) { (maxRequestCardWidth * 1.5f).roundToPx() }
         }
         val requestHeightPx = remember(baseCardHeight, density) {
-            with(density) { baseCardHeight.roundToPx() }
+            with(density) { (baseCardHeight * 1.5f).roundToPx() }
         }
         val imageUrl = if (focusedPosterBackdropExpandEnabled && isBackdropExpanded) {
             item.backdropUrl ?: item.poster
@@ -206,6 +208,7 @@ fun ContentCard(
                 .crossfade(false)
                 .memoryCacheKey("${imageUrl}_${requestWidthPx}x${requestHeightPx}")
                 .size(width = requestWidthPx, height = requestHeightPx)
+                .scale(coil.size.Scale.FILL)
                 .build()
         }
         val logoRequestHeightPx = remember(density) {
@@ -315,7 +318,7 @@ fun ContentCard(
                         placeholder = backgroundPainter,
                         error = backgroundPainter,
                         fallback = backgroundPainter,
-                        contentScale = ContentScale.Crop
+                        contentScale = if (isMaingroupItem) ContentScale.Fit else ContentScale.Crop
                     )
                 } else {
                     MonochromePosterPlaceholder()
@@ -374,7 +377,7 @@ fun ContentCard(
                     )
                 }
 
-                if (isBackdropExpanded) {
+                if (isBackdropExpanded && !isMaingroupItem) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.BottomStart)
@@ -443,7 +446,7 @@ fun ContentCard(
             }
         }
 
-        if (isBackdropExpanded) {
+        if (isBackdropExpanded && !isMaingroupItem) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -472,7 +475,7 @@ fun ContentCard(
             }
         }
 
-        if (showLabels && !isBackdropExpanded) {
+        if (showLabels && !isBackdropExpanded && !isMaingroupItem) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
@@ -152,6 +152,7 @@ fun GridContentCard(
                         .memoryCacheKey("${item.poster}_${requestWidthPx}x${requestHeightPx}")
                         .build()
                 }
+                val isMaingroupItem = item.rawType == "maingroup_item"
                 if (item.poster.isNullOrBlank()) {
                     MonochromePosterPlaceholder()
                 } else {
@@ -159,7 +160,7 @@ fun GridContentCard(
                         model = imageModel,
                         contentDescription = item.name,
                         modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop,
+                        contentScale = if (isMaingroupItem) ContentScale.Fit else ContentScale.Crop,
                         placeholder = bgPainter,
                         error = bgPainter,
                         fallback = bgPainter
@@ -187,7 +188,8 @@ fun GridContentCard(
             }
         }
 
-        if (showLabel) {
+        val isMaingroupItem = item.rawType == "maingroup_item"
+        if (showLabel && !isMaingroupItem) {
             Text(
                 text = item.name,
                 style = MaterialTheme.typography.titleMedium,

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -173,7 +173,7 @@ fun NuvioNavHost(
 
             HomeScreen(
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
-                    if (itemType == "other" && itemId.startsWith("subgroup_")) {
+                    if ((itemType == "maingroup_item" || itemType == "other") && itemId.startsWith("subgroup_")) {
                         navController.navigate(Screen.Subgroup.createRoute(itemId.substringAfter("subgroup_")))
                     } else {
                         val heroBackdrop = HeroBackdropState.currentHeroBackdropUrl

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -20,6 +20,8 @@ import com.nuvio.tv.ui.screens.detail.MetaDetailsScreen
 import com.nuvio.tv.ui.screens.home.HomeScreen
 import com.nuvio.tv.ui.screens.addon.AddonManagerScreen
 import com.nuvio.tv.ui.screens.addon.CatalogOrderScreen
+import com.nuvio.tv.ui.screens.addon.GroupManagementScreen
+import com.nuvio.tv.ui.screens.addon.SubgroupListingsScreen
 import com.nuvio.tv.ui.screens.library.LibraryScreen
 import com.nuvio.tv.ui.screens.player.PlayerScreen
 import com.nuvio.tv.ui.screens.plugin.PluginScreen
@@ -171,15 +173,19 @@ fun NuvioNavHost(
 
             HomeScreen(
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
-                    val heroBackdrop = HeroBackdropState.currentHeroBackdropUrl
-                    navController.navigate(
-                        Screen.Detail.createRoute(
-                            itemId = itemId,
-                            itemType = itemType,
-                            addonBaseUrl = addonBaseUrl,
-                            heroBackdropUrl = heroBackdrop
+                    if (itemType == "other" && itemId.startsWith("subgroup_")) {
+                        navController.navigate(Screen.Subgroup.createRoute(itemId.substringAfter("subgroup_")))
+                    } else {
+                        val heroBackdrop = HeroBackdropState.currentHeroBackdropUrl
+                        navController.navigate(
+                            Screen.Detail.createRoute(
+                                itemId = itemId,
+                                itemType = itemType,
+                                addonBaseUrl = addonBaseUrl,
+                                heroBackdropUrl = heroBackdrop
+                            )
                         )
-                    )
+                    }
                 },
                 onContinueWatchingClick = { item ->
                     navController.navigate(createContinueWatchingRoute(item))
@@ -925,13 +931,34 @@ fun NuvioNavHost(
         composable(Screen.AddonManager.route) {
             AddonManagerScreen(
                 showBuiltInHeader = !hideBuiltInHeaders,
-                onNavigateToCatalogOrder = { navController.navigate(Screen.CatalogOrder.route) }
+                onNavigateToCatalogOrder = { navController.navigate(Screen.CatalogOrder.route) },
+                onNavigateToGroupManagement = { navController.navigate(Screen.GroupManagement.route) }
             )
         }
 
         composable(Screen.CatalogOrder.route) {
             CatalogOrderScreen(
                 onBackPress = { navController.popBackStack() }
+            )
+        }
+
+        composable(Screen.GroupManagement.route) {
+            GroupManagementScreen()
+        }
+
+        composable(
+            route = Screen.Subgroup.route,
+            arguments = listOf(navArgument("subgroupId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val subgroupId = backStackEntry.arguments?.getString("subgroupId") ?: return@composable
+            SubgroupListingsScreen(
+                subgroupId = subgroupId,
+                onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
+                    navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
+                },
+                onNavigateToCatalogSeeAll = { catalogId, addonId, type ->
+                    navController.navigate(Screen.CatalogSeeAll.createRoute(catalogId, addonId, type))
+                }
             )
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -130,6 +130,7 @@ sealed class Screen(val route: String) {
     data object SupportersContributors : Screen("supporters_contributors")
     data object AddonManager : Screen("addon_manager")
     data object CatalogOrder : Screen("catalog_order")
+    data object GroupManagement : Screen("group_management")
     data object Plugins : Screen("plugins")
     data object LayoutSelection : Screen("layout_selection")
     data object LayoutSettings : Screen("layout_settings")
@@ -146,6 +147,11 @@ sealed class Screen(val route: String) {
         fun createRoute(catalogId: String, addonId: String, type: String): String {
             return "catalog_see_all/${encode(catalogId)}/${encode(addonId)}/${encode(type)}"
         }
+    }
+
+    data object Subgroup : Screen("subgroup/{subgroupId}") {
+        private fun encode(value: String): String = URLEncoder.encode(value, "UTF-8").replace("+", "%20")
+        fun createRoute(subgroupId: String): String = "subgroup/${encode(subgroupId)}"
     }
 
     data object ProfileSelection : Screen("profile_selection")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
@@ -97,7 +97,8 @@ import kotlinx.coroutines.delay
 fun AddonManagerScreen(
     viewModel: AddonManagerViewModel = hiltViewModel(),
     showBuiltInHeader: Boolean = true,
-    onNavigateToCatalogOrder: () -> Unit = {}
+    onNavigateToCatalogOrder: () -> Unit = {},
+    onNavigateToGroupManagement: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -325,6 +326,9 @@ fun AddonManagerScreen(
                 if (hasHomeVisibleCatalogs) {
                     item {
                         CatalogOrderEntryCard(onClick = onNavigateToCatalogOrder)
+                    }
+                    item {
+                        GroupManagementEntryCard(onClick = onNavigateToGroupManagement)
                     }
                 }
             }
@@ -561,6 +565,67 @@ private fun CatalogOrderEntryCard(onClick: () -> Unit) {
                     )
                     Text(
                         text = stringResource(R.string.addon_reorder_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = NuvioColors.TextSecondary
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.Default.ArrowDownward,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = NuvioColors.TextSecondary
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun GroupManagementEntryCard(onClick: () -> Unit) {
+    var isFocused by remember { mutableStateOf(false) }
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged { isFocused = it.isFocused },
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            focusedContainerColor = NuvioColors.FocusBackground
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(18.dp)
+            )
+        ),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(18.dp)),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Reorder,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = if (isFocused) NuvioColors.Secondary else NuvioColors.TextSecondary
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column {
+                    Text(
+                        text = "Group management",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        color = NuvioColors.TextPrimary
+                    )
+                    Text(
+                        text = "Create and manage home screen groups",
                         style = MaterialTheme.typography.bodySmall,
                         color = NuvioColors.TextSecondary
                     )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -2,9 +2,11 @@ package com.nuvio.tv.ui.screens.addon
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.data.local.GroupPreferenceDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.MainGroup
 import com.nuvio.tv.domain.repository.AddonRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +21,8 @@ import javax.inject.Inject
 @HiltViewModel
 class CatalogOrderViewModel @Inject constructor(
     private val addonRepository: AddonRepository,
-    private val layoutPreferenceDataStore: LayoutPreferenceDataStore
+    private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    private val groupPreferenceDataStore: GroupPreferenceDataStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CatalogOrderUiState())
@@ -70,12 +73,14 @@ class CatalogOrderViewModel @Inject constructor(
             combine(
                 addonRepository.getInstalledAddons(),
                 layoutPreferenceDataStore.homeCatalogOrderKeys,
-                layoutPreferenceDataStore.disabledHomeCatalogKeys
-            ) { addons, savedOrderKeys, disabledKeys ->
+                layoutPreferenceDataStore.disabledHomeCatalogKeys,
+                groupPreferenceDataStore.mainGroups
+            ) { addons, savedOrderKeys, disabledKeys, mainGroups ->
                 buildOrderedCatalogItems(
                     addons = addons,
                     savedOrderKeys = savedOrderKeys,
-                    disabledKeys = disabledKeys.toSet()
+                    disabledKeys = disabledKeys.toSet(),
+                    mainGroups = mainGroups
                 )
             }.collectLatest { orderedItems ->
                 disabledKeysCache = orderedItems.filter { it.isDisabled }.map { it.disableKey }.toSet()
@@ -92,9 +97,10 @@ class CatalogOrderViewModel @Inject constructor(
     private fun buildOrderedCatalogItems(
         addons: List<Addon>,
         savedOrderKeys: List<String>,
-        disabledKeys: Set<String>
+        disabledKeys: Set<String>,
+        mainGroups: List<MainGroup>
     ): List<CatalogOrderItem> {
-        val defaultEntries = buildDefaultCatalogEntries(addons)
+        val defaultEntries = buildDefaultCatalogEntries(addons, mainGroups)
         val availableMap = defaultEntries.associateBy { it.key }
         val defaultOrderKeys = defaultEntries.map { it.key }
 
@@ -123,9 +129,24 @@ class CatalogOrderViewModel @Inject constructor(
         }
     }
 
-    private fun buildDefaultCatalogEntries(addons: List<Addon>): List<CatalogOrderEntry> {
+    private fun buildDefaultCatalogEntries(addons: List<Addon>, mainGroups: List<MainGroup>): List<CatalogOrderEntry> {
         val entries = mutableListOf<CatalogOrderEntry>()
         val seenKeys = mutableSetOf<String>()
+
+        mainGroups.forEach { mainGroup ->
+            val key = "maingroup:${mainGroup.id}"
+            if (seenKeys.add(key)) {
+                entries.add(
+                    CatalogOrderEntry(
+                        key = key,
+                        disableKey = "maingroup_disable:${mainGroup.id}",
+                        catalogName = mainGroup.name,
+                        addonName = "Home Group",
+                        typeLabel = "Primary Group"
+                    )
+                )
+            }
+        }
 
         addons.forEach { addon ->
             addon.catalogs

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementScreen.kt
@@ -1,0 +1,1033 @@
+package com.nuvio.tv.ui.screens.addon
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.ui.theme.NuvioColors
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.Alignment
+import androidx.tv.material3.TabRow
+import androidx.tv.material3.Tab
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.Surface
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.tv.material3.Border
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.ViewList
+import androidx.tv.material3.Icon
+import com.nuvio.tv.domain.model.CatalogGroup
+import com.nuvio.tv.domain.model.MainGroup
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.foundation.Image
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import android.graphics.Bitmap
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun GroupManagementScreen(
+    viewModel: GroupManagementViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    var selectedTabIndex by remember { mutableStateOf(0) }
+    val tabs = listOf("Subgroups", "Primary Groups")
+
+    var editingSubgroup by remember { mutableStateOf<CatalogGroup?>(null) }
+    var creatingSubgroup by remember { mutableStateOf(false) }
+
+    var editingMainGroup by remember { mutableStateOf<MainGroup?>(null) }
+    var creatingMainGroup by remember { mutableStateOf(false) }
+
+    when {
+        creatingSubgroup || editingSubgroup != null -> {
+            SubgroupEditor(
+                initialGroup = editingSubgroup,
+                uiState = uiState,
+                onSave = { name, logo, keys ->
+                    viewModel.saveCatalogGroup(editingSubgroup?.id, name, logo, keys)
+                    creatingSubgroup = false
+                    editingSubgroup = null
+                },
+                onCancel = {
+                    creatingSubgroup = false
+                    editingSubgroup = null
+                },
+                onDelete = {
+                    editingSubgroup?.id?.let { viewModel.deleteCatalogGroup(it) }
+                    creatingSubgroup = false
+                    editingSubgroup = null
+                }
+            )
+        }
+        creatingMainGroup || editingMainGroup != null -> {
+            MainGroupEditor(
+                initialGroup = editingMainGroup,
+                uiState = uiState,
+                onSave = { name, type, size, logoUrl, keys ->
+                    viewModel.saveMainGroup(editingMainGroup?.id, name, type, size, logoUrl, keys)
+                    creatingMainGroup = false
+                    editingMainGroup = null
+                },
+                onCancel = {
+                    creatingMainGroup = false
+                    editingMainGroup = null
+                },
+                onDelete = {
+                    editingMainGroup?.id?.let { viewModel.deleteMainGroup(it) }
+                    creatingMainGroup = false
+                    editingMainGroup = null
+                }
+            )
+        }
+        else -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(NuvioColors.Background)
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    // Header
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 36.dp, end = 36.dp, top = 28.dp)
+                    ) {
+                        Text(
+                            text = "Group Management",
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = NuvioColors.TextPrimary
+                        )
+                        Spacer(modifier = Modifier.height(20.dp))
+
+                        TabRow(
+                            selectedTabIndex = selectedTabIndex,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            tabs.forEachIndexed { index, title ->
+                                Tab(
+                                    selected = index == selectedTabIndex,
+                                    onFocus = { selectedTabIndex = index },
+                                    onClick = { selectedTabIndex = index }
+                                ) {
+                                    Text(
+                                        text = title,
+                                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // Content
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 36.dp)
+                    ) {
+                        if (selectedTabIndex == 0) {
+                            SubgroupsContent(
+                                uiState = uiState,
+                                onCreateClick = { creatingSubgroup = true },
+                                onEditClick = { editingSubgroup = it },
+                                onManageFromPhone = { viewModel.startQrMode() }
+                            )
+                        } else {
+                            PrimaryGroupsContent(
+                                uiState = uiState,
+                                onCreateClick = { creatingMainGroup = true },
+                                onEditClick = { editingMainGroup = it }
+                            )
+                        }
+                    }
+                }
+
+                // QR Code overlay
+                if (uiState.isQrModeActive) {
+                    Popup(properties = PopupProperties(focusable = true)) {
+                        GroupQrCodeOverlay(
+                            qrBitmap = uiState.qrCodeBitmap,
+                            serverUrl = uiState.serverUrl,
+                            onClose = viewModel::stopQrMode,
+                            hasPendingChange = uiState.pendingChange != null
+                        )
+                    }
+                }
+
+                // Confirmation dialog overlay
+                if (uiState.pendingChange != null) {
+                    Popup(properties = PopupProperties(focusable = true)) {
+                        uiState.pendingChange?.let { pending ->
+                            GroupConfirmChangesDialog(
+                                onConfirm = { viewModel.confirmPendingChange() },
+                                onReject = { viewModel.rejectPendingChange() }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubgroupsContent(
+    uiState: GroupManagementUiState,
+    onCreateClick: () -> Unit,
+    onEditClick: (CatalogGroup) -> Unit,
+    onManageFromPhone: () -> Unit = {}
+) {
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = 28.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            CreateButton(text = "Create Subgroup", onClick = onCreateClick)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        item {
+            GroupManageFromPhoneCard(onClick = onManageFromPhone)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        if (uiState.catalogGroups.isEmpty()) {
+            item {
+                Text(
+                    text = "No subgroups configured. Create a subgroup to combine catalogs.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        } else {
+            items(uiState.catalogGroups, key = { it.id }) { group ->
+                GroupCard(
+                    title = group.name,
+                    subtitle = "${group.catalogKeys.size} catalogs",
+                    icon = Icons.Default.Folder,
+                    onClick = { onEditClick(group) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrimaryGroupsContent(
+    uiState: GroupManagementUiState,
+    onCreateClick: () -> Unit,
+    onEditClick: (MainGroup) -> Unit
+) {
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = 28.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            CreateButton(text = "Create Primary Group", onClick = onCreateClick)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        if (uiState.mainGroups.isEmpty()) {
+            item {
+                Text(
+                    text = "No primary groups configured. Create a primary group to appear on the home screen.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        } else {
+            items(uiState.mainGroups, key = { it.id }) { main ->
+                GroupCard(
+                    title = main.name,
+                    subtitle = "${main.subGroupIds.size} subgroups nested",
+                    icon = Icons.Default.ViewList,
+                    onClick = { onEditClick(main) }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun CreateButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.colors(
+            containerColor = NuvioColors.Surface,
+            contentColor = NuvioColors.TextPrimary,
+            focusedContainerColor = NuvioColors.FocusBackground,
+            focusedContentColor = NuvioColors.Primary
+        ),
+        shape = ButtonDefaults.shape(RoundedCornerShape(12.dp))
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(imageVector = Icons.Default.Add, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+            Text(text = text, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun GroupCard(title: String, subtitle: String, icon: androidx.compose.ui.graphics.vector.ImageVector, onClick: () -> Unit) {
+    var isFocused by remember { mutableStateOf(false) }
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged { isFocused = it.isFocused },
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            focusedContainerColor = NuvioColors.FocusBackground
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(18.dp)
+            )
+        ),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(18.dp)),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = if (isFocused) NuvioColors.Secondary else NuvioColors.TextSecondary
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        color = NuvioColors.TextPrimary
+                    )
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = NuvioColors.TextSecondary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SubgroupEditor(
+    initialGroup: CatalogGroup?,
+    uiState: GroupManagementUiState,
+    onSave: (name: String, logo: String?, keys: List<String>) -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit
+) {
+    var name by remember { mutableStateOf(initialGroup?.name ?: "") }
+    var logoUrl by remember { mutableStateOf(initialGroup?.logoUrl ?: "") }
+    var selectedKeys by remember { mutableStateOf(initialGroup?.catalogKeys?.toSet() ?: emptySet()) }
+    var isEditingName by remember { mutableStateOf(false) }
+    var isEditingLogo by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val textFieldFocusRequester = remember { FocusRequester() }
+    val logoFieldFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(isEditingName, isEditingLogo) {
+        if (isEditingName) {
+            textFieldFocusRequester.requestFocus()
+            keyboardController?.show()
+        } else if (isEditingLogo) {
+            logoFieldFocusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
+    BackHandler { onCancel() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(NuvioColors.Background)
+            .padding(36.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = if (initialGroup == null) "Create Subgroup" else "Edit Subgroup",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = NuvioColors.TextPrimary
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Button(
+                        onClick = { onSave(name, logoUrl.takeIf { it.isNotBlank() }, selectedKeys.toList()) },
+                        enabled = name.isNotBlank() && selectedKeys.isNotEmpty()
+                    ) {
+                        Text("Save")
+                    }
+                    Button(onClick = onCancel) {
+                        Text("Cancel")
+                    }
+                    if (initialGroup != null) {
+                        Button(onClick = onDelete, colors = ButtonDefaults.colors(containerColor = NuvioColors.Error)) {
+                            Text("Delete")
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Name Input
+            Surface(
+                onClick = { isEditingName = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ClickableSurfaceDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    focusedContainerColor = NuvioColors.FocusBackground
+                ),
+                border = ClickableSurfaceDefaults.border(
+                    focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
+                ),
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+            ) {
+                Box(modifier = Modifier.padding(16.dp)) {
+                    BasicTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(textFieldFocusRequester)
+                            .onFocusChanged {
+                                if (!it.isFocused && isEditingName) {
+                                    isEditingName = false
+                                    keyboardController?.hide()
+                                }
+                            },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        keyboardActions = KeyboardActions(
+                            onNext = {
+                                isEditingName = false
+                                isEditingLogo = true
+                            }
+                        ),
+                        textStyle = MaterialTheme.typography.titleMedium.copy(color = NuvioColors.TextPrimary),
+                        cursorBrush = SolidColor(if (isEditingName) NuvioColors.Primary else Color.Transparent),
+                        decorationBox = { innerTextField ->
+                            if (name.isEmpty()) {
+                                Text("Enter Subgroup Name", color = NuvioColors.TextTertiary)
+                            }
+                            innerTextField()
+                        }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Logo URL Input
+            Surface(
+                onClick = { isEditingLogo = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ClickableSurfaceDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    focusedContainerColor = NuvioColors.FocusBackground
+                ),
+                border = ClickableSurfaceDefaults.border(
+                    focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
+                ),
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+            ) {
+                Box(modifier = Modifier.padding(16.dp)) {
+                    BasicTextField(
+                        value = logoUrl,
+                        onValueChange = { logoUrl = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(logoFieldFocusRequester)
+                            .onFocusChanged {
+                                if (!it.isFocused && isEditingLogo) {
+                                    isEditingLogo = false
+                                    keyboardController?.hide()
+                                }
+                            },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Uri),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                isEditingLogo = false
+                                keyboardController?.hide()
+                            }
+                        ),
+                        textStyle = MaterialTheme.typography.titleMedium.copy(color = NuvioColors.TextPrimary),
+                        cursorBrush = SolidColor(if (isEditingLogo) NuvioColors.Primary else Color.Transparent),
+                        decorationBox = { innerTextField ->
+                            if (logoUrl.isEmpty()) {
+                                Text("Enter Custom Artwork URL (Hosted Image)", color = NuvioColors.TextTertiary)
+                            }
+                            innerTextField()
+                        }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Select Catalogs",
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioColors.TextSecondary
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(uiState.availableCatalogs, key = { it.key }) { catalog ->
+                    val isSelected = selectedKeys.contains(catalog.key)
+                    Surface(
+                        onClick = {
+                            selectedKeys = if (isSelected) selectedKeys - catalog.key else selectedKeys + catalog.key
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = NuvioColors.BackgroundElevated,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp))
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = if (isSelected) Icons.Default.Check else Icons.Default.Add,
+                                contentDescription = null,
+                                tint = if (isSelected) NuvioColors.Success else NuvioColors.TextSecondary,
+                                modifier = Modifier.padding(end = 16.dp)
+                            )
+                            Column {
+                                Text(text = catalog.catalogName, color = NuvioColors.TextPrimary)
+                                Text(text = "${catalog.addonName} • ${catalog.typeLabel}", color = NuvioColors.TextSecondary, style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun MainGroupEditor(
+    initialGroup: MainGroup?,
+    uiState: GroupManagementUiState,
+    onSave: (name: String, type: String, size: String, logoUrl: String?, keys: List<String>) -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit
+) {
+    var name by remember { mutableStateOf(initialGroup?.name ?: "") }
+    var logoUrl by remember { mutableStateOf(initialGroup?.logoUrl ?: "") }
+    var selectedSubGroups by remember { mutableStateOf(initialGroup?.subGroupIds?.toSet() ?: emptySet()) }
+    var isEditingName by remember { mutableStateOf(false) }
+    var isEditingLogo by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val textFieldFocusRequester = remember { FocusRequester() }
+    val logoFieldFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(isEditingName, isEditingLogo) {
+        if (isEditingName) {
+            textFieldFocusRequester.requestFocus()
+            keyboardController?.show()
+        } else if (isEditingLogo) {
+            logoFieldFocusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
+    BackHandler { onCancel() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(NuvioColors.Background)
+            .padding(36.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = if (initialGroup == null) "Create Primary Group" else "Edit Primary Group",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = NuvioColors.TextPrimary
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Button(
+                        onClick = { onSave(name, "Square", "Default", logoUrl.takeIf { it.isNotBlank() }, selectedSubGroups.toList()) },
+                        enabled = name.isNotBlank() && selectedSubGroups.isNotEmpty()
+                    ) {
+                        Text("Save")
+                    }
+                    Button(onClick = onCancel) {
+                        Text("Cancel")
+                    }
+                    if (initialGroup != null) {
+                        Button(onClick = onDelete, colors = ButtonDefaults.colors(containerColor = NuvioColors.Error)) {
+                            Text("Delete")
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Name Input
+            Surface(
+                onClick = { isEditingName = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ClickableSurfaceDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    focusedContainerColor = NuvioColors.FocusBackground
+                ),
+                border = ClickableSurfaceDefaults.border(
+                    focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
+                ),
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+            ) {
+                Box(modifier = Modifier.padding(16.dp)) {
+                    BasicTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(textFieldFocusRequester)
+                            .onFocusChanged {
+                                if (!it.isFocused && isEditingName) {
+                                    isEditingName = false
+                                    keyboardController?.hide()
+                                }
+                            },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        keyboardActions = KeyboardActions(
+                            onNext = {
+                                isEditingName = false
+                                isEditingLogo = true
+                            }
+                        ),
+                        textStyle = MaterialTheme.typography.titleMedium.copy(color = NuvioColors.TextPrimary),
+                        cursorBrush = SolidColor(if (isEditingName) NuvioColors.Primary else Color.Transparent),
+                        decorationBox = { innerTextField ->
+                            if (name.isEmpty()) {
+                                Text("Enter Primary Group Name", color = NuvioColors.TextTertiary)
+                            }
+                            innerTextField()
+                        }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Logo URL Input
+            Surface(
+                onClick = { isEditingLogo = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ClickableSurfaceDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    focusedContainerColor = NuvioColors.FocusBackground
+                ),
+                border = ClickableSurfaceDefaults.border(
+                    focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
+                ),
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+            ) {
+                Box(modifier = Modifier.padding(16.dp)) {
+                    BasicTextField(
+                        value = logoUrl,
+                        onValueChange = { logoUrl = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(logoFieldFocusRequester)
+                            .onFocusChanged {
+                                if (!it.isFocused && isEditingLogo) {
+                                    isEditingLogo = false
+                                    keyboardController?.hide()
+                                }
+                            },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Uri),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                isEditingLogo = false
+                                keyboardController?.hide()
+                            }
+                        ),
+                        textStyle = MaterialTheme.typography.titleMedium.copy(color = NuvioColors.TextPrimary),
+                        cursorBrush = SolidColor(if (isEditingLogo) NuvioColors.Primary else Color.Transparent),
+                        decorationBox = { innerTextField ->
+                            if (logoUrl.isEmpty()) {
+                                Text("Enter Custom Artwork URL (Hosted Image)", color = NuvioColors.TextTertiary)
+                            }
+                            innerTextField()
+                        }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Select Subgroups",
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioColors.TextSecondary
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(uiState.catalogGroups, key = { it.id }) { group ->
+                    val isSelected = selectedSubGroups.contains(group.id)
+                    Surface(
+                        onClick = {
+                            selectedSubGroups = if (isSelected) selectedSubGroups - group.id else selectedSubGroups + group.id
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = NuvioColors.BackgroundElevated,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp))
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = if (isSelected) Icons.Default.Check else Icons.Default.Add,
+                                contentDescription = null,
+                                tint = if (isSelected) NuvioColors.Success else NuvioColors.TextSecondary,
+                                modifier = Modifier.padding(end = 16.dp)
+                            )
+                            Column {
+                                Text(text = group.name, color = NuvioColors.TextPrimary)
+                                Text(text = "${group.catalogKeys.size} catalogs", color = NuvioColors.TextSecondary, style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun GroupManageFromPhoneCard(onClick: () -> Unit) {
+    var isFocused by remember { mutableStateOf(false) }
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged { isFocused = it.isFocused },
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            focusedContainerColor = NuvioColors.FocusBackground
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(18.dp)
+            )
+        ),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(18.dp)),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.QrCode2,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = if (isFocused) NuvioColors.Secondary else NuvioColors.TextSecondary
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column {
+                    Text(
+                        text = "Manage from phone",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        color = NuvioColors.TextPrimary
+                    )
+                    Text(
+                        text = "Scan QR to arrange groups on your mobile device",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = NuvioColors.TextSecondary
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.Default.PhoneAndroid,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = NuvioColors.TextSecondary
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun GroupQrCodeOverlay(
+    qrBitmap: Bitmap?,
+    serverUrl: String?,
+    onClose: () -> Unit,
+    hasPendingChange: Boolean = false
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(hasPendingChange) {
+        if (!hasPendingChange) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    BackHandler { onClose() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.85f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Scan with your phone's camera\nMake sure your TV and phone are on the same WiFi network.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = NuvioColors.TextSecondary,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (qrBitmap != null) {
+                Image(
+                    bitmap = qrBitmap.asImageBitmap(),
+                    contentDescription = "QR Code",
+                    modifier = Modifier.size(220.dp),
+                    contentScale = ContentScale.Fit
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (serverUrl != null) {
+                Text(
+                    text = serverUrl,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioColors.TextTertiary,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Surface(
+                onClick = onClose,
+                modifier = Modifier.focusRequester(focusRequester),
+                colors = ClickableSurfaceDefaults.colors(
+                    containerColor = NuvioColors.Surface,
+                    focusedContainerColor = NuvioColors.FocusBackground
+                ),
+                border = ClickableSurfaceDefaults.border(
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(50)
+                    )
+                ),
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(50)),
+                scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = NuvioColors.TextPrimary
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Close",
+                        color = NuvioColors.TextPrimary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun GroupConfirmChangesDialog(
+    onConfirm: () -> Unit,
+    onReject: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    BackHandler { onReject() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.8f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            onClick = { },
+            modifier = Modifier.width(360.dp),
+            colors = ClickableSurfaceDefaults.colors(
+                containerColor = NuvioColors.SurfaceVariant
+            ),
+            shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(16.dp))
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "Confirm Changes",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = NuvioColors.TextPrimary
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = "Your phone wants to save new group configuration. Apply these changes?",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    Button(
+                        onClick = onReject,
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioColors.Surface,
+                            contentColor = NuvioColors.TextPrimary
+                        )
+                    ) {
+                        Text("Cancel")
+                    }
+
+                    Button(
+                        onClick = onConfirm,
+                        modifier = Modifier.focusRequester(focusRequester),
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioColors.Primary,
+                            contentColor = NuvioColors.TextPrimary
+                        )
+                    ) {
+                        Text("Apply")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementScreen.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.addon
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -112,8 +113,8 @@ fun GroupManagementScreen(
             MainGroupEditor(
                 initialGroup = editingMainGroup,
                 uiState = uiState,
-                onSave = { name, type, size, logoUrl, keys ->
-                    viewModel.saveMainGroup(editingMainGroup?.id, name, type, size, logoUrl, keys)
+                onSave = { name, type, size, keys ->
+                    viewModel.saveMainGroup(editingMainGroup?.id, name, type, size, keys)
                     creatingMainGroup = false
                     editingMainGroup = null
                 },
@@ -454,9 +455,10 @@ private fun SubgroupEditor(
                 border = ClickableSurfaceDefaults.border(
                     focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
                 ),
-                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+                scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
             ) {
-                Box(modifier = Modifier.padding(16.dp)) {
+                Box(modifier = Modifier.padding(16.dp).clipToBounds()) {
                     BasicTextField(
                         value = name,
                         onValueChange = { name = it },
@@ -502,9 +504,10 @@ private fun SubgroupEditor(
                 border = ClickableSurfaceDefaults.border(
                     focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
                 ),
-                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+                scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
             ) {
-                Box(modifier = Modifier.padding(16.dp)) {
+                Box(modifier = Modifier.padding(16.dp).clipToBounds()) {
                     BasicTextField(
                         value = logoUrl,
                         onValueChange = { logoUrl = it },
@@ -529,7 +532,7 @@ private fun SubgroupEditor(
                         cursorBrush = SolidColor(if (isEditingLogo) NuvioColors.Primary else Color.Transparent),
                         decorationBox = { innerTextField ->
                             if (logoUrl.isEmpty()) {
-                                Text("Enter Custom Artwork URL (Hosted Image)", color = NuvioColors.TextTertiary)
+                                Text("Direct Image Link (.jpg/.png)", color = NuvioColors.TextTertiary)
                             }
                             innerTextField()
                         }
@@ -592,25 +595,19 @@ private fun SubgroupEditor(
 private fun MainGroupEditor(
     initialGroup: MainGroup?,
     uiState: GroupManagementUiState,
-    onSave: (name: String, type: String, size: String, logoUrl: String?, keys: List<String>) -> Unit,
+    onSave: (name: String, type: String, size: String, keys: List<String>) -> Unit,
     onCancel: () -> Unit,
     onDelete: () -> Unit
 ) {
     var name by remember { mutableStateOf(initialGroup?.name ?: "") }
-    var logoUrl by remember { mutableStateOf(initialGroup?.logoUrl ?: "") }
     var selectedSubGroups by remember { mutableStateOf(initialGroup?.subGroupIds?.toSet() ?: emptySet()) }
     var isEditingName by remember { mutableStateOf(false) }
-    var isEditingLogo by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
     val textFieldFocusRequester = remember { FocusRequester() }
-    val logoFieldFocusRequester = remember { FocusRequester() }
 
-    LaunchedEffect(isEditingName, isEditingLogo) {
+    LaunchedEffect(isEditingName) {
         if (isEditingName) {
             textFieldFocusRequester.requestFocus()
-            keyboardController?.show()
-        } else if (isEditingLogo) {
-            logoFieldFocusRequester.requestFocus()
             keyboardController?.show()
         }
     }
@@ -636,7 +633,7 @@ private fun MainGroupEditor(
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                     Button(
-                        onClick = { onSave(name, "Square", "Default", logoUrl.takeIf { it.isNotBlank() }, selectedSubGroups.toList()) },
+                        onClick = { onSave(name, "Square", "Default", selectedSubGroups.toList()) },
                         enabled = name.isNotBlank() && selectedSubGroups.isNotEmpty()
                     ) {
                         Text("Save")
@@ -664,9 +661,10 @@ private fun MainGroupEditor(
                 border = ClickableSurfaceDefaults.border(
                     focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
                 ),
-                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+                scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
             ) {
-                Box(modifier = Modifier.padding(16.dp)) {
+                Box(modifier = Modifier.padding(16.dp).clipToBounds()) {
                     BasicTextField(
                         value = name,
                         onValueChange = { name = it },
@@ -680,11 +678,11 @@ private fun MainGroupEditor(
                                 }
                             },
                         singleLine = true,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                         keyboardActions = KeyboardActions(
-                            onNext = {
+                            onDone = {
                                 isEditingName = false
-                                isEditingLogo = true
+                                keyboardController?.hide()
                             }
                         ),
                         textStyle = MaterialTheme.typography.titleMedium.copy(color = NuvioColors.TextPrimary),
@@ -692,54 +690,6 @@ private fun MainGroupEditor(
                         decorationBox = { innerTextField ->
                             if (name.isEmpty()) {
                                 Text("Enter Primary Group Name", color = NuvioColors.TextTertiary)
-                            }
-                            innerTextField()
-                        }
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Logo URL Input
-            Surface(
-                onClick = { isEditingLogo = true },
-                modifier = Modifier.fillMaxWidth(),
-                colors = ClickableSurfaceDefaults.colors(
-                    containerColor = NuvioColors.BackgroundCard,
-                    focusedContainerColor = NuvioColors.FocusBackground
-                ),
-                border = ClickableSurfaceDefaults.border(
-                    focusedBorder = Border(border = BorderStroke(2.dp, NuvioColors.FocusRing), shape = RoundedCornerShape(12.dp))
-                ),
-                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp))
-            ) {
-                Box(modifier = Modifier.padding(16.dp)) {
-                    BasicTextField(
-                        value = logoUrl,
-                        onValueChange = { logoUrl = it },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .focusRequester(logoFieldFocusRequester)
-                            .onFocusChanged {
-                                if (!it.isFocused && isEditingLogo) {
-                                    isEditingLogo = false
-                                    keyboardController?.hide()
-                                }
-                            },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Uri),
-                        keyboardActions = KeyboardActions(
-                            onDone = {
-                                isEditingLogo = false
-                                keyboardController?.hide()
-                            }
-                        ),
-                        textStyle = MaterialTheme.typography.titleMedium.copy(color = NuvioColors.TextPrimary),
-                        cursorBrush = SolidColor(if (isEditingLogo) NuvioColors.Primary else Color.Transparent),
-                        decorationBox = { innerTextField ->
-                            if (logoUrl.isEmpty()) {
-                                Text("Enter Custom Artwork URL (Hosted Image)", color = NuvioColors.TextTertiary)
                             }
                             innerTextField()
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementViewModel.kt
@@ -118,14 +118,13 @@ class GroupManagementViewModel @Inject constructor(
         }
     }
 
-    fun saveMainGroup(id: String?, name: String, posterType: String, posterSize: String, logoUrl: String?, subGroupIds: List<String>) {
+    fun saveMainGroup(id: String?, name: String, posterType: String, posterSize: String, subGroupIds: List<String>) {
         viewModelScope.launch {
             val group = MainGroup(
                 id = id ?: UUID.randomUUID().toString(),
                 name = name.trim(),
                 posterType = posterType,
                 posterSize = posterSize,
-                logoUrl = resolveImageUrl(logoUrl),
                 subGroupIds = subGroupIds
             )
             groupPreferenceDataStore.updateMainGroup(group)
@@ -241,9 +240,7 @@ class GroupManagementViewModel @Inject constructor(
             val sanitizedCatalogGroups = pending.proposedCatalogGroups.map { cg ->
                 cg.copy(logoUrl = resolveImageUrl(cg.logoUrl))
             }
-            val sanitizedMainGroups = pending.proposedMainGroups.map { mg ->
-                mg.copy(logoUrl = resolveImageUrl(mg.logoUrl))
-            }
+            val sanitizedMainGroups = pending.proposedMainGroups
             Log.d("GroupMgmt", "Syncing from phone: ${sanitizedCatalogGroups.size} catalog groups, ${sanitizedMainGroups.size} main groups")
             sanitizedCatalogGroups.forEach { cg ->
                 Log.d("GroupMgmt", "  CatalogGroup id=${cg.id} name=${cg.name} keys=${cg.catalogKeys}")
@@ -275,15 +272,30 @@ class GroupManagementViewModel @Inject constructor(
 
     private fun resolveImageUrl(url: String?): String? {
         if (url.isNullOrBlank()) return null
-        val driveRegex = Regex("""drive\.google\.com/file/d/([^/]+)""")
-        val match = driveRegex.find(url)
+        val trimmed = url.trim()
+
+        // 1. Handle HTML Embed codes (extract src="...")
+        if (trimmed.startsWith("<") && trimmed.contains("src=\"")) {
+            val srcMatch = Regex("""src="([^"]+)"""").find(trimmed)
+            if (srcMatch != null) {
+                return resolveImageUrl(srcMatch.groupValues[1])
+            }
+        }
+
+        // 2. Handle Google Drive links
+        val driveRegex = Regex("""drive\.google\.com/(?:file/d/|open\?id=|uc\?id=)([^/&?]+)""")
+        val match = driveRegex.find(trimmed)
         if (match != null) {
             val id = match.groupValues[1]
-            return "https://drive.google.com/thumbnail?id=$id&sz=w400"
+            // Using /uc?id= instead of /thumbnail ensures we get the original uncompressed file
+            // as requested by the user. Note: Large files may show a Google virus scan warning
+            // if fetched via browser, but Coil's loader handles the direct stream fine.
+            return "https://drive.google.com/uc?export=download&id=$id"
         }
+
         return try {
-            java.net.URL(url)
-            url.trim()
+            java.net.URL(trimmed)
+            trimmed
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/GroupManagementViewModel.kt
@@ -1,0 +1,310 @@
+package com.nuvio.tv.ui.screens.addon
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.data.local.GroupPreferenceDataStore
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogGroup
+import com.nuvio.tv.domain.model.MainGroup
+import com.nuvio.tv.domain.repository.AddonRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import android.graphics.Bitmap
+import android.content.Context
+import com.nuvio.tv.core.qr.QrCodeGenerator
+import com.nuvio.tv.core.server.DeviceIpAddress
+import com.nuvio.tv.core.server.GroupConfigServer
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.delay
+import com.nuvio.tv.R
+import android.util.Log
+
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupManagementViewModel @Inject constructor(
+    private val groupPreferenceDataStore: GroupPreferenceDataStore,
+    private val addonRepository: AddonRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GroupManagementUiState())
+    val uiState: StateFlow<GroupManagementUiState> = _uiState.asStateFlow()
+
+    private var server: GroupConfigServer? = null
+    private var logoBytes: ByteArray? = null
+
+    init {
+        observeData()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stopServerInternal()
+    }
+
+    private fun observeData() {
+        viewModelScope.launch {
+            combine(
+                groupPreferenceDataStore.catalogGroups,
+                groupPreferenceDataStore.mainGroups,
+                addonRepository.getInstalledAddons()
+            ) { catalogGroups, mainGroups, addons ->
+                
+                val allCatalogs = buildAvailableCatalogs(addons)
+                
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        catalogGroups = catalogGroups,
+                        mainGroups = mainGroups,
+                        availableCatalogs = allCatalogs
+                    )
+                }
+            }.collectLatest { }
+        }
+    }
+
+    private fun buildAvailableCatalogs(addons: List<Addon>): List<AvailableCatalog> {
+        val entries = mutableListOf<AvailableCatalog>()
+        val seenKeys = mutableSetOf<String>()
+
+        addons.forEach { addon ->
+            addon.catalogs
+                .filterNot { it.isSearchOnlyCatalog() }
+                .forEach { catalog ->
+                    val key = "${addon.id}:::${catalog.apiType}:::${catalog.id}"
+                    if (seenKeys.add(key)) {
+                        entries.add(
+                            AvailableCatalog(
+                                key = key,
+                                catalogName = catalog.name,
+                                addonName = addon.displayName,
+                                typeLabel = catalog.apiType
+                            )
+                        )
+                    }
+                }
+        }
+        return entries
+    }
+
+    fun saveCatalogGroup(id: String?, name: String, logoUrl: String?, catalogKeys: List<String>) {
+        viewModelScope.launch {
+            val group = CatalogGroup(
+                id = id ?: UUID.randomUUID().toString(),
+                name = name.trim(),
+                logoUrl = resolveImageUrl(logoUrl),
+                catalogKeys = catalogKeys
+            )
+            groupPreferenceDataStore.updateCatalogGroup(group)
+            
+            // Auto create main group if this is the first subgroup and there are no main groups? 
+            // Optional UX improvement, skip for now.
+        }
+    }
+
+    fun deleteCatalogGroup(id: String) {
+        viewModelScope.launch {
+            groupPreferenceDataStore.removeCatalogGroup(id)
+        }
+    }
+
+    fun saveMainGroup(id: String?, name: String, posterType: String, posterSize: String, logoUrl: String?, subGroupIds: List<String>) {
+        viewModelScope.launch {
+            val group = MainGroup(
+                id = id ?: UUID.randomUUID().toString(),
+                name = name.trim(),
+                posterType = posterType,
+                posterSize = posterSize,
+                logoUrl = resolveImageUrl(logoUrl),
+                subGroupIds = subGroupIds
+            )
+            groupPreferenceDataStore.updateMainGroup(group)
+        }
+    }
+
+    fun deleteMainGroup(id: String) {
+        viewModelScope.launch {
+            groupPreferenceDataStore.removeMainGroup(id)
+        }
+    }
+
+    fun startQrMode() {
+        val ip = DeviceIpAddress.get(context)
+        if (ip == null) {
+            _uiState.update { it.copy(serverUrl = "Connect to Wi-Fi to use this feature") }
+            return
+        }
+        
+        // Lazy load resources
+        try {
+            if (logoBytes == null) {
+                val inputStream = context.resources.openRawResource(R.drawable.app_logo_wordmark)
+                logoBytes = inputStream.use { it.readBytes() }
+            }
+        } catch (_: Exception) {}
+        
+        val webPageHtml = try {
+            context.assets.open("group_web.html").bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            _uiState.update { it.copy(serverUrl = "Missing HTML asset") }
+            return
+        }
+        
+        val activeToken = UUID.randomUUID().toString()
+
+        stopServerInternal()
+
+        server = GroupConfigServer.startOnAvailablePort(
+            serverToken = activeToken,
+            webPageHtml = webPageHtml,
+            currentPageStateProvider = {
+                GroupConfigServer.PageState(
+                    availableCatalogs = uiState.value.availableCatalogs.map { catalog ->
+                        GroupConfigServer.CatalogInfo(
+                            key = catalog.key,
+                            catalogName = catalog.catalogName,
+                            addonName = catalog.addonName,
+                            type = catalog.typeLabel,
+                            isSelected = false
+                        )
+                    },
+                    catalogGroups = uiState.value.catalogGroups,
+                    mainGroups = uiState.value.mainGroups
+                )
+            },
+            onChangeProposed = { change -> handleChangeProposed(change) },
+            logoProvider = { logoBytes }
+        )
+
+        val activeServer = server
+        if (activeServer == null) {
+            _uiState.update { it.copy(serverUrl = "Could not start server. All ports in use.") }
+            return
+        }
+
+        val url = "http://$ip:${activeServer.listeningPort}/?token=$activeToken"
+        val qrBitmap = QrCodeGenerator.generate(url, 512)
+
+        _uiState.update {
+            it.copy(
+                isQrModeActive = true,
+                qrCodeBitmap = qrBitmap,
+                serverUrl = url
+            )
+        }
+    }
+
+    fun stopQrMode() {
+        stopServerInternal()
+        logoBytes = null
+        _uiState.update {
+            it.copy(
+                isQrModeActive = false,
+                qrCodeBitmap = null,
+                serverUrl = null,
+                pendingChange = null
+            )
+        }
+    }
+
+    private fun stopServerInternal() {
+        server?.stop()
+        server = null
+    }
+
+    private fun handleChangeProposed(change: GroupConfigServer.PendingGroupChange) {
+        _uiState.update {
+            it.copy(
+                pendingChange = change
+            )
+        }
+    }
+
+    fun confirmPendingChange() {
+        val pending = _uiState.value.pendingChange ?: return
+        server?.confirmChange(pending.id)
+        
+        _uiState.update { it.copy(pendingChange = null) }
+        
+        viewModelScope.launch {
+            // Sanitize blank logoUrls to null so Coil doesn't fail on empty-string URLs
+            val sanitizedCatalogGroups = pending.proposedCatalogGroups.map { cg ->
+                cg.copy(logoUrl = resolveImageUrl(cg.logoUrl))
+            }
+            val sanitizedMainGroups = pending.proposedMainGroups.map { mg ->
+                mg.copy(logoUrl = resolveImageUrl(mg.logoUrl))
+            }
+            Log.d("GroupMgmt", "Syncing from phone: ${sanitizedCatalogGroups.size} catalog groups, ${sanitizedMainGroups.size} main groups")
+            sanitizedCatalogGroups.forEach { cg ->
+                Log.d("GroupMgmt", "  CatalogGroup id=${cg.id} name=${cg.name} keys=${cg.catalogKeys}")
+            }
+            sanitizedMainGroups.forEach { mg ->
+                Log.d("GroupMgmt", "  MainGroup id=${mg.id} name=${mg.name} subGroupIds=${mg.subGroupIds}")
+            }
+            groupPreferenceDataStore.setCatalogGroups(sanitizedCatalogGroups)
+            groupPreferenceDataStore.setMainGroups(sanitizedMainGroups)
+            delay(1500)
+            stopQrMode()
+        }
+    }
+
+    fun rejectPendingChange() {
+        val pending = _uiState.value.pendingChange ?: return
+        server?.rejectChange(pending.id)
+        _uiState.update { it.copy(pendingChange = null) }
+    }
+
+    fun clearQrSelectedKeys() {
+        _uiState.update { it.copy(qrSelectedKeys = null) }
+    }
+
+    // Helper extensions
+    private fun CatalogDescriptor.isSearchOnlyCatalog(): Boolean {
+        return extra.any { extra -> extra.name.equals("search", ignoreCase = true) && extra.isRequired }
+    }
+
+    private fun resolveImageUrl(url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        val driveRegex = Regex("""drive\.google\.com/file/d/([^/]+)""")
+        val match = driveRegex.find(url)
+        if (match != null) {
+            val id = match.groupValues[1]
+            return "https://drive.google.com/thumbnail?id=$id&sz=w400"
+        }
+        return try {
+            java.net.URL(url)
+            url.trim()
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+data class GroupManagementUiState(
+    val isLoading: Boolean = true,
+    val catalogGroups: List<CatalogGroup> = emptyList(),
+    val mainGroups: List<MainGroup> = emptyList(),
+    val availableCatalogs: List<AvailableCatalog> = emptyList(),
+    val isQrModeActive: Boolean = false,
+    val qrCodeBitmap: Bitmap? = null,
+    val serverUrl: String? = null,
+    val pendingChange: com.nuvio.tv.core.server.GroupConfigServer.PendingGroupChange? = null,
+    val qrSelectedKeys: List<String>? = null
+)
+
+data class AvailableCatalog(
+    val key: String,
+    val catalogName: String,
+    val addonName: String,
+    val typeLabel: String
+)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/SubgroupListingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/SubgroupListingsScreen.kt
@@ -218,7 +218,7 @@ fun SubgroupListingsScreen(
             item {
                 Text(
                     text = groupName,
-                    style = MaterialTheme.typography.headlineMedium,
+                    style = MaterialTheme.typography.titleLarge,
                     color = NuvioColors.TextPrimary,
                     modifier = Modifier.padding(start = rowHorizontalPadding, bottom = 24.dp)
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/SubgroupListingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/SubgroupListingsScreen.kt
@@ -1,0 +1,191 @@
+package com.nuvio.tv.ui.screens.addon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.ui.theme.NuvioColors
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.data.local.GroupPreferenceDataStore
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.repository.AddonRepository
+import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.core.network.NetworkResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+import kotlinx.coroutines.delay
+import com.nuvio.tv.domain.model.skipStep
+import com.nuvio.tv.domain.model.supportsExtra
+import com.nuvio.tv.ui.components.CatalogRowSection
+import com.nuvio.tv.ui.components.PosterCardDefaults
+import com.nuvio.tv.ui.components.PosterCardStyle
+
+@HiltViewModel
+class SubgroupListingsViewModel @Inject constructor(
+    private val groupPreferenceDataStore: GroupPreferenceDataStore,
+    private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    private val addonRepository: AddonRepository,
+    private val catalogRepository: CatalogRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<List<CatalogRow>>(emptyList())
+    val uiState: StateFlow<List<CatalogRow>> = _uiState.asStateFlow()
+    
+    private val _groupName = MutableStateFlow("")
+    val groupName: StateFlow<String> = _groupName.asStateFlow()
+    
+    val useLandscapePosters: StateFlow<Boolean> = layoutPreferenceDataStore.modernLandscapePostersEnabled
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+        
+    val posterCardWidthDp: StateFlow<Int> = layoutPreferenceDataStore.posterCardWidthDp
+        .stateIn(viewModelScope, SharingStarted.Lazily, 126)
+
+    fun loadSubgroup(subgroupId: String) {
+        viewModelScope.launch {
+            val groups = groupPreferenceDataStore.catalogGroups.first()
+            val group = groups.find { it.id == subgroupId } ?: return@launch
+            _groupName.value = group.name
+            val addons = addonRepository.getInstalledAddons().first()
+            
+            val rows = mutableListOf<CatalogRow>()
+            _uiState.value = rows
+            
+            group.catalogKeys.forEach { key ->
+                val delimiter = if (key.contains(":::")) ":::" else "_"
+                val parts = key.split(delimiter, limit = 3)
+                if (parts.size != 3) return@forEach
+                
+                val addonId = parts[0]
+                val apiType = parts[1]
+                val catalogId = parts[2]
+                
+                val addon = addons.find { it.id == addonId } ?: return@forEach
+                val catalog = addon.catalogs.find { it.id == catalogId && it.apiType == apiType } ?: return@forEach
+                
+                val supportsSkip = catalog.supportsExtra("skip")
+                val skipStep = catalog.skipStep()
+                
+                launch {
+                    catalogRepository.getCatalog(
+                        addonBaseUrl = addon.baseUrl,
+                        addonId = addon.id,
+                        addonName = addon.displayName,
+                        catalogId = catalog.id,
+                        catalogName = catalog.name,
+                        type = catalog.apiType,
+                        skip = 0,
+                        skipStep = skipStep,
+                        supportsSkip = supportsSkip
+                    ).collect { result ->
+                        if (result is NetworkResult.Success) {
+                            val newRow = result.data
+                            _uiState.value = _uiState.value + newRow
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun SubgroupListingsScreen(
+    subgroupId: String,
+    viewModel: SubgroupListingsViewModel = hiltViewModel(),
+    onNavigateToDetail: (String, String, String) -> Unit,
+    onNavigateToCatalogSeeAll: (String, String, String) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val groupName by viewModel.groupName.collectAsState()
+    val useLandscapePosters by viewModel.useLandscapePosters.collectAsState()
+    val posterCardWidthDp by viewModel.posterCardWidthDp.collectAsState()
+    
+    androidx.compose.runtime.LaunchedEffect(subgroupId) {
+        viewModel.loadSubgroup(subgroupId)
+    }
+
+    val computedWidthDp = if (useLandscapePosters) (posterCardWidthDp.dp * 1.35f) else posterCardWidthDp.dp
+    val computedHeightDp = if (useLandscapePosters) (computedWidthDp / 1.77f) else (posterCardWidthDp.dp * 1.5f)
+
+    val posterCardStyle = PosterCardStyle(
+        width = computedWidthDp,
+        height = computedHeightDp,
+        cornerRadius = 8.dp,
+        focusedBorderWidth = PosterCardDefaults.Style.focusedBorderWidth,
+        focusedScale = PosterCardDefaults.Style.focusedScale
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(NuvioColors.Background)
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(top = 36.dp, bottom = 36.dp)
+        ) {
+            item {
+                Text(
+                    text = groupName,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = NuvioColors.TextPrimary,
+                    modifier = Modifier.padding(start = 36.dp, bottom = 24.dp)
+                )
+            }
+            
+            items(uiState) { row ->
+                if (row.items.isNotEmpty()) {
+                    val finalRow = if (useLandscapePosters) {
+                        row.copy(items = row.items.map {
+                            it.copy(
+                                posterShape = PosterShape.LANDSCAPE,
+                                poster = it.backdropUrl ?: it.poster
+                            )
+                        })
+                    } else {
+                        row
+                    }
+                    CatalogRowSection(
+                        catalogRow = finalRow,
+                        posterCardStyle = posterCardStyle,
+                        onItemClick = { itemId, itemType, baseUrl ->
+                            onNavigateToDetail(itemId, itemType, baseUrl)
+                        },
+                        onSeeAll = {
+                            onNavigateToCatalogSeeAll(row.catalogId, row.addonId, row.apiType)
+                        },
+                        onItemLongPress = { _, _ -> },
+                        onItemFocus = { _ -> }
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/SubgroupListingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/SubgroupListingsScreen.kt
@@ -14,13 +14,39 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import androidx.compose.ui.res.stringResource
+import com.nuvio.tv.R
 import com.nuvio.tv.ui.theme.NuvioColors
+import com.nuvio.tv.ui.screens.home.HeroTitleBlock
+import com.nuvio.tv.ui.screens.home.toHeroPreview
+import com.nuvio.tv.ui.screens.home.MODERN_HERO_TEXT_WIDTH_FRACTION
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.data.local.GroupPreferenceDataStore
@@ -40,11 +66,13 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 import kotlinx.coroutines.delay
+import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.skipStep
 import com.nuvio.tv.domain.model.supportsExtra
 import com.nuvio.tv.ui.components.CatalogRowSection
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
+import androidx.compose.foundation.layout.Arrangement
 
 @HiltViewModel
 class SubgroupListingsViewModel @Inject constructor(
@@ -141,21 +169,58 @@ fun SubgroupListingsScreen(
         focusedScale = PosterCardDefaults.Style.focusedScale
     )
 
-    Box(
+    var activeBackdropItem by remember { mutableStateOf<MetaPreview?>(null) }
+    val firstItem = remember(uiState) { uiState.firstOrNull { it.items.isNotEmpty() }?.items?.firstOrNull() }
+    val heroItem = activeBackdropItem ?: firstItem
+
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
             .background(NuvioColors.Background)
     ) {
+        val rowsViewportHeightFraction = if (useLandscapePosters) 0.49f else 0.52f
+        val rowsViewportHeight = maxHeight * rowsViewportHeightFraction
+        val rowHorizontalPadding = 52.dp
+
+        if (heroItem != null) {
+            SubgroupHeroScene(
+                preview = heroItem,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .fillMaxWidth()
+                    .height(maxHeight)
+            )
+            HeroTitleBlock(
+                preview = heroItem.toHeroPreview(
+                    useLandscapePosters = useLandscapePosters,
+                    strTypeMovie = stringResource(id = R.string.type_movie),
+                    strTypeSeries = stringResource(id = R.string.type_series)
+                ),
+                portraitMode = !useLandscapePosters,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(
+                        start = rowHorizontalPadding,
+                        end = 48.dp,
+                        bottom = rowsViewportHeight + 16.dp
+                    )
+                    .fillMaxWidth(MODERN_HERO_TEXT_WIDTH_FRACTION)
+            )
+        }
+
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(top = 36.dp, bottom = 36.dp)
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .height(rowsViewportHeight),
+            contentPadding = PaddingValues(top = 16.dp, bottom = 36.dp)
         ) {
             item {
                 Text(
                     text = groupName,
                     style = MaterialTheme.typography.headlineMedium,
                     color = NuvioColors.TextPrimary,
-                    modifier = Modifier.padding(start = 36.dp, bottom = 24.dp)
+                    modifier = Modifier.padding(start = rowHorizontalPadding, bottom = 24.dp)
                 )
             }
             
@@ -181,11 +246,100 @@ fun SubgroupListingsScreen(
                             onNavigateToCatalogSeeAll(row.catalogId, row.addonId, row.apiType)
                         },
                         onItemLongPress = { _, _ -> },
-                        onItemFocus = { _ -> }
+                        onItemFocus = { item ->
+                            activeBackdropItem = item
+                        }
                     )
                     Spacer(modifier = Modifier.height(24.dp))
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SubgroupHeroScene(
+    preview: MetaPreview,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val screenConf = LocalConfiguration.current
+    val screenWPx = remember(screenConf, density) { with(density) { (screenConf.screenWidthDp.dp * 1.5f).roundToPx() } }
+    val screenHPx = remember(screenConf, density) { with(density) { (screenConf.screenHeightDp.dp * 1.5f).roundToPx() } }
+    
+    val rawBackdrop = preview.backdropUrl ?: preview.poster
+    val highResBackdrop = remember(rawBackdrop) {
+        rawBackdrop?.let {
+            if (it.contains("image.tmdb.org")) {
+                it.replace("/w500/", "/original/")
+                  .replace("/w780/", "/original/")
+                  .replace("/w1280/", "/original/")
+                  .replace("/w342/", "/original/")
+            } else it
+        }
+    }
+        
+    val imageModel = remember(context, highResBackdrop, screenWPx, screenHPx) {
+        ImageRequest.Builder(context)
+            .data(highResBackdrop)
+            .crossfade(400)
+            .size(width = screenWPx, height = screenHPx)
+            .build()
+    }
+
+    Box(modifier = modifier) {
+        AsyncImage(
+            model = imageModel,
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+            alignment = Alignment.TopEnd
+        )
+        
+        val bgColor = NuvioColors.Background
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .drawWithCache {
+                    val horizontalFadeEndX = size.width * 0.65f
+                    val horizontalGradient = Brush.horizontalGradient(
+                        colorStops = arrayOf(
+                            0.0f to bgColor,
+                            0.22f to bgColor.copy(alpha = 0.90f),
+                            0.46f to bgColor.copy(alpha = 0.80f),
+                            0.76f to bgColor.copy(alpha = 0.42f),
+                            1.0f to Color.Transparent
+                        ),
+                        startX = 0f,
+                        endX = horizontalFadeEndX
+                    )
+                    
+                    val bottomStripStartY = size.height * 0.64f
+                    val verticalGradient = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0.0f to Color.Transparent,
+                            0.30f to bgColor.copy(alpha = 0.35f),
+                            0.60f to bgColor.copy(alpha = 0.75f),
+                            1.0f to bgColor
+                        ),
+                        startY = bottomStripStartY,
+                        endY = size.height
+                    )
+
+                    onDrawBehind {
+                        drawRect(
+                            brush = horizontalGradient,
+                            topLeft = Offset(0f, 0f),
+                            size = Size(horizontalFadeEndX, size.height)
+                        )
+                        drawRect(
+                            brush = verticalGradient,
+                            topLeft = Offset(0f, bottomStripStartY),
+                            size = Size(size.width, size.height - bottomStripStartY)
+                        )
+                    }
+                }
+        )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -264,7 +264,7 @@ fun ClassicHomeContent(
             CatalogRowSection(
                 catalogRow = catalogRow,
                 posterCardStyle = posterCardStyle,
-                showPosterLabels = uiState.posterLabelsEnabled,
+                showPosterLabels = false,
                 showAddonName = uiState.catalogAddonNameEnabled,
                 showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,
                 focusedPosterBackdropExpandEnabled = uiState.focusedPosterBackdropExpandEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -289,7 +289,7 @@ fun GridHomeContent(
                                 "series" -> strTypeSeries
                                 else -> gridItem.type.replaceFirstChar { it.uppercase() }
                             }
-                            val displayName = if (uiState.catalogTypeSuffixEnabled && typeLabel.isNotBlank()) {
+                            val displayName = if (uiState.catalogTypeSuffixEnabled && typeLabel.isNotBlank() && gridItem.addonId != "maingroup") {
                                 "${gridItem.catalogName.replaceFirstChar { it.uppercase() }} - $typeLabel"
                             } else {
                                 gridItem.catalogName.replaceFirstChar { it.uppercase() }
@@ -324,7 +324,7 @@ fun GridHomeContent(
                                 item = gridItem.item,
                                 focusRequester = focusRequester,
                                 posterCardStyle = posterCardStyle,
-                                showLabel = uiState.posterLabelsEnabled,
+                                showLabel = false,
                                 isWatched = isCatalogItemWatched(gridItem.item),
                                 onFocused = { onItemFocus(gridItem.item) },
                                 onClick = {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.nuvio.tv.core.player.StreamAutoPlayPolicy
 import com.nuvio.tv.core.tmdb.TmdbMetadataService
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.AuthSessionNoticeDataStore
+import com.nuvio.tv.data.local.GroupPreferenceDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.StartupAuthNotice
@@ -19,6 +20,8 @@ import com.nuvio.tv.data.trailer.TrailerService
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
 import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.CatalogGroup
+import com.nuvio.tv.domain.model.MainGroup
 import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaPreview
@@ -53,6 +56,7 @@ class HomeViewModel @Inject constructor(
     internal val libraryRepository: LibraryRepository,
     internal val metaRepository: MetaRepository,
     internal val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    internal val groupPreferenceDataStore: GroupPreferenceDataStore,
     internal val playerSettingsDataStore: PlayerSettingsDataStore,
     internal val tmdbSettingsDataStore: TmdbSettingsDataStore,
     internal val traktSettingsDataStore: TraktSettingsDataStore,
@@ -101,6 +105,8 @@ class HomeViewModel @Inject constructor(
     internal val catalogsMap = linkedMapOf<String, CatalogRow>()
     internal val catalogOrder = mutableListOf<String>()
     internal var addonsCache: List<Addon> = emptyList()
+    internal var mainGroupsCache: List<MainGroup> = emptyList()
+    internal var catalogGroupsCache: List<CatalogGroup> = emptyList()
     internal var homeCatalogOrderKeys: List<String> = emptyList()
     internal var disabledHomeCatalogKeys: Set<String> = emptySet()
     internal var currentHeroCatalogKeys: List<String> = emptyList()
@@ -166,6 +172,7 @@ class HomeViewModel @Inject constructor(
         observeLayoutPreferences()
         observeModernHomePresentation()
         observeExternalMetaPrefetchPreference()
+        observeGroupPreferences()
         loadHomeCatalogOrderPreference()
         loadDisabledHomeCatalogPreference()
         observeLibraryState()
@@ -225,6 +232,8 @@ class HomeViewModel @Inject constructor(
     fun onItemFocus(item: MetaPreview) = onItemFocusPipeline(item)
 
     fun preloadAdjacentItem(item: MetaPreview) = preloadAdjacentItemPipeline(item)
+
+    private fun observeGroupPreferences() = observeGroupPreferencesPipeline()
 
     private fun loadHomeCatalogOrderPreference() = loadHomeCatalogOrderPreferencePipeline()
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -18,6 +18,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withPermit
 import com.nuvio.tv.core.util.filterReleasedItems
+import com.nuvio.tv.domain.model.PosterShape
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
@@ -62,6 +63,27 @@ internal fun HomeViewModel.observeTmdbSettingsPipeline() {
                 currentTmdbSettings = settings
                 scheduleUpdateCatalogRows()
             }
+    }
+}
+
+internal fun HomeViewModel.observeGroupPreferencesPipeline() {
+    viewModelScope.launch {
+        launch {
+            groupPreferenceDataStore.mainGroups.collectLatest { mainGroups ->
+                Log.d("GroupPipeline", "mainGroups changed: count=${mainGroups.size} ids=${mainGroups.map { it.id }}")
+                mainGroupsCache = mainGroups
+                rebuildCatalogOrder(addonsCache)
+                scheduleUpdateCatalogRows()
+            }
+        }
+        launch {
+            groupPreferenceDataStore.catalogGroups.collectLatest { catalogGroups ->
+                Log.d("GroupPipeline", "catalogGroups changed: count=${catalogGroups.size} ids=${catalogGroups.map { it.id }}")
+                catalogGroupsCache = catalogGroups
+                rebuildCatalogOrder(addonsCache)
+                scheduleUpdateCatalogRows()
+            }
+        }
     }
 }
 
@@ -289,7 +311,49 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
     val hideUnreleased = _uiState.value.hideUnreleasedContent
 
     val (displayRows, baseHeroItems, baseGridItems, fullRowsFiltered) = withContext(Dispatchers.Default) {
-        val rawRows = orderedKeys.mapNotNull { key -> catalogSnapshot[key] }
+        val rawRows = orderedKeys.mapNotNull { key ->
+            if (key.startsWith("maingroup:")) {
+                val mainGroupId = key.substringAfter("maingroup:")
+                val mainGroup = mainGroupsCache.find { it.id == mainGroupId }
+                if (mainGroup != null) {
+                    val subGroups = mainGroup.subGroupIds.mapNotNull { subGroupId ->
+                        catalogGroupsCache.find { it.id == subGroupId }
+                    }
+                    Log.d("GroupPipeline", "MainGroup '${mainGroup.name}': subGroupIds=${mainGroup.subGroupIds} resolved=${subGroups.size} subgroups")
+                    val items = subGroups.map { subGroup ->
+                        MetaPreview(
+                            id = "subgroup_${subGroup.id}",
+                            type = com.nuvio.tv.domain.model.ContentType.UNKNOWN,
+                            rawType = "other",
+                            name = subGroup.name,
+                            poster = subGroup.logoUrl,
+                            posterShape = if (mainGroup.posterType == "Square") PosterShape.SQUARE else PosterShape.POSTER,
+                            background = null,
+                            logo = null,
+                            description = null,
+                            releaseInfo = null,
+                            imdbRating = null,
+                            genres = emptyList()
+                        )
+                    }
+                    CatalogRow(
+                        addonId = "maingroup",
+                        addonName = "Local",
+                        addonBaseUrl = "local",
+                        catalogId = mainGroupId,
+                        catalogName = mainGroup.name,
+                        type = com.nuvio.tv.domain.model.ContentType.UNKNOWN,
+                        rawType = "other",
+                        items = items,
+                        supportsSkip = false,
+                        hasMore = false
+                    )
+                } else null
+            } else {
+                catalogSnapshot[key]
+            }
+        }
+        
         val orderedRows = if (hideUnreleased) {
             val today = LocalDate.now()
             rawRows.map { it.filterReleasedItems(today) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -324,7 +324,7 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                         MetaPreview(
                             id = "subgroup_${subGroup.id}",
                             type = com.nuvio.tv.domain.model.ContentType.UNKNOWN,
-                            rawType = "other",
+                            rawType = "maingroup_item",
                             name = subGroup.name,
                             poster = subGroup.logoUrl,
                             posterShape = if (mainGroup.posterType == "Square") PosterShape.SQUARE else PosterShape.POSTER,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -45,7 +45,9 @@ internal fun HomeViewModel.cancelInFlightCatalogLoads() {
 
 internal fun HomeViewModel.rebuildCatalogOrder(addons: List<Addon>) {
     val defaultOrder = buildDefaultCatalogOrder(addons)
-    val availableSet = defaultOrder.toSet()
+    val mainGroupOrderKeys = mainGroupsCache.map { "maingroup:${it.id}" }
+    val fullAvailableOrder = mainGroupOrderKeys + defaultOrder
+    val availableSet = fullAvailableOrder.toSet()
 
     val savedValid = homeCatalogOrderKeys
         .asSequence()
@@ -54,7 +56,7 @@ internal fun HomeViewModel.rebuildCatalogOrder(addons: List<Addon>) {
         .toList()
 
     val savedSet = savedValid.toSet()
-    val mergedOrder = savedValid + defaultOrder.filterNot { it in savedSet }
+    val mergedOrder = savedValid + fullAvailableOrder.filterNot { it in savedSet }
 
     catalogOrder.clear()
     catalogOrder.addAll(mergedOrder)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -561,9 +561,9 @@ fun ModernHomeContent(
         if (!fullScreenBackdrop && !heroSceneState.heroBackdrop.isNullOrBlank()) {
             val screenConf = LocalConfiguration.current
             val density = LocalDensity.current
-            val screenWPx = remember(screenConf, density) { with(density) { screenConf.screenWidthDp.dp.roundToPx() } }
-            val screenHPx = remember(screenConf, density) { with(density) { screenConf.screenHeightDp.dp.roundToPx() } }
-            val heroUrl = heroSceneState.heroBackdrop!!
+            val screenWPx = remember(screenConf, density) { with(density) { (screenConf.screenWidthDp * 1.5f).dp.roundToPx() } }
+            val screenHPx = remember(screenConf, density) { with(density) { (screenConf.screenHeightDp * 1.5f).dp.roundToPx() } }
+            val heroUrl = heroSceneState.heroBackdrop.upgradeToHighRes()!!
             val req = remember(prefetchContext, heroUrl, screenWPx, screenHPx) {
                 buildPrefetchRequest(prefetchContext, heroUrl, screenWPx, screenHPx)
             }
@@ -618,14 +618,14 @@ fun ModernHomeContent(
         }
         val heroMediaWidthPx = remember(maxWidth, localDensity, fullScreenBackdrop) {
             with(localDensity) {
-                if (fullScreenBackdrop) maxWidth.roundToPx()
-                else (maxWidth * MODERN_HERO_MEDIA_WIDTH_FRACTION).roundToPx()
+                if (fullScreenBackdrop) (maxWidth * 1.5f).roundToPx()
+                else (maxWidth * MODERN_HERO_MEDIA_WIDTH_FRACTION * 1.5f).roundToPx()
             }
         }
         val heroMediaHeightPx = remember(heroBackdropHeight, maxHeight, localDensity, fullScreenBackdrop) {
             with(localDensity) {
-                if (fullScreenBackdrop) maxHeight.roundToPx()
-                else heroBackdropHeight.roundToPx()
+                if (fullScreenBackdrop) (maxHeight * 1.5f).roundToPx()
+                else (heroBackdropHeight * 1.5f).roundToPx()
             }
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -785,7 +785,7 @@ fun ModernHomeContent(
                         },
                         onRowItemFocused = stableOnRowItemFocused,
                         useLandscapePosters = useLandscapePosters,
-                        showLabels = uiState.posterLabelsEnabled,
+                        showLabels = false,
                         posterCardCornerRadius = posterCardCornerRadius,
                         focusedPosterBackdropTrailerMuted = uiState.focusedPosterBackdropTrailerMuted,
                         effectiveExpandEnabled = effectiveExpandEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -115,7 +115,7 @@ internal fun ModernHeroMediaLayer(
 
     val imageModel = remember(localContext, stableBackdrop, requestWidthPx, requestHeightPx) {
         ImageRequest.Builder(localContext)
-            .data(stableBackdrop)
+            .data(stableBackdrop.upgradeToHighRes())
             .crossfade(400)
             .size(width = requestWidthPx, height = requestHeightPx)
             .build()
@@ -273,12 +273,12 @@ private fun HeroTitleContent(
     val headlineLarge = MaterialTheme.typography.headlineLarge
     val labelMedium = MaterialTheme.typography.labelMedium
     val bodyMedium = MaterialTheme.typography.bodyMedium
-    val logoMaxWidthPx = remember(density) { with(density) { 220.dp.roundToPx() } }
-    val logoHeightPx = remember(density) { with(density) { 100.dp.roundToPx() } }
+    val logoMaxWidthPx = remember(density) { with(density) { (220.dp * 1.5f).roundToPx() } }
+    val logoHeightPx = remember(density) { with(density) { (100.dp * 1.5f).roundToPx() } }
     val logoModel = remember(context, preview.logo, logoMaxWidthPx, logoHeightPx) {
         preview.logo?.let {
             ImageRequest.Builder(context)
-                .data(it)
+                .data(it.upgradeToHighRes())
                 .crossfade(false)
                 .decoderFactory(SvgDecoder.Factory())
                 .size(width = logoMaxWidthPx, height = logoHeightPx)
@@ -652,4 +652,15 @@ private fun HeroMetaDivider(scale: Float) {
             .clip(RoundedCornerShape(percent = 50))
             .background(NuvioColors.TextTertiary.copy(alpha = 0.78f))
     )
+}
+
+internal fun String?.upgradeToHighRes(): String? {
+    if (this == null) return null
+    if (this.contains("image.tmdb.org")) {
+        return this.replace("/w500/", "/original/")
+            .replace("/w780/", "/original/")
+            .replace("/w1280/", "/original/")
+            .replace("/w342/", "/original/")
+    }
+    return this
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -385,51 +385,32 @@ internal fun buildCatalogItem(
     val currentBackdrop = item.backdropUrl
     val currentLogo = item.logo
 
-    // First non-blank value wins and is never replaced.
-    val frozenBackdrop = carriedBackdrop?.takeIf { it.isNotBlank() }
-        ?: currentBackdrop
+    val frozenBackdrop = carriedBackdrop?.takeIf { it.isNotBlank() } ?: currentBackdrop
     val frozenLogo = carriedLogo?.takeIf { it.isNotBlank() }
         ?: currentLogo
 
-    val heroPreview = HeroPreview(
-        title = item.name,
-        logo = item.logo,
-        description = item.description,
-        contentTypeText = when (item.apiType.lowercase()) {
-            "movie" -> strTypeMovie.ifBlank { item.apiType.replaceFirstChar { ch -> ch.uppercase() } }
-            "series" -> strTypeSeries.ifBlank { item.apiType.replaceFirstChar { ch -> ch.uppercase() } }
-            else -> item.apiType.replaceFirstChar { ch -> ch.uppercase() }
-        },
-        isSeries = isSeriesType(item.apiType),
-        yearText = extractYearText(item.type, item.releaseInfo, item.released, showFullReleaseDate),
-        runtimeText = formatHeroRuntime(item.runtime),
-        imdbText = item.imdbRating?.let { String.format("%.1f", it) },
-        ageRatingText = item.ageRating,
-        statusText = item.status,
-        countryText = item.country,
-        languageText = item.language?.uppercase(),
-        genres = item.genres.take(3),
-        poster = item.poster,
-        backdrop = item.backdropUrl,
-        imageUrl = if (useLandscapePosters) {
-            item.backdropUrl ?: item.poster
-        } else {
-            item.poster ?: item.backdropUrl
-        },
-        frozenBackdropUrl = frozenBackdrop,
-        frozenLogoUrl = frozenLogo
+    val heroPreview = item.toHeroPreview(
+        useLandscapePosters = useLandscapePosters,
+        strTypeMovie = strTypeMovie,
+        strTypeSeries = strTypeSeries,
+        showFullReleaseDate = showFullReleaseDate,
+        frozenBackdrop = frozenBackdrop,
+        frozenLogo = frozenLogo
     )
 
     return ModernCarouselItem(
         key = "catalog_${row.key()}_${item.id}_${occurrence}",
-        title = item.name,
-        subtitle = item.releaseInfo,
+        title = if (row.addonId == "maingroup") "" else item.name,
+        subtitle = if (row.addonId == "maingroup") null else item.releaseInfo,
         imageUrl = if (useLandscapePosters) {
             item.backdropUrl ?: item.poster
         } else {
             item.poster ?: item.backdropUrl
         },
-        heroPreview = heroPreview,
+        heroPreview = heroPreview.copy(
+            title = if (row.addonId == "maingroup") "" else heroPreview.title,
+            contentTypeText = if (row.addonId == "maingroup") "" else heroPreview.contentTypeText
+        ),
         payload = ModernPayload.Catalog(
             focusKey = "${row.key()}::${item.id}",
             itemId = item.id,
@@ -440,6 +421,44 @@ internal fun buildCatalogItem(
             trailerApiType = item.apiType
         ),
         metaPreview = item
+    )
+}
+
+internal fun MetaPreview.toHeroPreview(
+    useLandscapePosters: Boolean,
+    strTypeMovie: String = "",
+    strTypeSeries: String = "",
+    showFullReleaseDate: Boolean = true,
+    frozenBackdrop: String? = null,
+    frozenLogo: String? = null
+): HeroPreview {
+    return HeroPreview(
+        title = name,
+        logo = logo,
+        description = description,
+        contentTypeText = when (apiType.lowercase()) {
+            "movie" -> strTypeMovie.ifBlank { apiType.replaceFirstChar { ch -> ch.uppercase() } }
+            "series" -> strTypeSeries.ifBlank { apiType.replaceFirstChar { ch -> ch.uppercase() } }
+            else -> apiType.replaceFirstChar { ch -> ch.uppercase() }
+        },
+        isSeries = isSeriesType(apiType),
+        yearText = extractYearText(type, releaseInfo, released, showFullReleaseDate),
+        runtimeText = formatHeroRuntime(runtime),
+        imdbText = imdbRating?.let { String.format("%.1f", it) },
+        ageRatingText = ageRating,
+        statusText = status,
+        countryText = country,
+        languageText = language?.uppercase(),
+        genres = genres.take(3),
+        poster = poster,
+        backdrop = backdropUrl,
+        imageUrl = if (useLandscapePosters) {
+            backdropUrl ?: poster
+        } else {
+            poster ?: backdropUrl
+        },
+        frozenBackdropUrl = frozenBackdrop ?: backdropUrl,
+        frozenLogoUrl = frozenLogo ?: logo
     )
 }
 
@@ -463,7 +482,7 @@ internal fun catalogRowTitle(
     strTypeSeries: String = ""
 ): String {
     val catalogName = row.catalogName.replaceFirstChar { it.uppercase() }
-    if (!showCatalogTypeSuffix) return catalogName
+    if (!showCatalogTypeSuffix || row.addonId == "maingroup") return catalogName
     val typeLabel = when (row.apiType.lowercase()) {
         "movie" -> strTypeMovie.ifBlank { row.apiType.replaceFirstChar { it.uppercase() } }
         "series" -> strTypeSeries.ifBlank { row.apiType.replaceFirstChar { it.uppercase() } }
@@ -505,7 +524,7 @@ internal fun extractYearText(type: ContentType, releaseInfo: String?, released: 
     return extractYear(releaseInfo)
 }
 
-private fun formatHeroRuntime(runtime: String?): String? {
+internal fun formatHeroRuntime(runtime: String?): String? {
     val normalized = runtime?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return null
     val hours = "(\\d+)\\s*h".toRegex().find(normalized)?.groupValues?.getOrNull(1)?.toIntOrNull()
     val minutes = "(\\d+)\\s*m(?:in)?".toRegex().find(normalized)?.groupValues?.getOrNull(1)?.toIntOrNull()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -320,9 +320,9 @@ internal fun ModernRowSection(
 
     val rowKey = row.key
     Column {
-        val titleMediumStyle = MaterialTheme.typography.titleMedium
-        val rowTitleStyle = remember(titleMediumStyle) {
-            titleMediumStyle.copy(fontWeight = FontWeight.SemiBold)
+        val titleSmallStyle = MaterialTheme.typography.titleSmall
+        val rowTitleStyle = remember(titleSmallStyle) {
+            titleSmallStyle.copy(fontWeight = FontWeight.SemiBold)
         }
         val rowTitle = remember(row.title) { row.title }
         val textColor = remember { NuvioColors.TextPrimary }
@@ -858,6 +858,7 @@ private fun ModernCarouselCard(
 
                 Box(modifier = mediaLayerModifier) {
                     if (hasImage) {
+                        val isMaingroupItem = item.metaPreview?.rawType == "maingroup_item"
                         AsyncImage(
                             model = safeImageModel,
                             contentDescription = item.title,
@@ -865,7 +866,7 @@ private fun ModernCarouselCard(
                             placeholder = backgroundPainter,
                             error = backgroundPainter,
                             fallback = backgroundPainter,
-                            contentScale = ContentScale.Crop
+                            contentScale = if (isMaingroupItem) ContentScale.Fit else ContentScale.Crop
                         )
                     } else {
                         MonochromePosterPlaceholder()
@@ -898,7 +899,7 @@ private fun ModernCarouselCard(
                         contentScale = ContentScale.Fit,
                         alignment = Alignment.CenterStart
                     )
-                } else if (useLandscapeOverlayTreatment || isBackdropExpanded) {
+                } else if ((useLandscapeOverlayTreatment || isBackdropExpanded) && item.title.isNotBlank()) {
                     Text(
                         text = item.title,
                         style = titleStyle,


### PR DESCRIPTION
## Summary
Added a way to group and organize home screen catalogs using a mobile phone or by scanning a QR code.

## PR type
- [ ] Bug fix
- [ ] Small maintenance improvement
- [ ] Docs fix
- [x] Approved larger change (link approval below)

## Why
This PR allows users to declutter their home screen and provides a cleaner  look for the entire app.

## Policy check
- [x] This PR is not cosmetic only.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
- Tested the mobile configuration tool to ensure it works and is secure.
- Checked that group custom images renders in high quality and text look correct on all screen layouts.
- Confirmed that clicking groups opens the correct lists.
- Verified that the app remains fast when scrolling.

## Screenshots / Video (UI changes only)
### Manage Catalogs on TV
https://github.com/user-attachments/assets/2ca24e16-acd4-41f9-bfc7-a8fbf1176f3f

### Manage Catalogs using a browser

https://github.com/user-attachments/assets/1738eb2e-2d89-4df9-9dc4-88eaae001d01


## Breaking changes
None

## Linked issues
- Fixes #1000