### PR TITLE
fix tmdb detail performance

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -15,10 +15,13 @@ import com.nuvio.tv.domain.model.MetaCompany
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PersonDetail
 import com.nuvio.tv.domain.model.PosterShape
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.util.concurrent.ConcurrentHashMap
@@ -35,12 +38,14 @@ class TmdbMetadataService @Inject constructor(
 ) {
     // In-memory caches
     private val enrichmentCache = ConcurrentHashMap<String, TmdbEnrichment>()
-    private val episodeCache = ConcurrentHashMap<String, Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
+    private val episodeSeasonCache = ConcurrentHashMap<String, Map<Int, TmdbEpisodeEnrichment>>()
+    private val episodeSeasonInFlight = ConcurrentHashMap<String, CompletableDeferred<Map<Int, TmdbEpisodeEnrichment>?>>()
     private val personCache = ConcurrentHashMap<String, PersonDetail>()
     private val moreLikeThisCache = ConcurrentHashMap<String, List<MetaPreview>>()
     private val entityHeaderCache = ConcurrentHashMap<String, TmdbEntityHeader>()
     private val entityRailCache = ConcurrentHashMap<String, List<MetaPreview>>()
     private val entityBrowseCache = ConcurrentHashMap<String, TmdbEntityBrowseData>()
+    private val localizedBackdropCache = ConcurrentHashMap<String, String>()
 
     suspend fun fetchEnrichment(
         tmdbId: String,
@@ -66,44 +71,29 @@ class TmdbMetadataService @Inject constructor(
                     append(",en,null")
                 }
 
-                // Fetch details, credits, and images in parallel
-                val (details, credits, images, ageRating) = coroutineScope {
-                    val detailsDeferred = async {
-                        when (tmdbType) {
-                            "tv" -> tmdbApi.getTvDetails(numericId, TMDB_API_KEY, normalizedLanguage)
-                            else -> tmdbApi.getMovieDetails(numericId, TMDB_API_KEY, normalizedLanguage)
-                        }.body()
-                    }
-                    val creditsDeferred = async {
-                        when (tmdbType) {
-                            "tv" -> tmdbApi.getTvCredits(numericId, TMDB_API_KEY, normalizedLanguage)
-                            else -> tmdbApi.getMovieCredits(numericId, TMDB_API_KEY, normalizedLanguage)
-                        }.body()
-                    }
-                    val imagesDeferred = async {
-                        when (tmdbType) {
-                            "tv" -> tmdbApi.getTvImages(numericId, TMDB_API_KEY, includeImageLanguage)
-                            else -> tmdbApi.getMovieImages(numericId, TMDB_API_KEY, includeImageLanguage)
-                        }.body()
-                    }
-                    val ageRatingDeferred = async {
-                        when (tmdbType) {
-                            "tv" -> {
-                                val ratings = tmdbApi.getTvContentRatings(numericId, TMDB_API_KEY).body()?.results.orEmpty()
-                                selectTvAgeRating(ratings, normalizedLanguage)
-                            }
-                            else -> {
-                                val releases = tmdbApi.getMovieReleaseDates(numericId, TMDB_API_KEY).body()?.results.orEmpty()
-                                selectMovieAgeRating(releases, normalizedLanguage)
-                            }
-                        }
-                    }
-                    Quadruple(
-                        detailsDeferred.await(),
-                        creditsDeferred.await(),
-                        imagesDeferred.await(),
-                        ageRatingDeferred.await()
+                val details = when (tmdbType) {
+                    "tv" -> tmdbApi.getTvDetails(
+                        tvId = numericId,
+                        apiKey = TMDB_API_KEY,
+                        language = normalizedLanguage,
+                        appendToResponse = "credits,images,content_ratings",
+                        includeImageLanguage = includeImageLanguage
                     )
+
+                    else -> tmdbApi.getMovieDetails(
+                        movieId = numericId,
+                        apiKey = TMDB_API_KEY,
+                        language = normalizedLanguage,
+                        appendToResponse = "credits,images,release_dates",
+                        includeImageLanguage = includeImageLanguage
+                    )
+                }.body()
+
+                val credits = details?.credits
+                val images = details?.images
+                val ageRating = when (tmdbType) {
+                    "tv" -> selectTvAgeRating(details?.contentRatings?.results.orEmpty(), normalizedLanguage)
+                    else -> selectMovieAgeRating(details?.releaseDates?.results.orEmpty(), normalizedLanguage)
                 }
 
                 val genres = details?.genres?.mapNotNull { genre ->
@@ -307,30 +297,101 @@ class TmdbMetadataService @Inject constructor(
         language: String = "en"
     ): Map<Pair<Int, Int>, TmdbEpisodeEnrichment> = withContext(Dispatchers.IO) {
         val normalizedLanguage = normalizeTmdbLanguage(language)
-        val cacheKey = "$tmdbId:${seasonNumbers.sorted().joinToString(",")}:$normalizedLanguage"
-        episodeCache[cacheKey]?.let { return@withContext it }
-
         val numericId = tmdbId.toIntOrNull() ?: return@withContext emptyMap()
-        val result = mutableMapOf<Pair<Int, Int>, TmdbEpisodeEnrichment>()
+        val distinctSeasons = seasonNumbers.distinct().sorted()
+        if (distinctSeasons.isEmpty()) return@withContext emptyMap()
 
-        seasonNumbers.distinct().forEach { season ->
-            try {
-                val response = tmdbApi.getTvSeasonDetails(numericId, season, TMDB_API_KEY, normalizedLanguage)
-                val episodes = response.body()?.episodes.orEmpty()
-                episodes.forEach { ep ->
-                    val epNum = ep.episodeNumber ?: return@forEach
-                    result[season to epNum] = ep.toEnrichment()
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to fetch TMDB season $season: ${e.message}")
+        val cachedSeasonData = mutableMapOf<Int, Map<Int, TmdbEpisodeEnrichment>>()
+        val missingSeasons = mutableListOf<Int>()
+
+        distinctSeasons.forEach { season ->
+            val cacheKey = episodeSeasonCacheKey(tmdbId = tmdbId, seasonNumber = season, language = normalizedLanguage)
+            val cached = episodeSeasonCache[cacheKey]
+            if (cached != null) {
+                cachedSeasonData[season] = cached
+            } else {
+                missingSeasons += season
             }
         }
 
-        if (result.isNotEmpty()) {
-            episodeCache[cacheKey] = result
+        val fetchedSeasonData = if (missingSeasons.isNotEmpty()) {
+            val semaphore = Semaphore(MAX_CONCURRENT_SEASON_REQUESTS)
+
+            coroutineScope {
+                missingSeasons.map { season ->
+                    async {
+                        semaphore.withPermit {
+                            season to fetchSeasonEpisodeEnrichment(
+                                tmdbId = tmdbId,
+                                numericId = numericId,
+                                seasonNumber = season,
+                                language = normalizedLanguage
+                            )
+                        }
+                    }
+                }.awaitAll().toMap()
+            }
+        } else {
+            emptyMap()
         }
-        result
+
+        buildMap {
+            distinctSeasons.forEach { season ->
+                val seasonEpisodes = cachedSeasonData[season] ?: fetchedSeasonData[season] ?: return@forEach
+                seasonEpisodes.forEach { (episodeNumber, enrichment) ->
+                    put(season to episodeNumber, enrichment)
+                }
+            }
+        }
     }
+
+    private suspend fun fetchSeasonEpisodeEnrichment(
+        tmdbId: String,
+        numericId: Int,
+        seasonNumber: Int,
+        language: String
+    ): Map<Int, TmdbEpisodeEnrichment>? {
+        val cacheKey = episodeSeasonCacheKey(tmdbId = tmdbId, seasonNumber = seasonNumber, language = language)
+
+        episodeSeasonCache[cacheKey]?.let { return it }
+        episodeSeasonInFlight[cacheKey]?.let { return it.await() }
+
+        val deferred = CompletableDeferred<Map<Int, TmdbEpisodeEnrichment>?>()
+        val existingDeferred = episodeSeasonInFlight.putIfAbsent(cacheKey, deferred)
+        if (existingDeferred != null) {
+            return existingDeferred.await()
+        }
+
+        return try {
+            val response = tmdbApi.getTvSeasonDetails(numericId, seasonNumber, TMDB_API_KEY, language)
+            if (!response.isSuccessful) {
+                Log.w(TAG, "Failed to fetch TMDB season $seasonNumber: HTTP ${response.code()} ${response.message()}")
+                deferred.complete(null)
+                null
+            } else {
+                val episodes = response.body()?.episodes.orEmpty()
+                val seasonData = episodes.mapNotNull { episode ->
+                    val episodeNumber = episode.episodeNumber ?: return@mapNotNull null
+                    episodeNumber to episode.toEnrichment()
+                }.toMap()
+                episodeSeasonCache[cacheKey] = seasonData
+                deferred.complete(seasonData)
+                seasonData
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch TMDB season $seasonNumber: ${e.message}")
+            deferred.complete(null)
+            null
+        } finally {
+            episodeSeasonInFlight.remove(cacheKey, deferred)
+        }
+    }
+
+    private fun episodeSeasonCacheKey(
+        tmdbId: String,
+        seasonNumber: Int,
+        language: String
+    ): String = "$tmdbId:$seasonNumber:$language"
 
     suspend fun fetchMoreLikeThis(
         tmdbId: String,
@@ -346,13 +407,6 @@ class TmdbMetadataService @Inject constructor(
         val tmdbType = when (contentType) {
             ContentType.SERIES, ContentType.TV -> "tv"
             else -> "movie"
-        }
-
-        val includeImageLanguage = buildString {
-            append(normalizedLanguage.substringBefore("-"))
-            append(",")
-            append(normalizedLanguage)
-            append(",en,null")
         }
 
         try {
@@ -385,65 +439,40 @@ class TmdbMetadataService @Inject constructor(
                 sortedResults
             }).take(maxItems.coerceAtLeast(1))
 
-            val items = coroutineScope {
-                recommendationResults.map { rec ->
-                    async {
-                        val recTmdbType = when (rec.mediaType?.trim()?.lowercase()) {
-                            "tv" -> "tv"
-                            "movie" -> "movie"
-                            else -> tmdbType
-                        }
-                        val recContentType = if (recTmdbType == "tv") ContentType.SERIES else ContentType.MOVIE
-                        val title = rec.title?.takeIf { it.isNotBlank() }
-                            ?: rec.name?.takeIf { it.isNotBlank() }
-                            ?: rec.originalTitle?.takeIf { it.isNotBlank() }
-                            ?: rec.originalName?.takeIf { it.isNotBlank() }
-                            ?: return@async null
+            val items = recommendationResults.mapNotNull { rec ->
+                val recTmdbType = when (rec.mediaType?.trim()?.lowercase()) {
+                    "tv" -> "tv"
+                    "movie" -> "movie"
+                    else -> tmdbType
+                }
+                val recContentType = if (recTmdbType == "tv") ContentType.SERIES else ContentType.MOVIE
+                val title = rec.title?.takeIf { it.isNotBlank() }
+                    ?: rec.name?.takeIf { it.isNotBlank() }
+                    ?: rec.originalTitle?.takeIf { it.isNotBlank() }
+                    ?: rec.originalName?.takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
 
-                        val localizedBackdropPath = runCatching {
-                            when (recTmdbType) {
-                                "tv" -> tmdbApi.getTvImages(rec.id, TMDB_API_KEY, includeImageLanguage).body()
-                                else -> tmdbApi.getMovieImages(rec.id, TMDB_API_KEY, includeImageLanguage).body()
-                            }
-                        }.getOrNull()?.let { images ->
-                            selectBestLocalizedImagePath(
-                                images = images.backdrops.orEmpty(),
-                                normalizedLanguage = normalizedLanguage
-                            )
-                        }
+                val backdrop = buildImageUrl(rec.backdropPath, size = "w1280")
+                val fallbackPoster = buildImageUrl(rec.posterPath, size = "w780")
+                val releaseInfo = if (recTmdbType == "tv") {
+                    rec.firstAirDate?.take(4)
+                } else {
+                    rec.releaseDate?.take(4)
+                }
 
-                        val backdrop = buildImageUrl(localizedBackdropPath ?: rec.backdropPath, size = "w1280")
-                        val fallbackPoster = buildImageUrl(rec.posterPath, size = "w780")
-
-                        val releaseInfo = if (recTmdbType == "tv") {
-                            val startYear = rec.firstAirDate?.take(4)
-                            if (startYear != null) {
-                                val tvDetails = runCatching {
-                                    tmdbApi.getTvDetails(rec.id, TMDB_API_KEY, normalizedLanguage).body()
-                                }.getOrNull()
-                                val status = tvDetails?.status
-                                val endYear = tvDetails?.lastAirDate?.take(4)
-                                buildShowYearRange(startYear, endYear, status)
-                            } else null
-                        } else {
-                            rec.releaseDate?.take(4)
-                        }
-
-                        MetaPreview(
-                            id = "tmdb:${rec.id}",
-                            type = recContentType,
-                            name = title,
-                            poster = backdrop ?: fallbackPoster,
-                            posterShape = PosterShape.LANDSCAPE,
-                            background = backdrop,
-                            logo = null,
-                            description = rec.overview?.takeIf { it.isNotBlank() },
-                            releaseInfo = releaseInfo,
-                            imdbRating = rec.voteAverage?.toFloat(),
-                            genres = emptyList()
-                        )
-                    }
-                }.awaitAll().filterNotNull()
+                MetaPreview(
+                    id = "tmdb:${rec.id}",
+                    type = recContentType,
+                    name = title,
+                    poster = backdrop ?: fallbackPoster,
+                    posterShape = PosterShape.LANDSCAPE,
+                    background = backdrop,
+                    logo = null,
+                    description = rec.overview?.takeIf { it.isNotBlank() },
+                    releaseInfo = releaseInfo,
+                    imdbRating = rec.voteAverage?.toFloat(),
+                    genres = emptyList()
+                )
             }
 
             moreLikeThisCache[cacheKey] = items
@@ -471,46 +500,25 @@ class TmdbMetadataService @Inject constructor(
             // Show in release order
             val sortedParts = rawParts.sortedBy { it.releaseDate ?: "9999" }
             
-            val includeImageLanguage = buildString {
-                append(normalizedLanguage.substringBefore("-"))
-                append(",")
-                append(normalizedLanguage)
-                append(",en,null")
-            }
+            val items = sortedParts.mapNotNull { part ->
+                val title = part.title ?: return@mapNotNull null
+                val backdrop = buildImageUrl(part.backdropPath, size = "w1280")
+                val fallbackPoster = buildImageUrl(part.posterPath, size = "w780")
+                val releaseInfo = part.releaseDate?.take(4)
 
-            val items = coroutineScope {
-                sortedParts.map { part ->
-                    async {
-                        val title = part.title ?: return@async null
-
-                        val localizedBackdropPath = runCatching {
-                            tmdbApi.getMovieImages(part.id, TMDB_API_KEY, includeImageLanguage).body()
-                        }.getOrNull()?.let { images ->
-                            selectBestLocalizedImagePath(
-                                images = images.backdrops.orEmpty(),
-                                normalizedLanguage = normalizedLanguage
-                            )
-                        }
-
-                        val backdrop = buildImageUrl(localizedBackdropPath ?: part.backdropPath, size = "w1280")
-                        val fallbackPoster = buildImageUrl(part.posterPath, size = "w780")
-                        val releaseInfo = part.releaseDate?.take(4)
-
-                        MetaPreview(
-                            id = "tmdb:${part.id}",
-                            type = ContentType.MOVIE,
-                            name = title,
-                            poster = backdrop ?: fallbackPoster,
-                            posterShape = PosterShape.LANDSCAPE,
-                            background = backdrop,
-                            logo = null,
-                            description = part.overview?.takeIf { it.isNotBlank() },
-                            releaseInfo = releaseInfo,
-                            imdbRating = part.voteAverage?.toFloat(),
-                            genres = emptyList()
-                        )
-                    }
-                }.awaitAll().filterNotNull()
+                MetaPreview(
+                    id = "tmdb:${part.id}",
+                    type = ContentType.MOVIE,
+                    name = title,
+                    poster = backdrop ?: fallbackPoster,
+                    posterShape = PosterShape.LANDSCAPE,
+                    background = backdrop,
+                    logo = null,
+                    description = part.overview?.takeIf { it.isNotBlank() },
+                    releaseInfo = releaseInfo,
+                    imdbRating = part.voteAverage?.toFloat(),
+                    genres = emptyList()
+                )
             }
             collectionCache[cacheKey] = items
             items
@@ -518,6 +526,49 @@ class TmdbMetadataService @Inject constructor(
             Log.w(TAG, "Failed to fetch collection for $collectionId: ${e.message}")
             emptyList()
         }
+    }
+
+    suspend fun fetchLocalizedBackdrop(
+        item: MetaPreview,
+        language: String = "en"
+    ): String? = withContext(Dispatchers.IO) {
+        val tmdbId = item.id.removePrefix("tmdb:").toIntOrNull() ?: return@withContext null
+        val normalizedLanguage = normalizeTmdbLanguage(language)
+        val includeImageLanguage = buildString {
+            append(normalizedLanguage.substringBefore("-"))
+            append(",")
+            append(normalizedLanguage)
+            append(",en,null")
+        }
+        val tmdbType = when (item.type) {
+            ContentType.SERIES, ContentType.TV -> "tv"
+            else -> "movie"
+        }
+        val cacheKey = "$tmdbType:$tmdbId:$normalizedLanguage:backdrop"
+
+        localizedBackdropCache[cacheKey]?.let { cached ->
+            return@withContext cached.takeUnless { it == NEGATIVE_IMAGE_CACHE }
+        }
+
+        val images = runCatching {
+            when (tmdbType) {
+                "tv" -> tmdbApi.getTvImages(tmdbId, TMDB_API_KEY, includeImageLanguage).body()
+                else -> tmdbApi.getMovieImages(tmdbId, TMDB_API_KEY, includeImageLanguage).body()
+            }
+        }.getOrElse {
+            Log.w(TAG, "Failed to fetch localized backdrop for ${item.id}: ${it.message}")
+            null
+        }
+
+        val localizedPath = images?.backdrops?.let {
+            selectBestLocalizedImagePath(
+                images = it,
+                normalizedLanguage = normalizedLanguage
+            )
+        }
+        val localizedBackdrop = buildImageUrl(localizedPath, size = "w1280")
+        localizedBackdropCache[cacheKey] = localizedBackdrop ?: NEGATIVE_IMAGE_CACHE
+        localizedBackdrop
     }
 
     suspend fun fetchEntityBrowse(
@@ -803,15 +854,6 @@ class TmdbMetadataService @Inject constructor(
         TmdbEntityRailType.RECENT -> "first_air_date.desc"
     }
 
-    private fun buildShowYearRange(startYear: String, endYear: String?, status: String?): String {
-        val isEnded = status != null && status != "Returning Series" && status != "In Production"
-        return when {
-            isEnded && endYear != null && endYear != startYear -> "$startYear - $endYear"
-            isEnded -> startYear
-            else -> "$startYear - "
-        }
-    }
-
     private fun buildImageUrl(path: String?, size: String): String? {
         val clean = path?.trim()?.takeIf { it.isNotBlank() } ?: return null
         return "https://image.tmdb.org/t/p/$size$clean"
@@ -861,6 +903,8 @@ class TmdbMetadataService @Inject constructor(
             "es" to "ES"
         )
         private const val ENTITY_RAIL_MAX_ITEMS = 20
+        private const val MAX_CONCURRENT_SEASON_REQUESTS = 3
+        private const val NEGATIVE_IMAGE_CACHE = "__none__"
         private const val TOP_RATED_VOTE_COUNT_FLOOR = 200
     }
 
@@ -1040,13 +1084,6 @@ class TmdbMetadataService @Inject constructor(
             }
     }
 }
-
-private data class Quadruple<A, B, C, D>(
-    val first: A,
-    val second: B,
-    val third: C,
-    val fourth: D
-)
 
 private fun preferredRegions(normalizedLanguage: String): List<String> {
     val fromLanguage = normalizedLanguage.substringAfter("-", "").uppercase(Locale.US).takeIf { it.length == 2 }

--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.core.tmdb
 import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.data.remote.api.TmdbApi
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -27,6 +28,10 @@ class TmdbService @Inject constructor(
     
     // Cache: TMDB ID -> IMDB ID  
     private val tmdbToImdbCache = ConcurrentHashMap<Int, String>()
+
+    // In-flight lookups to dedupe duplicate concurrent requests
+    private val imdbToTmdbInFlight = ConcurrentHashMap<String, CompletableDeferred<Int?>>()
+    private val tmdbToImdbInFlight = ConcurrentHashMap<String, CompletableDeferred<String?>>()
     
     // Mutex for thread-safe cache operations
     private val cacheMutex = Mutex()
@@ -44,11 +49,26 @@ class TmdbService @Inject constructor(
             Log.w(TAG, "Invalid IMDB ID format: $imdbId")
             return@withContext null
         }
+
+        val normalizedType = normalizeMediaType(mediaType)
+        val inFlightKey = "$normalizedType:$imdbId"
         
         // Check cache first
         imdbToTmdbCache[imdbId]?.let { cached ->
             Log.d(TAG, "Cache hit: IMDB $imdbId -> TMDB $cached")
             return@withContext cached
+        }
+
+        imdbToTmdbInFlight[inFlightKey]?.let { existing ->
+            Log.d(TAG, "Joining in-flight TMDB lookup for IMDB: $imdbId (type: $normalizedType)")
+            return@withContext existing.await()
+        }
+
+        val deferred = CompletableDeferred<Int?>()
+        val existingDeferred = imdbToTmdbInFlight.putIfAbsent(inFlightKey, deferred)
+        if (existingDeferred != null) {
+            Log.d(TAG, "Joining in-flight TMDB lookup for IMDB: $imdbId (type: $normalizedType)")
+            return@withContext existingDeferred.await()
         }
         
         try {
@@ -62,13 +82,16 @@ class TmdbService @Inject constructor(
             
             if (!response.isSuccessful) {
                 Log.e(TAG, "TMDB API error: ${response.code()} - ${response.message()}")
+                deferred.complete(null)
                 return@withContext null
             }
             
-            val body = response.body() ?: return@withContext null
+            val body = response.body() ?: run {
+                deferred.complete(null)
+                return@withContext null
+            }
             
             // Determine which results to use based on media type
-            val normalizedType = normalizeMediaType(mediaType)
             val result = when (normalizedType) {
                 "movie" -> body.movieResults?.firstOrNull()
                 "tv", "series" -> body.tvResults?.firstOrNull()
@@ -83,16 +106,21 @@ class TmdbService @Inject constructor(
                     imdbToTmdbCache[imdbId] = found.id
                     tmdbToImdbCache[found.id] = imdbId
                 }
+                deferred.complete(found.id)
                 
                 return@withContext found.id
             }
             
             Log.w(TAG, "No TMDB result found for IMDB: $imdbId")
+            deferred.complete(null)
             null
             
         } catch (e: Exception) {
             Log.e(TAG, "Error looking up TMDB ID for $imdbId: ${e.message}", e)
+            deferred.complete(null)
             null
+        } finally {
+            imdbToTmdbInFlight.remove(inFlightKey, deferred)
         }
     }
     
@@ -109,11 +137,25 @@ class TmdbService @Inject constructor(
             Log.d(TAG, "Cache hit: TMDB $tmdbId -> IMDB $cached")
             return@withContext cached
         }
+
+        val normalizedType = normalizeMediaType(mediaType)
+        val inFlightKey = "$normalizedType:$tmdbId"
+
+        tmdbToImdbInFlight[inFlightKey]?.let { existing ->
+            Log.d(TAG, "Joining in-flight IMDB lookup for TMDB: $tmdbId (type: $normalizedType)")
+            return@withContext existing.await()
+        }
+
+        val deferred = CompletableDeferred<String?>()
+        val existingDeferred = tmdbToImdbInFlight.putIfAbsent(inFlightKey, deferred)
+        if (existingDeferred != null) {
+            Log.d(TAG, "Joining in-flight IMDB lookup for TMDB: $tmdbId (type: $normalizedType)")
+            return@withContext existingDeferred.await()
+        }
         
         try {
             Log.d(TAG, "Looking up IMDB ID for TMDB: $tmdbId (type: $mediaType)")
             
-            val normalizedType = normalizeMediaType(mediaType)
             val response = when (normalizedType) {
                 "movie" -> tmdbApi.getMovieExternalIds(tmdbId, TMDB_API_KEY)
                 "tv", "series" -> tmdbApi.getTvExternalIds(tmdbId, TMDB_API_KEY)
@@ -122,10 +164,14 @@ class TmdbService @Inject constructor(
             
             if (!response.isSuccessful) {
                 Log.e(TAG, "TMDB API error: ${response.code()} - ${response.message()}")
+                deferred.complete(null)
                 return@withContext null
             }
             
-            val body = response.body() ?: return@withContext null
+            val body = response.body() ?: run {
+                deferred.complete(null)
+                return@withContext null
+            }
             
             body.imdbId?.let { imdbId ->
                 Log.d(TAG, "Found IMDB ID: $imdbId for TMDB: $tmdbId")
@@ -135,16 +181,21 @@ class TmdbService @Inject constructor(
                     tmdbToImdbCache[tmdbId] = imdbId
                     imdbToTmdbCache[imdbId] = tmdbId
                 }
+                deferred.complete(imdbId)
                 
                 return@withContext imdbId
             }
             
             Log.w(TAG, "No IMDB ID found for TMDB: $tmdbId")
+            deferred.complete(null)
             null
             
         } catch (e: Exception) {
             Log.e(TAG, "Error looking up IMDB ID for $tmdbId: ${e.message}", e)
+            deferred.complete(null)
             null
+        } finally {
+            tmdbToImdbInFlight.remove(inFlightKey, deferred)
         }
     }
     

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -46,14 +46,18 @@ interface TmdbApi {
     suspend fun getMovieDetails(
         @Path("movie_id") movieId: Int,
         @Query("api_key") apiKey: String,
-        @Query("language") language: String? = null
+        @Query("language") language: String? = null,
+        @Query("append_to_response") appendToResponse: String? = null,
+        @Query("include_image_language") includeImageLanguage: String? = null
     ): Response<TmdbDetailsResponse>
 
     @GET("tv/{tv_id}")
     suspend fun getTvDetails(
         @Path("tv_id") tvId: Int,
         @Query("api_key") apiKey: String,
-        @Query("language") language: String? = null
+        @Query("language") language: String? = null,
+        @Query("append_to_response") appendToResponse: String? = null,
+        @Query("include_image_language") includeImageLanguage: String? = null
     ): Response<TmdbDetailsResponse>
 
     @GET("movie/{movie_id}/credits")
@@ -242,7 +246,13 @@ data class TmdbDetailsResponse(
     @Json(name = "poster_path") val posterPath: String? = null,
     @Json(name = "last_air_date") val lastAirDate: String? = null,
     @Json(name = "status") val status: String? = null,
-    @Json(name = "belongs_to_collection") val belongsToCollection: TmdbCollectionSummary? = null
+    @Json(name = "belongs_to_collection") val belongsToCollection: TmdbCollectionSummary? = null,
+    @Json(name = "credits") val credits: TmdbCreditsResponse? = null,
+    @Json(name = "images") val images: TmdbImagesResponse? = null,
+    @Json(name = "release_dates") val releaseDates: TmdbMovieReleaseDatesResponse? = null,
+    @Json(name = "content_ratings") val contentRatings: TmdbTvContentRatingsResponse? = null,
+    @Json(name = "external_ids") val externalIds: TmdbExternalIdsResponse? = null,
+    @Json(name = "videos") val videos: TmdbVideosResponse? = null
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -593,6 +593,12 @@ fun MetaDetailsScreen(
                     },
                     commentOverlayDirection = commentOverlayDirection,
                     restorePlayFocusAfterTrailerBackToken = restorePlayFocusAfterTrailerBackToken,
+                    onMoreLikeThisItemFocused = {
+                        viewModel.onEvent(MetaDetailsEvent.OnMoreLikeThisItemFocused(it))
+                    },
+                    onCollectionItemFocused = {
+                        viewModel.onEvent(MetaDetailsEvent.OnCollectionItemFocused(it))
+                    },
                     onNavigateToCastDetail = onNavigateToCastDetail,
                     onNavigateToTmdbEntityBrowse = onNavigateToTmdbEntityBrowse,
                     onNavigateToDetail = onNavigateToDetail
@@ -732,6 +738,8 @@ private fun MetaDetailsContent(
     onDismissCommentOverlay: () -> Unit,
     commentOverlayDirection: Int,
     restorePlayFocusAfterTrailerBackToken: Int,
+    onMoreLikeThisItemFocused: (MetaPreview) -> Unit,
+    onCollectionItemFocused: (MetaPreview) -> Unit,
     onNavigateToCastDetail: (personId: Int, personName: String, preferCrew: Boolean) -> Unit = { _, _, _ -> },
     onNavigateToTmdbEntityBrowse: (entityKind: String, entityId: Int, entityName: String, sourceType: String) -> Unit = { _, _, _, _ -> },
     onNavigateToDetail: (itemId: String, itemType: String, addonBaseUrl: String?) -> Unit = { _, _, _ -> }
@@ -1503,6 +1511,7 @@ private fun MetaDetailsContent(
                                     onRestoreFocusHandled = {
                                         clearPendingRestore()
                                     },
+                                    onItemFocused = onMoreLikeThisItemFocused,
                                     onItemClick = { item ->
                                         markMoreLikeThisRestore(item.id)
                                         onNavigateToDetail(item.id, item.apiType, null)
@@ -1520,6 +1529,7 @@ private fun MetaDetailsContent(
                                     onRestoreFocusHandled = {
                                         clearPendingRestore()
                                     },
+                                    onItemFocused = onCollectionItemFocused,
                                     onItemClick = { item ->
                                         markCollectionRestore(item.id)
                                         onNavigateToDetail(item.id, item.apiType, null)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsUiState.kt
@@ -87,6 +87,8 @@ sealed class MetaDetailsEvent {
     data class OnMarkSeasonWatched(val season: Int) : MetaDetailsEvent()
     data class OnMarkSeasonUnwatched(val season: Int) : MetaDetailsEvent()
     data class OnMarkPreviousEpisodesWatched(val video: Video) : MetaDetailsEvent()
+    data class OnMoreLikeThisItemFocused(val item: MetaPreview) : MetaDetailsEvent()
+    data class OnCollectionItemFocused(val item: MetaPreview) : MetaDetailsEvent()
     data object OnLibraryLongPress : MetaDetailsEvent()
     data class OnPickerMembershipToggled(val listKey: String) : MetaDetailsEvent()
     data object OnPickerSave : MetaDetailsEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -23,6 +23,7 @@ import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import com.nuvio.tv.domain.model.Meta
+import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.NextToWatch
 import com.nuvio.tv.domain.model.TmdbSettings
 import com.nuvio.tv.domain.model.TraktCommentReview
@@ -102,6 +103,9 @@ class MetaDetailsViewModel @Inject constructor(
     private var nextToWatchJob: Job? = null
     private var commentsJob: Job? = null
     private var commentsLoadMoreJob: Job? = null
+    private var episodeThumbnailRetryJob: Job? = null
+    private val moreLikeThisLocalizedRequests = mutableSetOf<String>()
+    private val collectionLocalizedRequests = mutableSetOf<String>()
 
     private var trailerDelayMs = 7000L
     private var trailerAutoplayEnabled = false
@@ -283,6 +287,8 @@ class MetaDetailsViewModel @Inject constructor(
             is MetaDetailsEvent.OnMarkSeasonWatched -> markSeasonWatched(event.season)
             is MetaDetailsEvent.OnMarkSeasonUnwatched -> markSeasonUnwatched(event.season)
             is MetaDetailsEvent.OnMarkPreviousEpisodesWatched -> markPreviousEpisodesWatched(event.video)
+            is MetaDetailsEvent.OnMoreLikeThisItemFocused -> maybeUpgradeMoreLikeThisArtwork(event.item)
+            is MetaDetailsEvent.OnCollectionItemFocused -> maybeUpgradeCollectionArtwork(event.item)
             MetaDetailsEvent.OnLibraryLongPress -> openListPicker()
             is MetaDetailsEvent.OnPickerMembershipToggled -> togglePickerMembership(event.listKey)
             MetaDetailsEvent.OnPickerSave -> savePickerMembership()
@@ -442,6 +448,7 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun loadMeta() {
         viewModelScope.launch {
+            episodeThumbnailRetryJob?.cancel()
             cancelCommentsRequests()
             _uiState.update {
                 it.copy(
@@ -605,6 +612,7 @@ class MetaDetailsViewModel @Inject constructor(
         loadMoreLikeThisAsync(meta)
         val enriched = enrichMeta(meta)
         applyMeta(enriched)
+        scheduleEpisodeThumbnailRetries(enriched)
         // Episode ratings and MDBList are independent — launch both without waiting.
         loadEpisodeRatingsAsync(enriched)
         viewModelScope.launch { loadMDBListRatings(enriched) }
@@ -810,6 +818,7 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun loadMoreLikeThisAsync(meta: Meta) {
         moreLikeThisJob?.cancel()
+        moreLikeThisLocalizedRequests.clear()
         moreLikeThisJob = viewModelScope.launch {
             val source = if (shouldLoadTraktMoreLikeThis(meta)) {
                 MoreLikeThisSource.TRAKT
@@ -895,6 +904,7 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun loadCollectionAsync(collectionId: Int, collectionName: String?, settings: TmdbSettings) {
         collectionJob?.cancel()
+        collectionLocalizedRequests.clear()
         collectionJob = viewModelScope.launch {
             if (!settings.enabled || !settings.useCollections) {
                 _uiState.update { it.copy(collection = emptyList(), collectionName = null) }
@@ -922,6 +932,78 @@ class MetaDetailsViewModel @Inject constructor(
                 state.copy(collection = filteredItems, collectionName = collectionName)
             }
         }
+    }
+
+    private fun maybeUpgradeMoreLikeThisArtwork(item: MetaPreview) {
+        maybeUpgradeLocalizedArtwork(
+            item = item,
+            requestedIds = moreLikeThisLocalizedRequests,
+            currentItems = { state -> state.moreLikeThis },
+            updateItems = { state, items -> state.copy(moreLikeThis = items) }
+        )
+    }
+
+    private fun maybeUpgradeCollectionArtwork(item: MetaPreview) {
+        maybeUpgradeLocalizedArtwork(
+            item = item,
+            requestedIds = collectionLocalizedRequests,
+            currentItems = { state -> state.collection },
+            updateItems = { state, items -> state.copy(collection = items) }
+        )
+    }
+
+    private fun maybeUpgradeLocalizedArtwork(
+        item: MetaPreview,
+        requestedIds: MutableSet<String>,
+        currentItems: (MetaDetailsUiState) -> List<MetaPreview>,
+        updateItems: (MetaDetailsUiState, List<MetaPreview>) -> MetaDetailsUiState
+    ) {
+        if (!item.id.startsWith("tmdb:")) return
+
+        viewModelScope.launch {
+            val settings = tmdbSettingsDataStore.settings.first()
+            if (!settings.enabled) {
+                return@launch
+            }
+            if (!requestedIds.add(item.id)) {
+                return@launch
+            }
+
+            val localizedBackdrop = tmdbMetadataService.fetchLocalizedBackdrop(
+                item = item,
+                language = settings.language
+            ) ?: return@launch
+
+            val updatedItem = item.withLocalizedBackdrop(localizedBackdrop)
+            if (updatedItem == item) {
+                return@launch
+            }
+
+            _uiState.update { state ->
+                val items = currentItems(state)
+                if (items.none { it.id == item.id }) {
+                    state
+                } else {
+                    val updatedItems = items.map { existing ->
+                        if (existing.id == item.id) existing.withLocalizedBackdrop(localizedBackdrop) else existing
+                    }
+                    updateItems(state, updatedItems)
+                }
+            }
+        }
+    }
+
+    private fun MetaPreview.withLocalizedBackdrop(localizedBackdrop: String): MetaPreview {
+        val normalizedBackdrop = localizedBackdrop.trim()
+        if (normalizedBackdrop.isBlank()) return this
+        val updatedPoster = normalizedBackdrop
+        if (normalizedBackdrop == background && updatedPoster == poster) {
+            return this
+        }
+        return copy(
+            poster = updatedPoster,
+            background = normalizedBackdrop
+        )
     }
 
     private suspend fun loadMDBListRatings(meta: Meta) {
@@ -1130,19 +1212,7 @@ class MetaDetailsViewModel @Inject constructor(
         }
 
         if (!episodeMap.isNullOrEmpty()) {
-            updated = updated.copy(
-                videos = meta.videos.map { video ->
-                    val key = if (video.season != null && video.episode != null) video.season to video.episode else null
-                    val ep = key?.let { episodeMap[it] }
-                    video.copy(
-                        title = ep?.title ?: video.title,
-                        overview = ep?.overview ?: video.overview,
-                        released = ep?.airDate ?: video.released,
-                        thumbnail = ep?.thumbnail ?: video.thumbnail,
-                        runtime = ep?.runtimeMinutes
-                    )
-                }
-            )
+            updated = applyEpisodeEnrichment(updated, episodeMap)
         }
 
         if (enrichment?.collectionId != null) {
@@ -1150,6 +1220,100 @@ class MetaDetailsViewModel @Inject constructor(
         }
 
         return updated
+    }
+
+    private fun scheduleEpisodeThumbnailRetries(meta: Meta) {
+        episodeThumbnailRetryJob?.cancel()
+
+        episodeThumbnailRetryJob = viewModelScope.launch {
+            val settings = tmdbSettingsDataStore.settings.first()
+            if (!settings.enabled || !settings.useEpisodes) return@launch
+
+            val tmdbContentType = resolveTmdbContentType(meta)
+            if (tmdbContentType !in listOf(ContentType.SERIES, ContentType.TV)) return@launch
+
+            val tmdbLookupType = tmdbContentType.toApiString()
+            val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
+                ?: tmdbService.ensureTmdbId(itemId, itemType)
+                ?: return@launch
+
+            EPISODE_THUMBNAIL_RETRY_DELAYS_MS.forEach { delayMs ->
+                delay(delayMs)
+
+                val currentMeta = _uiState.value.meta ?: return@launch
+                if (currentMeta.id != meta.id) return@launch
+
+                val missingSeasons = findSeasonsMissingEpisodeThumbnails(currentMeta)
+                if (missingSeasons.isEmpty()) return@launch
+
+                val retryMap = tmdbMetadataService.fetchEpisodeEnrichment(
+                    tmdbId = tmdbId,
+                    seasonNumbers = missingSeasons,
+                    language = settings.language
+                )
+                if (retryMap.isEmpty()) {
+                    return@forEach
+                }
+
+                var mergedMeta: Meta? = null
+                _uiState.update { state ->
+                    val stateMeta = state.meta
+                    if (stateMeta == null || stateMeta.id != meta.id) {
+                        state
+                    } else {
+                        val updatedMeta = applyEpisodeEnrichment(stateMeta, retryMap)
+                        if (updatedMeta == stateMeta) {
+                            state
+                        } else {
+                            mergedMeta = updatedMeta
+                            state.copy(
+                                meta = updatedMeta,
+                                episodesForSeason = getEpisodesForSeason(updatedMeta.videos, state.selectedSeason)
+                            )
+                        }
+                    }
+                }
+
+                mergedMeta?.let {
+                    reevaluateSeriesWatchedBadge()
+                    calculateNextToWatch()
+                }
+
+                val latestMeta = _uiState.value.meta ?: return@launch
+                if (latestMeta.id != meta.id || findSeasonsMissingEpisodeThumbnails(latestMeta).isEmpty()) {
+                    return@launch
+                }
+            }
+        }
+    }
+
+    private fun applyEpisodeEnrichment(
+        meta: Meta,
+        episodeMap: Map<Pair<Int, Int>, com.nuvio.tv.core.tmdb.TmdbEpisodeEnrichment>
+    ): Meta {
+        val updatedVideos = meta.videos.map { video ->
+            val key = if (video.season != null && video.episode != null) video.season to video.episode else null
+            val episodeEnrichment = key?.let { episodeMap[it] }
+            video.copy(
+                title = episodeEnrichment?.title ?: video.title,
+                overview = episodeEnrichment?.overview ?: video.overview,
+                released = episodeEnrichment?.airDate ?: video.released,
+                thumbnail = episodeEnrichment?.thumbnail ?: video.thumbnail,
+                runtime = episodeEnrichment?.runtimeMinutes ?: video.runtime
+            )
+        }
+        return if (updatedVideos == meta.videos) meta else meta.copy(videos = updatedVideos)
+    }
+
+    private fun findSeasonsMissingEpisodeThumbnails(meta: Meta): List<Int> {
+        return meta.videos
+            .asSequence()
+            .filter { it.season != null && it.episode != null }
+            .filter { it.thumbnail.isNullOrBlank() }
+            .mapNotNull { it.season }
+            .distinct()
+            .sorted()
+            .toList()
     }
 
     private fun resolveTmdbContentType(meta: Meta): ContentType {
@@ -1995,5 +2159,10 @@ class MetaDetailsViewModel @Inject constructor(
         idleTimerJob?.cancel()
         trailerFetchJob?.cancel()
         nextToWatchJob?.cancel()
+        episodeThumbnailRetryJob?.cancel()
+    }
+
+    companion object {
+        private val EPISODE_THUMBNAIL_RETRY_DELAYS_MS = listOf(3_000L, 12_000L)
     }
 }


### PR DESCRIPTION
## Summary

- Reduce TMDB round trips on detail pages by fetching details with appended TMDB responses instead of making separate credits, images, and rating requests.
- Improve series detail resilience by retrying missing episode thumbnail loads and reapplying episode enrichment when artwork arrives later.
- Defer localized backdrop upgrades for `More Like This` and collection items until focus so the initial page render stays lighter while still allowing localized artwork to appear when needed.
- Deduplicate concurrent TMDB ID and season enrichment requests to avoid repeated work during detail screen loading.

## PR type

- Bug fix

## Why

TMDB-backed detail pages could feel slow and inconsistent because the screen performed too many separate network requests during load. This was most visible on series pages, where episode thumbnails could stay blank if a season request failed or returned incomplete data on the first attempt. The goal of this change is to make detail loading faster, reduce redundant API traffic, and avoid leaving episode art permanently missing after transient failures.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Reviewed the last commit changes across `TmdbMetadataService`, `TmdbService`, `TmdbApi`, and the detail screen/view model flow.
- Verified the implementation path covers the original problem areas: appended TMDB detail loading, localized artwork fetch-on-focus, in-flight request deduplication, and delayed episode thumbnail retries.


## Screenshots / Video (UI changes only)

- None.

## Breaking changes

- None.

## Linked issues

 fixes #1191 
