### PR TITLE
Move advanced playback options from Audio to Player settings

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,17 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/Player" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/android-tv-samples" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/ass" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/expat" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/fontconfig" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/freetype" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/freetype/subprojects/dlg" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/fribidi" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/harfbuzz" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/libass-android/lib_ass/src/main/cpp/libass-cmake/src/unibreak" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -67,7 +67,6 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onSetTrailerDelaySeconds: (Int) -> Unit,
     onSetSkipSilence: (Boolean) -> Unit,
     onSetTunnelingEnabled: (Boolean) -> Unit,
-    onSetMapDV7ToHevc: (Boolean) -> Unit,
     onItemFocused: () -> Unit = {},
     enabled: Boolean = true
 ) {
@@ -223,17 +222,6 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         )
     }
 
-    item(key = "audio_dv7_hevc_fallback") {
-        ToggleSettingsItem(
-            icon = Icons.Default.Tune,
-            title = stringResource(R.string.audio_dv_title),
-            subtitle = stringResource(R.string.audio_dv_sub),
-            isChecked = playerSettings.mapDV7ToHevc,
-            onCheckedChange = onSetMapDV7ToHevc,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
 }
 
 @Composable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -170,7 +170,6 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
             enabled = enabled
         )
     }
-
 }
 
 @Composable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -62,11 +62,9 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     trailerSettings: TrailerSettings,
     onShowAudioLanguageDialog: () -> Unit,
     onShowSecondaryAudioLanguageDialog: () -> Unit,
-    onShowDecoderPriorityDialog: () -> Unit,
     onSetTrailerEnabled: (Boolean) -> Unit,
     onSetTrailerDelaySeconds: (Int) -> Unit,
     onSetSkipSilence: (Boolean) -> Unit,
-    onSetTunnelingEnabled: (Boolean) -> Unit,
     onItemFocused: () -> Unit = {},
     enabled: Boolean = true
 ) {
@@ -168,55 +166,6 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
             subtitle = stringResource(R.string.audio_skip_silence_sub),
             isChecked = playerSettings.skipSilence,
             onCheckedChange = onSetSkipSilence,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
-
-    item(key = "audio_advanced_header") {
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(R.string.audio_advanced_section),
-            style = MaterialTheme.typography.titleMedium,
-            color = NuvioColors.TextSecondary,
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
-    }
-
-    item(key = "audio_advanced_warning") {
-        Text(
-            text = stringResource(R.string.audio_advanced_warning),
-            style = MaterialTheme.typography.bodySmall,
-            color = Color(0xFFFF9800),
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-    }
-
-    item(key = "audio_decoder_priority") {
-        val decoderName = when (playerSettings.decoderPriority) {
-            0 -> stringResource(R.string.audio_decoder_device_only)
-            1 -> stringResource(R.string.audio_decoder_prefer_device)
-            2 -> stringResource(R.string.audio_decoder_prefer_app)
-            else -> stringResource(R.string.audio_decoder_prefer_device)
-        }
-
-        NavigationSettingsItem(
-            icon = Icons.Default.Tune,
-            title = stringResource(R.string.audio_decoder_priority),
-            subtitle = decoderName,
-            onClick = onShowDecoderPriorityDialog,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
-
-    item(key = "audio_tunneled_playback") {
-        ToggleSettingsItem(
-            icon = Icons.Default.VolumeUp,
-            title = stringResource(R.string.audio_tunneled),
-            subtitle = stringResource(R.string.audio_tunneled_sub),
-            isChecked = playerSettings.tunnelingEnabled,
-            onCheckedChange = onSetTunnelingEnabled,
             onFocused = onItemFocused,
             enabled = enabled
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -304,6 +304,18 @@ internal fun PlaybackSettingsSections(
                 )
             }
 
+            item(key = "stream_strip_dolby_vision") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.Image,
+                    title = stringResource(R.string.audio_dv_title),
+                    subtitle = stringResource(R.string.audio_dv_sub),
+                    isChecked = playerSettings.mapDV7ToHevc,
+                    onCheckedChange = onSetMapDV7ToHevc,
+                    onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
+                    enabled = !generalUi.isExternalPlayer
+                )
+            }
+
             autoPlaySettingsItems(
                 playerSettings = playerSettings,
                 onShowModeDialog = onShowStreamAutoPlayModeDialog,
@@ -353,7 +365,6 @@ internal fun PlaybackSettingsSections(
                 onSetTrailerDelaySeconds = onSetTrailerDelaySeconds,
                 onSetSkipSilence = onSetSkipSilence,
                 onSetTunnelingEnabled = onSetTunnelingEnabled,
-                onSetMapDV7ToHevc = onSetMapDV7ToHevc,
                 onItemFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                 enabled = !generalUi.isExternalPlayer
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -68,6 +68,7 @@ private enum class PlaybackSection {
     GENERAL,
     STREAM_SELECTION,
     AUDIO_TRAILER,
+    ADVANCED,
     SUBTITLES
 }
 
@@ -138,15 +139,15 @@ internal fun PlaybackSettingsSections(
     var generalExpanded by rememberSaveable { mutableStateOf(false) }
     var afrExpanded by rememberSaveable { mutableStateOf(false) }
     var streamExpanded by rememberSaveable { mutableStateOf(false) }
-    var playerAdvancedExpanded by rememberSaveable { mutableStateOf(false) }
     var audioTrailerExpanded by rememberSaveable { mutableStateOf(false) }
+    var advancedExpanded by rememberSaveable { mutableStateOf(false) }
     var subtitlesExpanded by rememberSaveable { mutableStateOf(false) }
 
     val defaultGeneralHeaderFocus = remember { FocusRequester() }
     val afrHeaderFocus = remember { FocusRequester() }
     val streamHeaderFocus = remember { FocusRequester() }
-    val playerAdvancedHeaderFocus = remember { FocusRequester() }
     val audioTrailerHeaderFocus = remember { FocusRequester() }
+    val advancedHeaderFocus = remember { FocusRequester() }
     val subtitlesHeaderFocus = remember { FocusRequester() }
     val generalHeaderFocus = initialFocusRequester ?: defaultGeneralHeaderFocus
 
@@ -161,6 +162,8 @@ internal fun PlaybackSettingsSections(
     val strSectionPlayerDesc = stringResource(R.string.playback_section_player_desc)
     val strSectionAudio = stringResource(R.string.playback_section_audio)
     val strSectionAudioDesc = stringResource(R.string.playback_section_audio_desc)
+    val strSectionAdvanced = stringResource(R.string.playback_section_advanced)
+    val strSectionAdvancedDesc = stringResource(R.string.playback_section_advanced_desc)
     val strSectionSubtitles = stringResource(R.string.playback_section_subtitles)
     val strSectionSubtitlesDesc = stringResource(R.string.playback_section_subtitles_desc)
     val generalUi = PlaybackGeneralUi(
@@ -190,14 +193,14 @@ internal fun PlaybackSettingsSections(
             streamHeaderFocus.requestFocus()
         }
     }
-    LaunchedEffect(playerAdvancedExpanded, focusedSection) {
-        if (!playerAdvancedExpanded && focusedSection == PlaybackSection.STREAM_SELECTION) {
-            playerAdvancedHeaderFocus.requestFocus()
-        }
-    }
     LaunchedEffect(audioTrailerExpanded, focusedSection) {
         if (!audioTrailerExpanded && focusedSection == PlaybackSection.AUDIO_TRAILER) {
             audioTrailerHeaderFocus.requestFocus()
+        }
+    }
+    LaunchedEffect(advancedExpanded, focusedSection) {
+        if (!advancedExpanded && focusedSection == PlaybackSection.ADVANCED) {
+            advancedHeaderFocus.requestFocus()
         }
     }
     LaunchedEffect(subtitlesExpanded, focusedSection) {
@@ -342,61 +345,6 @@ internal fun PlaybackSettingsSections(
                 )
             }
 
-            item(key = "stream_player_advanced_header") {
-                PlaybackSectionHeader(
-                    title = stringResource(R.string.playback_advanced_section),
-                    description = stringResource(R.string.audio_advanced_warning),
-                    expanded = playerAdvancedExpanded,
-                    onToggle = { playerAdvancedExpanded = !playerAdvancedExpanded },
-                    focusRequester = playerAdvancedHeaderFocus,
-                    onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
-                    enabled = !generalUi.isExternalPlayer
-                )
-            }
-
-            if (playerAdvancedExpanded) {
-                item(key = "stream_decoder_priority") {
-                    val decoderName = when (playerSettings.decoderPriority) {
-                        0 -> stringResource(R.string.audio_decoder_device_only)
-                        1 -> stringResource(R.string.audio_decoder_prefer_device)
-                        2 -> stringResource(R.string.audio_decoder_prefer_app)
-                        else -> stringResource(R.string.audio_decoder_prefer_device)
-                    }
-
-                    NavigationSettingsItem(
-                        icon = Icons.Default.Tune,
-                        title = stringResource(R.string.audio_decoder_priority),
-                        subtitle = decoderName,
-                        onClick = onShowDecoderPriorityDialog,
-                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
-                        enabled = !generalUi.isExternalPlayer
-                    )
-                }
-
-                item(key = "stream_tunneled_playback") {
-                    ToggleSettingsItem(
-                        icon = Icons.Default.VolumeUp,
-                        title = stringResource(R.string.audio_tunneled),
-                        subtitle = stringResource(R.string.audio_tunneled_sub),
-                        isChecked = playerSettings.tunnelingEnabled,
-                        onCheckedChange = onSetTunnelingEnabled,
-                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
-                        enabled = !generalUi.isExternalPlayer
-                    )
-                }
-
-                item(key = "stream_strip_dolby_vision") {
-                    ToggleSettingsItem(
-                        icon = Icons.Default.Image,
-                        title = stringResource(R.string.audio_dv_title),
-                        subtitle = stringResource(R.string.audio_dv_sub),
-                        isChecked = playerSettings.mapDV7ToHevc,
-                        onCheckedChange = onSetMapDV7ToHevc,
-                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
-                        enabled = !generalUi.isExternalPlayer
-                    )
-                }
-            }
         }
 
         playbackCollapsibleSection(
@@ -419,6 +367,58 @@ internal fun PlaybackSettingsSections(
                 onItemFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                 enabled = !generalUi.isExternalPlayer
             )
+        }
+
+        playbackCollapsibleSection(
+            keyPrefix = "advanced",
+            title = strSectionAdvanced,
+            description = strSectionAdvancedDesc,
+            expanded = advancedExpanded,
+            onToggle = { advancedExpanded = !advancedExpanded },
+            focusRequester = advancedHeaderFocus,
+            onHeaderFocused = { focusedSection = PlaybackSection.ADVANCED }
+        ) {
+            item(key = "advanced_decoder_priority") {
+                val decoderName = when (playerSettings.decoderPriority) {
+                    0 -> stringResource(R.string.audio_decoder_device_only)
+                    1 -> stringResource(R.string.audio_decoder_prefer_device)
+                    2 -> stringResource(R.string.audio_decoder_prefer_app)
+                    else -> stringResource(R.string.audio_decoder_prefer_device)
+                }
+
+                NavigationSettingsItem(
+                    icon = Icons.Default.Tune,
+                    title = stringResource(R.string.audio_decoder_priority),
+                    subtitle = decoderName,
+                    onClick = onShowDecoderPriorityDialog,
+                    onFocused = { focusedSection = PlaybackSection.ADVANCED },
+                    enabled = !generalUi.isExternalPlayer
+                )
+            }
+
+            item(key = "advanced_tunneled_playback") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.VolumeUp,
+                    title = stringResource(R.string.audio_tunneled),
+                    subtitle = stringResource(R.string.audio_tunneled_sub),
+                    isChecked = playerSettings.tunnelingEnabled,
+                    onCheckedChange = onSetTunnelingEnabled,
+                    onFocused = { focusedSection = PlaybackSection.ADVANCED },
+                    enabled = !generalUi.isExternalPlayer
+                )
+            }
+
+            item(key = "advanced_dv7_hevc_fallback") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.Tune,
+                    title = stringResource(R.string.audio_dv_title),
+                    subtitle = stringResource(R.string.audio_dv_sub),
+                    isChecked = playerSettings.mapDV7ToHevc,
+                    onCheckedChange = onSetMapDV7ToHevc,
+                    onFocused = { focusedSection = PlaybackSection.ADVANCED },
+                    enabled = !generalUi.isExternalPlayer
+                )
+            }
         }
 
         playbackCollapsibleSection(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -29,6 +29,8 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PauseCircle
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -136,12 +138,14 @@ internal fun PlaybackSettingsSections(
     var generalExpanded by rememberSaveable { mutableStateOf(false) }
     var afrExpanded by rememberSaveable { mutableStateOf(false) }
     var streamExpanded by rememberSaveable { mutableStateOf(false) }
+    var playerAdvancedExpanded by rememberSaveable { mutableStateOf(false) }
     var audioTrailerExpanded by rememberSaveable { mutableStateOf(false) }
     var subtitlesExpanded by rememberSaveable { mutableStateOf(false) }
 
     val defaultGeneralHeaderFocus = remember { FocusRequester() }
     val afrHeaderFocus = remember { FocusRequester() }
     val streamHeaderFocus = remember { FocusRequester() }
+    val playerAdvancedHeaderFocus = remember { FocusRequester() }
     val audioTrailerHeaderFocus = remember { FocusRequester() }
     val subtitlesHeaderFocus = remember { FocusRequester() }
     val generalHeaderFocus = initialFocusRequester ?: defaultGeneralHeaderFocus
@@ -184,6 +188,11 @@ internal fun PlaybackSettingsSections(
     LaunchedEffect(streamExpanded, focusedSection) {
         if (!streamExpanded && focusedSection == PlaybackSection.STREAM_SELECTION) {
             streamHeaderFocus.requestFocus()
+        }
+    }
+    LaunchedEffect(playerAdvancedExpanded, focusedSection) {
+        if (!playerAdvancedExpanded && focusedSection == PlaybackSection.STREAM_SELECTION) {
+            playerAdvancedHeaderFocus.requestFocus()
         }
     }
     LaunchedEffect(audioTrailerExpanded, focusedSection) {
@@ -304,18 +313,6 @@ internal fun PlaybackSettingsSections(
                 )
             }
 
-            item(key = "stream_strip_dolby_vision") {
-                ToggleSettingsItem(
-                    icon = Icons.Default.Image,
-                    title = stringResource(R.string.audio_dv_title),
-                    subtitle = stringResource(R.string.audio_dv_sub),
-                    isChecked = playerSettings.mapDV7ToHevc,
-                    onCheckedChange = onSetMapDV7ToHevc,
-                    onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
-                    enabled = !generalUi.isExternalPlayer
-                )
-            }
-
             autoPlaySettingsItems(
                 playerSettings = playerSettings,
                 onShowModeDialog = onShowStreamAutoPlayModeDialog,
@@ -344,6 +341,62 @@ internal fun PlaybackSettingsSections(
                     onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION }
                 )
             }
+
+            item(key = "stream_player_advanced_header") {
+                PlaybackSectionHeader(
+                    title = stringResource(R.string.playback_advanced_section),
+                    description = stringResource(R.string.audio_advanced_warning),
+                    expanded = playerAdvancedExpanded,
+                    onToggle = { playerAdvancedExpanded = !playerAdvancedExpanded },
+                    focusRequester = playerAdvancedHeaderFocus,
+                    onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
+                    enabled = !generalUi.isExternalPlayer
+                )
+            }
+
+            if (playerAdvancedExpanded) {
+                item(key = "stream_decoder_priority") {
+                    val decoderName = when (playerSettings.decoderPriority) {
+                        0 -> stringResource(R.string.audio_decoder_device_only)
+                        1 -> stringResource(R.string.audio_decoder_prefer_device)
+                        2 -> stringResource(R.string.audio_decoder_prefer_app)
+                        else -> stringResource(R.string.audio_decoder_prefer_device)
+                    }
+
+                    NavigationSettingsItem(
+                        icon = Icons.Default.Tune,
+                        title = stringResource(R.string.audio_decoder_priority),
+                        subtitle = decoderName,
+                        onClick = onShowDecoderPriorityDialog,
+                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
+                        enabled = !generalUi.isExternalPlayer
+                    )
+                }
+
+                item(key = "stream_tunneled_playback") {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.VolumeUp,
+                        title = stringResource(R.string.audio_tunneled),
+                        subtitle = stringResource(R.string.audio_tunneled_sub),
+                        isChecked = playerSettings.tunnelingEnabled,
+                        onCheckedChange = onSetTunnelingEnabled,
+                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
+                        enabled = !generalUi.isExternalPlayer
+                    )
+                }
+
+                item(key = "stream_strip_dolby_vision") {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.Image,
+                        title = stringResource(R.string.audio_dv_title),
+                        subtitle = stringResource(R.string.audio_dv_sub),
+                        isChecked = playerSettings.mapDV7ToHevc,
+                        onCheckedChange = onSetMapDV7ToHevc,
+                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION },
+                        enabled = !generalUi.isExternalPlayer
+                    )
+                }
+            }
         }
 
         playbackCollapsibleSection(
@@ -360,11 +413,9 @@ internal fun PlaybackSettingsSections(
                 trailerSettings = trailerSettings,
                 onShowAudioLanguageDialog = onShowAudioLanguageDialog,
                 onShowSecondaryAudioLanguageDialog = onShowSecondaryAudioLanguageDialog,
-                onShowDecoderPriorityDialog = onShowDecoderPriorityDialog,
                 onSetTrailerEnabled = onSetTrailerEnabled,
                 onSetTrailerDelaySeconds = onSetTrailerDelaySeconds,
                 onSetSkipSilence = onSetSkipSilence,
-                onSetTunnelingEnabled = onSetTunnelingEnabled,
                 onItemFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                 enabled = !generalUi.isExternalPlayer
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,7 +364,7 @@
     <string name="audio_decoder_priority">Decoder Priority</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
-    <string name="audio_dv_sub">Map Dolby Vision Profile 7 to standard HEVC for devices without DV hardware support</string>
+    <string name="audio_dv_sub">Strip Dolby Vision from the internal player input by falling back DV Profile 7 to HEVC for TVs and boxes without DV support</string>
     <string name="audio_decoder_device_only_desc">Only use built-in hardware decoders. Most compatible but may not support all formats.</string>
     <string name="audio_decoder_prefer_device_desc">Use hardware decoders when available, fall back to FFmpeg. Recommended for most devices.</string>
     <string name="audio_decoder_prefer_app_desc">Use FFmpeg decoders when available. Better format support but higher CPU usage.</string>
@@ -1217,7 +1217,7 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, etc.) is automatic. When connected to a compatible AV receiver or soundbar via HDMI, lossless audio is sent as-is without decoding.</string>
-    <string name="audio_dv_title">DV7 - HEVC Fallback</string>
+    <string name="audio_dv_title">Strip Dolby Vision For Internal Player</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,7 +364,7 @@
     <string name="audio_decoder_priority">Decoder Priority</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
-    <string name="audio_dv_sub">Strip Dolby Vision from the internal player input by falling back DV Profile 7 to HEVC for TVs and boxes without DV support</string>
+    <string name="audio_dv_sub">Map Dolby Vision Profile 7 to standard HEVC for devices without DV hardware support</string>
     <string name="audio_decoder_device_only_desc">Only use built-in hardware decoders. Most compatible but may not support all formats.</string>
     <string name="audio_decoder_prefer_device_desc">Use hardware decoders when available, fall back to FFmpeg. Recommended for most devices.</string>
     <string name="audio_decoder_prefer_app_desc">Use FFmpeg decoders when available. Better format support but higher CPU usage.</string>
@@ -1217,7 +1217,8 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, etc.) is automatic. When connected to a compatible AV receiver or soundbar via HDMI, lossless audio is sent as-is without decoding.</string>
-    <string name="audio_dv_title">Strip Dolby Vision For Internal Player</string>
+    <string name="audio_dv_title">DV7 - HEVC Fallback</string>
+    <string name="playback_advanced_section">Advanced</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,8 @@
     <string name="playback_player_ask">Ask every time</string>
     <string name="playback_section_audio">Audio &amp; Trailer</string>
     <string name="playback_section_audio_desc">Trailer behavior and audio controls.</string>
+    <string name="playback_section_advanced">Audio &amp; Video Advanced</string>
+    <string name="playback_section_advanced_desc">Decoder, tunneling, and compatibility settings. Change only if needed.</string>
     <string name="playback_section_subtitles">Subtitles</string>
     <string name="playback_section_subtitles_desc">Language, style, and render mode.</string>
     <string name="playback_afr_open">Open</string>
@@ -1218,7 +1220,6 @@
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, etc.) is automatic. When connected to a compatible AV receiver or soundbar via HDMI, lossless audio is sent as-is without decoding.</string>
     <string name="audio_dv_title">DV7 - HEVC Fallback</string>
-    <string name="playback_advanced_section">Advanced</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Home</string>


### PR DESCRIPTION
## Summary

Moves non-audio advanced playback options from the Audio section to a dedicated Advanced subsection under Player settings.

The following settings were relocated:

Decoder Priority
Tunneled Playback
DV7 – HEVC Fallback

No functional changes were made. This is a UI/structure improvement only.

## PR type

- Small maintenance improvement


## Why

These settings were previously placed under Audio → Advanced, which is misleading.

They are not audio-specific. Instead, they affect broader player behavior such as:

decoder selection
tunneling
video compatibility/fallback handling

Keeping them under Audio makes them:

harder to discover
incorrectly categorized

Moving them to Player → Advanced aligns the UI with their actual purpose and improves overall settings clarity.

## Policy check

<!-- Confirm these before requesting review -->
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

Verified the settings are no longer present under Audio → Advanced
Verified they appear under Settings → Playback Settings → Player → Advanced
Verified Audio section now contains only audio-related options
Ran: ./gradlew :app:compileDebugKotlin

## Screenshots / Video (UI changes only)

Before:
Settings -> Playback Settings -> Audio -> Advanced Audio
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/cd8a8e2b-e3d6-4663-af23-836963335ee7" />

After:
Settings -> Playback Settings -> Player -> Advanced
<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/30d2f358-65e3-4b08-93f2-64d40214181d" />


## Breaking changes

None

## Linked issues

None
