### PR TITLE
Add MPV OSD Button Switch Players

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.app.Activity
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -56,6 +57,8 @@ class PlayerRuntimeController(
 
     companion object {
         internal const val TAG = "PlayerViewModel"
+        internal const val SWITCH_TRACE_TAG = "SwitchTrace"
+        internal const val SWITCH_TRACE_ENABLED = false
         internal const val TRACK_FRAME_RATE_GRACE_MS = 1500L
         internal const val ADDON_SUBTITLE_TRACK_ID_PREFIX = "nuvio-addon-sub:"
     }
@@ -69,7 +72,10 @@ class PlayerRuntimeController(
     internal data class RememberedTrackSelection(
         val language: String?,
         val name: String?,
-        val trackId: String? = null
+        val trackId: String? = null,
+        val indexHint: Int? = null,
+        val languageIndexHint: Int? = null,
+        val isForcedHint: Boolean? = null
     )
 
     internal sealed class RememberedSubtitleSelection {
@@ -88,6 +94,17 @@ class PlayerRuntimeController(
     internal data class TrackPreference(
         val audio: RememberedTrackSelection? = null,
         val subtitle: RememberedSubtitleSelection? = null
+    )
+
+    internal data class PendingEngineSwitchTrackPreference(
+        val streamUrl: String,
+        val preference: TrackPreference,
+        val sourceEngine: InternalPlayerEngine
+    )
+
+    internal data class ExplicitSubtitleSelectionForEngineSwitch(
+        val streamUrl: String,
+        val selection: RememberedSubtitleSelection
     )
 
     internal val navigationArgs = PlayerNavigationArgs.from(savedStateHandle)
@@ -209,6 +226,11 @@ class PlayerRuntimeController(
     internal var pendingAudioSelectionAfterSubtitleRefresh: PendingAudioSelection? = null
     internal var rememberedTrackPreference: TrackPreference? = null
     internal var persistedTrackPreference: TrackPreference? = null
+    internal var pendingEngineSwitchTrackPreference: PendingEngineSwitchTrackPreference? = null
+    internal var explicitSubtitleSelectionForEngineSwitch: ExplicitSubtitleSelectionForEngineSwitch? = null
+    internal var effectiveSubtitleSelectionForEngineSwitch: ExplicitSubtitleSelectionForEngineSwitch? = null
+    internal var switchTraceSessionId: Long = 0L
+    internal var switchTraceSequence: Long = 0L
     internal var subtitleDisabledByPersistedPreference: Boolean = false
     internal var subtitleAddonRestoredByPersistedPreference: Boolean = false
     internal var pendingRestoredAddonSubtitle: com.nuvio.tv.domain.model.Subtitle? = null
@@ -236,6 +258,7 @@ class PlayerRuntimeController(
     internal var currentMediaSession: MediaSession? = null
     internal var mpvView: NuvioMpvSurfaceView? = null
     internal var mpvInitializationInProgress: Boolean = false
+    internal var mpvTrackRefreshInProgress: Boolean = false
     internal var pendingMpvHardRestartOnNextAttach: Boolean = false
     internal var delayMpvResumeSeekUntilVideoTrack: Boolean = false
     internal var mpvDelayStartAfterAfrSwitch: Boolean = false
@@ -287,4 +310,33 @@ class PlayerRuntimeController(
         mediaSourceFactory.shutdown()
         sourceChipErrorDismissJob?.cancel()
     }
+}
+
+internal fun PlayerRuntimeController.beginSwitchTraceSession(
+    reason: String,
+    targetEngine: InternalPlayerEngine?
+) {
+    switchTraceSessionId = System.currentTimeMillis()
+    switchTraceSequence = 0L
+    logSwitchTrace(
+        stage = "session-begin",
+        message = "reason=$reason sourceEngine=$currentInternalPlayerEngine targetEngine=$targetEngine"
+    )
+}
+
+internal fun PlayerRuntimeController.logSwitchTrace(
+    stage: String,
+    message: String
+) {
+    if (!PlayerRuntimeController.SWITCH_TRACE_ENABLED) return
+    if (switchTraceSessionId == 0L) {
+        switchTraceSessionId = System.currentTimeMillis()
+        switchTraceSequence = 0L
+    }
+    val sequence = ++switchTraceSequence
+    val streamToken = currentStreamUrl.hashCode().toUInt().toString(16)
+    Log.w(
+        PlayerRuntimeController.SWITCH_TRACE_TAG,
+        "sid=$switchTraceSessionId seq=$sequence stage=$stage engine=$currentInternalPlayerEngine streamToken=$streamToken $message"
+    )
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
+import androidx.media3.common.C
 import com.nuvio.tv.R
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import kotlinx.coroutines.delay
@@ -20,13 +21,16 @@ internal fun PlayerRuntimeController.maybeAutoSwitchInternalPlayerOnStartupError
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
     }
+    beginSwitchTraceSession(reason = "startup-failover", targetEngine = targetEngine)
+    logSwitchTrace(
+        stage = "startup-failover-trigger",
+        message = "allowEngineFailover=$allowEngineFailover detailedError=${detailedError.take(220)}"
+    )
+    rememberCurrentTrackPreferenceForEngineSwitch()
     Log.w(PlayerRuntimeController.TAG, "Startup playback error; auto-switching engine: $detailedError")
     startupEngineFailoverTriggered = true
 
-    val targetEngineLabel = when (targetEngine) {
-        InternalPlayerEngine.EXOPLAYER -> context.getString(R.string.playback_engine_exoplayer)
-        InternalPlayerEngine.MVP_PLAYER -> context.getString(R.string.playback_engine_mvplayer)
-    }
+    val targetEngineLabel = targetEngineLabel(targetEngine)
     val switchMessage = context.getString(R.string.player_engine_switching_message, targetEngineLabel)
 
     hidePlayerEngineSwitchInfoJob?.cancel()
@@ -59,7 +63,798 @@ internal fun PlayerRuntimeController.maybeAutoSwitchInternalPlayerOnStartupError
     return true
 }
 
+internal fun PlayerRuntimeController.switchInternalPlayerEngineManually() {
+    if (currentStreamUrl.isBlank()) return
+
+    val targetEngine = when (currentInternalPlayerEngine) {
+        InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
+        InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
+    }
+    beginSwitchTraceSession(reason = "manual-osd", targetEngine = targetEngine)
+    val targetEngineLabel = targetEngineLabel(targetEngine)
+    val switchMessage = context.getString(R.string.player_engine_switching_manual_message, targetEngineLabel)
+    val currentPosition = currentPlaybackPositionMs()?.coerceAtLeast(0L) ?: 0L
+    logSwitchTrace(
+        stage = "manual-switch-trigger",
+        message = "targetEngine=$targetEngine positionMs=$currentPosition " +
+            "audioUiIndex=${_uiState.value.selectedAudioTrackIndex} subtitleUiIndex=${_uiState.value.selectedSubtitleTrackIndex}"
+    )
+
+    rememberCurrentTrackPreferenceForEngineSwitch()
+
+    if (currentPosition > 0L) {
+        pendingResumeProgress = null
+        _uiState.update { it.copy(pendingSeekPosition = currentPosition) }
+    }
+
+    startupEngineFailoverTriggered = false
+    userPausedManually = false
+    resetErrorRetryState()
+    hidePlayerEngineSwitchInfoJob?.cancel()
+    _uiState.update {
+        it.copy(
+            error = null,
+            showPauseOverlay = false,
+            showLoadingOverlay = it.loadingOverlayEnabled,
+            showControls = false,
+            showAudioOverlay = false,
+            showSubtitleOverlay = false,
+            showSubtitleStylePanel = false,
+            showSubtitleDelayOverlay = false,
+            showSpeedDialog = false,
+            showMoreDialog = false,
+            internalPlayerEngine = targetEngine,
+            showPlayerEngineSwitchInfo = true,
+            playerEngineSwitchInfoText = switchMessage
+        )
+    }
+
+    val switchingToMpv = targetEngine == InternalPlayerEngine.MVP_PLAYER
+    pendingMpvHardRestartOnNextAttach = switchingToMpv
+    delayMpvResumeSeekUntilVideoTrack = switchingToMpv
+
+    releasePlayer(flushPlaybackState = true)
+    initializePlayer(
+        url = currentStreamUrl,
+        headers = currentHeaders,
+        overrideInternalPlayerEngine = targetEngine,
+        allowEngineFailover = true
+    )
+
+    hidePlayerEngineSwitchInfoJob = scope.launch {
+        delay(2200)
+        _uiState.update { state -> state.copy(showPlayerEngineSwitchInfo = false) }
+    }
+}
+
 private fun PlayerRuntimeController.isStartupPhaseForEngineFailover(): Boolean {
     val state = _uiState.value
     return !hasRenderedFirstFrame && (state.showLoadingOverlay || state.isBuffering || state.currentPosition <= 0L)
+}
+
+private fun PlayerRuntimeController.targetEngineLabel(targetEngine: InternalPlayerEngine): String {
+    return when (targetEngine) {
+        InternalPlayerEngine.EXOPLAYER -> context.getString(R.string.playback_engine_exoplayer)
+        InternalPlayerEngine.MVP_PLAYER -> context.getString(R.string.playback_engine_mvplayer)
+    }
+}
+
+internal fun PlayerRuntimeController.clearPendingEngineSwitchTrackPreference() {
+    logSwitchTrace(
+        stage = "pending-switch-pref-clear",
+        message = "reason=explicit-clear previous=${pendingEngineSwitchTrackPreference != null}"
+    )
+    pendingEngineSwitchTrackPreference = null
+}
+
+private fun PlayerRuntimeController.rememberCurrentTrackPreferenceForEngineSwitch() {
+    val state = _uiState.value
+    val sourceEngine = currentInternalPlayerEngine
+    logSwitchTrace(
+        stage = "capture-start",
+        message = "sourceEngine=$sourceEngine uiAudioIndex=${state.selectedAudioTrackIndex} " +
+            "uiSubtitleIndex=${state.selectedSubtitleTrackIndex} " +
+            "uiAudioCount=${state.audioTracks.size} uiSubtitleCount=${state.subtitleTracks.size} " +
+            "uiAddonSelected=${state.selectedAddonSubtitle?.let { "${it.lang}/${it.addonName}/${it.id}" } ?: "none"}"
+    )
+
+    val rememberedAudio = captureCurrentAudioSelectionForEngineSwitch(
+        state = state,
+        sourceEngine = sourceEngine
+    )
+    val rememberedSubtitle = resolveCurrentSubtitleSelectionForEngineSwitch(
+        state = state,
+        sourceEngine = sourceEngine
+    )
+
+    val mergedPreference = PlayerRuntimeController.TrackPreference(
+        audio = rememberedAudio,
+        subtitle = rememberedSubtitle
+    )
+    val capturedPreference = mergedPreference.takeUnless { it.audio == null && it.subtitle == null }
+    pendingEngineSwitchTrackPreference = capturedPreference?.let { preference ->
+        PlayerRuntimeController.PendingEngineSwitchTrackPreference(
+            streamUrl = currentStreamUrl,
+            preference = preference,
+            sourceEngine = sourceEngine
+        )
+    }
+    logSwitchTrace(
+        stage = "capture-finish",
+        message = "sourceEngine=$sourceEngine " +
+            "audio=${describeRememberedTrackForLog(rememberedAudio)} " +
+            "subtitle=${describeRememberedSubtitleForLog(rememberedSubtitle)} " +
+            "savedForSwitch=${capturedPreference != null}"
+    )
+    subtitleDisabledByPersistedPreference = false
+    subtitleAddonRestoredByPersistedPreference = false
+    pendingRestoredAddonSubtitle = null
+}
+
+private fun PlayerRuntimeController.captureCurrentAudioSelectionForEngineSwitch(
+    state: PlayerUiState,
+    sourceEngine: InternalPlayerEngine
+): PlayerRuntimeController.RememberedTrackSelection? {
+    val mpvSelected = if (sourceEngine == InternalPlayerEngine.MVP_PLAYER) {
+        mpvView?.readTrackSnapshot()?.audioTracks?.firstOrNull { it.isSelected }
+    } else {
+        null
+    }
+    if (mpvSelected != null) {
+        logSwitchTrace(
+            stage = "capture-audio",
+            message = "source=mpv-snapshot lang=${mpvSelected.language} name=${mpvSelected.name} id=${mpvSelected.id}"
+        )
+        return PlayerRuntimeController.RememberedTrackSelection(
+            language = mpvSelected.language,
+            name = mpvSelected.name,
+            trackId = mpvSelected.id.toString()
+        )
+    }
+
+    val exoSelected = run {
+        val player = _exoPlayer ?: return@run null
+        player.currentTracks.groups.forEach { group ->
+            if (group.type != C.TRACK_TYPE_AUDIO) return@forEach
+            for (i in 0 until group.length) {
+                if (!group.isTrackSelected(i)) continue
+                val format = group.getTrackFormat(i)
+                return@run PlayerRuntimeController.RememberedTrackSelection(
+                    language = format.language,
+                    name = format.label ?: format.language ?: "Audio",
+                    trackId = format.id
+                )
+            }
+        }
+        null
+    }
+    if (exoSelected != null) {
+        logSwitchTrace(
+            stage = "capture-audio",
+            message = "source=exo-tracks lang=${exoSelected.language} name=${exoSelected.name} id=${exoSelected.trackId}"
+        )
+        return exoSelected
+    }
+
+    val uiTrack = state.audioTracks.getOrNull(state.selectedAudioTrackIndex)
+        ?: state.audioTracks.firstOrNull { it.isSelected }
+
+    return uiTrack?.let { track ->
+        logSwitchTrace(
+            stage = "capture-audio",
+            message = "source=ui-fallback lang=${track.language} name=${track.name} id=${track.trackId}"
+        )
+        PlayerRuntimeController.RememberedTrackSelection(
+            language = track.language,
+            name = track.name,
+            trackId = track.trackId
+        )
+    }.also { selection ->
+        if (selection == null) {
+            logSwitchTrace(
+                stage = "capture-audio",
+                message = "source=none result=null"
+            )
+        }
+    }
+}
+
+private fun PlayerRuntimeController.captureCurrentSubtitleSelectionForEngineSwitch(
+    state: PlayerUiState,
+    sourceEngine: InternalPlayerEngine
+): PlayerRuntimeController.RememberedSubtitleSelection? {
+    data class SelectedExoTextTrack(
+        val id: String?,
+        val language: String?,
+        val label: String?,
+        val isForced: Boolean,
+        val indexHint: Int?,
+        val languageIndexHint: Int?
+    )
+
+    val mpvSnapshot = if (sourceEngine == InternalPlayerEngine.MVP_PLAYER) mpvView?.readTrackSnapshot() else null
+    logSwitchTrace(
+        stage = "capture-subtitle-start",
+        message = "sourceEngine=$sourceEngine uiSubtitleCount=${state.subtitleTracks.size} " +
+            "uiSelectedSubtitleIndex=${state.selectedSubtitleTrackIndex} " +
+            "uiAddonSelected=${state.selectedAddonSubtitle?.let { "${it.lang}/${it.addonName}/${it.id}" } ?: "none"} " +
+            "mpvSnapshotSubs=${mpvSnapshot?.subtitleTracks?.size ?: -1}"
+    )
+    if (sourceEngine == InternalPlayerEngine.MVP_PLAYER) {
+        val mpvSelectedSubtitle = mpvSnapshot?.subtitleTracks?.firstOrNull { it.isSelected }
+        if (mpvSelectedSubtitle != null) {
+            if (mpvSelectedSubtitle.isExternal) {
+                val addon = findAddonSubtitleByTrackIdOrLanguage(
+                    state = state,
+                    trackId = mpvSelectedSubtitle.name,
+                    language = mpvSelectedSubtitle.language
+                )
+                if (addon != null) {
+                    logSwitchTrace(
+                        stage = "capture-subtitle",
+                        message = "source=mpv-external->addon id=${addon.id} lang=${addon.lang} addon=${addon.addonName}"
+                    )
+                    return PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+                        id = addon.id,
+                        url = addon.url,
+                        language = addon.lang,
+                        addonName = addon.addonName
+                    )
+                }
+                state.selectedAddonSubtitle?.let { selectedAddonFromUi ->
+                    logSwitchTrace(
+                        stage = "capture-subtitle",
+                        message = "source=mpv-external->ui-addon id=${selectedAddonFromUi.id} " +
+                            "lang=${selectedAddonFromUi.lang} addon=${selectedAddonFromUi.addonName}"
+                    )
+                    return PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+                        id = selectedAddonFromUi.id,
+                        url = selectedAddonFromUi.url,
+                        language = selectedAddonFromUi.lang,
+                        addonName = selectedAddonFromUi.addonName
+                    )
+                }
+            }
+            logSwitchTrace(
+                stage = "capture-subtitle",
+                message = "source=mpv-selected-internal id=${mpvSelectedSubtitle.id} lang=${mpvSelectedSubtitle.language} " +
+                    "name=${mpvSelectedSubtitle.name} forced=${mpvSelectedSubtitle.isForced} external=${mpvSelectedSubtitle.isExternal}"
+            )
+            return PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+                track = buildRememberedInternalSubtitleSelectionForEngineSwitch(
+                    state = state,
+                    language = mpvSelectedSubtitle.language,
+                    name = mpvSelectedSubtitle.name,
+                    trackId = mpvSelectedSubtitle.id.toString(),
+                    isForced = mpvSelectedSubtitle.isForced,
+                    selectedUiTrackOverride = resolveUiSubtitleTrackForEngineSwitchHints(
+                        state = state,
+                        trackId = mpvSelectedSubtitle.id.toString(),
+                        language = mpvSelectedSubtitle.language,
+                        name = mpvSelectedSubtitle.name
+                    ),
+                    allowUiStateFallbackForHints = false
+                )
+            )
+        }
+        logSwitchTrace(
+            stage = "capture-subtitle",
+            message = "source=mpv-selected-internal result=none"
+        )
+    }
+
+    if (sourceEngine == InternalPlayerEngine.EXOPLAYER) {
+        val exoPlayer = _exoPlayer
+        val exoTextTrackDisabled =
+            exoPlayer?.trackSelectionParameters?.disabledTrackTypes?.contains(C.TRACK_TYPE_TEXT) == true
+        logSwitchTrace(
+            stage = "capture-subtitle-exo",
+            message = "textTrackDisabled=$exoTextTrackDisabled hasPlayer=${exoPlayer != null}"
+        )
+        val exoSelectedText = run {
+            val player = exoPlayer ?: return@run null
+            val internalTracks = mutableListOf<SelectedExoTextTrack>()
+            var selectedTrack: SelectedExoTextTrack? = null
+            player.currentTracks.groups.forEach { group ->
+                if (group.type != C.TRACK_TYPE_TEXT) return@forEach
+                for (i in 0 until group.length) {
+                    val format = group.getTrackFormat(i)
+                    val trackId = format.id
+                    val isForced = (format.selectionFlags and C.SELECTION_FLAG_FORCED) != 0
+                    val isAddonTrack =
+                        trackId?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true
+                    val currentTrack = SelectedExoTextTrack(
+                        id = trackId,
+                        language = format.language,
+                        label = format.label,
+                        isForced = isForced,
+                        indexHint = if (isAddonTrack) null else internalTracks.size,
+                        languageIndexHint = null
+                    )
+                    if (!isAddonTrack) {
+                        internalTracks += currentTrack
+                    }
+                    if (group.isTrackSelected(i)) {
+                        selectedTrack = currentTrack
+                    }
+                }
+            }
+            val selected = selectedTrack ?: run {
+                val preferredTargets = subtitleLanguageTargets()
+                internalTracks.firstOrNull { track ->
+                    preferredTargets.any { target ->
+                        val normalizedTarget = target.trim().lowercase()
+                        if (normalizedTarget == "forced") {
+                            track.isForced
+                        } else {
+                            PlayerSubtitleUtils.matchesLanguageCode(track.language, target)
+                        }
+                    }
+                } ?: internalTracks.firstOrNull { !it.isForced }
+                    ?: internalTracks.firstOrNull()
+            } ?: return@run null
+            val selectedIndex = selected.indexHint ?: return@run selected
+            val selectedInternalTrack = internalTracks.getOrNull(selectedIndex) ?: return@run selected
+            val selectedVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+                language = selectedInternalTrack.language,
+                name = selectedInternalTrack.label ?: selectedInternalTrack.language,
+                trackId = selectedInternalTrack.id
+            )
+            val languageCandidates = internalTracks.indices.filter { index ->
+                val candidate = internalTracks[index]
+                val candidateVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+                    language = candidate.language,
+                    name = candidate.label ?: candidate.language,
+                    trackId = candidate.id
+                )
+                candidateVariant == selectedVariant ||
+                    (!selectedInternalTrack.language.isNullOrBlank() &&
+                        PlayerSubtitleUtils.matchesLanguageCode(
+                            candidate.language,
+                            selectedInternalTrack.language
+                        ))
+            }
+            selected.copy(
+                languageIndexHint = languageCandidates.indexOf(selectedIndex).takeIf { it >= 0 }
+            )
+        }
+        if (exoSelectedText == null && exoTextTrackDisabled) {
+            logSwitchTrace(
+                stage = "capture-subtitle",
+                message = "source=exo-selected result=disabled(no-selected-and-disabled=true)"
+            )
+            return PlayerRuntimeController.RememberedSubtitleSelection.Disabled
+        }
+        if (exoSelectedText != null) {
+            val formatId = exoSelectedText.id
+            val formatLanguage = exoSelectedText.language
+            val formatLabel = exoSelectedText.label
+            if (formatId?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) {
+                val addon = findAddonSubtitleByTrackIdOrLanguage(
+                    state = state,
+                    trackId = formatId,
+                    language = formatLanguage
+                )
+                if (addon != null) {
+                    logSwitchTrace(
+                        stage = "capture-subtitle",
+                        message = "source=exo-addon-track->addon id=${addon.id} lang=${addon.lang} addon=${addon.addonName}"
+                    )
+                    return PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+                        id = addon.id,
+                        url = addon.url,
+                        language = addon.lang,
+                        addonName = addon.addonName
+                    )
+                }
+                state.selectedAddonSubtitle?.let { selectedAddonFromUi ->
+                    logSwitchTrace(
+                        stage = "capture-subtitle",
+                        message = "source=exo-addon-track->ui-addon id=${selectedAddonFromUi.id} " +
+                            "lang=${selectedAddonFromUi.lang} addon=${selectedAddonFromUi.addonName}"
+                    )
+                    return PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+                        id = selectedAddonFromUi.id,
+                        url = selectedAddonFromUi.url,
+                        language = selectedAddonFromUi.lang,
+                        addonName = selectedAddonFromUi.addonName
+                    )
+                }
+            }
+
+            logSwitchTrace(
+                stage = "capture-subtitle",
+                message = "source=exo-selected-internal id=$formatId lang=$formatLanguage name=$formatLabel " +
+                    "indexHint=${exoSelectedText.indexHint} languageIndexHint=${exoSelectedText.languageIndexHint} " +
+                    "forced=${exoSelectedText.isForced}"
+            )
+            return PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+                track = PlayerRuntimeController.RememberedTrackSelection(
+                    language = formatLanguage,
+                    name = formatLabel ?: formatLanguage ?: "Subtitle",
+                    trackId = formatId,
+                    indexHint = exoSelectedText.indexHint,
+                    languageIndexHint = exoSelectedText.languageIndexHint,
+                    isForcedHint = exoSelectedText.isForced
+                )
+            )
+        }
+    }
+
+    val uiTrack = state.subtitleTracks.getOrNull(state.selectedSubtitleTrackIndex)
+        ?: state.subtitleTracks.firstOrNull { it.isSelected }
+    if (uiTrack != null) {
+        logSwitchTrace(
+            stage = "capture-subtitle",
+            message = "source=ui-track id=${uiTrack.trackId} lang=${uiTrack.language} name=${uiTrack.name} forced=${uiTrack.isForced}"
+        )
+        return PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+            track = buildRememberedInternalSubtitleSelectionForEngineSwitch(
+                state = state,
+                language = uiTrack.language,
+                name = uiTrack.name,
+                trackId = uiTrack.trackId,
+                isForced = uiTrack.isForced
+            )
+        )
+    }
+    if (sourceEngine == InternalPlayerEngine.EXOPLAYER) {
+        val uiFallbackTrack = pickUiInternalSubtitleTrackForEngineSwitchFallback(state)
+        if (uiFallbackTrack != null) {
+            logSwitchTrace(
+                stage = "capture-subtitle",
+                message = "source=ui-fallback id=${uiFallbackTrack.trackId} lang=${uiFallbackTrack.language} " +
+                    "name=${uiFallbackTrack.name} forced=${uiFallbackTrack.isForced}"
+            )
+            return PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+                track = buildRememberedInternalSubtitleSelectionForEngineSwitch(
+                    state = state,
+                    language = uiFallbackTrack.language,
+                    name = uiFallbackTrack.name,
+                    trackId = uiFallbackTrack.trackId,
+                    isForced = uiFallbackTrack.isForced,
+                    selectedUiTrackOverride = uiFallbackTrack
+                )
+            )
+        }
+    }
+
+    state.selectedAddonSubtitle?.let { selectedAddonFromUi ->
+        logSwitchTrace(
+            stage = "capture-subtitle",
+            message = "source=ui-selected-addon id=${selectedAddonFromUi.id} " +
+                "lang=${selectedAddonFromUi.lang} addon=${selectedAddonFromUi.addonName}"
+        )
+        return PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+            id = selectedAddonFromUi.id,
+            url = selectedAddonFromUi.url,
+            language = selectedAddonFromUi.lang,
+            addonName = selectedAddonFromUi.addonName
+        )
+    }
+
+    val mpvHasSubtitleTracks = mpvSnapshot?.subtitleTracks?.isNotEmpty() == true
+    val exoHasSubtitleTracks = if (sourceEngine == InternalPlayerEngine.EXOPLAYER) {
+        run {
+            val player = _exoPlayer ?: return@run false
+            player.currentTracks.groups.any { group ->
+                group.type == C.TRACK_TYPE_TEXT && group.length > 0
+            }
+        }
+    } else {
+        false
+    }
+    if (mpvHasSubtitleTracks || exoHasSubtitleTracks) {
+        logSwitchTrace(
+            stage = "capture-subtitle",
+            message = "source=implicit-disabled mpvHasTracks=$mpvHasSubtitleTracks exoHasTracks=$exoHasSubtitleTracks"
+        )
+        return PlayerRuntimeController.RememberedSubtitleSelection.Disabled
+    }
+
+    logSwitchTrace(
+        stage = "capture-subtitle",
+        message = "source=none result=null"
+    )
+    return null
+}
+
+private fun PlayerRuntimeController.resolveCurrentSubtitleSelectionForEngineSwitch(
+    state: PlayerUiState,
+    sourceEngine: InternalPlayerEngine
+): PlayerRuntimeController.RememberedSubtitleSelection? {
+    val capturedSelection = captureCurrentSubtitleSelectionForEngineSwitch(
+        state = state,
+        sourceEngine = sourceEngine
+    )
+    logSwitchTrace(
+        stage = "resolve-subtitle-start",
+        message = "captured=${describeRememberedSubtitleForLog(capturedSelection)} sourceEngine=$sourceEngine"
+    )
+    val shouldUseFallback =
+        capturedSelection == null || capturedSelection == PlayerRuntimeController.RememberedSubtitleSelection.Disabled
+    if (!shouldUseFallback) {
+        logSwitchTrace(
+            stage = "resolve-subtitle",
+            message = "result=${describeRememberedSubtitleForLog(capturedSelection)} reason=captured-direct"
+        )
+        return capturedSelection
+    }
+
+    effectiveSubtitleSelectionForEngineSwitch
+        ?.takeIf { effective -> effective.streamUrl == currentStreamUrl }
+        ?.selection
+        ?.let { effectiveSelection ->
+            logSwitchTrace(
+                stage = "resolve-subtitle",
+                message = "result=${describeRememberedSubtitleForLog(effectiveSelection)} " +
+                    "reason=effective-fallback captured=${describeRememberedSubtitleForLog(capturedSelection)}"
+            )
+            return effectiveSelection
+        }
+
+    explicitSubtitleSelectionForEngineSwitch
+        ?.takeIf { explicit -> explicit.streamUrl == currentStreamUrl }
+        ?.selection
+        ?.let { explicitSelection ->
+            logSwitchTrace(
+                stage = "resolve-subtitle",
+                message = "result=${describeRememberedSubtitleForLog(explicitSelection)} " +
+                    "reason=explicit-fallback captured=${describeRememberedSubtitleForLog(capturedSelection)}"
+            )
+            return explicitSelection
+        }
+
+    rememberedTrackPreference?.subtitle?.let { rememberedSelection ->
+        logSwitchTrace(
+            stage = "resolve-subtitle",
+            message = "result=${describeRememberedSubtitleForLog(rememberedSelection)} " +
+                "reason=remembered-fallback captured=${describeRememberedSubtitleForLog(capturedSelection)}"
+        )
+        return rememberedSelection
+    }
+
+    logSwitchTrace(
+        stage = "resolve-subtitle",
+        message = "result=${describeRememberedSubtitleForLog(capturedSelection)} reason=no-fallback-available"
+    )
+    return capturedSelection
+}
+
+private fun PlayerRuntimeController.pickUiInternalSubtitleTrackForEngineSwitchFallback(
+    state: PlayerUiState
+): TrackInfo? {
+    if (state.subtitleTracks.isEmpty()) {
+        logSwitchTrace(
+            stage = "capture-subtitle-ui-fallback",
+            message = "result=null reason=no-ui-tracks"
+        )
+        return null
+    }
+
+    state.subtitleTracks.getOrNull(state.selectedSubtitleTrackIndex)?.let {
+        logSwitchTrace(
+            stage = "capture-subtitle-ui-fallback",
+            message = "reason=selectedSubtitleTrackIndex index=${it.index} id=${it.trackId} lang=${it.language}"
+        )
+        return it
+    }
+    state.subtitleTracks.firstOrNull { it.isSelected }?.let {
+        logSwitchTrace(
+            stage = "capture-subtitle-ui-fallback",
+            message = "reason=first-isSelected index=${it.index} id=${it.trackId} lang=${it.language}"
+        )
+        return it
+    }
+
+    val preferredIndex = findBestInternalSubtitleTrackIndex(
+        subtitleTracks = state.subtitleTracks,
+        targets = subtitleLanguageTargets()
+    )
+    if (preferredIndex >= 0) {
+        state.subtitleTracks.getOrNull(preferredIndex)?.let {
+            logSwitchTrace(
+                stage = "capture-subtitle-ui-fallback",
+                message = "reason=preferred-language index=${it.index} id=${it.trackId} lang=${it.language}"
+            )
+            return it
+        }
+    }
+
+    state.subtitleTracks.firstOrNull { !it.isForced }?.let {
+        logSwitchTrace(
+            stage = "capture-subtitle-ui-fallback",
+            message = "reason=first-non-forced index=${it.index} id=${it.trackId} lang=${it.language}"
+        )
+        return it
+    }
+    return state.subtitleTracks.firstOrNull().also { selected ->
+        logSwitchTrace(
+            stage = "capture-subtitle-ui-fallback",
+            message = "reason=first-any index=${selected?.index} id=${selected?.trackId} lang=${selected?.language}"
+        )
+    }
+}
+
+internal fun PlayerRuntimeController.buildRememberedInternalSubtitleSelectionForEngineSwitch(
+    state: PlayerUiState,
+    language: String?,
+    name: String?,
+    trackId: String?,
+    isForced: Boolean,
+    selectedUiTrackOverride: TrackInfo? = null,
+    allowUiStateFallbackForHints: Boolean = true
+): PlayerRuntimeController.RememberedTrackSelection {
+    val selectedUiTrack = selectedUiTrackOverride
+        ?: if (allowUiStateFallbackForHints) {
+            state.subtitleTracks.getOrNull(state.selectedSubtitleTrackIndex)
+                ?: state.subtitleTracks.firstOrNull { it.isSelected }
+        } else {
+            null
+        }
+
+    val selection = PlayerRuntimeController.RememberedTrackSelection(
+        language = language,
+        name = name,
+        trackId = trackId,
+        indexHint = selectedUiTrack?.index?.takeIf { it >= 0 },
+        languageIndexHint = selectedUiTrack?.let { track ->
+            subtitleLanguageOrdinalHintForEngineSwitch(state.subtitleTracks, track)
+        },
+        isForcedHint = selectedUiTrack?.isForced ?: isForced
+    )
+    logSwitchTrace(
+        stage = "capture-subtitle-hints-build",
+        message = "inputId=$trackId inputLang=$language inputName=$name inputForced=$isForced " +
+            "uiTrack=${selectedUiTrack?.let { "${it.index}/${it.trackId}/${it.language}/${it.name}/forced=${it.isForced}" } ?: "none"} " +
+            "result=${describeRememberedTrackForLog(selection)} allowUiFallback=$allowUiStateFallbackForHints"
+    )
+    return selection
+}
+
+private fun PlayerRuntimeController.resolveUiSubtitleTrackForEngineSwitchHints(
+    state: PlayerUiState,
+    trackId: String?,
+    language: String?,
+    name: String?
+): TrackInfo? {
+    val normalizedTrackId = normalizeTrackMatchValue(trackId)
+    if (!normalizedTrackId.isNullOrBlank()) {
+        state.subtitleTracks.firstOrNull { track ->
+            normalizeTrackMatchValue(track.trackId) == normalizedTrackId
+        }?.let {
+            logSwitchTrace(
+                stage = "capture-subtitle-hints",
+                message = "reason=track-id id=${it.trackId} lang=${it.language} name=${it.name}"
+            )
+            return it
+        }
+    }
+
+    val normalizedLanguage = normalizeTrackMatchValue(language)
+    val normalizedName = normalizeTrackMatchValue(name)
+
+    if (!normalizedLanguage.isNullOrBlank() && !normalizedName.isNullOrBlank()) {
+        state.subtitleTracks.firstOrNull { track ->
+            normalizeTrackMatchValue(track.language) == normalizedLanguage &&
+                normalizeTrackMatchValue(track.name) == normalizedName
+        }?.let {
+            logSwitchTrace(
+                stage = "capture-subtitle-hints",
+                message = "reason=lang+name id=${it.trackId} lang=${it.language} name=${it.name}"
+            )
+            return it
+        }
+    }
+
+    if (!normalizedLanguage.isNullOrBlank()) {
+        state.subtitleTracks.firstOrNull { track ->
+            normalizeTrackMatchValue(track.language) == normalizedLanguage && track.isSelected
+        }?.let {
+            logSwitchTrace(
+                stage = "capture-subtitle-hints",
+                message = "reason=lang+selected id=${it.trackId} lang=${it.language} name=${it.name}"
+            )
+            return it
+        }
+    }
+
+    logSwitchTrace(
+        stage = "capture-subtitle-hints",
+        message = "reason=no-ui-match trackId=$trackId language=$language name=$name"
+    )
+    return null
+}
+
+internal fun PlayerRuntimeController.subtitleLanguageOrdinalHintForEngineSwitch(
+    tracks: List<TrackInfo>,
+    selectedTrack: TrackInfo
+): Int? {
+    val selectedVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+        language = selectedTrack.language,
+        name = selectedTrack.name,
+        trackId = selectedTrack.trackId
+    )
+    val selectedTrackPosition = tracks.indexOfFirst { it.index == selectedTrack.index }
+    if (selectedTrackPosition < 0) return null
+
+    val candidates = tracks.indices.filter { index ->
+        val candidate = tracks[index]
+        val candidateVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+            language = candidate.language,
+            name = candidate.name,
+            trackId = candidate.trackId
+        )
+        candidateVariant == selectedVariant ||
+            (!selectedTrack.language.isNullOrBlank() &&
+                PlayerSubtitleUtils.matchesLanguageCode(candidate.language, selectedTrack.language))
+    }
+
+    val ordinal = candidates.indexOf(selectedTrackPosition).takeIf { it >= 0 }
+    logSwitchTrace(
+        stage = "capture-subtitle-language-ordinal",
+        message = "selectedIndex=${selectedTrack.index} selectedId=${selectedTrack.trackId} " +
+            "selectedLang=${selectedTrack.language} candidates=$candidates ordinal=$ordinal"
+    )
+    return ordinal
+}
+
+private fun PlayerRuntimeController.findAddonSubtitleByTrackIdOrLanguage(
+    state: PlayerUiState,
+    trackId: String?,
+    language: String?
+): com.nuvio.tv.domain.model.Subtitle? {
+    val normalizedTrackId = trackId?.trim()
+    if (!normalizedTrackId.isNullOrBlank()) {
+        state.addonSubtitles.firstOrNull { subtitle ->
+            val addonTrackId = buildAddonSubtitleTrackId(subtitle)
+            addonTrackId.equals(normalizedTrackId, ignoreCase = true) ||
+                normalizedTrackId.contains(addonTrackId, ignoreCase = true)
+        }?.let {
+            logSwitchTrace(
+                stage = "capture-subtitle-addon-match",
+                message = "reason=trackId matchId=${it.id} matchLang=${it.lang} addon=${it.addonName} trackId=$trackId"
+            )
+            return it
+        }
+    }
+    val lang = language?.trim()
+    if (!lang.isNullOrBlank()) {
+        state.addonSubtitles.firstOrNull { subtitle ->
+            PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, lang)
+        }?.let {
+            logSwitchTrace(
+                stage = "capture-subtitle-addon-match",
+                message = "reason=language matchId=${it.id} matchLang=${it.lang} addon=${it.addonName} language=$language"
+            )
+            return it
+        }
+    }
+    logSwitchTrace(
+        stage = "capture-subtitle-addon-match",
+        message = "reason=no-match trackId=$trackId language=$language addonPool=${state.addonSubtitles.size}"
+    )
+    return null
+}
+
+private fun PlayerRuntimeController.describeRememberedSubtitleForLog(
+    selection: PlayerRuntimeController.RememberedSubtitleSelection?
+): String {
+    return when (selection) {
+        null -> "none"
+        PlayerRuntimeController.RememberedSubtitleSelection.Disabled -> "disabled"
+        is PlayerRuntimeController.RememberedSubtitleSelection.Internal ->
+            "internal:${describeRememberedTrackForLog(selection.track)}"
+        is PlayerRuntimeController.RememberedSubtitleSelection.Addon ->
+            "addon:${selection.language}/${selection.addonName}/${selection.id}"
+    }
+}
+
+private fun PlayerRuntimeController.describeRememberedTrackForLog(
+    selection: PlayerRuntimeController.RememberedTrackSelection?
+): String {
+    if (selection == null) return "none"
+    return "lang=${selection.language} name=${selection.name} trackId=${selection.trackId} " +
+        "indexHint=${selection.indexHint} languageIndexHint=${selection.languageIndexHint} " +
+        "forcedHint=${selection.isForcedHint}"
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -598,12 +598,26 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
 }
 
 internal fun PlayerRuntimeController.resetAddonSubtitleStateForNewStream() {
+    logSwitchTrace(
+        stage = "reset-addon-state-new-stream",
+        message = "autoSubtitleSelectedBefore=$autoSubtitleSelected " +
+            "subtitleDisabledByPersistedPreference=$subtitleDisabledByPersistedPreference " +
+            "subtitleAddonRestoredByPersistedPreference=$subtitleAddonRestoredByPersistedPreference " +
+            "explicitSelectionBefore=${explicitSubtitleSelectionForEngineSwitch?.selection?.javaClass?.simpleName ?: "none"} " +
+            "effectiveSelectionBefore=${effectiveSubtitleSelectionForEngineSwitch?.selection?.javaClass?.simpleName ?: "none"}"
+    )
     autoSubtitleSelected = subtitleDisabledByPersistedPreference || subtitleAddonRestoredByPersistedPreference
     hasScannedTextTracksOnce = false
     pendingAddonSubtitleLanguage = null
     pendingAddonSubtitleTrackId = null
     pendingAudioSelectionAfterSubtitleRefresh = null
+    explicitSubtitleSelectionForEngineSwitch = null
+    effectiveSubtitleSelectionForEngineSwitch = null
     attachedAddonSubtitleKeys = emptySet()
+    logSwitchTrace(
+        stage = "reset-addon-state-new-stream",
+        message = "autoSubtitleSelectedAfter=$autoSubtitleSelected explicitSelectionAfter=none effectiveSelectionAfter=none"
+    )
     _uiState.update {
         it.copy(
             addonSubtitles = emptyList(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -170,7 +170,19 @@ internal fun PlayerRuntimeController.pauseForLifecycle() {
 
 internal fun PlayerRuntimeController.updateMpvAvailableTracks() {
     if (!isUsingMpvEngine()) return
+    if (mpvTrackRefreshInProgress) return
+    mpvTrackRefreshInProgress = true
+    try {
     val snapshot = mpvView?.readTrackSnapshot() ?: return
+    val switchPending = pendingEngineSwitchTrackPreference
+        ?.takeIf { it.streamUrl == currentStreamUrl && it.sourceEngine == InternalPlayerEngine.EXOPLAYER }
+    logSwitchTrace(
+        stage = "mpv-snapshot-read",
+        message = "switchPending=${switchPending != null} audioCount=${snapshot.audioTracks.size} " +
+            "subtitleCount=${snapshot.subtitleTracks.size} " +
+            "selectedAudioId=${snapshot.audioTracks.firstOrNull { it.isSelected }?.id} " +
+            "selectedSubtitleId=${snapshot.subtitleTracks.firstOrNull { it.isSelected }?.id}"
+    )
 
     val audioTracks = snapshot.audioTracks
         .mapIndexed { index, track ->
@@ -212,6 +224,12 @@ internal fun PlayerRuntimeController.updateMpvAvailableTracks() {
     val selectedSubtitleIndex = internalSubtitleTracks.indexOfFirst { it.isSelected }
     val selectedExternalSubtitleTrack = snapshot.subtitleTracks.firstOrNull { it.isExternal && it.isSelected }
     val selectedExternalSubtitle = selectedExternalSubtitleTrack != null
+    logSwitchTrace(
+        stage = "mpv-snapshot-mapped",
+        message = "selectedAudioIndex=$selectedAudioIndex selectedSubtitleIndex=$selectedSubtitleIndex " +
+            "selectedExternalSubtitle=${selectedExternalSubtitleTrack?.id ?: "none"} " +
+            "mappedInternalSubtitleCount=${internalSubtitleTracks.size}"
+    )
 
     hasScannedTextTracksOnce = true
     maybeRestorePendingAudioSelectionAfterSubtitleRefresh(audioTracks)
@@ -257,6 +275,15 @@ internal fun PlayerRuntimeController.updateMpvAvailableTracks() {
         audioTracks = audioTracks,
         subtitleTracks = internalSubtitleTracks
     )
+    logSwitchTrace(
+        stage = "mpv-snapshot-after-restore",
+        message = "uiAudioIndex=${_uiState.value.selectedAudioTrackIndex} " +
+            "uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex} " +
+            "uiAddonSelected=${_uiState.value.selectedAddonSubtitle?.let { "${it.lang}/${it.addonName}/${it.id}" } ?: "none"}"
+    )
+    } finally {
+        mpvTrackRefreshInProgress = false
+    }
 }
 
 private fun PlayerRuntimeController.performPendingMpvHardRestartIfNeeded(view: NuvioMpvSurfaceView): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -566,6 +566,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSelectAudioTrack -> {
+            logSwitchTrace(
+                stage = "event-select-audio",
+                message = "index=${event.index}"
+            )
             rememberAudioSelection(event.index)
             selectAudioTrack(event.index)
             _uiState.update { it.copy(showAudioOverlay = false, showSubtitleDelayOverlay = false) }
@@ -590,6 +594,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSelectSubtitleTrack -> {
+            logSwitchTrace(
+                stage = "event-select-subtitle-internal",
+                message = "index=${event.index}"
+            )
             autoSubtitleSelected = true
             pendingAddonSubtitleLanguage = null
             pendingAddonSubtitleTrackId = null
@@ -607,6 +615,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         PlayerEvent.OnDisableSubtitles -> {
+            logSwitchTrace(
+                stage = "event-disable-subtitles",
+                message = "selectedSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex}"
+            )
             autoSubtitleSelected = true
             pendingAddonSubtitleLanguage = null
             pendingAddonSubtitleTrackId = null
@@ -625,6 +637,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSelectAddonSubtitle -> {
+            logSwitchTrace(
+                stage = "event-select-subtitle-addon",
+                message = "addonId=${event.subtitle.id} addonLang=${event.subtitle.lang} addonName=${event.subtitle.addonName}"
+            )
             autoSubtitleSelected = true
             rememberAddonSubtitleSelection(event.subtitle)
             selectAddonSubtitle(event.subtitle)
@@ -828,6 +844,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             hasRenderedFirstFrame = false
             hasRetriedCurrentStreamAfter416 = false
             resetErrorRetryState()
+            clearPendingEngineSwitchTrackPreference()
             resetNextEpisodeCardState(clearEpisode = false)
             _uiState.update { state ->
                 state.copy(
@@ -947,6 +964,13 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
                 delay(1500)
                 _uiState.update { it.copy(showAspectRatioIndicator = false) }
             }
+        }
+        PlayerEvent.OnSwitchInternalPlayerEngine -> {
+            logSwitchTrace(
+                stage = "event-switch-engine",
+                message = "requestedByUser=true"
+            )
+            switchInternalPlayerEngineManually()
         }
         PlayerEvent.OnShowStreamInfo -> {
             val info = buildStreamInfoData()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -9,6 +9,12 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
     headers: Map<String, String>,
     loadSavedProgress: Boolean
 ) {
+    logSwitchTrace(
+        stage = "prepare-playback-before-start",
+        message = "urlHash=${url.hashCode().toUInt().toString(16)} loadSavedProgress=$loadSavedProgress " +
+            "clearPendingSwitchPref=true"
+    )
+    clearPendingEngineSwitchTrackPreference()
     playbackPreparationJob?.cancel()
     playbackPreparationJob = scope.launch {
         warmTraktEpisodeMappingForCurrentPlayback()
@@ -16,6 +22,11 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
         if (persistedTrackPreference == null) {
             contentId?.let { id ->
                 val loaded = trackPreferenceDataStore.load(id)?.toTrackPreference()
+                logSwitchTrace(
+                    stage = "track-pref-load",
+                    message = "contentId=$id loadedAudio=${loaded?.audio?.language}/${loaded?.audio?.name} " +
+                        "loadedSubtitle=${loaded?.subtitle?.javaClass?.simpleName ?: "none"}"
+                )
                 Log.d(
                     PlayerRuntimeController.TAG,
                     "TRACK_PREF load: contentId=$id S${currentSeason}E${currentEpisode} " +
@@ -29,6 +40,12 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
                 "TRACK_PREF load: skipped (persistedTrackPreference already set: " +
                     "audio=${persistedTrackPreference?.audio?.language}/${persistedTrackPreference?.audio?.name} " +
                     "subtitle=${persistedTrackPreference?.subtitle?.javaClass?.simpleName})"
+            )
+            logSwitchTrace(
+                stage = "track-pref-load",
+                message = "skipped=true reason=persisted-already-set " +
+                    "audio=${persistedTrackPreference?.audio?.language}/${persistedTrackPreference?.audio?.name} " +
+                    "subtitle=${persistedTrackPreference?.subtitle?.javaClass?.simpleName ?: "none"}"
             )
         }
         initializePlayer(url, headers)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -79,6 +79,11 @@ internal fun PlayerRuntimeController.selectedAudioRequiresPcmForSpeed(player: Pl
 }
 
 internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {
+    logSwitchTrace(
+        stage = "select-audio-track",
+        message = "trackIndex=$trackIndex usingMpv=${isUsingMpvEngine()} " +
+            "track=${_uiState.value.audioTracks.getOrNull(trackIndex)?.let { "${it.language}/${it.name}/${it.trackId}" } ?: "none"}"
+    )
     if (isUsingMpvEngine()) {
         val wasPlaying = isPlaybackCurrentlyPlaying()
         val track = _uiState.value.audioTracks.getOrNull(trackIndex)
@@ -118,9 +123,15 @@ internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {
 
 internal fun PlayerRuntimeController.rememberAudioSelection(trackIndex: Int) {
     val selectedTrack = _uiState.value.audioTracks.getOrNull(trackIndex) ?: return
+    logSwitchTrace(
+        stage = "user-remember-audio",
+        message = "trackIndex=$trackIndex lang=${selectedTrack.language} name=${selectedTrack.name} id=${selectedTrack.trackId}"
+    )
+    val basePreference = currentTrackPreferenceForPersistence()
+    clearPendingEngineSwitchTrackPreference()
     persistedTrackPreference = null
     rememberedTrackPreference =
-        (rememberedTrackPreference ?: PlayerRuntimeController.TrackPreference())
+        basePreference
             .copy(
                 audio = PlayerRuntimeController.RememberedTrackSelection(
                     language = selectedTrack.language,
@@ -192,6 +203,11 @@ internal fun PlayerRuntimeController.applyAddonSubtitleOverrideByLanguage(
 }
 
 internal fun PlayerRuntimeController.selectSubtitleTrack(trackIndex: Int) {
+    logSwitchTrace(
+        stage = "select-subtitle-track",
+        message = "trackIndex=$trackIndex usingMpv=${isUsingMpvEngine()} " +
+            "track=${_uiState.value.subtitleTracks.getOrNull(trackIndex)?.let { "${it.language}/${it.name}/${it.trackId}/forced=${it.isForced}" } ?: "none"}"
+    )
     if (isUsingMpvEngine()) {
         Log.d(PlayerRuntimeController.TAG, "Selecting INTERNAL subtitle trackIndex=$trackIndex (mpv)")
         val shouldKeepPlaying = !userPausedManually && !_uiState.value.playbackEnded
@@ -236,25 +252,48 @@ internal fun PlayerRuntimeController.selectSubtitleTrack(trackIndex: Int) {
 
 internal fun PlayerRuntimeController.rememberInternalSubtitleSelection(trackIndex: Int) {
     val selectedTrack = _uiState.value.subtitleTracks.getOrNull(trackIndex) ?: return
+    logSwitchTrace(
+        stage = "user-remember-subtitle-internal",
+        message = "trackIndex=$trackIndex lang=${selectedTrack.language} name=${selectedTrack.name} " +
+            "id=${selectedTrack.trackId} forced=${selectedTrack.isForced}"
+    )
+    val rememberedSelection = PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+        track = buildRememberedInternalSubtitleSelectionForEngineSwitch(
+            state = _uiState.value,
+            language = selectedTrack.language,
+            name = selectedTrack.name,
+            trackId = selectedTrack.trackId,
+            isForced = selectedTrack.isForced,
+            selectedUiTrackOverride = selectedTrack
+        )
+    )
+    val basePreference = currentTrackPreferenceForPersistence()
+    clearPendingEngineSwitchTrackPreference()
     persistedTrackPreference = null
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
+    explicitSubtitleSelectionForEngineSwitch =
+        PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+            streamUrl = currentStreamUrl,
+            selection = rememberedSelection
+        )
+    effectiveSubtitleSelectionForEngineSwitch =
+        PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+            streamUrl = currentStreamUrl,
+            selection = rememberedSelection
+        )
     rememberedTrackPreference =
-        (rememberedTrackPreference ?: PlayerRuntimeController.TrackPreference())
-            .copy(
-                subtitle = PlayerRuntimeController.RememberedSubtitleSelection.Internal(
-                    track = PlayerRuntimeController.RememberedTrackSelection(
-                        language = selectedTrack.language,
-                        name = selectedTrack.name,
-                        trackId = selectedTrack.trackId
-                    )
-                )
-            )
+        basePreference
+            .copy(subtitle = rememberedSelection)
     persistTrackPreference()
 }
 
 internal fun PlayerRuntimeController.disableSubtitles() {
+    logSwitchTrace(
+        stage = "disable-subtitles",
+        message = "usingMpv=${isUsingMpvEngine()} selectedSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex}"
+    )
     if (isUsingMpvEngine()) {
         if (mpvView?.disableSubtitles() == true) {
             pendingAddonSubtitleLanguage = null
@@ -280,12 +319,28 @@ internal fun PlayerRuntimeController.disableSubtitles() {
 }
 
 internal fun PlayerRuntimeController.rememberSubtitleDisabled() {
+    logSwitchTrace(
+        stage = "user-remember-subtitle-disabled",
+        message = "selectedSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex} addonSelected=${_uiState.value.selectedAddonSubtitle != null}"
+    )
+    val basePreference = currentTrackPreferenceForPersistence()
+    clearPendingEngineSwitchTrackPreference()
     persistedTrackPreference = null
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
+    explicitSubtitleSelectionForEngineSwitch =
+        PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+            streamUrl = currentStreamUrl,
+            selection = PlayerRuntimeController.RememberedSubtitleSelection.Disabled
+        )
+    effectiveSubtitleSelectionForEngineSwitch =
+        PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+            streamUrl = currentStreamUrl,
+            selection = PlayerRuntimeController.RememberedSubtitleSelection.Disabled
+        )
     rememberedTrackPreference =
-        (rememberedTrackPreference ?: PlayerRuntimeController.TrackPreference())
+        basePreference
             .copy(subtitle = PlayerRuntimeController.RememberedSubtitleSelection.Disabled)
     persistTrackPreference()
 }
@@ -293,6 +348,21 @@ internal fun PlayerRuntimeController.rememberSubtitleDisabled() {
 internal fun PlayerRuntimeController.buildAddonSubtitleTrackId(subtitle: Subtitle): String {
     val urlHashSuffix = subtitle.url.hashCode().toUInt().toString(16)
     return "${PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX}${subtitle.id}:$urlHashSuffix"
+}
+
+internal fun PlayerRuntimeController.isMpvAddonSubtitleTrackActive(
+    subtitle: Subtitle
+): Boolean {
+    if (!isUsingMpvEngine()) return false
+
+    val targetTrackId = buildAddonSubtitleTrackId(subtitle)
+    return mpvView?.readTrackSnapshot()?.subtitleTracks?.any { track ->
+        if (!track.isExternal || !track.isSelected) return@any false
+        val normalizedTrackName = track.name.trim()
+        normalizedTrackName.equals(targetTrackId, ignoreCase = true) ||
+            normalizedTrackName.contains(targetTrackId, ignoreCase = true) ||
+            targetTrackId.contains(normalizedTrackName, ignoreCase = true)
+    } == true
 }
 
 internal fun PlayerRuntimeController.addonSubtitleKey(subtitle: Subtitle): String {
@@ -315,9 +385,17 @@ internal fun PlayerRuntimeController.toSubtitleConfiguration(subtitle: Subtitle)
 }
 
 internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
+    logSwitchTrace(
+        stage = "select-addon-subtitle",
+        message = "usingMpv=${isUsingMpvEngine()} addonId=${subtitle.id} addonLang=${subtitle.lang} addonName=${subtitle.addonName}"
+    )
     if (isUsingMpvEngine()) {
         val currentlySelected = _uiState.value.selectedAddonSubtitle
-        if (currentlySelected?.id == subtitle.id && currentlySelected.url == subtitle.url) {
+        if (
+            currentlySelected?.id == subtitle.id &&
+            currentlySelected.url == subtitle.url &&
+            isMpvAddonSubtitleTrackActive(subtitle)
+        ) {
             return
         }
         Log.d(PlayerRuntimeController.TAG, "Selecting ADDON subtitle lang=${subtitle.lang} id=${subtitle.id} (mpv)")
@@ -434,21 +512,40 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
 
 
 internal fun PlayerRuntimeController.rememberAddonSubtitleSelection(subtitle: Subtitle) {
+    logSwitchTrace(
+        stage = "user-remember-subtitle-addon",
+        message = "addonId=${subtitle.id} addonLang=${subtitle.lang} addonName=${subtitle.addonName}"
+    )
+    val rememberedSelection = PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+        id = subtitle.id,
+        url = subtitle.url,
+        language = PlayerSubtitleUtils.normalizeLanguageCode(subtitle.lang),
+        addonName = subtitle.addonName
+    )
+    val basePreference = currentTrackPreferenceForPersistence()
+    clearPendingEngineSwitchTrackPreference()
     persistedTrackPreference = null
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
+    explicitSubtitleSelectionForEngineSwitch =
+        PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+            streamUrl = currentStreamUrl,
+            selection = rememberedSelection
+        )
+    effectiveSubtitleSelectionForEngineSwitch =
+        PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+            streamUrl = currentStreamUrl,
+            selection = rememberedSelection
+        )
     rememberedTrackPreference =
-        (rememberedTrackPreference ?: PlayerRuntimeController.TrackPreference())
-            .copy(
-                subtitle = PlayerRuntimeController.RememberedSubtitleSelection.Addon(
-                    id = subtitle.id,
-                    url = subtitle.url,
-                    language = PlayerSubtitleUtils.normalizeLanguageCode(subtitle.lang),
-                    addonName = subtitle.addonName
-                )
-            )
+        basePreference
+            .copy(subtitle = rememberedSelection)
     persistTrackPreference()
+}
+
+private fun PlayerRuntimeController.currentTrackPreferenceForPersistence(): PlayerRuntimeController.TrackPreference {
+    return rememberedTrackPreference ?: persistedTrackPreference ?: PlayerRuntimeController.TrackPreference()
 }
 
 internal fun PlayerRuntimeController.persistTrackPreference() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.core.player.FrameRateUtils
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.SUBTITLE_LANGUAGE_FORCED
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -19,6 +20,11 @@ import java.util.Locale
 import com.nuvio.tv.ui.util.languageCodeToName
 
 internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
+    logSwitchTrace(
+        stage = "exo-tracks-update-start",
+        message = "groupCount=${tracks.groups.size} uiAudioIndex=${_uiState.value.selectedAudioTrackIndex} " +
+            "uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex}"
+    )
     val audioTracks = mutableListOf<TrackInfo>()
     val subtitleTracks = mutableListOf<TrackInfo>()
     var selectedAudioIndex = -1
@@ -170,12 +176,71 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
             selectedSubtitleTrackIndex = selectedSubtitleIndex
         )
     }
+    logSwitchTrace(
+        stage = "exo-tracks-update-end",
+        message = "audioCount=${audioTracks.size} subtitleCount=${subtitleTracks.size} " +
+            "selectedAudioIndex=$selectedAudioIndex selectedSubtitleIndex=$selectedSubtitleIndex"
+    )
+    rememberEffectiveExoSubtitleSelectionForEngineSwitch(
+        subtitleTracks = subtitleTracks,
+        selectedSubtitleIndex = selectedSubtitleIndex
+    )
     applyPersistedTrackPreference(
         audioTracks = audioTracks,
         subtitleTracks = subtitleTracks
     )
     tryAutoSelectPreferredSubtitleFromAvailableTracks()
     maybeAdjustLibassPipelineForTracks(tracks)
+}
+
+private fun PlayerRuntimeController.rememberEffectiveExoSubtitleSelectionForEngineSwitch(
+    subtitleTracks: List<TrackInfo>,
+    selectedSubtitleIndex: Int
+) {
+    if (isUsingMpvEngine()) return
+
+    val selection = when {
+        selectedSubtitleIndex >= 0 -> {
+            val selectedTrack = subtitleTracks.getOrNull(selectedSubtitleIndex) ?: return
+            PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+                track = buildRememberedInternalSubtitleSelectionForEngineSwitch(
+                    state = _uiState.value,
+                    language = selectedTrack.language,
+                    name = selectedTrack.name,
+                    trackId = selectedTrack.trackId,
+                    isForced = selectedTrack.isForced,
+                    selectedUiTrackOverride = selectedTrack
+                )
+            )
+        }
+        _uiState.value.selectedAddonSubtitle != null -> {
+            val addon = _uiState.value.selectedAddonSubtitle ?: return
+            PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+                id = addon.id,
+                url = addon.url,
+                language = addon.lang,
+                addonName = addon.addonName
+            )
+        }
+        else -> null
+    }
+
+    if (selection != null) {
+        logSwitchTrace(
+            stage = "remember-effective-exo-subtitle",
+            message = "selection=${describeRememberedSubtitleForSwitchTrace(selection)} selectedSubtitleIndex=$selectedSubtitleIndex"
+        )
+        effectiveSubtitleSelectionForEngineSwitch =
+            PlayerRuntimeController.ExplicitSubtitleSelectionForEngineSwitch(
+                streamUrl = currentStreamUrl,
+                selection = selection
+            )
+    } else {
+        logSwitchTrace(
+            stage = "remember-effective-exo-subtitle",
+            message = "selection=none selectedSubtitleIndex=$selectedSubtitleIndex addonSelected=${_uiState.value.selectedAddonSubtitle != null}"
+        )
+    }
 }
 
 internal fun PlayerRuntimeController.maybeAdjustLibassPipelineForTracks(tracks: Tracks) {
@@ -243,6 +308,10 @@ internal fun PlayerRuntimeController.maybeRestorePendingAudioSelectionAfterSubti
 ): Int? {
     val pending = pendingAudioSelectionAfterSubtitleRefresh ?: return null
     if (pending.streamUrl != currentStreamUrl) {
+        logSwitchTrace(
+            stage = "restore-audio-after-subtitle-refresh",
+            message = "action=clear reason=stream-mismatch pendingStream=${pending.streamUrl} currentStream=$currentStreamUrl"
+        )
         pendingAudioSelectionAfterSubtitleRefresh = null
         return null
     }
@@ -290,6 +359,10 @@ internal fun PlayerRuntimeController.maybeRestorePendingAudioSelectionAfterSubti
 
     pendingAudioSelectionAfterSubtitleRefresh = null
     if (index < 0) {
+        logSwitchTrace(
+            stage = "restore-audio-after-subtitle-refresh",
+            message = "result=no-match lang=$targetLang name=$targetName candidates=${describeTrackCandidatesForRestoreLog(audioTracks)}"
+        )
         Log.d(
             PlayerRuntimeController.TAG,
             "Audio restore skipped after subtitle refresh: no match for lang=$targetLang name=$targetName"
@@ -298,6 +371,10 @@ internal fun PlayerRuntimeController.maybeRestorePendingAudioSelectionAfterSubti
     }
 
     val restoredTrack = audioTracks[index]
+    logSwitchTrace(
+        stage = "restore-audio-after-subtitle-refresh",
+        message = "result=match index=$index lang=${restoredTrack.language} name=${restoredTrack.name}"
+    )
     Log.d(
         PlayerRuntimeController.TAG,
         "Restoring audio after subtitle refresh index=$index lang=${restoredTrack.language} name=${restoredTrack.name}"
@@ -307,6 +384,111 @@ internal fun PlayerRuntimeController.maybeRestorePendingAudioSelectionAfterSubti
 }
 
 internal fun PlayerRuntimeController.findMatchingTrackIndex(
+    tracks: List<TrackInfo>,
+    target: PlayerRuntimeController.RememberedTrackSelection
+): Int {
+    val strictIndex = findStrictMatchingTrackIndex(
+        tracks = tracks,
+        target = target
+    )
+    if (strictIndex >= 0) {
+        logSwitchTrace(
+            stage = "track-match-regular",
+            message = "result=strict index=$strictIndex target=${describeRememberedTrackForSwitchTrace(target)}"
+        )
+        return strictIndex
+    }
+
+    val fallbackIndex = findLanguageFallbackTrackIndex(
+        tracks = tracks,
+        target = target
+    )
+    logSwitchTrace(
+        stage = "track-match-regular",
+        message = "result=language-fallback index=$fallbackIndex target=${describeRememberedTrackForSwitchTrace(target)}"
+    )
+    return fallbackIndex
+}
+
+internal fun PlayerRuntimeController.findMatchingTrackIndexForEngineSwitchToMpv(
+    tracks: List<TrackInfo>,
+    target: PlayerRuntimeController.RememberedTrackSelection,
+    sourceEngine: InternalPlayerEngine
+): Int {
+    val strictIndex = findStrictMatchingTrackIndex(
+        tracks = tracks,
+        target = target
+    )
+    if (strictIndex >= 0) {
+        logSwitchTrace(
+            stage = "track-match-switch",
+            message = "result=strict index=$strictIndex sourceEngine=$sourceEngine target=${describeRememberedTrackForSwitchTrace(target)}"
+        )
+        return strictIndex
+    }
+
+    if (sourceEngine == InternalPlayerEngine.EXOPLAYER && isUsingMpvEngine()) {
+        val hintedIndex = findEngineSwitchHintTrackIndex(
+            tracks = tracks,
+            target = target
+        )
+        if (hintedIndex >= 0) {
+            logSwitchTrace(
+                stage = "track-match-switch",
+                message = "result=hint index=$hintedIndex sourceEngine=$sourceEngine target=${describeRememberedTrackForSwitchTrace(target)}"
+            )
+            return hintedIndex
+        }
+    }
+
+    val fallbackIndex = findLanguageFallbackTrackIndex(
+        tracks = tracks,
+        target = target
+    )
+    logSwitchTrace(
+        stage = "track-match-switch",
+        message = "result=language-fallback index=$fallbackIndex sourceEngine=$sourceEngine " +
+            "target=${describeRememberedTrackForSwitchTrace(target)}"
+    )
+    return fallbackIndex
+}
+
+private fun PlayerRuntimeController.describeTrackInfoForRestoreLog(track: TrackInfo): String {
+    return "index=${track.index} lang=${track.language} name=${track.name} id=${track.trackId} " +
+        "forced=${track.isForced} selected=${track.isSelected}"
+}
+
+private fun PlayerRuntimeController.describeTrackCandidatesForRestoreLog(
+    tracks: List<TrackInfo>
+): String {
+    return tracks.joinToString(prefix = "[", postfix = "]") { track ->
+        "{${describeTrackInfoForRestoreLog(track)}}"
+    }
+}
+
+private fun PlayerRuntimeController.describeRememberedTrackForSwitchTrace(
+    selection: PlayerRuntimeController.RememberedTrackSelection?
+): String {
+    if (selection == null) return "none"
+    return "lang=${selection.language} name=${selection.name} trackId=${selection.trackId} " +
+        "indexHint=${selection.indexHint} languageIndexHint=${selection.languageIndexHint} " +
+        "forcedHint=${selection.isForcedHint}"
+}
+
+private fun PlayerRuntimeController.describeRememberedSubtitleForSwitchTrace(
+    selection: PlayerRuntimeController.RememberedSubtitleSelection?
+): String {
+    return when (selection) {
+        null -> "none"
+        PlayerRuntimeController.RememberedSubtitleSelection.Disabled -> "disabled"
+        is PlayerRuntimeController.RememberedSubtitleSelection.Internal ->
+            "internal:${describeRememberedTrackForSwitchTrace(selection.track)}"
+        is PlayerRuntimeController.RememberedSubtitleSelection.Addon ->
+            "addon:${selection.language}/${selection.addonName}/${selection.id}"
+    }
+}
+
+private fun PlayerRuntimeController.findStrictMatchingTrackIndex(
     tracks: List<TrackInfo>,
     target: PlayerRuntimeController.RememberedTrackSelection
 ): Int {
@@ -346,7 +528,15 @@ internal fun PlayerRuntimeController.findMatchingTrackIndex(
     }
     if (nameContainsIndex >= 0) return nameContainsIndex
 
-    return if (!targetLang.isNullOrBlank()) {
+    return -1
+}
+
+private fun PlayerRuntimeController.findLanguageFallbackTrackIndex(
+    tracks: List<TrackInfo>,
+    target: PlayerRuntimeController.RememberedTrackSelection
+): Int {
+    val targetLang = normalizeTrackMatchValue(target.language)
+    val result = if (!targetLang.isNullOrBlank()) {
         // Detect the regional variant from the remembered selection's name/language
         val targetVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
             language = target.language,
@@ -377,24 +567,201 @@ internal fun PlayerRuntimeController.findMatchingTrackIndex(
     } else {
         -1
     }
+    logSwitchTrace(
+        stage = "track-match-language-fallback",
+        message = "targetLang=$targetLang result=$result target=${describeRememberedTrackForSwitchTrace(target)}"
+    )
+    return result
+}
+
+private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
+    tracks: List<TrackInfo>,
+    target: PlayerRuntimeController.RememberedTrackSelection
+): Int {
+    val indexHint = target.indexHint?.takeIf { it >= 0 } ?: -1
+    val languageIndexHint = target.languageIndexHint?.takeIf { it >= 0 }
+    val targetForced = target.isForcedHint
+    val sparseMetadata = hasSparseMpvSubtitleMetadataForEngineSwitch(tracks)
+    val targetVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
+        language = target.language,
+        name = target.name,
+        trackId = target.trackId
+    )
+
+    val baseCandidates = tracks.indices.filter { index ->
+        val track = tracks[index]
+        target.language.isNullOrBlank() ||
+            PlayerSubtitleUtils.matchesLanguageCode(track.language, target.language) ||
+            PlayerSubtitleUtils.detectTrackLanguageVariant(
+                language = track.language,
+                name = track.name,
+                trackId = track.trackId
+            ) == targetVariant
+    }
+    val sparseCandidates = if (sparseMetadata) {
+        if (targetForced == null) {
+            tracks.indices.toList()
+        } else {
+            tracks.indices.filter { index -> tracks[index].isForced == targetForced }
+                .ifEmpty { tracks.indices.toList() }
+        }
+    } else {
+        emptyList()
+    }
+
+    if (baseCandidates.isEmpty()) {
+        if (indexHint in sparseCandidates) {
+            logSwitchTrace(
+                stage = "track-match-hint",
+                message = "result=indexHint-from-sparse index=$indexHint " +
+                    "indexHint=$indexHint languageIndexHint=$languageIndexHint targetForced=$targetForced"
+            )
+            return indexHint
+        }
+        if (languageIndexHint != null && languageIndexHint in sparseCandidates.indices) {
+            val resolved = sparseCandidates[languageIndexHint]
+            logSwitchTrace(
+                stage = "track-match-hint",
+                message = "result=languageIndexHint-from-sparse index=$resolved " +
+                    "indexHint=$indexHint languageIndexHint=$languageIndexHint targetForced=$targetForced"
+            )
+            return resolved
+        }
+        logSwitchTrace(
+            stage = "track-match-hint",
+            message = "result=-1 reason=empty-base-and-no-sparse-match indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+                "targetForced=$targetForced sparseMetadata=$sparseMetadata"
+        )
+        return -1
+    }
+
+    val preferredCandidates = if (targetForced == null) {
+        baseCandidates
+    } else {
+        baseCandidates.filter { index -> tracks[index].isForced == targetForced }
+            .ifEmpty { baseCandidates }
+    }
+
+    if (indexHint in preferredCandidates) {
+        logSwitchTrace(
+            stage = "track-match-hint",
+            message = "result=indexHint-preferred index=$indexHint indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+        )
+        return indexHint
+    }
+    if (languageIndexHint != null && languageIndexHint in preferredCandidates.indices) {
+        val resolved = preferredCandidates[languageIndexHint]
+        logSwitchTrace(
+            stage = "track-match-hint",
+            message = "result=languageIndexHint-preferred index=$resolved indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+        )
+        return resolved
+    }
+    if (indexHint in baseCandidates) {
+        logSwitchTrace(
+            stage = "track-match-hint",
+            message = "result=indexHint-base index=$indexHint indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+        )
+        return indexHint
+    }
+    if (indexHint in sparseCandidates) {
+        logSwitchTrace(
+            stage = "track-match-hint",
+            message = "result=indexHint-sparse index=$indexHint indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+        )
+        return indexHint
+    }
+    if (languageIndexHint != null && languageIndexHint in sparseCandidates.indices) {
+        val resolved = sparseCandidates[languageIndexHint]
+        logSwitchTrace(
+            stage = "track-match-hint",
+            message = "result=languageIndexHint-sparse index=$resolved indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+        )
+        return resolved
+    }
+
+    logSwitchTrace(
+        stage = "track-match-hint",
+        message = "result=-1 reason=no-hint-match indexHint=$indexHint languageIndexHint=$languageIndexHint " +
+            "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates " +
+            "sparseCandidates=$sparseCandidates sparseMetadata=$sparseMetadata"
+    )
+    return -1
+}
+
+private fun PlayerRuntimeController.hasSparseMpvSubtitleMetadataForEngineSwitch(
+    tracks: List<TrackInfo>
+): Boolean {
+    if (tracks.isEmpty()) return false
+    val sparseCount = tracks.count { track ->
+        val normalizedName = normalizeTrackMatchValue(track.name)
+        track.language.isNullOrBlank() &&
+            (
+                normalizedName.isNullOrBlank() ||
+                    normalizedName == "subtitle" ||
+                    normalizedName.startsWith("subtitle ")
+                )
+    }
+    return sparseCount > 0 && sparseCount * 2 >= tracks.size
 }
 
 internal fun PlayerRuntimeController.applyPersistedTrackPreference(
     audioTracks: List<TrackInfo>,
     subtitleTracks: List<TrackInfo>
 ) {
-    val pending = persistedTrackPreference ?: return
+    val switchPending = pendingEngineSwitchTrackPreference
+        ?.takeIf { it.streamUrl == currentStreamUrl }
+    if (pendingEngineSwitchTrackPreference != null && switchPending == null) {
+        logSwitchTrace(
+            stage = "restore-switch-pref-clear",
+            message = "reason=stream-mismatch pendingStream=${pendingEngineSwitchTrackPreference?.streamUrl} currentStream=$currentStreamUrl"
+        )
+        pendingEngineSwitchTrackPreference = null
+    }
+    val usingSwitchPending = switchPending != null
+    val pendingCandidate = switchPending?.preference ?: persistedTrackPreference
+    logSwitchTrace(
+        stage = "restore-enter",
+        message = "usingSwitchPending=$usingSwitchPending switchPending=${switchPending != null} persisted=${persistedTrackPreference != null} " +
+            "audioTracks=${audioTracks.size} subtitleTracks=${subtitleTracks.size} " +
+            "uiAudioIndex=${_uiState.value.selectedAudioTrackIndex} uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex} " +
+            "pendingAudio=${describeRememberedTrackForSwitchTrace(pendingCandidate?.audio)} " +
+            "pendingSubtitle=${describeRememberedSubtitleForSwitchTrace(pendingCandidate?.subtitle)}"
+    )
+    val pending: PlayerRuntimeController.TrackPreference = pendingCandidate ?: run {
+        logSwitchTrace(
+            stage = "restore-skip",
+            message = "reason=no-pending-preference"
+        )
+        return
+    }
+    val switchSourceEngine = switchPending?.sourceEngine
     var updatedPending = pending
     var updatedSubtitleIndex: Int? = null
     var updatedAddonSubtitle: com.nuvio.tv.domain.model.Subtitle? = null
 
     pending.audio?.let { audioSelection ->
         if (audioTracks.isEmpty()) {
+            logSwitchTrace(
+                stage = "restore-audio",
+                message = "result=defer reason=no-audio-tracks"
+            )
             Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: audio deferred (no tracks yet)")
         } else {
             val index = findMatchingTrackIndex(audioTracks, audioSelection)
             if (index >= 0) {
                 val alreadySelected = audioTracks.getOrNull(index)?.isSelected == true
+                logSwitchTrace(
+                    stage = "restore-audio",
+                    message = "result=match index=$index alreadySelected=$alreadySelected " +
+                        "target=${describeRememberedTrackForSwitchTrace(audioSelection)} " +
+                        "matched=${audioTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
+                )
                 if (!alreadySelected) {
                     Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: audio index=$index lang=${audioTracks[index].language} name=${audioTracks[index].name}")
                     selectAudioTrack(index)
@@ -404,6 +771,11 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                     updatedPending = updatedPending.copy(audio = null)
                 }
             } else {
+                logSwitchTrace(
+                    stage = "restore-audio",
+                    message = "result=no-match target=${describeRememberedTrackForSwitchTrace(audioSelection)} " +
+                        "candidates=${describeTrackCandidatesForRestoreLog(audioTracks)}"
+                )
                 Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: audio no match for lang=${audioSelection.language} name=${audioSelection.name}, clearing")
                 updatedPending = updatedPending.copy(audio = null)
             }
@@ -414,6 +786,10 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         null -> Unit
         PlayerRuntimeController.RememberedSubtitleSelection.Disabled -> {
             val alreadyDisabled = subtitleTracks.none { it.isSelected }
+            logSwitchTrace(
+                stage = "restore-subtitle-disabled",
+                message = "alreadyDisabled=$alreadyDisabled subtitleTrackCount=${subtitleTracks.size}"
+            )
             if (!alreadyDisabled) {
                 Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: subtitle disabled (re-applying)")
                 autoSubtitleSelected = true
@@ -430,11 +806,33 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         }
         is PlayerRuntimeController.RememberedSubtitleSelection.Internal -> {
             if (subtitleTracks.isEmpty()) {
+                logSwitchTrace(
+                    stage = "restore-subtitle-internal",
+                    message = "result=defer reason=no-subtitle-tracks target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)}"
+                )
                 Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle deferred (no tracks yet)")
             } else {
-                val index = findMatchingTrackIndex(subtitleTracks, subtitleSelection.track)
+                val index = if (usingSwitchPending && switchSourceEngine != null) {
+                    findMatchingTrackIndexForEngineSwitchToMpv(
+                        tracks = subtitleTracks,
+                        target = subtitleSelection.track,
+                        sourceEngine = switchSourceEngine
+                    )
+                } else {
+                    findMatchingTrackIndex(subtitleTracks, subtitleSelection.track)
+                }
+                logSwitchTrace(
+                    stage = "restore-subtitle-internal",
+                    message = "mode=${if (usingSwitchPending && switchSourceEngine != null) "switch-hint-aware" else "regular"} " +
+                        "sourceEngine=$switchSourceEngine resultIndex=$index target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)}"
+                )
                 if (index >= 0) {
                     val alreadySelected = subtitleTracks.getOrNull(index)?.isSelected == true
+                    logSwitchTrace(
+                        stage = "restore-subtitle-internal-match",
+                        message = "index=$index alreadySelected=$alreadySelected " +
+                            "matched=${subtitleTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
+                    )
                     if (!alreadySelected) {
                         Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$index (re-applying)")
                         autoSubtitleSelected = true
@@ -446,17 +844,37 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                         updatedSubtitleIndex = index
                     }
                 } else {
+                    val shouldDeferSwitchRestore = usingSwitchPending &&
+                        switchSourceEngine == InternalPlayerEngine.EXOPLAYER &&
+                        isUsingMpvEngine() &&
+                        hasSparseMpvSubtitleMetadataForEngineSwitch(subtitleTracks)
+                    logSwitchTrace(
+                        stage = "restore-subtitle-internal-no-match",
+                        message = "shouldDeferSwitchRestore=$shouldDeferSwitchRestore " +
+                            "target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)} " +
+                            "candidates=${describeTrackCandidatesForRestoreLog(subtitleTracks)}"
+                    )
                     // No internal track matches — try addon fallback with the same language variant.
                     val resolvedVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
                         language = subtitleSelection.track.language,
                         name = subtitleSelection.track.name,
                         trackId = subtitleSelection.track.trackId
                     )
-                    val state = _uiState.value
-                    val addonFallback = state.addonSubtitles.firstOrNull { subtitle ->
-                        PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, resolvedVariant)
-                    }
-                    if (addonFallback != null) {
+                    if (shouldDeferSwitchRestore) {
+                        logSwitchTrace(
+                            stage = "restore-subtitle-internal-no-match",
+                            message = "action=defer reason=sparse-mpv-metadata"
+                        )
+                    } else {
+                        val state = _uiState.value
+                        val addonFallback = state.addonSubtitles.firstOrNull { subtitle ->
+                            PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, resolvedVariant)
+                        }
+                        if (addonFallback != null) {
+                        logSwitchTrace(
+                            stage = "restore-subtitle-internal-fallback-addon",
+                            message = "addonId=${addonFallback.id} addonLang=${addonFallback.lang} variant=$resolvedVariant"
+                        )
                         Log.d(
                             PlayerRuntimeController.TAG,
                             "TRACK_PREF restore: internal no match, falling back to addon lang=${addonFallback.lang} variant=$resolvedVariant"
@@ -467,9 +885,14 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                         selectAddonSubtitle(addonFallback)
                         updatedAddonSubtitle = addonFallback
                         updatedPending = updatedPending.copy(subtitle = null)
-                    } else {
-                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle no match, no addon fallback for variant=$resolvedVariant, clearing")
-                        updatedPending = updatedPending.copy(subtitle = null)
+                        } else {
+                            logSwitchTrace(
+                                stage = "restore-subtitle-internal-no-match",
+                                message = "action=clear reason=no-addon-fallback variant=$resolvedVariant"
+                            )
+                            Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle no match, no addon fallback for variant=$resolvedVariant, clearing")
+                            updatedPending = updatedPending.copy(subtitle = null)
+                        }
                     }
                 }
             }
@@ -485,6 +908,10 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, subtitleSelection.language)
             }
             if (addonMatch != null) {
+                logSwitchTrace(
+                    stage = "restore-subtitle-addon",
+                    message = "result=match addonId=${addonMatch.id} addonLang=${addonMatch.lang} addon=${addonMatch.addonName}"
+                )
                 Log.d(
                     PlayerRuntimeController.TAG,
                     "Restoring same-series addon subtitle lang=${addonMatch.lang} id=${addonMatch.id}"
@@ -494,7 +921,26 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 pendingRestoredAddonSubtitle = addonMatch
                 selectAddonSubtitle(addonMatch)
                 updatedAddonSubtitle = addonMatch
-                updatedPending = updatedPending.copy(subtitle = null)
+                val shouldKeepPendingUntilMpvConfirmsSelection =
+                    usingSwitchPending && isUsingMpvEngine()
+                val addonSelectedInMpv =
+                    !shouldKeepPendingUntilMpvConfirmsSelection ||
+                        isMpvAddonSubtitleTrackActive(addonMatch)
+                if (addonSelectedInMpv) {
+                    updatedPending = updatedPending.copy(subtitle = null)
+                } else {
+                    logSwitchTrace(
+                        stage = "restore-subtitle-addon",
+                        message = "result=defer-clear reason=mpv-addon-not-active-yet " +
+                            "addonId=${addonMatch.id} addonLang=${addonMatch.lang}"
+                    )
+                }
+            } else {
+                logSwitchTrace(
+                    stage = "restore-subtitle-addon",
+                    message = "result=no-match targetAddonId=${subtitleSelection.id} targetLang=${subtitleSelection.language} " +
+                        "addonPool=${state.addonSubtitles.size}"
+                )
             }
         }
     }
@@ -505,8 +951,28 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
             selectedAddonSubtitle = updatedAddonSubtitle ?: if (updatedSubtitleIndex != null) null else state.selectedAddonSubtitle
         )
     }
-    persistedTrackPreference =
-        updatedPending.takeUnless { it.audio == null && it.subtitle == null }
+    val normalizedPending = updatedPending.takeUnless { it.audio == null && it.subtitle == null }
+    if (usingSwitchPending) {
+        logSwitchTrace(
+            stage = "restore-exit-switch",
+            message = "remainingAudio=${describeRememberedTrackForSwitchTrace(normalizedPending?.audio)} " +
+                "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
+        )
+        pendingEngineSwitchTrackPreference = normalizedPending?.let { preference ->
+            PlayerRuntimeController.PendingEngineSwitchTrackPreference(
+                streamUrl = currentStreamUrl,
+                preference = preference,
+                sourceEngine = switchSourceEngine ?: currentInternalPlayerEngine
+            )
+        }
+    } else {
+        logSwitchTrace(
+            stage = "restore-exit-persisted",
+            message = "remainingAudio=${describeRememberedTrackForSwitchTrace(normalizedPending?.audio)} " +
+                "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
+        )
+        persistedTrackPreference = normalizedPending
+    }
 }
 
 internal fun PlayerRuntimeController.subtitleLanguageTargets(): List<String> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -777,6 +777,7 @@ fun PlayerScreen(
                     Log.d("PlayerScreen", "onToggleAspectRatio called - dispatching event")
                     viewModel.onEvent(PlayerEvent.OnToggleAspectRatio)
                 },
+                onSwitchPlayerEngine = { viewModel.onEvent(PlayerEvent.OnSwitchInternalPlayerEngine) },
                 onToggleMoreActions = {
                     if (uiState.showMoreDialog) {
                         viewModel.onEvent(PlayerEvent.OnDismissMoreDialog)
@@ -1064,6 +1065,7 @@ private fun PlayerControlsOverlay(
     onShowSubtitleDialog: () -> Unit,
     onShowSpeedDialog: () -> Unit,
     onToggleAspectRatio: () -> Unit,
+    onSwitchPlayerEngine: () -> Unit,
     onToggleMoreActions: () -> Unit,
     onOpenInExternalPlayer: () -> Unit,
     onShowStreamInfo: () -> Unit,
@@ -1279,6 +1281,15 @@ private fun PlayerControlsOverlay(
                         iconPainter = customSourcePainter,
                         contentDescription = stringResource(R.string.cd_sources),
                         onClick = onShowSourcesPanel,
+                        upFocusRequester = progressBarFocusRequester,
+                        onDownKey = onHideControls,
+                        onFocused = onResetHideTimer
+                    )
+
+                    ControlButton(
+                        icon = Icons.Default.SwapHoriz,
+                        contentDescription = stringResource(R.string.cd_switch_player_engine),
+                        onClick = onSwitchPlayerEngine,
                         upFocusRequester = progressBarFocusRequester,
                         onDownKey = onHideControls,
                         onFocused = onResetHideTimer

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -221,6 +221,7 @@ sealed class PlayerEvent {
     data class OnSetSubtitleVerticalOffset(val offset: Int) : PlayerEvent()
     data object OnResetSubtitleDefaults : PlayerEvent()
     data object OnToggleAspectRatio : PlayerEvent()
+    data object OnSwitchInternalPlayerEngine : PlayerEvent()
     data object OnShowStreamInfo : PlayerEvent()
     data object OnDismissStreamInfo : PlayerEvent()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -847,6 +847,7 @@
     <string name="player_loading_buffering">Buffering…</string>
     <string name="player_engine_switching_title">Switching Player Engine</string>
     <string name="player_engine_switching_message">Startup failed. Switching to %1$s…</string>
+    <string name="player_engine_switching_manual_message">Switching to %1$s...</string>
     <string name="playback_show_loading_status">Show loading status</string>
     <string name="playback_show_loading_status_sub">Display step-by-step progress while the player is initializing.</string>
 
@@ -1331,6 +1332,7 @@
     <string name="cd_subtitles">Subtitles</string>
     <string name="cd_audio_tracks">Audio tracks</string>
     <string name="cd_sources">Sources</string>
+    <string name="cd_switch_player_engine">Switch player engine</string>
     <string name="cd_episodes">Episodes</string>
     <string name="cd_playback_speed">Playback speed</string>
     <string name="cd_aspect_ratio">Aspect ratio</string>


### PR DESCRIPTION
## Summary

Users can now switch playback engine directly from the OSD between ExoPlayer and libmpv.


## PR type

Small maintenance improvement

## Why

Users did not previously have an in-player way to switch engine during playback.
This change enables direct engine switching (Exo <-> MPV) and improves continuity by restoring the selected audio/subtitle track across the switch, reducing manual re-selection and improving playback resilience.

## Policy check
[X] This PR is not cosmetic-only, unless it is a translation PR.
[X]  This PR does not add a new major feature without prior approval.
[X]  This PR is small in scope and focused on one problem.
[X]  If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manual testing with repeated Exo <-> MPV switches from OSD.
Verified selected audio and subtitle carry over during engine switch.



Screenshots / Video (UI changes only)



https://github.com/user-attachments/assets/9fd6ab1f-5204-496b-9163-fa393443e9e2




## Breaking changes

None.

## Linked issues

It's linked with the new mpv player.