### PR TITLE
player aspect mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
@@ -1,0 +1,83 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.annotation.StringRes
+import androidx.media3.ui.PlayerView
+import com.nuvio.tv.R
+
+enum class AspectMode(@StringRes val labelResId: Int) {
+    ORIGINAL(R.string.player_aspect_fit),
+    FULL_SCREEN(R.string.player_aspect_crop),
+    SLIGHT_ZOOM(R.string.player_aspect_mode_slight_zoom),
+    CINEMA_ZOOM(R.string.player_aspect_mode_cinema_zoom),
+    VERTICAL_STRETCH(R.string.player_aspect_fit_height),
+    HORIZONTAL_STRETCH(R.string.player_aspect_fit_width)
+}
+
+internal fun nextAspectMode(current: AspectMode): AspectMode {
+    val modes = AspectMode.entries
+    val nextIndex = (modes.indexOf(current) + 1) % modes.size
+    return modes[nextIndex]
+}
+
+internal fun aspectModeLabel(mode: AspectMode, getString: (Int) -> String): String =
+    getString(mode.labelResId)
+
+internal fun applyAspectMode(playerView: PlayerView, mode: AspectMode) {
+    when (mode) {
+        AspectMode.ORIGINAL -> {
+            playerView.scaleX = 1.0f
+            playerView.scaleY = 1.0f
+        }
+
+        AspectMode.FULL_SCREEN -> applyCoverAspectScale(playerView)
+
+        AspectMode.SLIGHT_ZOOM -> {
+            playerView.scaleX = 1.15f
+            playerView.scaleY = 1.15f
+        }
+
+        AspectMode.CINEMA_ZOOM -> {
+            playerView.scaleX = 1.33f
+            playerView.scaleY = 1.33f
+        }
+
+        AspectMode.VERTICAL_STRETCH -> {
+            playerView.scaleX = 1.0f
+            playerView.scaleY = 1.33f
+        }
+
+        AspectMode.HORIZONTAL_STRETCH -> {
+            playerView.scaleX = 1.3333f
+            playerView.scaleY = 1.0f
+        }
+    }
+}
+
+private fun applyCoverAspectScale(playerView: PlayerView) {
+    val videoSize = playerView.player?.videoSize
+    val videoAspect = if ((videoSize?.height ?: 0) > 0) {
+        ((videoSize?.width ?: 0).toFloat() * (videoSize?.pixelWidthHeightRatio ?: 1f)) /
+            videoSize!!.height.toFloat()
+    } else {
+        0f
+    }
+
+    val viewAspect = if (playerView.width > 0 && playerView.height > 0) {
+        playerView.width.toFloat() / playerView.height.toFloat()
+    } else {
+        0f
+    }
+
+    if (videoAspect > 0f && viewAspect > 0f) {
+        if (videoAspect > viewAspect) {
+            playerView.scaleX = 1.0f
+            playerView.scaleY = videoAspect / viewAspect
+        } else {
+            playerView.scaleX = viewAspect / videoAspect
+            playerView.scaleY = 1.0f
+        }
+    } else {
+        playerView.scaleX = 1.0f
+        playerView.scaleY = 1.0f
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
@@ -1,5 +1,9 @@
 package com.nuvio.tv.ui.screens.player
 
+import android.view.SurfaceView
+import android.view.TextureView
+import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.StringRes
 import androidx.media3.ui.PlayerView
 import com.nuvio.tv.R
@@ -23,37 +27,41 @@ internal fun aspectModeLabel(mode: AspectMode, getString: (Int) -> String): Stri
     getString(mode.labelResId)
 
 internal fun applyAspectMode(playerView: PlayerView, mode: AspectMode) {
+    val targetView = resolveVideoSurfaceView(playerView) ?: playerView
+    playerView.scaleX = 1.0f
+    playerView.scaleY = 1.0f
+
     when (mode) {
         AspectMode.ORIGINAL -> {
-            playerView.scaleX = 1.0f
-            playerView.scaleY = 1.0f
+            targetView.scaleX = 1.0f
+            targetView.scaleY = 1.0f
         }
 
-        AspectMode.FULL_SCREEN -> applyCoverAspectScale(playerView)
+        AspectMode.FULL_SCREEN -> applyCoverAspectScale(playerView, targetView)
 
         AspectMode.SLIGHT_ZOOM -> {
-            playerView.scaleX = 1.15f
-            playerView.scaleY = 1.15f
+            targetView.scaleX = 1.15f
+            targetView.scaleY = 1.15f
         }
 
         AspectMode.CINEMA_ZOOM -> {
-            playerView.scaleX = 1.33f
-            playerView.scaleY = 1.33f
+            targetView.scaleX = 1.33f
+            targetView.scaleY = 1.33f
         }
 
         AspectMode.VERTICAL_STRETCH -> {
-            playerView.scaleX = 1.0f
-            playerView.scaleY = 1.33f
+            targetView.scaleX = 1.0f
+            targetView.scaleY = 1.33f
         }
 
         AspectMode.HORIZONTAL_STRETCH -> {
-            playerView.scaleX = 1.3333f
-            playerView.scaleY = 1.0f
+            targetView.scaleX = 1.3333f
+            targetView.scaleY = 1.0f
         }
     }
 }
 
-private fun applyCoverAspectScale(playerView: PlayerView) {
+private fun applyCoverAspectScale(playerView: PlayerView, targetView: View) {
     val videoSize = playerView.player?.videoSize
     val videoAspect = if ((videoSize?.height ?: 0) > 0) {
         ((videoSize?.width ?: 0).toFloat() * (videoSize?.pixelWidthHeightRatio ?: 1f)) /
@@ -70,14 +78,35 @@ private fun applyCoverAspectScale(playerView: PlayerView) {
 
     if (videoAspect > 0f && viewAspect > 0f) {
         if (videoAspect > viewAspect) {
-            playerView.scaleX = 1.0f
-            playerView.scaleY = videoAspect / viewAspect
+            targetView.scaleX = 1.0f
+            targetView.scaleY = videoAspect / viewAspect
         } else {
-            playerView.scaleX = viewAspect / videoAspect
-            playerView.scaleY = 1.0f
+            targetView.scaleX = viewAspect / videoAspect
+            targetView.scaleY = 1.0f
         }
     } else {
-        playerView.scaleX = 1.0f
-        playerView.scaleY = 1.0f
+        targetView.scaleX = 1.0f
+        targetView.scaleY = 1.0f
+    }
+}
+
+private fun resolveVideoSurfaceView(playerView: PlayerView): View? {
+    return findVideoSurfaceView(playerView)
+}
+
+private fun findVideoSurfaceView(view: View): View? {
+    return when (view) {
+        is SurfaceView, is TextureView -> view
+        is ViewGroup -> {
+            for (index in 0 until view.childCount) {
+                val child = findVideoSurfaceView(view.getChildAt(index))
+                if (child != null) {
+                    return child
+                }
+            }
+            null
+        }
+
+        else -> null
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -78,7 +78,8 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
             _uiState.update {
                 it.copy(
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
-                    resizeMode = playerSettings.resizeMode
+                    resizeMode = playerSettings.resizeMode,
+                    tunnelingEnabled = playerSettings.tunnelingEnabled
                 )
             }
             val afrJob = async {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -191,6 +191,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     pauseOverlayEnabled = settings.pauseOverlayEnabled,
                     osdClockEnabled = settings.osdClockEnabled,
                     frameRateMatchingMode = settings.frameRateMatchingMode,
+                    tunnelingEnabled = settings.tunnelingEnabled,
                     persistAudioAmplification = settings.persistAudioAmplification,
                     audioAmplificationDb = resolvedAudioAmplificationDb
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -814,6 +814,20 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         PlayerEvent.OnToggleAspectRatio -> {
             val state = _uiState.value
+            if (state.tunnelingEnabled) {
+                _uiState.update {
+                    it.copy(
+                        showAspectRatioIndicator = true,
+                        aspectRatioIndicatorText = context.getString(R.string.player_aspect_tunneling_unavailable)
+                    )
+                }
+                hideAspectRatioIndicatorJob?.cancel()
+                hideAspectRatioIndicatorJob = scope.launch {
+                    delay(1500)
+                    _uiState.update { it.copy(showAspectRatioIndicator = false) }
+                }
+                return
+            }
             val newMode = nextAspectMode(state.aspectMode)
             val label = aspectModeLabel(newMode, context::getString)
             Log.d("PlayerViewModel", "Aspect mode toggled: ${state.aspectMode} -> $newMode ($label)")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -813,18 +813,17 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         PlayerEvent.OnToggleAspectRatio -> {
-            val currentMode = _uiState.value.resizeMode
-            val newMode = PlayerDisplayModeUtils.nextResizeMode(currentMode)
-            val modeText = PlayerDisplayModeUtils.resizeModeLabel(newMode, context)
-            Log.d("PlayerViewModel", "Aspect ratio toggled: $currentMode -> $newMode")
+            val state = _uiState.value
+            val newMode = nextAspectMode(state.aspectMode)
+            val label = aspectModeLabel(newMode, context::getString)
+            Log.d("PlayerViewModel", "Aspect mode toggled: ${state.aspectMode} -> $newMode ($label)")
             _uiState.update {
                 it.copy(
-                    resizeMode = newMode,
+                    aspectMode = newMode,
                     showAspectRatioIndicator = true,
-                    aspectRatioIndicatorText = modeText
+                    aspectRatioIndicatorText = label
                 )
             }
-            scope.launch { playerSettingsDataStore.setResizeMode(newMode) }
             hideAspectRatioIndicatorJob?.cancel()
             hideAspectRatioIndicatorJob = scope.launch {
                 delay(1500)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -489,7 +490,7 @@ fun PlayerScreen(
         // Video Player
         viewModel.exoPlayer?.let { player ->
             val subtitleStyle = uiState.subtitleStyle
-            val resizeMode = uiState.resizeMode
+            val aspectMode = uiState.aspectMode
             
             AndroidView(
                 factory = { context ->
@@ -503,8 +504,8 @@ fun PlayerScreen(
                 update = { playerView ->
                     // Keep device awake only while playback is active (or buffering), not when paused.
                     playerView.keepScreenOn = uiState.isPlaying || uiState.isBuffering
-                    Log.d("PlayerScreen", "Applying resizeMode: $resizeMode")
-                    playerView.resizeMode = resizeMode
+                    playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    applyAspectMode(playerView, aspectMode)
                     playerView.subtitleView?.apply {
                         // Calculate font size based on percentage (100% = 24sp base)
                         val baseFontSize = 24f

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -126,6 +126,7 @@ data class PlayerUiState(
     // Aspect ratio / resize mode
     val resizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
     val aspectMode: AspectMode = AspectMode.ORIGINAL,
+    val tunnelingEnabled: Boolean = false,
     val showAspectRatioIndicator: Boolean = false,
     val aspectRatioIndicatorText: String = "",
     // Stream info overlay

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -125,6 +125,7 @@ data class PlayerUiState(
     val showDisplayModeInfo: Boolean = false,
     // Aspect ratio / resize mode
     val resizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
+    val aspectMode: AspectMode = AspectMode.ORIGINAL,
     val showAspectRatioIndicator: Boolean = false,
     val aspectRatioIndicatorText: String = "",
     // Stream info overlay

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -991,7 +991,7 @@
     <string name="library_delete_subtitle">Isso removerá a lista e todos os seus itens do Trakt.</string>
     <string name="library_delete_confirm">Excluir</string>
     <string name="library_source_local">LOCAL</string>
-    string name="library_source_nuvio">NUVIO</string>
+    <string name="library_source_nuvio">NUVIO</string>
     <string name="library_source_trakt">TRAKT</string>
     <string name="library_syncing_library">Sincronizando biblioteca…</string>
     <string name="library_type_all">Todos</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -847,6 +847,7 @@
     <string name="player_aspect_fit_width">Genişliğe Sığdır</string>
     <string name="player_aspect_fit_height">Yüksekliğe Sığdır</string>
     <string name="player_aspect_crop">Kırp</string>
+    <string name="player_aspect_tunneling_unavailable">Tünellenmiş oynatım sırasında kullanılamaz</string>
     <string name="player_aspect_mode_slight_zoom">Hafif Yakınlaştırma</string>
     <string name="player_aspect_mode_cinema_zoom">Sinema Yakınlaştırma</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -847,6 +847,8 @@
     <string name="player_aspect_fit_width">Genişliğe Sığdır</string>
     <string name="player_aspect_fit_height">Yüksekliğe Sığdır</string>
     <string name="player_aspect_crop">Kırp</string>
+    <string name="player_aspect_mode_slight_zoom">Hafif Yakınlaştırma</string>
+    <string name="player_aspect_mode_cinema_zoom">Sinema Yakınlaştırma</string>
 
     <!-- AudioDialog -->
     <string name="audio_dialog_title">Ses</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -850,6 +850,7 @@
     <string name="player_aspect_fit_width">Fit Width</string>
     <string name="player_aspect_fit_height">Fit Height</string>
     <string name="player_aspect_crop">Crop</string>
+    <string name="player_aspect_tunneling_unavailable">Unavailable during tunneled playback</string>
     <string name="player_aspect_mode_slight_zoom">Slight Zoom</string>
     <string name="player_aspect_mode_cinema_zoom">Cinema Zoom</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -850,6 +850,8 @@
     <string name="player_aspect_fit_width">Fit Width</string>
     <string name="player_aspect_fit_height">Fit Height</string>
     <string name="player_aspect_crop">Crop</string>
+    <string name="player_aspect_mode_slight_zoom">Slight Zoom</string>
+    <string name="player_aspect_mode_cinema_zoom">Cinema Zoom</string>
 
     <!-- AudioDialog -->
     <string name="audio_dialog_title">Audio</string>


### PR DESCRIPTION
## Summary

- replace the main aspect ratio flow with typed aspect modes instead of the old resize-mode toggle
- keep subtitle sizing and position unaffected by aspect scaling by applying scaling to the video surface only
- show an aspect ratio warning during tunneled playback and include the small pt-BR string markup fix already present on this branch

## PR type

- Small maintenance improvement

## Why

The previous aspect ratio behavior was unreliable and mixed display mode state with scaling values. This branch makes the aspect controls more predictable, prevents subtitle UI from being distorted by aspect changes, and avoids confusing no-op behavior when tunneled playback blocks aspect scaling.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- manually tested the updated aspect ratio flow in player playback
- verified subtitle size and position stay stable while switching aspect modes
- verified tunneled playback shows the warning message instead of attempting aspect changes

### Special thanks

Thanks to everyone who helped with testing and review on this change.
@skoruppa 
[@Venom - Senpai](https://discordapp.com/users/277700015508553728)
[@Harsh74](https://discordapp.com/users/1483396418822475892)


## Screenshots / Video (UI changes only)

- aspect ratio control now shows a short warning during tunneled playback instead of attempting a change that cannot be applied

## Breaking changes

None .

## Linked issues

None .
