### PR TITLE
Fix player: Up on seek bar returns to fullscreen

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1329,6 +1329,7 @@ private fun PlayerControlsOverlay(
                 focusRequester = progressBarFocusRequester,
                 upFocusRequester = progressBarUpFocusRequester,
                 downFocusRequester = playPauseFocusRequester,
+                onUpKey = onHideControls,
                 onFocused = onResetHideTimer
 )
 
@@ -1597,6 +1598,7 @@ private fun ProgressBar(
     focusRequester: FocusRequester? = null,
     upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
+    onUpKey: (() -> Unit)? = null,
     onFocused: (() -> Unit)? = null
 ) {
     val progress = if (duration > 0) {
@@ -1665,6 +1667,9 @@ private fun ProgressBar(
                                     upFocusRequester.requestFocus()
                                 } catch (_: Exception) {
                                 }
+                                true
+                            } else if (onUpKey != null) {
+                                onUpKey.invoke()
                                 true
                             } else {
                                 false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -729,6 +729,11 @@ fun PlayerScreen(
             onFocused = { viewModel.scheduleHideControls() },
             focusRequester = skipIntroFocusRequester,
             downFocusRequester = if (uiState.showControls) progressBarFocusRequester else null,
+            upFocusRequester = null,
+            onHideControls = {
+                if (uiState.showControls) viewModel.hideControls()
+                else viewModel.onEvent(PlayerEvent.OnToggleControls)
+            },
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .padding(start = 32.dp, bottom = skipButtonBottomPadding)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
@@ -62,12 +62,15 @@ fun SkipIntroButton(
     controlsVisible: Boolean,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
+    onHideControls: (() -> Unit)? = null,
     onVisibilityChanged: (Boolean) -> Unit = {},
     onFocused: (() -> Unit)? = null,
     focusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
+    upFocusRequester: FocusRequester? = null,
     modifier: Modifier = Modifier
 ) {
+
     var lastType by remember { mutableStateOf(interval?.type) }
     if (interval != null) lastType = interval.type
     val shouldShow = interval != null && (!dismissed || controlsVisible)
@@ -138,20 +141,40 @@ fun SkipIntroButton(
             modifier = Modifier
                 .focusRequester(activeFocusRequester)
                 .then(
-                    if (downFocusRequester != null) {
-                        Modifier.focusProperties { down = downFocusRequester }
+                    if (downFocusRequester != null || upFocusRequester != null) {
+                        Modifier.focusProperties {
+                            downFocusRequester?.let { down = it }
+                            upFocusRequester?.let { up = it }
+                        }
                     } else {
                         Modifier
                     }
                 )
                 .onPreviewKeyEvent { keyEvent ->
-                    if (
-                        downFocusRequester != null &&
-                        keyEvent.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN &&
-                        keyEvent.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DPAD_DOWN
-                    ) {
-                        try { downFocusRequester.requestFocus() } catch (_: Exception) {}
-                        true
+                    if (keyEvent.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN) {
+                        when (keyEvent.nativeKeyEvent.keyCode) {
+                            android.view.KeyEvent.KEYCODE_DPAD_DOWN -> {
+                                if (downFocusRequester != null) {
+                                    try { downFocusRequester.requestFocus() } catch (_: Exception) {}
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            android.view.KeyEvent.KEYCODE_DPAD_UP -> {
+                                // Pressing UP from Skip Intro button navigates to upFocusRequester or hides controls
+                                if (upFocusRequester != null) {
+                                    try { upFocusRequester.requestFocus() } catch (_: Exception) {}
+                                    true
+                                } else if (onHideControls != null) {
+                                    onHideControls()
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            else -> false
+                        }
                     } else {
                         false
                     }


### PR DESCRIPTION
When progress bar is focused, pressing UP now hides controls and fullscreen

## Summary

<!-- What changed in this PR? -->

## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why

<!-- Why this change is needed. Link bug/issue/context. -->
The expected behavior is that when you are on the seek bar, going up would put you back into fullscreen. This is how youtube and many platforms work and matter of fact it was how nuvio used to work before, and then it broke for some reason.

## Policy check

<!-- Confirm these before requesting review -->
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

<!-- What you tested and how (manual + automated). -->

## Screenshots / Video (UI changes only)

<!-- If UI changed, add before/after screenshots or a short clip. -->
BEFORE

https://github.com/user-attachments/assets/37cb3d3e-3a1e-47ef-8dfd-37e46110891b

AFTER

https://github.com/user-attachments/assets/4df5872f-9c09-44bf-8325-7e7d66690efc


## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None -->
None

## Linked issues

None
<!-- Example: Fixes #123 -->
