### PR TITLE
Bypass hard-strict subtitle parsing to reduce malformed subtitle startup delays

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
@@ -43,7 +43,7 @@ internal fun ExoPlayer.Builder.buildWithAssSupportCompat(
     val mediaSourceFactory = DefaultMediaSourceFactory(
         dataSourceFactory,
         assExtractorsFactory
-    )
+    ).experimentalParseSubtitlesDuringExtraction(false)
     mediaSourceFactory.setSubtitleParserFactory(assSubtitleParserFactory)
 
     val player = this
@@ -62,6 +62,8 @@ private class CompatAssSubtitleParserFactory(
     private val delegate = AssSubtitleParserFactory(assHandler)
 
     override fun supportsFormat(format: Format): Boolean {
+        val isSsa = format.sampleMimeType == MimeTypes.TEXT_SSA || format.codecs == MimeTypes.TEXT_SSA
+        if (!isSsa) return false
         return delegate.supportsFormat(normalizeSsaFormat(format))
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -25,7 +25,9 @@ import androidx.media3.exoplayer.audio.AudioTrackAudioOutputProvider
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.text.SubtitleDecoderFactory
 import androidx.media3.exoplayer.text.TextOutput
+import androidx.media3.exoplayer.text.TextRenderer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
@@ -240,6 +242,9 @@ internal fun PlayerRuntimeController.initializePlayer(
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || forceDv7ToHevc)
 
+            val baseMediaSourceFactory = DefaultMediaSourceFactory(context, extractorsFactory)
+                .experimentalParseSubtitlesDuringExtraction(false)
+
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             val buildDefaultPlayer = {
                 mediaSourceFactory.configureSubtitleParsing(
@@ -249,7 +254,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)
                     .setTrackSelector(trackSelector!!)
-                    .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
+                    .setMediaSourceFactory(baseMediaSourceFactory)
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
                     .setReleaseTimeoutMs(3000)
@@ -261,7 +266,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 ExoPlayer.Builder(context)
                     .setLoadControl(loadControl)
                     .setTrackSelector(trackSelector!!)
-                    .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
+                    .setMediaSourceFactory(baseMediaSourceFactory)
                     .setReleaseTimeoutMs(3000)
                     .buildWithAssSupportCompat(
                         context = context,
@@ -771,7 +776,13 @@ private class SubtitleOffsetRenderersFactory(
             shouldNormalizeCuePositionProvider = shouldNormalizeCuePositionProvider
         )
         val startIndex = out.size
-        super.buildTextRenderers(context, normalizingOutput, outputLooper, extensionRendererMode, out)
+        
+        // Explicitly instantiate TextRenderer with legacy SubtitleDecoderFactory 
+        // because DefaultRenderersFactory disables it by default in Media3 
+        val textRenderer = TextRenderer(normalizingOutput, outputLooper, SubtitleDecoderFactory.DEFAULT)
+        textRenderer.experimentalSetLegacyDecodingEnabled(true)
+        out.add(textRenderer)
+        
         for (index in startIndex until out.size) {
             out[index] = SubtitleOffsetRenderer(out[index], subtitleDelayUsProvider)
         }


### PR DESCRIPTION
## Summary

- Disable subtitle parsing during extraction for the player media source path so malformed text subtitles do not slow down startup as early.
- Restrict the ASS subtitle parser compatibility path to actual SSA/ASS formats instead of attempting to participate in other text subtitle formats.
- Instantiate the text subtitle renderer with legacy decoding enabled so malformed subtitles can fall back to the more tolerant decoding path during playback setup.

## PR type

- Bug fix

## Why

Some streams include malformed text subtitles that trigger stricter parsing behavior during player setup. That can introduce subtitle-related startup delays before playback is ready. This change keeps subtitle parsing on a more tolerant path and limits the custom ASS handling to the formats it is intended for.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- assembleDebug was successful. checked both video playback and subtitle functionality, and everything seems to be working perfectly

## Screenshots / Video (UI changes only)

Not applicable. This PR does not change UI.

## Breaking changes

None expected. The change only adjusts subtitle parsing and text renderer setup for playback initialization.

## Linked issues

No linked issue.