### PR TITLE
Batch of fixes - CW Nuvio Sync, Random pauses & "See all" button in search results 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|density|uiMode|keyboard|keyboardHidden|navigation|layoutDirection|fontScale|locale"
             android:theme="@style/Theme.MyApplication.Launcher">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -58,6 +58,7 @@ fun CatalogRowSection(
     catalogRow: CatalogRow,
     onItemClick: (String, String, String) -> Unit,
     onSeeAll: () -> Unit = {},
+    showSeeAll: Boolean = catalogRow.items.size >= 15,
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
     showPosterLabels: Boolean = true,
     showAddonName: Boolean = true,
@@ -227,7 +228,7 @@ fun CatalogRowSection(
                 )
             }
 
-            if (catalogRow.items.size >= 15) {
+            if (showSeeAll) {
                 item(key = "${catalogRow.type}_${catalogRow.catalogId}_see_all") {
                     Card(
                         onClick = onSeeAll,

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -834,13 +834,18 @@ fun NuvioNavHost(
             )
         }
 
-        composable(Screen.Search.route) {
+        composable(Screen.Search.route) { backStackEntry ->
+            val searchViewModel: com.nuvio.tv.ui.screens.search.SearchViewModel =
+                androidx.hilt.navigation.compose.hiltViewModel(backStackEntry)
             SearchScreen(
+                viewModel = searchViewModel,
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
                     navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
                 },
                 onNavigateToSeeAll = { catalogId, addonId, type ->
-                    navController.navigate(Screen.CatalogSeeAll.createRoute(catalogId, addonId, type))
+                    navController.navigate(
+                        Screen.CatalogSeeAll.createRoute(catalogId, addonId, type, fromSearch = true)
+                    )
                 },
                 onOpenDiscover = { navController.navigate(Screen.Discover.route) }
             )
@@ -972,16 +977,35 @@ fun NuvioNavHost(
             arguments = listOf(
                 navArgument("catalogId") { type = NavType.StringType },
                 navArgument("addonId") { type = NavType.StringType },
-                navArgument("type") { type = NavType.StringType }
+                navArgument("type") { type = NavType.StringType },
+                navArgument("fromSearch") {
+                    type = NavType.BoolType
+                    defaultValue = false
+                }
             )
         ) { backStackEntry ->
             val catalogId = backStackEntry.arguments?.getString("catalogId") ?: ""
             val addonId = backStackEntry.arguments?.getString("addonId") ?: ""
             val type = backStackEntry.arguments?.getString("type") ?: ""
+            val fromSearch = backStackEntry.arguments?.getBoolean("fromSearch") ?: false
+
+            // When coming from search, get the SearchViewModel from the Search back stack entry
+            // so we share the same data (existing results + pagination)
+            val searchBackStackEntry = androidx.compose.runtime.remember(fromSearch) {
+                if (fromSearch) {
+                    try { navController.getBackStackEntry(Screen.Search.route) } catch (_: Exception) { null }
+                } else null
+            }
+            val searchViewModel: com.nuvio.tv.ui.screens.search.SearchViewModel? =
+                if (searchBackStackEntry != null) {
+                    androidx.hilt.navigation.compose.hiltViewModel<com.nuvio.tv.ui.screens.search.SearchViewModel>(searchBackStackEntry)
+                } else null
+
             CatalogSeeAllScreen(
                 catalogId = catalogId,
                 addonId = addonId,
                 type = type,
+                searchViewModel = searchViewModel,
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
                     navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
                 },

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -139,12 +139,12 @@ sealed class Screen(val route: String) {
     data object AuthQrSignIn : Screen("auth_qr_sign_in")
     data object SyncCodeGenerate : Screen("sync_code_generate")
     data object SyncCodeClaim : Screen("sync_code_claim")
-    data object CatalogSeeAll : Screen("catalog_see_all/{catalogId}/{addonId}/{type}") {
+    data object CatalogSeeAll : Screen("catalog_see_all/{catalogId}/{addonId}/{type}?fromSearch={fromSearch}") {
         private fun encode(value: String): String =
             URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
-        fun createRoute(catalogId: String, addonId: String, type: String): String {
-            return "catalog_see_all/${encode(catalogId)}/${encode(addonId)}/${encode(type)}"
+        fun createRoute(catalogId: String, addonId: String, type: String, fromSearch: Boolean = false): String {
+            return "catalog_see_all/${encode(catalogId)}/${encode(addonId)}/${encode(type)}?fromSearch=$fromSearch"
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -3,8 +3,8 @@
 package com.nuvio.tv.ui.screens
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,6 +13,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -23,43 +29,39 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.itemsIndexed
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.GridView
-import androidx.compose.foundation.layout.Box
-import com.nuvio.tv.ui.components.GridContentCard
+import com.nuvio.tv.R
 import com.nuvio.tv.ui.components.EmptyScreenState
+import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
 import com.nuvio.tv.ui.screens.home.HomeEvent
 import com.nuvio.tv.ui.screens.home.HomeViewModel
+import com.nuvio.tv.ui.screens.search.SearchEvent
+import com.nuvio.tv.ui.screens.search.SearchViewModel
 import com.nuvio.tv.ui.theme.NuvioColors
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
-import androidx.compose.runtime.withFrameNanos
-import androidx.compose.ui.res.stringResource
-import com.nuvio.tv.R
 
 @Composable
 fun CatalogSeeAllScreen(
     catalogId: String,
     addonId: String,
     type: String,
+    searchViewModel: SearchViewModel? = null,
     viewModel: HomeViewModel = hiltViewModel(),
     onNavigateToDetail: (String, String, String) -> Unit,
     onBackPress: () -> Unit
@@ -77,11 +79,19 @@ fun CatalogSeeAllScreen(
 
     BackHandler { onBackPress() }
 
-    // Find the matching catalog row from full (untruncated) data
+    val isSearchMode = searchViewModel != null
     val catalogKey = "${addonId}_${type}_${catalogId}"
-    val catalogRow = fullCatalogRows.find {
+
+    // In search mode, get the catalog row from SearchViewModel's existing results.
+    // Otherwise fall back to HomeViewModel's fullCatalogRows (home screen catalogs).
+    val searchUiState = searchViewModel?.uiState?.collectAsState()
+    val searchCatalogRow = searchUiState?.value?.catalogRows?.find {
         "${it.addonId}_${it.apiType}_${it.catalogId}" == catalogKey
     }
+    val homeCatalogRow = fullCatalogRows.find {
+        "${it.addonId}_${it.apiType}_${it.catalogId}" == catalogKey
+    }
+    val catalogRow = if (isSearchMode) searchCatalogRow else homeCatalogRow
 
     val gridState = rememberLazyGridState()
     val restoreFocusRequester = remember { FocusRequester() }
@@ -101,9 +111,15 @@ fun CatalogSeeAllScreen(
                 if (total > 0 && lastVisible >= total - 10) {
                     val row = catalogRow
                     if (row != null && row.hasMore && !row.isLoading) {
-                        viewModel.onEvent(
-                            HomeEvent.OnLoadMoreCatalog(row.catalogId, row.addonId, row.apiType)
-                        )
+                        if (isSearchMode) {
+                            searchViewModel?.onEvent(
+                                SearchEvent.LoadMoreCatalog(row.catalogId, row.addonId, row.apiType)
+                            )
+                        } else {
+                            viewModel.onEvent(
+                                HomeEvent.OnLoadMoreCatalog(row.catalogId, row.addonId, row.apiType)
+                            )
+                        }
                     }
                 }
             }
@@ -144,7 +160,6 @@ fun CatalogSeeAllScreen(
             .fillMaxSize()
             .padding(vertical = 24.dp)
     ) {
-        // Header
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 48.dp),
             verticalAlignment = Alignment.CenterVertically
@@ -199,9 +214,7 @@ fun CatalogSeeAllScreen(
                             showLabel = uiState.posterLabelsEnabled,
                             isWatched = isWatched,
                             focusRequester = if (index == focusedItemIndex) restoreFocusRequester else null,
-                            onFocused = {
-                                focusedItemIndex = index
-                            },
+                            onFocused = { focusedItemIndex = index },
                             onClick = {
                                 onNavigateToDetail(
                                     item.id,
@@ -213,7 +226,6 @@ fun CatalogSeeAllScreen(
                     }
                 }
 
-                // Loading indicator at bottom when loading more items
                 if (catalogRow.isLoading) {
                     Box(
                         modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -40,7 +40,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
 private const val CW_MAX_RECENT_PROGRESS_ITEMS = 300
-private const val CW_MAX_NEXT_UP_LOOKUPS = 48
+private const val CW_MAX_NEXT_UP_LOOKUPS = 32
 private const val CW_MAX_NEXT_UP_CONCURRENCY = 4
 private const val CW_MAX_ENRICHMENT_CONCURRENCY = 4
 private const val CW_PROGRESS_DEBOUNCE_MS = 500L
@@ -562,12 +562,18 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 }.awaitAll().filterNotNull()
 
                                 if (discoveredNextUpItems.isNotEmpty()) {
-                                    val releaseAlerts = discoveredNextUpItems.filter { it.info.isReleaseAlert }
+                                    // For Trakt users, only inject release alerts.
+                                    // For Nuvio Sync users, inject all next-up items (workaround for seed limit).
+                                    val itemsToInject = if (useTraktProgress) {
+                                        discoveredNextUpItems.filter { it.info.isReleaseAlert }
+                                    } else {
+                                        discoveredNextUpItems
+                                    }
                                     synchronized(discoveredOlderNextUpItems) {
                                         discoveredOlderNextUpItems.removeAll { old ->
-                                            releaseAlerts.any { it.info.contentId == old.info.contentId }
+                                            itemsToInject.any { it.info.contentId == old.info.contentId }
                                         }
-                                        discoveredOlderNextUpItems.addAll(releaseAlerts)
+                                        discoveredOlderNextUpItems.addAll(itemsToInject)
                                     }
                                     _uiState.update { state ->
                                         val existingContentIds = state.continueWatchingItems
@@ -578,12 +584,12 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                                 }
                                             }
                                             .toSet()
-                                        val newAlerts = releaseAlerts.filter {
+                                        val newItems = itemsToInject.filter {
                                             it.info.contentId !in existingContentIds &&
                                                 nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
                                         }
-                                        if (newAlerts.isEmpty()) return@update state
-                                        state.copy(continueWatchingItems = state.continueWatchingItems + newAlerts)
+                                        if (newItems.isEmpty()) return@update state
+                                        state.copy(continueWatchingItems = state.continueWatchingItems + newItems)
                                     }
                                 }
                             }
@@ -596,9 +602,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val persistedOlderItems = synchronized(discoveredOlderNextUpItems) {
                     discoveredOlderNextUpItems.toList()
                 }
-                // Also preserve cached release alerts from disk until async inject re-verifies them.
-                val cachedReleaseAlerts = cachedNextUp
-                    .filter { it.isReleaseAlert }
+                // Preserve cached next-up items from disk until async inject re-verifies them.
+                // For Trakt: only release alerts. For Nuvio Sync: all items.
+                val cachedOlderNextUp = cachedNextUp
+                    .filter { if (useTraktProgress) it.isReleaseAlert else true }
                     .map { cached ->
                         ContinueWatchingItem.NextUp(
                             info = NextUpInfo(
@@ -632,10 +639,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     }
                 val recentIds = nextUpItems.map { it.info.contentId }.toSet()
                 val inProgressIds = inProgressOnly.map { it.progress.contentId }.toSet()
-                val olderToInclude = (persistedOlderItems + cachedReleaseAlerts)
+                val olderToInclude = (persistedOlderItems + cachedOlderNextUp)
                     .distinctBy { it.info.contentId }
                     .filter {
-                        it.info.isReleaseAlert &&
+                        (if (useTraktProgress) it.info.isReleaseAlert else true) &&
                             it.info.contentId !in recentIds &&
                             it.info.contentId !in inProgressIds &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -568,11 +568,13 @@ fun SearchScreen(
                                 "${item.addonId}_${item.type}_${item.catalogId}_${trimmedSubmittedQuery}_$index"
                             }
                         ) { index, catalogRow ->
-                            val truncatedRow = if (catalogRow.items.size >= 15) {
+                            val hasEnoughForSeeAll = catalogRow.items.size >= 15
+                            val truncatedRow = if (hasEnoughForSeeAll) {
                                 catalogRow.copy(items = catalogRow.items.take(14))
                             } else catalogRow
                             CatalogRowSection(
                                 catalogRow = truncatedRow,
+                                showSeeAll = hasEnoughForSeeAll,
                                 showPosterLabels = uiState.posterLabelsEnabled,
                                 showAddonName = uiState.catalogAddonNameEnabled,
                                 showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -256,13 +256,10 @@ fun SearchScreen(
     }
     val showRecentSearches = remember(
         trimmedQuery,
-        uiState.recentSearches,
-        isSearchFieldFocused,
-        isRecentSearchSectionFocused
+        uiState.recentSearches
     ) {
         trimmedQuery.isEmpty() &&
-            uiState.recentSearches.isNotEmpty() &&
-            (isSearchFieldFocused || isRecentSearchSectionFocused)
+            uiState.recentSearches.isNotEmpty()
     }
     val canMoveToResults = remember(
         isDiscoverMode,
@@ -571,8 +568,11 @@ fun SearchScreen(
                                 "${item.addonId}_${item.type}_${item.catalogId}_${trimmedSubmittedQuery}_$index"
                             }
                         ) { index, catalogRow ->
+                            val truncatedRow = if (catalogRow.items.size >= 15) {
+                                catalogRow.copy(items = catalogRow.items.take(14))
+                            } else catalogRow
                             CatalogRowSection(
-                                catalogRow = catalogRow,
+                                catalogRow = truncatedRow,
                                 showPosterLabels = uiState.posterLabelsEnabled,
                                 showAddonName = uiState.catalogAddonNameEnabled,
                                 showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1349,4 +1349,16 @@
     <string name="web_status_timeout">Przekroczono czas</string>
     <string name="web_status_msg_timeout">Brak odpowiedzi z TV. Spróbuj ponownie.</string>
     <string name="web_status_msg_connection_lost">Serwer TV jest nieosiągalny. Zmiany mogły zostać zastosowane.</string>
+
+    <string name="playback_internal_player_engine">Silnik wewnętrzny</string>
+    <string name="playback_engine_exoplayer">ExoPlayer</string>
+    <string name="playback_engine_mvplayer">Libmpv (Beta)</string>
+    <string name="playback_auto_switch_internal_player_on_error">Automatyczne przełączanie silnika przy błędzie</string>
+    <string name="playback_auto_switch_internal_player_on_error_sub">Jeśli uruchomienie strumienia się nie powiedzie, automatycznie przełącz między ExoPlayer a libmpv.</string>
+    <string name="playback_engine_exoplayer_desc">Najlepsza kompatybilność z funkcjami Nuvio.</string>
+    <string name="playback_engine_mvplayer_desc">Używa libmpv z kontrolkami Nuvio OSD. Eksperymentalny.</string>
+    <string name="player_engine_switching_title">Przełączanie silnika odtwarzacza</string>
+    <string name="player_engine_switching_message">Uruchomienie nie powiodło się. Przełączanie na %1$s…</string>
+    <string name="search_recent_title">Ostatnie wyszukiwania</string>
+    <string name="search_recent_clear">Wyczyść historię</string>
 </resources>


### PR DESCRIPTION
## Summary

- Use async inject to fill all next up for Nuvio sync
- Add `android:configChanges` to `MainActivity` to prevent activity recreation during playback
- Fix "See All" from search results navigating to an empty screen
- Add 11 missing Polish translations

## PR type

- Bug fix
- Small maintenance improvement
- Translation update

## Why

1. **Random pauses during playback** - On certain TV devices (e.g. Realtek-based), configuration changes (HDR, frame rate switching) triggered a full Activity destroy/recreate cycle, killing the AudioTrack and pausing video. Logs provided by the user showed `onPause -> onStop -> onDestroy -> onCreate` repeating every 30–60 seconds with `dead IAudioTrack` errors each time.

2. **"See All" in search results was broken** - `CatalogSeeAllScreen` used `HomeViewModel.fullCatalogRows` to find data, but search results live in `SearchViewModel.catalogRows`. Clicking "See All" from search opened an empty screen because the search catalog key (e.g. `aio-metadata_movie_search.movie`) never exists in Home's catalog rows

3. One of the users with huge watch history had constant issues with CW items going missing. With async inject flow checking all of his watch history to take care of missing next up no item should be missing.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- **configChanges fix**: Verified by providing a test build to user - streams were not pausing anymore
- **See All fix**: Verified via ADB logcat that `CatalogSeeAllScreen` now receives search results from shared `SearchViewModel`. Tested with Cinemeta and AIOMetadata addons
- Provided a test build for the user with huge watch history - now his CW has every item he was expecting to ahve 

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break 

## Linked issues

N/A
