### PR TITLE
Support per-profile Trakt accounts with comments fallback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -220,12 +220,11 @@ class StartupSyncService @Inject constructor(
                 addonRepository.isSyncingFromRemote = false
             }
 
-            val isPrimaryProfile = profileManager.activeProfileId.value == 1
-            val isTraktConnected = isPrimaryProfile && traktAuthDataStore.isAuthenticated.first()
+            val isTraktConnected = traktAuthDataStore.isAuthenticated.first()
             val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
             Log.d(
                 TAG,
-                "Watch progress sync: isTraktConnected=$isTraktConnected isPrimaryProfile=$isPrimaryProfile shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
+                "Watch progress sync: isTraktConnected=$isTraktConnected shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
             )
             if (!isTraktConnected) {
                 // Pull library and watched items first — these are lightweight and critical.

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktAuthDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktAuthDataStore.kt
@@ -1,26 +1,20 @@
 package com.nuvio.tv.data.local
 
-import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.remote.dto.trakt.TraktDeviceCodeResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktTokenResponseDto
-import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
-
-private val Context.traktAuthDataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "trakt_auth_store"
-)
 
 private const val TRAKT_ACCESS_TOKEN_MAX_LIFETIME_SECONDS = 86_400
 
@@ -48,10 +42,15 @@ data class TraktAuthState(
 }
 
 @Singleton
+@OptIn(ExperimentalCoroutinesApi::class)
 class TraktAuthDataStore @Inject constructor(
-    @ApplicationContext private val context: Context,
+    private val factory: ProfileDataStoreFactory,
     private val profileManager: ProfileManager
 ) {
+    private companion object {
+        const val FEATURE = "trakt_auth_store"
+    }
+
     private val accessTokenKey = stringPreferencesKey("access_token")
     private val refreshTokenKey = stringPreferencesKey("refresh_token")
     private val tokenTypeKey = stringPreferencesKey("token_type")
@@ -67,34 +66,50 @@ class TraktAuthDataStore @Inject constructor(
     private val expiresAtKey = longPreferencesKey("expires_at")
     private val pollIntervalKey = intPreferencesKey("poll_interval")
 
-    val state: Flow<TraktAuthState> = context.traktAuthDataStore.data.map { preferences ->
-        TraktAuthState(
-            accessToken = preferences[accessTokenKey],
-            refreshToken = preferences[refreshTokenKey],
-            tokenType = preferences[tokenTypeKey],
-            createdAt = preferences[createdAtKey],
-            expiresIn = preferences[expiresInKey]?.let(::normalizeTraktTokenLifetimeSeconds),
-            username = preferences[usernameKey],
-            userSlug = preferences[userSlugKey],
-            deviceCode = preferences[deviceCodeKey],
-            userCode = preferences[userCodeKey],
-            verificationUrl = preferences[verificationUrlKey],
-            expiresAt = preferences[expiresAtKey],
-            pollInterval = preferences[pollIntervalKey]
-        )
+    private fun store(profileId: Int = profileManager.activeProfileId.value) =
+        factory.get(profileId, FEATURE)
+
+    private fun preferencesToState(
+        preferences: androidx.datastore.preferences.core.Preferences
+    ): TraktAuthState = TraktAuthState(
+        accessToken = preferences[accessTokenKey],
+        refreshToken = preferences[refreshTokenKey],
+        tokenType = preferences[tokenTypeKey],
+        createdAt = preferences[createdAtKey],
+        expiresIn = preferences[expiresInKey]?.let(::normalizeTraktTokenLifetimeSeconds),
+        username = preferences[usernameKey],
+        userSlug = preferences[userSlugKey],
+        deviceCode = preferences[deviceCodeKey],
+        userCode = preferences[userCodeKey],
+        verificationUrl = preferences[verificationUrlKey],
+        expiresAt = preferences[expiresAtKey],
+        pollInterval = preferences[pollIntervalKey]
+    )
+
+    val state: Flow<TraktAuthState> = profileManager.activeProfileId.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map(::preferencesToState)
     }
 
     val isAuthenticated: Flow<Boolean> = state.map { it.isAuthenticated }
 
-    val isEffectivelyAuthenticated: Flow<Boolean> = combine(
-        isAuthenticated,
-        profileManager.activeProfileId
-    ) { authenticated, profileId ->
-        authenticated && profileId == 1
-    }
+    val isEffectivelyAuthenticated: Flow<Boolean> = isAuthenticated
 
-    suspend fun saveToken(token: TraktTokenResponseDto) {
-        context.traktAuthDataStore.edit { preferences ->
+    fun state(profileId: Int): Flow<TraktAuthState> =
+        factory.get(profileId, FEATURE).data
+            .map(::preferencesToState)
+            .distinctUntilChanged()
+
+    fun isAuthenticated(profileId: Int): Flow<Boolean> =
+        state(profileId).map { it.isAuthenticated }.distinctUntilChanged()
+
+    suspend fun getState(profileId: Int = profileManager.activeProfileId.value): TraktAuthState =
+        store(profileId).data.map(::preferencesToState).first()
+
+    suspend fun saveToken(
+        token: TraktTokenResponseDto,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             preferences[accessTokenKey] = token.accessToken
             preferences[refreshTokenKey] = token.refreshToken
             preferences[tokenTypeKey] = token.tokenType
@@ -103,8 +118,12 @@ class TraktAuthDataStore @Inject constructor(
         }
     }
 
-    suspend fun saveUser(username: String?, userSlug: String?) {
-        context.traktAuthDataStore.edit { preferences ->
+    suspend fun saveUser(
+        username: String?,
+        userSlug: String?,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             if (username.isNullOrBlank()) {
                 preferences.remove(usernameKey)
             } else {
@@ -118,9 +137,12 @@ class TraktAuthDataStore @Inject constructor(
         }
     }
 
-    suspend fun saveDeviceFlow(data: TraktDeviceCodeResponseDto) {
+    suspend fun saveDeviceFlow(
+        data: TraktDeviceCodeResponseDto,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         val now = System.currentTimeMillis()
-        context.traktAuthDataStore.edit { preferences ->
+        store(profileId).edit { preferences ->
             preferences[deviceCodeKey] = data.deviceCode
             preferences[userCodeKey] = data.userCode
             preferences[verificationUrlKey] = data.verificationUrl
@@ -129,14 +151,17 @@ class TraktAuthDataStore @Inject constructor(
         }
     }
 
-    suspend fun updatePollInterval(seconds: Int) {
-        context.traktAuthDataStore.edit { preferences ->
+    suspend fun updatePollInterval(
+        seconds: Int,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             preferences[pollIntervalKey] = seconds
         }
     }
 
-    suspend fun clearDeviceFlow() {
-        context.traktAuthDataStore.edit { preferences ->
+    suspend fun clearDeviceFlow(profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { preferences ->
             preferences.remove(deviceCodeKey)
             preferences.remove(userCodeKey)
             preferences.remove(verificationUrlKey)
@@ -145,8 +170,8 @@ class TraktAuthDataStore @Inject constructor(
         }
     }
 
-    suspend fun clearAuth() {
-        context.traktAuthDataStore.edit { preferences ->
+    suspend fun clearAuth(profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { preferences ->
             preferences.remove(accessTokenKey)
             preferences.remove(refreshTokenKey)
             preferences.remove(tokenTypeKey)

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.repository
 
 import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.AuthSessionNoticeDataStore
 import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktAuthState
@@ -35,7 +36,8 @@ sealed interface TraktTokenPollResult {
 class TraktAuthService @Inject constructor(
     private val traktApi: TraktApi,
     private val traktAuthDataStore: TraktAuthDataStore,
-    private val authSessionNoticeDataStore: AuthSessionNoticeDataStore
+    private val authSessionNoticeDataStore: AuthSessionNoticeDataStore,
+    private val profileManager: ProfileManager
 ) {
     private val refreshLeewaySeconds = 60L
     private val writeRequestMutex = Mutex()
@@ -118,6 +120,8 @@ class TraktAuthService @Inject constructor(
     }
 
     suspend fun getCurrentAuthState(): TraktAuthState = traktAuthDataStore.state.first()
+
+    suspend fun getAuthState(profileId: Int): TraktAuthState = traktAuthDataStore.getState(profileId)
 
     suspend fun startDeviceAuth(): Result<TraktDeviceCodeResponseDto> {
         if (!hasRequiredCredentials()) {
@@ -211,17 +215,21 @@ class TraktAuthService @Inject constructor(
     }
 
     suspend fun refreshTokenIfNeeded(force: Boolean = false): Boolean {
+        return refreshTokenIfNeeded(profileId = profileManager.activeProfileId.value, force = force)
+    }
+
+    suspend fun refreshTokenIfNeeded(profileId: Int, force: Boolean = false): Boolean {
         if (!hasRequiredCredentials()) return false
 
         return tokenRefreshMutex.withLock {
-            val state = getCurrentAuthState()
+            val state = traktAuthDataStore.getState(profileId)
             val refreshToken = state.refreshToken ?: return@withLock false
             if (!force && !isTokenExpiredOrExpiring(state)) {
-                trace("refreshTokenIfNeeded: token still valid, skip refresh")
+                trace("refreshTokenIfNeeded[p$profileId]: token still valid, skip refresh")
                 return@withLock true
             }
 
-            trace("refreshTokenIfNeeded: refreshing token (force=$force)")
+            trace("refreshTokenIfNeeded[p$profileId]: refreshing token (force=$force)")
             val response = try {
                 traktApi.refreshToken(
                     TraktRefreshTokenRequestDto(
@@ -232,24 +240,24 @@ class TraktAuthService @Inject constructor(
                     )
                 )
             } catch (e: IOException) {
-                Log.w("TraktAuthService", "Network error while refreshing token", e)
+                Log.w("TraktAuthService", "Network error while refreshing token for profile $profileId", e)
                 return@withLock false
             }
 
             val tokenBody = response.body()
             if (!response.isSuccessful || tokenBody == null) {
-                trace("refreshTokenIfNeeded: failed code=${response.code()}")
+                trace("refreshTokenIfNeeded[p$profileId]: failed code=${response.code()}")
                 if (response.code() == 401 || response.code() == 403) {
                     authSessionNoticeDataStore.markUnexpectedTraktLogoutIfNeeded()
-                    traktAuthDataStore.clearAuth()
-                    tripCircuit("Token refresh returned ${response.code()}")
+                    traktAuthDataStore.clearAuth(profileId)
+                    tripCircuit("Token refresh returned ${response.code()} for profile $profileId")
                 }
                 return@withLock false
             }
 
-            traktAuthDataStore.saveToken(tokenBody)
+            traktAuthDataStore.saveToken(tokenBody, profileId = profileId)
             authSessionNoticeDataStore.markTraktAuthenticated()
-            trace("refreshTokenIfNeeded: success")
+            trace("refreshTokenIfNeeded[p$profileId]: success")
             true
         }
     }
@@ -368,6 +376,92 @@ class TraktAuthService @Inject constructor(
         }
     }
 
+    suspend fun <T> executeAuthorizedRequestAsProfile(
+        profileId: Int,
+        call: suspend (authorizationHeader: String) -> Response<T>
+    ): Response<T>? {
+        if (profileId == profileManager.activeProfileId.value) {
+            return executeAuthorizedRequest(call)
+        }
+        if (isCircuitOpen()) {
+            trace("authorized request[p$profileId]: circuit breaker is OPEN, skipping request")
+            return null
+        }
+
+        var token = getValidAccessToken(profileId) ?: return null
+        var retriedAuth = false
+        var retriedRateLimit = false
+        var retriedTransient = false
+        var retriedNetwork = false
+
+        while (true) {
+            acquireGetRateSlot()
+
+            val response = try {
+                call("Bearer $token")
+            } catch (e: IOException) {
+                if (!retriedNetwork) {
+                    trace("authorized request[p$profileId]: network error, retrying once")
+                    delay(1_000L)
+                    retriedNetwork = true
+                    continue
+                }
+                Log.w("TraktAuthService", "Network error during authorized request for profile $profileId", e)
+                return null
+            }
+
+            val code = response.code()
+
+            if (response.isSuccessful) {
+                resetCircuit()
+                return response
+            }
+
+            if (code == 403) {
+                tripCircuit("403 Forbidden (invalid API key or unapproved app) for ${responseTarget(response)}")
+                return response
+            }
+
+            if (code == 423) {
+                tripCircuit("423 Locked User Account for ${responseTarget(response)}")
+                return response
+            }
+
+            if (code in nonRetryableStatusCodes) {
+                trace("authorized request[p$profileId]: non-retryable $code for ${responseTarget(response)}")
+                return response
+            }
+
+            if (code == 401 && !retriedAuth) {
+                val refreshed = refreshTokenIfNeeded(profileId = profileId, force = true)
+                if (refreshed) {
+                    trace("authorized request[p$profileId]: 401 for ${responseTarget(response)}, retrying after token refresh")
+                    token = traktAuthDataStore.getState(profileId).accessToken ?: return response
+                    retriedAuth = true
+                    continue
+                }
+                tripCircuit("401 Unauthorized and token refresh failed for ${responseTarget(response)} (profile $profileId)")
+                return response
+            }
+
+            if (code == 429 && !retriedRateLimit) {
+                val waitSeconds = delayForRetryAfter(response = response, fallbackSeconds = 2L, maxSeconds = 60L)
+                trace("authorized request[p$profileId]: 429 for ${responseTarget(response)}, retrying in ${waitSeconds}s")
+                retriedRateLimit = true
+                continue
+            }
+
+            if (code in transientRetryStatusCodes && !retriedTransient) {
+                val waitSeconds = delayForRetryAfter(response = response, fallbackSeconds = 30L, maxSeconds = 30L)
+                trace("authorized request[p$profileId]: transient $code for ${responseTarget(response)}, retrying in ${waitSeconds}s")
+                retriedTransient = true
+                continue
+            }
+
+            return response
+        }
+    }
+
     suspend fun <T> executeAuthorizedWriteRequest(
         call: suspend (authorizationHeader: String) -> Response<T>
     ): Response<T>? {
@@ -380,11 +474,11 @@ class TraktAuthService @Inject constructor(
         return executeAuthorizedRequest(call)
     }
 
-    private suspend fun getValidAccessToken(): String? {
-        val state = getCurrentAuthState()
+    private suspend fun getValidAccessToken(profileId: Int = profileManager.activeProfileId.value): String? {
+        val state = traktAuthDataStore.getState(profileId)
         if (state.accessToken.isNullOrBlank()) return null
-        if (refreshTokenIfNeeded(force = false)) {
-            return getCurrentAuthState().accessToken
+        if (refreshTokenIfNeeded(profileId = profileId, force = false)) {
+            return traktAuthDataStore.getState(profileId).accessToken
         }
         return null
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
@@ -1,5 +1,7 @@
 package com.nuvio.tv.data.repository
 
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.data.remote.dto.trakt.TraktCommentDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktIdsDto
@@ -7,6 +9,9 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktSearchResultDto
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.TraktCommentReview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -41,7 +46,9 @@ data class TraktCommentsPage(
 @Singleton
 class TraktCommentsService @Inject constructor(
     private val traktApi: TraktApi,
-    private val traktAuthService: TraktAuthService
+    private val traktAuthService: TraktAuthService,
+    private val traktAuthDataStore: TraktAuthDataStore,
+    private val profileManager: ProfileManager
 ) {
     private data class TimedCache(
         val pages: Map<Int, List<TraktCommentReview>>,
@@ -52,6 +59,14 @@ class TraktCommentsService @Inject constructor(
 
     private val cacheMutex = Mutex()
     private val cache = mutableMapOf<String, TimedCache>()
+
+    val authAvailableForComments: Flow<Boolean> = combine(
+        profileManager.activeProfileId,
+        traktAuthDataStore.isAuthenticated,
+        traktAuthDataStore.isAuthenticated(1)
+    ) { activeProfileId, activeAuthenticated, primaryAuthenticated ->
+        activeAuthenticated || (activeProfileId != 1 && primaryAuthenticated)
+    }.distinctUntilChanged()
 
     suspend fun getCommentsPage(
         meta: Meta,
@@ -93,7 +108,7 @@ class TraktCommentsService @Inject constructor(
             }
         }
 
-        val response = traktAuthService.executeAuthorizedRequest { authHeader ->
+        val response = executeCommentsAuthorizedRequest { authHeader ->
             when (target.type) {
                 TraktCommentsType.MOVIE -> traktApi.getMovieComments(
                     authorization = authHeader,
@@ -153,7 +168,7 @@ class TraktCommentsService @Inject constructor(
         }
 
         val tmdbId = resolveTmdbCandidate(meta = meta, fallbackItemId = fallbackItemId) ?: return null
-        val searchResponse = traktAuthService.executeAuthorizedRequest { authHeader ->
+        val searchResponse = executeCommentsAuthorizedRequest { authHeader ->
             traktApi.searchById(
                 authorization = authHeader,
                 idType = "tmdb",
@@ -213,6 +228,25 @@ class TraktCommentsService @Inject constructor(
         if (metaIds.tmdb != null) return metaIds.tmdb
 
         return parseContentIds(fallbackItemId).tmdb
+    }
+
+    private suspend fun <T> executeCommentsAuthorizedRequest(
+        call: suspend (authorizationHeader: String) -> retrofit2.Response<T>
+    ): retrofit2.Response<T>? {
+        val activeProfileId = profileManager.activeProfileId.value
+        val activeState = traktAuthDataStore.getState(activeProfileId)
+        if (activeState.isAuthenticated) {
+            return traktAuthService.executeAuthorizedRequest(call)
+        }
+
+        if (activeProfileId != 1) {
+            val primaryState = traktAuthDataStore.getState(1)
+            if (primaryState.isAuthenticated) {
+                return traktAuthService.executeAuthorizedRequestAsProfile(1, call)
+            }
+        }
+
+        return null
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.repository
 
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.data.remote.dto.trakt.TraktCreateOrUpdateListRequestDto
@@ -25,6 +26,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -44,7 +46,8 @@ import javax.inject.Singleton
 class TraktLibraryService @Inject constructor(
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService,
-    private val metaRepository: MetaRepository
+    private val metaRepository: MetaRepository,
+    private val profileManager: ProfileManager
 ) {
     private data class LibraryMetadata(
         val name: String?,
@@ -78,6 +81,26 @@ class TraktLibraryService @Inject constructor(
     private val metadataHydrationLimit = 500
     private val listFetchConcurrency = 3
     private val metadataFetchSemaphore = Semaphore(5)
+    @Volatile
+    private var observedProfileId: Int? = null
+
+    init {
+        scope.launch {
+            profileManager.activeProfileId
+                .collectLatest { profileId ->
+                    if (observedProfileId == null) {
+                        observedProfileId = profileId
+                        return@collectLatest
+                    }
+                    if (observedProfileId == profileId) return@collectLatest
+                    observedProfileId = profileId
+                    snapshotState.value = Snapshot()
+                    metadataState.value = emptyMap()
+                    lastRefreshMs = 0L
+                    refresh(force = true)
+                }
+        }
+    }
 
     fun observeListTabs(): Flow<List<LibraryListTab>> {
         return snapshotState

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.data.remote.dto.trakt.TraktEpisodeDto
@@ -69,7 +70,8 @@ class TraktProgressService @Inject constructor(
     private val metaRepository: MetaRepository,
     private val tmdbService: com.nuvio.tv.core.tmdb.TmdbService,
     private val traktSettingsDataStore: TraktSettingsDataStore,
-    private val traktEpisodeMappingService: TraktEpisodeMappingService
+    private val traktEpisodeMappingService: TraktEpisodeMappingService,
+    private val profileManager: ProfileManager
 ) {
     companion object {
         private const val TAG = "TraktProgressSvc"
@@ -212,8 +214,23 @@ class TraktProgressService @Inject constructor(
     private var consecutiveRefreshFailures = 0
     @Volatile
     private var continueWatchingWindowDays: Int = TraktSettingsDataStore.DEFAULT_CONTINUE_WATCHING_DAYS_CAP
+    @Volatile
+    private var observedProfileId: Int? = null
 
     init {
+        scope.launch {
+            profileManager.activeProfileId
+                .collectLatest { profileId ->
+                    if (observedProfileId == null) {
+                        observedProfileId = profileId
+                        return@collectLatest
+                    }
+                    if (observedProfileId == profileId) return@collectLatest
+                    observedProfileId = profileId
+                    resetProfileScopedState()
+                    requestFastSync()
+                }
+        }
         scope.launch {
             traktSettingsDataStore.continueWatchingDaysCap.collectLatest { days ->
                 continueWatchingWindowDays = days
@@ -230,6 +247,59 @@ class TraktProgressService @Inject constructor(
                 }
                 updateRefreshBackoff(success)
             }
+        }
+    }
+
+    private suspend fun resetProfileScopedState() {
+        remoteProgress.value = emptyList()
+        optimisticProgress.value = emptyMap()
+        metadataState.value = emptyMap()
+        watchedMoviesState.value = emptySet()
+        watchedShowSeedsState.value = emptyList()
+        episodeProgressState.value = emptyMap()
+        hasLoadedRemoteProgress.value = false
+
+        cacheMutex.withLock {
+            cachedMoviesPlayback = null
+            cachedEpisodesPlayback = null
+            cachedUserStats = null
+            forceRefreshUntilMs = 0L
+            watchedMoviesUpdatedAtMs = 0L
+            watchedMoviesLastAttemptAtMs = 0L
+            hasLoadedWatchedMovies = false
+            watchedMoviesStale = true
+            watchedShowSeedsUpdatedAtMs = 0L
+            watchedShowSeedsLastAttemptAtMs = 0L
+            hasLoadedWatchedShowSeeds = false
+            watchedShowSeedsStale = true
+            lastFastSyncRequestMs = 0L
+            lastKnownActivityFingerprint = null
+            lastKnownMoviesWatchedAt = null
+            lastKnownEpisodeActivityFingerprint = null
+            lastManualRefreshSignalMs = 0L
+            metadataWarmupScheduled = false
+            consecutiveRefreshFailures = 0
+            refreshIntervalMs = baseRefreshIntervalMs
+            episodeProgressActivityVersion.set(0L)
+        }
+
+        metadataMutex.withLock {
+            inFlightMetadataKeys.clear()
+        }
+
+        watchedMoviesMutex.withLock {
+            watchedShowEpisodesMap = emptyMap()
+            showIdToTraktPathId = emptyMap()
+            episodeVideoIdCache.clear()
+        }
+
+        watchedShowSeedsMutex.withLock {
+            // No additional mutable state beyond atoms/caches reset above.
+        }
+
+        episodeProgressMutex.withLock {
+            inFlightEpisodeProgressKeys.clear()
+            episodeProgressLastAttemptAtMs.clear()
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktScrobbleService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktScrobbleService.kt
@@ -7,7 +7,6 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktIdsDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktMovieDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktScrobbleRequestDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktShowDto
-import com.nuvio.tv.core.profile.ProfileManager
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.abs
@@ -41,8 +40,7 @@ sealed interface TraktScrobbleItem {
 class TraktScrobbleService @Inject constructor(
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService,
-    private val traktProgressService: TraktProgressService,
-    private val profileManager: ProfileManager
+    private val traktProgressService: TraktProgressService
 ) {
     private data class ScrobbleStamp(
         val action: String,
@@ -72,7 +70,6 @@ class TraktScrobbleService @Inject constructor(
         item: TraktScrobbleItem,
         progressPercent: Float
     ) {
-        if (profileManager.activeProfileId.value != 1) return
         if (!traktAuthService.getCurrentAuthState().isAuthenticated) return
         if (!traktAuthService.hasRequiredCredentials()) return
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -596,12 +596,11 @@ class AccountViewModel @Inject constructor(
             )
             addonRepository.isSyncingFromRemote = false
 
-            val isPrimaryProfile = profileManager.activeProfileId.value == 1
-            val isTraktConnected = isPrimaryProfile && traktAuthDataStore.isAuthenticated.first()
+            val isTraktConnected = traktAuthDataStore.isAuthenticated.first()
             val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
             Log.d(
                 "AccountViewModel",
-                "pullRemoteData: isTraktConnected=$isTraktConnected isPrimaryProfile=$isPrimaryProfile shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
+                "pullRemoteData: isTraktConnected=$isTraktConnected shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
             )
             if (!isTraktConnected) {
                 watchProgressRepository.isSyncingFromRemote = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -10,7 +10,6 @@ import com.nuvio.tv.core.tmdb.TmdbMetadataService
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
-import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.TmdbSettingsDataStore
 import com.nuvio.tv.data.repository.ImdbEpisodeRatingsRepository
@@ -75,7 +74,6 @@ class MetaDetailsViewModel @Inject constructor(
     private val watchedItemsPreferences: WatchedItemsPreferences,
     private val trailerService: TrailerService,
     private val trailerSettingsDataStore: TrailerSettingsDataStore,
-    private val traktAuthDataStore: TraktAuthDataStore,
     private val traktCommentsService: TraktCommentsService,
     private val traktRelatedService: TraktRelatedService,
     private val traktSettingsDataStore: TraktSettingsDataStore,
@@ -162,7 +160,7 @@ class MetaDetailsViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 traktSettingsDataStore.showMetaComments,
-                traktAuthDataStore.isAuthenticated
+                traktCommentsService.authAvailableForComments
             ) { enabled, authenticated ->
                 enabled to authenticated
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -196,7 +196,6 @@ fun SettingsScreen(
                 SettingsCategory.DEBUG -> BuildConfig.IS_DEBUG_BUILD
                 SettingsCategory.PROFILES -> isPrimaryProfileActive
                 SettingsCategory.ACCOUNT -> isPrimaryProfileActive
-                SettingsCategory.TRAKT -> isPrimaryProfileActive
                 else -> true
             }
         }


### PR DESCRIPTION
## Summary
This PR updates Trakt behavior for multi-profile setups:

Trakt auth is now profile-scoped (each profile can have its own Trakt account).
Trakt comments now support a fallback for secondary profiles:
If the active profile has no Trakt auth, comments are fetched using profile 1 auth (comments-only fallback).
Primary-only Trakt gating was removed where it blocked multi-profile behavior.
Trakt-related caches/state are reset on profile switch to avoid cross-profile data bleed.

## PR type
Small Impromevement

## Why

There was clear demand from users (Reddit and Discord) for proper multi-profile Trakt support.
The core issue was that Trakt was effectively behaving as a single-account setup in multi-profile usage, which did not match how profiles are expected to work.

This PR prioritizes that need by enabling Trakt per profile (separate Trakt auth/state per profile), so each profile can use its own Trakt account independently.

Additionally, to preserve usability for households already relying on shared behavior, this includes a comments-only fallback: if a secondary profile has no Trakt login, Trakt comments can still be read via profile 1 auth.
Progress/scrobble/library remain profile-scoped.

## Policy check
[X] This PR is not cosmetic-only, unless it is a translation PR.
[X] This PR does not add a new major feature without prior approval.
[X]  This PR is small in scope and focused on one problem.
[]  If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Tested multi profiles with Trakt enabled sync.

## Screenshots / Video (UI changes only)
N/A

## Breaking changes

None. 

## Linked issues

On Discord and reddit