### PR TITLE
fix playback speed compatibility and player exit stability

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioOutputProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioOutputProvider.kt
@@ -16,16 +16,16 @@ internal class PlaybackSpeedAwareAudioOutputProvider(
     private var playbackSpeed: Float = 1f
 
     @Volatile
-    private var forcePcmForCurrentEac3Session: Boolean = false
+    private var forcePcmForCurrentSession: Boolean = false
 
-    fun updatePlaybackSpeed(speed: Float, selectedAudioIsEac3: Boolean = false) {
+    fun updatePlaybackSpeed(speed: Float, selectedAudioRequiresPcmForSpeed: Boolean = false) {
         val normalizedSpeed = speed.takeIf { it > 0f } ?: 1f
-        val wasForcingPcm = forcePcmForCurrentEac3Session
-        if (selectedAudioIsEac3 && normalizedSpeed != 1f) {
-            forcePcmForCurrentEac3Session = true
+        val wasForcingPcm = forcePcmForCurrentSession
+        if (selectedAudioRequiresPcmForSpeed && normalizedSpeed != 1f) {
+            forcePcmForCurrentSession = true
         }
         playbackSpeed = normalizedSpeed
-        val isForcingPcm = forcePcmForCurrentEac3Session
+        val isForcingPcm = forcePcmForCurrentSession
         if (wasForcingPcm != isForcingPcm) {
             listeners.forEach(AudioOutputProvider.Listener::onFormatSupportChanged)
         }
@@ -52,13 +52,33 @@ internal class PlaybackSpeedAwareAudioOutputProvider(
     }
 
     private fun shouldForcePcm(format: Format): Boolean {
-        if (!forcePcmForCurrentEac3Session) {
+        if (!forcePcmForCurrentSession) {
             return false
         }
-        return when (format.sampleMimeType) {
-            MimeTypes.AUDIO_E_AC3,
-            MimeTypes.AUDIO_E_AC3_JOC -> true
-            else -> format.codecs?.contains("ec-3", ignoreCase = true) == true
+        val mimeType = format.sampleMimeType
+        if (mimeType != null && (
+                mimeType == MimeTypes.AUDIO_E_AC3 ||
+                mimeType == MimeTypes.AUDIO_E_AC3_JOC ||
+                mimeType == MimeTypes.AUDIO_AC3 ||
+                mimeType == MimeTypes.AUDIO_AC4 ||
+                mimeType == MimeTypes.AUDIO_TRUEHD ||
+                mimeType == MimeTypes.AUDIO_DTS ||
+                mimeType == MimeTypes.AUDIO_DTS_HD ||
+                mimeType == MimeTypes.AUDIO_DTS_EXPRESS ||
+                mimeType.startsWith("audio/vnd.dts")
+            )
+        ) {
+            return true
         }
+        val codecs = format.codecs
+        if (codecs != null) {
+            return codecs.contains("ac-3", ignoreCase = true) ||
+                    codecs.contains("ac-4", ignoreCase = true) ||
+                    codecs.contains("ec-3", ignoreCase = true) ||
+                    codecs.contains("dts", ignoreCase = true) ||
+                    codecs.contains("truehd", ignoreCase = true) ||
+                    codecs.contains("dtshd", ignoreCase = true)
+        }
+        return false
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioOutputProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioOutputProvider.kt
@@ -1,0 +1,64 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.exoplayer.audio.AudioOutputProvider
+import androidx.media3.exoplayer.audio.ForwardingAudioOutputProvider
+import java.util.concurrent.CopyOnWriteArraySet
+
+internal class PlaybackSpeedAwareAudioOutputProvider(
+    audioOutputProvider: AudioOutputProvider
+) : ForwardingAudioOutputProvider(audioOutputProvider) {
+
+    private val listeners = CopyOnWriteArraySet<AudioOutputProvider.Listener>()
+
+    @Volatile
+    private var playbackSpeed: Float = 1f
+
+    @Volatile
+    private var forcePcmForCurrentEac3Session: Boolean = false
+
+    fun updatePlaybackSpeed(speed: Float, selectedAudioIsEac3: Boolean = false) {
+        val normalizedSpeed = speed.takeIf { it > 0f } ?: 1f
+        val wasForcingPcm = forcePcmForCurrentEac3Session
+        if (selectedAudioIsEac3 && normalizedSpeed != 1f) {
+            forcePcmForCurrentEac3Session = true
+        }
+        playbackSpeed = normalizedSpeed
+        val isForcingPcm = forcePcmForCurrentEac3Session
+        if (wasForcingPcm != isForcingPcm) {
+            listeners.forEach(AudioOutputProvider.Listener::onFormatSupportChanged)
+        }
+    }
+
+    override fun addListener(listener: AudioOutputProvider.Listener) {
+        listeners += listener
+        super.addListener(listener)
+    }
+
+    override fun removeListener(listener: AudioOutputProvider.Listener) {
+        listeners -= listener
+        super.removeListener(listener)
+    }
+
+    override fun getFormatSupport(formatConfig: AudioOutputProvider.FormatConfig): AudioOutputProvider.FormatSupport {
+        val support = super.getFormatSupport(formatConfig)
+        if (!shouldForcePcm(formatConfig.format) || support.supportLevel != AudioOutputProvider.FORMAT_SUPPORTED_DIRECTLY) {
+            return support
+        }
+        return AudioOutputProvider.FormatSupport.Builder()
+            .setFormatSupportLevel(AudioOutputProvider.FORMAT_UNSUPPORTED)
+            .build()
+    }
+
+    private fun shouldForcePcm(format: Format): Boolean {
+        if (!forcePcmForCurrentEac3Session) {
+            return false
+        }
+        return when (format.sampleMimeType) {
+            MimeTypes.AUDIO_E_AC3,
+            MimeTypes.AUDIO_E_AC3_JOC -> true
+            else -> format.codecs?.contains("ec-3", ignoreCase = true) == true
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -161,6 +161,8 @@ class PlayerRuntimeController(
     internal var _exoPlayer: ExoPlayer? = null
     val exoPlayer: ExoPlayer?
         get() = _exoPlayer
+    internal var playbackSpeedAwareAudioOutputProvider: PlaybackSpeedAwareAudioOutputProvider? = null
+    internal var isReleasingPlayer: Boolean = false
 
     internal var progressJob: Job? = null
     internal var hideControlsJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -231,7 +231,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                 setAudioAttributes(audioAttributes, true)
                 playbackSpeedAwareAudioOutputProvider?.updatePlaybackSpeed(
                     _uiState.value.playbackSpeed,
-                    selectedAudioIsEac3(this)
+                    selectedAudioRequiresPcmForSpeed(this)
                 )
                 setPlaybackSpeed(_uiState.value.playbackSpeed)
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -20,6 +20,7 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.ForwardingRenderer
 import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.audio.AudioTrackAudioOutputProvider
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -182,7 +183,9 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     selectedAddonSubtitle != null &&
                         PlayerSubtitleUtils.mimeTypeFromUrl(selectedAddonSubtitle.url) == MimeTypes.TEXT_VTT
                 },
-                gainAudioProcessor = gainAudioProcessor
+                gainAudioProcessor = gainAudioProcessor,
+                playbackSpeedProvider = { _uiState.value.playbackSpeed },
+                onPlaybackSpeedAwareAudioOutputProviderCreated = { playbackSpeedAwareAudioOutputProvider = it }
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc)
 
@@ -196,6 +199,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     .setMediaSourceFactory(DefaultMediaSourceFactory(context, extractorsFactory))
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
+                    .setReleaseTimeoutMs(3000)
                     .build()
             }
 
@@ -204,6 +208,7 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     .setLoadControl(loadControl)
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(context, extractorsFactory))
+                    .setReleaseTimeoutMs(3000)
                     .buildWithAssSupportCompat(
                         context = context,
                         renderType = libassRenderType,
@@ -224,6 +229,11 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
                     .build()
                 setAudioAttributes(audioAttributes, true)
+                playbackSpeedAwareAudioOutputProvider?.updatePlaybackSpeed(
+                    _uiState.value.playbackSpeed,
+                    selectedAudioIsEac3(this)
+                )
+                setPlaybackSpeed(_uiState.value.playbackSpeed)
 
                 
                 if (playerSettings.skipSilence) {
@@ -356,6 +366,9 @@ internal fun PlayerRuntimeController.initializePlayer(url: String, headers: Map<
                     }
 
                     override fun onPlayerError(error: PlaybackException) {
+                        if (isReleasingPlayer && error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) {
+                            return
+                        }
                         val detailedError = buildString {
                             append(error.message ?: "Playback error")
                             val cause = error.cause
@@ -582,7 +595,9 @@ private class SubtitleOffsetRenderersFactory(
     context: Context,
     private val subtitleDelayUsProvider: () -> Long,
     private val shouldNormalizeCuePositionProvider: () -> Boolean,
-    private val gainAudioProcessor: GainAudioProcessor
+    private val gainAudioProcessor: GainAudioProcessor,
+    private val playbackSpeedProvider: () -> Float,
+    private val onPlaybackSpeedAwareAudioOutputProviderCreated: (PlaybackSpeedAwareAudioOutputProvider) -> Unit
 ) : DefaultRenderersFactory(context) {
 
     override fun buildAudioSink(
@@ -590,11 +605,19 @@ private class SubtitleOffsetRenderersFactory(
         enableFloatOutput: Boolean,
         enableAudioTrackPlaybackParams: Boolean
     ): AudioSink {
+        val baseAudioOutputProvider = AudioTrackAudioOutputProvider.Builder(context)
+            .setAudioTrackBufferSizeProvider(FormatAwareAudioTrackBufferProvider())
+            .setMaxPlaybackSpeed(PLAYBACK_SPEEDS.maxOrNull() ?: 2f)
+            .build()
+        val audioOutputProvider = PlaybackSpeedAwareAudioOutputProvider(baseAudioOutputProvider)
+        audioOutputProvider.updatePlaybackSpeed(playbackSpeedProvider())
+        onPlaybackSpeedAwareAudioOutputProviderCreated(audioOutputProvider)
+
         return DefaultAudioSink.Builder(context)
             .setEnableFloatOutput(enableFloatOutput)
-            .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+            .setEnableAudioOutputPlaybackParameters(enableAudioTrackPlaybackParams)
             .setAudioProcessors(arrayOf(gainAudioProcessor))
-            .setAudioTrackBufferSizeProvider(FormatAwareAudioTrackBufferProvider())
+            .setAudioOutputProvider(audioOutputProvider)
             .build()
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -8,6 +8,7 @@ internal fun PlayerRuntimeController.releasePlayer() {
 }
 
 internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) {
+    isReleasingPlayer = true
     if (flushPlaybackState) {
         flushPlaybackSnapshotForSwitchOrExit()
     }
@@ -33,8 +34,16 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     nextEpisodeAutoPlayJob = null
     errorRetryJob?.cancel()
     errorRetryJob = null
-    _exoPlayer?.release()
+    _exoPlayer?.let { player ->
+        runCatching { player.playWhenReady = false }
+        runCatching { player.pause() }
+        runCatching { player.clearVideoSurface() }
+        runCatching { player.stop() }
+        runCatching { player.release() }
+    }
     _exoPlayer = null
+    playbackSpeedAwareAudioOutputProvider = null
+    isReleasingPlayer = false
 }
 
 internal fun PlayerRuntimeController.notifyAudioSessionUpdate(active: Boolean) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -560,10 +560,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSetPlaybackSpeed -> {
-            val selectedAudioIsEac3 = _exoPlayer?.let(::selectedAudioIsEac3) == true
+            val requiresPcm = _exoPlayer?.let(::selectedAudioRequiresPcmForSpeed) == true
             playbackSpeedAwareAudioOutputProvider?.updatePlaybackSpeed(
                 event.speed,
-                selectedAudioIsEac3 = selectedAudioIsEac3
+                selectedAudioRequiresPcmForSpeed = requiresPcm
             )
             _exoPlayer?.let { player ->
                 player.setPlaybackSpeed(event.speed)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -560,7 +560,14 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSetPlaybackSpeed -> {
-            _exoPlayer?.setPlaybackSpeed(event.speed)
+            val selectedAudioIsEac3 = _exoPlayer?.let(::selectedAudioIsEac3) == true
+            playbackSpeedAwareAudioOutputProvider?.updatePlaybackSpeed(
+                event.speed,
+                selectedAudioIsEac3 = selectedAudioIsEac3
+            )
+            _exoPlayer?.let { player ->
+                player.setPlaybackSpeed(event.speed)
+            }
             _uiState.update { 
                 it.copy(
                     playbackSpeed = event.speed,
@@ -634,6 +641,21 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             adjustSubtitleDelay(event.deltaMs)
         }
         PlayerEvent.OnShowSpeedDialog -> {
+            val state = _uiState.value
+            if (state.tunnelingEnabled) {
+                _uiState.update {
+                    it.copy(
+                        showAspectRatioIndicator = true,
+                        aspectRatioIndicatorText = context.getString(R.string.player_aspect_tunneling_unavailable)
+                    )
+                }
+                hideAspectRatioIndicatorJob?.cancel()
+                hideAspectRatioIndicatorJob = scope.launch {
+                    delay(1500)
+                    _uiState.update { it.copy(showAspectRatioIndicator = false) }
+                }
+                return
+            }
             _uiState.update {
                 it.copy(
                     showSpeedDialog = true,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -42,18 +42,36 @@ internal fun PlayerRuntimeController.showSeekOverlayTemporarily() {
     }
 }
 
-internal fun PlayerRuntimeController.selectedAudioIsEac3(player: Player): Boolean {
+internal fun PlayerRuntimeController.selectedAudioRequiresPcmForSpeed(player: Player): Boolean {
     player.currentTracks.groups.forEach { trackGroup ->
         if (trackGroup.type != C.TRACK_TYPE_AUDIO) return@forEach
         for (i in 0 until trackGroup.length) {
             if (!trackGroup.isTrackSelected(i)) continue
             val format = trackGroup.getTrackFormat(i)
-            val sampleMimeType = format.sampleMimeType
-            if (sampleMimeType == MimeTypes.AUDIO_E_AC3 || sampleMimeType == MimeTypes.AUDIO_E_AC3_JOC) {
+            val mimeType = format.sampleMimeType
+            if (mimeType != null && (
+                mimeType == MimeTypes.AUDIO_E_AC3 ||
+                mimeType == MimeTypes.AUDIO_E_AC3_JOC ||
+                mimeType == MimeTypes.AUDIO_AC3 ||
+                mimeType == MimeTypes.AUDIO_AC4 ||
+                mimeType == MimeTypes.AUDIO_TRUEHD ||
+                mimeType == MimeTypes.AUDIO_DTS ||
+                mimeType == MimeTypes.AUDIO_DTS_HD ||
+                mimeType == MimeTypes.AUDIO_DTS_EXPRESS ||
+                mimeType.startsWith("audio/vnd.dts")
+            )) {
                 return true
             }
-            if (format.codecs?.contains("ec-3", ignoreCase = true) == true) {
-                return true
+            val codecs = format.codecs
+            if (codecs != null) {
+                if (codecs.contains("ac-3", ignoreCase = true) ||
+                    codecs.contains("ac-4", ignoreCase = true) ||
+                    codecs.contains("ec-3", ignoreCase = true) ||
+                    codecs.contains("dts", ignoreCase = true) ||
+                    codecs.contains("truehd", ignoreCase = true) ||
+                    codecs.contains("dtshd", ignoreCase = true)) {
+                    return true
+                }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionOverride
 import com.nuvio.tv.domain.model.Subtitle
@@ -39,6 +40,24 @@ internal fun PlayerRuntimeController.showSeekOverlayTemporarily() {
         delay(1500)
         _uiState.update { it.copy(showSeekOverlay = false) }
     }
+}
+
+internal fun PlayerRuntimeController.selectedAudioIsEac3(player: Player): Boolean {
+    player.currentTracks.groups.forEach { trackGroup ->
+        if (trackGroup.type != C.TRACK_TYPE_AUDIO) return@forEach
+        for (i in 0 until trackGroup.length) {
+            if (!trackGroup.isTrackSelected(i)) continue
+            val format = trackGroup.getTrackFormat(i)
+            val sampleMimeType = format.sampleMimeType
+            if (sampleMimeType == MimeTypes.AUDIO_E_AC3 || sampleMimeType == MimeTypes.AUDIO_E_AC3_JOC) {
+                return true
+            }
+            if (format.codecs?.contains("ec-3", ignoreCase = true) == true) {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {


### PR DESCRIPTION
## Summary

- Improve playback speed handling for E-AC-3 audio by switching to a safer audio output path when speed is not 1x.
- Avoid false player errors during exit by hardening the release timeout flow.
- Block the Playback Speed dialog during tunneled playback and reuse the existing unavailable OSD.
- Add the supporting player runtime updates needed for these playback speed and exit fixes.

## PR type

- Bug fix

## Why



Playback speed does not work correctly with E-AC-3 audio. This change makes the player use a safer audio path for E-AC-3 when speed is not 1x.

Tunneled playback also does not support playback speed. The player now shows the existing unavailable OSD instead of opening the speed dialog.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manual testing completed by me:


- Play a stream with selected E-AC-3 audio, change playback speed away from 1x, and confirm playback continues with audio.
- Exit the player during playback and buffering, then confirm the app closes the player cleanly without showing a release-time timeout error.
- Enable tunneled or hardware playback, open Playback Speed, and confirm the dialog is blocked and the unavailable OSD is shown.
- Disable tunneled playback and confirm Playback Speed opens and still applies speed changes normally.

## Screenshots / Video (UI changes only)

Not included. The visible UI change is limited to reusing an existing unavailable OSD for the playback speed action during tunneled playback.

## Breaking changes

None.

## Linked issues

- Fixes #910
- Fixes #957

