### PR TITLE
fix crashes: Disable VideoEasy scrapers by default and require opt-in confirmation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -547,6 +547,13 @@ class PluginManager @Inject constructor(
                 
                 // Create scraper info
                 val scraperId = "$repoId:${info.id}"
+                val existingScraper = existingScrapers.firstOrNull { it.id == scraperId }
+                val defaultEnabled = info.enabled &&
+                    !PluginSafety.isVideoEasyScraper(
+                        scraperId = info.id,
+                        scraperName = info.name,
+                        filename = info.filename
+                    )
                 val scraper = ScraperInfo(
                     id = scraperId,
                     repositoryId = repoId,
@@ -555,7 +562,7 @@ class PluginManager @Inject constructor(
                     version = info.version,
                     filename = info.filename,
                     supportedTypes = info.supportedTypes,
-                    enabled = true,
+                    enabled = existingScraper?.enabled ?: defaultEnabled,
                     manifestEnabled = info.enabled,
                     logo = info.logo,
                     contentLanguage = info.contentLanguage ?: emptyList(),

--- a/app/src/main/java/com/nuvio/tv/core/plugin/PluginSafety.kt
+++ b/app/src/main/java/com/nuvio/tv/core/plugin/PluginSafety.kt
@@ -1,0 +1,13 @@
+package com.nuvio.tv.core.plugin
+
+internal object PluginSafety {
+    fun isVideoEasyScraper(
+        scraperId: String?,
+        scraperName: String? = null,
+        filename: String? = null
+    ): Boolean {
+        return listOf(scraperId, scraperName, filename).any { value ->
+            value?.contains("videasy", ignoreCase = true) == true
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginScreen.kt
@@ -282,6 +282,18 @@ fun PluginScreenContent(
             }
         }
     }
+
+    if (uiState.pendingScraperEnable != null) {
+        Popup(properties = PopupProperties(focusable = true)) {
+            uiState.pendingScraperEnable?.let { pending ->
+                ConfirmScraperEnableDialog(
+                    scraperName = pending.scraperName,
+                    onConfirm = { viewModel.onEvent(PluginUiEvent.ConfirmPendingScraperEnable) },
+                    onDismiss = { viewModel.onEvent(PluginUiEvent.DismissPendingScraperEnable) }
+                )
+            }
+        }
+    }
     }
 }
 
@@ -833,6 +845,126 @@ private fun ConfirmRepoChangesDialog(
                             Text(
                                 text = stringResource(R.string.plugin_confirm_confirm),
                                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                                color = NuvioColors.OnSecondary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfirmScraperEnableDialog(
+    scraperName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    BackHandler { onDismiss() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.8f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            onClick = { },
+            modifier = Modifier.width(560.dp),
+            colors = ClickableSurfaceDefaults.colors(
+                containerColor = NuvioColors.SurfaceVariant
+            ),
+            shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(16.dp))
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.plugin_risky_enable_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = NuvioColors.TextPrimary
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(R.string.plugin_risky_enable_message, scraperName),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Surface(
+                        onClick = onDismiss,
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = NuvioColors.Surface,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        border = ClickableSurfaceDefaults.border(
+                            focusedBorder = Border(
+                                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                                shape = RoundedCornerShape(50)
+                            )
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(50))
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = NuvioColors.TextPrimary
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.plugin_risky_enable_cancel),
+                                color = NuvioColors.TextPrimary
+                            )
+                        }
+                    }
+
+                    Surface(
+                        onClick = onConfirm,
+                        modifier = Modifier.focusRequester(focusRequester),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = NuvioColors.Secondary,
+                            focusedContainerColor = NuvioColors.SecondaryVariant
+                        ),
+                        border = ClickableSurfaceDefaults.border(
+                            focusedBorder = Border(
+                                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                                shape = RoundedCornerShape(50)
+                            )
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(50))
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = NuvioColors.OnSecondary
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.plugin_risky_enable_confirm),
                                 color = NuvioColors.OnSecondary
                             )
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginUiState.kt
@@ -21,7 +21,9 @@ data class PluginUiState(
     val qrCodeBitmap: Bitmap? = null,
     val serverUrl: String? = null,
     // Pending change from phone
-    val pendingRepoChange: PendingRepoChangeInfo? = null
+    val pendingRepoChange: PendingRepoChangeInfo? = null,
+    // Pending scraper enable confirmation
+    val pendingScraperEnable: PendingScraperEnableInfo? = null
 )
 
 data class PendingRepoChangeInfo(
@@ -30,6 +32,11 @@ data class PendingRepoChangeInfo(
     val addedUrls: List<String>,
     val removedUrls: List<String>,
     val isApplying: Boolean = false
+)
+
+data class PendingScraperEnableInfo(
+    val scraperId: String,
+    val scraperName: String
 )
 
 sealed interface PluginUiEvent {
@@ -46,4 +53,6 @@ sealed interface PluginUiEvent {
     object StopQrMode : PluginUiEvent
     object ConfirmPendingRepoChange : PluginUiEvent
     object RejectPendingRepoChange : PluginUiEvent
+    object ConfirmPendingScraperEnable : PluginUiEvent
+    object DismissPendingScraperEnable : PluginUiEvent
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.R
 import com.nuvio.tv.core.plugin.PluginManager
+import com.nuvio.tv.core.plugin.PluginSafety
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.qr.QrCodeGenerator
 import com.nuvio.tv.core.server.DeviceIpAddress
@@ -91,6 +92,8 @@ class PluginViewModel @Inject constructor(
             PluginUiEvent.StopQrMode -> stopQrMode()
             PluginUiEvent.ConfirmPendingRepoChange -> confirmPendingRepoChange()
             PluginUiEvent.RejectPendingRepoChange -> rejectPendingRepoChange()
+            PluginUiEvent.ConfirmPendingScraperEnable -> confirmPendingScraperEnable()
+            PluginUiEvent.DismissPendingScraperEnable -> dismissPendingScraperEnable()
         }
     }
 
@@ -157,9 +160,34 @@ class PluginViewModel @Inject constructor(
     }
 
     private fun toggleScraper(scraperId: String, enabled: Boolean) {
+        val scraper = _uiState.value.scrapers.firstOrNull { it.id == scraperId }
+        if (enabled && scraper != null && PluginSafety.isVideoEasyScraper(scraper.id, scraper.name, scraper.filename)) {
+            _uiState.update {
+                it.copy(
+                    pendingScraperEnable = PendingScraperEnableInfo(
+                        scraperId = scraper.id,
+                        scraperName = scraper.name
+                    )
+                )
+            }
+            return
+        }
+
         viewModelScope.launch {
             pluginManager.toggleScraper(scraperId, enabled)
         }
+    }
+
+    private fun confirmPendingScraperEnable() {
+        val pending = _uiState.value.pendingScraperEnable ?: return
+        _uiState.update { it.copy(pendingScraperEnable = null) }
+        viewModelScope.launch {
+            pluginManager.toggleScraper(pending.scraperId, true)
+        }
+    }
+
+    private fun dismissPendingScraperEnable() {
+        _uiState.update { it.copy(pendingScraperEnable = null) }
     }
 
     private fun setPluginsEnabled(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1075,6 +1075,10 @@
     <string name="plugin_confirm_total">Total repositories: %1$d</string>
     <string name="plugin_confirm_reject">Reject</string>
     <string name="plugin_confirm_confirm">Confirm</string>
+    <string name="plugin_risky_enable_title">Enable provider?</string>
+    <string name="plugin_risky_enable_message">%1$s is known to cause crashes on some content. Enable anyway?</string>
+    <string name="plugin_risky_enable_cancel">Cancel</string>
+    <string name="plugin_risky_enable_confirm">Enable</string>
     <string name="plugin_updated_format">Updated: %1$s</string>
     <string name="plugin_test_btn">Test</string>
     <string name="plugin_test_results">Test Results (%1$d streams)</string>


### PR DESCRIPTION
## Summary
This PR adds a safety mitigation for VideoEasy-based scrapers in the plugin flow.

Changes included:

VideoEasy-based scrapers are now installed as disabled by default.
Existing scraper enabled state is preserved on repository refresh (no forced re-enable/reset).
When a user tries to enable a VideoEasy-based scraper, the app now shows a confirmation warning dialog before enabling it.
This is intentionally a product-level safeguard, not a full runtime architecture rewrite.

## PR type
Bug fix

## Why
This is needed to reduce user-facing crashes tied to VideoEasy plugin execution paths and to make the risk explicit at the moment of enablement.

Disabling VideoEasy manually is not realistic for most users because they usually do not know why the app is crashing or even that a specific provider is causing crashes and will assume the app itself is unstable.

Notes on alternative approach (as discussed in #1187)
The more robust long-term direction is to run plugin/QuickJS execution in a separate process from the main app process.

Why this is more robust:

if QuickJS crashes natively, only the plugin process dies
the main app process stays alive
the app can report a plugin failure instead of hard-crashing

Why this is not included in this PR:

requires a significant architecture change (process boundary + IPC layer)
needs request/result marshalling and lifecycle handling for the plugin process
requires binder/process-death handling and restart/recovery logic
increases complexity in timeout/cancellation semantics across process boundaries
adds substantial QA/regression surface for all plugin execution flows
can introduce overhead/latency tradeoffs and more complex debugging/observability
Given those risks and scope, this PR applies a focused mitigation now and leaves process isolation as a future, larger change.

Context:

Bug request: #1187
Policy check
[X] This PR is not cosmetic-only, unless it is a translation PR.
[X] This PR does not add a new major feature without prior approval.
[X] This PR is small in scope and focused on one problem.
[] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Installed/updated plugin repositories containing VideoEasy and confirmed those scrapers default to disabled.
Tried enabling a VideoEasy scraper and confirmed warning dialog appears.
Confirmed enabling proceeds only after explicit confirmation.
Confirmed non-VideoEasy scrapers are unaffected.

## Screenshots / Video (UI changes only)

Videasy disable by default:

<img width="964" height="770" alt="image" src="https://github.com/user-attachments/assets/0fabeff2-8ab8-4119-ac1c-69db9322194c" />

UI dialog:

<img width="1007" height="364" alt="image" src="https://github.com/user-attachments/assets/47b0cbb3-1a24-4a3d-9ad4-308c90ccb375" />


## Breaking changes

None.

## Linked issues
Fixes #1187
