### PR TITLE
Support for addons with query parameters

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/AddonSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/AddonSyncService.kt
@@ -122,10 +122,14 @@ class AddonSyncService @Inject constructor(
 
     private fun canonicalizeUrl(url: String): String {
         val trimmed = url.trim().trimEnd('/')
-        return if (trimmed.endsWith("/manifest.json", ignoreCase = true)) {
-            trimmed.dropLast("/manifest.json".length).trimEnd('/')
+        val queryStart = trimmed.indexOf('?')
+        val path = if (queryStart >= 0) trimmed.substring(0, queryStart) else trimmed
+        val query = if (queryStart >= 0) trimmed.substring(queryStart) else ""
+        val cleanPath = if (path.endsWith("/manifest.json", ignoreCase = true)) {
+            path.dropLast("/manifest.json".length).trimEnd('/')
         } else {
-            trimmed
+            path.trimEnd('/')
         }
+        return cleanPath + query
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/local/AddonPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/AddonPreferences.kt
@@ -51,11 +51,15 @@ class AddonPreferences @Inject constructor(
 
     private fun canonicalizeUrl(url: String): String {
         val trimmed = url.trim().trimEnd('/')
-        return if (trimmed.endsWith(manifestSuffix, ignoreCase = true)) {
-            trimmed.dropLast(manifestSuffix.length).trimEnd('/')
+        val queryStart = trimmed.indexOf('?')
+        val path = if (queryStart >= 0) trimmed.substring(0, queryStart) else trimmed
+        val query = if (queryStart >= 0) trimmed.substring(queryStart) else ""
+        val cleanPath = if (path.endsWith(manifestSuffix, ignoreCase = true)) {
+            path.dropLast(manifestSuffix.length).trimEnd('/')
         } else {
-            trimmed
+            path.trimEnd('/')
         }
+        return cleanPath + query
     }
 
     val installedAddonUrls: Flow<List<String>> = effectiveProfileIdFlow.flatMapLatest { pid ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -54,11 +54,17 @@ class AddonRepositoryImpl @Inject constructor(
 
     private fun canonicalizeUrl(url: String): String {
         val trimmed = url.trim().trimEnd('/')
-        return if (trimmed.endsWith(MANIFEST_SUFFIX, ignoreCase = true)) {
-            trimmed.dropLast(MANIFEST_SUFFIX.length).trimEnd('/')
+        // Separate path from query string so we can detect /manifest.json
+        // even when the URL carries query parameters (e.g. configurable addons).
+        val queryStart = trimmed.indexOf('?')
+        val path = if (queryStart >= 0) trimmed.substring(0, queryStart) else trimmed
+        val query = if (queryStart >= 0) trimmed.substring(queryStart) else ""
+        val cleanPath = if (path.endsWith(MANIFEST_SUFFIX, ignoreCase = true)) {
+            path.dropLast(MANIFEST_SUFFIX.length).trimEnd('/')
         } else {
-            trimmed
+            path.trimEnd('/')
         }
+        return cleanPath + query
     }
 
     private fun normalizeUrl(url: String): String = canonicalizeUrl(url).lowercase()
@@ -175,7 +181,10 @@ class AddonRepositoryImpl @Inject constructor(
 
     override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> {
         val cleanBaseUrl = canonicalizeUrl(baseUrl)
-        val manifestUrl = "$cleanBaseUrl/manifest.json"
+        val queryStart = cleanBaseUrl.indexOf('?')
+        val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
+        val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
+        val manifestUrl = "$basePath/manifest.json$baseQuery"
 
         return when (val result = safeApiCall { api.getManifest(manifestUrl) }) {
             is NetworkResult.Success -> {

--- a/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
@@ -116,29 +116,36 @@ class CatalogRepositoryImpl @Inject constructor(
         skip: Int,
         extraArgs: Map<String, String>
     ): String {
-        val cleanBaseUrl = baseUrl.trimEnd('/')
+        // Separate path from query string so the catalog path segment is
+        // inserted before any query parameters (configurable addon URLs).
+        val trimmedBase = baseUrl.trimEnd('/')
+        val queryStart = trimmedBase.indexOf('?')
+        val basePath = if (queryStart >= 0) trimmedBase.substring(0, queryStart).trimEnd('/') else trimmedBase
+        val baseQuery = if (queryStart >= 0) trimmedBase.substring(queryStart) else ""
 
-        if (extraArgs.isEmpty()) {
-            return if (skip > 0) {
-                "$cleanBaseUrl/catalog/$type/$catalogId/skip=$skip.json"
+        val catalogPath = if (extraArgs.isEmpty()) {
+            if (skip > 0) {
+                "$basePath/catalog/$type/$catalogId/skip=$skip.json"
             } else {
-                "$cleanBaseUrl/catalog/$type/$catalogId.json"
+                "$basePath/catalog/$type/$catalogId.json"
             }
+        } else {
+            val allArgs = LinkedHashMap<String, String>()
+            allArgs.putAll(extraArgs)
+
+            // For Stremio catalogs, pagination is controlled by `skip` inside extraArgs.
+            if (!allArgs.containsKey("skip") && skip > 0) {
+                allArgs["skip"] = skip.toString()
+            }
+
+            val encodedArgs = allArgs.entries.joinToString("&") { (key, value) ->
+                "${encodeArg(key)}=${encodeArg(value)}"
+            }
+
+            "$basePath/catalog/$type/$catalogId/$encodedArgs.json"
         }
 
-        val allArgs = LinkedHashMap<String, String>()
-        allArgs.putAll(extraArgs)
-
-        // For Stremio catalogs, pagination is controlled by `skip` inside extraArgs.
-        if (!allArgs.containsKey("skip") && skip > 0) {
-            allArgs["skip"] = skip.toString()
-        }
-
-        val encodedArgs = allArgs.entries.joinToString("&") { (key, value) ->
-            "${encodeArg(key)}=${encodeArg(value)}"
-        }
-
-        return "$cleanBaseUrl/catalog/$type/$catalogId/$encodedArgs.json"
+        return catalogPath + baseQuery
     }
 
     private fun encodeArg(value: String): String {

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -305,9 +305,12 @@ class MetaRepositoryImpl @Inject constructor(
 
     private fun buildMetaUrl(baseUrl: String, type: String, id: String): String {
         val cleanBaseUrl = baseUrl.trimEnd('/')
+        val queryStart = cleanBaseUrl.indexOf('?')
+        val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
+        val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
         val encodedType = encodePathSegment(type)
         val encodedId = encodePathSegment(id)
-        return "$cleanBaseUrl/meta/$encodedType/$encodedId.json"
+        return "$basePath/meta/$encodedType/$encodedId.json$baseQuery"
     }
 
     private fun Addon.supportsMetaType(type: String): Boolean {

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -306,9 +306,12 @@ class StreamRepositoryImpl @Inject constructor(
         videoId: String
     ): NetworkResult<List<Stream>> {
         val cleanBaseUrl = baseUrl.trimEnd('/')
+        val queryStart = cleanBaseUrl.indexOf('?')
+        val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
+        val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
         val encodedType = encodePathSegment(type)
         val encodedVideoId = encodePathSegment(videoId)
-        val streamUrl = "$cleanBaseUrl/stream/$encodedType/$encodedVideoId.json"
+        val streamUrl = "$basePath/stream/$encodedType/$encodedVideoId.json$baseQuery"
         Log.d(TAG, "Fetching streams type=$type videoId=$videoId url=$streamUrl")
 
         // First, get addon info for name and logo

--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -142,12 +142,15 @@ class SubtitleRepositoryImpl @Inject constructor(
         }
         
         // Build the subtitle URL with optional extra parameters
-        val baseUrl = addon.baseUrl.trimEnd('/')
+        val rawBaseUrl = addon.baseUrl.trimEnd('/')
+        val queryStart = rawBaseUrl.indexOf('?')
+        val basePath = if (queryStart >= 0) rawBaseUrl.substring(0, queryStart).trimEnd('/') else rawBaseUrl
+        val baseQuery = if (queryStart >= 0) rawBaseUrl.substring(queryStart) else ""
         val extraParams = buildExtraParams(videoHash, videoSize, filename)
         val subtitleUrl = if (extraParams.isNotEmpty()) {
-            "$baseUrl/subtitles/$normalizedType/$actualId/$extraParams.json"
+            "$basePath/subtitles/$normalizedType/$actualId/$extraParams.json$baseQuery"
         } else {
-            "$baseUrl/subtitles/$normalizedType/$actualId.json"
+            "$basePath/subtitles/$normalizedType/$actualId.json$baseQuery"
         }
         
         Log.d(TAG, "Fetching subtitles from ${addon.name}: $subtitleUrl")


### PR DESCRIPTION
## Summary

Fix addon URL building for addons whose manifest URL contains query parameters (e.g. `manifest.json?list=...&name=...`). The path segments (`/catalog/`, `/stream/`, `/meta/`, `/subtitles/`) were appended after the query string, producing invalid URLs and empty catalog results.

## PR type

- Bug fix

## Why

Addons with configurable manifest URLs (like IMDB list addons from journey.co.il) include query parameters in their URL. The `canonicalizeUrl` function didn't recognize `/manifest.json` when followed by `?params`, so the full URL including query string was used as `baseUrl`. All resource paths were then appended after the query string, e.g.:
`https://example.com/manifest.json?list=123/catalog/series/id.json` instead of
`https://example.com/catalog/series/id.json?list=123`

This caused catalogs to return 0 items despite the addon being correctly detected and listed. Reported on Discord.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: installed IMDB list addon (`journey.co.il/stremio/manifest.json?list=...`) and verified catalogs now load on home screen and in discovery
- Verified via ADB logs that catalog URL is correctly formed with query params after `.json`
- Confirmed standard addons (without query params) are unaffected

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing Should break

## Linked issues

Reported on [Discord](https://discord.com/channels/1379902184207941732/1492029486072463470)
