### PR TITLE
feat/subtitle-opacity: add opacity controls for subtitle text color

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.res.stringResource
+import kotlin.math.roundToInt
 import androidx.tv.material3.Card
 import androidx.tv.material3.Border
 import androidx.tv.material3.CardDefaults
@@ -840,6 +841,29 @@ private fun SubtitleStyleRail(
                 }
             }
             item {
+                OverlaySectionCard(title = stringResource(R.string.subtitle_style_text_opacity)) {
+                    val currentColor = Color(subtitleStyle.textColor)
+                    val currentAlphaPercent = (currentColor.alpha * 100f).roundToInt().coerceIn(0, 100)
+                    StepperRow(
+                        value = "$currentAlphaPercent%",
+                        onDecrease = {
+                            val newAlpha = (currentAlphaPercent - 10).coerceAtLeast(0) / 100f
+                            onEvent(PlayerEvent.OnSetSubtitleTextColor(currentColor.copy(alpha = newAlpha).toArgb()))
+                        },
+                        onIncrease = {
+                            val newAlpha = (currentAlphaPercent + 10).coerceAtMost(100) / 100f
+                            onEvent(PlayerEvent.OnSetSubtitleTextColor(currentColor.copy(alpha = newAlpha).toArgb()))
+                        },
+                        onMoveLeft = onMoveLeft,
+                        decrementFocusRequester = focusRequesters[StyleFocusKey.OpacityDecrease],
+                        incrementFocusRequester = focusRequesters[StyleFocusKey.OpacityIncrease],
+                        decrementFocusKey = StyleFocusKey.OpacityDecrease,
+                        incrementFocusKey = StyleFocusKey.OpacityIncrease,
+                        onFocusChanged = onStyleFocused
+                    )
+                }
+            }
+            item {
                 OverlaySectionCard(title = stringResource(R.string.subtitle_style_outline)) {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         ToggleChip(
@@ -1523,6 +1547,8 @@ private object StyleFocusKey {
     const val DelaySet = "delay_set"
     const val Reset = "reset"
     const val TextColorPrefix = "text_color"
+    const val OpacityDecrease = "opacity_decrease"
+    const val OpacityIncrease = "opacity_increase"
     const val OutlineColorPrefix = "outline_color"
 }
 
@@ -1538,9 +1564,10 @@ private fun styleListIndexForFocusKey(focusKey: String): Int {
         focusKey == StyleFocusKey.FontSizeDecrease || focusKey == StyleFocusKey.FontSizeIncrease -> 1
         focusKey == StyleFocusKey.Bold -> 2
         focusKey.startsWith("${StyleFocusKey.TextColorPrefix}:") -> 3
-        focusKey == StyleFocusKey.OutlineToggle || focusKey.startsWith("${StyleFocusKey.OutlineColorPrefix}:") -> 4
-        focusKey == StyleFocusKey.OffsetDecrease || focusKey == StyleFocusKey.OffsetIncrease -> 5
-        focusKey == StyleFocusKey.Reset -> 6
+        focusKey == StyleFocusKey.OpacityDecrease || focusKey == StyleFocusKey.OpacityIncrease -> 4
+        focusKey == StyleFocusKey.OutlineToggle || focusKey.startsWith("${StyleFocusKey.OutlineColorPrefix}:") -> 5
+        focusKey == StyleFocusKey.OffsetDecrease || focusKey == StyleFocusKey.OffsetIncrease -> 6
+        focusKey == StyleFocusKey.Reset -> 7
         else -> 0
     }
 }
@@ -1557,6 +1584,8 @@ private fun rememberStyleFocusRequesters(): Map<String, FocusRequester> {
             StyleFocusKey.FontSizeDecrease,
             StyleFocusKey.FontSizeIncrease,
             StyleFocusKey.Bold,
+            StyleFocusKey.OpacityDecrease,
+            StyleFocusKey.OpacityIncrease,
             StyleFocusKey.OutlineToggle,
             StyleFocusKey.OffsetDecrease,
             StyleFocusKey.OffsetIncrease,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleStyleSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleStyleSidePanel.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
+import kotlin.math.roundToInt
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -89,7 +91,7 @@ internal fun SubtitleStyleSidePanel(
     Column(
         modifier = modifier
             .width(760.dp)
-            .height(292.dp)
+            .height(330.dp)
             .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
             .background(Color(0xFF101010))
             .padding(start = 16.dp, end = 16.dp, top = 22.dp, bottom = 10.dp)
@@ -156,16 +158,46 @@ internal fun SubtitleStyleSidePanel(
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 SubtitleStyleSection(
                     title = stringResource(R.string.subtitle_style_text_color),
+                    centerContent = false,
                     modifier = Modifier
                         .width(StyleCardWidth)
-                        .height(StyleCardHeight)
+                        .height(140.dp)
                 ) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        PANEL_TEXT_COLORS.forEach { color ->
-                            SubtitleStyleColorChip(
-                                color = color,
-                                isSelected = subtitleStyle.textColor == color.toArgb(),
-                                onClick = { onEvent(PlayerEvent.OnSetSubtitleTextColor(color.toArgb())) }
+                    val currentAlphaPercent = (Color(subtitleStyle.textColor).alpha * 100f).roundToInt().coerceIn(0, 100)
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            PANEL_TEXT_COLORS.forEach { color ->
+                                SubtitleStyleColorChip(
+                                    color = color,
+                                    isSelected = Color(subtitleStyle.textColor).copy(alpha = 1f).toArgb() == color.copy(alpha = 1f).toArgb(),
+                                    onClick = {
+                                        val currentAlpha = Color(subtitleStyle.textColor).alpha
+                                        onEvent(PlayerEvent.OnSetSubtitleTextColor(color.copy(alpha = currentAlpha).toArgb()))
+                                    }
+                                )
+                            }
+                        }
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            SubtitleStyleStepperButton(
+                                icon = Icons.Default.Remove,
+                                onClick = {
+                                    val newAlpha = (currentAlphaPercent - 10).coerceAtLeast(0) / 100f
+                                    onEvent(PlayerEvent.OnSetSubtitleTextColor(Color(subtitleStyle.textColor).copy(alpha = newAlpha).toArgb()))
+                                }
+                            )
+                            SubtitleStyleValueDisplay(text = "$currentAlphaPercent%")
+                            SubtitleStyleStepperButton(
+                                icon = Icons.Default.Add,
+                                onClick = {
+                                    val newAlpha = (currentAlphaPercent + 10).coerceAtMost(100) / 100f
+                                    onEvent(PlayerEvent.OnSetSubtitleTextColor(Color(subtitleStyle.textColor).copy(alpha = newAlpha).toArgb()))
+                                }
                             )
                         }
                     }
@@ -344,6 +376,7 @@ private fun SubtitleStyleStepperButton(
 private fun SubtitleStyleValueDisplay(text: String) {
     Box(
         modifier = Modifier
+            .widthIn(min = 52.dp)
             .clip(RoundedCornerShape(10.dp))
             .background(Color.White.copy(alpha = 0.12f))
             .padding(horizontal = 10.dp, vertical = 5.dp),
@@ -352,7 +385,9 @@ private fun SubtitleStyleValueDisplay(text: String) {
         Text(
             text = text,
             style = MaterialTheme.typography.bodySmall,
-            color = Color.White
+            color = Color.White,
+            maxLines = 1,
+            softWrap = false
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -46,8 +46,10 @@ import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import kotlin.math.roundToInt
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -1062,6 +1064,13 @@ internal fun ColorSelectionDialog(
 ) {
     val focusRequester = remember { FocusRequester() }
 
+    val initialChip = colors.find { it.toArgb() == selectedColor.toArgb() }
+        ?: colors.find { it.copy(alpha = 1f).toArgb() == selectedColor.copy(alpha = 1f).toArgb() }
+        ?: colors.firstOrNull()
+        ?: selectedColor
+    var currentChipColor by remember { mutableStateOf(initialChip) }
+    var alphaPercent by remember { mutableIntStateOf((selectedColor.alpha * 100f).roundToInt().coerceIn(0, 100)) }
+
     NuvioDialog(
         onDismiss = onDismiss,
         title = title,
@@ -1070,7 +1079,7 @@ internal fun ColorSelectionDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(max = 240.dp)
+                .heightIn(max = 360.dp)
         ) {
             // Color grid using LazyRow for proper TV focus
             LazyRow(
@@ -1084,40 +1093,154 @@ internal fun ColorSelectionDialog(
                     val color = colors[index]
                     ColorOption(
                         color = color,
-                        isSelected = color.toArgb() == selectedColor.toArgb(),
+                        isSelected = color.toArgb() == currentChipColor.toArgb(),
                         isTransparent = color.alpha == 0f,
-                        onClick = { onColorSelected(color) }
+                        onClick = {
+                            currentChipColor = color
+                            if (color.alpha < 1f) {
+                                alphaPercent = (color.alpha * 100f).roundToInt().coerceIn(0, 100)
+                            }
+                        }
                     )
                 }
             }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Cancel button
-            Card(
-                onClick = onDismiss,
-                colors = CardDefaults.colors(
-                    containerColor = NuvioColors.BackgroundElevated,
-                    focusedContainerColor = NuvioColors.Primary
-                ),
-                border = CardDefaults.border(
-                    focusedBorder = Border(
-                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
-                        shape = RoundedCornerShape(8.dp)
-                    )
-                ),
-                shape = CardDefaults.shape(shape = RoundedCornerShape(8.dp)),
+            // Opacity stepper
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(
-                    text = stringResource(R.string.action_cancel),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = NuvioColors.TextPrimary,
-                    modifier = Modifier
-                        .padding(12.dp)
-                        .fillMaxWidth(),
-                    textAlign = TextAlign.Center
+                    text = stringResource(R.string.sub_opacity),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.width(70.dp)
                 )
+                Card(
+                    onClick = { alphaPercent = (alphaPercent - 10).coerceAtLeast(0) },
+                    colors = CardDefaults.colors(
+                        containerColor = NuvioColors.BackgroundElevated,
+                        focusedContainerColor = NuvioColors.Primary
+                    ),
+                    border = CardDefaults.border(
+                        focusedBorder = Border(
+                            border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                    ),
+                    shape = CardDefaults.shape(shape = RoundedCornerShape(8.dp))
+                ) {
+                    Text(
+                        text = "−",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = NuvioColors.TextPrimary,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+                // Progress bar
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(NuvioColors.BackgroundElevated)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(alphaPercent / 100f)
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(NuvioColors.Primary)
+                    )
+                }
+                Text(
+                    text = "$alphaPercent%",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextPrimary
+                )
+                Card(
+                    onClick = { alphaPercent = (alphaPercent + 10).coerceAtMost(100) },
+                    colors = CardDefaults.colors(
+                        containerColor = NuvioColors.BackgroundElevated,
+                        focusedContainerColor = NuvioColors.Primary
+                    ),
+                    border = CardDefaults.border(
+                        focusedBorder = Border(
+                            border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                    ),
+                    shape = CardDefaults.shape(shape = RoundedCornerShape(8.dp))
+                ) {
+                    Text(
+                        text = "+",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = NuvioColors.TextPrimary,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Cancel / Apply buttons
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Card(
+                    onClick = onDismiss,
+                    colors = CardDefaults.colors(
+                        containerColor = NuvioColors.BackgroundElevated,
+                        focusedContainerColor = NuvioColors.Primary
+                    ),
+                    border = CardDefaults.border(
+                        focusedBorder = Border(
+                            border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                    ),
+                    shape = CardDefaults.shape(shape = RoundedCornerShape(8.dp)),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = stringResource(R.string.action_cancel),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = NuvioColors.TextPrimary,
+                        modifier = Modifier
+                            .padding(12.dp)
+                            .fillMaxWidth(),
+                        textAlign = TextAlign.Center
+                    )
+                }
+                Card(
+                    onClick = { onColorSelected(currentChipColor.copy(alpha = alphaPercent / 100f)) },
+                    colors = CardDefaults.colors(
+                        containerColor = NuvioColors.BackgroundElevated,
+                        focusedContainerColor = NuvioColors.Primary
+                    ),
+                    border = CardDefaults.border(
+                        focusedBorder = Border(
+                            border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                    ),
+                    shape = CardDefaults.shape(shape = RoundedCornerShape(8.dp)),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = stringResource(R.string.action_apply),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = NuvioColors.TextPrimary,
+                        modifier = Modifier
+                            .padding(12.dp)
+                            .fillMaxWidth(),
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,8 @@
     <string name="cd_decrease">Decrease</string>
     <string name="cd_increase">Increase</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_apply">Apply</string>
+    <string name="sub_opacity">Opacity</string>
     <string name="action_none">None</string>
     <string name="action_close">Close</string>
 
@@ -897,6 +899,7 @@
     <string name="subtitle_style_font_size">Font Size</string>
     <string name="subtitle_style_bold">Bold</string>
     <string name="subtitle_style_text_color">Text Color</string>
+    <string name="subtitle_style_text_opacity">Text Opacity</string>
     <string name="subtitle_style_outline">Outline</string>
     <string name="subtitle_style_bottom_offset">Bottom Offset</string>
     <string name="subtitle_style_defaults">Defaults</string>


### PR DESCRIPTION
## Summary
Added a transparency/opacity slider to the subtitle color selection dialogs to control the opacity of subtitle text, background, and outline colors. Both the settings screen (ColorSelectionDialog) and the in-player quick panel (SubtitleStyleSidePanel) now include a slider / control for adjusting opacity in 10% increments.

## PR type
  * Feature addition

## Why
Previously, users had no way to adjust subtitle transparency beyond picking a predefined color. This change gives users control over subtitle opacity (0–100% in steps of 10), improving readability across different content and backgrounds.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
- Manually tested all three color dialogs (Text Color, Background Color, Outline Color) in PlaybackSettingsScreen
- Verified the opacity stepper increments/decrements by 10% and clamps at 0–100%
- Verified Cancel discards changes and Apply commits the selected color + alpha
- Tested the in-player SubtitleStyleSidePanel opacity stepper

## Screenshots / Video (UI changes only)

https://github.com/user-attachments/assets/1420364e-49ec-48a8-9196-f7d3d30d4957
<img width="1935" height="1119" alt="image" src="https://github.com/user-attachments/assets/64dc21f5-ecc6-48f7-aebb-22a2cdf6d7e8" />
<img width="1944" height="1118" alt="image" src="https://github.com/user-attachments/assets/3606b116-6f9d-4ba8-982e-54d2e8694597" />


## Breaking changes
None

## Linked issues
None