### PR TITLE
Fix stale hero backdrop in MetaDetails

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1735,6 +1735,9 @@ private fun BackdropLayer(
     leftGradient: ImageBitmap,
     bottomGradient: ImageBitmap,
 ) {
+    var showHeroBackdropUnderlay by remember(heroBackdropRequest, backdropRequest) {
+        mutableStateOf(heroBackdropRequest != null)
+    }
     val backdropAlphaState = animateFloatAsState(
         targetValue = if (isTrailerPlaying) 0f else if (isScrolledPastHero) 0.15f else 1f,
         animationSpec = tween(durationMillis = if (isScrolledPastHero) 300 else 800),
@@ -1748,7 +1751,7 @@ private fun BackdropLayer(
     Box(modifier = Modifier.fillMaxSize()) {
         // Show hero backdrop from previous screen as persistent underlay
         // to prevent flash/re-render during navigation transition
-        if (heroBackdropRequest != null) {
+        if (showHeroBackdropUnderlay && heroBackdropRequest != null) {
             AsyncImage(
                 model = heroBackdropRequest,
                 contentDescription = null,
@@ -1763,6 +1766,7 @@ private fun BackdropLayer(
             contentDescription = null,
             modifier = Modifier.fillMaxSize(),
             alpha = backdropAlphaState.value,
+            onSuccess = { showHeroBackdropUnderlay = false },
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopEnd
         )


### PR DESCRIPTION
## Summary

- Fix detail screen background bleed while scrolling in `MetaDetails`

## PR type

- Bug fix

## Why

- The Home backdrop could remain visible behind `MetaDetails` when the detail backdrop faded during scroll.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified that scrolling `MetaDetails` no longer shows the Home backdrop underneath.

## Screenshots / Video (UI changes only)

- None

## Breaking changes

- None

## Linked issues

- fixes #1178 
