### PR TITLE
Original Audio Track + bunch of fixes 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
@@ -39,7 +39,8 @@ data class CachedNextUpItem(
     val isReleaseAlert: Boolean = false,
     val isNewSeasonRelease: Boolean = false,
     val seedSeason: Int? = null,
-    val seedEpisode: Int? = null
+    val seedEpisode: Int? = null,
+    val contentLanguage: String? = null
 )
 
 data class CachedInProgressItem(
@@ -61,7 +62,8 @@ data class CachedInProgressItem(
     val episodeDescription: String? = null,
     val episodeImdbRating: Float? = null,
     val genres: List<String> = emptyList(),
-    val releaseInfo: String? = null
+    val releaseInfo: String? = null,
+    val contentLanguage: String? = null
 )
 
 @Singleton

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -150,6 +150,7 @@ data class BufferSettings(
 object AudioLanguageOption {
     const val DEFAULT = "default"  // Use media file default
     const val DEVICE = "device"    // Use device locale
+    const val ORIGINAL = "original"  // Use content's original language (from TMDB)
 }
 
 /**
@@ -833,6 +834,7 @@ class PlayerSettingsDataStore @Inject constructor(
         return when (normalized) {
             AudioLanguageOption.DEFAULT,
             AudioLanguageOption.DEVICE,
+            AudioLanguageOption.ORIGINAL,
             SUBTITLE_LANGUAGE_FORCED -> null
             else -> normalized
         }

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -144,7 +144,8 @@ fun NuvioNavHost(
                         manualSelection = manualSelection,
                         returnToDetailOnBack = item.progress.contentType.equals("series", ignoreCase = true),
                         returnToHomeOnBack = true,
-                        startFromBeginning = startFromBeginning
+                        startFromBeginning = startFromBeginning,
+                        contentLanguage = item.contentLanguage
                     )
                     is ContinueWatchingItem.NextUp -> Screen.Stream.createRoute(
                         videoId = item.info.videoId,
@@ -164,7 +165,8 @@ fun NuvioNavHost(
                         manualSelection = manualSelection,
                         returnToDetailOnBack = item.info.contentType.equals("series", ignoreCase = true),
                         returnToHomeOnBack = true,
-                        startFromBeginning = startFromBeginning
+                        startFromBeginning = startFromBeginning,
+                        contentLanguage = item.info.contentLanguage
                     )
                 }
             }
@@ -279,7 +281,7 @@ fun NuvioNavHost(
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
                     navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
                 },
-                onPlayClick = { videoId, contentType, contentId, title, poster, backdrop, logo, season, episode, episodeName, genres, year, runtime ->
+                onPlayClick = { videoId, contentType, contentId, title, poster, backdrop, logo, season, episode, episodeName, genres, year, runtime, contentLanguage ->
                     navController.navigate(
                         Screen.Stream.createRoute(
                             videoId = videoId,
@@ -296,11 +298,12 @@ fun NuvioNavHost(
                             contentId = contentId,
                             contentName = title,
                             runtime = runtime,
-                            returnToDetailOnBack = contentType.equals("series", ignoreCase = true)
+                            returnToDetailOnBack = contentType.equals("series", ignoreCase = true),
+                            contentLanguage = contentLanguage
                         )
                     )
                 },
-                onPlayManuallyClick = { videoId, contentType, contentId, title, poster, backdrop, logo, season, episode, episodeName, genres, year, runtime ->
+                onPlayManuallyClick = { videoId, contentType, contentId, title, poster, backdrop, logo, season, episode, episodeName, genres, year, runtime, contentLanguage ->
                     navController.navigate(
                         Screen.Stream.createRoute(
                             videoId = videoId,
@@ -318,7 +321,8 @@ fun NuvioNavHost(
                             contentName = title,
                             runtime = runtime,
                             manualSelection = true,
-                            returnToDetailOnBack = contentType.equals("series", ignoreCase = true)
+                            returnToDetailOnBack = contentType.equals("series", ignoreCase = true),
+                            contentLanguage = contentLanguage
                         )
                     )
                 }
@@ -405,6 +409,11 @@ fun NuvioNavHost(
                     type = NavType.StringType
                     nullable = true
                     defaultValue = "false"
+                },
+                navArgument("contentLanguage") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
                 }
             )
         ) { backStackEntry ->
@@ -478,7 +487,8 @@ fun NuvioNavHost(
                                 startFromBeginning = startFromBeginning,
                                 addonName = playbackInfo.addonName,
                                 addonLogo = playbackInfo.addonLogo,
-                                streamDescription = playbackInfo.streamDescription
+                                streamDescription = playbackInfo.streamDescription,
+                                contentLanguage = playbackInfo.contentLanguage
                             )
                         )
                     }
@@ -512,7 +522,8 @@ fun NuvioNavHost(
                                 startFromBeginning = startFromBeginning,
                                 addonName = playbackInfo.addonName,
                                 addonLogo = playbackInfo.addonLogo,
-                                streamDescription = playbackInfo.streamDescription
+                                streamDescription = playbackInfo.streamDescription,
+                                contentLanguage = playbackInfo.contentLanguage
                             )
                         ) {
                             popUpTo(Screen.Stream.route) { inclusive = true }
@@ -643,6 +654,11 @@ fun NuvioNavHost(
                     defaultValue = null
                 },
                 navArgument("streamDescription") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+                navArgument("contentLanguage") {
                     type = NavType.StringType
                     nullable = true
                     defaultValue = null

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -24,7 +24,7 @@ sealed class Screen(val route: String) {
             return "detail/$encodedItemId/$encodedItemType?addonBaseUrl=$encodedAddon&returnFocusSeason=${returnFocusSeason ?: ""}&returnFocusEpisode=${returnFocusEpisode ?: ""}&returnToHomeOnBack=$returnToHomeOnBack&heroBackdropUrl=$encodedHeroBackdrop"
         }
     }
-    data object Stream : Screen("stream/{videoId}/{contentType}/{title}?poster={poster}&backdrop={backdrop}&logo={logo}&season={season}&episode={episode}&episodeName={episodeName}&genres={genres}&year={year}&contentId={contentId}&contentName={contentName}&runtime={runtime}&manualSelection={manualSelection}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&startFromBeginning={startFromBeginning}") {
+    data object Stream : Screen("stream/{videoId}/{contentType}/{title}?poster={poster}&backdrop={backdrop}&logo={logo}&season={season}&episode={episode}&episodeName={episodeName}&genres={genres}&year={year}&contentId={contentId}&contentName={contentName}&runtime={runtime}&manualSelection={manualSelection}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&startFromBeginning={startFromBeginning}&contentLanguage={contentLanguage}") {
         private fun encode(value: String): String =
             URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
@@ -46,7 +46,8 @@ sealed class Screen(val route: String) {
             manualSelection: Boolean = false,
             returnToDetailOnBack: Boolean = false,
             returnToHomeOnBack: Boolean = false,
-            startFromBeginning: Boolean = false
+            startFromBeginning: Boolean = false,
+            contentLanguage: String? = null
         ): String {
             val encodedVideoId = encode(videoId)
             val encodedContentTypePath = encode(contentType)
@@ -59,10 +60,11 @@ sealed class Screen(val route: String) {
             val encodedYear = year?.let { encode(it) } ?: ""
             val encodedContentId = contentId?.let { encode(it) } ?: ""
             val encodedContentName = contentName?.let { encode(it) } ?: ""
-            return "stream/$encodedVideoId/$encodedContentTypePath/$encodedTitle?poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&season=${season ?: ""}&episode=${episode ?: ""}&episodeName=$encodedEpisodeName&genres=$encodedGenres&year=$encodedYear&contentId=$encodedContentId&contentName=$encodedContentName&runtime=${runtime ?: ""}&manualSelection=$manualSelection&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&startFromBeginning=$startFromBeginning"
+            val encodedContentLanguage = contentLanguage?.let { encode(it) } ?: ""
+            return "stream/$encodedVideoId/$encodedContentTypePath/$encodedTitle?poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&season=${season ?: ""}&episode=${episode ?: ""}&episodeName=$encodedEpisodeName&genres=$encodedGenres&year=$encodedYear&contentId=$encodedContentId&contentName=$encodedContentName&runtime=${runtime ?: ""}&manualSelection=$manualSelection&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&startFromBeginning=$startFromBeginning&contentLanguage=$encodedContentLanguage"
         }
     }
-    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}&startFromBeginning={startFromBeginning}&addonName={addonName}&addonLogo={addonLogo}&streamDescription={streamDescription}") {
+    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}&startFromBeginning={startFromBeginning}&addonName={addonName}&addonLogo={addonLogo}&streamDescription={streamDescription}&contentLanguage={contentLanguage}") {
         private fun encode(value: String): String =
             URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
@@ -92,7 +94,8 @@ sealed class Screen(val route: String) {
             startFromBeginning: Boolean = false,
             addonName: String? = null,
             addonLogo: String? = null,
-            streamDescription: String? = null
+            streamDescription: String? = null,
+            contentLanguage: String? = null
         ): String {
             val encodedUrl = encode(streamUrl)
             val encodedTitle = encode(title)
@@ -115,7 +118,8 @@ sealed class Screen(val route: String) {
             val encodedAddonName = addonName?.let { encode(it) } ?: ""
             val encodedAddonLogo = addonLogo?.let { encode(it) } ?: ""
             val encodedStreamDescription = streamDescription?.let { encode(it) } ?: ""
-            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}&startFromBeginning=$startFromBeginning&addonName=$encodedAddonName&addonLogo=$encodedAddonLogo&streamDescription=$encodedStreamDescription"
+            val encodedContentLanguage = contentLanguage?.let { encode(it) } ?: ""
+            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}&startFromBeginning=$startFromBeginning&addonName=$encodedAddonName&addonLogo=$encodedAddonLogo&streamDescription=$encodedStreamDescription&contentLanguage=$encodedContentLanguage"
         }
     }
     data object Search : Screen("search")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -90,6 +90,7 @@ fun SeasonTabs(
     onSeasonSelected: (Int) -> Unit,
     onSeasonLongPress: (Int) -> Unit = {},
     selectedTabFocusRequester: FocusRequester,
+    upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null
 ) {
     // Move season 0 (specials) to the end
@@ -148,6 +149,9 @@ fun SeasonTabs(
                     .focusProperties {
                         if (isSelected && downFocusRequester != null) {
                             down = downFocusRequester
+                        }
+                        if (upFocusRequester != null) {
+                            up = upFocusRequester
                         }
                     }
                     .onFocusChanged {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -211,8 +211,9 @@ fun MetaDetailsScreen(
         episodeName: String?,
         genres: String?,
         year: String?,
-        runtime: Int?
-    ) -> Unit = { _, _, _, _, _, _, _, _, _, _, _, _, _ -> },
+        runtime: Int?,
+        contentLanguage: String?
+    ) -> Unit = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ -> },
     onPlayManuallyClick: (
         videoId: String,
         contentType: String,
@@ -226,8 +227,9 @@ fun MetaDetailsScreen(
         episodeName: String?,
         genres: String?,
         year: String?,
-        runtime: Int?
-    ) -> Unit = { _, _, _, _, _, _, _, _, _, _, _, _, _ -> }
+        runtime: Int?,
+        contentLanguage: String?
+    ) -> Unit = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val effectiveAutoplayEnabled by viewModel.effectiveAutoplayEnabled.collectAsStateWithLifecycle(
@@ -450,7 +452,8 @@ fun MetaDetailsScreen(
                             video.title,
                             null,
                             null,
-                            video.runtime
+                            video.runtime,
+                            meta.language
                         )
                     },
                     onEpisodeManualPlayClick = { video ->
@@ -467,7 +470,8 @@ fun MetaDetailsScreen(
                             video.title,
                             null,
                             null,
-                            video.runtime
+                            video.runtime,
+                            meta.language
                         )
                     },
                     onPlayClick = { videoId ->
@@ -484,7 +488,8 @@ fun MetaDetailsScreen(
                             null,
                             genresString,
                             yearString,
-                            null
+                            null,
+                            meta.language
                         )
                     },
                     onPlayManuallyClick = { videoId ->
@@ -501,7 +506,8 @@ fun MetaDetailsScreen(
                             null,
                             genresString,
                             yearString,
-                            null
+                            null,
+                            meta.language
                         )
                     },
                     showManualPlayOption = effectiveAutoplayEnabled,
@@ -1400,6 +1406,7 @@ private fun MetaDetailsContent(
                             onSeasonSelected = onSeasonSelected,
                             onSeasonLongPress = { seasonOptionsDialogSeason = it },
                             selectedTabFocusRequester = selectedSeasonFocusRequester,
+                            upFocusRequester = heroPlayFocusRequester,
                             downFocusRequester = seasonDownFocusRequester
                         )
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -66,7 +66,8 @@ sealed class ContinueWatchingItem {
         val episodeThumbnail: String? = null,
         val episodeImdbRating: Float? = null,
         val genres: List<String> = emptyList(),
-        val releaseInfo: String? = null
+        val releaseInfo: String? = null,
+        val contentLanguage: String? = null
     ) : ContinueWatchingItem()
 
     @Immutable
@@ -99,7 +100,8 @@ data class NextUpInfo(
     val isReleaseAlert: Boolean = false,
     val isNewSeasonRelease: Boolean = false,
     val seedSeason: Int? = null,
-    val seedEpisode: Int? = null
+    val seedEpisode: Int? = null,
+    val contentLanguage: String? = null
 )
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -73,7 +73,8 @@ class HomeViewModel @Inject constructor(
     internal val trailerService: TrailerService,
     internal val watchedItemsPreferences: WatchedItemsPreferences,
     internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
-    internal val cwEnrichmentCache: ContinueWatchingEnrichmentCache
+    internal val cwEnrichmentCache: ContinueWatchingEnrichmentCache,
+    private val profileManager: com.nuvio.tv.core.profile.ProfileManager
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
@@ -195,6 +196,16 @@ class HomeViewModel @Inject constructor(
         loadContinueWatching()
         observeCollections()
         observeInstalledAddons()
+        // Clear CW state when profile changes so items don't leak between profiles.
+        viewModelScope.launch {
+            var previousProfileId = profileManager.activeProfileId.value
+            profileManager.activeProfileId.collect { newId ->
+                if (newId != previousProfileId) {
+                    previousProfileId = newId
+                    _uiState.update { it.copy(continueWatchingItems = emptyList()) }
+                }
+            }
+        }
         viewModelScope.launch {
             delay(STARTUP_GRACE_PERIOD_MS)
             startupGracePeriodActive = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1082,9 +1082,17 @@ internal fun mergeContinueWatchingItems(
     inProgressItems.forEach { combined.add(it.progress.lastWatched to it) }
     filteredNextUpItems.forEach { combined.add(it.info.sortTimestamp to it) }
 
+    val seen = mutableSetOf<String>()
     return combined
         .sortedByDescending { it.first }
         .map { it.second }
+        .filter { item ->
+            val contentId = when (item) {
+                is ContinueWatchingItem.InProgress -> item.progress.contentId
+                is ContinueWatchingItem.NextUp -> item.info.contentId
+            }
+            contentId.isBlank() || seen.add(contentId)
+        }
 }
 
 private suspend fun HomeViewModel.buildNextUpItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -136,7 +136,8 @@ private data class NextUpTmdbData(
     val airDate: String?,
     val overview: String?,
     val showDescription: String?,
-    val rating: Double?
+    val rating: Double?,
+    val contentLanguage: String? = null
 )
 
 internal data class NextUpResolution(
@@ -299,7 +300,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                     episodeDescription = cached?.episodeDescription,
                                     episodeImdbRating = cached?.episodeImdbRating,
                                     genres = cached?.genres ?: emptyList(),
-                                    releaseInfo = cached?.releaseInfo
+                                    releaseInfo = cached?.releaseInfo,
+                                    contentLanguage = cached?.contentLanguage
                                 )
                             )
                         }
@@ -423,7 +425,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                             backdrop = cached.backdrop ?: nextUp.info.backdrop,
                                             poster = cached.poster ?: nextUp.info.poster,
                                             logo = cached.logo ?: nextUp.info.logo,
-                                            name = cached.name.takeIf { it.isNotBlank() } ?: nextUp.info.name
+                                            name = cached.name.takeIf { it.isNotBlank() } ?: nextUp.info.name,
+                                            contentLanguage = cached.contentLanguage ?: nextUp.info.contentLanguage
                                         ))
                                     } else nextUp
                                 }
@@ -674,7 +677,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 episodeDescription = cached.episodeDescription ?: nextUp.info.episodeDescription,
                                 imdbRating = cached.imdbRating ?: nextUp.info.imdbRating,
                                 genres = cached.genres.ifEmpty { nextUp.info.genres },
-                                releaseInfo = cached.releaseInfo ?: nextUp.info.releaseInfo
+                                releaseInfo = cached.releaseInfo ?: nextUp.info.releaseInfo,
+                                contentLanguage = cached.contentLanguage ?: nextUp.info.contentLanguage
                             ))
                         } else nextUp
                     }
@@ -711,7 +715,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             releaseInfo = info.releaseInfo, sortTimestamp = info.sortTimestamp,
                             releaseTimestamp = info.releaseTimestamp, isReleaseAlert = info.isReleaseAlert,
                             isNewSeasonRelease = info.isNewSeasonRelease, seedSeason = info.seedSeason,
-                            seedEpisode = info.seedEpisode
+                            seedEpisode = info.seedEpisode, contentLanguage = info.contentLanguage
                         )
                     }
                     val ipSnap = currentItems.mapNotNull { item ->
@@ -725,7 +729,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             lastWatched = p.lastWatched, progressPercent = p.progressPercent,
                             episodeThumbnail = ip.episodeThumbnail?.takeIf { it !in brokenUrls },
                             episodeDescription = ip.episodeDescription, episodeImdbRating = ip.episodeImdbRating,
-                            genres = ip.genres, releaseInfo = ip.releaseInfo
+                            genres = ip.genres, releaseInfo = ip.releaseInfo,
+                            contentLanguage = ip.contentLanguage
                         )
                     }
                     runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap) }
@@ -1205,7 +1210,8 @@ private suspend fun HomeViewModel.enrichInProgressItem(
         episodeThumbnail = if (settings.useEpisodes) tmdbData?.thumbnail ?: video?.thumbnail.normalizeImageUrl() ?: item.episodeThumbnail else video?.thumbnail.normalizeImageUrl() ?: item.episodeThumbnail,
         episodeImdbRating = if (settings.useBasicInfo) imdbRating else meta.imdbRating,
         genres = genres,
-        releaseInfo = releaseInfo
+        releaseInfo = releaseInfo,
+        contentLanguage = tmdbData?.contentLanguage ?: item.contentLanguage
     )
 }
 
@@ -1285,7 +1291,8 @@ private suspend fun HomeViewModel.enrichNextUpItem(
         sortTimestamp = item.info.sortTimestamp,
         releaseTimestamp = releaseState.releaseTimestamp,
         isReleaseAlert = releaseState.isReleaseAlert,
-        isNewSeasonRelease = releaseState.isNewSeasonRelease
+        isNewSeasonRelease = releaseState.isNewSeasonRelease,
+        contentLanguage = tmdbData?.contentLanguage ?: item.info.contentLanguage
     )
     if (shouldTraceNextUpSeries(progressSeed)) {
         logNextUpDecision(
@@ -1729,7 +1736,8 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
             isReleaseAlert = info.isReleaseAlert,
             isNewSeasonRelease = info.isNewSeasonRelease,
             seedSeason = info.seedSeason,
-            seedEpisode = info.seedEpisode
+            seedEpisode = info.seedEpisode,
+            contentLanguage = info.contentLanguage
         )
     }
 
@@ -1756,7 +1764,8 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
             episodeDescription = ip.episodeDescription,
             episodeImdbRating = ip.episodeImdbRating,
             genres = ip.genres,
-            releaseInfo = ip.releaseInfo
+            releaseInfo = ip.releaseInfo,
+            contentLanguage = ip.contentLanguage
         )
     }
 
@@ -1915,7 +1924,8 @@ private suspend fun HomeViewModel.resolveContinueWatchingTmdbData(
                 airDate = null,
                 overview = it.description?.trim()?.takeIf { t -> t.isNotEmpty() },
                 showDescription = null,
-                rating = mdbImdbRating ?: it.rating
+                rating = mdbImdbRating ?: it.rating,
+                contentLanguage = it.language
             )
         }
     }
@@ -1968,7 +1978,8 @@ private suspend fun HomeViewModel.resolveContinueWatchingTmdbData(
         airDate = episodeMeta?.airDate?.trim()?.takeIf { it.isNotEmpty() },
         overview = episodeMeta?.overview?.trim()?.takeIf { it.isNotEmpty() },
         showDescription = showMeta?.description?.trim()?.takeIf { it.isNotEmpty() },
-        rating = mdbImdbRating ?: showMeta?.rating
+        rating = mdbImdbRating ?: showMeta?.rating,
+        contentLanguage = showMeta?.language
     )
 
     return if (

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -281,5 +281,42 @@ internal class PlayerMediaSourceFactory {
             if (read <= 0) return null
             return String(buffer, 0, read, Charsets.UTF_8)
         }
+
+        /**
+         * Extracts `user:password` from a URL's userinfo component and converts it
+         * to a Basic Auth header. Returns the cleaned URL (without userinfo) and
+         * merged headers. If the URL has no userinfo, returns the original URL and headers unchanged.
+         *
+         * Example: `https://user:pass@host/path` → URL `https://host/path` + header `Authorization: Basic dXNlcjpwYXNz`
+         */
+        fun extractUserInfoAuth(
+            url: String,
+            headers: Map<String, String>
+        ): Pair<String, Map<String, String>> {
+            if (url.isBlank()) return url to headers
+            val uri = try { java.net.URI(url) } catch (_: Exception) { return url to headers }
+            val userInfo = uri.userInfo ?: return url to headers
+            if (userInfo.isBlank()) return url to headers
+            // Already has an Authorization header — don't override
+            if (headers.any { it.key.equals("Authorization", ignoreCase = true) }) {
+                return url to headers
+            }
+            val encoded = android.util.Base64.encodeToString(
+                userInfo.toByteArray(Charsets.UTF_8),
+                android.util.Base64.NO_WRAP
+            )
+            val cleanUri = java.net.URI(
+                uri.scheme,
+                null, // no userinfo
+                uri.host,
+                uri.port,
+                uri.path,
+                uri.query,
+                uri.fragment
+            )
+            val mergedHeaders = LinkedHashMap(headers)
+            mergedHeaders["Authorization"] = "Basic $encoded"
+            return cleanUri.toString() to mergedHeaders
+        }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
@@ -26,7 +26,8 @@ internal data class PlayerNavigationArgs(
     val startFromBeginning: Boolean,
     val addonName: String?,
     val addonLogo: String?,
-    val streamDescription: String?
+    val streamDescription: String?,
+    val contentLanguage: String?
 ) {
     companion object {
         fun from(savedStateHandle: SavedStateHandle): PlayerNavigationArgs {
@@ -59,7 +60,8 @@ internal data class PlayerNavigationArgs(
                 startFromBeginning = savedStateHandle.get<String>("startFromBeginning")?.toBooleanStrictOrNull() == true,
                 addonName = decodedOrNull("addonName"),
                 addonLogo = decodedOrNull("addonLogo"),
-                streamDescription = decodedOrNull("streamDescription")
+                streamDescription = decodedOrNull("streamDescription"),
+                contentLanguage = decodedOrNull("contentLanguage")
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -134,18 +134,27 @@ class PlayerRuntimeController(
     internal var currentAddonName: String? = navigationArgs.addonName
     internal var currentAddonLogo: String? = navigationArgs.addonLogo
     internal var currentStreamDescription: String? = navigationArgs.streamDescription
+    internal val contentLanguage: String? = navigationArgs.contentLanguage
     internal var currentVideoCodec: String? = null
     internal var currentVideoWidth: Int? = null
     internal var currentVideoHeight: Int? = null
     internal var currentVideoBitrate: Int? = null
-    internal var currentStreamUrl: String = initialStreamUrl
-    internal var currentStreamMimeType: String? =
-        PlayerMediaSourceFactory.inferMimeType(
-            url = initialStreamUrl,
+    internal var currentStreamUrl: String
+    internal var currentStreamMimeType: String?
+    internal var currentHeaders: Map<String, String>
+
+    init {
+        val (cleanInitialUrl, mergedInitialHeaders) = PlayerMediaSourceFactory.extractUserInfoAuth(
+            initialStreamUrl,
+            PlayerMediaSourceFactory.sanitizeHeaders(PlayerMediaSourceFactory.parseHeaders(headersJson))
+        )
+        currentStreamUrl = cleanInitialUrl
+        currentStreamMimeType = PlayerMediaSourceFactory.inferMimeType(
+            url = cleanInitialUrl,
             filename = currentFilename
         )
-    internal var currentHeaders: Map<String, String> =
-        PlayerMediaSourceFactory.sanitizeHeaders(PlayerMediaSourceFactory.parseHeaders(headersJson))
+        currentHeaders = mergedInitialHeaders
+    }
 
     fun getCurrentStreamUrl(): String = currentStreamUrl
     fun getCurrentHeaders(): Map<String, String> = currentHeaders

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -298,11 +298,12 @@ class PlayerRuntimeController(
     internal var libassPipelineDecisionStreamUrl: String? = null
     internal var episodeStreamsJob: Job? = null
     internal var episodeStreamsCacheRequestKey: String? = null
-    internal val streamCacheKey: String? by lazy {
-        val type = contentType?.lowercase()
-        val vid = currentVideoId
-        if (type.isNullOrBlank() || vid.isNullOrBlank()) null else "$type|$vid"
-    }
+    internal val streamCacheKey: String?
+        get() {
+            val type = contentType?.lowercase()
+            val vid = currentVideoId
+            return if (type.isNullOrBlank() || vid.isNullOrBlank()) null else "$type|$vid"
+        }
 
     init {
         if (!navigationArgs.startFromBeginning) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -92,7 +92,8 @@ internal fun PlayerRuntimeController.initializePlayer(
             val preferredAudioLanguages = resolvePreferredAudioLanguages(
                 preferredAudioLanguage = playerSettings.preferredAudioLanguage,
                 secondaryPreferredAudioLanguage = playerSettings.secondaryPreferredAudioLanguage,
-                deviceLanguages = resolveDeviceAudioLanguages()
+                deviceLanguages = resolveDeviceAudioLanguages(),
+                contentOriginalLanguage = contentLanguage
             )
             mpvPreferredAudioLanguages = preferredAudioLanguages
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
@@ -477,7 +478,8 @@ internal fun PlayerRuntimeController.initializePlayer(
 internal fun resolvePreferredAudioLanguages(
     preferredAudioLanguage: String,
     secondaryPreferredAudioLanguage: String?,
-    deviceLanguages: List<String>
+    deviceLanguages: List<String>,
+    contentOriginalLanguage: String? = null
 ): List<String> {
     fun normalize(language: String?): String? {
         val normalized = language
@@ -488,6 +490,7 @@ internal fun resolvePreferredAudioLanguages(
         return when (normalized) {
             AudioLanguageOption.DEFAULT,
             AudioLanguageOption.DEVICE,
+            AudioLanguageOption.ORIGINAL,
             SUBTITLE_LANGUAGE_FORCED -> null
             else -> normalized
         }
@@ -502,6 +505,21 @@ internal fun resolvePreferredAudioLanguages(
             .mapNotNull(::normalize)
             + listOfNotNull(normalize(secondaryPreferredAudioLanguage))
             ).distinct()
+        AudioLanguageOption.ORIGINAL -> {
+            val originalLang = normalize(contentOriginalLanguage)
+            if (originalLang != null) {
+                listOfNotNull(
+                    originalLang,
+                    normalize(secondaryPreferredAudioLanguage)
+                ).distinct()
+            } else {
+                // Fallback to device languages when original language is unknown
+                (deviceLanguages
+                    .mapNotNull(::normalize)
+                    + listOfNotNull(normalize(secondaryPreferredAudioLanguage))
+                ).distinct()
+            }
+        }
         else -> listOfNotNull(
             normalize(preferredAudioLanguage),
             normalize(secondaryPreferredAudioLanguage)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -247,7 +247,8 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             val resolvedAudioLanguages = resolvePreferredAudioLanguages(
                 preferredAudioLanguage = settings.preferredAudioLanguage,
                 secondaryPreferredAudioLanguage = settings.secondaryPreferredAudioLanguage,
-                deviceLanguages = resolveDeviceAudioLanguages()
+                deviceLanguages = resolveDeviceAudioLanguages(),
+                contentOriginalLanguage = contentLanguage
             )
             if (resolvedAudioLanguages != mpvPreferredAudioLanguages) {
                 mpvPreferredAudioLanguages = resolvedAudioLanguages

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -271,11 +271,12 @@ private fun PlayerRuntimeController.applySelectedStreamState(
     url: String,
     headers: Map<String, String>
 ) {
-    currentStreamUrl = url
-    currentHeaders = headers
+    val (cleanUrl, mergedHeaders) = PlayerMediaSourceFactory.extractUserInfoAuth(url, headers)
+    currentStreamUrl = cleanUrl
+    currentHeaders = mergedHeaders
     currentFilename = stream.behaviorHints?.filename ?: navigationArgs.filename
     currentStreamMimeType = PlayerMediaSourceFactory.inferMimeType(
-        url = url,
+        url = cleanUrl,
         filename = currentFilename
     )
     currentStreamBingeGroup = stream.behaviorHints?.bingeGroup

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -134,6 +134,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         val audioLangName = when (playerSettings.preferredAudioLanguage) {
             AudioLanguageOption.DEFAULT -> stringResource(R.string.audio_lang_default)
             AudioLanguageOption.DEVICE -> stringResource(R.string.audio_lang_device)
+            AudioLanguageOption.ORIGINAL -> stringResource(R.string.audio_lang_original)
             else -> AVAILABLE_SUBTITLE_LANGUAGES.find {
                 it.code == playerSettings.preferredAudioLanguage
             }?.displayName ?: playerSettings.preferredAudioLanguage
@@ -333,7 +334,9 @@ private fun AudioLanguageSelectionDialog(
     val specialOptions = listOf(
         AudioLanguageOption.DEFAULT to stringResource(R.string.audio_lang_default),
         AudioLanguageOption.DEVICE to stringResource(R.string.audio_lang_device)
+        AudioLanguageOption.ORIGINAL to stringResource(R.string.audio_lang_original),
     )
+    val originalHint = stringResource(R.string.audio_lang_original_hint)
     val allOptions = specialOptions + AVAILABLE_SUBTITLE_LANGUAGES.sortedBy { it.displayName.lowercase() }.map { it.code to it.displayName }
 
     LaunchedEffect(Unit) {
@@ -362,6 +365,7 @@ private fun AudioLanguageSelectionDialog(
                 ) { index ->
                     val (code, name) = allOptions[index]
                     val isSelected = code == selectedLanguage
+                    val isOriginal = code == AudioLanguageOption.ORIGINAL
                     var isFocused by remember { mutableStateOf(false) }
 
                     Card(
@@ -383,12 +387,21 @@ private fun AudioLanguageSelectionDialog(
                                 .padding(16.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
-                                text = name,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = if (isSelected) NuvioColors.Primary else NuvioColors.TextPrimary,
-                                modifier = Modifier.weight(1f)
-                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = name,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = if (isSelected) NuvioColors.Primary else NuvioColors.TextPrimary
+                                )
+                                if (isOriginal) {
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                    Text(
+                                        text = originalHint,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = NuvioColors.TextSecondary
+                                    )
+                                }
+                            }
                             if (isSelected) {
                                 Spacer(modifier = Modifier.width(12.dp))
                                 Icon(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -333,8 +333,8 @@ private fun AudioLanguageSelectionDialog(
     val focusRequester = remember { FocusRequester() }
     val specialOptions = listOf(
         AudioLanguageOption.DEFAULT to stringResource(R.string.audio_lang_default),
-        AudioLanguageOption.DEVICE to stringResource(R.string.audio_lang_device)
-        AudioLanguageOption.ORIGINAL to stringResource(R.string.audio_lang_original),
+        AudioLanguageOption.DEVICE to stringResource(R.string.audio_lang_device),
+        AudioLanguageOption.ORIGINAL to stringResource(R.string.audio_lang_original)
     )
     val originalHint = stringResource(R.string.audio_lang_original_hint)
     val allOptions = specialOptions + AVAILABLE_SUBTITLE_LANGUAGES.sortedBy { it.displayName.lowercase() }.map { it.code to it.displayName }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -72,6 +72,7 @@ class StreamScreenViewModel @Inject constructor(
     private val year: String? = savedStateHandle.getOptionalString("year")
     private val contentId: String? = savedStateHandle.getOptionalString("contentId")
     private val contentName: String? = savedStateHandle.getOptionalString("contentName")
+    private val contentLanguage: String? = savedStateHandle.getOptionalString("contentLanguage")
     private val manualSelection: Boolean = savedStateHandle.get<String>("manualSelection")
         ?.toBooleanStrictOrNull()
         ?: false
@@ -235,7 +236,8 @@ class StreamScreenViewModel @Inject constructor(
                                 bingeGroup = null,
                                 filename = cached.filename,
                                 videoHash = cached.videoHash,
-                                videoSize = cached.videoSize
+                                videoSize = cached.videoSize,
+                                contentLanguage = contentLanguage
                             )
                         )
                     }
@@ -658,7 +660,8 @@ class StreamScreenViewModel @Inject constructor(
             videoSize = stream.behaviorHints?.videoSize,
             addonName = stream.addonName,
             addonLogo = stream.addonLogo,
-            streamDescription = stream.description
+            streamDescription = stream.description,
+            contentLanguage = contentLanguage
         )
 
         val url = playbackInfo.url
@@ -714,5 +717,6 @@ data class StreamPlaybackInfo(
     val videoSize: Long? = null,
     val addonName: String? = null,
     val addonLogo: String? = null,
-    val streamDescription: String? = null
+    val streamDescription: String? = null,
+    val contentLanguage: String? = null
 )

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -202,6 +202,8 @@
     <string name="audio_section">Audio</string>
     <string name="audio_lang_default">Domyślny (plik multimedialny)</string>
     <string name="audio_lang_device">Język urządzenia</string>
+    <string name="audio_lang_original">Język oryginalny</string>
+    <string name="audio_lang_original_hint">Wymaga włączonego wzbogacania TMDB</string>
     <string name="audio_preferred_lang">Preferowany język audio</string>
     <string name="audio_skip_silence">Pomijaj ciszę</string>
     <string name="audio_skip_silence_sub">Pomijaj ciche fragmenty podczas odtwarzania</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -216,6 +216,18 @@
     <string name="audio_tunneled">Tunelowane odtwarzanie</string>
     <string name="audio_tunneled_sub">Synchronizacja audio/wideo na poziomie sprzętu. Może poprawić odtwarzanie na niektórych urządzeniach Android TV</string>
     <string name="audio_dv_sub">Mapuj Dolby Vision Profil 7 na standardowy HEVC dla urządzeń bez obsługi DV</string>
+    <string name="audio_mpv_hwdec_title">Dekodowanie sprzętowe (tylko MPV)</string>
+    <string name="audio_mpv_hwdec_dialog_subtitle">Wybierz jak libmpv powinien używać dekoderów sprzętowych.</string>
+    <string name="audio_mpv_hwdec_legacy_direct_copy">Starszy (direct -&gt; copy)</string>
+    <string name="audio_mpv_hwdec_legacy_direct_copy_desc">Poprzednie domyślne zachowanie: najpierw bezpośredni sprzęt, potem kopiowanie.</string>
+    <string name="audio_mpv_hwdec_auto_safe">Auto (auto-safe)</string>
+    <string name="audio_mpv_hwdec_auto_safe_desc">Bezpieczniejszy tryb automatyczny z awaryjnym przełączaniem gdy dekodery zawiodą.</string>
+    <string name="audio_mpv_hwdec_hardware_copy">Sprzętowy (copy) (mediacodec-copy)</string>
+    <string name="audio_mpv_hwdec_hardware_copy_desc">Dekodowanie sprzętowe z kopiowaniem do pamięci programowej.</string>
+    <string name="audio_mpv_hwdec_hardware_direct">Sprzętowy (direct) (mediacodec)</string>
+    <string name="audio_mpv_hwdec_hardware_direct_desc">Bezpośrednie dekodowanie sprzętowe. Najszybsza ścieżka na kompatybilnych urządzeniach.</string>
+    <string name="audio_mpv_hwdec_disabled">Wyłączone (no)</string>
+    <string name="audio_mpv_hwdec_disabled_desc">Wyłącza dekodowanie sprzętowe i używa tylko dekodowania programowego.</string>
     <string name="audio_decoder_device_only_desc">Używaj tylko wbudowanych dekoderów sprzętowych. Najbardziej kompatybilne, ale może nie obsługiwać wszystkich formatów.</string>
     <string name="audio_decoder_prefer_device_desc">Używaj dekoderów sprzętowych gdy dostępne, w przeciwnym razie FFmpeg. Zalecane dla większości urządzeń.</string>
     <string name="audio_decoder_prefer_app_desc">Używaj dekoderów FFmpeg gdy dostępne. Lepsza obsługa formatów, ale wyższe użycie CPU.</string>
@@ -877,6 +889,10 @@
     <string name="plugin_confirm_total">Łącznie repozytoriów: %1$d</string>
     <string name="plugin_confirm_reject">Odrzuć</string>
     <string name="plugin_confirm_confirm">Potwierdź</string>
+    <string name="plugin_risky_enable_title">Włączyć dostawcę?</string>
+    <string name="plugin_risky_enable_message">%1$s może powodować awarie przy niektórych treściach. Włączyć mimo to?</string>
+    <string name="plugin_risky_enable_cancel">Anuluj</string>
+    <string name="plugin_risky_enable_confirm">Włącz</string>
     <string name="plugin_updated_format">Zaktualizowano: %1$s</string>
     <string name="plugin_test_btn">Testuj</string>
     <string name="plugin_test_results">Wyniki testu (%1$d źródeł)</string>
@@ -1215,6 +1231,7 @@
     <string name="cd_subtitles">Napisy</string>
     <string name="cd_audio_tracks">Ścieżki audio</string>
     <string name="cd_sources">Źródła</string>
+    <string name="cd_switch_player_engine">Przełącz silnik odtwarzacza</string>
     <string name="cd_episodes">Odcinki</string>
     <string name="cd_playback_speed">Prędkość odtwarzania</string>
     <string name="cd_aspect_ratio">Proporcje obrazu</string>
@@ -1335,6 +1352,9 @@
     <string name="web_installed">Zainstalowany</string>
     <string name="web_error_addon_exists">Ten dodatek jest już na liście</string>
     <string name="web_error_repo_exists">To repozytorium jest już na liście</string>
+    <string name="web_manage_collections_title">Zarządzaj kolekcjami</string>
+    <string name="web_manage_collections_subtitle">Twórz i zarządzaj swoimi kolekcjami</string>
+    <string name="web_status_msg_collections_updated">Twoje kolekcje zostały zaktualizowane na TV.</string>
     <string name="web_error_failed_save">Nie udało się zapisać. Sprawdź połączenie z TV.</string>
     <string name="web_no_repos">Brak zainstalowanych repozytoriów</string>
     <string name="web_manage_repos_title">Zarządzaj repozytoriami</string>
@@ -1361,6 +1381,7 @@
     <string name="playback_engine_mvplayer_desc">Używa libmpv z kontrolkami Nuvio OSD. Eksperymentalny.</string>
     <string name="player_engine_switching_title">Przełączanie silnika odtwarzacza</string>
     <string name="player_engine_switching_message">Uruchomienie nie powiodło się. Przełączanie na %1$s…</string>
+    <string name="player_engine_switching_manual_message">Przełączanie na %1$s…</string>
     <string name="search_recent_title">Ostatnie wyszukiwania</string>
     <string name="search_recent_clear">Wyczyść historię</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,6 +363,8 @@
     <string name="audio_section">Audio</string>
     <string name="audio_lang_default">Default (media file)</string>
     <string name="audio_lang_device">Device language</string>
+    <string name="audio_lang_original">Original language</string>
+    <string name="audio_lang_original_hint">Requires TMDB enrichment to be enabled</string>
     <string name="audio_preferred_lang">Preferred Audio Language</string>
     <string name="audio_skip_silence">Skip Silence</string>
     <string name="audio_skip_silence_sub">Skip silent portions of audio during playback</string>


### PR DESCRIPTION
## Summary

- **Original Audio Language option**: New "Original language" choice in the preferred audio language picker. When selected, the player automatically picks the content's original language (e.g. Korean for K-dramas, Japanese for anime) based on TMDB metadata. Language flows through the full chain: Detail screen -> Stream -> Player, and is also persisted in the CW enrichment cache so it works from Continue Watching too.

- **WebDAV basic auth support**: URLs with embedded credentials (`user:password@host`) are now parsed into a proper `Authorization: Basic` header. Previously the userinfo was silently stripped by Java's URL class, causing 401s on WebDAV servers #1255 

- **Stream link cache key fix**: `streamCacheKey` in the player was `lazy` (computed once), so after switching episodes via the player menu, the cache key still pointed to the first episode. Changed to a computed property so "reuse last link" works correctly for subsequent episodes.

- **CW duplicate prevention**: Added `contentId` deduplication in `mergeContinueWatchingItems` to prevent the same series appearing twice in Continue Watching.

- **Detail screen focus fix**: D-pad UP from season tabs now always navigates to the Play button instead of landing on "Add to List" when scrolled horizontally.

## PR type

- Bug fix
- Small maintenance improvement

## Why

**New feature**: Original language audio selection requested by users who watch foreign-language content and prefer to always use original audio if available 

Multiple user-reported issues addressed:
- WebDAV streams failing with 401 (credentials stripped from URL)
- "Reuse last link" not working after switching episodes in player
- Duplicate entries in Continue Watching
- D-pad focus landing on wrong button in detail screen


## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [ ] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual testing on TCL Android TV via ADB
- Verified stream cache key updates after episode switch
- Verified Original Language option appears in picker with TMDB hint
- Verified if Original Audio Language is selected when available 
- Verified season tab UP navigation lands on Play button

## Screenshots / Video (UI changes only)
![IMG20260407094343](https://github.com/user-attachments/assets/f48cce5c-9cea-4803-9674-75b73c85a8a9)
audio language picker has a new "Original language" entry available with subtitle "_Requires TMDB enrichment to be enabled_"

## Breaking changes

Nothing should break 

## Linked issues
Fixes #1255, other issues reported on discord