### PR TITLE
fix: cache YouTube visitor_data + API key to prevent 429 rate limiting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.withTimeout
@@ -18,6 +20,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -150,17 +153,108 @@ class InAppYouTubeExtractor @Inject constructor() {
         .followSslRedirects(true)
         .build()
 
+    // --- Cached watch config (api key + visitor data) ---
+    private data class CachedConfig(
+        val apiKey: String,
+        val visitorData: String?,
+        val fetchedAt: Long = System.currentTimeMillis()
+    )
+
+    private val cachedConfig = AtomicReference<CachedConfig?>(null)
+    private val configMutex = Mutex()
+
+    companion object {
+        /** How long cached visitor_data stays valid before a proactive refresh. */
+        private const val CONFIG_TTL_MS = 3 * 60 * 60 * 1000L // 3 hours
+    }
+
+    /**
+     * Returns cached watch config, fetching from watch page only if:
+     *  - No cached config exists yet (first call)
+     *  - Cache is older than CONFIG_TTL_MS
+     *  - [forceRefresh] is true (e.g. after LOGIN_REQUIRED)
+     */
+    private suspend fun ensureWatchConfig(forceRefresh: Boolean = false): CachedConfig {
+        // Fast path: return valid cache without locking
+        if (!forceRefresh) {
+            val current = cachedConfig.get()
+            if (current != null && !isConfigStale(current)) {
+                return current
+            }
+        }
+
+        // Slow path: fetch new config under mutex (only one fetch at a time)
+        return configMutex.withLock {
+            // Double-check after acquiring lock
+            if (!forceRefresh) {
+                val current = cachedConfig.get()
+                if (current != null && !isConfigStale(current)) {
+                    return@withLock current
+                }
+            }
+
+            Log.d(TAG, "Fetching watch page for visitor_data (forceRefresh=$forceRefresh)")
+            val watchUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&hl=en"
+            val watchResponse = performRequest(
+                url = watchUrl,
+                method = "GET",
+                headers = DEFAULT_HEADERS
+            )
+            if (!watchResponse.ok) {
+                // If we have a stale config, prefer it over failing
+                val stale = cachedConfig.get()
+                if (stale != null) {
+                    Log.w(TAG, "Watch page failed (${watchResponse.status}), using stale config")
+                    return@withLock stale
+                }
+                throw IllegalStateException("Failed to fetch watch page (${watchResponse.status})")
+            }
+
+            val parsed = getWatchConfig(watchResponse.body)
+            val apiKey = parsed.apiKey ?: "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8" // fallback key
+            val newConfig = CachedConfig(
+                apiKey = apiKey,
+                visitorData = parsed.visitorData
+            )
+            cachedConfig.set(newConfig)
+            Log.d(TAG, "Watch config cached (visitor=${!parsed.visitorData.isNullOrBlank()})")
+            newConfig
+        }
+    }
+
+    private fun isConfigStale(config: CachedConfig): Boolean {
+        return System.currentTimeMillis() - config.fetchedAt > CONFIG_TTL_MS
+    }
+
+    /** Invalidate cached config so next extraction re-fetches watch page. */
+    fun invalidateConfig() {
+        cachedConfig.set(null)
+        Log.d(TAG, "Watch config invalidated")
+    }
+
     suspend fun extractPlaybackSource(youtubeUrl: String): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
         if (youtubeUrl.isBlank()) return@withContext null
 
         Log.d(TAG, "Starting Kotlin extraction for ${summarizeUrl(youtubeUrl)}")
-        val source = try {
-            withTimeout(EXTRACTOR_TIMEOUT_MS) {
-                extractPlaybackSourceInternal(youtubeUrl)
+        var source: TrailerPlaybackSource? = null
+        try {
+            source = withTimeout(EXTRACTOR_TIMEOUT_MS) {
+                extractPlaybackSourceInternal(youtubeUrl, forceRefreshConfig = false)
             }
         } catch (error: Exception) {
             Log.w(TAG, "Kotlin extractor failed for $youtubeUrl: ${error.message}")
-            null
+        }
+
+        // Retry with fresh config if first attempt returned nothing
+        if (source == null) {
+            Log.d(TAG, "First attempt failed, retrying with fresh watch config...")
+            try {
+                source = withTimeout(EXTRACTOR_TIMEOUT_MS) {
+                    extractPlaybackSourceInternal(youtubeUrl, forceRefreshConfig = true)
+                }
+            } catch (error: Exception) {
+                Log.w(TAG, "Kotlin extractor retry failed for $youtubeUrl: ${error.message}")
+            }
         }
 
         if (source == null) {
@@ -176,37 +270,40 @@ class InAppYouTubeExtractor @Inject constructor() {
         source
     }
 
-    private suspend fun extractPlaybackSourceInternal(youtubeUrl: String): TrailerPlaybackSource? {
+    private suspend fun extractPlaybackSourceInternal(
+        youtubeUrl: String,
+        forceRefreshConfig: Boolean
+    ): TrailerPlaybackSource? {
         val videoId = extractVideoId(youtubeUrl) ?: return null
 
-        val watchUrl = "https://www.youtube.com/watch?v=$videoId&hl=en"
-        val watchResponse = performRequest(
-            url = watchUrl,
-            method = "GET",
-            headers = DEFAULT_HEADERS
-        )
-        if (!watchResponse.ok) {
-            throw IllegalStateException("Failed to fetch watch page (${watchResponse.status})")
-        }
-
-        val watchConfig = getWatchConfig(watchResponse.body)
-        val apiKey = watchConfig.apiKey
-            ?: throw IllegalStateException("Unable to extract INNERTUBE_API_KEY")
+        // Use cached config instead of fetching watch page every time
+        val config = ensureWatchConfig(forceRefresh = forceRefreshConfig)
+        Log.d(TAG, "Using config: apiKey=${config.apiKey.take(10)}... visitor=${!config.visitorData.isNullOrBlank()}")
 
         val progressive = mutableListOf<StreamCandidate>()
         val adaptiveVideo = mutableListOf<StreamCandidate>()
         val adaptiveAudio = mutableListOf<StreamCandidate>()
         val manifestUrls = mutableListOf<Triple<String, Int, String>>()
+        var loginRequiredCount = 0
 
         for (client in CLIENTS) {
             try {
                 val playerResponse = fetchPlayerResponse(
-                    apiKey = apiKey,
+                    apiKey = config.apiKey,
                     videoId = videoId,
                     client = client,
-                    visitorData = watchConfig.visitorData,
+                    visitorData = config.visitorData,
                     cookieHeader = null
                 )
+
+                // Check for LOGIN_REQUIRED which means visitor_data is stale
+                val playabilityStatus = playerResponse.mapValue("playabilityStatus")
+                val status = playabilityStatus?.stringValue("status")
+                if (status == "LOGIN_REQUIRED") {
+                    loginRequiredCount++
+                    Log.w(TAG, "Client ${client.key}: LOGIN_REQUIRED (visitor may be stale)")
+                    continue
+                }
 
                 val streamingData = playerResponse.mapValue("streamingData") ?: continue
                 val hlsManifestUrl = streamingData.stringValue("hlsManifestUrl")
@@ -290,6 +387,13 @@ class InAppYouTubeExtractor @Inject constructor() {
                     Log.w(TAG, "Client ${client.key} failed: ${error.message}")
                 }
             }
+        }
+
+        // If all clients returned LOGIN_REQUIRED, invalidate config for next attempt
+        if (loginRequiredCount == CLIENTS.size) {
+            Log.w(TAG, "All ${CLIENTS.size} clients returned LOGIN_REQUIRED, invalidating config")
+            invalidateConfig()
+            return null
         }
 
         if (manifestUrls.isEmpty() && progressive.isEmpty() && adaptiveVideo.isEmpty() && adaptiveAudio.isEmpty()) {


### PR DESCRIPTION
## Summary

Cache YouTube `visitor_data` and `API key` from the watch page instead of fetching them on every trailer extraction. The watch page is now fetched only once (on first use) and cached for 3 hours. On `LOGIN_REQUIRED` errors, the cache is invalidated and both credentials are refreshed together before retrying.

## PR type

- Bug fix

## Why

Heavy trailer browsing triggers YouTube's rate limiting (HTTP 429) on the watch page endpoint (`/watch?v=`), which causes all subsequent trailer extractions to fail. 

Investigation revealed:
- The **watch page** is the bottleneck — it gets rate-limited under load, while the Player API (`/youtubei/v1/player`) is much more resilient
- The **API key** (`INNERTUBE_API_KEY`) is not actually validated by YouTube — requests work without it
- The **`visitor_data`** is the critical credential — without it, most videos return `LOGIN_REQUIRED`
- A single `visitor_data` works across all videos and doesn't change between requests

By caching `visitor_data` + API key and only refreshing on errors, watch page requests are reduced by ~99%, effectively eliminating the 429 rate-limit problem.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

**Manual testing:**
1. Installed debug build on Android TV emulator
2. Browsed home screen trailers — trailers load on first focus with only 1 watch page request
3. Verified subsequent trailer loads use cached config (no additional watch page fetches in logcat)

**Automated stress testing (Python scripts):**
1. Sent 100 concurrent requests per wave × 6 waves (1200+ HTTP calls) to reproduce 429
2. Confirmed watch page gets 429 while Player API stays healthy
3. Verified `visitor_data` works across all videos with a single fetch
4. Confirmed API key is not required (YouTube ignores it)
5. Tested `LOGIN_REQUIRED` detection triggers cache refresh

## Screenshots / Video (UI changes only)

N/A — no UI changes.

## Breaking changes

None. The `InAppYouTubeExtractor` public API is unchanged. The only behavioral change is internal: watch page is now cached instead of fetched per-extraction.

## Linked issues

Fixes YouTube 403/429 rate limiting when browsing trailers.
#1172  #807 
