### PR TITLE
Feat: add pause overlay description + cast toggles

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -175,6 +175,8 @@ data class PlayerSettings(
     val loadingOverlayEnabled: Boolean = true,
     val showPlayerLoadingStatus: Boolean = true,
     val pauseOverlayEnabled: Boolean = true,
+    val pauseOverlayDescriptionEnabled: Boolean = true,
+    val pauseOverlayCastEnabled: Boolean = true,
     val osdClockEnabled: Boolean = true,
     val skipIntroEnabled: Boolean = true,
     // Dolby Vision Profile 7 → HEVC fallback (requires forked ExoPlayer)
@@ -305,6 +307,8 @@ class PlayerSettingsDataStore @Inject constructor(
     private val loadingOverlayEnabledKey = booleanPreferencesKey("loading_overlay_enabled")
     private val showPlayerLoadingStatusKey = booleanPreferencesKey("show_player_loading_status")
     private val pauseOverlayEnabledKey = booleanPreferencesKey("pause_overlay_enabled")
+    private val pauseOverlayDescriptionEnabledKey = booleanPreferencesKey("pause_overlay_description_enabled")
+    private val pauseOverlayCastEnabledKey = booleanPreferencesKey("pause_overlay_cast_enabled")
     private val osdClockEnabledKey = booleanPreferencesKey("osd_clock_enabled")
     private val skipIntroEnabledKey = booleanPreferencesKey("skip_intro_enabled")
     private val mapDV7ToHevcKey = booleanPreferencesKey("map_dv7_to_hevc")
@@ -455,6 +459,8 @@ class PlayerSettingsDataStore @Inject constructor(
                 loadingOverlayEnabled = prefs[loadingOverlayEnabledKey] ?: true,
                 showPlayerLoadingStatus = prefs[showPlayerLoadingStatusKey] ?: true,
                 pauseOverlayEnabled = prefs[pauseOverlayEnabledKey] ?: true,
+                pauseOverlayDescriptionEnabled = prefs[pauseOverlayDescriptionEnabledKey] ?: true,
+                pauseOverlayCastEnabled = prefs[pauseOverlayCastEnabledKey] ?: true,
                 osdClockEnabled = prefs[osdClockEnabledKey] ?: true,
                 skipIntroEnabled = prefs[skipIntroEnabledKey] ?: true,
                 mapDV7ToHevc = prefs[mapDV7ToHevcKey] ?: false,
@@ -635,6 +641,18 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setPauseOverlayEnabled(enabled: Boolean) {
         store().edit { prefs ->
             prefs[pauseOverlayEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setPauseOverlayDescriptionEnabled(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[pauseOverlayDescriptionEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setPauseOverlayCastEnabled(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[pauseOverlayCastEnabledKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
@@ -61,6 +61,8 @@ fun PauseOverlay(
     year: String?,
     type: String?,
     description: String?,
+    showDescription: Boolean,
+    showCast: Boolean,
     cast: List<MetaCastMember>,
     modifier: Modifier = Modifier
 ) {
@@ -101,6 +103,8 @@ fun PauseOverlay(
                     year = year,
                     type = type,
                     description = description,
+                    showDescription = showDescription,
+                    showCast = showCast,
                     cast = cast,
                     onCastSelected = { selectedCastMember = it }
                 )
@@ -143,6 +147,8 @@ private fun PauseMetadataView(
     year: String?,
     type: String?,
     description: String?,
+    showDescription: Boolean,
+    showCast: Boolean,
     cast: List<MetaCastMember>,
     onCastSelected: (MetaCastMember) -> Unit
 ) {
@@ -219,7 +225,7 @@ private fun PauseMetadataView(
                 )
             }
 
-            if (!description.isNullOrBlank()) {
+            if (showDescription && !description.isNullOrBlank()) {
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodyLarge,
@@ -230,7 +236,7 @@ private fun PauseMetadataView(
                 )
             }
 
-            if (cast.isNotEmpty()) {
+            if (showCast && cast.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(20.dp))
 
                 Text(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -214,6 +214,8 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     loadingOverlayEnabled = settings.loadingOverlayEnabled,
                     showLoadingOverlay = shouldShowOverlay,
                     pauseOverlayEnabled = settings.pauseOverlayEnabled,
+                    pauseOverlayDescriptionEnabled = settings.pauseOverlayDescriptionEnabled,
+                    pauseOverlayCastEnabled = settings.pauseOverlayCastEnabled,
                     osdClockEnabled = settings.osdClockEnabled,
                     internalPlayerEngine = resolvedInternalPlayerEngine,
                     frameRateMatchingMode = settings.frameRateMatchingMode,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -680,6 +680,8 @@ fun PlayerScreen(
             year = uiState.releaseYear,
             type = uiState.contentType,
             description = uiState.description,
+            showDescription = uiState.pauseOverlayDescriptionEnabled,
+            showCast = uiState.pauseOverlayCastEnabled,
             cast = uiState.castMembers,
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -40,6 +40,8 @@ data class PlayerUiState(
     val loadingMessage: String? = null,
     val loadingProgress: Float? = null,
     val pauseOverlayEnabled: Boolean = true,
+    val pauseOverlayDescriptionEnabled: Boolean = true,
+    val pauseOverlayCastEnabled: Boolean = true,
     val osdClockEnabled: Boolean = true,
     val showPauseOverlay: Boolean = false,
     val audioTracks: List<TrackInfo> = emptyList(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -247,6 +247,8 @@ fun PlaybackSettingsContent(
                 onSetShowPlayerLoadingStatus = { enabled -> coroutineScope.launch { viewModel.setShowPlayerLoadingStatus(enabled) } },
                 onSetLoadingOverlayEnabled = { enabled -> coroutineScope.launch { viewModel.setLoadingOverlayEnabled(enabled) } },
                 onSetPauseOverlayEnabled = { enabled -> coroutineScope.launch { viewModel.setPauseOverlayEnabled(enabled) } },
+                onSetPauseOverlayDescriptionEnabled = { enabled -> coroutineScope.launch { viewModel.setPauseOverlayDescriptionEnabled(enabled) } },
+                onSetPauseOverlayCastEnabled = { enabled -> coroutineScope.launch { viewModel.setPauseOverlayCastEnabled(enabled) } },
                 onSetOsdClockEnabled = { enabled -> coroutineScope.launch { viewModel.setOsdClockEnabled(enabled) } },
                 onSetSkipIntroEnabled = { enabled -> coroutineScope.launch { viewModel.setSkipIntroEnabled(enabled) } },
                 onSetFrameRateMatchingMode = { mode -> coroutineScope.launch { viewModel.setFrameRateMatchingMode(mode) } },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -27,7 +27,9 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PauseCircle
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Subject
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.runtime.Composable
@@ -124,6 +126,8 @@ internal fun PlaybackSettingsSections(
     onSetShowPlayerLoadingStatus: (Boolean) -> Unit,
     onSetLoadingOverlayEnabled: (Boolean) -> Unit,
     onSetPauseOverlayEnabled: (Boolean) -> Unit,
+    onSetPauseOverlayDescriptionEnabled: (Boolean) -> Unit,
+    onSetPauseOverlayCastEnabled: (Boolean) -> Unit,
     onSetOsdClockEnabled: (Boolean) -> Unit,
     onSetSkipIntroEnabled: (Boolean) -> Unit,
     onSetFrameRateMatchingMode: (FrameRateMatchingMode) -> Unit,
@@ -258,6 +262,30 @@ internal fun PlaybackSettingsSections(
                     onCheckedChange = onSetPauseOverlayEnabled,
                     onFocused = { focusedSection = PlaybackSection.GENERAL },
                     enabled = !generalUi.isExternalPlayer
+                )
+            }
+
+            item(key = "general_pause_overlay_description") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.Subject,
+                    title = stringResource(R.string.playback_pause_overlay_description),
+                    subtitle = stringResource(R.string.playback_pause_overlay_description_sub),
+                    isChecked = playerSettings.pauseOverlayDescriptionEnabled,
+                    onCheckedChange = onSetPauseOverlayDescriptionEnabled,
+                    onFocused = { focusedSection = PlaybackSection.GENERAL },
+                    enabled = playerSettings.pauseOverlayEnabled && !generalUi.isExternalPlayer
+                )
+            }
+
+            item(key = "general_pause_overlay_cast") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.People,
+                    title = stringResource(R.string.playback_pause_overlay_cast),
+                    subtitle = stringResource(R.string.playback_pause_overlay_cast_sub),
+                    isChecked = playerSettings.pauseOverlayCastEnabled,
+                    onCheckedChange = onSetPauseOverlayCastEnabled,
+                    onFocused = { focusedSection = PlaybackSection.GENERAL },
+                    enabled = playerSettings.pauseOverlayEnabled && !generalUi.isExternalPlayer
                 )
             }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -116,6 +116,14 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setPauseOverlayEnabled(enabled)
     }
 
+    suspend fun setPauseOverlayDescriptionEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setPauseOverlayDescriptionEnabled(enabled)
+    }
+
+    suspend fun setPauseOverlayCastEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setPauseOverlayCastEnabled(enabled)
+    }
+
     suspend fun setOsdClockEnabled(enabled: Boolean) {
         playerSettingsDataStore.setOsdClockEnabled(enabled)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,10 @@
     <string name="playback_loading_overlay_sub">Show loading screen until first video frame appears.</string>
     <string name="playback_pause_overlay">Pause Overlay</string>
     <string name="playback_pause_overlay_sub">Show details overlay after 5 seconds while paused.</string>
+    <string name="playback_pause_overlay_description">Description</string>
+    <string name="playback_pause_overlay_description_sub">Show episode description on pause overlay.</string>
+    <string name="playback_pause_overlay_cast">Cast</string>
+    <string name="playback_pause_overlay_cast_sub">Show cast list on pause overlay.</string>
     <string name="playback_show_clock_sub">Show current time and end time while controls are visible.</string>
     <string name="playback_osd_clock">OSD Clock</string>
     <string name="playback_skip_intro">Skip Intro</string>


### PR DESCRIPTION
## Summary

Added settings options to toggle the episode description and the cast list section individually on the player pause overlay UI. Included the underlying data store logic, the settings screen toggles under "Pause Overlay", and UI conditionals for rendering the content.

## PR type

- Small maintenance improvement

## Why

Sometimes the episode description has spoilers, as does the cast list, so I quite like not seeing this and hitting play. When pausing, this shows on screen.
https://github.com/NuvioMedia/NuvioTV/issues/1325

## Policy check


 - [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the issue where it was approved.


## Testing

This follows the code setup at the moment, in theory should work, however I have not been able to test myself as of yet.

## Screenshots / Video (UI changes only)

None as not tested, but the code setup and changes I've made there leads me to believe this should be working fine.

## Breaking changes

There are no breaking changes in this pull request based on the code changes I've made.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1325
