### PR TITLE
Fix/update dialog width consistency

### DIFF
--- a/app/src/main/java/com/nuvio/tv/updater/UpdateViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/updater/UpdateViewModel.kt
@@ -158,6 +158,7 @@ class UpdateViewModel @Inject constructor(
             return
         }
 
+        _uiState.update { it.copy(showUnknownSourcesDialog = false) }
         ApkInstaller.launchInstall(context, apkFile)
     }
 

--- a/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
@@ -77,6 +77,10 @@ import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.updater.UpdateUiState
 import kotlinx.coroutines.delay
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.runtime.DisposableEffect
 import com.nuvio.tv.R
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -112,6 +116,19 @@ fun UpdatePromptDialog(
         } else {
             installButtonEnabled = true
         }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, state.showUnknownSourcesDialog) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (state.showUnknownSourcesDialog) {
+                    onInstall()
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Dialog(

--- a/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
@@ -114,7 +114,10 @@ fun UpdatePromptDialog(
         }
     }
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
+    ) {
         var isVisible by remember { mutableStateOf(false) }
         LaunchedEffect(Unit) {
             isVisible = true
@@ -132,19 +135,21 @@ fun UpdatePromptDialog(
         )
 
         val shape = RoundedCornerShape(16.dp)
-        Box(
-            modifier = Modifier
-                .graphicsLayer {
-                    scaleX = scale
-                    scaleY = scale
-                    this.alpha = alpha
-                }
-                .fillMaxWidth(0.9f)
-                .background(NuvioColors.BackgroundCard, shape)
-                .border(BorderStroke(2.dp, NuvioColors.FocusRing), shape)
-                .padding(32.dp)
-        ) {
-            Column(
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Box(
+                modifier = Modifier
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        this.alpha = alpha
+                    }
+                    .width(500.dp)
+                    .fillMaxWidth(0.9f)
+                    .background(NuvioColors.BackgroundCard, shape)
+                    .border(BorderStroke(2.dp, NuvioColors.FocusRing), shape)
+                    .padding(32.dp)
+            ) {
+                Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 Row(
@@ -492,6 +497,7 @@ fun UpdatePromptDialog(
                     }
                 }
             }
+        }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/updater/ui/UpdatePromptDialog.kt
@@ -170,7 +170,7 @@ fun UpdatePromptDialog(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalAlignment = Alignment.Top,
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -178,50 +178,14 @@ fun UpdatePromptDialog(
                         verticalArrangement = Arrangement.spacedBy(4.dp),
                         modifier = Modifier.weight(1f)
                     ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.update_title),
-                                style = MaterialTheme.typography.headlineMedium.copy(
-                                    fontWeight = FontWeight.Bold,
-                                    letterSpacing = (-0.5).sp
-                                ),
-                                color = NuvioColors.TextPrimary
-                            )
-
-                            if (state.update != null && state.isUpdateAvailable && !showDownloadMode && state.downloadedApkPath == null) {
-                                Box(
-                                    modifier = Modifier
-                                        .background(
-                                            brush = Brush.horizontalGradient(
-                                                colors = listOf(
-                                                    NuvioColors.Primary.copy(alpha = 0.25f),
-                                                    NuvioColors.Primary.copy(alpha = 0.05f)
-                                                )
-                                            ),
-                                            shape = RoundedCornerShape(percent = 50)
-                                        )
-                                        .border(
-                                            width = 1.dp,
-                                            color = NuvioColors.Primary.copy(alpha = 0.35f),
-                                            shape = RoundedCornerShape(percent = 50)
-                                        )
-                                        .padding(horizontal = 14.dp, vertical = 6.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(
-                                        text = state.update.tag,
-                                        style = MaterialTheme.typography.labelMedium.copy(
-                                            fontWeight = FontWeight.Bold,
-                                            letterSpacing = 0.5.sp
-                                        ),
-                                        color = NuvioColors.Primary
-                                    )
-                                }
-                            }
-                        }
+                        Text(
+                            text = stringResource(R.string.update_title),
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                letterSpacing = (-0.5).sp
+                            ),
+                            color = NuvioColors.TextPrimary
+                        )
 
                         val subtitle = when {
                             state.errorMessage != null -> state.errorMessage
@@ -238,6 +202,26 @@ fun UpdatePromptDialog(
                                 color = NuvioColors.TextSecondary,
                                 maxLines = 2,
                                 overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+
+                    if (state.update != null && state.isUpdateAvailable && !showDownloadMode && state.downloadedApkPath == null) {
+                        Box(
+                            modifier = Modifier.padding(top = 8.dp)
+                        ) {
+                            val displayTag = if (state.update.tag.startsWith("v", ignoreCase = true)) {
+                                state.update.tag
+                            } else {
+                                "v${state.update.tag}"
+                            }
+                            Text(
+                                text = displayTag,
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.SemiBold,
+                                    letterSpacing = 1.sp
+                                ),
+                                color = NuvioColors.TextSecondary.copy(alpha = 0.75f)
                             )
                         }
                     }


### PR DESCRIPTION
## Summary
- standardize UpdatePromptDialog layout width to enforce consistency across screens
-  auto-resume installation after unknown sources permission is granted
-  move version tag to top right and add v prefix in update dialog
## PR type
- Bug fix
- Small maintenance improvement
## Why
**1. Narrow Layout on 720p Screens & Scroll Fix:**
On screens with lower resolutions, particularly 1280x720, the previous `UpdatePromptDialog` was horizontally too narrow and did not render properly. This narrow bounding box caused:
- Markdown text and long words to wrap awkwardly to the next line.
- The scrollable area to become cramped, forcing users to scroll excessively down with the D-pad to read the changelog.
The dialog width has been standardized to accommodate all screen sizes properly, improving both reading and navigation experiences.

**2. Interrupted Installation Flow (Unknown Sources):**
When users granted the "Unknown Sources" permission and returned to the application, the installation process would not resume automatically. This PR introduces an auto-resume mechanism tied to the lifecycle, automatically triggering the installation once the permission is granted and the app regains focus.

**3. Title Clutter and Cropped Version Numbers:**
The previous version tag was placed right next to the title, creating visual clutter. On narrow screens, long tags like "0.6.0-beta" wouldn't fit correctly and could wrap weirdly inside the badge (e.g., "be" / "ta" on separate lines). The version tag has been moved to the top right corner of the dialog, styled subtly with a dynamically prepended 'v' prefix, resulting in a much cleaner UI hierarchy.
## Policy check
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
 - [x] This PR does not add a new major feature without prior approval.
 - [x] This PR is small in scope and focused on one problem.
 - [ ] If this is a larger or directional change, I linked the issue where it was approved.
## Testing
- Tested the updated layout on an Android TV emulator (specifically configured to 720p resolution).
- Verified that the standardized width improves markdown readability and resolves text wrapping/scroll overflow issues.
- Confirmed that the version tag properly prepends 'v' dynamically and is securely positioned at the top right without disrupting the layout.
- Simulated the "Unknown Sources" settings return flow and confirmed that the installation resumes automatically without requiring manual action.
## Screenshots / Video (UI changes only)
| Normal / High Res (Before) | 720p Resolution / Cropped (Before) | New Layout (After) |
| :---: | :---: | :---: |
|<img width="1366" height="768" alt="Screenshot_20260410_171519" src="https://github.com/user-attachments/assets/0d4377c8-ec50-43a4-90bf-b9f201865dec" /> | ![IMG_6761](https://github.com/user-attachments/assets/7ac391c9-cc52-44ff-83cb-af6a10a176f4)  | <img width="1280" height="720" alt="Screenshot_20260410_174354" src="https://github.com/user-attachments/assets/4c398472-aeba-4d14-af09-b36c1a9823b3" /> |
## Breaking changes
- None 
## Linked issues
Reported on [Discord](https://discord.com/channels/1379902184207941732/1492127667833802874)