### PR TITLE
Fix CW stability, proxy headers, and stream source OSD

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -415,7 +415,6 @@ class TraktProgressService @Inject constructor(
             val mergedByKey = linkedMapOf<String, WatchProgress>()
             remote.forEach { mergedByKey[progressKey(it)] = it }
             validOptimistic.forEach { (key, value) -> mergedByKey[key] = value }
-            val hiddenCount = mergedByKey.values.count { isShowHiddenFromProgress(it.contentId) }
             val result = mergedByKey.values
                 .filter { !isShowHiddenFromProgress(it.contentId) }
                 .map { enrichWithMetadata(it, metadata) }
@@ -849,8 +848,9 @@ class TraktProgressService @Inject constructor(
 
         val force = System.currentTimeMillis() < forceRefreshUntilMs
 
-        if (!force && !hasActivityChanged()) return
-
+        if (!force && !hasActivityChanged()) {
+            return
+        }
         // Load dropped shows first so all downstream flows emit pre-filtered data.
         ensureHiddenProgressShows(force = force)
 
@@ -1440,32 +1440,53 @@ class TraktProgressService @Inject constructor(
             Triple(historyDeferred.await(), moviesDeferred.await(), episodesDeferred.await())
         }
 
+        inProgressEpisodes.take(5).forEach { p ->
+        }
+        recentCompletedEpisodes.take(5).forEach { p ->
+        }
+
         val mergedByKey = linkedMapOf<String, WatchProgress>()
 
-        // In-progress items first, then completed episodes override them.
-        (inProgressMovies + inProgressEpisodes)
-            .sortedByDescending { it.lastWatched }
-            .forEach { progress ->
-                mergedByKey[progressKey(progress)] = progress
-            }
-
+        // Completed episodes first (from history).
         recentCompletedEpisodes
             .sortedByDescending { it.lastWatched }
             .forEach { progress ->
                 mergedByKey[progressKey(progress)] = progress
             }
 
+        // In-progress items override completed entries for the same episode.
+        // This ensures that a partially-watched episode shows as "Resume"
+        // rather than "Next Up" even if it also appears in watched history
+        // (e.g. user rewatching, or scrobble/stop saved playback progress
+        // after the history entry was created).
+        (inProgressMovies + inProgressEpisodes)
+            .sortedByDescending { it.lastWatched }
+            .forEach { progress ->
+                val key = progressKey(progress)
+                val existing = mergedByKey[key]
+                if (existing == null || progress.isInProgress()) {
+                    mergedByKey[key] = progress
+                }
+            }
+
         val completedEpisodeKeys = recentCompletedEpisodes
             .filter { it.season != null && it.episode != null }
             .map { "${it.contentId}_s${it.season}e${it.episode}" }
             .toSet()
+        // Remove playback entries that are completed (not in-progress) and
+        // already covered by a history entry — avoids duplicates.
         mergedByKey.entries.removeAll { (key, progress) ->
             progress.source == WatchProgress.SOURCE_TRAKT_PLAYBACK &&
+                !progress.isInProgress() &&
                 progress.season != null && progress.episode != null &&
                 "${progress.contentId}_s${progress.season}e${progress.episode}" in completedEpisodeKeys
         }
 
         val finalSnapshot = mergedByKey.values.sortedByDescending { it.lastWatched }
+        finalSnapshot.take(8).forEach { p ->
+            val tag = if (p.source == WatchProgress.SOURCE_TRAKT_PLAYBACK) "PB" else "HI"
+            val pct = p.progressPercentage.times(100).toInt()
+        }
         return finalSnapshot
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -588,8 +588,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
     override suspend fun saveProgressBatch(progressList: List<WatchProgress>, syncRemote: Boolean) {
         if (progressList.isEmpty()) return
         if (shouldUseTraktProgress()) {
-            progressList.forEach { progress ->
-                traktProgressService.applyOptimisticProgress(progress)
+            if (syncRemote) {
+                progressList.forEach { progress ->
+                    traktProgressService.applyOptimisticProgress(progress)
+                }
             }
             watchProgressPreferences.saveProgressBatch(progressList)
             return

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -104,9 +104,9 @@ sealed class Screen(val route: String) {
             val encodedTitle = encode(title)
             val encodedStreamName = streamName?.let { encode(it) } ?: ""
             val encodedYear = year?.let { encode(it) } ?: ""
-            val encodedHeaders = headers?.entries?.joinToString("&") { (k, v) ->
-                "${encode(k)}=${encode(v)}"
-            }?.let { encode(it) } ?: ""
+            val encodedHeaders = headers?.let {
+                encode(org.json.JSONObject(it).toString())
+            } ?: ""
             val encodedContentId = contentId?.let { encode(it) } ?: ""
             val encodedContentType = contentType?.let { encode(it) } ?: ""
             val encodedContentName = contentName?.let { encode(it) } ?: ""

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -159,6 +159,9 @@ class HomeViewModel @Inject constructor(
     internal val cwNextUpNegativeCacheTimestamps = Collections.synchronizedMap(mutableMapOf<String, Long>())
     internal val discoveredOlderNextUpItems = Collections.synchronizedList(mutableListOf<ContinueWatchingItem.NextUp>())
     internal val cwLastProcessedNextUpContentIds = Collections.synchronizedSet(mutableSetOf<String>())
+    internal val cwEnrichedNextUpOverlay = Collections.synchronizedMap(mutableMapOf<String, NextUpInfo>())
+    /** In-memory cache of enriched InProgress items per contentId+episode key. */
+    internal val cwEnrichedInProgressOverlay = Collections.synchronizedMap(mutableMapOf<String, ContinueWatchingItem.InProgress>())
     internal val fullyWatchedSeriesIds get() = watchedSeriesStateHolder
     internal var tmdbEnrichFocusJob: Job? = null
     internal var pendingTmdbEnrichItemId: String? = null
@@ -215,6 +218,8 @@ class HomeViewModel @Inject constructor(
                     cwNextUpNegativeCacheTimestamps.clear()
                     discoveredOlderNextUpItems.clear()
                     cwLastProcessedNextUpContentIds.clear()
+                    cwEnrichedNextUpOverlay.clear()
+                    cwEnrichedInProgressOverlay.clear()
                     _uiState.update { it.copy(continueWatchingItems = emptyList()) }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -205,6 +205,16 @@ class HomeViewModel @Inject constructor(
             profileManager.activeProfileId.collect { newId ->
                 if (newId != previousProfileId) {
                     previousProfileId = newId
+                    // Clear all in-memory CW caches so data from the previous
+                    // profile doesn't leak into the new one.
+                    cwMetaCache.clear()
+                    cwMetaNegativeCacheTimestamps.clear()
+                    cwBadgeEpisodeCache.clear()
+                    cwTmdbIdCache.clear()
+                    cwNextUpResolutionCache.clear()
+                    cwNextUpNegativeCacheTimestamps.clear()
+                    discoveredOlderNextUpItems.clear()
+                    cwLastProcessedNextUpContentIds.clear()
                     _uiState.update { it.copy(continueWatchingItems = emptyList()) }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -423,6 +423,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             val partialCount = partialNextUpItems.size
                             if (partialCount > publishedPartialNextUpCount.get()) {
                                 publishedPartialNextUpCount.set(partialCount)
+                                val freshIds = partialNextUpItems.map { it.info.contentId }.toSet()
                                 val cachedPartialNextUp = partialNextUpItems.map { nextUp ->
                                     val cached = cachedEnrichmentFromNextUp[nextUp.info.contentId]
                                     if (cached != null) {
@@ -436,9 +437,14 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                         ))
                                     } else nextUp
                                 }
+                                // Keep cached next-up items for series not yet processed
+                                // by the fresh pipeline so they don't disappear mid-build.
+                                val retainedCached = cachedNextUpItems.filter {
+                                    it.info.contentId !in freshIds
+                                }
                                 val partialItems = mergeContinueWatchingItems(
                                     inProgressItems = inProgressOnly,
-                                    nextUpItems = cachedPartialNextUp
+                                    nextUpItems = cachedPartialNextUp + retainedCached
                                 )
                                 _uiState.update { state ->
                                     if (state.continueWatchingItems == partialItems) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -282,6 +282,41 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 // Build enrichment lookup from cached snapshots (replaces old CwEnrichmentEntry)
                 val cachedEnrichmentFromInProgress = cachedInProgress.associateBy { it.contentId }
                 val cachedEnrichmentFromNextUp = cachedNextUp.associateBy { it.contentId }
+
+                // Seed the in-memory enrichment overlay from disk cache on first cycle
+                // so that fresh builds use enriched titles/thumbnails from the start.
+                if (cwEnrichedNextUpOverlay.isEmpty() && cachedNextUp.isNotEmpty()) {
+                    cachedNextUp.forEach { cached ->
+                        cwEnrichedNextUpOverlay[cached.contentId] = NextUpInfo(
+                            contentId = cached.contentId,
+                            contentType = cached.contentType,
+                            name = cached.name,
+                            poster = cached.poster,
+                            backdrop = cached.backdrop,
+                            logo = cached.logo,
+                            videoId = cached.videoId,
+                            season = cached.season,
+                            episode = cached.episode,
+                            episodeTitle = cached.episodeTitle,
+                            episodeDescription = cached.episodeDescription,
+                            thumbnail = cached.thumbnail,
+                            released = cached.released,
+                            hasAired = cached.hasAired,
+                            airDateLabel = cached.airDateLabel,
+                            lastWatched = cached.lastWatched,
+                            imdbRating = cached.imdbRating,
+                            genres = cached.genres,
+                            releaseInfo = cached.releaseInfo,
+                            sortTimestamp = cached.sortTimestamp,
+                            releaseTimestamp = cached.releaseTimestamp,
+                            isReleaseAlert = cached.isReleaseAlert,
+                            isNewSeasonRelease = cached.isNewSeasonRelease,
+                            seedSeason = cached.seedSeason,
+                            seedEpisode = cached.seedEpisode,
+                            contentLanguage = cached.contentLanguage
+                        )
+                    }
+                }
                 val inProgressOnly = buildList {
                     val liveInProgress = deduplicateInProgress(
                         recentItems.filter { shouldTreatAsInProgressForContinueWatching(it) }
@@ -383,12 +418,13 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     )
                 }
                 if (inProgressOnly.isNotEmpty() || cachedNextUpItems.isNotEmpty()) {
-                    val initialItems = mergeContinueWatchingItems(
-                        inProgressItems = inProgressOnly,
-                        nextUpItems = cachedNextUpItems
+                    val initialItems = applyContinueWatchingEnrichmentOverlay(
+                        mergeContinueWatchingItems(
+                            inProgressItems = inProgressOnly,
+                            nextUpItems = cachedNextUpItems
+                        )
                     )
-                    _uiState.update { state ->
-                        if (state.continueWatchingItems == initialItems) {
+                    _uiState.update { state ->                        if (state.continueWatchingItems == initialItems) {
                             state
                         } else {
                             state.copy(continueWatchingItems = initialItems)
@@ -442,9 +478,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 val retainedCached = cachedNextUpItems.filter {
                                     it.info.contentId !in freshIds
                                 }
-                                val partialItems = mergeContinueWatchingItems(
-                                    inProgressItems = inProgressOnly,
-                                    nextUpItems = cachedPartialNextUp + retainedCached
+                                val partialItems = applyContinueWatchingEnrichmentOverlay(
+                                    mergeContinueWatchingItems(
+                                        inProgressItems = inProgressOnly,
+                                        nextUpItems = cachedPartialNextUp + retainedCached
+                                    )
                                 )
                                 _uiState.update { state ->
                                     if (state.continueWatchingItems == partialItems) {
@@ -681,25 +719,27 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             !watchProgressRepository.isDroppedShow(it.info.contentId)
                     }
                 val allNextUpItems = nextUpItems + olderToInclude
-                val normalItems = mergeContinueWatchingItems(
-                    inProgressItems = inProgressOnly,
-                    nextUpItems = allNextUpItems.map { nextUp ->
-                        val cached = cachedEnrichmentFromNextUp[nextUp.info.contentId]
-                        if (cached != null) {
-                            nextUp.copy(info = nextUp.info.copy(
-                                thumbnail = cached.thumbnail ?: nextUp.info.thumbnail,
-                                backdrop = cached.backdrop ?: nextUp.info.backdrop,
-                                poster = cached.poster ?: nextUp.info.poster,
-                                logo = cached.logo ?: nextUp.info.logo,
-                                name = cached.name.takeIf { it.isNotBlank() } ?: nextUp.info.name,
-                                episodeDescription = cached.episodeDescription ?: nextUp.info.episodeDescription,
-                                imdbRating = cached.imdbRating ?: nextUp.info.imdbRating,
-                                genres = cached.genres.ifEmpty { nextUp.info.genres },
-                                releaseInfo = cached.releaseInfo ?: nextUp.info.releaseInfo,
-                                contentLanguage = cached.contentLanguage ?: nextUp.info.contentLanguage
-                            ))
-                        } else nextUp
-                    }
+                val normalItems = applyContinueWatchingEnrichmentOverlay(
+                    mergeContinueWatchingItems(
+                        inProgressItems = inProgressOnly,
+                        nextUpItems = allNextUpItems.map { nextUp ->
+                            val cached = cachedEnrichmentFromNextUp[nextUp.info.contentId]
+                            if (cached != null) {
+                                nextUp.copy(info = nextUp.info.copy(
+                                    thumbnail = cached.thumbnail ?: nextUp.info.thumbnail,
+                                    backdrop = cached.backdrop ?: nextUp.info.backdrop,
+                                    poster = cached.poster ?: nextUp.info.poster,
+                                    logo = cached.logo ?: nextUp.info.logo,
+                                    name = cached.name.takeIf { it.isNotBlank() } ?: nextUp.info.name,
+                                    episodeDescription = cached.episodeDescription ?: nextUp.info.episodeDescription,
+                                    imdbRating = cached.imdbRating ?: nextUp.info.imdbRating,
+                                    genres = cached.genres.ifEmpty { nextUp.info.genres },
+                                    releaseInfo = cached.releaseInfo ?: nextUp.info.releaseInfo,
+                                    contentLanguage = cached.contentLanguage ?: nextUp.info.contentLanguage
+                                ))
+                            } else nextUp
+                        }
+                    )
                 )
 
                 _uiState.update { state ->
@@ -1073,6 +1113,20 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
         .map { it.second }
 
     if (enrichedItems == finalItems) return@coroutineScope false
+
+    // Save enriched next-up info to in-memory overlay so the next CW cycle's
+    // cached/partial/normal emissions use enriched data from the start,
+    // preventing title/thumbnail flickering between addon and TMDB values.
+    enrichedItems.forEach { item ->
+        when (item) {
+            is ContinueWatchingItem.NextUp -> {
+                cwEnrichedNextUpOverlay[item.info.contentId] = item.info
+            }
+            is ContinueWatchingItem.InProgress -> {
+                cwEnrichedInProgressOverlay[item.progress.contentId] = item
+            }
+        }
+    }
 
     _uiState.update { state ->
         if (state.continueWatchingItems == enrichedItems) {
@@ -1844,6 +1898,72 @@ private fun NextUpInfo.toProgressSeed(): WatchProgress {
 
 private fun isSeriesTypeCW(type: String?): Boolean {
     return type.equals("series", ignoreCase = true) || type.equals("tv", ignoreCase = true)
+}
+
+/** Applies enriched overlay from the previous enrichment cycle to avoid
+ *  flickering between addon meta and TMDB-enriched values during fresh builds. */
+private fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
+    items: List<ContinueWatchingItem>
+): List<ContinueWatchingItem> {
+    if (cwEnrichedNextUpOverlay.isEmpty() && cwEnrichedInProgressOverlay.isEmpty()) return items
+    return items.map { item ->
+        when (item) {
+            is ContinueWatchingItem.NextUp -> {
+                val overlay = cwEnrichedNextUpOverlay[item.info.contentId] ?: return@map item
+                if (overlay.season != item.info.season || overlay.episode != item.info.episode) return@map item
+                item.copy(info = item.info.copy(
+                    name = overlay.name.takeIf { it.isNotBlank() } ?: item.info.name,
+                    episodeTitle = overlay.episodeTitle ?: item.info.episodeTitle,
+                    episodeDescription = overlay.episodeDescription ?: item.info.episodeDescription,
+                    thumbnail = overlay.thumbnail ?: item.info.thumbnail,
+                    poster = overlay.poster ?: item.info.poster,
+                    backdrop = overlay.backdrop ?: item.info.backdrop,
+                    logo = overlay.logo ?: item.info.logo,
+                    imdbRating = overlay.imdbRating ?: item.info.imdbRating,
+                    genres = overlay.genres.ifEmpty { item.info.genres },
+                    releaseInfo = overlay.releaseInfo ?: item.info.releaseInfo,
+                    isReleaseAlert = overlay.isReleaseAlert,
+                    isNewSeasonRelease = overlay.isNewSeasonRelease,
+                    releaseTimestamp = overlay.releaseTimestamp ?: item.info.releaseTimestamp,
+                    contentLanguage = overlay.contentLanguage ?: item.info.contentLanguage
+                ))
+            }
+            is ContinueWatchingItem.InProgress -> {
+                val overlay = cwEnrichedInProgressOverlay[item.progress.contentId] ?: return@map item
+                if (overlay.progress.season != item.progress.season || overlay.progress.episode != item.progress.episode) return@map item
+                item.copy(
+                    progress = item.progress.copy(
+                        name = overlay.progress.name.takeIf { it.isNotBlank() } ?: item.progress.name,
+                        poster = overlay.progress.poster ?: item.progress.poster,
+                        backdrop = overlay.progress.backdrop ?: item.progress.backdrop,
+                        logo = overlay.progress.logo ?: item.progress.logo,
+                        episodeTitle = overlay.progress.episodeTitle ?: item.progress.episodeTitle
+                    ),
+                    episodeThumbnail = overlay.episodeThumbnail ?: item.episodeThumbnail,
+                    episodeDescription = overlay.episodeDescription ?: item.episodeDescription,
+                    episodeImdbRating = overlay.episodeImdbRating ?: item.episodeImdbRating,
+                    genres = overlay.genres.ifEmpty { item.genres },
+                    releaseInfo = overlay.releaseInfo ?: item.releaseInfo,
+                    contentLanguage = overlay.contentLanguage ?: item.contentLanguage
+                )
+            }
+        }
+    }
+}
+
+    val summary = items.take(8).joinToString { item ->
+        when (item) {
+            is ContinueWatchingItem.InProgress -> {
+                val p = item.progress
+                "IP(${p.contentId.takeLast(6)} S${p.season}E${p.episode} ${p.progressPercentage.times(100).toInt()}%)"
+            }
+            is ContinueWatchingItem.NextUp -> {
+                val i = item.info
+                val tag = if (i.isReleaseAlert) "RA" else "NU"
+                "$tag(${i.contentId.takeLast(6)} S${i.season}E${i.episode} \"${i.episodeTitle?.take(20) ?: "?"}\")"
+            }
+        }
+    }
 }
 
 private fun HomeViewModel.publishBadgeUpdate(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -145,6 +145,20 @@ internal class PlayerMediaSourceFactory {
             if (headers.isNullOrEmpty()) return emptyMap()
 
             return try {
+                // Try JSON format first (new)
+                if (headers.trimStart().startsWith("{")) {
+                    val json = org.json.JSONObject(headers)
+                    val result = LinkedHashMap<String, String>()
+                    json.keys().forEach { key ->
+                        val value = json.optString(key, "")
+                        if (key.isNotEmpty() && value.isNotEmpty()) {
+                            result[key] = value
+                        }
+                    }
+                    return sanitizeHeaders(result)
+                }
+
+                // Legacy key=value&key=value format (backward compat)
                 val parsed = headers.split("&").associate { pair ->
                     val parts = pair.split("=", limit = 2)
                     if (parts.size == 2) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -28,6 +28,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     seekProgressSyncJob?.cancel()
     frameRateProbeJob?.cancel()
     hideStreamSourceIndicatorJob?.cancel()
+    hideStreamSourceIndicatorJob = null
+    _uiState.update { it.copy(showStreamSourceIndicator = false) }
     hidePlayerEngineSwitchInfoJob?.cancel()
     hideSubtitleDelayOverlayJob?.cancel()
     subtitleAutoSyncLoadJob?.cancel()


### PR DESCRIPTION
## Summary

- Fix proxy headers with cookies being corrupted during navigation - switched from `key=value&` serialization to JSON format so cookie values containing `&` or `=` are preserved correctly
- Keep cached next-up items in CW partial updates until they are processed by the fresh pipeline, preventing items from disappearing mid-build
- Fix CW infinite refresh loop caused by `saveProgressBatch(syncRemote=false)` still triggering Trakt optimistic progress and fast sync on every enrichment cycle
- Fix Trakt in-progress episodes being overwritten by history entries - prioritize playback (in-progress) over completed in the merge so paused episodes show "Resume" instead of "Next Up"
- Fix CW title/thumbnail flickering between addon and TMDB values by adding an in-memory enrichment overlay that persists enriched data across pipeline cycles
- Clear all in-memory CW caches on profile switch to prevent data leaking between profiles
- Fix stream source indicator OSD getting stuck permanently during back-to-back auto-play episodes — reset indicator state on player release

## PR type

- Bug fix

## Why

Multiple user-reported issues from Discord and Reddit: cookies not being passed to player, CW items flickering/looping, Trakt marking paused episodes as watched, stream source OSD stuck after auto-play.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified cookies in proxyHeaders are passed correctly to player
- Manual: verified CW no longer loops infinitely on Trakt accounts
- Manual: verified CW titles/thumbnails are stable after first enrichment cycle
- Manual: verified in-progress episodes show "Resume" instead of "Next Up"
- Manual: verified profile switch clears CW data completely
- Manual: verified stream source OSD disappears correctly during auto-play chain
- Build: confirmed compilation succeeds

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break

## Linked issues

Reported on Discord and Reddit
