### PR TITLE
Small cleanup for collections

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -241,12 +241,7 @@ class FolderDetailViewModel @Inject constructor(
         val loadedRows = sourceTabs.mapNotNull { it.catalogRow }
         if (loadedRows.isEmpty()) return
 
-        // Strip descriptions from catalog items so the Modern hero area
-        // doesn't redundantly show the collection/catalog description.
-        val strippedRows = loadedRows.map { row ->
-            row.copy(items = row.items.map { it.copy(description = null) })
-        }
-        val homeRows = strippedRows.map { HomeRow.Catalog(it) }
+        val homeRows = loadedRows.map { HomeRow.Catalog(it) }
         val gridItems = buildList<GridItem> {
             loadedRows.forEach { row ->
                 add(GridItem.SectionDivider(
@@ -456,7 +451,6 @@ class FolderDetailViewModel @Inject constructor(
                         }
                         rebuildAllTab()
                         rebuildFollowLayoutState()
-                        observeWatchedStatus()
                     }
                     is NetworkResult.Error -> {
                         _uiState.update { s ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -481,7 +481,7 @@ internal fun buildCollectionFolderItem(
             title = if (folder.hideTitle) "" else title,
             logo = null,
             description = null,
-            contentTypeText = if (folder.hideTitle) null else collection.title,
+            contentTypeText = null,
             yearText = null,
             imdbText = null,
             genres = emptyList(),


### PR DESCRIPTION
## Summary

- Remove redundant collection title from hero metadata when focusing a collection folder on home screen
- Stop stripping item descriptions in collection FOLLOW_LAYOUT mode so hero shows content descriptions
- Remove unnecessary `observeWatchedStatus()` call in `loadMoreItems` - the combined observer already reacts to tab changes automatically

## PR type

- Bug fix

## Why

- Collection folder hero on home displayed the collection title as `contentTypeText` below the folder name, which was redundant
- Item descriptions were being stripped in FOLLOW_LAYOUT collections, preventing them from showing in the hero area
- `observeWatchedStatus()` in `loadMoreItems` was a leftover from PR #1298 that referenced a removed function (build error) and was unnecessary since `observeWatchedStatusCombined()` uses `combine` to auto-react to item changes

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified collection folders no longer show collection title in hero metadata on home screen
- Manual: verified item descriptions appear in hero when browsing collections in FOLLOW_LAYOUT mode
- Build: confirmed compilation succeeds (previously failed due to unresolved `observeWatchedStatus` reference)

## Screenshots / Video (UI changes only)

Nothing Changed

## Breaking changes

Nothing should break

## Linked issues

N/A
