### PR TITLE
stale in-progress items persisting in Continue Watching

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -42,22 +42,21 @@ class WatchProgressPreferences @Inject constructor(
             val json = preferences[watchProgressKey] ?: "{}"
             val allItems = parseProgressMap(json)
 
-            val contentLevelEntries = allItems.entries
-                .filter { (key, progress) -> key == progress.contentId }
-                .associate { it.value.contentId to it.value }
-                .toMutableMap()
-
-            val latestEpisodeFallbacks = allItems.values
+            // Group all entries by contentId and pick the most recently watched.
+            // When lastWatched is equal (e.g. batch mark-as-watched), prefer the highest season/episode.
+            val latestByContent = allItems.values
                 .groupBy { it.contentId }
-                .mapValues { (_, items) -> items.maxByOrNull { it.lastWatched } }
-
-            latestEpisodeFallbacks.forEach { (contentId, latest) ->
-                if (contentLevelEntries[contentId] == null && latest != null) {
-                    contentLevelEntries[contentId] = latest
+                .mapValues { (_, items) ->
+                    items.maxWithOrNull(
+                        compareBy<WatchProgress> { it.lastWatched }
+                            .thenBy { it.season ?: 0 }
+                            .thenBy { it.episode ?: 0 }
+                    )
                 }
-            }
+                .values
+                .filterNotNull()
 
-            val result = contentLevelEntries.values.sortedByDescending { it.lastWatched }
+            val result = latestByContent.sortedByDescending { it.lastWatched }
             result
         }
     }
@@ -85,7 +84,10 @@ class WatchProgressPreferences @Inject constructor(
         return store().data.map { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json)
-            map[contentId]
+            // Try direct key first (movies), then find latest episode entry (series).
+            map[contentId] ?: map.values
+                .filter { it.contentId == contentId }
+                .maxByOrNull { it.lastWatched }
         }
     }
 
@@ -325,12 +327,12 @@ class WatchProgressPreferences @Inject constructor(
             val key = createKey(progress)
             map[key] = progress
 
+            // Remove legacy series-level mirror key if this is an episode entry.
+            // Mirror keys caused race conditions with stale progress data.
             if (progress.season != null && progress.episode != null) {
                 val seriesKey = progress.contentId
-                val existingSeriesProgress = map[seriesKey]
-
-                if (existingSeriesProgress == null || progress.lastWatched >= existingSeriesProgress.lastWatched) {
-                    map[seriesKey] = progress.copy(videoId = progress.videoId)
+                if (seriesKey != key && map.containsKey(seriesKey)) {
+                    map.remove(seriesKey)
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -346,7 +346,6 @@ class TraktProgressService @Inject constructor(
 
             // Avoid emitting a transient empty state before first remote fetch completes.
             if (!loaded && remote.isEmpty() && validOptimistic.isEmpty()) {
-                Log.d(TAG, "observeAllProgress: skipping emission (loaded=$loaded remote=${remote.size} optimistic=${validOptimistic.size})")
                 return@combine null
             }
 
@@ -358,7 +357,6 @@ class TraktProgressService @Inject constructor(
                 .filter { !isShowHiddenFromProgress(it.contentId) }
                 .map { enrichWithMetadata(it, metadata) }
                 .sortedByDescending { it.lastWatched }
-            Log.d(TAG, "observeAllProgress: remote=${remote.size} optimistic=${validOptimistic.size} hidden=$hiddenCount result=${result.size}")
             result
         }
             .filterNotNull()
@@ -803,7 +801,6 @@ class TraktProgressService @Inject constructor(
         }
 
         val snapshot = fetchAllProgressSnapshot(force = force)
-        Log.d(TAG, "refreshRemoteSnapshot: snapshot size=${snapshot.size}, setting remoteProgress")
         remoteProgress.value = snapshot
         hasLoadedRemoteProgress.value = true
         reconcileOptimistic(snapshot)
@@ -974,9 +971,6 @@ class TraktProgressService @Inject constructor(
             hiddenProgressShowsLoadedAtMs = System.currentTimeMillis()
         }
         trace("hidden-progress-shows refreshed: ${ids.size} shows")
-        if (ids.isNotEmpty()) {
-            Log.d(TAG, "hidden-progress-shows IDs: ${ids.take(20)}")
-        }
     }
 
     private suspend fun fetchHiddenProgressShowIds(): Set<String> {
@@ -993,18 +987,14 @@ class TraktProgressService @Inject constructor(
                     limit = limit
                 )
             } ?: break
-            Log.d(TAG, "fetchDroppedShows: page=$page code=${response.code()}")
             if (!response.isSuccessful) {
                 Log.w(TAG, "fetchDroppedShows: failed code=${response.code()}")
                 break
             }
             val items = response.body().orEmpty()
-            Log.d(TAG, "fetchDroppedShows: page=$page items=${items.size}")
             if (items.isEmpty()) break
             for (item in items) {
                 val ids = item.show?.ids ?: continue
-                val title = item.show?.title ?: "?"
-                Log.d(TAG, "fetchDroppedShows: show='$title' imdb=${ids.imdb} tmdb=${ids.tmdb} trakt=${ids.trakt}")
                 ids.imdb?.takeIf { it.isNotBlank() }?.let { allIds.add(it) }
                 ids.tmdb?.let { allIds.add("tmdb:$it") }
                 ids.trakt?.let { allIds.add("trakt:$it") }
@@ -1368,15 +1358,12 @@ class TraktProgressService @Inject constructor(
 
     private suspend fun fetchAllProgressSnapshot(force: Boolean = false): List<WatchProgress> {
         val recentCompletedEpisodes = fetchRecentEpisodeHistorySnapshot()
-        Log.d(TAG, "fetchAllProgress: recentCompletedEpisodes=${recentCompletedEpisodes.size}")
         val playbackStartAt = recentWatchWindowMs()?.let { windowMs ->
             toTraktUtcDateTime(System.currentTimeMillis() - windowMs)
         }
         val inProgressMovies = getPlayback("movies", force = force, startAt = playbackStartAt).mapNotNull { mapPlaybackMovie(it) }
-        Log.d(TAG, "fetchAllProgress: inProgressMovies=${inProgressMovies.size}")
         val inProgressEpisodes = getPlayback("episodes", force = force, startAt = playbackStartAt)
             .mapNotNull { mapPlaybackEpisode(it, applyAddonRemap = true) }
-        Log.d(TAG, "fetchAllProgress: inProgressEpisodes=${inProgressEpisodes.size}")
 
         val mergedByKey = linkedMapOf<String, WatchProgress>()
 
@@ -1393,7 +1380,6 @@ class TraktProgressService @Inject constructor(
             }
 
         return mergedByKey.values.sortedByDescending { it.lastWatched }
-            .also { Log.d(TAG, "fetchAllProgress: total merged=${it.size}") }
     }
 
     private suspend fun fetchRecentEpisodeHistorySnapshot(): List<WatchProgress> {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1367,17 +1367,28 @@ class TraktProgressService @Inject constructor(
 
         val mergedByKey = linkedMapOf<String, WatchProgress>()
 
+        // In-progress items first, then completed episodes override them.
+        (inProgressMovies + inProgressEpisodes)
+            .sortedByDescending { it.lastWatched }
+            .forEach { progress ->
+                mergedByKey[progressKey(progress)] = progress
+            }
+
         recentCompletedEpisodes
             .sortedByDescending { it.lastWatched }
             .forEach { progress ->
                 mergedByKey[progressKey(progress)] = progress
             }
 
-        (inProgressMovies + inProgressEpisodes)
-            .sortedByDescending { it.lastWatched }
-            .forEach { progress ->
-                mergedByKey[progressKey(progress)] = progress
-            }
+        val completedEpisodeKeys = recentCompletedEpisodes
+            .filter { it.season != null && it.episode != null }
+            .map { "${it.contentId}_s${it.season}e${it.episode}" }
+            .toSet()
+        mergedByKey.entries.removeAll { (key, progress) ->
+            progress.source == WatchProgress.SOURCE_TRAKT_PLAYBACK &&
+                progress.season != null && progress.episode != null &&
+                "${progress.contentId}_s${progress.season}e${progress.episode}" in completedEpisodeKeys
+        }
 
         return mergedByKey.values.sortedByDescending { it.lastWatched }
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -871,6 +871,8 @@ class WatchProgressRepositoryImpl @Inject constructor(
         return traktProgressService.isShowHiddenFromProgress(contentId)
     }
 
+    override suspend fun isTraktProgressActive(): Boolean = shouldUseTraktProgress()
+
     private fun progressKey(progress: WatchProgress): String {
         return if (progress.season != null && progress.episode != null) {
             "${progress.contentId}_s${progress.season}e${progress.episode}"

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -113,4 +113,9 @@ interface WatchProgressRepository {
      * Returns true if the show is dropped/hidden from progress on the active source.
      */
     fun isDroppedShow(contentId: String): Boolean
+
+    /**
+     * Returns true if Trakt is both configured AND authenticated as the active progress source.
+     */
+    suspend fun isTraktProgressActive(): Boolean
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -306,33 +306,55 @@ class HomeViewModel @Inject constructor(
             val cachedNextUp = runCatching { cwEnrichmentCache.getNextUpSnapshot() }.getOrDefault(emptyList())
             if (cachedInProgress.isEmpty() && cachedNextUp.isEmpty()) return@launch
             val dismissedNextUp = traktSettingsDataStore.dismissedNextUpKeys.first()
+            // Cross-reference cached in-progress items with current WatchProgressPreferences
+            // to avoid showing stale progress (e.g. item completed since cache was saved).
+            val currentProgress = runCatching {
+                watchProgressRepository.allProgress.first()
+            }.getOrDefault(emptyList())
+            val currentProgressByContentId = currentProgress.associateBy { it.contentId }
             val inProgressItems = cachedInProgress
                 .filter { !watchProgressRepository.isDroppedShow(it.contentId) }
-                .map { cached ->
-                ContinueWatchingItem.InProgress(
-                    progress = com.nuvio.tv.domain.model.WatchProgress(
-                        contentId = cached.contentId,
-                        contentType = cached.contentType,
-                        name = cached.name,
-                        poster = cached.poster,
-                        backdrop = cached.backdrop,
-                        logo = cached.logo,
-                        videoId = cached.videoId,
-                        season = cached.season,
-                        episode = cached.episode,
-                        episodeTitle = cached.episodeTitle,
-                        position = cached.position,
-                        duration = cached.duration,
-                        lastWatched = cached.lastWatched,
-                        progressPercent = cached.progressPercent
-                    ),
-                    episodeThumbnail = cached.episodeThumbnail,
-                    episodeDescription = cached.episodeDescription,
-                    episodeImdbRating = cached.episodeImdbRating,
-                    genres = cached.genres,
-                    releaseInfo = cached.releaseInfo
-                )
-            }
+                .mapNotNull { cached ->
+                    // Use live progress data if available; skip if item is now completed.
+                    val liveProgress = currentProgressByContentId[cached.contentId]
+                    val progress = if (liveProgress != null) {
+                        if (liveProgress.isCompleted()) return@mapNotNull null
+                        if (!liveProgress.isInProgress() && liveProgress.position <= 0L) return@mapNotNull null
+                        liveProgress.copy(
+                            poster = liveProgress.poster ?: cached.poster,
+                            backdrop = liveProgress.backdrop ?: cached.backdrop,
+                            logo = liveProgress.logo ?: cached.logo,
+                            name = liveProgress.name.takeIf { it.isNotBlank() } ?: cached.name,
+                            episodeTitle = liveProgress.episodeTitle ?: cached.episodeTitle
+                        )
+                    } else {
+                        // No live data — trust cached item as-is.
+                        com.nuvio.tv.domain.model.WatchProgress(
+                            contentId = cached.contentId,
+                            contentType = cached.contentType,
+                            name = cached.name,
+                            poster = cached.poster,
+                            backdrop = cached.backdrop,
+                            logo = cached.logo,
+                            videoId = cached.videoId,
+                            season = cached.season,
+                            episode = cached.episode,
+                            episodeTitle = cached.episodeTitle,
+                            position = cached.position,
+                            duration = cached.duration,
+                            lastWatched = cached.lastWatched,
+                            progressPercent = cached.progressPercent
+                        )
+                    }
+                    ContinueWatchingItem.InProgress(
+                        progress = progress,
+                        episodeThumbnail = cached.episodeThumbnail,
+                        episodeDescription = cached.episodeDescription,
+                        episodeImdbRating = cached.episodeImdbRating,
+                        genres = cached.genres,
+                        releaseInfo = cached.releaseInfo
+                    )
+                }
             val nextUpItems = cachedNextUp
                 .filter { !watchProgressRepository.isDroppedShow(it.contentId) }
                 .filter { nextUpDismissKey(it.contentId, it.seedSeason, it.seedEpisode) !in dismissedNextUp }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -231,8 +231,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
             try {
                 debug.markPhase("filter-snapshot")
                 val cycleStartMs = SystemClock.elapsedRealtime()
-                val useTraktProgress = traktSettingsDataStore.watchProgressSource.first() ==
-                    com.nuvio.tv.data.local.WatchProgressSource.TRAKT
+                val useTraktProgress = watchProgressRepository.isTraktProgressActive()
                 val items = snapshot.items
                 val nextUpSeeds = snapshot.nextUpSeeds
                 val daysCap = snapshot.daysCap
@@ -379,6 +378,13 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         inProgressItems = inProgressOnly,
                         nextUpItems = cachedNextUpItems
                     )
+                    _uiState.update { state ->
+                        if (state.continueWatchingItems == initialItems) {
+                            state
+                        } else {
+                            state.copy(continueWatchingItems = initialItems)
+                        }
+                    }
                     _uiState.update { state ->
                         if (state.continueWatchingItems == initialItems) {
                             state
@@ -639,10 +645,14 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     }
                 val recentIds = nextUpItems.map { it.info.contentId }.toSet()
                 val inProgressIds = inProgressOnly.map { it.progress.contentId }.toSet()
+                val allSeedContentIds = nextUpSeeds
+                    .map { it.contentId }
+                    .toSet()
                 val olderToInclude = (persistedOlderItems + cachedOlderNextUp)
                     .distinctBy { it.info.contentId }
                     .filter {
                         (if (useTraktProgress) it.info.isReleaseAlert else true) &&
+                            it.info.contentId in allSeedContentIds &&
                             it.info.contentId !in recentIds &&
                             it.info.contentId !in inProgressIds &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&
@@ -680,6 +690,46 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     count = normalItems.size,
                     elapsedMs = SystemClock.elapsedRealtime() - cycleStartMs
                 )
+
+                // Save lightweight CW snapshot to disk immediately so cache stays fresh
+                // even if enrichment is cancelled by collectLatest.
+                viewModelScope.launch(Dispatchers.IO) {
+                    val currentItems = _uiState.value.continueWatchingItems
+                    val brokenUrls = com.nuvio.tv.ui.components.brokenImageUrls
+                    val nextUpSnap = currentItems.mapNotNull { item ->
+                        val nu = item as? ContinueWatchingItem.NextUp ?: return@mapNotNull null
+                        val info = nu.info
+                        com.nuvio.tv.data.local.CachedNextUpItem(
+                            contentId = info.contentId, contentType = info.contentType, name = info.name,
+                            poster = info.poster, backdrop = info.backdrop, logo = info.logo,
+                            videoId = info.videoId, season = info.season, episode = info.episode,
+                            episodeTitle = info.episodeTitle, episodeDescription = info.episodeDescription,
+                            thumbnail = info.thumbnail?.takeIf { it !in brokenUrls },
+                            released = info.released, hasAired = info.hasAired, airDateLabel = info.airDateLabel,
+                            lastWatched = info.lastWatched, imdbRating = info.imdbRating, genres = info.genres,
+                            releaseInfo = info.releaseInfo, sortTimestamp = info.sortTimestamp,
+                            releaseTimestamp = info.releaseTimestamp, isReleaseAlert = info.isReleaseAlert,
+                            isNewSeasonRelease = info.isNewSeasonRelease, seedSeason = info.seedSeason,
+                            seedEpisode = info.seedEpisode
+                        )
+                    }
+                    val ipSnap = currentItems.mapNotNull { item ->
+                        val ip = item as? ContinueWatchingItem.InProgress ?: return@mapNotNull null
+                        val p = ip.progress
+                        com.nuvio.tv.data.local.CachedInProgressItem(
+                            contentId = p.contentId, contentType = p.contentType, name = p.name,
+                            poster = p.poster, backdrop = p.backdrop, logo = p.logo,
+                            videoId = p.videoId, season = p.season, episode = p.episode,
+                            episodeTitle = p.episodeTitle, position = p.position, duration = p.duration,
+                            lastWatched = p.lastWatched, progressPercent = p.progressPercent,
+                            episodeThumbnail = ip.episodeThumbnail?.takeIf { it !in brokenUrls },
+                            episodeDescription = ip.episodeDescription, episodeImdbRating = ip.episodeImdbRating,
+                            genres = ip.genres, releaseInfo = ip.releaseInfo
+                        )
+                    }
+                    runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap) }
+                    runCatching { cwEnrichmentCache.saveInProgressSnapshot(ipSnap) }
+                }
 
                 // Rich metadata only runs after the final lightweight CW list is visible.
                 // If TMDB enrichment is enabled for CW, skip grace period to avoid
@@ -727,9 +777,10 @@ private fun shouldTreatAsInProgressForContinueWatching(progress: WatchProgress):
     // Rewatch edge case: a started replay can be below the default 2% "in progress"
     // threshold, but should still suppress Next Up and appear as resume.
     val hasStartedPlayback = progress.position > 0L || progress.progressPercent?.let { it > 0f } == true
-    return hasStartedPlayback &&
+    val result = hasStartedPlayback &&
         progress.source != WatchProgress.SOURCE_TRAKT_HISTORY &&
         progress.source != WatchProgress.SOURCE_TRAKT_SHOW_PROGRESS
+    return result
 }
 
 private fun shouldUseAsCompletedSeed(progress: WatchProgress): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -303,8 +303,9 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 )
                             )
                         }
-                    } else if (useTraktProgress && cachedInProgress.isNotEmpty()) {
-                        // Trakt hasn't responded yet — restore last known in-progress items from disk.
+                    }
+                    // For Trakt: show cached in-progress until Trakt responds (items non-empty).
+                    if (liveInProgress.isEmpty() && useTraktProgress && cachedInProgress.isNotEmpty() && items.isEmpty()) {
                         cachedInProgress.forEach { cached ->
                             add(
                                 ContinueWatchingItem.InProgress(


### PR DESCRIPTION
## Summary

Fix stale in-progress items persisting in Continue Watching for both Nuvio Sync and Trakt users. Items that were completed or removed would incorrectly remain visible with old progress percentages.

## PR type

- Bug fix

## Why

Users reported episodes stuck in Continue Watching with incorrect progress (e.g. showing "50% left" despite being fully watched). The root causes were:

1. **Nuvio Sync**: Legacy series-level mirror keys in WatchProgressPreferences created race conditions where stale progress data won over fresh episode-level data.
2. **Trakt**: `useTraktProgress` in the CW pipeline checked only the settings preference, not whether Trakt was actually authenticated - causing cached in-progress fallback to activate incorrectly. Additionally, `reconcileOptimistic` didn't remove optimistic entries when remote had higher progress, and stale Trakt playback entries weren't filtered against completed history.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual testing on Android TV with both Trakt and Nuvio Sync accounts
- Verified: completing an episode removes it from CW in-progress for both backends
- Verified: marking episodes as unwatched removes next-up from CW
- Verified: no flash of stale progress on app restart
- Verified: cached in-progress items display instantly on cold start, then update when backend responds

## Screenshots / Video (UI changes only)
behavioral fix, no UI layout changes.

## Breaking changes
Nothing, fixes for not yet released things - #1221

## Linked issues

None
