### PR TITLE
Latin American Spanish Localization

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -1,8 +1,65 @@
 <resources>
     <string name="app_name">Nuvio</string>
     <string name="type_movie">Película</string>
-    <string name="type_series">Serie</string>
+    <string name="type_series">Series</string>
     <string name="type_unknown">Desconocido</string>
+
+    <!-- WebConfigServers -->
+    <string name="web_manage_addons_title">Gestionar addons</string>
+    <string name="web_manage_addons_subtitle">Gestiona addons, catálogos y colecciones</string>
+    <string name="web_add_addon_url">Añadir addon mediante URL</string>
+    <string name="web_placeholder_url">https://example.com/manifest.json</string>
+    <string name="web_btn_add">Añadir</string>
+    <string name="web_installed_addons">Addons instalados</string>
+    <string name="web_no_addons">No hay addons instalados</string>
+    <string name="web_home_catalogs">Catálogos y colecciones de inicio</string>
+    <string name="web_no_catalogs">No hay catálogos de inicio disponibles</string>
+    <string name="web_btn_save">Guardar cambios</string>
+    <string name="web_connection_lost">Conexión con la TV perdida</string>
+    <string name="web_btn_remove">Eliminar</string>
+    <string name="web_badge_new">Nuevo</string>
+    <string name="web_badge_disabled">Desactivado</string>
+    <string name="web_btn_enable">Activar</string>
+    <string name="web_btn_disable">Desactivar</string>
+    <string name="web_error_addon_exists">Este addon ya está en la lista</string>
+    <string name="web_status_waiting_tv">Esperando la TV</string>
+    <string name="web_status_msg_waiting_tv">Por favor confirma los cambios en tu TV para aplicarlos.</string>
+    <string name="web_status_changes_applied">Cambios aplicados</string>
+    <string name="web_status_msg_addon_updated">La configuración del addon ha sido actualizada en la TV.</string>
+    <string name="web_status_msg_repo_updated">La configuración del repositorio ha sido actualizada en la TV.</string>
+    <string name="web_status_changes_rejected">Cambios rechazados</string>
+    <string name="web_status_msg_changes_rejected">Los cambios fueron rechazados en la TV. La lista ha sido restaurada.</string>
+    <string name="web_status_error">Algo salió mal</string>
+    <string name="web_error_failed_save">Error al guardar. Verifica la conexión con la TV.</string>
+    <string name="web_btn_dismiss">Cerrar</string>
+    <string name="web_status_timeout">Tiempo agotado</string>
+    <string name="web_status_msg_timeout">Sin respuesta de la TV. Inténtalo nuevamente.</string>
+    <string name="web_status_msg_connection_lost">El servidor de la TV ya no es accesible. Los cambios pueden haberse aplicado.</string>
+    <string name="web_manage_repos_title">Gestionar repositorios</string>
+    <string name="web_manage_repos_subtitle">Gestiona tus repositorios</string>
+    <string name="web_add_repo_url">Añadir repositorio mediante URL</string>
+    <string name="web_installed">Instalado</string>
+    <string name="web_no_repos">No hay repositorios instalados</string>
+    <string name="web_error_repo_exists">Este repositorio ya está en la lista</string>
+    <string name="web_manage_collections_title">Gestionar colecciones</string>
+    <string name="web_manage_collections_subtitle">Crea y gestiona tus colecciones personalizadas</string>
+    <string name="web_status_msg_collections_updated">Tus colecciones han sido actualizadas en la TV.</string>
+    <string name="web_tab_addons">Addons</string>
+    <string name="web_tab_home_layout">Diseño de inicio</string>
+    <string name="web_tab_collections">Colecciones</string>
+    <string name="web_btn_enable_all">Activar todo</string>
+    <string name="web_btn_disable_all">Desactivar todo</string>
+    <string name="web_btn_show_all">Mostrar todo</string>
+    <string name="web_btn_hide_all">Ocultar todo</string>
+    <string name="web_btn_new_collection">+ Nueva colección</string>
+    <string name="web_btn_export">Exportar</string>
+    <string name="web_btn_import">Importar</string>
+    <string name="web_no_collections">Aún no hay colecciones</string>
+    <string name="web_badge_collection">Colección</string>
+    <string name="web_import_collections_title">Importar colecciones</string>
+    <string name="web_import_tab_paste">Pegar</string>
+    <string name="web_import_tab_file">Archivo</string>
+    <string name="web_import_tab_url">URL</string>
 
     <!-- HomeScreen -->
     <string name="home_no_addons">No hay addons instalados. Agrega uno para empezar.</string>
@@ -67,6 +124,7 @@
     <!-- CatalogRowSection -->
     <string name="catalog_from_addon">de %1$s</string>
     <string name="action_see_all">Ver todo</string>
+    <string name="action_load_more">Cargar más</string>
 
     <!-- HeroSection -->
     <string name="hero_creator">Creador: %1$s</string>
@@ -124,6 +182,8 @@
     <string name="cast_role_writer">Escritor</string>
     <string name="detail_tab_ratings">Calificaciones</string>
     <string name="detail_tab_more_like_this">Similares</string>
+    <string name="detail_more_like_this_powered_by_tmdb">Con tecnología de TMDB</string>
+    <string name="detail_more_like_this_powered_by_trakt">Con tecnología de Trakt</string>
     <string name="detail_comments_title">Comentarios</string>
     <string name="detail_comments_subtitle">Reseñas de Trakt</string>
     <string name="detail_section_network">Cadena</string>
@@ -288,6 +348,11 @@
     <string name="playback_player_internal">Interno</string>
     <string name="playback_player_external">Externo</string>
     <string name="playback_player_ask">Preguntar siempre</string>
+    <string name="playback_internal_player_engine">Motor interno</string>
+    <string name="playback_engine_exoplayer">ExoPlayer</string>
+    <string name="playback_engine_mvplayer">Libmpv (Beta)</string>
+    <string name="playback_auto_switch_internal_player_on_error">Cambiar automáticamente de motor en caso de error al iniciar</string>
+    <string name="playback_auto_switch_internal_player_on_error_sub">Si falla el inicio del stream, alterna automáticamente entre ExoPlayer y libmpv.</string>
     <string name="playback_section_audio">Audio y Tráiler</string>
     <string name="playback_section_audio_desc">Comportamiento del tráiler y controles de audio.</string>
     <string name="playback_section_subtitles">Subtítulos</string>
@@ -304,6 +369,8 @@
     <string name="playback_resolution_matching_sub">Permitir cambios en el modo de pantalla para coincidir con la resolución del video.</string>
     <string name="playback_player_external_desc">Abrir siempre los enlaces en una app externa</string>
     <string name="playback_player_ask_desc">Elegir el reproductor en cada ocasión</string>
+    <string name="playback_engine_exoplayer_desc">Mejor compatibilidad con las funciones actuales de Nuvio.</string>
+    <string name="playback_engine_mvplayer_desc">Usa libmpv con controles OSD de Nuvio. Experimental.</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_trailer_section">Tráiler</string>
@@ -313,6 +380,8 @@
     <string name="audio_section">Audio</string>
     <string name="audio_lang_default">Predeterminado (del archivo)</string>
     <string name="audio_lang_device">Idioma del dispositivo</string>
+    <string name="audio_lang_original">Idioma original</string>
+    <string name="audio_lang_original_hint">Requiere que el enriquecimiento de TMDB esté activado</string>
     <string name="audio_preferred_lang">Idioma de Audio Preferido</string>
     <string name="audio_skip_silence">Omitir Silencios</string>
     <string name="audio_skip_silence_sub">Omitir las partes silenciosas del audio durante la reproducción</string>
@@ -325,6 +394,18 @@
     <string name="audio_tunneled">Reproducción Tunelizada (Tunneled Playback)</string>
     <string name="audio_tunneled_sub">Sincronización de audio/video a nivel de hardware. Puede mejorar la reproducción en algunos dispositivos Android TV</string>
     <string name="audio_dv_sub">Mapear el perfil 7 de Dolby Vision a HEVC estándar para dispositivos sin soporte de hardware DV</string>
+    <string name="audio_mpv_hwdec_title">Decodificación por hardware (solo MPV)</string>
+    <string name="audio_mpv_hwdec_dialog_subtitle">Selecciona cómo libmpv debe usar los decodificadores por hardware.</string>
+    <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (directo -&gt; copia)</string>
+    <string name="audio_mpv_hwdec_legacy_direct_copy_desc">Comportamiento predeterminado anterior: intenta primero hardware directo, luego copia a memoria.</string>
+    <string name="audio_mpv_hwdec_auto_safe">Automático (seguro)</string>
+    <string name="audio_mpv_hwdec_auto_safe_desc">Modo automático más seguro con fallback cuando fallan algunos decodificadores por hardware.</string>
+    <string name="audio_mpv_hwdec_hardware_copy">Hardware (copia) (mediacodec-copy)</string>
+    <string name="audio_mpv_hwdec_hardware_copy_desc">Usa decodificación por hardware con copia a memoria de software.</string>
+    <string name="audio_mpv_hwdec_hardware_direct">Hardware (directo) (mediacodec)</string>
+    <string name="audio_mpv_hwdec_hardware_direct_desc">Usa decodificación directa por hardware. Es la opción más rápida en dispositivos compatibles.</string>
+    <string name="audio_mpv_hwdec_disabled">Desactivado (no)</string>
+    <string name="audio_mpv_hwdec_disabled_desc">Desactiva la decodificación por hardware y usa solo decodificación por software.</string>
     <string name="audio_decoder_device_only_desc">Usar solo decodificadores de hardware integrados. Más compatible, pero podría no soportar todos los formatos.</string>
     <string name="audio_decoder_prefer_device_desc">Usar decodificadores de hardware cuando estén disponibles, recurriendo a FFmpeg si fallan. Recomendado para la mayoría.</string>
     <string name="audio_decoder_prefer_app_desc">Usar decodificadores FFmpeg cuando estén disponibles. Mejor soporte de formatos, pero mayor uso de CPU.</string>
@@ -444,6 +525,8 @@
     <string name="layout_modern_sidebar_sub">Habilitar la navegación de la barra lateral flotante.</string>
     <string name="layout_modern_sidebar_blur">Desenfocar Barra Lateral Moderna</string>
     <string name="layout_modern_sidebar_blur_sub">Activar el efecto de desenfoque para las superficies de la barra lateral moderna.</string>
+    <string name="layout_fullscreen_hero_backdrop">Fondo principal en pantalla completa</string>
+    <string name="layout_fullscreen_hero_backdrop_sub">Expande el fondo principal para que ocupe toda la pantalla.</string>
     <string name="layout_show_hero">Mostrar Sección Destacada</string>
     <string name="layout_show_hero_sub">Mostrar el carrusel destacado en la parte superior del inicio.</string>
     <string name="layout_show_discover">Mostrar Descubrir en Búsqueda</string>
@@ -459,7 +542,9 @@
     <string name="layout_section_detail">Página de Detalles</string>
     <string name="layout_section_detail_desc">Ajustes para las pantallas de detalles y episodios.</string>
     <string name="layout_blur_unwatched">Desenfocar Episodios No Vistos</string>
+    <string name="layout_blur_unwatched_sub">Difumina las miniaturas de los episodios hasta que se vean para evitar spoilers.</string>
     <string name="layout_blur_unwatched_sub">Desenfocar miniaturas de episodios hasta que sean vistos para evitar spoilers.</string>
+    <string name="layout_blur_cw_next_up_sub">Difumina las miniaturas del siguiente episodio en “Continuar viendo” para evitar spoilers.</string>
     <string name="layout_trailer_button">Mostrar Botón de Tráiler</string>
     <string name="layout_trailer_button_sub">Mostrar el botón de tráiler en la página de detalles (solo si está disponible).</string>
     <string name="layout_prefer_external_meta">Preferir metadatos de addon externo</string>
@@ -551,6 +636,8 @@
     <string name="tmdb_enable_subtitle">Usar TMDB como fuente de metadatos para mejorar los datos de los addons</string>
     <string name="tmdb_modern_home_title">Activar en Inicio Moderno</string>
     <string name="tmdb_modern_home_subtitle">Aplicar también el enriquecimiento de TMDB al banner principal y a las tarjetas enfocadas en Inicio Moderno</string>
+    <string name="tmdb_enrich_continue_watching_title">Enriquecer “Continuar viendo”</string>
+    <string name="tmdb_enrich_continue_watching_subtitle">Aplicar el enriquecimiento de TMDB a los elementos de “Continuar viendo”</string>
     <string name="tmdb_language_title">Idioma</string>
     <string name="tmdb_language_subtitle">Idioma de los metadatos de TMDB para el título, logo y campos habilitados</string>
     <string name="tmdb_artwork_title">Arte</string>
@@ -559,6 +646,8 @@
     <string name="tmdb_basic_info_subtitle">Descripción, géneros y calificación desde TMDB</string>
     <string name="tmdb_details_title">Detalles</string>
     <string name="tmdb_details_subtitle">Duración, fecha de lanzamiento, país e idioma desde TMDB</string>
+    <string name="tmdb_release_dates_title">Fechas de estreno</string>
+    <string name="tmdb_release_dates_subtitle">Fechas de estreno y emisión desde TMDB</string>
     <string name="tmdb_credits_title">Créditos</string>
     <string name="tmdb_credits_subtitle">Elenco con fotos, director y escritor desde TMDB</string>
     <string name="tmdb_productions_title">Producciones</string>
@@ -583,6 +672,11 @@
     <string name="qr_login_approved">Inicio de sesión aprobado. Finalizando…</string>
     <string name="qr_login_pending">Esperando aprobación en tu teléfono…</string>
     <string name="qr_login_expired">El inicio de sesión QR ha expirado. Genera un nuevo código.</string>
+    <string name="qr_login_scan_prompt">Escanea el QR e inicia sesión en tu teléfono</string>
+    <string name="qr_login_start_failed">No se pudo iniciar el inicio de sesión con QR</string>
+    <string name="qr_login_signing_in">Iniciando sesión…</string>
+    <string name="qr_login_success">Sesión iniciada correctamente</string>
+    <string name="qr_login_exchange_failed">No se pudo completar el inicio de sesión con QR</string>
     <string name="trakt_code_expires">El código expira en %1$s</string>
     <string name="trakt_token_refreshes">El token de acceso de Trakt se actualiza en %1$s</string>
     <string name="trakt_login_instruction">Presiona Iniciar Sesión para comenzar la autenticación del dispositivo con Trakt. Aquí aparecerá un código QR.</string>
@@ -669,6 +763,7 @@
     <string name="profile_primary_label">Principal</string>
     <string name="profile_shares_primary">Comparte los %1$s del perfil principal</string>
     <string name="profile_edit_label">Editar</string>
+    <string name="profile_edit_header">Editar perfil</string>
     <string name="profile_add">Agregar perfil</string>
     <string name="profile_create_title">Crear perfil</string>
     <string name="profile_edit_title">Editar perfil %1$s</string>
@@ -773,6 +868,16 @@
     <string name="stream_finding_source">Buscando fuentes de transmisión</string>
     <string name="stream_type_torrent">Torrent</string>
     <string name="stream_type_youtube">YouTube</string>
+    <string name="p2p_consent_title">Streaming P2P</string>
+    <string name="p2p_consent_body">Este contenido utiliza tecnología peer-to-peer (P2P). Al habilitar P2P, reconoces y aceptas que:\n\n\u2022 Tu dirección IP será visible para otros pares en la red\n\u2022 Eres el único responsable del contenido al que accedes\n\u2022 Confirmas que tienes el derecho legal para reproducir este contenido en tu jurisdicción\n\u2022 Nuvio no aloja, distribuye ni controla contenido P2P\n\u2022 Nuvio no asume responsabilidad por consecuencias legales derivadas del uso de P2P\n\nUsas esta función bajo tu propio riesgo. Puedes desactivar P2P en cualquier momento desde Configuración.</string>
+    <string name="p2p_consent_enable">Activar P2P</string>
+    <string name="p2p_consent_cancel">Cancelar</string>
+    <string name="settings_p2p_title">Streaming P2P</string>
+    <string name="settings_p2p_subtitle">Permitir transmisiones peer-to-peer (torrent)</string>
+    <string name="settings_p2p_hide_stats_title">Ocultar estadísticas de torrent</string>
+    <string name="settings_p2p_hide_stats_subtitle">Ocultar buffer, seeds, peers y velocidad de descarga durante la carga y reproducción</string>
+    <string name="p2p_download_title">Descargando motor P2P</string>
+    <string name="p2p_download_subtitle">Esta es una descarga única necesaria para el streaming P2P.</string>
     <string name="stream_type_external">Externo</string>
     <string name="stream_player_picker_title">¿Qué reproductor se debería usar?</string>
     <string name="stream_player_internal">Interno</string>
@@ -780,6 +885,22 @@
 
     <!-- PlayerScreen -->
     <string name="player_no_external_player">No se encontró un reproductor externo</string>
+    <string name="player_loading_preparing">Preparando reproducción…</string>
+    <string name="player_loading_detecting_format">Detectando formato del stream…</string>
+    <string name="player_loading_subtitles">Buscando subtítulos…</string>
+    <string name="player_loading_subtitles_from">Buscando subtítulos desde %1$d addons…</string>
+    <string name="player_loading_subtitles_progress">Buscando subtítulos… (%1$d / %2$d)</string>
+    <string name="player_loading_subtitles_addon">Subtítulos: %1$s (%2$d / %3$d)</string>
+    <string name="player_loading_building">Preparando reproductor…</string>
+    <string name="player_loading_starting">Iniciando reproducción…</string>
+    <string name="player_loading_buffering">Cargando buffer…</string>
+    <string name="player_loading_fallback_pcm_audio">Error al iniciar la pista de audio, cambiando a audio PCM…</string>
+    <string name="player_loading_fallback_hevc_decoder">Error al iniciar el decodificador, cambiando a decodificador HEVC…</string>
+    <string name="player_engine_switching_title">Cambiando motor del reproductor</string>
+    <string name="player_engine_switching_message">Fallo al iniciar. Cambiando a %1$s…</string>
+    <string name="player_engine_switching_manual_message">Cambiando a %1$s...</string>
+    <string name="playback_show_loading_status">Mostrar estado de carga</string>
+    <string name="playback_show_loading_status_sub">Muestra el progreso paso a paso mientras se inicializa el reproductor.</string>
 
     <!-- ParentalGuideOverlay -->
     <string name="parental_nudity">Desnudez</string>
@@ -799,7 +920,27 @@
     <string name="player_more_actions_title">Más Acciones</string>
     <string name="player_more_speed">Velocidad de Reproducción</string>
     <string name="player_more_aspect_ratio">Relación de Aspecto</string>
-    <string name="player_more_open_external">Abrir en un Reproductor Externo</string>
+    <string name="player_more_open_external">Abrir en reproductor externo</string>
+
+    <!-- StreamInfoOverlay -->
+    <string name="stream_info_section_source">ORIGEN</string>
+    <string name="stream_info_section_file">ARCHIVO</string>
+    <string name="stream_info_section_video">VIDEO</string>
+    <string name="stream_info_section_audio">AUDIO</string>
+    <string name="stream_info_section_subtitle">SUBTÍTULOS</string>
+    <string name="stream_info_filename">Nombre de archivo</string>
+    <string name="stream_info_size">Tamaño</string>
+    <string name="stream_info_codec">Códec</string>
+    <string name="stream_info_resolution">Resolución</string>
+    <string name="stream_info_frame_rate">Frecuencia de fotogramas</string>
+    <string name="stream_info_bitrate">Tasa de bits</string>
+    <string name="stream_info_channels">Canales</string>
+    <string name="stream_info_sample_rate">Frecuencia de muestreo</string>
+    <string name="stream_info_language">Idioma</string>
+    <string name="stream_info_name">Nombre</string>
+    <string name="stream_info_source">Origen</string>
+    <string name="stream_info_subtitle_source_addon">Addon</string>
+    <string name="stream_info_subtitle_source_embedded">Integrado</string>
 
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Fuentes</string>
@@ -822,6 +963,9 @@
     <string name="player_aspect_fit_width">Ajustar al Ancho</string>
     <string name="player_aspect_fit_height">Ajustar al Alto</string>
     <string name="player_aspect_crop">Recortar</string>
+    <string name="player_aspect_tunneling_unavailable">No disponible durante reproducción con tunneling</string>
+    <string name="player_aspect_mode_slight_zoom">Zoom ligero</string>
+    <string name="player_aspect_mode_cinema_zoom">Zoom cine</string>
 
     <!-- AudioDialog -->
     <string name="audio_dialog_title">Audio</string>
@@ -849,6 +993,7 @@
     <string name="subtitle_tab_style">Estilo</string>
     <string name="subtitle_tab_delay">Retraso</string>
     <string name="subtitle_none">Ninguno</string>
+    <string name="subtitle_built_in">Integrado</string>
     <string name="subtitle_all">Todos</string>
     <string name="subtitle_section_core">Principal</string>
     <string name="subtitle_section_advanced">Avanzado</string>
@@ -900,6 +1045,8 @@
     <string name="search_start_title">Empezar a buscar</string>
     <string name="search_start_subtitle">Ingresa al menos 2 caracteres</string>
     <string name="search_start_subtitle_no_discover">Descubrir está desactivado. Ingresa al menos 2 caracteres</string>
+    <string name="search_recent_title">Búsquedas recientes</string>
+    <string name="search_recent_clear">Borrar historial</string>
     <string name="search_voice_no_speech">No se detectó voz. Intenta de nuevo.</string>
     <string name="search_voice_mic_permission">Se requiere permiso de micrófono para búsqueda por voz.</string>
     <string name="search_voice_failed">Error en el reconocimiento de voz. Intenta de nuevo.</string>
@@ -911,6 +1058,37 @@
     <string name="library_filter_list">Lista</string>
     <string name="library_filter_type">Tipo</string>
     <string name="library_filter_sort">Ordenar</string>
+    <string name="library_filter_genre">Género</string>
+    <string name="library_filter_year">Año</string>
+    <!-- Genre names (from TMDB movie + TV) -->
+    <string name="genre_action">Acción</string>
+    <string name="genre_adventure">Aventura</string>
+    <string name="genre_animation">Animación</string>
+    <string name="genre_comedy">Comedia</string>
+    <string name="genre_crime">Crimen</string>
+    <string name="genre_documentary">Documental</string>
+    <string name="genre_drama">Drama</string>
+    <string name="genre_family">Familiar</string>
+    <string name="genre_fantasy">Fantasía</string>
+    <string name="genre_history">Historia</string>
+    <string name="genre_horror">Terror</string>
+    <string name="genre_music">Música</string>
+    <string name="genre_mystery">Misterio</string>
+    <string name="genre_romance">Romance</string>
+    <string name="genre_science_fiction">Ciencia ficción</string>
+    <string name="genre_tv_movie">Película de TV</string>
+    <string name="genre_thriller">Suspenso</string>
+    <string name="genre_war">Guerra</string>
+    <string name="genre_western">Western</string>
+    <!-- TV-specific genres -->
+    <string name="genre_action_adventure">Acción y aventura</string>
+    <string name="genre_kids">Infantil</string>
+    <string name="genre_news">Noticias</string>
+    <string name="genre_reality">Reality</string>
+    <string name="genre_sci_fi_fantasy">Ciencia ficción y fantasía</string>
+    <string name="genre_soap">Telenovela</string>
+    <string name="genre_talk">Talk show</string>
+    <string name="genre_war_politics">Guerra y política</string>
     <string name="library_sort_trakt_order">Orden de Trakt</string>
     <string name="library_sort_added_desc">Agregado ↓</string>
     <string name="library_sort_added_asc">Agregado ↑</string>
@@ -932,6 +1110,9 @@
     <string name="library_delete_subtitle">Esto eliminará la lista y todos sus elementos de Trakt.</string>
     <string name="library_delete_confirm">Eliminar</string>
     <string name="library_source_local">LOCAL</string>
+    <string name="library_source_nuvio">NUVIO</string>
+    <string name="library_source_trakt">TRAKT</string>
+    <string name="library_syncing_library">Sincronizando biblioteca…</string>
     <string name="library_type_all">Todos</string>
     <string name="library_type_items">elementos</string>
     <string name="library_empty_local_title">Aún no hay %1$s</string>
@@ -1013,6 +1194,10 @@
     <string name="plugin_confirm_total">Total de repositorios: %1$d</string>
     <string name="plugin_confirm_reject">Rechazar</string>
     <string name="plugin_confirm_confirm">Confirmar</string>
+    <string name="plugin_risky_enable_title">¿Activar proveedor?</string>
+    <string name="plugin_risky_enable_message">%1$s es conocido por causar fallos con algunos contenidos. ¿Activarlo de todas formas?</string>
+    <string name="plugin_risky_enable_cancel">Cancelar</string>
+    <string name="plugin_risky_enable_confirm">Activar</string>
     <string name="plugin_updated_format">Actualizado: %1$s</string>
     <string name="plugin_test_btn">Probar</string>
     <string name="plugin_test_results">Resultados de la prueba (%1$d enlaces)</string>
@@ -1112,12 +1297,214 @@
     <string name="cd_expand_sidebar">Expandir barra lateral</string>
 
     <string name="update_checking">Buscando actualizaciones…</string>
-    <string name="update_download_complete">Descarga completada. Listo para instalar.</string>
+    <string name="update_download_complete">Descarga completa. Listo para instalar.</string>
     <string name="update_up_to_date">El sistema está actualizado. Últimos cambios:</string>
     <string name="update_close">Cerrar</string>
-    <string name="update_open_settings">Abrir Ajustes</string>
+    <string name="update_open_settings">Abrir configuración</string>
     <string name="update_install">Instalar</string>
     <string name="update_ignore">Ignorar</string>
-    <string name="watchlist_added">Añadido a la lista para ver</string>
-    <string name="watchlist_removed">Eliminado de la lista para ver</string>
+    <string name="watchlist_added">Añadido a la lista de seguimiento</string>
+    <string name="watchlist_removed">Eliminado de la lista de seguimiento</string>
+
+    <!-- Profile PIN errors -->
+    <string name="profile_pin_save_error">No se pudo guardar el PIN. Inténtalo de nuevo.</string>
+    <string name="profile_pin_locked">El perfil está bloqueado. Inténtalo de nuevo en %1$ds.</string>
+    <string name="profile_pin_invalid">PIN inválido. Inténtalo de nuevo.</string>
+    <string name="profile_pin_verify_error">No se pudo verificar el PIN. Inténtalo de nuevo.</string>
+    <string name="profile_pin_incorrect">El PIN actual es incorrecto.</string>
+
+    <!-- Account Screen -->
+    <string name="account_signin_create_title">Iniciar sesión / Crear cuenta</string>
+    <string name="account_signin_create_desc">Usa correo y contraseña para crear o iniciar sesión en tu cuenta.</string>
+    <string name="account_generate_sync_desc">Crea un código en este dispositivo para que otros dispositivos puedan vincularse.</string>
+    <string name="account_enter_sync_desc">Vincula este dispositivo a otro usando un código de sincronización.</string>
+    <string name="account_signed_in_as">Sesión iniciada como</string>
+    <string name="account_generate_sync_signed_in_desc">Crea un código para que otros dispositivos se sincronicen con esta cuenta.</string>
+    <string name="account_unknown_device">Dispositivo desconocido</string>
+
+    <!-- Sync screens -->
+    <string name="sync_claim_linking">Vinculando…</string>
+    <string name="sync_generate_generating">Generando…</string>
+    <string name="sync_generate_code_btn">Generar código</string>
+
+    <!-- Search -->
+    <string name="search_no_results_title">Sin resultados</string>
+    <string name="search_no_results_subtitle">Prueba con otras palabras clave</string>
+    <string name="discover_disabled_title">Discover está desactivado</string>
+    <string name="discover_disabled_subtitle">Activa Discover en la configuración de búsqueda</string>
+
+    <!-- Library -->
+    <string name="library_list_create_dialog_title">Crear lista</string>
+    <string name="library_list_edit_dialog_title">Editar lista</string>
+    <string name="library_sync_btn">Sincronizar</string>
+    <string name="library_syncing_btn">Sincronizando…</string>
+
+    <!-- Error messages (shared) -->
+    <string name="error_network_required">Conéctate a Wi-Fi o Ethernet para usar esta función</string>
+    <string name="error_server_ports_unavailable">No se pudo iniciar el servidor. Todos los puertos están en uso.</string>
+
+    <!-- Plugin errors -->
+    <string name="plugin_error_invalid_url">Introduce una URL válida</string>
+    <string name="plugin_error_add_repo">Error al añadir el repositorio: %1$s</string>
+    <string name="plugin_error_refresh">Error al actualizar: %1$s</string>
+    <string name="plugin_error_test">Error en la prueba: %1$s</string>
+    <string name="plugin_test_no_results">No se encontraron resultados</string>
+    <string name="plugin_test_found_streams">Se encontraron %1$d streams</string>
+
+    <!-- Trakt errors -->
+    <string name="trakt_error_code_expired">El código del dispositivo ha expirado. Inténtalo de nuevo.</string>
+    <string name="trakt_error_code_used">El código del dispositivo ya fue usado. Inténtalo de nuevo.</string>
+    <string name="trakt_error_denied">Autorización denegada en Trakt.</string>
+
+    <!-- Account errors -->
+    <string name="account_error_signin_required">Primero debes iniciar sesión con una cuenta.</string>
+
+    <!-- Search errors -->
+    <string name="search_error_no_catalogs">No se encontraron catálogos de búsqueda en los addons instalados</string>
+
+    <!-- Home errors -->
+    <string name="home_error_no_addons">No hay addons instalados</string>
+    <string name="home_error_no_catalog_addons">No hay addons de catálogo instalados</string>
+
+    <!-- Player errors -->
+    <string name="player_error_no_stream_url">No se proporcionó una URL de reproducción</string>
+
+    <!-- Playback subtitle settings -->
+    <string name="sub_mode_overlay_canvas_sub">Soporte HDR con renderizado en canvas. Puede bloquear el hilo de la interfaz.</string>
+    <string name="subtitle_style_weight">Grosor</string>
+
+    <!-- Plugin screen -->
+    <string name="plugin_version">Versión %1$s</string>
+
+    <!-- Stream screen -->
+    <string name="stream_episode_label">T%1$d E%2$d</string>
+
+    <!-- Episode ratings -->
+    <string name="ratings_season_label">T%1$d</string>
+    <string name="ratings_episode_label">E%1$d</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_play">Reproducir</string>
+    <string name="cd_pause">Pausar</string>
+    <string name="cd_subtitles">Subtítulos</string>
+    <string name="cd_audio_tracks">Pistas de audio</string>
+    <string name="cd_sources">Fuentes</string>
+    <string name="cd_switch_player_engine">Cambiar motor de reproducción</string>
+    <string name="cd_episodes">Episodios</string>
+    <string name="cd_playback_speed">Velocidad de reproducción</string>
+    <string name="cd_aspect_ratio">Relación de aspecto</string>
+    <string name="cd_open_external_player">Abrir en reproductor externo</string>
+    <string name="cd_stream_info">Información del stream</string>
+    <string name="cd_more_actions">Más acciones</string>
+    <string name="cd_close_more_actions">Cerrar más acciones</string>
+    <string name="cd_back">Volver</string>
+    <string name="cd_next_episode_thumbnail">Miniatura del siguiente episodio</string>
+    <string name="cd_current">Actual</string>
+    <string name="cd_loading_backdrop">Cargando fondo</string>
+    <string name="cd_loading_logo">Cargando logo</string>
+    <string name="cd_move_up">Mover arriba</string>
+    <string name="cd_move_down">Mover abajo</string>
+    <string name="cd_edit">Editar</string>
+    <string name="cd_delete">Eliminar</string>
+    <string name="cd_qr_code">Código QR</string>
+    <string name="cd_add">Agregar</string>
+    <string name="cd_refresh">Actualizar</string>
+    <string name="cd_remove">Eliminar</string>
+    <string name="cd_preview">Vista previa</string>
+    <string name="cd_test">Probar</string>
+    <string name="cd_unlink">Desvincular</string>
+    <string name="cd_nuvio_logo">NuvioTV</string>
+    <string name="cd_trakt_logo">Logo de Trakt</string>
+    <string name="cd_trakt_qr">QR de activación de Trakt</string>
+    <string name="cd_imdb">IMDb</string>
+    <string name="cd_open_discover">Abrir Discover</string>
+    <string name="cd_voice_search">Búsqueda por voz</string>
+    <string name="cd_donation_qr">Código QR de donación</string>
+    <string name="cd_contributor_qr">Código QR de apoyo al desarrollador</string>
+    <string name="cd_expand">Expandir %1$s</string>
+    <string name="cd_collapse">Contraer %1$s</string>
+    <string name="cd_qr_login">Código QR de inicio de sesión</string>
+    <string name="cd_nuvio">Nuvio</string>
+
+    <!-- Debug -->
+    <string name="debug_signin_success">Inicio de sesión exitoso</string>
+    <string name="debug_generate_description">Elemento generado para depuración %1$s #%2$d</string>
+    <string name="debug_generate_result_failed">Error: %1$s</string>
+
+    <!-- Collection Management -->
+    <string name="collections_header">Colecciones</string>
+    <string name="collections_empty">No hay colecciones aún. Crea una para organizar tus catálogos.</string>
+    <string name="collections_new">Nueva colección</string>
+    <string name="collections_import">Importar</string>
+    <string name="collections_export_file">Exportar archivo</string>
+    <string name="collections_saved_downloads">Guardado en Descargas</string>
+    <string name="collections_export_failed">Error al exportar</string>
+    <string name="collections_import_header">Importar colecciones</string>
+    <string name="collections_import_description">Importa colecciones desde JSON. Los catálogos de addons no instalados mostrarán una advertencia.</string>
+    <string name="collections_cancel">Cancelar</string>
+    <string name="collections_mode_paste">Pegar JSON</string>
+    <string name="collections_mode_file">Desde archivo</string>
+    <string name="collections_mode_url">Desde URL</string>
+    <string name="collections_paste_clipboard">Pegar desde el portapapeles</string>
+    <string name="collections_validate">Validar</string>
+    <string name="collections_paste_hint">Pega aquí el JSON de colecciones…</string>
+    <string name="collections_file_description">Lee nuvio-collections.json desde la carpeta Descargas.</string>
+    <string name="collections_load_file">Cargar archivo</string>
+    <string name="collections_file_loaded">Archivo cargado (%1$d caracteres)</string>
+    <string name="collections_fetch_url">Obtener URL</string>
+    <string name="collections_fetching">Cargando…</string>
+    <string name="collections_valid_json">JSON válido</string>
+    <string name="collections_valid_summary">%1$d colección(es), %2$d carpeta(s)</string>
+    <string name="collections_confirm_import">Confirmar importación</string>
+    <string name="collections_folder_count">%1$d carpeta(s)</string>
+
+    <!-- Collection Editor -->
+    <string name="collections_editor_row_title">Título de fila</string>
+    <string name="collections_editor_save">Guardar</string>
+    <string name="collections_editor_backdrop">Imagen de fondo</string>
+    <string name="collections_editor_pin_above">Fijar arriba</string>
+    <string name="collections_editor_pin_above_desc">Muestra esta colección sobre los catálogos principales. Varias colecciones siguen el orden de creación.</string>
+    <string name="collections_editor_focus_glow">Brillo de enfoque</string>
+    <string name="collections_editor_focus_glow_desc">Usa el efecto de brillo nativo del TV en las tarjetas</string>
+    <string name="collections_editor_view_mode">Modo de vista</string>
+    <string name="collections_editor_show_all_tab">Mostrar "Todo"</string>
+    <string name="collections_editor_show_all_tab_desc">Combina todos los catálogos en una sola pestaña</string>
+    <string name="collections_editor_folders">Carpetas</string>
+    <string name="collections_editor_add_folder">Agregar carpeta</string>
+    <string name="collections_editor_edit_folder">Editar carpeta</string>
+    <string name="collections_editor_folder_title">Título de carpeta</string>
+    <string name="collections_editor_cover">Portada</string>
+    <string name="collections_editor_cover_none">Ninguna</string>
+    <string name="collections_editor_cover_emoji">Emoji</string>
+    <string name="collections_editor_cover_image_url">URL de imagen</string>
+    <string name="collections_editor_focus_gif">GIF de enfoque</string>
+    <string name="collections_editor_play_gif">Reproducir GIF al enfocar</string>
+    <string name="collections_editor_tile_shape">Forma de tarjeta</string>
+    <string name="collections_editor_hide_title">Ocultar título</string>
+    <string name="collections_editor_hide_title_desc">Mostrar solo la imagen</string>
+    <string name="collections_editor_display">Visualización</string>
+    <string name="collections_editor_catalogs">Catálogos</string>
+    <string name="collections_editor_add_catalog">Agregar catálogo</string>
+    <string name="collections_editor_select_catalogs">Seleccionar catálogos</string>
+    <string name="collections_editor_done">Listo</string>
+    <string name="collections_editor_choose_emoji">Elegir emoji</string>
+    <string name="collections_editor_back">Volver</string>
+    <string name="collections_editor_edit_collection">Editar colección</string>
+    <string name="collections_editor_catalog_count">%1$d catálogo(s)</string>
+    <string name="collections_editor_view_mode_tabs">Pestañas</string>
+    <string name="collections_editor_view_mode_rows">Filas</string>
+    <string name="collections_editor_view_mode_follow">Seguir diseño principal</string>
+    <string name="collections_editor_shape_poster">Poster</string>
+    <string name="collections_editor_shape_wide">Horizontal</string>
+    <string name="collections_editor_shape_square">Cuadrado</string>
+    <string name="collections_editor_addon_missing">Addon no instalado: %1$s</string>
+    <string name="collections_editor_placeholder_name">Nombre de la colección</string>
+    <string name="collections_editor_placeholder_backdrop">URL de imagen de fondo (opcional)</string>
+    <string name="collections_editor_placeholder_folder">Nombre de carpeta</string>
+    <string name="collections_editor_placeholder_gif">URL de GIF animado (solo al enfocar)</string>
+    <string name="collections_card_title">Colecciones</string>
+    <string name="collections_card_subtitle">Agrupa catálogos en carpetas en tu pantalla principal</string>
+    <string name="collections_tab_all">Todo</string>
+    <string name="collections_tab_combined">Combinado</string>
+ 
 </resources>


### PR DESCRIPTION
## Summary
Adds Spanish (Latin America) localization strings (values-es-r419)

## PR type
- Translation update

## Why
To provide Spanish (Latin America) localization for better accessibility and usability for Spanish-speaking users.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Verified translations manually in the app to ensure correct display and no missing strings.

## Screenshots / Video (UI changes only)
None

## Breaking changes
No breaking changes.

## Linked issues
No linked issues.
