### PR TITLE
Bunch of small fixes 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -489,7 +489,7 @@ private fun EpisodeCard(
     val thumbnailRequest = remember(context, episode.thumbnail, thumbnailWidthPx, thumbnailHeightPx, shouldBlur) {
         ImageRequest.Builder(context)
             .data(episode.thumbnail)
-            .crossfade(false)
+            .crossfade(true)
             .size(width = thumbnailWidthPx, height = thumbnailHeightPx)
             .apply {
                 if (shouldBlur) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -157,6 +157,7 @@ class HomeViewModel @Inject constructor(
     internal val cwNextUpResolutionCache = Collections.synchronizedMap(mutableMapOf<String, NextUpResolution?>())
     internal val cwNextUpNegativeCacheTimestamps = Collections.synchronizedMap(mutableMapOf<String, Long>())
     internal val discoveredOlderNextUpItems = Collections.synchronizedList(mutableListOf<ContinueWatchingItem.NextUp>())
+    internal val cwLastProcessedNextUpContentIds = Collections.synchronizedSet(mutableSetOf<String>())
     internal val fullyWatchedSeriesIds get() = watchedSeriesStateHolder
     internal var tmdbEnrichFocusJob: Job? = null
     internal var pendingTmdbEnrichItemId: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -36,6 +36,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.util.Collections
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -652,6 +653,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val allSeedContentIds = nextUpSeeds
                     .map { it.contentId }
                     .toSet()
+                // Exclude cached older items for series that the fresh pipeline evaluated
+                // but didn't produce a next-up for (e.g. fully watched series).
+                val rejectedByFreshPipeline = synchronized(cwLastProcessedNextUpContentIds) {
+                    cwLastProcessedNextUpContentIds.toSet()
+                } - recentIds
                 val olderToInclude = (persistedOlderItems + cachedOlderNextUp)
                     .distinctBy { it.info.contentId }
                     .filter {
@@ -659,6 +665,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             it.info.contentId in allSeedContentIds &&
                             it.info.contentId !in recentIds &&
                             it.info.contentId !in inProgressIds &&
+                            it.info.contentId !in rejectedByFreshPipeline &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&
                             !watchProgressRepository.isDroppedShow(it.info.contentId)
                     }
@@ -998,10 +1005,12 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
     val lookupSemaphore = Semaphore(CW_MAX_NEXT_UP_CONCURRENCY)
     val mergeMutex = Mutex()
     val nextUpByContent = linkedMapOf<String, ContinueWatchingItem.NextUp>()
+    val processedContentIds = Collections.synchronizedSet(mutableSetOf<String>())
 
     val jobs = latestCompletedBySeries.map { progress ->
         launch(Dispatchers.IO) {
             lookupSemaphore.withPermit {
+                processedContentIds.add(progress.contentId)
                 val nextUp = buildNextUpItem(
                     progress = progress,
                     showUnairedNextUp = showUnairedNextUp,
@@ -1019,6 +1028,12 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
         }
     }
     jobs.joinAll()
+
+    // Store which contentIds were evaluated so olderToInclude can skip fully-watched series.
+    synchronized(cwLastProcessedNextUpContentIds) {
+        cwLastProcessedNextUpContentIds.clear()
+        cwLastProcessedNextUpContentIds.addAll(processedContentIds)
+    }
 
     nextUpByContent.values.toList()
 }

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -597,10 +597,10 @@
     <string name="addon_empty">Brak zainstalowanych dodatków. Dodaj jeden, aby zacząć.</string>
     <string name="addon_remove">Usuń</string>
     <string name="addon_manage_from_phone_title">Zarządzaj z telefonu</string>
-    <string name="addon_manage_from_phone_subtitle">Zeskanuj kod QR, aby zarządzać dodatkami i katalogami z telefonu</string>
+    <string name="addon_manage_from_phone_subtitle">Zeskanuj kod QR, aby zarządzać dodatkami, katalogami i kolekcjami z telefonu</string>
     <string name="addon_reorder_title">Zmień kolejność katalogów</string>
-    <string name="addon_reorder_subtitle">Kontroluje kolejność wierszy katalogów na ekranie głównym</string>
-    <string name="addon_qr_scan_instruction">Zeskanuj telefonem, aby zarządzać dodatkami i katalogami</string>
+    <string name="addon_reorder_subtitle">Kontroluje kolejność wierszy katalogów i kolekcji na ekranie głównym</string>
+    <string name="addon_qr_scan_instruction">Zeskanuj telefonem, aby zarządzać dodatkami, katalogami i kolekcjami</string>
     <string name="addon_qr_close">Zamknij</string>
     <string name="addon_confirm_title">Potwierdź zmiany dodatków i katalogów</string>
     <string name="addon_confirm_subtitle">Następujące zmiany zostały wprowadzone z telefonu:</string>


### PR DESCRIPTION
## Summary

- Fixed fully-watched series persisting in Continue Watching after marking all episodes as watched from the detail screen. The CW pipeline now clears stale next-up resolution caches and in-memory discovered items on each run, and excludes cached older items for series that the fresh pipeline evaluated but found no next episode for.

- Added crossfade animation to episode thumbnails on the detail screen so they fade in smoothly instead of popping in abruptly.

## PR type

- Bug fix
- Small maintenance improvement
- Translation update

## Why

Users reported that marking an entire season as watched from the detail screen didn't remove the series from Continue Watching until app restart. Root cause: stale entries in `cwNextUpResolutionCache`, `discoveredOlderNextUpItems`, and disk-cached next-up snapshots survived pipeline re-runs and were re-injected into the CW list.

Episode thumbnails on the detail screen appeared abruptly without any transition, which felt jarring compared to other image loading in the app.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual testing on TCL Android TV
- Verified: mark season 3 as watched -> return to home -> series removed from CW immediately
- Verified: mark episodes one by one until last -> series removed from CW after marking final episode
- Verified: episode thumbnails fade in smoothly on detail screen

## Screenshots / Video (UI changes only)

No changes in UI

## Breaking changes

Nothing should break

## Linked issues

Reported on discord 
