### PR TITLE
Series Watched Badges - trakt improvements

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -1,8 +1,11 @@
 package com.nuvio.tv.data.local
 
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -27,12 +30,18 @@ class WatchedSeriesStateHolder @Inject constructor(
     companion object {
         private const val FEATURE = "watched_series_cache"
         private val KEY = stringSetPreferencesKey("fully_watched_ids")
+        private val TIMESTAMPS_KEY = stringPreferencesKey("validated_timestamps")
+        private const val VALIDATION_TTL_MS = 12L * 60 * 60 * 1000 // 12 hours
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val gson = Gson()
     private val _fullyWatchedSeriesIds = MutableStateFlow<Set<String>>(emptySet())
     val fullyWatchedSeriesIds: StateFlow<Set<String>> = _fullyWatchedSeriesIds.asStateFlow()
 
+    /** Per-series validation timestamps (contentId → epochMs). */
+    @Volatile
+    private var validatedAtMap: Map<String, Long> = emptyMap()
     private var loaded = false
 
     private fun store() = factory.get(profileManager.activeProfileId.value, FEATURE)
@@ -40,7 +49,9 @@ class WatchedSeriesStateHolder @Inject constructor(
     fun loadFromDisk() {
         if (loaded) return
         scope.launch {
-            val persisted = store().data.first()[KEY] ?: emptySet()
+            val prefs = store().data.first()
+            val persisted = prefs[KEY] ?: emptySet()
+            validatedAtMap = parseTimestamps(prefs[TIMESTAMPS_KEY])
             if (_fullyWatchedSeriesIds.value.isEmpty() && persisted.isNotEmpty()) {
                 _fullyWatchedSeriesIds.value = persisted
             }
@@ -53,5 +64,52 @@ class WatchedSeriesStateHolder @Inject constructor(
         scope.launch {
             store().edit { prefs -> prefs[KEY] = ids }
         }
+    }
+
+    /**
+     * Update badge IDs and mark the given series as freshly validated.
+     */
+    fun updateWithValidation(ids: Set<String>, validatedIds: Set<String>) {
+        _fullyWatchedSeriesIds.value = ids
+        val now = System.currentTimeMillis()
+        val updated = validatedAtMap.toMutableMap()
+        validatedIds.forEach { updated[it] = now }
+        // Prune entries no longer in the badge set.
+        updated.keys.retainAll(ids)
+        validatedAtMap = updated
+        scope.launch {
+            store().edit { prefs ->
+                prefs[KEY] = ids
+                prefs[TIMESTAMPS_KEY] = gson.toJson(updated)
+            }
+        }
+    }
+
+    /**
+     * Returns true if the given series was validated within the TTL window.
+     */
+    fun isSeriesValidationFresh(contentId: String): Boolean {
+        val ts = validatedAtMap[contentId] ?: return false
+        return System.currentTimeMillis() - ts < VALIDATION_TTL_MS
+    }
+
+    /**
+     * Filters the given set to only those series that need re-validation
+     * (not validated within TTL).
+     */
+    fun filterStaleIds(ids: Set<String>): Set<String> {
+        val now = System.currentTimeMillis()
+        return ids.filter { id ->
+            val ts = validatedAtMap[id] ?: return@filter true
+            now - ts >= VALIDATION_TTL_MS
+        }.toSet()
+    }
+
+    private fun parseTimestamps(json: String?): Map<String, Long> {
+        if (json.isNullOrBlank()) return emptyMap()
+        return runCatching {
+            val type = object : TypeToken<Map<String, Long>>() {}.type
+            gson.fromJson<Map<String, Long>>(json, type) ?: emptyMap()
+        }.getOrDefault(emptyMap())
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -67,6 +67,7 @@ class TraktProgressService @Inject constructor(
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService,
     private val metaRepository: MetaRepository,
+    private val tmdbService: com.nuvio.tv.core.tmdb.TmdbService,
     private val traktSettingsDataStore: TraktSettingsDataStore,
     private val traktEpisodeMappingService: TraktEpisodeMappingService
 ) {
@@ -147,6 +148,12 @@ class TraktProgressService @Inject constructor(
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
     private val watchedMoviesState = MutableStateFlow<Set<String>>(emptySet())
     private val watchedShowSeedsState = MutableStateFlow<List<WatchProgress>>(emptyList())
+    /** Per-show set of watched (season, episode) pairs from /sync/watched/shows. */
+    @Volatile
+    private var watchedShowEpisodesMap: Map<String, Set<Pair<Int, Int>>> = emptyMap()
+    /** Maps any content key (tmdb:X, trakt:X, imdb) to a Trakt-accepted path ID (slug or trakt numeric). */
+    @Volatile
+    private var showIdToTraktPathId: Map<String, String> = emptyMap()
     private val episodeProgressState = MutableStateFlow<Map<String, EpisodeProgressCacheEntry>>(emptyMap())
     private val hasLoadedRemoteProgress = MutableStateFlow(false)
     private val cacheMutex = Mutex()
@@ -359,6 +366,12 @@ class TraktProgressService @Inject constructor(
             }
             .distinctUntilChanged()
     }
+
+    /**
+     * Returns the per-show watched episodes from the last /sync/watched/shows fetch.
+     * Keys are content IDs, values are sets of (season, episode) pairs.
+     */
+    fun getWatchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>> = watchedShowEpisodesMap
 
     fun observeEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> {
         val cacheKey = canonicalLookupKey(contentId)
@@ -998,9 +1011,51 @@ class TraktProgressService @Inject constructor(
                 return@withLock watchedShowSeedsState.value
             }
 
-            val watchedShowSeeds = response.body().orEmpty()
+            val items = response.body().orEmpty()
+            val watchedShowSeeds = items
                 .mapNotNull(::mapWatchedShowSeed)
                 .sortedByDescending { it.lastWatched }
+
+            // Build per-show watched episodes map from the same response.
+            // Store under ALL available IDs (IMDB, TMDB, Trakt) so badge evaluation
+            // matches regardless of which ID the catalog or addon uses.
+            val episodesMap = mutableMapOf<String, MutableSet<Pair<Int, Int>>>()
+            val idLookup = mutableMapOf<String, String>()
+            items.forEach { item ->
+                val show = item.show ?: return@forEach
+                val ids = show.ids ?: return@forEach
+                val keys = buildList {
+                    ids.imdb?.takeIf { it.isNotBlank() }?.let { add(it) }
+                    ids.tmdb?.let { add("tmdb:$it") }
+                    ids.trakt?.let { add("trakt:$it") }
+                }
+                if (keys.isEmpty()) return@forEach
+                // Resolve a Trakt-accepted path ID: prefer slug, then trakt numeric
+                val traktAccepted = ids.slug?.takeIf { it.isNotBlank() }
+                    ?: ids.trakt?.toString()
+                if (traktAccepted != null) {
+                    keys.forEach { key -> idLookup[key] = traktAccepted }
+                }
+                val episodes = mutableSetOf<Pair<Int, Int>>()
+                item.seasons.orEmpty()
+                    .filter { (it.number ?: 0) > 0 }
+                    .forEach { season ->
+                        val seasonNumber = season.number ?: return@forEach
+                        season.episodes.orEmpty()
+                            .filter { (it.number ?: 0) > 0 && (it.plays ?: 1) > 0 }
+                            .forEach { episode ->
+                                val episodeNumber = episode.number ?: return@forEach
+                                episodes.add(seasonNumber to episodeNumber)
+                            }
+                    }
+                if (episodes.isNotEmpty()) {
+                    keys.forEach { key ->
+                        episodesMap.getOrPut(key) { mutableSetOf() }.addAll(episodes)
+                    }
+                }
+            }
+            watchedShowEpisodesMap = episodesMap
+            showIdToTraktPathId = idLookup
 
             watchedShowSeedsState.value = watchedShowSeeds
             watchedShowSeedsUpdatedAtMs = System.currentTimeMillis()
@@ -1169,6 +1224,52 @@ class TraktProgressService @Inject constructor(
         return if (canonical.isNotBlank()) canonical else contentId.trim()
     }
 
+    /**
+     * Resolves a content ID to a format accepted by Trakt path endpoints.
+     * Trakt path segments accept: IMDB ID, Trakt numeric ID, or Trakt slug.
+     * They do NOT accept tmdb:X format. When the content ID is tmdb-only,
+     * we use /search/tmdb/{id} to resolve it to a Trakt slug.
+     */
+    private suspend fun resolveToTraktAcceptedId(contentId: String): String {
+        val parsed = parseContentIds(contentId)
+        // IMDB ID - accepted directly
+        if (!parsed.imdb.isNullOrBlank()) return parsed.imdb
+        // Trakt numeric ID - accepted directly
+        if (parsed.trakt != null) return parsed.trakt.toString()
+        // TMDB ID - need to resolve
+        if (parsed.tmdb != null) {
+            // 1) Check local watched shows cache (instant, no network)
+            val fromWatchedShows = showIdToTraktPathId["tmdb:${parsed.tmdb}"]
+            if (fromWatchedShows != null) return fromWatchedShows
+            // 2) Try TMDB → IMDB lookup (cached, may hit network on first call)
+            try {
+                val imdbFromTmdb = tmdbService.tmdbToImdb(parsed.tmdb, "series")
+                    ?: tmdbService.tmdbToImdb(parsed.tmdb, "movie")
+                if (!imdbFromTmdb.isNullOrBlank()) return imdbFromTmdb
+            } catch (_: Exception) { }
+            // 3) Try Trakt search API (network call)
+            try {
+                val response = traktAuthService.executeAuthorizedRequest { authHeader ->
+                    traktApi.searchById(
+                        authorization = authHeader,
+                        idType = "tmdb",
+                        id = parsed.tmdb.toString(),
+                        type = "show"
+                    )
+                }
+                val result = response?.body()?.firstOrNull()
+                val slug = result?.show?.ids?.slug?.takeIf { it.isNotBlank() }
+                val traktId = result?.show?.ids?.trakt
+                val imdbId = result?.show?.ids?.imdb?.takeIf { it.isNotBlank() }
+                val resolved = imdbId ?: slug ?: traktId?.toString()
+                if (resolved != null) return resolved
+            } catch (_: Exception) { }
+            // Last resort - try tmdb:X anyway
+            return "tmdb:${parsed.tmdb}"
+        }
+        return contentId
+    }
+
     private fun buildLightweightEpisodeVideoId(contentId: String, season: Int, episode: Int): String {
         return "$contentId:$season:$episode"
     }
@@ -1311,7 +1412,7 @@ class TraktProgressService @Inject constructor(
     private suspend fun fetchEpisodeProgressSnapshot(
         contentId: String
     ): EpisodeProgressFetchResult {
-        val pathId = toTraktPathId(contentId)
+        val pathId = resolveToTraktAcceptedId(contentId)
         val completed = mutableMapOf<Pair<Int, Int>, WatchProgress>()
         var airedEpisodes = emptyList<Pair<Int, Int>>()
         var hasCompletedSnapshot = false
@@ -1325,7 +1426,8 @@ class TraktProgressService @Inject constructor(
 
         if (response?.isSuccessful == true) {
             hasCompletedSnapshot = true
-            val seasons = response.body()?.seasons.orEmpty()
+            val responseBody = response.body()
+            val seasons = responseBody?.seasons.orEmpty()
             airedEpisodes = seasons
                 .asSequence()
                 .filter { (it.number ?: 0) > 0 }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -465,6 +465,24 @@ class WatchProgressRepositoryImpl @Inject constructor(
             .distinctUntilChanged()
     }
 
+    /**
+     * Returns per-show watched episodes from the active source.
+     * For Trakt: from /sync/watched/shows response.
+     * For Nuvio sync: from watchedItemsPreferences.
+     */
+    override suspend fun getWatchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>> {
+        return if (shouldUseTraktProgress()) {
+            traktProgressService.getWatchedShowEpisodes()
+        } else {
+            watchedItemsPreferences.allItems.first()
+                .filter { it.season != null && it.episode != null }
+                .groupBy { it.contentId }
+                .mapValues { (_, items) ->
+                    items.map { it.season!! to it.episode!! }.toSet()
+                }
+        }
+    }
+
     override fun isWatched(contentId: String, videoId: String?, season: Int?, episode: Int?): Flow<Boolean> {
         return useTraktProgressFlow()
             .flatMapLatest { useTraktProgress ->

--- a/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
@@ -54,16 +54,31 @@ data class Meta(
 
     /**
      * Returns the list of watchable episodes — non-special (season > 0),
-     * excluding entire seasons where the first episode is not yet available.
+     * excluding entire seasons where the first episode is not yet available
+     * (either via the `available` flag or because its release date is in the future).
      */
     fun watchableEpisodes(): List<Video> {
+        val today = java.time.LocalDate.now()
         val candidates = videos.filter {
             it.season != null && it.episode != null && (it.season ?: 0) > 0
         }
         val unavailableSeasons = candidates.groupBy { it.season }
             .filter { (_, eps) ->
                 val first = eps.minByOrNull { it.episode ?: Int.MAX_VALUE }
-                first?.available == false
+                    ?: return@filter false
+                // Exclude if explicitly marked unavailable
+                if (first.available == false) return@filter true
+                // Exclude if release date is in the future
+                val released = first.released?.substringBefore('T')?.trim()
+                if (!released.isNullOrBlank()) {
+                    try {
+                        return@filter java.time.LocalDate.parse(
+                            released,
+                            java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
+                        ).isAfter(today)
+                    } catch (_: java.time.format.DateTimeParseException) { }
+                }
+                false
             }.keys
         return if (unavailableSeasons.isEmpty()) candidates
         else candidates.filter { it.season !in unavailableSeasons }

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -59,6 +59,12 @@ interface WatchProgressRepository {
     fun observeWatchedMovieIds(): Flow<Set<String>>
 
     /**
+     * Returns per-show watched episodes from the active source.
+     * Empty map when no data is available.
+     */
+    suspend fun getWatchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>>
+
+    /**
      * Save or update watch progress
      */
     suspend fun saveProgress(progress: WatchProgress, syncRemote: Boolean = true)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1203,44 +1203,10 @@ class MetaDetailsViewModel @Inject constructor(
 
         val watchedEpisodes = _uiState.value.watchedEpisodes
         val progressMap = _uiState.value.episodeProgressMap
+
         val allWatched = episodes.all { video ->
             val key = video.season!! to video.episode!!
             key in watchedEpisodes || progressMap[key]?.isCompleted() == true
-        }
-
-        // If not all episodes are watched, check if the unwatched ones are only
-        // from a season whose first episode hasn't aired yet. In that case the
-        // user has watched everything available — keep the badge.
-        val effectivelyWatched = if (!allWatched) {
-            val today = LocalDate.now()
-            val unwatchedEpisodes = episodes.filter { video ->
-                val key = video.season!! to video.episode!!
-                key !in watchedEpisodes && progressMap[key]?.isCompleted() != true
-            }
-            val unwatchedSeasons = unwatchedEpisodes.mapNotNull { it.season }.distinct()
-            val watchedSeasons = episodes
-                .filter { video ->
-                    val key = video.season!! to video.episode!!
-                    key in watchedEpisodes || progressMap[key]?.isCompleted() == true
-                }
-                .mapNotNull { it.season }
-                .distinct()
-            // Only grant badge if: user watched at least one season, and every
-            // unwatched season's first episode hasn't aired yet.
-            watchedSeasons.isNotEmpty() && unwatchedSeasons.all { season ->
-                season !in watchedSeasons && run {
-                    val firstEpisode = episodes
-                        .filter { it.season == season }
-                        .minByOrNull { it.episode ?: Int.MAX_VALUE }
-                    val released = firstEpisode?.released?.substringBefore('T')
-                    if (released.isNullOrBlank()) false
-                    else try {
-                        LocalDate.parse(released, java.time.format.DateTimeFormatter.ISO_LOCAL_DATE).isAfter(today)
-                    } catch (_: Exception) { false }
-                }
-            }
-        } else {
-            true
         }
 
         val current = watchedSeriesStateHolder.fullyWatchedSeriesIds.value
@@ -1251,7 +1217,7 @@ class MetaDetailsViewModel @Inject constructor(
             meta.id.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
             itemId.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
         }
-        val updated = if (effectivelyWatched) current + allIds else current - allIds
+        val updated = if (allWatched) current + allIds else current - allIds
         if (updated != current) {
             watchedSeriesStateHolder.updateWithValidation(updated, allIds)
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -544,7 +544,9 @@ class MetaDetailsViewModel @Inject constructor(
             .toIntOrNull()
             ?: return raw
 
-        return tmdbService.tmdbToImdb(tmdbNumericId, itemType) ?: raw
+        return tmdbService.tmdbToImdb(tmdbNumericId, itemType)
+            ?.takeIf { it.isNotBlank() }
+            ?: raw
     }
 
     private fun applyMeta(meta: Meta) {
@@ -1216,7 +1218,7 @@ class MetaDetailsViewModel @Inject constructor(
         }
         val updated = if (allWatched) current + allIds else current - allIds
         if (updated != current) {
-            watchedSeriesStateHolder.update(updated)
+            watchedSeriesStateHolder.updateWithValidation(updated, allIds)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1208,6 +1208,41 @@ class MetaDetailsViewModel @Inject constructor(
             key in watchedEpisodes || progressMap[key]?.isCompleted() == true
         }
 
+        // If not all episodes are watched, check if the unwatched ones are only
+        // from a season whose first episode hasn't aired yet. In that case the
+        // user has watched everything available — keep the badge.
+        val effectivelyWatched = if (!allWatched) {
+            val today = LocalDate.now()
+            val unwatchedEpisodes = episodes.filter { video ->
+                val key = video.season!! to video.episode!!
+                key !in watchedEpisodes && progressMap[key]?.isCompleted() != true
+            }
+            val unwatchedSeasons = unwatchedEpisodes.mapNotNull { it.season }.distinct()
+            val watchedSeasons = episodes
+                .filter { video ->
+                    val key = video.season!! to video.episode!!
+                    key in watchedEpisodes || progressMap[key]?.isCompleted() == true
+                }
+                .mapNotNull { it.season }
+                .distinct()
+            // Only grant badge if: user watched at least one season, and every
+            // unwatched season's first episode hasn't aired yet.
+            watchedSeasons.isNotEmpty() && unwatchedSeasons.all { season ->
+                season !in watchedSeasons && run {
+                    val firstEpisode = episodes
+                        .filter { it.season == season }
+                        .minByOrNull { it.episode ?: Int.MAX_VALUE }
+                    val released = firstEpisode?.released?.substringBefore('T')
+                    if (released.isNullOrBlank()) false
+                    else try {
+                        LocalDate.parse(released, java.time.format.DateTimeFormatter.ISO_LOCAL_DATE).isAfter(today)
+                    } catch (_: Exception) { false }
+                }
+            }
+        } else {
+            true
+        }
+
         val current = watchedSeriesStateHolder.fullyWatchedSeriesIds.value
         // Include both effectiveContentId and meta.id so badges match
         // regardless of whether the catalog uses IMDB or TMDB IDs.
@@ -1216,7 +1251,7 @@ class MetaDetailsViewModel @Inject constructor(
             meta.id.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
             itemId.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
         }
-        val updated = if (allWatched) current + allIds else current - allIds
+        val updated = if (effectivelyWatched) current + allIds else current - allIds
         if (updated != current) {
             watchedSeriesStateHolder.updateWithValidation(updated, allIds)
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.home
 
 import android.os.SystemClock
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.TraktSettingsDataStore
@@ -307,150 +308,177 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
                     }
                     .toSet()
-                // Preserve entries added by detail screen that CW pipeline cannot validate
-                // (e.g. Trakt series not in candidates because watchedItemsPreferences is empty).
+                // Preserve persisted badges that we couldn't validate this cycle.
+                // A badge is only removed if we had meta AND the validation said "not fully watched".
                 val currentIds = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
-                val preservedFromDetail = currentIds.filter { it !in seriesCandidateIds }
-                val finalFullyWatched = newFullyWatched + preservedFromDetail
+                val activelyRejectedIds = seriesCandidateIds.filter { contentId ->
+                    val cacheKey = "series:$contentId"
+                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
+                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
+                    // Only reject if we have meta and it's NOT in newFullyWatched
+                    meta != null && contentId !in newFullyWatched
+                }.toSet()
+                // Also collect the TMDB aliases of rejected IDs so they're removed too.
+                val rejectedWithAliases = activelyRejectedIds.flatMap { contentId ->
+                    val cacheKey = "series:$contentId"
+                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
+                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
+                    val metaId = meta?.id?.takeIf { it.isNotBlank() && it != contentId }
+                    if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
+                }.toSet()
+                val preservedPersistedIds = currentIds.filter {
+                    it !in rejectedWithAliases
+                }
+                val finalFullyWatched = (newFullyWatched + preservedPersistedIds).toSet()
                 if (currentIds != finalFullyWatched) {
                     fullyWatchedSeriesIds.update(finalFullyWatched)
                 }
 
-                // For series without meta in cache, resolve async when CW discovers them.
-                val recentSeedContentIds = recentNextUpSeeds
-                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
-                    .map { it.contentId }
-                    .toSet()
-                val allSeedContentIds = nextUpSeeds
-                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
-                    .map { it.contentId }
-                    .toSet()
-                val olderSeedContentIds = allSeedContentIds - recentSeedContentIds
-                // Also include series from watchedItems that have no meta cached yet.
-                val uncachedWatchedSeriesIds = seriesCandidateIds.filter { contentId ->
-                    val cacheKey = "series:$contentId"
-                    synchronized(cwMetaCache) {
-                        cwMetaCache[cacheKey] == null && cwMetaCache["tv:$contentId"] == null
-                    }
-                }.toSet()
-                val uncachedOlderSeedIds = (olderSeedContentIds + uncachedWatchedSeriesIds).filter { contentId ->
-                    synchronized(cwNextUpResolutionCache) {
-                        cwNextUpResolutionCache.keys.none { it.startsWith("$contentId|") }
-                    }
-                }.toSet()
-                if (uncachedOlderSeedIds.isNotEmpty()) {
-                    // Build seeds from nextUpSeeds where available, otherwise create
-                    // lightweight seeds from watchedItems for meta resolution.
-                    val seedsFromNextUp = nextUpSeeds
-                        .filter { it.contentId in uncachedOlderSeedIds }
-                        .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null && it.season != 0 }
-                        .filter { shouldUseAsCompletedSeed(it) }
-                    val seedsFromWatchedItems = uncachedOlderSeedIds
-                        .filter { contentId -> seedsFromNextUp.none { it.contentId == contentId } }
-                        .mapNotNull { contentId ->
-                            val latestEpisode = allWatchedItems
-                                .filter { it.contentId == contentId && it.season != null && it.episode != null }
-                                .maxWithOrNull(compareBy({ it.season }, { it.episode }))
-                                ?: return@mapNotNull null
-                            com.nuvio.tv.domain.model.WatchProgress(
-                                contentId = contentId,
-                                contentType = "series",
-                                name = latestEpisode.title,
-                                poster = null,
-                                backdrop = null,
-                                logo = null,
-                                videoId = contentId,
-                                season = latestEpisode.season,
-                                episode = latestEpisode.episode,
-                                episodeTitle = null,
-                                position = 1L,
-                                duration = 1L,
-                                lastWatched = latestEpisode.watchedAt,
-                                progressPercent = 100f
-                            )
+                // --- Async badge evaluation ---
+                // Resolve meta for all series with watched episodes and evaluate badges.
+                // Uses getWatchedShowEpisodes() as the single source of truth.
+                launch(Dispatchers.IO) {
+                    val allWatchedEpisodes = watchProgressRepository.getWatchedShowEpisodes()
+
+                    // Resolve meta for all watched series that don't have it cached.
+                    // Use IMDB IDs as primary (addon usually resolves by IMDB).
+                    // Also resolve TMDB IDs that don't have meta — handles cases where
+                    // multiple TMDB shows share the same IMDB (e.g. Monsters vs Monster).
+                    val idsToResolve = allWatchedEpisodes.keys.filter { contentId ->
+                        val cacheKey = "series:$contentId"
+                        synchronized(cwMetaCache) {
+                            cwMetaCache[cacheKey] == null && cwMetaCache["tv:$contentId"] == null
                         }
-                    val uncachedSeeds = (seedsFromNextUp + seedsFromWatchedItems)
-                        .groupBy { it.contentId }
-                        .mapNotNull { (_, items) -> choosePreferredNextUpSeed(items) }
-                        .take(CW_MAX_NEXT_UP_LOOKUPS)
-                    if (uncachedSeeds.isNotEmpty()) {
-                        launch(Dispatchers.IO) {
-                            val lookupSemaphore = Semaphore(CW_MAX_NEXT_UP_CONCURRENCY)
-                            val discoveredNextUpItems = uncachedSeeds.map { seed ->
-                                async {
-                                    lookupSemaphore.withPermit {
-                                        buildNextUpItem(
-                                            progress = seed,
-                                            showUnairedNextUp = showUnairedNextUp
+                    }
+                    val staleIds = fullyWatchedSeriesIds.filterStaleIds(idsToResolve.toSet())
+                    // Prioritize IMDB IDs first (more likely to resolve), then TMDB.
+                    val sortedStaleIds = staleIds.sortedBy { if (it.startsWith("tt")) 0 else 1 }
+                    if (sortedStaleIds.isNotEmpty()) {
+                        val metaSemaphore = Semaphore(2)
+                        val resolvedCount = java.util.concurrent.atomic.AtomicInteger(0)
+                        val batchSize = 10
+                        sortedStaleIds.map { contentId ->
+                            async {
+                                metaSemaphore.withPermit {
+                                    // Skip if meta was already cached by a prior resolve
+                                    // (e.g. IMDB resolve cached it, TMDB alias not needed).
+                                    val alreadyCached = synchronized(cwMetaCache) {
+                                        cwMetaCache["series:$contentId"] != null || cwMetaCache["tv:$contentId"] != null
+                                    }
+                                    if (!alreadyCached) {
+                                        val seed = WatchProgress(
+                                            contentId = contentId,
+                                            contentType = "series",
+                                            name = contentId,
+                                            poster = null, backdrop = null, logo = null,
+                                            videoId = contentId,
+                                            season = 1, episode = 1,
+                                            episodeTitle = null,
+                                            position = 1L, duration = 1L,
+                                            lastWatched = 0L,
+                                            progressPercent = 100f
                                         )
-                                    }
-                                }
-                            }.awaitAll().filterNotNull()
-
-                            // Re-evaluate watched badge after meta cache is populated.
-                            val updatedFullyWatched = (localCandidateIds + seedCandidateIds)
-                                .filter { contentId ->
-                                    val cacheKey = "series:$contentId"
-                                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                                    if (meta == null) return@filter false
-
-                                    val episodes = meta.watchableEpisodes()
-                                    if (episodes.isEmpty()) return@filter false
-
-                                    val asyncLocalWatched = watchedItemsPreferences
-                                        .getWatchedEpisodesForContent(contentId)
-                                        .first()
-                                    val allEpisodesLocal = episodes.all { video ->
-                                        (video.season!! to video.episode!!) in asyncLocalWatched
-                                    }
-                                    if (allEpisodesLocal) return@filter true
-
-                                    val hasSeed = contentId in seedCandidateIds
-                                    val hasNextUp = contentId in nextUpContentIds
-                                    hasSeed && !hasNextUp
-                                }
-                                .flatMap { contentId ->
-                                    val cacheKey = "series:$contentId"
-                                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                                    val metaId = meta?.id?.takeIf { it.isNotBlank() && it != contentId }
-                                    if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
-                                }
-                                .toSet()
-                            if (fullyWatchedSeriesIds.fullyWatchedSeriesIds.value != updatedFullyWatched) {
-                                fullyWatchedSeriesIds.update(updatedFullyWatched)
-                            }
-
-                            // Inject discovered next-up items into CW (e.g. new season alerts).
-                            // Only add genuinely new items — don't replace already-enriched ones.
-                            // Skip CW injection for Trakt users — Trakt's watched/shows includes
-                            // dropped series which shouldn't appear as new episode alerts.
-                            if (discoveredNextUpItems.isNotEmpty() && !useTraktProgress) {
-                                synchronized(discoveredOlderNextUpItems) {
-                                    discoveredOlderNextUpItems.removeAll { old ->
-                                        discoveredNextUpItems.any { it.info.contentId == old.info.contentId }
-                                    }
-                                    // Only persist release alerts for CW row injection
-                                    discoveredOlderNextUpItems.addAll(discoveredNextUpItems.filter { it.info.isReleaseAlert })
-                                }
-                                _uiState.update { state ->
-                                    val existingContentIds = state.continueWatchingItems
-                                        .map {
-                                            when (it) {
-                                                is ContinueWatchingItem.NextUp -> it.info.contentId
-                                                is ContinueWatchingItem.InProgress -> it.progress.contentId
-                                            }
+                                        val meta = resolveMetaForProgress(seed, cwMetaCache)
+                                        if (meta == null) {
+                                            Log.d("CW-BADGE", "meta resolve FAILED for $contentId")
                                         }
-                                        .toSet()
-                                    // Only inject items with release alerts (new season/episode)
-                                    // into CW row — don't bypass the days-cap for old series.
-                                    val newAlerts = discoveredNextUpItems.filter {
-                                        it.info.contentId !in existingContentIds && it.info.isReleaseAlert
                                     }
-                                    if (newAlerts.isEmpty()) return@update state
-                                    val merged = state.continueWatchingItems + newAlerts
-                                    state.copy(continueWatchingItems = merged)
+                                    if (resolvedCount.incrementAndGet() % batchSize == 0) {
+                                        publishBadgeUpdate(allWatchedEpisodes)
+                                    }
+                                }
+                            }
+                        }.awaitAll()
+                    }
+
+                    // Final badge evaluation after all meta is resolved.
+                    publishBadgeUpdate(allWatchedEpisodes)
+                }
+
+                // --- CW next-up injection (Nuvio sync only) ---
+                // Discover next-up items for older seeds and inject release alerts into CW.
+                if (!useTraktProgress) {
+                    val recentSeedContentIds = recentNextUpSeeds
+                        .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
+                        .map { it.contentId }
+                        .toSet()
+                    val allSeedContentIds = nextUpSeeds
+                        .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
+                        .map { it.contentId }
+                        .toSet()
+                    val olderSeedContentIds = allSeedContentIds - recentSeedContentIds
+                    val uncachedOlderSeedIds = olderSeedContentIds.filter { contentId ->
+                        // Skip series validated recently — no new episodes expected within TTL.
+                        if (fullyWatchedSeriesIds.isSeriesValidationFresh(contentId)) return@filter false
+                        synchronized(cwNextUpResolutionCache) {
+                            cwNextUpResolutionCache.keys.none { it.startsWith("$contentId|") }
+                        }
+                    }.toSet()
+                    if (uncachedOlderSeedIds.isNotEmpty()) {
+                        val seedsFromNextUp = nextUpSeeds
+                            .filter { it.contentId in uncachedOlderSeedIds }
+                            .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null && it.season != 0 }
+                            .filter { shouldUseAsCompletedSeed(it) }
+                        val seedsFromWatchedItems = uncachedOlderSeedIds
+                            .filter { contentId -> seedsFromNextUp.none { it.contentId == contentId } }
+                            .mapNotNull { contentId ->
+                                val latestEpisode = allWatchedItems
+                                    .filter { it.contentId == contentId && it.season != null && it.episode != null }
+                                    .maxWithOrNull(compareBy({ it.season }, { it.episode }))
+                                    ?: return@mapNotNull null
+                                WatchProgress(
+                                    contentId = contentId,
+                                    contentType = "series",
+                                    name = latestEpisode.title,
+                                    poster = null, backdrop = null, logo = null,
+                                    videoId = contentId,
+                                    season = latestEpisode.season,
+                                    episode = latestEpisode.episode,
+                                    episodeTitle = null,
+                                    position = 1L, duration = 1L,
+                                    lastWatched = latestEpisode.watchedAt,
+                                    progressPercent = 100f
+                                )
+                            }
+                        val uncachedSeeds = (seedsFromNextUp + seedsFromWatchedItems)
+                            .groupBy { it.contentId }
+                            .mapNotNull { (_, items) -> choosePreferredNextUpSeed(items) }
+                        if (uncachedSeeds.isNotEmpty()) {
+                            launch(Dispatchers.IO) {
+                                val lookupSemaphore = Semaphore(2)
+                                val discoveredNextUpItems = uncachedSeeds.map { seed ->
+                                    async {
+                                        lookupSemaphore.withPermit {
+                                            buildNextUpItem(
+                                                progress = seed,
+                                                showUnairedNextUp = showUnairedNextUp
+                                            )
+                                        }
+                                    }
+                                }.awaitAll().filterNotNull()
+
+                                if (discoveredNextUpItems.isNotEmpty()) {
+                                    synchronized(discoveredOlderNextUpItems) {
+                                        discoveredOlderNextUpItems.removeAll { old ->
+                                            discoveredNextUpItems.any { it.info.contentId == old.info.contentId }
+                                        }
+                                        discoveredOlderNextUpItems.addAll(discoveredNextUpItems.filter { it.info.isReleaseAlert })
+                                    }
+                                    _uiState.update { state ->
+                                        val existingContentIds = state.continueWatchingItems
+                                            .map {
+                                                when (it) {
+                                                    is ContinueWatchingItem.NextUp -> it.info.contentId
+                                                    is ContinueWatchingItem.InProgress -> it.progress.contentId
+                                                }
+                                            }
+                                            .toSet()
+                                        val newAlerts = discoveredNextUpItems.filter {
+                                            it.info.contentId !in existingContentIds && it.info.isReleaseAlert
+                                        }
+                                        if (newAlerts.isEmpty()) return@update state
+                                        state.copy(continueWatchingItems = state.continueWatchingItems + newAlerts)
+                                    }
                                 }
                             }
                         }
@@ -1342,6 +1370,40 @@ private fun NextUpInfo.toProgressSeed(): WatchProgress {
 
 private fun isSeriesTypeCW(type: String?): Boolean {
     return type.equals("series", ignoreCase = true) || type.equals("tv", ignoreCase = true)
+}
+
+private fun HomeViewModel.publishBadgeUpdate(
+    allWatchedEpisodes: Map<String, Set<Pair<Int, Int>>>
+) {
+    val updatedFullyWatched = allWatchedEpisodes.keys
+        .filter { contentId ->
+            val cacheKey = "series:$contentId"
+            val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
+                ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
+            if (meta == null) return@filter false
+            val episodes = meta.watchableEpisodes()
+            if (episodes.isEmpty()) return@filter false
+            val watched = allWatchedEpisodes[contentId] ?: return@filter false
+            val allWatched = episodes.all { (it.season!! to it.episode!!) in watched }
+            if (!allWatched && watched.isNotEmpty()) {
+                Log.d("CW-BADGE", "NOT fully watched: $contentId episodes=${episodes.size} watched=${watched.size}")
+            }
+            allWatched
+        }
+        .flatMap { contentId ->
+            val cacheKey = "series:$contentId"
+            val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
+                ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
+            val metaId = meta?.id?.takeIf { it.isNotBlank() && it != contentId }
+            if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
+        }
+        .toSet()
+    // Merge with persisted badges — don't remove badges we haven't re-validated yet.
+    val current = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
+    val merged = current + updatedFullyWatched
+    if (current != merged) {
+        fullyWatchedSeriesIds.updateWithValidation(merged, updatedFullyWatched)
+    }
 }
 
 private fun parseEpisodeReleaseDate(raw: String?): LocalDate? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -259,81 +259,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     elapsedMs = SystemClock.elapsedRealtime() - nextUpStartMs
                 )
 
-                // Derive fully-watched series candidates from both watchedItemsPreferences
-                // (local/Nuvio sync) and nextUpSeeds (Trakt watched show seeds).
+                // Badge evaluation is handled exclusively by publishBadgeUpdate below,
+                // which uses getWatchedShowEpisodes() as the single source of truth.
+                // No seed-based heuristics here.
                 val allWatchedItems = watchedItemsPreferences.allItems.first()
-                val localCandidateIds = allWatchedItems
-                    .filter { it.season != null && it.episode != null }
-                    .map { it.contentId }
-                    .toSet()
-                val seedCandidateIds = nextUpSeeds
-                    .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
-                    .map { it.contentId }
-                    .toSet()
-                val seriesCandidateIds = localCandidateIds + seedCandidateIds
-                val nextUpContentIds = nextUpItems.map { it.info.contentId }.toSet()
-
-                val newFullyWatched = seriesCandidateIds
-                    .filter { contentId ->
-                        val cacheKey = "series:$contentId"
-                        val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                            ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                        if (meta == null) return@filter false
-
-                        val episodes = meta.watchableEpisodes()
-                        if (episodes.isEmpty()) return@filter false
-
-                        // Check watchedItemsPreferences (covers Nuvio sync + local playback)
-                        val localWatched = allWatchedItems
-                            .filter { it.contentId == contentId && it.season != null && it.episode != null }
-                            .map { it.season!! to it.episode!! }
-                            .toSet()
-                        if (episodes.all { (it.season!! to it.episode!!) in localWatched }) {
-                            return@filter true
-                        }
-
-                        // For Trakt: if the series has a seed and CW found no next-up,
-                        // it means all episodes in meta are completed on Trakt.
-                        val hasSeed = contentId in seedCandidateIds
-                        val hasNextUp = contentId in nextUpContentIds
-                        hasSeed && !hasNextUp
-                    }
-                    .flatMap { contentId ->
-                        // Include both the candidate ID and the meta ID so badges
-                        // match regardless of whether the catalog uses IMDB or TMDB IDs.
-                        val cacheKey = "series:$contentId"
-                        val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                            ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                        val metaId = meta?.id?.takeIf { it.isNotBlank() && it != contentId }
-                        if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
-                    }
-                    .toSet()
-                // Preserve persisted badges that we couldn't validate this cycle.
-                // A badge is only removed if we had meta AND the validation said "not fully watched".
-                val currentIds = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
-                val activelyRejectedIds = seriesCandidateIds.filter { contentId ->
-                    val cacheKey = "series:$contentId"
-                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                    // Only reject if we have meta and it's NOT in newFullyWatched
-                    meta != null && contentId !in newFullyWatched
-                }.toSet()
-                // Also collect the TMDB aliases of rejected IDs so they're removed too.
-                val rejectedWithAliases = activelyRejectedIds.flatMap { contentId ->
-                    val cacheKey = "series:$contentId"
-                    val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                        ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-                    val metaId = meta?.id?.takeIf { it.isNotBlank() && it != contentId }
-                    if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
-                }.toSet()
-                val preservedPersistedIds = currentIds.filter {
-                    it !in rejectedWithAliases
-                }
-                val finalFullyWatched = (newFullyWatched + preservedPersistedIds).toSet()
-                if (currentIds != finalFullyWatched) {
-                    fullyWatchedSeriesIds.update(finalFullyWatched)
-                }
-
                 // --- Async badge evaluation ---
                 // Resolve meta for all series with watched episodes and evaluate badges.
                 // Uses getWatchedShowEpisodes() as the single source of truth.
@@ -462,7 +391,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                         discoveredOlderNextUpItems.removeAll { old ->
                                             discoveredNextUpItems.any { it.info.contentId == old.info.contentId }
                                         }
-                                        discoveredOlderNextUpItems.addAll(discoveredNextUpItems.filter { it.info.isReleaseAlert })
+                                        discoveredOlderNextUpItems.addAll(discoveredNextUpItems)
                                     }
                                     _uiState.update { state ->
                                         val existingContentIds = state.continueWatchingItems
@@ -474,7 +403,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                             }
                                             .toSet()
                                         val newAlerts = discoveredNextUpItems.filter {
-                                            it.info.contentId !in existingContentIds && it.info.isReleaseAlert
+                                            it.info.contentId !in existingContentIds
                                         }
                                         if (newAlerts.isEmpty()) return@update state
                                         state.copy(continueWatchingItems = state.continueWatchingItems + newAlerts)
@@ -501,7 +430,6 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     val olderToInclude = persistedOlderItems.filter {
                         it.info.contentId !in recentIds &&
                             it.info.contentId !in inProgressIds &&
-                            it.info.isReleaseAlert &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
                     }
                     nextUpItems + olderToInclude
@@ -1375,6 +1303,7 @@ private fun isSeriesTypeCW(type: String?): Boolean {
 private fun HomeViewModel.publishBadgeUpdate(
     allWatchedEpisodes: Map<String, Set<Pair<Int, Int>>>
 ) {
+    val validatedNotFullyWatched = mutableSetOf<String>()
     val updatedFullyWatched = allWatchedEpisodes.keys
         .filter { contentId ->
             val cacheKey = "series:$contentId"
@@ -1387,6 +1316,10 @@ private fun HomeViewModel.publishBadgeUpdate(
             val allWatched = episodes.all { (it.season!! to it.episode!!) in watched }
             if (!allWatched && watched.isNotEmpty()) {
                 Log.d("CW-BADGE", "NOT fully watched: $contentId episodes=${episodes.size} watched=${watched.size}")
+                // Track IDs we've validated as NOT fully watched so we can remove stale badges.
+                validatedNotFullyWatched.add(contentId)
+                val metaId = meta.id.takeIf { it.isNotBlank() && it != contentId }
+                if (metaId != null) validatedNotFullyWatched.add(metaId)
             }
             allWatched
         }
@@ -1399,8 +1332,9 @@ private fun HomeViewModel.publishBadgeUpdate(
         }
         .toSet()
     // Merge with persisted badges — don't remove badges we haven't re-validated yet.
+    // But DO remove badges for series we've confirmed are NOT fully watched.
     val current = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
-    val merged = current + updatedFullyWatched
+    val merged = (current - validatedNotFullyWatched) + updatedFullyWatched
     if (current != merged) {
         fullyWatchedSeriesIds.updateWithValidation(merged, updatedFullyWatched)
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -441,10 +441,9 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                         selectSubtitleTrack(index)
                         updatedSubtitleIndex = index
                     } else {
-                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$index already selected, clearing")
+                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$index already selected, keeping for pipeline restart")
                         autoSubtitleSelected = true
                         updatedSubtitleIndex = index
-                        updatedPending = updatedPending.copy(subtitle = null)
                     }
                 } else {
                     // No internal track matches — try addon fallback with the same language variant.

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -991,7 +991,7 @@
     <string name="library_delete_subtitle">Isso removerá a lista e todos os seus itens do Trakt.</string>
     <string name="library_delete_confirm">Excluir</string>
     <string name="library_source_local">LOCAL</string>
-    string name="library_source_nuvio">NUVIO</string>
+    <string name="library_source_nuvio">NUVIO</string>
     <string name="library_source_trakt">TRAKT</string>
     <string name="library_syncing_library">Sincronizando biblioteca…</string>
     <string name="library_type_all">Todos</string>


### PR DESCRIPTION
## Summary

Overhauled Trakt series watched badge resolution and improved TMDB-only ID fallback for Trakt API endpoints.

## PR type

- Bug fix
- Small maintenance improvement

## Why

After user testing it became clear that Trakt watched status handling needed further improvement. The Continue Watching seed-based approach for badge calculation was unreliable. Additionally, series with only a TMDB ID (no IMDB ID) were never resolved against Trakt's `/shows/{id}/progress/watched` endpoint, since Trakt does not accept `tmdb:X` in path segments.

This is a continuation of #1074 and #1111.

## Changes

- Completely removed Continue Watching seed-based badge calculation. Badges are now computed solely from `/sync/watched/shows`, storing IMDB, TMDB, and Trakt IDs for broader compatibility.
- For every returned series, we fetch meta to determine total episode count. Meta lookups are throttled to avoid overwhelming the meta addon.
- Once a series badge status is determined (fully watched or not), the result is cached with a 12h TTL so we don't re-check all meta on every app launch.
- Improved TMDB-only ID fallback for Trakt API path endpoints. When `tmdbService.tmdbToImdb` returns nothing, we now:
  1. Check local `showIdToTraktPathId` cache (built from `/sync/watched/shows` - most compatible, instant)
  2. Fall back to `tmdbService.tmdbToImdb()` lookup
  3. Last resort: Trakt search API `/search/tmdb/{id}?type=show`
- Injected `TmdbService` into `TraktProgressService` for TMDB->IMDB resolution.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Tested with Nuvio Sync as watch progress source
- Tested separately with a Trakt account containing a large watch history (~200 watched series)
- Verified TMDB-only series (tmdb:225634, tmdb:286801) now correctly show watched badges
- Verified 12h TTL cache prevents redundant meta lookups on subsequent launches

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

Nothing should break 

## Linked issues

Continuation of #1074 and #1111
