### PR TITLE
Try to match CW to the Mobile Implementation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -135,8 +135,10 @@ class HomeViewModel @Inject constructor(
     internal var pendingExternalMetaPrefetchItemId: String? = null
     internal val prefetchedTmdbIds = Collections.synchronizedSet(mutableSetOf<String>())
     internal val cwMetaCache = Collections.synchronizedMap(mutableMapOf<String, Meta?>())
+    internal val cwMetaNegativeCacheTimestamps = Collections.synchronizedMap(mutableMapOf<String, Long>())
     internal val cwTmdbIdCache = Collections.synchronizedMap(mutableMapOf<String, String?>())
     internal val cwNextUpResolutionCache = Collections.synchronizedMap(mutableMapOf<String, NextUpResolution?>())
+    internal val cwNextUpNegativeCacheTimestamps = Collections.synchronizedMap(mutableMapOf<String, Long>())
     internal val discoveredOlderNextUpItems = Collections.synchronizedList(mutableListOf<ContinueWatchingItem.NextUp>())
     internal val fullyWatchedSeriesIds get() = watchedSeriesStateHolder
     internal var tmdbEnrichFocusJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -35,11 +35,12 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
-private const val CW_MAX_RECENT_PROGRESS_ITEMS = 150
-private const val CW_MAX_NEXT_UP_LOOKUPS = 15
+private const val CW_MAX_RECENT_PROGRESS_ITEMS = 300
+private const val CW_MAX_NEXT_UP_LOOKUPS = 24
 private const val CW_MAX_NEXT_UP_CONCURRENCY = 4
 private const val CW_MAX_ENRICHMENT_CONCURRENCY = 4
 private const val CW_PROGRESS_DEBOUNCE_MS = 500L
@@ -984,12 +985,29 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
     synchronized(cwNextUpResolutionCache) {
         if (cwNextUpResolutionCache.containsKey(cacheKey)) {
             val cached = cwNextUpResolutionCache[cacheKey]
-            debug?.recordNextUpCacheHit(
-                progress = progress,
-                resolved = cached != null,
-                showUnairedNextUp = showUnairedNextUp
-            )
-            return cached
+            if (cached != null) {
+                debug?.recordNextUpCacheHit(
+                    progress = progress,
+                    resolved = true,
+                    showUnairedNextUp = showUnairedNextUp
+                )
+                return cached
+            }
+            // Negative cache entry — check TTL
+            val negativeCachedAt = cwNextUpNegativeCacheTimestamps[cacheKey]
+            if (negativeCachedAt != null &&
+                SystemClock.elapsedRealtime() - negativeCachedAt < CW_META_NEGATIVE_CACHE_TTL_MS
+            ) {
+                debug?.recordNextUpCacheHit(
+                    progress = progress,
+                    resolved = false,
+                    showUnairedNextUp = showUnairedNextUp
+                )
+                return null
+            }
+            // TTL expired — retry
+            cwNextUpResolutionCache.remove(cacheKey)
+            cwNextUpNegativeCacheTimestamps.remove(cacheKey)
         }
     }
     val contentId = progress.contentId
@@ -1008,6 +1026,7 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         )
         synchronized(cwNextUpResolutionCache) {
             cwNextUpResolutionCache[cacheKey] = null
+            cwNextUpNegativeCacheTimestamps[cacheKey] = SystemClock.elapsedRealtime()
         }
         return null
     }
@@ -1022,10 +1041,15 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         logNextUpDecision("drop contentId=$contentId name=${progress.name} reason=no-meta-for-seed")
         synchronized(cwNextUpResolutionCache) {
             cwNextUpResolutionCache[cacheKey] = null
+            cwNextUpNegativeCacheTimestamps[cacheKey] = SystemClock.elapsedRealtime()
         }
         return null
     }
-    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp) ?: run {
+    val nextVideo = run {
+        // Fetch watched episodes for this show to skip already-watched episodes (matching mobile)
+        val watchedEpisodes = watchProgressRepository.getWatchedShowEpisodes()[contentId]
+        resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp, watchedEpisodes)
+    } ?: run {
         debug?.recordNextUpResult(
             progress = progress,
             reason = "no-next-video-after-seed",
@@ -1034,6 +1058,7 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         )
         synchronized(cwNextUpResolutionCache) {
             cwNextUpResolutionCache[cacheKey] = null
+            cwNextUpNegativeCacheTimestamps[cacheKey] = SystemClock.elapsedRealtime()
         }
         return null
     }
@@ -1078,10 +1103,13 @@ private fun resolveNextUpVideoFromMeta(
     meta: Meta
 ): Video? = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp = true)
 
+private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
+
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: Meta,
-    showUnairedNextUp: Boolean
+    showUnairedNextUp: Boolean,
+    watchedEpisodes: Set<Pair<Int, Int>>? = null
 ): Video? {
     val episodes = meta.videos
         .filter { video ->
@@ -1107,6 +1135,13 @@ private fun resolveNextUpVideoFromMeta(
 
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
+        // Skip already-watched episodes (matching mobile's isAlreadyWatched)
+        if (watchedEpisodes != null && video.season != null && video.episode != null) {
+            if ((video.season!! to video.episode!!) in watchedEpisodes) {
+                return@firstOrNull false
+            }
+        }
+
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != seedSeason
         if (isSeasonRollover) {
@@ -1119,6 +1154,13 @@ private fun resolveNextUpVideoFromMeta(
             }
             if (!releaseDate.isAfter(todayLocal)) {
                 return@firstOrNull true
+            }
+            // Match mobile: show unaired next-season episodes within 7-day window
+            if (showUnairedNextUp) {
+                val daysUntil = java.time.temporal.ChronoUnit.DAYS.between(todayLocal, releaseDate)
+                if (daysUntil <= CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS) {
+                    return@firstOrNull true
+                }
             }
             return@firstOrNull false
         }
@@ -1143,6 +1185,8 @@ private fun resolveNextUpVideoFromMeta(
     return nextVideo
 }
 
+private const val CW_META_NEGATIVE_CACHE_TTL_MS = 5 * 60_000L
+
 private suspend fun HomeViewModel.resolveMetaForProgress(
     progress: WatchProgress,
     metaCache: MutableMap<String, Meta?>,
@@ -1152,8 +1196,20 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
     val cacheKey = "${progress.contentType}:${progress.contentId}"
     synchronized(metaCache) {
         if (metaCache.containsKey(cacheKey)) {
-            debug?.recordMetaCacheHit(progress)
-            return metaCache[cacheKey]
+            val cached = metaCache[cacheKey]
+            if (cached != null) {
+                debug?.recordMetaCacheHit(progress)
+                return cached
+            }
+            val negativeCachedAt = cwMetaNegativeCacheTimestamps[cacheKey]
+            if (negativeCachedAt != null &&
+                SystemClock.elapsedRealtime() - negativeCachedAt < CW_META_NEGATIVE_CACHE_TTL_MS
+            ) {
+                debug?.recordMetaCacheHit(progress)
+                return null
+            }
+            metaCache.remove(cacheKey)
+            cwMetaNegativeCacheTimestamps.remove(cacheKey)
         }
     }
 
@@ -1227,6 +1283,11 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
 
     synchronized(metaCache) {
         metaCache[cacheKey] = resolved
+        if (resolved == null) {
+            cwMetaNegativeCacheTimestamps[cacheKey] = SystemClock.elapsedRealtime()
+        } else {
+            cwMetaNegativeCacheTimestamps.remove(cacheKey)
+        }
     }
     return resolved
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1104,8 +1104,7 @@ private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: Meta,
-    showUnairedNextUp: Boolean,
-    watchedEpisodes: Set<Pair<Int, Int>>? = null
+    showUnairedNextUp: Boolean
 ): Video? {
     val episodes = meta.videos
         .filter { video ->
@@ -1131,13 +1130,6 @@ private fun resolveNextUpVideoFromMeta(
 
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
-        // Skip already-watched episodes (matching mobile's isAlreadyWatched)
-        if (watchedEpisodes != null && video.season != null && video.episode != null) {
-            if ((video.season!! to video.episode!!) in watchedEpisodes) {
-                return@firstOrNull false
-            }
-        }
-
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != seedSeason
         if (isSeasonRollover) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1045,11 +1045,7 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         }
         return null
     }
-    val nextVideo = run {
-        // Fetch watched episodes for this show to skip already-watched episodes (matching mobile)
-        val watchedEpisodes = watchProgressRepository.getWatchedShowEpisodes()[contentId]
-        resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp, watchedEpisodes)
-    } ?: run {
+    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp) ?: run {
         debug?.recordNextUpResult(
             progress = progress,
             reason = "no-next-video-after-seed",


### PR DESCRIPTION
## Summary

Align Continue Watching (CW) pipeline on TV with the mobile implementation to fix missing/disappearing items.

Changes:
- Raise `CW_MAX_RECENT_PROGRESS_ITEMS` from 150 -> 300 and `CW_MAX_NEXT_UP_LOOKUPS` from 15 -> 24 (matching mobile constants)
- ~~Add watched episodes skip in Next Up resolution - previously TV picked the very next episode after the seed, even if it was already watched; now it skips watched episodes like mobile does via `getWatchedShowEpisodes()`~~
- Add 7-day window for unaired next-season episodes - mobile shows upcoming season premieres within 7 days, TV was dropping them entirely
- Add 5-minute TTL on negative meta/next-up cache - previously a failed meta resolve (addon timeout) cached `null` forever, permanently dropping items until app restart; now retries after 5 minutes

## PR type

- Bug fix

## Why

Multiple users reported that CW on TV is missing items that appear correctly on mobile. After comparing both implementations, possible causes were: lower item caps cutting off entries, no watched-episode skipping causing wrong Next Up picks, no unaired season window, and permanent negative caching silently dropping items when addons were temporarily slow.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

[Test build](http://morigal.pl/upload/app-universal-benchmark-cw.apk) provided for users that reported issues with CW for confirmation if changes do anything for them

## Screenshots / Video (UI changes only)

no visual changes, only data pipeline fixes.

## Breaking changes

nothing should break, although there is a chance CW might work worse, not better ><

## Linked issues

Maybe #1066 
