### PR TITLE
Fix TMDB runtime enrichment and duplicate stream key crash

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -539,6 +539,7 @@ class FolderDetailViewModel @Inject constructor(
                     }
                     if (tmdbSettings.useDetails) {
                         result = result.copy(
+                            runtime = finalEnrichment.runtimeMinutes?.toString() ?: result.runtime,
                             ageRating = finalEnrichment.ageRating ?: result.ageRating,
                             status = finalEnrichment.status ?: result.status
                         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -551,6 +551,7 @@ private fun HomeViewModel.updateCatalogItemWithTmdb(itemId: String, enrichment: 
         }
         if (currentTmdbSettings.useDetails) {
             merged = merged.copy(
+                runtime = enrichment.runtimeMinutes?.toString() ?: merged.runtime,
                 ageRating = enrichment.ageRating ?: merged.ageRating,
                 status = enrichment.status ?: merged.status
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -875,8 +875,8 @@ private fun StreamsList(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp)
     ) {
-        itemsIndexed(streams, key = { _, stream ->
-            stream.stableKey()
+        itemsIndexed(streams, key = { index, stream ->
+            stream.stableKey(index)
         }) { index, stream ->
             StreamCard(
                 stream = stream,


### PR DESCRIPTION
## Summary

- TMDB enrichment on focus (`updateCatalogItemWithTmdb`) was missing `runtime` in the `useDetails` block - hero cards never showed enriched runtime.
- Same issue in `FolderDetailViewModel.onItemFocused` for collection/folder screens.
- `StreamScreen` LazyColumn crashed with duplicate key when two streams had identical addon+url+name+title - now passes `index` to `stableKey()`.

## PR type

- Bug fix

## Why

1. `enrichHeroItemsPipeline` (initial hero load) correctly copied all `useDetails` fields, but `updateCatalogItemWithTmdb` (on-focus enrichment) only copied `ageRating` and `status`, not using runtime
2. `StreamScreen` used `stableKey()` without occurrence index, while `StreamSourcesSidePanel` already used `stableKey(index)` - inconsistency caused a crash when addons returned duplicate streams.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Verified TMDB enrichment now propagates runtime to hero metadata row on focus.
- Verified collection folder items show enriched runtime after TMDB fetch.
- Verified StreamScreen no longer crashes with duplicate stream entries from the same addon.

## Screenshots / Video (UI changes only)

Nothing changed 

## Breaking changes

Nothing should break 

## Linked issues

Reported on discord 