### PR TITLE
Revert RTL player controls to LTR

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -126,8 +126,6 @@ fun PlayerScreen(
     onPlaybackEnded: ((nextVideoId: String?, nextSeason: Int?, nextEpisode: Int?) -> Unit)? = null
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val layoutDirection = LocalLayoutDirection.current
-    val isRtl = layoutDirection == LayoutDirection.Rtl
     val lifecycleOwner = LocalLifecycleOwner.current
     val containerFocusRequester = remember { FocusRequester() }
     val playPauseFocusRequester = remember { FocusRequester() }
@@ -477,7 +475,7 @@ fun PlayerScreen(
                                     else -> 10_000L
                                 }
                                 val isLeft = keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_LEFT
-                                val deltaMs = if (isLeft xor isRtl) -stepMs else stepMs
+                                val deltaMs = if (isLeft) -stepMs else stepMs
                                 viewModel.onEvent(PlayerEvent.OnPreviewSeekBy(deltaMs))
                                 true
                             } else {
@@ -1253,7 +1251,6 @@ private fun PlayerControlsOverlay(
     onBack: () -> Unit,
     skipButtonVisible: Boolean = false
 ) {
-    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val customPlayPainter = rememberRawSvgPainter(R.raw.ic_player_play)
     val customPausePainter = rememberRawSvgPainter(R.raw.ic_player_pause)
     val customSubtitlePainter = rememberRawSvgPainter(R.raw.ic_player_subtitles)
@@ -1373,7 +1370,8 @@ private fun PlayerControlsOverlay(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Progress bar
+            // Progress bar — always LTR regardless of locale
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             ProgressBar(
                 currentPosition = uiState.pendingPreviewSeekPosition ?: uiState.currentPosition,
                 duration = uiState.duration,
@@ -1383,17 +1381,18 @@ private fun PlayerControlsOverlay(
                 onSeekCommit = {
                     viewModel.onEvent(PlayerEvent.OnCommitPreviewSeek)
                 },
-                isRtl = isRtl,
                 focusRequester = progressBarFocusRequester,
                 upFocusRequester = progressBarUpFocusRequester,
                 downFocusRequester = playPauseFocusRequester,
                 onUpKey = onHideControls,
                 onFocused = onResetHideTimer
-)
+            )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Control buttons row
+            // Control buttons row — always LTR regardless of locale
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -1567,6 +1566,7 @@ private fun PlayerControlsOverlay(
                     color = Color.White.copy(alpha = 0.9f)
                 )
             }
+            }
         }
     }
 }
@@ -1652,7 +1652,6 @@ private fun ProgressBar(
     duration: Long,
     onSeekPreview: (Long) -> Unit,
     onSeekCommit: () -> Unit,
-    isRtl: Boolean = false,
     focusRequester: FocusRequester? = null,
     upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
@@ -1734,11 +1733,11 @@ private fun ProgressBar(
                             }
                         }
                         KeyEvent.KEYCODE_DPAD_LEFT -> {
-                            onSeekPreview(if (isRtl) 10_000L else -10_000L)
+                            onSeekPreview(-10_000L)
                             true
                         }
                         KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                            onSeekPreview(if (isRtl) -10_000L else 10_000L)
+                            onSeekPreview(10_000L)
                             true
                         }
                         else -> false
@@ -1770,12 +1769,14 @@ private fun SeekOverlay(uiState: PlayerUiState) {
             .fillMaxWidth()
             .padding(horizontal = 32.dp, vertical = 24.dp)
     ) {
-        ProgressBar(
-            currentPosition = uiState.currentPosition,
-            duration = uiState.duration,
-            onSeekPreview = {},
-            onSeekCommit = {}
-        )
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            ProgressBar(
+                currentPosition = uiState.currentPosition,
+                duration = uiState.duration,
+                onSeekPreview = {},
+                onSeekCommit = {}
+            )
+        }
 
         Spacer(modifier = Modifier.height(12.dp))
 


### PR DESCRIPTION
## Summary

From a poll with the RTL community, 80% prefer the player to stay LTR and not be adjusted to the right (due to recent PR i merged)

  - Removed isRtl logic from seek direction and control key handling — direction is no longer flipped for RTL languages
  - Wrapped the progress bar and control buttons with CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) to prevent Compose from auto-mirroring the layout when an RTL locale (e.g. Hebrew) is active
  - Subtitle selection overlay RTL navigation is intentionally unchanged 

## PR type
- Player Rtl revert


## Why

 RTL-adjusted video players feel unintuitive — playback controls like progress bars and seek buttons are universally expected to flow left-to-right, regardless of reading direction. The poll confirmed this: most RTL users      
  prefer the player to match the standard they're used to from every other video app.

## Policy check

<!-- Confirm these before requesting review -->
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

  - Verified player controls, progress bar, and seek behave correctly in LTR layout with Hebrew locale active                                                                                                                       
  - Verified seek forward/backward direction is correct                                                                                                                                                                             
  - Confirmed subtitle selection overlay RTL navigation is unaffected                                                                                                                                                               
  - Tested engine switch overlay — progress bar remains LTR after toggling  

## Screenshots / Video (UI changes only)
None.

## Breaking changes
None.

## Linked issues
None.