### PR TITLE
CW pipeline overhaul: caching, batch ops, dropped show filtering, flicker fixes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
@@ -167,4 +167,39 @@ class WatchedItemsSyncService @Inject constructor(
             Result.failure(e)
         }
     }
+
+    suspend fun deleteFromRemoteBatch(
+        contentId: String,
+        episodes: List<Pair<Int, Int>>
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            if (!shouldUseSupabaseWatchProgressSync()) {
+                return@withContext Result.success(Unit)
+            }
+            if (episodes.isEmpty()) return@withContext Result.success(Unit)
+
+            val profileId = profileManager.activeProfileId.value
+            val params = buildJsonObject {
+                put("p_profile_id", profileId)
+                put("p_keys", buildJsonArray {
+                    episodes.forEach { (season, episode) ->
+                        addJsonObject {
+                            put("content_id", contentId)
+                            put("season", season)
+                            put("episode", episode)
+                        }
+                    }
+                })
+            }
+            withJwtRefreshRetry {
+                postgrest.rpc("sync_delete_watched_items", params)
+            }
+
+            Log.d(TAG, "Batch deleted ${episodes.size} watched items from remote for $contentId profile $profileId")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to batch delete watched items from remote", e)
+            Result.failure(e)
+        }
+    }
 }

--- a/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
@@ -1,0 +1,146 @@
+package com.nuvio.tv.data.local
+
+import android.content.Context
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.nuvio.tv.core.profile.ProfileManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class CwEnrichmentEntry(
+    val episodeThumbnail: String? = null,
+    val episodeDescription: String? = null,
+    val episodeImdbRating: Float? = null,
+    val genres: List<String> = emptyList(),
+    val releaseInfo: String? = null,
+    val backdrop: String? = null,
+    val poster: String? = null,
+    val logo: String? = null,
+    val name: String? = null
+)
+
+data class CachedNextUpItem(
+    val contentId: String,
+    val contentType: String,
+    val name: String,
+    val poster: String?,
+    val backdrop: String?,
+    val logo: String?,
+    val videoId: String,
+    val season: Int,
+    val episode: Int,
+    val episodeTitle: String?,
+    val episodeDescription: String? = null,
+    val thumbnail: String?,
+    val released: String? = null,
+    val hasAired: Boolean = true,
+    val airDateLabel: String? = null,
+    val lastWatched: Long,
+    val imdbRating: Float? = null,
+    val genres: List<String> = emptyList(),
+    val releaseInfo: String? = null,
+    val sortTimestamp: Long,
+    val releaseTimestamp: Long? = null,
+    val isReleaseAlert: Boolean = false,
+    val isNewSeasonRelease: Boolean = false,
+    val seedSeason: Int? = null,
+    val seedEpisode: Int? = null
+)
+
+@Singleton
+class ContinueWatchingEnrichmentCache @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val profileManager: ProfileManager
+) {
+    companion object {
+        private const val TAG = "CwEnrichCache"
+    }
+
+    private val gson = Gson()
+    private val mutex = Mutex()
+
+    private fun cacheFile(): File {
+        val profileId = profileManager.activeProfileId.value
+        val dir = File(context.cacheDir, "cw_enrichment")
+        dir.mkdirs()
+        return File(dir, "profile_${profileId}.json")
+    }
+
+    suspend fun getAll(): Map<String, CwEnrichmentEntry> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            try {
+                val file = cacheFile()
+                if (!file.exists()) return@withContext emptyMap()
+                val json = file.readText()
+                gson.fromJson(json, object : TypeToken<Map<String, CwEnrichmentEntry>>() {}.type)
+                    ?: emptyMap()
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to read cache: ${e.message}")
+                emptyMap()
+            }
+        }
+    }
+
+    suspend fun save(entries: Map<String, CwEnrichmentEntry>) = withContext(Dispatchers.IO) {
+        if (entries.isEmpty()) return@withContext
+        mutex.withLock {
+            try {
+                val file = cacheFile()
+                val existing = if (file.exists()) {
+                    try {
+                        gson.fromJson<Map<String, CwEnrichmentEntry>>(
+                            file.readText(),
+                            object : TypeToken<Map<String, CwEnrichmentEntry>>() {}.type
+                        ) ?: emptyMap()
+                    } catch (_: Exception) { emptyMap() }
+                } else emptyMap()
+                val merged = existing.toMutableMap()
+                merged.putAll(entries)
+                file.writeText(gson.toJson(merged))
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to write cache: ${e.message}")
+            }
+        }
+    }
+
+    // --- Next Up snapshot cache ---
+
+    private fun nextUpFile(): File {
+        val profileId = profileManager.activeProfileId.value
+        val dir = File(context.cacheDir, "cw_enrichment")
+        dir.mkdirs()
+        return File(dir, "nextup_${profileId}.json")
+    }
+
+    suspend fun getNextUpSnapshot(): List<CachedNextUpItem> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            try {
+                val file = nextUpFile()
+                if (!file.exists()) return@withContext emptyList()
+                gson.fromJson(file.readText(), object : TypeToken<List<CachedNextUpItem>>() {}.type)
+                    ?: emptyList()
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to read next-up cache: ${e.message}")
+                emptyList()
+            }
+        }
+    }
+
+    suspend fun saveNextUpSnapshot(items: List<CachedNextUpItem>) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            try {
+                val file = nextUpFile()
+                file.writeText(gson.toJson(items))
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to write next-up cache: ${e.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
@@ -54,6 +54,28 @@ data class CachedNextUpItem(
     val seedEpisode: Int? = null
 )
 
+data class CachedInProgressItem(
+    val contentId: String,
+    val contentType: String,
+    val name: String,
+    val poster: String?,
+    val backdrop: String?,
+    val logo: String?,
+    val videoId: String,
+    val season: Int?,
+    val episode: Int?,
+    val episodeTitle: String?,
+    val position: Long,
+    val duration: Long,
+    val lastWatched: Long,
+    val progressPercent: Float?,
+    val episodeThumbnail: String? = null,
+    val episodeDescription: String? = null,
+    val episodeImdbRating: Float? = null,
+    val genres: List<String> = emptyList(),
+    val releaseInfo: String? = null
+)
+
 @Singleton
 class ContinueWatchingEnrichmentCache @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -140,6 +162,40 @@ class ContinueWatchingEnrichmentCache @Inject constructor(
                 file.writeText(gson.toJson(items))
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to write next-up cache: ${e.message}")
+            }
+        }
+    }
+
+    // --- In-progress snapshot cache ---
+
+    private fun inProgressFile(): File {
+        val profileId = profileManager.activeProfileId.value
+        val dir = File(context.cacheDir, "cw_enrichment")
+        dir.mkdirs()
+        return File(dir, "inprogress_${profileId}.json")
+    }
+
+    suspend fun getInProgressSnapshot(): List<CachedInProgressItem> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            try {
+                val file = inProgressFile()
+                if (!file.exists()) return@withContext emptyList()
+                gson.fromJson(file.readText(), object : TypeToken<List<CachedInProgressItem>>() {}.type)
+                    ?: emptyList()
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to read in-progress cache: ${e.message}")
+                emptyList()
+            }
+        }
+    }
+
+    suspend fun saveInProgressSnapshot(items: List<CachedInProgressItem>) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            try {
+                val file = inProgressFile()
+                file.writeText(gson.toJson(items))
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to write in-progress cache: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
@@ -14,18 +14,6 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
-data class CwEnrichmentEntry(
-    val episodeThumbnail: String? = null,
-    val episodeDescription: String? = null,
-    val episodeImdbRating: Float? = null,
-    val genres: List<String> = emptyList(),
-    val releaseInfo: String? = null,
-    val backdrop: String? = null,
-    val poster: String? = null,
-    val logo: String? = null,
-    val name: String? = null
-)
-
 data class CachedNextUpItem(
     val contentId: String,
     val contentType: String,
@@ -87,50 +75,6 @@ class ContinueWatchingEnrichmentCache @Inject constructor(
 
     private val gson = Gson()
     private val mutex = Mutex()
-
-    private fun cacheFile(): File {
-        val profileId = profileManager.activeProfileId.value
-        val dir = File(context.cacheDir, "cw_enrichment")
-        dir.mkdirs()
-        return File(dir, "profile_${profileId}.json")
-    }
-
-    suspend fun getAll(): Map<String, CwEnrichmentEntry> = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            try {
-                val file = cacheFile()
-                if (!file.exists()) return@withContext emptyMap()
-                val json = file.readText()
-                gson.fromJson(json, object : TypeToken<Map<String, CwEnrichmentEntry>>() {}.type)
-                    ?: emptyMap()
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to read cache: ${e.message}")
-                emptyMap()
-            }
-        }
-    }
-
-    suspend fun save(entries: Map<String, CwEnrichmentEntry>) = withContext(Dispatchers.IO) {
-        if (entries.isEmpty()) return@withContext
-        mutex.withLock {
-            try {
-                val file = cacheFile()
-                val existing = if (file.exists()) {
-                    try {
-                        gson.fromJson<Map<String, CwEnrichmentEntry>>(
-                            file.readText(),
-                            object : TypeToken<Map<String, CwEnrichmentEntry>>() {}.type
-                        ) ?: emptyMap()
-                    } catch (_: Exception) { emptyMap() }
-                } else emptyMap()
-                val merged = existing.toMutableMap()
-                merged.putAll(entries)
-                file.writeText(gson.toJson(merged))
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to write cache: ${e.message}")
-            }
-        }
-    }
 
     // --- Next Up snapshot cache ---
 

--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -207,7 +207,7 @@ class LayoutPreferenceDataStore @Inject constructor(
     }
 
     val preferExternalMetaAddonDetail: Flow<Boolean> = profileFlow { prefs ->
-        prefs[preferExternalMetaAddonDetailKey] ?: false
+        prefs[preferExternalMetaAddonDetailKey] ?: true
     }
 
     val hideUnreleasedContent: Flow<Boolean> = profileFlow { prefs ->

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -57,8 +57,8 @@ class WatchProgressPreferences @Inject constructor(
                 }
             }
 
-            contentLevelEntries.values
-                .sortedByDescending { it.lastWatched }
+            val result = contentLevelEntries.values.sortedByDescending { it.lastWatched }
+            result
         }
     }
 
@@ -176,6 +176,23 @@ class WatchProgressPreferences @Inject constructor(
     }
 
     /**
+     * Remove watch progress for multiple episodes in a single DataStore transaction.
+     */
+    suspend fun removeProgressBatch(contentId: String, episodes: List<Pair<Int, Int>>) {
+        if (episodes.isEmpty()) return
+        store().edit { preferences ->
+            val json = preferences[watchProgressKey] ?: "{}"
+            val map = parseProgressMap(json).toMutableMap()
+            for ((season, episode) in episodes) {
+                map.remove("${contentId}_s${season}e${episode}")
+            }
+            map.remove(contentId)
+            Log.d(TAG, "removeProgressBatch contentId=$contentId removed=${episodes.size} episodes entriesAfter=${map.size}")
+            preferences[watchProgressKey] = gson.toJson(map)
+        }
+    }
+
+    /**
      * Mark content as completed
      */
     suspend fun markAsCompleted(progress: WatchProgress) {
@@ -196,6 +213,29 @@ class WatchProgressPreferences @Inject constructor(
             lastWatched = System.currentTimeMillis()
         )
         saveProgress(completedProgress)
+    }
+
+    /**
+     * Mark multiple items as completed in a single DataStore transaction.
+     */
+    suspend fun markAsCompletedBatch(progressList: List<WatchProgress>) {
+        if (progressList.isEmpty()) return
+        val rawEntries = getAllRawEntries()
+        val now = System.currentTimeMillis()
+        val completed = progressList.map { progress ->
+            val effectiveDuration = if (progress.duration <= 1L) {
+                val key = createKey(progress)
+                rawEntries[key]?.duration?.takeIf { it > 1L } ?: progress.duration
+            } else {
+                progress.duration
+            }
+            progress.copy(
+                position = effectiveDuration,
+                duration = effectiveDuration,
+                lastWatched = now
+            )
+        }
+        saveProgressBatch(completed)
     }
 
     /**
@@ -289,7 +329,7 @@ class WatchProgressPreferences @Inject constructor(
                 val seriesKey = progress.contentId
                 val existingSeriesProgress = map[seriesKey]
 
-                if (existingSeriesProgress == null || progress.lastWatched > existingSeriesProgress.lastWatched) {
+                if (existingSeriesProgress == null || progress.lastWatched >= existingSeriesProgress.lastWatched) {
                     map[seriesKey] = progress.copy(videoId = progress.videoId)
                 }
             }
@@ -299,11 +339,11 @@ class WatchProgressPreferences @Inject constructor(
     private fun mergeDisplayMetadata(remote: WatchProgress, existing: WatchProgress?): WatchProgress {
         if (existing == null) return remote
         return remote.copy(
-            name = remote.name.takeIf { it.isNotBlank() } ?: existing.name,
-            poster = remote.poster ?: existing.poster,
-            backdrop = remote.backdrop ?: existing.backdrop,
-            logo = remote.logo ?: existing.logo,
-            episodeTitle = remote.episodeTitle ?: existing.episodeTitle,
+            name = existing.name.takeIf { it.isNotBlank() } ?: remote.name.takeIf { it.isNotBlank() } ?: existing.name,
+            poster = existing.poster ?: remote.poster,
+            backdrop = existing.backdrop ?: remote.backdrop,
+            logo = existing.logo ?: remote.logo,
+            episodeTitle = existing.episodeTitle ?: remote.episodeTitle,
             addonBaseUrl = remote.addonBaseUrl ?: existing.addonBaseUrl
         )
     }

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -79,6 +79,22 @@ class WatchedItemsPreferences @Inject constructor(
         }
     }
 
+    suspend fun markAsWatchedBatch(items: List<WatchedItem>) {
+        if (items.isEmpty()) return
+        store().edit { preferences ->
+            val current = preferences[watchedItemsKey] ?: emptySet()
+            val newKeys = items.map { Triple(it.contentId, it.season, it.episode) }.toSet()
+            val filtered = current.filterNot { json ->
+                runCatching {
+                    gson.fromJson(json, WatchedItem::class.java)
+                }.getOrNull()?.let { existing ->
+                    Triple(existing.contentId, existing.season, existing.episode) in newKeys
+                } ?: false
+            }
+            preferences[watchedItemsKey] = filtered.toSet() + items.map { gson.toJson(it) }
+        }
+    }
+
     suspend fun unmarkAsWatched(contentId: String, season: Int? = null, episode: Int? = null) {
         store().edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
@@ -89,6 +105,22 @@ class WatchedItemsPreferences @Inject constructor(
                     existing.contentId == contentId &&
                         existing.season == season &&
                         existing.episode == episode
+                } ?: false
+            }
+            preferences[watchedItemsKey] = filtered.toSet()
+        }
+    }
+
+    suspend fun unmarkAsWatchedBatch(contentId: String, episodes: List<Pair<Int, Int>>) {
+        if (episodes.isEmpty()) return
+        val removeKeys = episodes.map { (s, e) -> Triple(contentId, s, e) }.toSet()
+        store().edit { preferences ->
+            val current = preferences[watchedItemsKey] ?: emptySet()
+            val filtered = current.filterNot { json ->
+                runCatching {
+                    gson.fromJson(json, WatchedItem::class.java)
+                }.getOrNull()?.let { existing ->
+                    Triple(existing.contentId, existing.season, existing.episode) in removeKeys
                 } ?: false
             }
             preferences[watchedItemsKey] = filtered.toSet()

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
@@ -33,6 +33,7 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktUserSettingsResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktUserStatsResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktWatchedMovieItemDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktWatchedShowItemDto
+import com.nuvio.tv.data.remote.dto.trakt.TraktHiddenItemDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -114,6 +115,15 @@ interface TraktApi {
         @Header("Authorization") authorization: String,
         @Query("extended") extended: String? = null
     ): Response<List<TraktWatchedShowItemDto>>
+
+    @GET("users/hidden/{section}")
+    suspend fun getHiddenItems(
+        @Header("Authorization") authorization: String,
+        @Path("section") section: String,
+        @Query("type") type: String? = null,
+        @Query("page") page: Int = 1,
+        @Query("limit") limit: Int = 100
+    ): Response<List<TraktHiddenItemDto>>
 
     @GET("sync/history/episodes")
     suspend fun getEpisodeHistory(

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/trakt/TraktSyncDtos.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/trakt/TraktSyncDtos.kt
@@ -196,3 +196,11 @@ data class TraktHistoryItemDto(
     @Json(name = "show") val show: TraktShowDto? = null,
     @Json(name = "episode") val episode: TraktEpisodeDto? = null
 )
+
+@JsonClass(generateAdapter = true)
+data class TraktHiddenItemDto(
+    @Json(name = "hidden_at") val hiddenAt: String? = null,
+    @Json(name = "type") val type: String? = null,
+    @Json(name = "show") val show: TraktShowDto? = null,
+    @Json(name = "movie") val movie: TraktMovieDto? = null
+)

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1773,6 +1773,94 @@ class TraktProgressService @Inject constructor(
             !notFound.episodes.isNullOrEmpty()
     }
 
+    /**
+     * Mark multiple episodes as watched on Trakt in a single API call.
+     * Groups episodes by show and sends one POST /sync/history request.
+     */
+    suspend fun markSeasonWatchedBatch(progressList: List<WatchProgress>) {
+        if (progressList.isEmpty()) return
+        val first = progressList.first()
+        val ids = resolveHistoryIds(first)
+        if (!ids.hasAnyId()) {
+            Log.w(TAG, "markSeasonWatchedBatch: no valid Trakt IDs for ${first.contentId}")
+            return
+        }
+        val watchedAt = toTraktUtcDateTime(System.currentTimeMillis())
+        val episodesBySeason = progressList
+            .filter { it.season != null && it.episode != null }
+            .groupBy { it.season!! }
+            .mapValues { (_, episodes) ->
+                episodes.map { ep ->
+                    TraktHistoryEpisodeAddDto(
+                        number = ep.episode,
+                        watchedAt = watchedAt
+                    )
+                }
+            }
+        val body = TraktHistoryAddRequestDto(
+            shows = listOf(
+                TraktHistoryShowAddDto(
+                    title = first.name.takeIf { it.isNotBlank() },
+                    year = null,
+                    ids = ids,
+                    seasons = episodesBySeason.map { (seasonNumber, episodes) ->
+                        TraktHistorySeasonAddDto(
+                            number = seasonNumber,
+                            episodes = episodes
+                        )
+                    }
+                )
+            )
+        )
+        Log.d(TAG, "markSeasonWatchedBatch: ${progressList.size} episodes in ${episodesBySeason.size} season(s)")
+        val response = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
+            traktApi.addHistory(authHeader, body)
+        }
+        Log.d(TAG, "markSeasonWatchedBatch RESPONSE: code=${response?.code()} " +
+            "added=${response?.body()?.added}")
+        if (response?.isSuccessful != true) {
+            throw IllegalStateException("Trakt batch mark watched failed (${response?.code()})")
+        }
+        refreshNow()
+    }
+
+    /**
+     * Remove multiple episodes from Trakt history in a single API call.
+     */
+    suspend fun removeSeasonFromHistoryBatch(
+        contentId: String,
+        episodes: List<Pair<Int, Int>>
+    ) {
+        if (episodes.isEmpty()) return
+        val ids = toTraktIds(parseContentIds(contentId))
+        if (!ids.hasAnyId()) {
+            Log.w(TAG, "removeSeasonFromHistoryBatch: no valid Trakt IDs for $contentId")
+            return
+        }
+        val episodesBySeason = episodes.groupBy { it.first }
+        val body = TraktHistoryRemoveRequestDto(
+            shows = listOf(
+                TraktHistoryShowRemoveDto(
+                    ids = ids,
+                    seasons = episodesBySeason.map { (seasonNumber, eps) ->
+                        TraktHistorySeasonRemoveDto(
+                            number = seasonNumber,
+                            episodes = eps.map { (_, episodeNumber) ->
+                                TraktHistoryEpisodeRemoveDto(number = episodeNumber)
+                            }
+                        )
+                    }
+                )
+            )
+        )
+        Log.d(TAG, "removeSeasonFromHistoryBatch: ${episodes.size} episodes in ${episodesBySeason.size} season(s)")
+        val response = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
+            traktApi.removeHistory(authHeader, body)
+        }
+        Log.d(TAG, "removeSeasonFromHistoryBatch RESPONSE: code=${response?.code()}")
+        refreshNow()
+    }
+
     private fun buildHistoryAddRequest(
         progress: WatchProgress,
         title: String?,

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -148,7 +148,7 @@ class TraktProgressService @Inject constructor(
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
     private val watchedMoviesState = MutableStateFlow<Set<String>>(emptySet())
     private val watchedShowSeedsState = MutableStateFlow<List<WatchProgress>>(emptyList())
-    /** Content IDs of shows hidden from progress_watched on Trakt (dropped shows). */
+    /** Content IDs of shows dropped on Trakt (from users/hidden/dropped). */
     @Volatile
     private var hiddenProgressShowIds: Set<String> = emptySet()
     private var hiddenProgressShowsLoadedAtMs: Long = 0L
@@ -976,7 +976,7 @@ class TraktProgressService @Inject constructor(
             val response = traktAuthService.executeAuthorizedRequest { authHeader ->
                 traktApi.getHiddenItems(
                     authorization = authHeader,
-                    section = "progress_watched",
+                    section = "dropped",
                     type = "show",
                     page = page,
                     limit = limit

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -148,6 +148,11 @@ class TraktProgressService @Inject constructor(
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
     private val watchedMoviesState = MutableStateFlow<Set<String>>(emptySet())
     private val watchedShowSeedsState = MutableStateFlow<List<WatchProgress>>(emptyList())
+    /** Content IDs of shows hidden from progress_watched on Trakt (dropped shows). */
+    @Volatile
+    private var hiddenProgressShowIds: Set<String> = emptySet()
+    private var hiddenProgressShowsLoadedAtMs: Long = 0L
+    private val hiddenProgressShowsMutex = Mutex()
     /** Per-show set of watched (season, episode) pairs from /sync/watched/shows. */
     @Volatile
     private var watchedShowEpisodesMap: Map<String, Set<Pair<Int, Int>>> = emptyMap()
@@ -348,6 +353,7 @@ class TraktProgressService @Inject constructor(
             remote.forEach { mergedByKey[progressKey(it)] = it }
             validOptimistic.forEach { (key, value) -> mergedByKey[key] = value }
             mergedByKey.values
+                .filter { !isShowHiddenFromProgress(it.contentId) }
                 .map { enrichWithMetadata(it, metadata) }
                 .sortedByDescending { it.lastWatched }
         }
@@ -364,6 +370,7 @@ class TraktProgressService @Inject constructor(
             .onStart {
                 emit(getWatchedShowSeedsSnapshot(forceRefresh = false))
             }
+            .map { seeds -> seeds.filter { !isShowHiddenFromProgress(it.contentId) } }
             .distinctUntilChanged()
     }
 
@@ -795,6 +802,7 @@ class TraktProgressService @Inject constructor(
         if (!force && watchedShowSeedsStale && hasLoadedWatchedShowSeeds) {
             getWatchedShowSeedsSnapshot(forceRefresh = true)
         }
+        ensureHiddenProgressShows(force = force)
     }
 
     private suspend fun hasActivityChanged(): Boolean {
@@ -931,6 +939,62 @@ class TraktProgressService @Inject constructor(
         if (!entry.hasCompletedSnapshot) return false
         if (entry.activityVersion != episodeProgressActivityVersion.get()) return false
         return now - entry.updatedAtMs <= episodeProgressCacheTtlMs
+    }
+
+    /**
+     * Returns true if the given content ID belongs to a show hidden from
+     * Trakt's "progress watched" section (i.e. dropped/abandoned shows).
+     */
+    fun isShowHiddenFromProgress(contentId: String): Boolean {
+        val ids = hiddenProgressShowIds
+        if (ids.isEmpty()) return false
+        val canonical = canonicalLookupKey(contentId)
+        return ids.contains(contentId) || ids.contains(canonical)
+    }
+
+    private suspend fun ensureHiddenProgressShows(force: Boolean) {
+        val now = System.currentTimeMillis()
+        val ttlMs = 30 * 60_000L // refresh every 30 minutes
+        hiddenProgressShowsMutex.withLock {
+            if (!force && hiddenProgressShowsLoadedAtMs > 0 && now - hiddenProgressShowsLoadedAtMs < ttlMs) {
+                return
+            }
+        }
+        val ids = fetchHiddenProgressShowIds()
+        hiddenProgressShowsMutex.withLock {
+            hiddenProgressShowIds = ids
+            hiddenProgressShowsLoadedAtMs = System.currentTimeMillis()
+        }
+        trace("hidden-progress-shows refreshed: ${ids.size} shows")
+    }
+
+    private suspend fun fetchHiddenProgressShowIds(): Set<String> {
+        val allIds = mutableSetOf<String>()
+        var page = 1
+        val limit = 100
+        while (true) {
+            val response = traktAuthService.executeAuthorizedRequest { authHeader ->
+                traktApi.getHiddenItems(
+                    authorization = authHeader,
+                    section = "progress_watched",
+                    type = "show",
+                    page = page,
+                    limit = limit
+                )
+            } ?: break
+            if (!response.isSuccessful) break
+            val items = response.body().orEmpty()
+            if (items.isEmpty()) break
+            for (item in items) {
+                val ids = item.show?.ids ?: continue
+                ids.imdb?.takeIf { it.isNotBlank() }?.let { allIds.add(it) }
+                ids.tmdb?.let { allIds.add("tmdb:$it") }
+                ids.trakt?.let { allIds.add("trakt:$it") }
+            }
+            if (items.size < limit) break
+            page++
+        }
+        return allIds
     }
 
     private suspend fun getWatchedMoviesSnapshot(forceRefresh: Boolean): Set<String> {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -148,9 +148,8 @@ class TraktProgressService @Inject constructor(
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
     private val watchedMoviesState = MutableStateFlow<Set<String>>(emptySet())
     private val watchedShowSeedsState = MutableStateFlow<List<WatchProgress>>(emptyList())
-    /** Content IDs of shows dropped on Trakt (from users/hidden/dropped). */
-    @Volatile
-    private var hiddenProgressShowIds: Set<String> = emptySet()
+    /** Content IDs of shows dropped on Trakt (from users/hidden/progress_watched). */
+    private val hiddenProgressShowIds = MutableStateFlow<Set<String>>(emptySet())
     private var hiddenProgressShowsLoadedAtMs: Long = 0L
     private val hiddenProgressShowsMutex = Mutex()
     /** Per-show set of watched (season, episode) pairs from /sync/watched/shows. */
@@ -337,8 +336,9 @@ class TraktProgressService @Inject constructor(
             remoteProgress,
             optimisticProgress,
             metadataState,
-            hasLoadedRemoteProgress
-        ) { remote, optimistic, metadata, loaded ->
+            hasLoadedRemoteProgress,
+            hiddenProgressShowIds
+        ) { remote, optimistic, metadata, loaded, hiddenIds ->
             val now = System.currentTimeMillis()
             val validOptimistic = optimistic
                 .filterValues { it.expiresAtMs > now }
@@ -346,16 +346,20 @@ class TraktProgressService @Inject constructor(
 
             // Avoid emitting a transient empty state before first remote fetch completes.
             if (!loaded && remote.isEmpty() && validOptimistic.isEmpty()) {
+                Log.d(TAG, "observeAllProgress: skipping emission (loaded=$loaded remote=${remote.size} optimistic=${validOptimistic.size})")
                 return@combine null
             }
 
             val mergedByKey = linkedMapOf<String, WatchProgress>()
             remote.forEach { mergedByKey[progressKey(it)] = it }
             validOptimistic.forEach { (key, value) -> mergedByKey[key] = value }
-            mergedByKey.values
+            val hiddenCount = mergedByKey.values.count { isShowHiddenFromProgress(it.contentId) }
+            val result = mergedByKey.values
                 .filter { !isShowHiddenFromProgress(it.contentId) }
                 .map { enrichWithMetadata(it, metadata) }
                 .sortedByDescending { it.lastWatched }
+            Log.d(TAG, "observeAllProgress: remote=${remote.size} optimistic=${validOptimistic.size} hidden=$hiddenCount result=${result.size}")
+            result
         }
             .filterNotNull()
             .distinctUntilChanged()
@@ -366,12 +370,13 @@ class TraktProgressService @Inject constructor(
     }
 
     fun observeWatchedShowSeeds(): Flow<List<WatchProgress>> {
-        return watchedShowSeedsState
-            .onStart {
-                emit(getWatchedShowSeedsSnapshot(forceRefresh = false))
-            }
-            .map { seeds -> seeds.filter { !isShowHiddenFromProgress(it.contentId) } }
-            .distinctUntilChanged()
+        return combine(
+            watchedShowSeedsState
+                .onStart { emit(getWatchedShowSeedsSnapshot(forceRefresh = false)) },
+            hiddenProgressShowIds
+        ) { seeds, _ ->
+            seeds.filter { !isShowHiddenFromProgress(it.contentId) }
+        }.distinctUntilChanged()
     }
 
     /**
@@ -786,6 +791,9 @@ class TraktProgressService @Inject constructor(
 
         if (!force && !hasActivityChanged()) return
 
+        // Load dropped shows first so all downstream flows emit pre-filtered data.
+        ensureHiddenProgressShows(force = force)
+
         if ((force || watchedMoviesStale) && hasLoadedWatchedMovies) {
             getWatchedMoviesSnapshot(forceRefresh = true)
         }
@@ -795,6 +803,7 @@ class TraktProgressService @Inject constructor(
         }
 
         val snapshot = fetchAllProgressSnapshot(force = force)
+        Log.d(TAG, "refreshRemoteSnapshot: snapshot size=${snapshot.size}, setting remoteProgress")
         remoteProgress.value = snapshot
         hasLoadedRemoteProgress.value = true
         reconcileOptimistic(snapshot)
@@ -802,7 +811,6 @@ class TraktProgressService @Inject constructor(
         if (!force && watchedShowSeedsStale && hasLoadedWatchedShowSeeds) {
             getWatchedShowSeedsSnapshot(forceRefresh = true)
         }
-        ensureHiddenProgressShows(force = force)
     }
 
     private suspend fun hasActivityChanged(): Boolean {
@@ -946,7 +954,7 @@ class TraktProgressService @Inject constructor(
      * Trakt's "progress watched" section (i.e. dropped/abandoned shows).
      */
     fun isShowHiddenFromProgress(contentId: String): Boolean {
-        val ids = hiddenProgressShowIds
+        val ids = hiddenProgressShowIds.value
         if (ids.isEmpty()) return false
         val canonical = canonicalLookupKey(contentId)
         return ids.contains(contentId) || ids.contains(canonical)
@@ -962,10 +970,13 @@ class TraktProgressService @Inject constructor(
         }
         val ids = fetchHiddenProgressShowIds()
         hiddenProgressShowsMutex.withLock {
-            hiddenProgressShowIds = ids
+            hiddenProgressShowIds.value = ids
             hiddenProgressShowsLoadedAtMs = System.currentTimeMillis()
         }
         trace("hidden-progress-shows refreshed: ${ids.size} shows")
+        if (ids.isNotEmpty()) {
+            Log.d(TAG, "hidden-progress-shows IDs: ${ids.take(20)}")
+        }
     }
 
     private suspend fun fetchHiddenProgressShowIds(): Set<String> {
@@ -982,11 +993,18 @@ class TraktProgressService @Inject constructor(
                     limit = limit
                 )
             } ?: break
-            if (!response.isSuccessful) break
+            Log.d(TAG, "fetchDroppedShows: page=$page code=${response.code()}")
+            if (!response.isSuccessful) {
+                Log.w(TAG, "fetchDroppedShows: failed code=${response.code()}")
+                break
+            }
             val items = response.body().orEmpty()
+            Log.d(TAG, "fetchDroppedShows: page=$page items=${items.size}")
             if (items.isEmpty()) break
             for (item in items) {
                 val ids = item.show?.ids ?: continue
+                val title = item.show?.title ?: "?"
+                Log.d(TAG, "fetchDroppedShows: show='$title' imdb=${ids.imdb} tmdb=${ids.tmdb} trakt=${ids.trakt}")
                 ids.imdb?.takeIf { it.isNotBlank() }?.let { allIds.add(it) }
                 ids.tmdb?.let { allIds.add("tmdb:$it") }
                 ids.trakt?.let { allIds.add("trakt:$it") }
@@ -1350,12 +1368,15 @@ class TraktProgressService @Inject constructor(
 
     private suspend fun fetchAllProgressSnapshot(force: Boolean = false): List<WatchProgress> {
         val recentCompletedEpisodes = fetchRecentEpisodeHistorySnapshot()
+        Log.d(TAG, "fetchAllProgress: recentCompletedEpisodes=${recentCompletedEpisodes.size}")
         val playbackStartAt = recentWatchWindowMs()?.let { windowMs ->
             toTraktUtcDateTime(System.currentTimeMillis() - windowMs)
         }
         val inProgressMovies = getPlayback("movies", force = force, startAt = playbackStartAt).mapNotNull { mapPlaybackMovie(it) }
+        Log.d(TAG, "fetchAllProgress: inProgressMovies=${inProgressMovies.size}")
         val inProgressEpisodes = getPlayback("episodes", force = force, startAt = playbackStartAt)
             .mapNotNull { mapPlaybackEpisode(it, applyAddonRemap = true) }
+        Log.d(TAG, "fetchAllProgress: inProgressEpisodes=${inProgressEpisodes.size}")
 
         val mergedByKey = linkedMapOf<String, WatchProgress>()
 
@@ -1372,6 +1393,7 @@ class TraktProgressService @Inject constructor(
             }
 
         return mergedByKey.values.sortedByDescending { it.lastWatched }
+            .also { Log.d(TAG, "fetchAllProgress: total merged=${it.size}") }
     }
 
     private suspend fun fetchRecentEpisodeHistorySnapshot(): List<WatchProgress> {

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -651,6 +651,52 @@ class WatchProgressRepositoryImpl @Inject constructor(
         triggerWatchedItemsSync()
     }
 
+    override suspend fun removeFromHistoryBatch(
+        contentId: String,
+        videoId: String?,
+        episodes: List<Pair<Int, Int>>
+    ) {
+        if (episodes.isEmpty()) return
+        val useTraktProgress = shouldUseTraktProgress()
+        val hasEffectiveTraktConnection = hasEffectiveTraktConnection()
+
+        // Batch local removes (single DataStore transaction each)
+        watchProgressPreferences.removeProgressBatch(contentId, episodes)
+        watchedItemsPreferences.unmarkAsWatchedBatch(contentId, episodes)
+
+        // Batch Trakt remove (single API call)
+        if (hasEffectiveTraktConnection) {
+            episodes.forEach { (season, episode) ->
+                traktProgressService.applyOptimisticRemoval(contentId, season, episode)
+            }
+            runCatching {
+                traktProgressService.removeSeasonFromHistoryBatch(contentId, episodes)
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to batch remove from Trakt history", error)
+            }
+        }
+
+        if (!useTraktProgress) {
+            val remoteDeleteKeys = episodes.flatMap { (season, episode) ->
+                listOf("${contentId}_s${season}e${episode}")
+            } + contentId
+            if (authManager.isAuthenticated && remoteDeleteKeys.isNotEmpty()) {
+                watchProgressSyncService.deleteFromRemote(remoteDeleteKeys.distinct())
+                    .onFailure { error ->
+                        Log.w(TAG, "removeFromHistoryBatch remote delete failed", error)
+                    }
+            }
+            if (authManager.isAuthenticated) {
+                watchedItemsSyncService.deleteFromRemoteBatch(contentId, episodes)
+                    .onFailure { error ->
+                        Log.w(TAG, "removeFromHistoryBatch watched item remote delete failed", error)
+                    }
+            }
+            triggerRemoteSync()
+            triggerWatchedItemsSync()
+        }
+    }
+
     override suspend fun markAsCompleted(progress: WatchProgress) {
         // Clear any CW dismiss keys for this series so it reappears in Continue Watching.
         if (progress.contentType.equals("series", ignoreCase = true) ||
@@ -728,6 +774,86 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 Log.w(TAG, "Failed to mirror completed state to Trakt", error)
             }
         }
+        triggerRemoteSync()
+        triggerWatchedItemsSync()
+    }
+
+    override suspend fun markAsCompletedBatch(progressList: List<WatchProgress>) {
+        if (progressList.isEmpty()) return
+        val firstProgress = progressList.first()
+        // Clear CW dismiss keys once for the series
+        if (firstProgress.contentType.equals("series", ignoreCase = true) ||
+            firstProgress.contentType.equals("tv", ignoreCase = true)) {
+            traktSettingsDataStore.removeDismissedNextUpKeysForContent(firstProgress.contentId)
+        }
+        val useTraktProgress = shouldUseTraktProgress()
+        val hasEffectiveTraktConnection = hasEffectiveTraktConnection()
+        val now = System.currentTimeMillis()
+
+        val completedList = progressList.map { progress ->
+            val duration = progress.duration.takeIf { it > 0L } ?: 1L
+            progress.copy(
+                position = duration,
+                duration = duration,
+                progressPercent = 100f,
+                lastWatched = now
+            )
+        }
+
+        if (useTraktProgress && hasEffectiveTraktConnection) {
+            // Trakt is primary — optimistic update + batch Trakt call + local save
+            completedList.forEach {
+                optimisticContinueWatchingUpdates.tryEmit(it)
+                traktProgressService.applyOptimisticProgress(it)
+            }
+            runCatching {
+                traktProgressService.markSeasonWatchedBatch(completedList)
+            }.onFailure {
+                completedList.forEach { ep ->
+                    traktProgressService.applyOptimisticRemoval(ep.contentId, ep.season, ep.episode)
+                }
+                throw it
+            }
+            // Also save locally for offline access
+            watchProgressPreferences.markAsCompletedBatch(progressList)
+            val watchedItems = progressList.map { progress ->
+                WatchedItem(
+                    contentId = progress.contentId,
+                    contentType = progress.contentType,
+                    title = progress.name,
+                    season = progress.season,
+                    episode = progress.episode,
+                    watchedAt = now
+                )
+            }
+            watchedItemsPreferences.markAsWatchedBatch(watchedItems)
+            return
+        }
+
+        // Nuvio sync is primary — batch local save first
+        watchProgressPreferences.markAsCompletedBatch(progressList)
+        val watchedItems = progressList.map { progress ->
+            WatchedItem(
+                contentId = progress.contentId,
+                contentType = progress.contentType,
+                title = progress.name,
+                season = progress.season,
+                episode = progress.episode,
+                watchedAt = now
+            )
+        }
+        watchedItemsPreferences.markAsWatchedBatch(watchedItems)
+
+        // Mirror to Trakt if connected (same as single markAsCompleted)
+        if (hasEffectiveTraktConnection) {
+            completedList.forEach { optimisticContinueWatchingUpdates.tryEmit(it) }
+            runCatching {
+                traktProgressService.markSeasonWatchedBatch(completedList)
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to mirror batch mark watched to Trakt", error)
+            }
+        }
+
         triggerRemoteSync()
         triggerWatchedItemsSync()
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -867,6 +867,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
         watchProgressPreferences.clearAll()
     }
 
+    override fun isDroppedShow(contentId: String): Boolean {
+        return traktProgressService.isShowHiddenFromProgress(contentId)
+    }
+
     private fun progressKey(progress: WatchProgress): String {
         return if (progress.season != null && progress.episode != null) {
             "${progress.contentId}_s${progress.season}e${progress.episode}"

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -88,6 +88,21 @@ interface WatchProgressRepository {
      * Mark content as completed
      */
     suspend fun markAsCompleted(progress: WatchProgress)
+
+    /**
+     * Mark multiple episodes as completed in a single batch operation.
+     * More efficient than calling [markAsCompleted] in a loop.
+     */
+    suspend fun markAsCompletedBatch(progressList: List<WatchProgress>)
+
+    /**
+     * Remove multiple episodes from history in a single batch operation.
+     */
+    suspend fun removeFromHistoryBatch(
+        contentId: String,
+        videoId: String?,
+        episodes: List<Pair<Int, Int>>
+    )
     
     /**
      * Clear all watch progress

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -108,4 +108,9 @@ interface WatchProgressRepository {
      * Clear all watch progress
      */
     suspend fun clearAll()
+
+    /**
+     * Returns true if the show is dropped/hidden from progress on the active source.
+     */
+    fun isDroppedShow(contentId: String): Boolean
 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -72,6 +72,9 @@ private val BadgeShape = RoundedCornerShape(4.dp)
 private val CwNewEpisodeBadgeColor = Color(0xFF1D4ED8)
 private val CwNewSeasonBadgeColor = Color(0xFFB45309)
 
+/** URLs that failed to load — skip them immediately on next recomposition. */
+internal val brokenImageUrls = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun ContinueWatchingSection(
@@ -274,26 +277,43 @@ fun ContinueWatchingCard(
     }
     val progressFraction = remember(progress) { progress?.progressPercentage ?: 0f }
     val imageModel = remember(nextUp, progress, item) {
+        fun firstNonBroken(vararg candidates: String?): String? {
+            return candidates.firstOrNull { !it.isNullOrBlank() && it !in brokenImageUrls }?.trim()
+        }
         when {
-            nextUp != null && !nextUp.hasAired -> firstNonBlank(
+            nextUp != null && !nextUp.hasAired -> firstNonBroken(
                 nextUp.backdrop,
                 nextUp.poster,
-                nextUp.thumbnail,
-                progress?.backdrop,
-                progress?.poster
+                nextUp.thumbnail
             )
-            nextUp != null -> firstNonBlank(
+            nextUp != null -> firstNonBroken(
                 nextUp.thumbnail,
                 nextUp.backdrop,
                 nextUp.poster
             )
-            else -> firstNonBlank(
+            else -> firstNonBroken(
                 (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail,
                 progress?.backdrop,
                 progress?.poster
             )
         }
     }
+    val fallbackImageModel = remember(nextUp, progress, item) {
+        when {
+            nextUp != null -> firstNonBlank(
+                nextUp.backdrop,
+                nextUp.poster
+            )
+            else -> firstNonBlank(
+                progress?.backdrop,
+                progress?.poster
+            )
+        }
+    }
+    var usesFallbackImage by remember { mutableStateOf(false) }
+    // Reset fallback state when the item changes
+    LaunchedEffect(imageModel) { usesFallbackImage = false }
+    val effectiveImageModel = if (usesFallbackImage) fallbackImageModel else imageModel
     val titleText = remember(progress, nextUp) { progress?.name ?: nextUp?.name.orEmpty() }
     val context = LocalContext.current
     val strAirsDateForEpisode = nextUp?.airDateLabel?.let { stringResource(R.string.cw_airs_date, it) }
@@ -312,11 +332,11 @@ fun ContinueWatchingCard(
         with(density) { imageHeight.roundToPx() }
     }
     val shouldBlur = blurUnwatchedEpisodes && nextUp != null
-    val imageRequest = remember(imageModel, requestWidthPx, requestHeightPx, shouldBlur) {
+    val imageRequest = remember(effectiveImageModel, requestWidthPx, requestHeightPx, shouldBlur) {
         ImageRequest.Builder(context)
-            .data(imageModel)
+            .data(effectiveImageModel)
             .crossfade(false)
-            .memoryCacheKey("${imageModel}_${requestWidthPx}x${requestHeightPx}_blur${shouldBlur}")
+            .memoryCacheKey("${effectiveImageModel}_${requestWidthPx}x${requestHeightPx}_blur${shouldBlur}")
             .size(width = requestWidthPx, height = requestHeightPx)
             .apply {
                 if (shouldBlur) transformations(com.nuvio.tv.ui.util.BlurTransformation())
@@ -389,7 +409,7 @@ fun ContinueWatchingCard(
                     .clip(CwClipShape)
             ) {
                 // Background image with size hints for efficient decoding
-                if (imageModel.isNullOrBlank()) {
+                if (effectiveImageModel.isNullOrBlank()) {
                     MonochromePosterPlaceholder()
                 } else {
                     AsyncImage(
@@ -399,7 +419,16 @@ fun ContinueWatchingCard(
                         placeholder = backgroundPainter,
                         error = backgroundPainter,
                         fallback = backgroundPainter,
-                        contentScale = ContentScale.Crop
+                        contentScale = ContentScale.Crop,
+                        onError = {
+                            // Primary image failed (e.g. broken thumbnail URL) — remember and try fallback.
+                            if (!usesFallbackImage && effectiveImageModel != null) {
+                                brokenImageUrls.add(effectiveImageModel)
+                                if (fallbackImageModel != null && fallbackImageModel != effectiveImageModel) {
+                                    usesFallbackImage = true
+                                }
+                            }
+                        }
                     )
                 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -106,6 +106,7 @@ class MetaDetailsViewModel @Inject constructor(
     private var trailerDelayMs = 7000L
     private var trailerAutoplayEnabled = false
     private var trailerHasPlayed = false
+    private var suppressSeasonAutoSwitch = false
 
     private var isPlayButtonFocused = false
     private var hideUnreleasedContent = false
@@ -233,7 +234,8 @@ class MetaDetailsViewModel @Inject constructor(
             if (state.nextToWatch == nextToWatch) return@update state
             val nextSeason = nextToWatch.nextSeason
             val meta = state.meta
-            val shouldSwitchSeason = nextSeason != null &&
+            val shouldSwitchSeason = !suppressSeasonAutoSwitch &&
+                nextSeason != null &&
                 nextSeason != state.selectedSeason &&
                 meta != null &&
                 state.seasons.contains(nextSeason)
@@ -1628,6 +1630,7 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun markSeasonWatched(season: Int) {
         val meta = _uiState.value.meta ?: return
+        suppressSeasonAutoSwitch = true
         viewModelScope.launch {
             val episodes = meta.videos.filter { it.season == season && it.episode != null }
             val unwatched = episodes.filter { video ->
@@ -1647,26 +1650,23 @@ class MetaDetailsViewModel @Inject constructor(
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKeys)
             }
 
-            var marked = 0
-            for (video in unwatched) {
-                val key = episodePendingKey(video)
-                runCatching {
-                    watchProgressRepository.markAsCompleted(buildCompletedEpisodeProgress(meta, video))
-                    marked++
-                }.onFailure { error ->
-                    Log.w(TAG, "Failed to mark S${video.season}E${video.episode} as watched: ${error.message}")
-                }
-                _uiState.update {
-                    it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - key)
-                }
+            runCatching {
+                val progressList = unwatched.map { buildCompletedEpisodeProgress(meta, it) }
+                watchProgressRepository.markAsCompletedBatch(progressList)
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to batch mark season $season as watched: ${error.message}")
             }
 
-            showMessage(context.getString(R.string.detail_marked_episodes_watched, marked))
+            _uiState.update {
+                it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
+            }
+            showMessage(context.getString(R.string.detail_marked_episodes_watched, unwatched.size))
         }
     }
 
     private fun markSeasonUnwatched(season: Int) {
         val meta = _uiState.value.meta ?: return
+        suppressSeasonAutoSwitch = true
         viewModelScope.launch {
             val episodes = meta.videos.filter { it.season == season && it.episode != null }
             val watched = episodes.filter { video ->
@@ -1685,21 +1685,21 @@ class MetaDetailsViewModel @Inject constructor(
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKeys)
             }
 
-            var unmarked = 0
-            for (video in watched) {
-                val key = episodePendingKey(video)
-                runCatching {
-                    watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = resolveFallbackVideoId(), season = video.season!!, episode = video.episode!!)
-                    unmarked++
-                }.onFailure { error ->
-                    Log.w(TAG, "Failed to unmark S${video.season}E${video.episode}: ${error.message}")
-                }
-                _uiState.update {
-                    it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - key)
-                }
+            runCatching {
+                val episodePairs = watched.map { it.season!! to it.episode!! }
+                watchProgressRepository.removeFromHistoryBatch(
+                    contentId = _effectiveContentId.value,
+                    videoId = resolveFallbackVideoId(),
+                    episodes = episodePairs
+                )
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to batch unmark season $season: ${error.message}")
             }
 
-            showMessage(context.getString(R.string.detail_marked_episodes_unwatched, unmarked))
+            _uiState.update {
+                it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
+            }
+            showMessage(context.getString(R.string.detail_marked_episodes_unwatched, watched.size))
         }
     }
 
@@ -1729,21 +1729,17 @@ class MetaDetailsViewModel @Inject constructor(
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKeys)
             }
 
-            var marked = 0
-            for (ep in unwatched) {
-                val key = episodePendingKey(ep)
-                runCatching {
-                    watchProgressRepository.markAsCompleted(buildCompletedEpisodeProgress(meta, ep))
-                    marked++
-                }.onFailure { error ->
-                    Log.w(TAG, "Failed to mark S${ep.season}E${ep.episode} as watched: ${error.message}")
-                }
-                _uiState.update {
-                    it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - key)
-                }
+            runCatching {
+                val progressList = unwatched.map { buildCompletedEpisodeProgress(meta, it) }
+                watchProgressRepository.markAsCompletedBatch(progressList)
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to batch mark previous episodes as watched: ${error.message}")
             }
 
-            showMessage(context.getString(R.string.detail_marked_previous_watched, marked))
+            _uiState.update {
+                it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
+            }
+            showMessage(context.getString(R.string.detail_marked_previous_watched, unwatched.size))
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -141,8 +141,10 @@ class HomeViewModel @Inject constructor(
     internal var externalMetaPrefetchJob: Job? = null
     internal var pendingExternalMetaPrefetchItemId: String? = null
     internal val prefetchedTmdbIds = Collections.synchronizedSet(mutableSetOf<String>())
-    internal val cwMetaCache = Collections.synchronizedMap(mutableMapOf<String, Meta?>())
+    internal val cwMetaCache = Collections.synchronizedMap(mutableMapOf<String, CwMetaSummary?>())
     internal val cwMetaNegativeCacheTimestamps = Collections.synchronizedMap(mutableMapOf<String, Long>())
+    /** Ultra-light cache for badge evaluation: contentId → set of aired (season, episode) pairs. */
+    internal val cwBadgeEpisodeCache = Collections.synchronizedMap(mutableMapOf<String, Set<Pair<Int, Int>>?>())
     internal val cwTmdbIdCache = Collections.synchronizedMap(mutableMapOf<String, String?>())
     internal val cwNextUpResolutionCache = Collections.synchronizedMap(mutableMapOf<String, NextUpResolution?>())
     internal val cwNextUpNegativeCacheTimestamps = Collections.synchronizedMap(mutableMapOf<String, Long>())

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -16,6 +16,7 @@ import com.nuvio.tv.data.local.MDBListSettingsDataStore
 import com.nuvio.tv.data.local.TmdbSettingsDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchedItemsPreferences
+import com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache
 import com.nuvio.tv.data.trailer.TrailerService
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
@@ -67,7 +68,8 @@ class HomeViewModel @Inject constructor(
     internal val mdbListRepository: MDBListRepository,
     internal val trailerService: TrailerService,
     internal val watchedItemsPreferences: WatchedItemsPreferences,
-    internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
+    internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
+    internal val cwEnrichmentCache: ContinueWatchingEnrichmentCache
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -304,7 +305,10 @@ class HomeViewModel @Inject constructor(
             val cachedInProgress = runCatching { cwEnrichmentCache.getInProgressSnapshot() }.getOrDefault(emptyList())
             val cachedNextUp = runCatching { cwEnrichmentCache.getNextUpSnapshot() }.getOrDefault(emptyList())
             if (cachedInProgress.isEmpty() && cachedNextUp.isEmpty()) return@launch
-            val inProgressItems = cachedInProgress.map { cached ->
+            val dismissedNextUp = traktSettingsDataStore.dismissedNextUpKeys.first()
+            val inProgressItems = cachedInProgress
+                .filter { !watchProgressRepository.isDroppedShow(it.contentId) }
+                .map { cached ->
                 ContinueWatchingItem.InProgress(
                     progress = com.nuvio.tv.domain.model.WatchProgress(
                         contentId = cached.contentId,
@@ -329,7 +333,10 @@ class HomeViewModel @Inject constructor(
                     releaseInfo = cached.releaseInfo
                 )
             }
-            val nextUpItems = cachedNextUp.map { cached ->
+            val nextUpItems = cachedNextUp
+                .filter { !watchProgressRepository.isDroppedShow(it.contentId) }
+                .filter { nextUpDismissKey(it.contentId, it.seedSeason, it.seedEpisode) !in dismissedNextUp }
+                .map { cached ->
                 ContinueWatchingItem.NextUp(
                     info = NextUpInfo(
                         contentId = cached.contentId,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -299,6 +299,79 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun loadContinueWatching() {
+        // Immediately restore last known CW from disk cache for instant display.
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            val cachedInProgress = runCatching { cwEnrichmentCache.getInProgressSnapshot() }.getOrDefault(emptyList())
+            val cachedNextUp = runCatching { cwEnrichmentCache.getNextUpSnapshot() }.getOrDefault(emptyList())
+            if (cachedInProgress.isEmpty() && cachedNextUp.isEmpty()) return@launch
+            val inProgressItems = cachedInProgress.map { cached ->
+                ContinueWatchingItem.InProgress(
+                    progress = com.nuvio.tv.domain.model.WatchProgress(
+                        contentId = cached.contentId,
+                        contentType = cached.contentType,
+                        name = cached.name,
+                        poster = cached.poster,
+                        backdrop = cached.backdrop,
+                        logo = cached.logo,
+                        videoId = cached.videoId,
+                        season = cached.season,
+                        episode = cached.episode,
+                        episodeTitle = cached.episodeTitle,
+                        position = cached.position,
+                        duration = cached.duration,
+                        lastWatched = cached.lastWatched,
+                        progressPercent = cached.progressPercent
+                    ),
+                    episodeThumbnail = cached.episodeThumbnail,
+                    episodeDescription = cached.episodeDescription,
+                    episodeImdbRating = cached.episodeImdbRating,
+                    genres = cached.genres,
+                    releaseInfo = cached.releaseInfo
+                )
+            }
+            val nextUpItems = cachedNextUp.map { cached ->
+                ContinueWatchingItem.NextUp(
+                    info = NextUpInfo(
+                        contentId = cached.contentId,
+                        contentType = cached.contentType,
+                        name = cached.name,
+                        poster = cached.poster,
+                        backdrop = cached.backdrop,
+                        logo = cached.logo,
+                        videoId = cached.videoId,
+                        season = cached.season,
+                        episode = cached.episode,
+                        episodeTitle = cached.episodeTitle,
+                        episodeDescription = cached.episodeDescription,
+                        thumbnail = cached.thumbnail,
+                        released = cached.released,
+                        hasAired = cached.hasAired,
+                        airDateLabel = cached.airDateLabel,
+                        lastWatched = cached.lastWatched,
+                        imdbRating = cached.imdbRating,
+                        genres = cached.genres,
+                        releaseInfo = cached.releaseInfo,
+                        sortTimestamp = cached.sortTimestamp,
+                        releaseTimestamp = cached.releaseTimestamp,
+                        isReleaseAlert = cached.isReleaseAlert,
+                        isNewSeasonRelease = cached.isNewSeasonRelease,
+                        seedSeason = cached.seedSeason,
+                        seedEpisode = cached.seedEpisode
+                    )
+                )
+            }
+            val items = mergeContinueWatchingItems(
+                inProgressItems = inProgressItems,
+                nextUpItems = nextUpItems
+            )
+            if (items.isNotEmpty()) {
+                _uiState.update { state ->
+                    if (state.continueWatchingItems.isEmpty()) {
+                        state.copy(continueWatchingItems = items)
+                    } else state
+                }
+            }
+        }
         loadContinueWatchingPipeline()
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -316,6 +316,7 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
             val totalCatalogs = rows.size.coerceAtLeast(1)
             val baseSlot = 7 / totalCatalogs
             val remainder = 7 % totalCatalogs
+            val seen = mutableSetOf<String>()
             val result = mutableListOf<MetaPreview>()
             rows.forEachIndexed { index, row ->
                 val slot = baseSlot + if (index < remainder) 1 else 0
@@ -326,7 +327,9 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                     row = row,
                     candidates = byId.values.filter { it.id !in existing }
                 )
-                result += (ordered + new).take(slot)
+                // Filter out duplicates but keep taking until slot is filled
+                val unique = (ordered + new).filter { seen.add(it.id) }
+                result += unique.take(slot)
             }
             return result
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -263,13 +263,39 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     cutoffMs = cutoffMs
                 )
 
+                // Load cached enrichment data to avoid flicker on lightweight render
+                val (cachedEnrichment, cachedNextUp) = coroutineScope {
+                    val enrichmentDeferred = async(Dispatchers.IO) {
+                        runCatching { cwEnrichmentCache.getAll() }.getOrDefault(emptyMap())
+                    }
+                    val nextUpDeferred = async(Dispatchers.IO) {
+                        runCatching { cwEnrichmentCache.getNextUpSnapshot() }.getOrDefault(emptyList())
+                    }
+                    enrichmentDeferred.await() to nextUpDeferred.await()
+                }
                 val inProgressOnly = buildList {
                     deduplicateInProgress(
                         recentItems.filter { shouldTreatAsInProgressForContinueWatching(it) }
                     ).forEach { progress ->
+                        val cached = cachedEnrichment[progress.contentId]
+                        val displayProgress = if (cached != null && (cached.backdrop != null || cached.poster != null || cached.logo != null || cached.name != null)) {
+                            progress.copy(
+                                backdrop = cached.backdrop ?: progress.backdrop,
+                                poster = cached.poster ?: progress.poster,
+                                logo = cached.logo ?: progress.logo,
+                                name = cached.name?.takeIf { it.isNotBlank() } ?: progress.name
+                            )
+                        } else {
+                            progress
+                        }
                         add(
                             ContinueWatchingItem.InProgress(
-                                progress = progress
+                                progress = displayProgress,
+                                episodeThumbnail = cached?.episodeThumbnail,
+                                episodeDescription = cached?.episodeDescription,
+                                episodeImdbRating = cached?.episodeImdbRating,
+                                genres = cached?.genres ?: emptyList(),
+                                releaseInfo = cached?.releaseInfo
                             )
                         )
                     }
@@ -277,8 +303,45 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 debug.recordInProgressCount(inProgressOnly.size)
 
                 debug.markPhase("render-in-progress")
-                if (inProgressOnly.isNotEmpty()) {
-                    val initialItems = inProgressOnly.map { it as ContinueWatchingItem }
+                // Render in-progress items + cached next-up immediately
+                val cachedNextUpItems = cachedNextUp.mapNotNull { cached ->
+                    // Skip if this show is already in-progress (suppression)
+                    if (inProgressOnly.any { it.progress.contentId == cached.contentId }) return@mapNotNull null
+                    ContinueWatchingItem.NextUp(
+                        info = NextUpInfo(
+                            contentId = cached.contentId,
+                            contentType = cached.contentType,
+                            name = cached.name,
+                            poster = cached.poster,
+                            backdrop = cached.backdrop,
+                            logo = cached.logo,
+                            videoId = cached.videoId,
+                            season = cached.season,
+                            episode = cached.episode,
+                            episodeTitle = cached.episodeTitle,
+                            episodeDescription = cached.episodeDescription,
+                            thumbnail = cached.thumbnail,
+                            released = cached.released,
+                            hasAired = cached.hasAired,
+                            airDateLabel = cached.airDateLabel,
+                            lastWatched = cached.lastWatched,
+                            imdbRating = cached.imdbRating,
+                            genres = cached.genres,
+                            releaseInfo = cached.releaseInfo,
+                            sortTimestamp = cached.sortTimestamp,
+                            releaseTimestamp = cached.releaseTimestamp,
+                            isReleaseAlert = cached.isReleaseAlert,
+                            isNewSeasonRelease = cached.isNewSeasonRelease,
+                            seedSeason = cached.seedSeason,
+                            seedEpisode = cached.seedEpisode
+                        )
+                    )
+                }
+                if (inProgressOnly.isNotEmpty() || cachedNextUpItems.isNotEmpty()) {
+                    val initialItems = mergeContinueWatchingItems(
+                        inProgressItems = inProgressOnly,
+                        nextUpItems = cachedNextUpItems
+                    )
                     _uiState.update { state ->
                         if (state.continueWatchingItems == initialItems) {
                             state
@@ -308,9 +371,21 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             val partialCount = partialNextUpItems.size
                             if (partialCount > publishedPartialNextUpCount.get()) {
                                 publishedPartialNextUpCount.set(partialCount)
+                                val cachedPartialNextUp = partialNextUpItems.map { nextUp ->
+                                    val cached = cachedEnrichment[nextUp.info.contentId]
+                                    if (cached != null) {
+                                        nextUp.copy(info = nextUp.info.copy(
+                                            thumbnail = cached.episodeThumbnail ?: nextUp.info.thumbnail,
+                                            backdrop = cached.backdrop ?: nextUp.info.backdrop,
+                                            poster = cached.poster ?: nextUp.info.poster,
+                                            logo = cached.logo ?: nextUp.info.logo,
+                                            name = cached.name?.takeIf { it.isNotBlank() } ?: nextUp.info.name
+                                        ))
+                                    } else nextUp
+                                }
                                 val partialItems = mergeContinueWatchingItems(
                                     inProgressItems = inProgressOnly,
-                                    nextUpItems = partialNextUpItems
+                                    nextUpItems = cachedPartialNextUp
                                 )
                                 _uiState.update { state ->
                                     if (state.continueWatchingItems == partialItems) {
@@ -497,7 +572,22 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 }
                 val normalItems = mergeContinueWatchingItems(
                     inProgressItems = inProgressOnly,
-                    nextUpItems = allNextUpItems
+                    nextUpItems = allNextUpItems.map { nextUp ->
+                        val cached = cachedEnrichment[nextUp.info.contentId]
+                        if (cached != null) {
+                            nextUp.copy(info = nextUp.info.copy(
+                                thumbnail = cached.episodeThumbnail ?: nextUp.info.thumbnail,
+                                backdrop = cached.backdrop ?: nextUp.info.backdrop,
+                                poster = cached.poster ?: nextUp.info.poster,
+                                logo = cached.logo ?: nextUp.info.logo,
+                                name = cached.name?.takeIf { it.isNotBlank() } ?: nextUp.info.name,
+                                episodeDescription = cached.episodeDescription ?: nextUp.info.episodeDescription,
+                                imdbRating = cached.episodeImdbRating ?: nextUp.info.imdbRating,
+                                genres = cached.genres.ifEmpty { nextUp.info.genres },
+                                releaseInfo = cached.releaseInfo ?: nextUp.info.releaseInfo
+                            ))
+                        } else nextUp
+                    }
                 )
 
                 _uiState.update { state ->
@@ -513,8 +603,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 )
 
                 // Rich metadata only runs after the final lightweight CW list is visible.
+                // If TMDB enrichment is enabled for CW, skip grace period to avoid
+                // visible flash of addon data being replaced by TMDB data.
                 debug.markPhase("enrichment-grace")
-                val enrichmentDelayMs = remainingContinueWatchingEnrichmentGraceMs()
+                val tmdbEnrichCw = currentTmdbSettings.enabled && currentTmdbSettings.enrichContinueWatching
+                val enrichmentDelayMs = if (tmdbEnrichCw) 0L else remainingContinueWatchingEnrichmentGraceMs()
                 debug.recordEnrichmentDelay(enrichmentDelayMs)
                 if (enrichmentDelayMs > 0L) {
                     delay(enrichmentDelayMs)
@@ -926,15 +1019,33 @@ private suspend fun HomeViewModel.enrichInProgressItem(
     item: ContinueWatchingItem.InProgress,
     metaCache: MutableMap<String, CwMetaSummary?>,
     debug: CwDebugSession? = null
-): ContinueWatchingItem.InProgress {
+): ContinueWatchingItem.InProgress = coroutineScope {
+    val shouldEnrichTmdb = currentTmdbSettings.enabled && currentTmdbSettings.enrichContinueWatching
+
+    // Start TMDB ID resolve early (cache hit = instant, cache miss = network)
+    val tmdbIdDeferred = if (shouldEnrichTmdb) {
+        async(Dispatchers.IO) {
+            val cacheKey = "${item.progress.contentType}:${item.progress.contentId}"
+            synchronized(cwTmdbIdCache) { cwTmdbIdCache[cacheKey] }
+                ?: runCatching { tmdbService.ensureTmdbId(item.progress.contentId, item.progress.contentType) }.getOrNull()
+        }
+    } else null
+
     val meta = resolveMetaForProgress(item.progress, metaCache, debug)
     if (meta == null) {
-        return item
+        return@coroutineScope item
     }
     val video = resolveVideoForProgress(item.progress, meta)
     val genres = meta.genres.take(3)
     val releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() }
-    val tmdbData = if (currentTmdbSettings.enabled && currentTmdbSettings.enrichContinueWatching) {
+    val tmdbData = if (shouldEnrichTmdb) {
+        // Use early-resolved TMDB ID if available, otherwise fall back to full resolve
+        val earlyTmdbId = tmdbIdDeferred?.await()
+        if (earlyTmdbId != null) {
+            // Cache the early result
+            val cacheKey = "${item.progress.contentType}:${item.progress.contentId}"
+            synchronized(cwTmdbIdCache) { cwTmdbIdCache[cacheKey] = earlyTmdbId }
+        }
         resolveContinueWatchingTmdbData(
             progress = item.progress,
             meta = meta,
@@ -945,7 +1056,7 @@ private suspend fun HomeViewModel.enrichInProgressItem(
     } else null
     val imdbRating = tmdbData?.rating?.toFloat() ?: meta.imdbRating
     val settings = currentTmdbSettings
-    return item.copy(
+    item.copy(
         progress = item.progress.copy(
             name = if (settings.useBasicInfo) tmdbData?.name ?: meta.name else meta.name,
             poster = item.progress.poster ?: meta.poster.normalizeImageUrl() ?: if (settings.useArtwork) tmdbData?.poster.normalizeImageUrl() else null,
@@ -971,11 +1082,28 @@ private suspend fun HomeViewModel.enrichNextUpItem(
     item: ContinueWatchingItem.NextUp,
     metaCache: MutableMap<String, CwMetaSummary?>,
     debug: CwDebugSession? = null
-): ContinueWatchingItem.NextUp {
+): ContinueWatchingItem.NextUp = coroutineScope {
     val progressSeed = item.info.toProgressSeed()
-    val meta = resolveMetaForProgress(progressSeed, metaCache, debug) ?: return item
+    val shouldEnrichTmdb = currentTmdbSettings.enabled && currentTmdbSettings.enrichContinueWatching
+
+    // Start TMDB ID resolve early (cache hit = instant, cache miss = network)
+    val tmdbIdDeferred = if (shouldEnrichTmdb) {
+        async(Dispatchers.IO) {
+            val cacheKey = "${progressSeed.contentType}:${progressSeed.contentId}"
+            synchronized(cwTmdbIdCache) { cwTmdbIdCache[cacheKey] }
+                ?: runCatching { tmdbService.ensureTmdbId(progressSeed.contentId, progressSeed.contentType) }.getOrNull()
+        }
+    } else null
+
+    val meta = resolveMetaForProgress(progressSeed, metaCache, debug) ?: return@coroutineScope item
     val video = resolveNextUpVideoFromMeta(progressSeed, meta)
-    val tmdbData = if (currentTmdbSettings.enabled && currentTmdbSettings.enrichContinueWatching) {
+
+    val tmdbData = if (shouldEnrichTmdb) {
+        val earlyTmdbId = tmdbIdDeferred?.await()
+        if (earlyTmdbId != null) {
+            val cacheKey = "${progressSeed.contentType}:${progressSeed.contentId}"
+            synchronized(cwTmdbIdCache) { cwTmdbIdCache[cacheKey] = earlyTmdbId }
+        }
         resolveContinueWatchingTmdbData(
             progress = progressSeed,
             meta = meta,
@@ -1035,7 +1163,7 @@ private suspend fun HomeViewModel.enrichNextUpItem(
                 "released=${enrichedInfo.released} hasAired=${enrichedInfo.hasAired} title=${enrichedInfo.episodeTitle}"
         )
     }
-    return item.copy(info = enrichedInfo)
+    item.copy(info = enrichedInfo)
 }
 
 private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
@@ -1434,13 +1562,98 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
     val localItems = enrichedItems.indices.mapNotNull { index ->
         val original = originalItems.getOrNull(index) as? ContinueWatchingItem.InProgress ?: return@mapNotNull null
         val enriched = enrichedItems.getOrNull(index) as? ContinueWatchingItem.InProgress ?: return@mapNotNull null
-        enriched.progress
-            .takeIf { it.source == WatchProgress.SOURCE_LOCAL }
-            ?.takeIf { it != original.progress }
+        enriched.progress.takeIf { it != original.progress }
     }
-    if (localItems.isEmpty()) return
+
+    // Persist enrichment extras for InProgress items
+    val enrichmentEntries = mutableMapOf<String, com.nuvio.tv.data.local.CwEnrichmentEntry>()
+    enrichedItems.forEach { item ->
+        when (item) {
+            is ContinueWatchingItem.InProgress -> {
+                val hasData = item.episodeThumbnail != null ||
+                    item.episodeDescription != null ||
+                    item.episodeImdbRating != null ||
+                    item.genres.isNotEmpty() ||
+                    item.releaseInfo != null ||
+                    item.progress.backdrop != null ||
+                    item.progress.poster != null
+                if (hasData) {
+                    enrichmentEntries[item.progress.contentId] = com.nuvio.tv.data.local.CwEnrichmentEntry(
+                        episodeThumbnail = item.episodeThumbnail,
+                        episodeDescription = item.episodeDescription,
+                        episodeImdbRating = item.episodeImdbRating,
+                        genres = item.genres,
+                        releaseInfo = item.releaseInfo,
+                        backdrop = item.progress.backdrop,
+                        poster = item.progress.poster,
+                        logo = item.progress.logo,
+                        name = item.progress.name.takeIf { it.isNotBlank() }
+                    )
+                }
+            }
+            is ContinueWatchingItem.NextUp -> {
+                val info = item.info
+                val hasData = info.thumbnail != null ||
+                    info.backdrop != null ||
+                    info.poster != null ||
+                    info.episodeDescription != null
+                if (hasData) {
+                    enrichmentEntries[info.contentId] = com.nuvio.tv.data.local.CwEnrichmentEntry(
+                        episodeThumbnail = info.thumbnail,
+                        episodeDescription = info.episodeDescription,
+                        episodeImdbRating = info.imdbRating,
+                        genres = info.genres,
+                        releaseInfo = info.releaseInfo,
+                        backdrop = info.backdrop,
+                        poster = info.poster,
+                        logo = info.logo,
+                        name = info.name.takeIf { it.isNotBlank() }
+                    )
+                }
+            }
+        }
+    }
+
+    // Build next-up snapshot for cache
+    val nextUpSnapshot = enrichedItems.mapNotNull { item ->
+        val nextUp = item as? ContinueWatchingItem.NextUp ?: return@mapNotNull null
+        val info = nextUp.info
+        com.nuvio.tv.data.local.CachedNextUpItem(
+            contentId = info.contentId,
+            contentType = info.contentType,
+            name = info.name,
+            poster = info.poster,
+            backdrop = info.backdrop,
+            logo = info.logo,
+            videoId = info.videoId,
+            season = info.season,
+            episode = info.episode,
+            episodeTitle = info.episodeTitle,
+            episodeDescription = info.episodeDescription,
+            thumbnail = info.thumbnail,
+            released = info.released,
+            hasAired = info.hasAired,
+            airDateLabel = info.airDateLabel,
+            lastWatched = info.lastWatched,
+            imdbRating = info.imdbRating,
+            genres = info.genres,
+            releaseInfo = info.releaseInfo,
+            sortTimestamp = info.sortTimestamp,
+            releaseTimestamp = info.releaseTimestamp,
+            isReleaseAlert = info.isReleaseAlert,
+            isNewSeasonRelease = info.isNewSeasonRelease,
+            seedSeason = info.seedSeason,
+            seedEpisode = info.seedEpisode
+        )
+    }
 
     viewModelScope.launch(Dispatchers.IO) {
+        if (enrichmentEntries.isNotEmpty()) {
+            runCatching { cwEnrichmentCache.save(enrichmentEntries) }
+        }
+        if (nextUpSnapshot.isNotEmpty()) {
+            runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnapshot) }
+        }
         val persistable = localItems.filter { it.hasRenderableMetadata() }
         if (persistable.isEmpty()) return@launch
         runCatching {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -54,6 +54,78 @@ private data class ContinueWatchingSettingsSnapshot(
     val watchedItemsVersion: Int  // triggers re-evaluation when watched items change
 )
 
+/**
+ * Lightweight projection of [Meta] for CW pipeline caching.
+ * Drops cast, crew, trailers, streams, release dates, and other heavy fields
+ * that are never read by continue-watching or badge evaluation.
+ */
+internal data class CwMetaSummary(
+    val id: String,
+    val name: String,
+    val poster: String?,
+    val backdropUrl: String?,
+    val logo: String?,
+    val description: String?,
+    val genres: List<String>,
+    val releaseInfo: String?,
+    val imdbRating: Float?,
+    val videos: List<CwVideoSummary>
+) {
+    fun watchableEpisodes(): List<CwVideoSummary> {
+        val today = java.time.LocalDate.now()
+        val candidates = videos.filter { (it.season ?: 0) > 0 }
+        val unavailableSeasons = candidates.groupBy { it.season }
+            .filter { (_, eps) ->
+                val first = eps.minByOrNull { it.episode ?: Int.MAX_VALUE } ?: return@filter false
+                val released = first.released?.substringBefore('T')?.trim()
+                if (!released.isNullOrBlank()) {
+                    try {
+                        return@filter java.time.LocalDate.parse(
+                            released,
+                            java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
+                        ).isAfter(today)
+                    } catch (_: java.time.format.DateTimeParseException) { }
+                }
+                false
+            }.keys
+        return if (unavailableSeasons.isEmpty()) candidates
+        else candidates.filter { it.season !in unavailableSeasons }
+    }
+}
+
+internal data class CwVideoSummary(
+    val id: String,
+    val title: String?,
+    val released: String?,
+    val thumbnail: String?,
+    val season: Int?,
+    val episode: Int?,
+    val overview: String?
+)
+
+private fun Meta.toCwSummary(): CwMetaSummary = CwMetaSummary(
+    id = id,
+    name = name,
+    poster = poster,
+    backdropUrl = backdropUrl,
+    logo = logo,
+    description = description,
+    genres = genres,
+    releaseInfo = releaseInfo,
+    imdbRating = imdbRating,
+    videos = videos.map { v ->
+        CwVideoSummary(
+            id = v.id,
+            title = v.title,
+            released = v.released,
+            thumbnail = v.thumbnail,
+            season = v.season,
+            episode = v.episode,
+            overview = v.overview
+        )
+    }
+)
+
 private data class NextUpTmdbData(
     val thumbnail: String?,
     val backdrop: String?,
@@ -276,8 +348,9 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     // multiple TMDB shows share the same IMDB (e.g. Monsters vs Monster).
                     val idsToResolve = allWatchedEpisodes.keys.filter { contentId ->
                         val cacheKey = "series:$contentId"
-                        synchronized(cwMetaCache) {
-                            cwMetaCache[cacheKey] == null && cwMetaCache["tv:$contentId"] == null
+                        synchronized(cwBadgeEpisodeCache) {
+                            !cwBadgeEpisodeCache.containsKey(cacheKey) &&
+                                !cwBadgeEpisodeCache.containsKey("tv:$contentId")
                         }
                     }
                     val staleIds = fullyWatchedSeriesIds.filterStaleIds(idsToResolve.toSet())
@@ -290,27 +363,15 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         sortedStaleIds.map { contentId ->
                             async {
                                 metaSemaphore.withPermit {
-                                    // Skip if meta was already cached by a prior resolve
-                                    // (e.g. IMDB resolve cached it, TMDB alias not needed).
-                                    val alreadyCached = synchronized(cwMetaCache) {
-                                        cwMetaCache["series:$contentId"] != null || cwMetaCache["tv:$contentId"] != null
+                                    // Skip if already resolved by a prior task in this batch.
+                                    val alreadyCached = synchronized(cwBadgeEpisodeCache) {
+                                        cwBadgeEpisodeCache.containsKey("series:$contentId") ||
+                                            cwBadgeEpisodeCache.containsKey("tv:$contentId")
                                     }
                                     if (!alreadyCached) {
-                                        val seed = WatchProgress(
-                                            contentId = contentId,
-                                            contentType = "series",
-                                            name = contentId,
-                                            poster = null, backdrop = null, logo = null,
-                                            videoId = contentId,
-                                            season = 1, episode = 1,
-                                            episodeTitle = null,
-                                            position = 1L, duration = 1L,
-                                            lastWatched = 0L,
-                                            progressPercent = 100f
-                                        )
-                                        val meta = resolveMetaForProgress(seed, cwMetaCache)
-                                        if (meta == null) {
-                                            Log.d("CW-BADGE", "meta resolve FAILED for $contentId")
+                                        val episodes = resolveBadgeEpisodes(contentId, "series")
+                                        if (episodes == null) {
+                                            Log.d("CW-BADGE", "badge resolve FAILED for $contentId")
                                         }
                                     }
                                     if (resolvedCount.incrementAndGet() % batchSize == 0) {
@@ -325,9 +386,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     publishBadgeUpdate(allWatchedEpisodes)
                 }
 
-                // --- CW next-up injection (Nuvio sync only) ---
+                // --- CW next-up injection ---
                 // Discover next-up items for older seeds and inject release alerts into CW.
-                if (!useTraktProgress) {
+                // Hidden (dropped) shows are already filtered out by observeWatchedShowSeeds().
+                if (true) {
                     val recentSeedContentIds = recentNextUpSeeds
                         .filter { isSeriesTypeCW(it.contentType) && it.season != null && it.episode != null }
                         .map { it.contentId }
@@ -418,12 +480,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 debug.markPhase("merge-lightweight")
                 // Include previously discovered older next-up items so they survive collectLatest restarts.
                 // Skip for Trakt users — async inject is disabled for them.
-                val persistedOlderItems = if (!useTraktProgress) {
-                    synchronized(discoveredOlderNextUpItems) {
-                        discoveredOlderNextUpItems.toList()
-                    }
-                } else {
-                    emptyList()
+                val persistedOlderItems = synchronized(discoveredOlderNextUpItems) {
+                    discoveredOlderNextUpItems.toList()
                 }
                 val allNextUpItems = if (persistedOlderItems.isNotEmpty()) {
                     val recentIds = nextUpItems.map { it.info.contentId }.toSet()
@@ -581,8 +639,8 @@ private fun choosePreferredNextUpSeed(items: List<WatchProgress>): WatchProgress
 
 private suspend fun HomeViewModel.resolveCurrentEpisodeDescription(
     progress: WatchProgress,
-    meta: Meta,
-    video: Video?,
+    meta: CwMetaSummary,
+    video: CwVideoSummary?,
     debug: CwDebugSession? = null
 ): String? {
     if (isSeriesTypeCW(progress.contentType)) {
@@ -615,7 +673,7 @@ private suspend fun HomeViewModel.resolveCurrentEpisodeDescription(
     return meta.description?.takeIf { it.isNotBlank() }
 }
 
-private fun resolveVideoForProgress(progress: WatchProgress, meta: Meta): Video? {
+private fun resolveVideoForProgress(progress: WatchProgress, meta: CwMetaSummary): CwVideoSummary? {
     if (!isSeriesTypeCW(progress.contentType)) return null
     val videos = meta.videos.filter { it.season != null && it.episode != null && it.season != 0 }
     if (videos.isEmpty()) return null
@@ -866,7 +924,7 @@ private suspend fun HomeViewModel.buildNextUpItem(
 
 private suspend fun HomeViewModel.enrichInProgressItem(
     item: ContinueWatchingItem.InProgress,
-    metaCache: MutableMap<String, Meta?>,
+    metaCache: MutableMap<String, CwMetaSummary?>,
     debug: CwDebugSession? = null
 ): ContinueWatchingItem.InProgress {
     val meta = resolveMetaForProgress(item.progress, metaCache, debug)
@@ -911,7 +969,7 @@ private suspend fun HomeViewModel.enrichInProgressItem(
 
 private suspend fun HomeViewModel.enrichNextUpItem(
     item: ContinueWatchingItem.NextUp,
-    metaCache: MutableMap<String, Meta?>,
+    metaCache: MutableMap<String, CwMetaSummary?>,
     debug: CwDebugSession? = null
 ): ContinueWatchingItem.NextUp {
     val progressSeed = item.info.toProgressSeed()
@@ -1081,7 +1139,7 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
                 nextSeason,
                 nextEpisode
             ),
-        episodeTitle = nextVideo.title.takeIf { it.isNotBlank() },
+        episodeTitle = nextVideo.title?.takeIf { it.isNotBlank() },
         released = nextVideo.released?.trim()?.takeIf { it.isNotBlank() },
         hasAired = nextVideo.released?.let(::parseEpisodeReleaseDate)?.let { !it.isAfter(LocalDate.now(ZoneId.systemDefault())) } ?: true,
         airDateLabel = nextVideo.released?.let(::parseEpisodeReleaseDate)?.takeIf { it.isAfter(LocalDate.now(ZoneId.systemDefault())) }?.let(::formatEpisodeAirDateLabel),
@@ -1101,23 +1159,23 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
 
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
-    meta: Meta
-): Video? = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp = true)
+    meta: CwMetaSummary
+): CwVideoSummary? = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp = true)
 
 private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
-    meta: Meta,
+    meta: CwMetaSummary,
     showUnairedNextUp: Boolean
-): Video? {
+): CwVideoSummary? {
     val episodes = meta.videos
         .filter { video ->
             val season = video.season
             val episode = video.episode
             season != null && episode != null && season != 0
         }
-        .sortedWith(compareBy<Video>({ it.season ?: Int.MAX_VALUE }, { it.episode ?: Int.MAX_VALUE }))
+        .sortedWith(compareBy<CwVideoSummary>({ it.season ?: Int.MAX_VALUE }, { it.episode ?: Int.MAX_VALUE }))
 
     if (episodes.isEmpty()) return null
 
@@ -1182,9 +1240,9 @@ private const val CW_META_NEGATIVE_CACHE_TTL_MS = 5 * 60_000L
 
 private suspend fun HomeViewModel.resolveMetaForProgress(
     progress: WatchProgress,
-    metaCache: MutableMap<String, Meta?>,
+    metaCache: MutableMap<String, CwMetaSummary?>,
     debug: CwDebugSession? = null
-): Meta? {
+): CwMetaSummary? {
     val startedAtMs = SystemClock.elapsedRealtime()
     val cacheKey = "${progress.contentType}:${progress.contentId}"
     synchronized(metaCache) {
@@ -1215,7 +1273,7 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
     val typeCandidates = listOf(progress.contentType, "series", "tv").distinct()
     val useAllAddons = externalMetaPrefetchEnabled
     val resolved = run {
-        var meta: Meta? = null
+        var summary: CwMetaSummary? = null
         var attempts = 0
         for (type in typeCandidates) {
             for (candidateId in idCandidates) {
@@ -1268,18 +1326,18 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
                     }
                     NetworkResult.Loading -> Unit
                 }
-                meta = (result as? NetworkResult.Success<*>)?.data as? Meta
-                if (meta != null) break
+                summary = ((result as? NetworkResult.Success<*>)?.data as? Meta)?.toCwSummary()
+                if (summary != null) break
             }
-            if (meta != null) break
+            if (summary != null) break
         }
         debug?.recordMetaResolveFinished(
             progress = progress,
             elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
-            success = meta != null,
+            success = summary != null,
             attempts = attempts
         )
-        meta
+        summary
     }
 
     synchronized(metaCache) {
@@ -1291,6 +1349,61 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
         }
     }
     return resolved
+}
+
+/**
+ * Lightweight badge-only resolve: fetches meta and extracts only aired (season, episode) pairs.
+ * Does NOT populate cwMetaCache — keeps memory minimal for badge evaluation of many series.
+ */
+private suspend fun HomeViewModel.resolveBadgeEpisodes(
+    contentId: String,
+    contentType: String
+): Set<Pair<Int, Int>>? {
+    val cacheKey = "$contentType:$contentId"
+    synchronized(cwBadgeEpisodeCache) {
+        if (cwBadgeEpisodeCache.containsKey(cacheKey)) return cwBadgeEpisodeCache[cacheKey]
+    }
+    // If cwMetaCache already has this entry, extract from there instead of fetching again.
+    val existingSummary = synchronized(cwMetaCache) {
+        cwMetaCache[cacheKey] ?: cwMetaCache["series:$contentId"] ?: cwMetaCache["tv:$contentId"]
+    }
+    if (existingSummary != null) {
+        val episodes = existingSummary.watchableEpisodes()
+            .mapNotNull { v -> v.season?.let { s -> v.episode?.let { e -> s to e } } }
+            .toSet()
+        synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = episodes }
+        return episodes
+    }
+
+    val idCandidates = buildList {
+        add(contentId)
+        if (contentId.startsWith("tmdb:")) add(contentId.substringAfter(':'))
+        if (contentId.startsWith("trakt:")) add(contentId.substringAfter(':'))
+    }.distinct()
+    val typeCandidates = listOf(contentType, "series", "tv").distinct()
+    val useAllAddons = externalMetaPrefetchEnabled
+
+    for (type in typeCandidates) {
+        for (candidateId in idCandidates) {
+            val result = withTimeoutOrNull(2_500L) {
+                if (useAllAddons) {
+                    metaRepository.getMetaFromAllAddons(type = type, id = candidateId)
+                        .first { it !is NetworkResult.Loading }
+                } else {
+                    metaRepository.getMetaFromPrimaryAddon(type = type, id = candidateId)
+                        .first { it !is NetworkResult.Loading }
+                }
+            } ?: continue
+            val meta = (result as? NetworkResult.Success<*>)?.data as? Meta ?: continue
+            val episodes = meta.watchableEpisodes()
+                .mapNotNull { v -> v.season?.let { s -> v.episode?.let { e -> s to e } } }
+                .toSet()
+            synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = episodes }
+            return episodes
+        }
+    }
+    synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = null }
+    return null
 }
 
 private fun buildLightweightEpisodeVideoId(
@@ -1369,28 +1482,17 @@ private fun HomeViewModel.publishBadgeUpdate(
     val updatedFullyWatched = allWatchedEpisodes.keys
         .filter { contentId ->
             val cacheKey = "series:$contentId"
-            val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-            if (meta == null) return@filter false
-            val episodes = meta.watchableEpisodes()
-            if (episodes.isEmpty()) return@filter false
+            val airedEpisodes = synchronized(cwBadgeEpisodeCache) {
+                cwBadgeEpisodeCache[cacheKey] ?: cwBadgeEpisodeCache["tv:$contentId"]
+            } ?: return@filter false
+            if (airedEpisodes.isEmpty()) return@filter false
             val watched = allWatchedEpisodes[contentId] ?: return@filter false
-            val allWatched = episodes.all { (it.season!! to it.episode!!) in watched }
+            val allWatched = airedEpisodes.all { it in watched }
             if (!allWatched && watched.isNotEmpty()) {
-                Log.d("CW-BADGE", "NOT fully watched: $contentId episodes=${episodes.size} watched=${watched.size}")
-                // Track IDs we've validated as NOT fully watched so we can remove stale badges.
+                Log.d("CW-BADGE", "NOT fully watched: $contentId episodes=${airedEpisodes.size} watched=${watched.size}")
                 validatedNotFullyWatched.add(contentId)
-                val metaId = meta.id.takeIf { it.isNotBlank() && it != contentId }
-                if (metaId != null) validatedNotFullyWatched.add(metaId)
             }
             allWatched
-        }
-        .flatMap { contentId ->
-            val cacheKey = "series:$contentId"
-            val meta = synchronized(cwMetaCache) { cwMetaCache[cacheKey] }
-                ?: synchronized(cwMetaCache) { cwMetaCache["tv:$contentId"] }
-            val metaId = meta?.id?.takeIf { it.isNotBlank() && it != contentId }
-            if (metaId != null) listOf(contentId, metaId) else listOf(contentId)
         }
         .toSet()
     // Merge with persisted badges — don't remove badges we haven't re-validated yet.
@@ -1444,7 +1546,7 @@ private fun parseEpisodeReleaseInstant(raw: String?): Instant? {
 
 private suspend fun HomeViewModel.resolveContinueWatchingTmdbData(
     progress: WatchProgress,
-    meta: Meta,
+    meta: CwMetaSummary,
     season: Int,
     episode: Int,
     debug: CwDebugSession? = null
@@ -1558,7 +1660,7 @@ private suspend fun HomeViewModel.resolveContinueWatchingTmdbData(
 
 private suspend fun HomeViewModel.resolveTmdbIdForNextUp(
     progress: WatchProgress,
-    meta: Meta,
+    meta: CwMetaSummary,
     debug: CwDebugSession? = null
 ): String? {
     val startedAtMs = SystemClock.elapsedRealtime()
@@ -1609,8 +1711,8 @@ private suspend fun HomeViewModel.resolveTmdbIdForNextUp(
 
 private fun shouldFetchNextUpTmdbFallback(
     item: ContinueWatchingItem.NextUp,
-    meta: Meta,
-    video: Video?
+    meta: CwMetaSummary,
+    video: CwVideoSummary?
 ): Boolean {
     val hasName = !(item.info.name.isBlank() && meta.name.isNullOrBlank())
     val hasPoster = item.info.poster != null || meta.poster.normalizeImageUrl() != null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1213,6 +1213,7 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
     }.distinct()
 
     val typeCandidates = listOf(progress.contentType, "series", "tv").distinct()
+    val useAllAddons = externalMetaPrefetchEnabled
     val resolved = run {
         var meta: Meta? = null
         var attempts = 0
@@ -1221,10 +1222,17 @@ private suspend fun HomeViewModel.resolveMetaForProgress(
                 attempts += 1
                 val attemptStartedAtMs = SystemClock.elapsedRealtime()
                 val result = withTimeoutOrNull(2_500L) {
-                    metaRepository.getMetaFromPrimaryAddon(
-                        type = type,
-                        id = candidateId
-                    ).first { it !is NetworkResult.Loading }
+                    if (useAllAddons) {
+                        metaRepository.getMetaFromAllAddons(
+                            type = type,
+                            id = candidateId
+                        ).first { it !is NetworkResult.Loading }
+                    } else {
+                        metaRepository.getMetaFromPrimaryAddon(
+                            type = type,
+                            id = candidateId
+                        ).first { it !is NetworkResult.Loading }
+                    }
                 }
                 val attemptElapsedMs = SystemClock.elapsedRealtime() - attemptStartedAtMs
                 if (result == null) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -342,6 +342,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val cachedNextUpItems = cachedNextUp.mapNotNull { cached ->
                     // Skip if this show is already in-progress (suppression)
                     if (inProgressOnly.any { it.progress.contentId == cached.contentId }) return@mapNotNull null
+                    // Skip dismissed items
+                    if (nextUpDismissKey(cached.contentId, cached.seedSeason, cached.seedEpisode) in dismissedNextUp) return@mapNotNull null
                     ContinueWatchingItem.NextUp(
                         info = NextUpInfo(
                             contentId = cached.contentId,
@@ -560,11 +562,12 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 }.awaitAll().filterNotNull()
 
                                 if (discoveredNextUpItems.isNotEmpty()) {
+                                    val releaseAlerts = discoveredNextUpItems.filter { it.info.isReleaseAlert }
                                     synchronized(discoveredOlderNextUpItems) {
                                         discoveredOlderNextUpItems.removeAll { old ->
-                                            discoveredNextUpItems.any { it.info.contentId == old.info.contentId }
+                                            releaseAlerts.any { it.info.contentId == old.info.contentId }
                                         }
-                                        discoveredOlderNextUpItems.addAll(discoveredNextUpItems)
+                                        discoveredOlderNextUpItems.addAll(releaseAlerts)
                                     }
                                     _uiState.update { state ->
                                         val existingContentIds = state.continueWatchingItems
@@ -575,8 +578,9 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                                 }
                                             }
                                             .toSet()
-                                        val newAlerts = discoveredNextUpItems.filter {
-                                            it.info.contentId !in existingContentIds
+                                        val newAlerts = releaseAlerts.filter {
+                                            it.info.contentId !in existingContentIds &&
+                                                nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
                                         }
                                         if (newAlerts.isEmpty()) return@update state
                                         state.copy(continueWatchingItems = state.continueWatchingItems + newAlerts)
@@ -589,22 +593,55 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
 
                 debug.markPhase("merge-lightweight")
                 // Include previously discovered older next-up items so they survive collectLatest restarts.
-                // Skip for Trakt users — async inject is disabled for them.
                 val persistedOlderItems = synchronized(discoveredOlderNextUpItems) {
                     discoveredOlderNextUpItems.toList()
                 }
-                val allNextUpItems = if (persistedOlderItems.isNotEmpty()) {
-                    val recentIds = nextUpItems.map { it.info.contentId }.toSet()
-                    val inProgressIds = inProgressOnly.map { it.progress.contentId }.toSet()
-                    val olderToInclude = persistedOlderItems.filter {
-                        it.info.contentId !in recentIds &&
-                            it.info.contentId !in inProgressIds &&
-                            nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
+                // Also preserve cached release alerts from disk until async inject re-verifies them.
+                val cachedReleaseAlerts = cachedNextUp
+                    .filter { it.isReleaseAlert }
+                    .map { cached ->
+                        ContinueWatchingItem.NextUp(
+                            info = NextUpInfo(
+                                contentId = cached.contentId,
+                                contentType = cached.contentType,
+                                name = cached.name,
+                                poster = cached.poster,
+                                backdrop = cached.backdrop,
+                                logo = cached.logo,
+                                videoId = cached.videoId,
+                                season = cached.season,
+                                episode = cached.episode,
+                                episodeTitle = cached.episodeTitle,
+                                episodeDescription = cached.episodeDescription,
+                                thumbnail = cached.thumbnail,
+                                released = cached.released,
+                                hasAired = cached.hasAired,
+                                airDateLabel = cached.airDateLabel,
+                                lastWatched = cached.lastWatched,
+                                imdbRating = cached.imdbRating,
+                                genres = cached.genres,
+                                releaseInfo = cached.releaseInfo,
+                                sortTimestamp = cached.sortTimestamp,
+                                releaseTimestamp = cached.releaseTimestamp,
+                                isReleaseAlert = cached.isReleaseAlert,
+                                isNewSeasonRelease = cached.isNewSeasonRelease,
+                                seedSeason = cached.seedSeason,
+                                seedEpisode = cached.seedEpisode
+                            )
+                        )
                     }
-                    nextUpItems + olderToInclude
-                } else {
-                    nextUpItems
-                }
+                val recentIds = nextUpItems.map { it.info.contentId }.toSet()
+                val inProgressIds = inProgressOnly.map { it.progress.contentId }.toSet()
+                val olderToInclude = (persistedOlderItems + cachedReleaseAlerts)
+                    .distinctBy { it.info.contentId }
+                    .filter {
+                        it.info.isReleaseAlert &&
+                            it.info.contentId !in recentIds &&
+                            it.info.contentId !in inProgressIds &&
+                            nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&
+                            !watchProgressRepository.isDroppedShow(it.info.contentId)
+                    }
+                val allNextUpItems = nextUpItems + olderToInclude
                 val normalItems = mergeContinueWatchingItems(
                     inProgressItems = inProgressOnly,
                     nextUpItems = allNextUpItems.map { nextUp ->
@@ -1600,8 +1637,12 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
         enriched.progress.takeIf { it != original.progress }
     }
 
+    // Use the full UI state for cache snapshots so async-injected items are included.
+    val currentUiItems = _uiState.value.continueWatchingItems
+
     // Build next-up snapshot for cache
-    val nextUpSnapshot = enrichedItems.mapNotNull { item ->
+    val brokenUrls = com.nuvio.tv.ui.components.brokenImageUrls
+    val nextUpSnapshot = currentUiItems.mapNotNull { item ->
         val nextUp = item as? ContinueWatchingItem.NextUp ?: return@mapNotNull null
         val info = nextUp.info
         com.nuvio.tv.data.local.CachedNextUpItem(
@@ -1616,7 +1657,7 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
             episode = info.episode,
             episodeTitle = info.episodeTitle,
             episodeDescription = info.episodeDescription,
-            thumbnail = info.thumbnail,
+            thumbnail = info.thumbnail?.takeIf { it !in brokenUrls },
             released = info.released,
             hasAired = info.hasAired,
             airDateLabel = info.airDateLabel,
@@ -1634,7 +1675,7 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
     }
 
     // Build in-progress snapshot for cache
-    val inProgressSnapshot = enrichedItems.mapNotNull { item ->
+    val inProgressSnapshot = currentUiItems.mapNotNull { item ->
         val ip = item as? ContinueWatchingItem.InProgress ?: return@mapNotNull null
         val p = ip.progress
         com.nuvio.tv.data.local.CachedInProgressItem(
@@ -1652,7 +1693,7 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
             duration = p.duration,
             lastWatched = p.lastWatched,
             progressPercent = p.progressPercent,
-            episodeThumbnail = ip.episodeThumbnail,
+            episodeThumbnail = ip.episodeThumbnail?.takeIf { it !in brokenUrls },
             episodeDescription = ip.episodeDescription,
             episodeImdbRating = ip.episodeImdbRating,
             genres = ip.genres,
@@ -1983,7 +2024,7 @@ private fun String?.normalizeImageUrl(): String? = this
     ?.trim()
     ?.takeIf { it.isNotEmpty() }
 
-private fun nextUpDismissKey(
+internal fun nextUpDismissKey(
     contentId: String,
     season: Int?,
     episode: Int?

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -264,40 +264,75 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 )
 
                 // Load cached enrichment data to avoid flicker on lightweight render
-                val (cachedEnrichment, cachedNextUp) = coroutineScope {
+                val (cachedEnrichment, cachedNextUp, cachedInProgress) = coroutineScope {
                     val enrichmentDeferred = async(Dispatchers.IO) {
                         runCatching { cwEnrichmentCache.getAll() }.getOrDefault(emptyMap())
                     }
                     val nextUpDeferred = async(Dispatchers.IO) {
                         runCatching { cwEnrichmentCache.getNextUpSnapshot() }.getOrDefault(emptyList())
                     }
-                    enrichmentDeferred.await() to nextUpDeferred.await()
+                    val inProgressDeferred = async(Dispatchers.IO) {
+                        runCatching { cwEnrichmentCache.getInProgressSnapshot() }.getOrDefault(emptyList())
+                    }
+                    Triple(enrichmentDeferred.await(), nextUpDeferred.await(), inProgressDeferred.await())
                 }
                 val inProgressOnly = buildList {
-                    deduplicateInProgress(
+                    val liveInProgress = deduplicateInProgress(
                         recentItems.filter { shouldTreatAsInProgressForContinueWatching(it) }
-                    ).forEach { progress ->
-                        val cached = cachedEnrichment[progress.contentId]
-                        val displayProgress = if (cached != null && (cached.backdrop != null || cached.poster != null || cached.logo != null || cached.name != null)) {
-                            progress.copy(
-                                backdrop = cached.backdrop ?: progress.backdrop,
-                                poster = cached.poster ?: progress.poster,
-                                logo = cached.logo ?: progress.logo,
-                                name = cached.name?.takeIf { it.isNotBlank() } ?: progress.name
+                    )
+                    if (liveInProgress.isNotEmpty()) {
+                        liveInProgress.forEach { progress ->
+                            val cached = cachedEnrichment[progress.contentId]
+                            val displayProgress = if (cached != null && (cached.backdrop != null || cached.poster != null || cached.logo != null || cached.name != null)) {
+                                progress.copy(
+                                    backdrop = cached.backdrop ?: progress.backdrop,
+                                    poster = cached.poster ?: progress.poster,
+                                    logo = cached.logo ?: progress.logo,
+                                    name = cached.name?.takeIf { it.isNotBlank() } ?: progress.name
+                                )
+                            } else {
+                                progress
+                            }
+                            add(
+                                ContinueWatchingItem.InProgress(
+                                    progress = displayProgress,
+                                    episodeThumbnail = cached?.episodeThumbnail,
+                                    episodeDescription = cached?.episodeDescription,
+                                    episodeImdbRating = cached?.episodeImdbRating,
+                                    genres = cached?.genres ?: emptyList(),
+                                    releaseInfo = cached?.releaseInfo
+                                )
                             )
-                        } else {
-                            progress
                         }
-                        add(
-                            ContinueWatchingItem.InProgress(
-                                progress = displayProgress,
-                                episodeThumbnail = cached?.episodeThumbnail,
-                                episodeDescription = cached?.episodeDescription,
-                                episodeImdbRating = cached?.episodeImdbRating,
-                                genres = cached?.genres ?: emptyList(),
-                                releaseInfo = cached?.releaseInfo
+                    } else if (useTraktProgress && cachedInProgress.isNotEmpty()) {
+                        // Trakt hasn't responded yet — restore last known in-progress items from disk.
+                        cachedInProgress.forEach { cached ->
+                            add(
+                                ContinueWatchingItem.InProgress(
+                                    progress = WatchProgress(
+                                        contentId = cached.contentId,
+                                        contentType = cached.contentType,
+                                        name = cached.name,
+                                        poster = cached.poster,
+                                        backdrop = cached.backdrop,
+                                        logo = cached.logo,
+                                        videoId = cached.videoId,
+                                        season = cached.season,
+                                        episode = cached.episode,
+                                        episodeTitle = cached.episodeTitle,
+                                        position = cached.position,
+                                        duration = cached.duration,
+                                        lastWatched = cached.lastWatched,
+                                        progressPercent = cached.progressPercent
+                                    ),
+                                    episodeThumbnail = cached.episodeThumbnail,
+                                    episodeDescription = cached.episodeDescription,
+                                    episodeImdbRating = cached.episodeImdbRating,
+                                    genres = cached.genres,
+                                    releaseInfo = cached.releaseInfo
+                                )
                             )
-                        )
+                        }
                     }
                 }
                 debug.recordInProgressCount(inProgressOnly.size)
@@ -1647,12 +1682,42 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
         )
     }
 
+    // Build in-progress snapshot for cache
+    val inProgressSnapshot = enrichedItems.mapNotNull { item ->
+        val ip = item as? ContinueWatchingItem.InProgress ?: return@mapNotNull null
+        val p = ip.progress
+        com.nuvio.tv.data.local.CachedInProgressItem(
+            contentId = p.contentId,
+            contentType = p.contentType,
+            name = p.name,
+            poster = p.poster,
+            backdrop = p.backdrop,
+            logo = p.logo,
+            videoId = p.videoId,
+            season = p.season,
+            episode = p.episode,
+            episodeTitle = p.episodeTitle,
+            position = p.position,
+            duration = p.duration,
+            lastWatched = p.lastWatched,
+            progressPercent = p.progressPercent,
+            episodeThumbnail = ip.episodeThumbnail,
+            episodeDescription = ip.episodeDescription,
+            episodeImdbRating = ip.episodeImdbRating,
+            genres = ip.genres,
+            releaseInfo = ip.releaseInfo
+        )
+    }
+
     viewModelScope.launch(Dispatchers.IO) {
         if (enrichmentEntries.isNotEmpty()) {
             runCatching { cwEnrichmentCache.save(enrichmentEntries) }
         }
         if (nextUpSnapshot.isNotEmpty()) {
             runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnapshot) }
+        }
+        if (inProgressSnapshot.isNotEmpty()) {
+            runCatching { cwEnrichmentCache.saveInProgressSnapshot(inProgressSnapshot) }
         }
         val persistable = localItems.filter { it.hasRenderableMetadata() }
         if (persistable.isEmpty()) return@launch

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -40,7 +40,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
 private const val CW_MAX_RECENT_PROGRESS_ITEMS = 300
-private const val CW_MAX_NEXT_UP_LOOKUPS = 24
+private const val CW_MAX_NEXT_UP_LOOKUPS = 48
 private const val CW_MAX_NEXT_UP_CONCURRENCY = 4
 private const val CW_MAX_ENRICHMENT_CONCURRENCY = 4
 private const val CW_PROGRESS_DEBOUNCE_MS = 500L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1223,7 +1223,7 @@ private suspend fun HomeViewModel.enrichNextUpItem(
         imdbRating = if (settings.useBasicInfo) tmdbData?.rating?.toFloat() ?: meta.imdbRating ?: item.info.imdbRating else meta.imdbRating ?: item.info.imdbRating,
         genres = meta.genres.take(3).ifEmpty { item.info.genres },
         releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: item.info.releaseInfo,
-        sortTimestamp = releaseState.sortTimestamp,
+        sortTimestamp = item.info.sortTimestamp,
         releaseTimestamp = releaseState.releaseTimestamp,
         isReleaseAlert = releaseState.isReleaseAlert,
         isNewSeasonRelease = releaseState.isNewSeasonRelease

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -263,32 +263,32 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     cutoffMs = cutoffMs
                 )
 
-                // Load cached enrichment data to avoid flicker on lightweight render
-                val (cachedEnrichment, cachedNextUp, cachedInProgress) = coroutineScope {
-                    val enrichmentDeferred = async(Dispatchers.IO) {
-                        runCatching { cwEnrichmentCache.getAll() }.getOrDefault(emptyMap())
-                    }
+                // Load cached CW snapshots for instant render before Trakt responds
+                val (cachedNextUp, cachedInProgress) = coroutineScope {
                     val nextUpDeferred = async(Dispatchers.IO) {
                         runCatching { cwEnrichmentCache.getNextUpSnapshot() }.getOrDefault(emptyList())
                     }
                     val inProgressDeferred = async(Dispatchers.IO) {
                         runCatching { cwEnrichmentCache.getInProgressSnapshot() }.getOrDefault(emptyList())
                     }
-                    Triple(enrichmentDeferred.await(), nextUpDeferred.await(), inProgressDeferred.await())
+                    nextUpDeferred.await() to inProgressDeferred.await()
                 }
+                // Build enrichment lookup from cached snapshots (replaces old CwEnrichmentEntry)
+                val cachedEnrichmentFromInProgress = cachedInProgress.associateBy { it.contentId }
+                val cachedEnrichmentFromNextUp = cachedNextUp.associateBy { it.contentId }
                 val inProgressOnly = buildList {
                     val liveInProgress = deduplicateInProgress(
                         recentItems.filter { shouldTreatAsInProgressForContinueWatching(it) }
                     )
                     if (liveInProgress.isNotEmpty()) {
                         liveInProgress.forEach { progress ->
-                            val cached = cachedEnrichment[progress.contentId]
-                            val displayProgress = if (cached != null && (cached.backdrop != null || cached.poster != null || cached.logo != null || cached.name != null)) {
+                            val cached = cachedEnrichmentFromInProgress[progress.contentId]
+                            val displayProgress = if (cached != null && (cached.backdrop != null || cached.poster != null || cached.logo != null || cached.name.isNotBlank())) {
                                 progress.copy(
                                     backdrop = cached.backdrop ?: progress.backdrop,
                                     poster = cached.poster ?: progress.poster,
                                     logo = cached.logo ?: progress.logo,
-                                    name = cached.name?.takeIf { it.isNotBlank() } ?: progress.name
+                                    name = cached.name.takeIf { it.isNotBlank() } ?: progress.name
                                 )
                             } else {
                                 progress
@@ -407,14 +407,14 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             if (partialCount > publishedPartialNextUpCount.get()) {
                                 publishedPartialNextUpCount.set(partialCount)
                                 val cachedPartialNextUp = partialNextUpItems.map { nextUp ->
-                                    val cached = cachedEnrichment[nextUp.info.contentId]
+                                    val cached = cachedEnrichmentFromNextUp[nextUp.info.contentId]
                                     if (cached != null) {
                                         nextUp.copy(info = nextUp.info.copy(
-                                            thumbnail = cached.episodeThumbnail ?: nextUp.info.thumbnail,
+                                            thumbnail = cached.thumbnail ?: nextUp.info.thumbnail,
                                             backdrop = cached.backdrop ?: nextUp.info.backdrop,
                                             poster = cached.poster ?: nextUp.info.poster,
                                             logo = cached.logo ?: nextUp.info.logo,
-                                            name = cached.name?.takeIf { it.isNotBlank() } ?: nextUp.info.name
+                                            name = cached.name.takeIf { it.isNotBlank() } ?: nextUp.info.name
                                         ))
                                     } else nextUp
                                 }
@@ -608,16 +608,16 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val normalItems = mergeContinueWatchingItems(
                     inProgressItems = inProgressOnly,
                     nextUpItems = allNextUpItems.map { nextUp ->
-                        val cached = cachedEnrichment[nextUp.info.contentId]
+                        val cached = cachedEnrichmentFromNextUp[nextUp.info.contentId]
                         if (cached != null) {
                             nextUp.copy(info = nextUp.info.copy(
-                                thumbnail = cached.episodeThumbnail ?: nextUp.info.thumbnail,
+                                thumbnail = cached.thumbnail ?: nextUp.info.thumbnail,
                                 backdrop = cached.backdrop ?: nextUp.info.backdrop,
                                 poster = cached.poster ?: nextUp.info.poster,
                                 logo = cached.logo ?: nextUp.info.logo,
-                                name = cached.name?.takeIf { it.isNotBlank() } ?: nextUp.info.name,
+                                name = cached.name.takeIf { it.isNotBlank() } ?: nextUp.info.name,
                                 episodeDescription = cached.episodeDescription ?: nextUp.info.episodeDescription,
-                                imdbRating = cached.episodeImdbRating ?: nextUp.info.imdbRating,
+                                imdbRating = cached.imdbRating ?: nextUp.info.imdbRating,
                                 genres = cached.genres.ifEmpty { nextUp.info.genres },
                                 releaseInfo = cached.releaseInfo ?: nextUp.info.releaseInfo
                             ))
@@ -961,7 +961,7 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
     true
 }
 
-private fun mergeContinueWatchingItems(
+internal fun mergeContinueWatchingItems(
     inProgressItems: List<ContinueWatchingItem.InProgress>,
     nextUpItems: List<ContinueWatchingItem.NextUp>
 ): List<ContinueWatchingItem> {
@@ -1600,55 +1600,6 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
         enriched.progress.takeIf { it != original.progress }
     }
 
-    // Persist enrichment extras for InProgress items
-    val enrichmentEntries = mutableMapOf<String, com.nuvio.tv.data.local.CwEnrichmentEntry>()
-    enrichedItems.forEach { item ->
-        when (item) {
-            is ContinueWatchingItem.InProgress -> {
-                val hasData = item.episodeThumbnail != null ||
-                    item.episodeDescription != null ||
-                    item.episodeImdbRating != null ||
-                    item.genres.isNotEmpty() ||
-                    item.releaseInfo != null ||
-                    item.progress.backdrop != null ||
-                    item.progress.poster != null
-                if (hasData) {
-                    enrichmentEntries[item.progress.contentId] = com.nuvio.tv.data.local.CwEnrichmentEntry(
-                        episodeThumbnail = item.episodeThumbnail,
-                        episodeDescription = item.episodeDescription,
-                        episodeImdbRating = item.episodeImdbRating,
-                        genres = item.genres,
-                        releaseInfo = item.releaseInfo,
-                        backdrop = item.progress.backdrop,
-                        poster = item.progress.poster,
-                        logo = item.progress.logo,
-                        name = item.progress.name.takeIf { it.isNotBlank() }
-                    )
-                }
-            }
-            is ContinueWatchingItem.NextUp -> {
-                val info = item.info
-                val hasData = info.thumbnail != null ||
-                    info.backdrop != null ||
-                    info.poster != null ||
-                    info.episodeDescription != null
-                if (hasData) {
-                    enrichmentEntries[info.contentId] = com.nuvio.tv.data.local.CwEnrichmentEntry(
-                        episodeThumbnail = info.thumbnail,
-                        episodeDescription = info.episodeDescription,
-                        episodeImdbRating = info.imdbRating,
-                        genres = info.genres,
-                        releaseInfo = info.releaseInfo,
-                        backdrop = info.backdrop,
-                        poster = info.poster,
-                        logo = info.logo,
-                        name = info.name.takeIf { it.isNotBlank() }
-                    )
-                }
-            }
-        }
-    }
-
     // Build next-up snapshot for cache
     val nextUpSnapshot = enrichedItems.mapNotNull { item ->
         val nextUp = item as? ContinueWatchingItem.NextUp ?: return@mapNotNull null
@@ -1710,9 +1661,6 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
     }
 
     viewModelScope.launch(Dispatchers.IO) {
-        if (enrichmentEntries.isNotEmpty()) {
-            runCatching { cwEnrichmentCache.save(enrichmentEntries) }
-        }
         if (nextUpSnapshot.isNotEmpty()) {
             runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnapshot) }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -36,7 +36,7 @@ class SearchViewModel @Inject constructor(
     private val addonRepository: AddonRepository,
     private val catalogRepository: CatalogRepository,
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
-    private val searchHistoryDataStore: SearchHistoryDataStore
+    private val searchHistoryDataStore: SearchHistoryDataStore,
     private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
     private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     @ApplicationContext private val context: Context

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -64,6 +64,7 @@ class TraktViewModel @Inject constructor(
     private val watchedItemsPreferences: WatchedItemsPreferences,
     private val watchedItemsSyncService: WatchedItemsSyncService,
     private val watchedSeriesStateHolder: WatchedSeriesStateHolder,
+    private val cwEnrichmentCache: com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache,
     @dagger.hilt.android.qualifiers.ApplicationContext private val context: Context
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TraktUiState())
@@ -129,6 +130,9 @@ class TraktViewModel @Inject constructor(
     fun onWatchProgressSourceSelected(source: WatchProgressSource) {
         viewModelScope.launch {
             traktSettingsDataStore.setWatchProgressSource(source)
+            // Clear CW cache so stale items from the previous source don't flash on screen.
+            cwEnrichmentCache.saveInProgressSnapshot(emptyList())
+            cwEnrichmentCache.saveNextUpSnapshot(emptyList())
             if (source == WatchProgressSource.TRAKT) {
                 watchedItemsPreferences.clearAll()
                 watchedSeriesStateHolder.update(emptySet())
@@ -204,6 +208,9 @@ class TraktViewModel @Inject constructor(
             pollJob?.cancel()
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             traktAuthService.revokeAndLogout()
+            // Clear CW cache so stale Trakt items don't flash on next launch.
+            cwEnrichmentCache.saveInProgressSnapshot(emptyList())
+            cwEnrichmentCache.saveNextUpSnapshot(emptyList())
             // Repopulate watched items from Nuvio sync now that Trakt is no
             // longer the source of truth.
             watchedSeriesStateHolder.update(emptySet())


### PR DESCRIPTION
## Summary

Major Continue Watching improvements to match mobile behavior, plus several quality-of-life fixes.

**CW Pipeline:**
- Filter Trakt dropped/hidden shows from CW using `GET /users/hidden/dropped`
- Lightweight CW meta cache (`CwMetaSummary`) -drops cast, crew, trailers, streams from memory; badge evaluation uses separate ultra-light episode-count cache - should help with some OOM crashes
- CW enrichment cache (`cacheDir`) - persists episode thumbnails, backdrop, poster, genres, ratings between app restarts so CW renders instantly without flicker
- Cached Next Up snapshot - Next Up items load immediately from cache instead of waiting for meta resolve
- Parallel cache loading (enrichment + next-up read concurrently)
- Skip grace period for TMDB enrichment when enabled for CW - reduces visible data swap
- Parallel TMDB ID resolve alongside addon meta fetch during enrichment
- Prefer external addon metadata in CW when "Prefer external addon metadata" is enabled (was ignored, only used primary addon) - should help for those rare empty posters in CW
- Enable async older-seeds Next Up injection for Trakt users (was disabled; now safe because hidden shows are filtered)
- Persist enriched metadata back to DataStore for all sources (was limited to SOURCE_LOCAL)
- Fix `mergeDisplayMetadata` to prefer local enriched data over remote origin data on sync pull
- Fix `upsertProgressEntries` to update series-level entry on equal `lastWatched` (`>` -> `>=`)
- "Prefer external addon metadata" now defaults to enabled - a lot of Stremio users don't understand this option and this is default Stremio behaviour

**Batch Operations:**
- `markAsCompletedBatch` - single DataStore transaction + single Trakt `POST /sync/history` for marking season watched
- `removeFromHistoryBatch` - single DataStore transaction + single Trakt `POST /sync/history/remove` for unmarking season
- Batch `WatchedItemsPreferences` and `WatchedItemsSyncService` operations
- `markSeasonWatched`, `markSeasonUnwatched`, `markPreviousEpisodesWatched` all use batch APIs

**Hero & UI:**
- Deduplicate hero items by content ID across catalogs
- Prevent season auto-switch when manually marking season watched/unwatched

## PR type

- Bug fix
- Small maintenance improvement

## Why

Users reported CW on TV missing items that appear on mobile, flickering images during enrichment, and slow season mark operations. This PR aligns TV CW behavior with mobile, reduces memory usage, eliminates visual flicker, and makes batch operations instant.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [ ] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manual testing with Trakt and Nuvio sync accounts. Verified: dropped shows filtered, enrichment cache persists across restarts, no image flicker, batch mark season completes in single API call, hero deduplication works, season doesn't auto-switch on mark. 

Again, a [test build](http://morigal.pl/upload/app-universal-benchmark-cw2.apk) ready for other to test 

## Screenshots / Video (UI changes only)

data pipeline and performance changes, no visual design changes.

## Breaking changes

- "Prefer external addon metadata" now defaults to `true` (was `false`). Users who never changed this setting will now get external addon metadata by default. Can be toggled off in Layout settings.

## Linked issues

Fixes #918 and a bunch of Discord reported issues
