### PR TITLE
Fixes 2

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -102,6 +102,45 @@ class FolderDetailViewModel @Inject constructor(
 
     init {
         loadFolder()
+        // Observe watched status immediately so badges are ready before catalogs load.
+        observeWatchedMovieIdsGlobal()
+        observeWatchedSeriesIdsGlobal()
+    }
+
+    private fun observeWatchedMovieIdsGlobal() {
+        movieWatchedJob = viewModelScope.launch {
+            watchProgressRepository.observeWatchedMovieIds().collectLatest { watchedIds ->
+                _uiState.update { s ->
+                    val newStatus = s.movieWatchedStatus.toMutableMap()
+                    s.tabs.flatMap { it.catalogRow?.items.orEmpty() }
+                        .filter { it.apiType == "movie" }
+                        .forEach { item ->
+                            val key = com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
+                            newStatus[key] = item.id in watchedIds
+                        }
+                    if (newStatus == s.movieWatchedStatus) s else s.copy(movieWatchedStatus = newStatus)
+                }
+                rebuildFollowLayoutState()
+            }
+        }
+    }
+
+    private fun observeWatchedSeriesIdsGlobal() {
+        seriesWatchedJob = viewModelScope.launch {
+            watchedSeriesStateHolder.fullyWatchedSeriesIds.collectLatest { fullyWatched ->
+                _uiState.update { s ->
+                    val newStatus = s.movieWatchedStatus.toMutableMap()
+                    s.tabs.flatMap { it.catalogRow?.items.orEmpty() }
+                        .filter { it.apiType in listOf("series", "tv") }
+                        .forEach { item ->
+                            val key = com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
+                            newStatus[key] = item.id in fullyWatched
+                        }
+                    if (newStatus == s.movieWatchedStatus) s else s.copy(movieWatchedStatus = newStatus)
+                }
+                rebuildFollowLayoutState()
+            }
+        }
     }
 
     private val hasAllTab: Boolean
@@ -319,7 +358,6 @@ class FolderDetailViewModel @Inject constructor(
                         }
                         rebuildAllTab()
                         rebuildFollowLayoutState()
-                        observeWatchedStatus()
                     }
                     is NetworkResult.Error -> {
                         _uiState.update { state ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -25,7 +25,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -85,7 +88,6 @@ class FolderDetailViewModel @Inject constructor(
     val uiState: StateFlow<FolderDetailUiState> = _uiState.asStateFlow()
 
     private var movieWatchedJob: Job? = null
-    private var seriesWatchedJob: Job? = null
     private var enrichFocusJob: Job? = null
     private val enrichedItemIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
     private val _enrichingItemId = MutableStateFlow<String?>(null)
@@ -102,41 +104,32 @@ class FolderDetailViewModel @Inject constructor(
 
     init {
         loadFolder()
-        // Observe watched status immediately so badges are ready before catalogs load.
-        observeWatchedMovieIdsGlobal()
-        observeWatchedSeriesIdsGlobal()
+        // Observe watched status immediately so badges are ready when catalogs load.
+        observeWatchedStatusCombined()
     }
 
-    private fun observeWatchedMovieIdsGlobal() {
+    private fun observeWatchedStatusCombined() {
         movieWatchedJob = viewModelScope.launch {
-            watchProgressRepository.observeWatchedMovieIds().collectLatest { watchedIds ->
-                _uiState.update { s ->
-                    val newStatus = s.movieWatchedStatus.toMutableMap()
-                    s.tabs.flatMap { it.catalogRow?.items.orEmpty() }
-                        .filter { it.apiType == "movie" }
-                        .forEach { item ->
-                            val key = com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
-                            newStatus[key] = item.id in watchedIds
-                        }
-                    if (newStatus == s.movieWatchedStatus) s else s.copy(movieWatchedStatus = newStatus)
+            combine(
+                watchProgressRepository.observeWatchedMovieIds(),
+                watchedSeriesStateHolder.fullyWatchedSeriesIds,
+                _uiState.map { state -> state.tabs.flatMap { it.catalogRow?.items.orEmpty() } }
+                    .distinctUntilChanged()
+            ) { movieWatchedIds, seriesWatchedIds, allItems ->
+                Triple(movieWatchedIds, seriesWatchedIds, allItems)
+            }.collectLatest { (movieWatchedIds, seriesWatchedIds, allItems) ->
+                val newStatus = mutableMapOf<String, Boolean>()
+                allItems.forEach { item ->
+                    val key = com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
+                    val isWatched = when (item.apiType) {
+                        "movie" -> item.id in movieWatchedIds
+                        "series", "tv" -> item.id in seriesWatchedIds
+                        else -> false
+                    }
+                    newStatus[key] = isWatched
                 }
-                rebuildFollowLayoutState()
-            }
-        }
-    }
-
-    private fun observeWatchedSeriesIdsGlobal() {
-        seriesWatchedJob = viewModelScope.launch {
-            watchedSeriesStateHolder.fullyWatchedSeriesIds.collectLatest { fullyWatched ->
                 _uiState.update { s ->
-                    val newStatus = s.movieWatchedStatus.toMutableMap()
-                    s.tabs.flatMap { it.catalogRow?.items.orEmpty() }
-                        .filter { it.apiType in listOf("series", "tv") }
-                        .forEach { item ->
-                            val key = com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
-                            newStatus[key] = item.id in fullyWatched
-                        }
-                    if (newStatus == s.movieWatchedStatus) s else s.copy(movieWatchedStatus = newStatus)
+                    if (s.movieWatchedStatus == newStatus) s else s.copy(movieWatchedStatus = newStatus)
                 }
                 rebuildFollowLayoutState()
             }
@@ -450,52 +443,6 @@ class FolderDetailViewModel @Inject constructor(
         )
         if (_followLayoutFocusState.value != nextState) {
             _followLayoutFocusState.value = nextState
-        }
-    }
-
-    private fun observeWatchedStatus() {
-        val allItems = _uiState.value.tabs
-            .mapNotNull { it.catalogRow }
-            .flatMap { it.items }
-
-        val movieIds = mutableMapOf<String, String>()
-        val seriesIds = mutableMapOf<String, String>()
-        allItems.forEach { item ->
-            val key = homeItemStatusKey(item.id, item.apiType)
-            if (item.apiType.equals("movie", ignoreCase = true)) {
-                movieIds[key] = item.id
-            } else if (item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)) {
-                seriesIds[key] = item.id
-            }
-        }
-
-        movieWatchedJob?.cancel()
-        if (movieIds.isNotEmpty()) {
-            movieWatchedJob = viewModelScope.launch {
-                watchProgressRepository.observeWatchedMovieIds()
-                    .collectLatest { watchedIds ->
-                        val status = movieIds.mapValues { (_, contentId) -> contentId in watchedIds }
-                        _uiState.update { s ->
-                            val merged = s.movieWatchedStatus.filterKeys { it !in movieIds } + status
-                            if (s.movieWatchedStatus == merged) s else s.copy(movieWatchedStatus = merged)
-                        }
-                        rebuildFollowLayoutState()
-                    }
-            }
-        }
-
-        seriesWatchedJob?.cancel()
-        if (seriesIds.isNotEmpty()) {
-            seriesWatchedJob = viewModelScope.launch {
-                watchedSeriesStateHolder.fullyWatchedSeriesIds.collectLatest { fullyWatched ->
-                    val status = seriesIds.mapValues { (_, contentId) -> contentId in fullyWatched }
-                    _uiState.update { s ->
-                        val merged = s.movieWatchedStatus.filterKeys { it !in seriesIds } + status
-                        if (s.movieWatchedStatus == merged) s else s.copy(movieWatchedStatus = merged)
-                    }
-                    rebuildFollowLayoutState()
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -546,7 +546,10 @@ class MetaDetailsViewModel @Inject constructor(
             .toIntOrNull()
             ?: return raw
 
-        return tmdbService.tmdbToImdb(tmdbNumericId, itemType)
+        // Use a short timeout so a blocked TMDB API doesn't stall the detail screen.
+        return kotlinx.coroutines.withTimeoutOrNull(5_000L) {
+            tmdbService.tmdbToImdb(tmdbNumericId, itemType)
+        }
             ?.takeIf { it.isNotBlank() }
             ?: raw
     }

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -81,7 +81,7 @@
     <string name="error_state_prefix_tried_meta_addons">Addons consultados:</string>
     <string name="error_state_fix_tried_meta_addons">instale um addon que suporte este ID ou atualize as configurações e tente novamente.</string>
     <string name="error_state_issue_missing_metadata_for_id">não possui informações para este ID</string>
-    <string name="error_state_fix_missing_metadata_for_id">abra este título em outro addon, desative 'Preferir addon de meta externo' ou confirme se o addon suporta este ID.</string>
+    <string name="error_state_fix_missing_metadata_for_id">abra este título em outro addon, desative \'Preferir addon de meta externo\' ou confirme se o addon suporta este ID.</string>
     <string name="error_state_issue_addon_unreachable">está inacessível</string>
     <string name="error_state_fix_addon_unreachable">verifique sua conexão com a internet ou se a URL do addon ainda está ativa.</string>
     <string name="error_state_issue_addon_connection_failed">recusou a conexão</string>


### PR DESCRIPTION
## Summary

- Fix series watched checkmarks not appearing in collection screens (Rows/Tabs/Follow Layout modes)
- Fix escaped apostrophe in PT-BR translation causing build failure
- Add 5s timeout to TMDB ID resolution in detail screen to prevent infinite loading when TMDB is blocked

## PR type

- Bug fix

## Why

- Series in collections never showed the watched checkmark because the watched status observer was only triggered after catalogs loaded, and didn't re-evaluate when new items appeared. Replaced with a reactive `combine` of watched IDs + catalog items so status updates whenever either changes.
- PT-BR string `error_state_fix_missing_metadata_for_id` had unescaped apostrophes causing `mergeBenchmarkResources` to fail.
- Users in countries where TMDB is blocked experienced infinite loading on the detail screen because `resolveMetaLookupId` waited for the full 30s OkHttp timeout before falling back.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Verified series checkmarks appear in collection Rows and Tabs modes
- Verified PT-BR build compiles successfully
- Verified detail screen loads within 5s when TMDB is unreachable (falls back to raw ID)

## Screenshots / Video (UI changes only)

Nothing changed 

## Breaking changes

Nothing should break 

## Linked issues

Discord reports
