### PR TITLE
fix: avoid concurrent home catalog mutations during enrichment

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -111,7 +111,9 @@ class HomeViewModel @Inject constructor(
     val enrichingItemId: StateFlow<String?> = _enrichingItemId.asStateFlow()
     internal fun setEnrichingItemId(id: String?) { _enrichingItemId.value = id }
 
+    internal val catalogStateLock = Any()
     internal val catalogsMap = linkedMapOf<String, CatalogRow>()
+    internal val catalogItemKeyIndex = mutableMapOf<String, MutableSet<String>>()
     internal val catalogOrder = mutableListOf<String>()
     internal var addonsCache: List<Addon> = emptyList()
     internal var collectionsCache: List<Collection> = emptyList()
@@ -456,7 +458,7 @@ class HomeViewModel @Inject constructor(
             val debounceMs = when {
                 // First render: use minimal debounce to show content ASAP while still
                 // batching near-simultaneous arrivals.
-                !hasRenderedFirstCatalog && catalogsMap.isNotEmpty() -> {
+                !hasRenderedFirstCatalog && hasAnyCatalogRows() -> {
                     hasRenderedFirstCatalog = true
                     50L
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -112,7 +112,7 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
     val signature = buildHomeCatalogLoadSignature(addons)
     if (!forceReload &&
         signature == activeCatalogLoadSignature &&
-        (catalogsLoadInProgress || catalogsMap.isNotEmpty())
+        (catalogsLoadInProgress || hasAnyCatalogRows())
     ) {
         return
     }
@@ -124,12 +124,13 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
     cancelInFlightCatalogLoads()
 
     _uiState.update { it.copy(isLoading = true, error = null, installedAddonsCount = addons.size) }
-    catalogOrder.clear()
-    catalogsMap.clear()
+    synchronized(catalogStateLock) {
+        catalogOrder.clear()
+    }
+    clearCatalogData()
     posterStatusReconcileJob?.cancel()
     reconcilePosterStatusObserversPipeline(emptyList())
     _fullCatalogRows.value = emptyList()
-    truncatedRowCache.clear()
     hasRenderedFirstCatalog = false
     trailerPreviewLoadingIds.clear()
     trailerPreviewNegativeCache.clear()
@@ -166,7 +167,7 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
         val heroCatalogSet = currentHeroCatalogKeys.toSet()
         val hasHeroSelections = heroCatalogSet.isNotEmpty()
 
-        if (catalogOrder.isEmpty() && !hasHeroSelections) {
+        if (isCatalogOrderEmpty() && !hasHeroSelections) {
             catalogsLoadInProgress = false
             _uiState.update { it.copy(isLoading = false, error = appContext.getString(R.string.home_error_no_catalog_addons)) }
             return
@@ -210,7 +211,7 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
             // No home catalogs and no hero catalogs to load —
             // but collections may still exist to render.
             catalogsLoadInProgress = false
-            if (catalogOrder.isNotEmpty()) {
+            if (hasCatalogOrderEntries()) {
                 scheduleUpdateCatalogRows()
             } else {
                 _uiState.update { it.copy(isLoading = false, error = appContext.getString(R.string.home_error_no_catalog_addons)) }
@@ -239,7 +240,7 @@ internal fun HomeViewModel.loadHeroCatalogsPipeline() {
     if (heroCatalogKeys.isEmpty() || addonsCache.isEmpty()) return
 
     val heroCatalogSet = heroCatalogKeys.toSet()
-    val alreadyLoadedKeys = catalogsMap.keys.toSet()
+    val alreadyLoadedKeys = snapshotCatalogKeys()
     val missingHeroKeys = heroCatalogSet - alreadyLoadedKeys
     if (missingHeroKeys.isEmpty()) {
         // All hero catalogs already loaded — just refresh presentation
@@ -302,7 +303,7 @@ internal fun HomeViewModel.loadCatalogPipeline(
                             type = catalog.apiType,
                             catalogId = catalog.id
                         )
-                        catalogsMap[key] = result.data
+                        replaceCatalogRow(key, result.data)
                         if (!hasCountedCompletion) {
                             pendingCatalogLoads = (pendingCatalogLoads - 1).coerceAtLeast(0)
                             hasCountedCompletion = true
@@ -342,12 +343,12 @@ internal fun HomeViewModel.loadCatalogPipeline(
 
 internal fun HomeViewModel.loadMoreCatalogItemsPipeline(catalogId: String, addonId: String, type: String) {
     val key = catalogKey(addonId = addonId, type = type, catalogId = catalogId)
-    val currentRow = catalogsMap[key] ?: return
+    val currentRow = readCatalogRow(key) ?: return
 
     if (currentRow.isLoading || !currentRow.hasMore) return
     if (key in _loadingCatalogs.value) return
 
-    catalogsMap[key] = currentRow.copy(isLoading = true)
+    updateCatalogRow(key) { it.copy(isLoading = true) }
     _loadingCatalogs.update { it + key }
 
     viewModelScope.launch {
@@ -367,20 +368,22 @@ internal fun HomeViewModel.loadMoreCatalogItemsPipeline(catalogId: String, addon
         ).collect { result ->
             when (result) {
                 is NetworkResult.Success -> {
-                    val existingIds = currentRow.items.asSequence()
-                        .map { "${it.apiType}:${it.id}" }
-                        .toHashSet()
-                    val newUniqueItems = result.data.items.filter { item ->
-                        "${item.apiType}:${item.id}" !in existingIds
+                    updateCatalogRow(key) { latestRow ->
+                        val existingIds = latestRow.items.asSequence()
+                            .map { "${it.apiType}:${it.id}" }
+                            .toHashSet()
+                        val newUniqueItems = result.data.items.filter { item ->
+                            "${item.apiType}:${item.id}" !in existingIds
+                        }
+                        val mergedItems = latestRow.items + newUniqueItems
+                        val hasMore = if (newUniqueItems.isEmpty()) false else result.data.hasMore
+                        result.data.copy(items = mergedItems, hasMore = hasMore)
                     }
-                    val mergedItems = currentRow.items + newUniqueItems
-                    val hasMore = if (newUniqueItems.isEmpty()) false else result.data.hasMore
-                    catalogsMap[key] = result.data.copy(items = mergedItems, hasMore = hasMore)
                     _loadingCatalogs.update { it - key }
                     scheduleUpdateCatalogRows()
                 }
                 is NetworkResult.Error -> {
-                    catalogsMap[key] = currentRow.copy(isLoading = false)
+                    updateCatalogRow(key) { it.copy(isLoading = false) }
                     _loadingCatalogs.update { it - key }
                     scheduleUpdateCatalogRows()
                 }
@@ -391,8 +394,7 @@ internal fun HomeViewModel.loadMoreCatalogItemsPipeline(catalogId: String, addon
 }
 
 internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
-    val orderedKeys = catalogOrder.toList()
-    val catalogSnapshot = catalogsMap.toMap()
+    val (orderedKeys, catalogSnapshot) = snapshotCatalogState()
     val collectionsSnapshot = collectionsCache.associateBy { "collection_${it.id}" }
     val heroCatalogKeys = currentHeroCatalogKeys
     val currentLayout = _uiState.value.homeLayout
@@ -502,20 +504,23 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
             val shouldKeepFullRowInModern = currentLayout == HomeLayout.MODERN && row.supportsSkip
             if (row.items.size > 25 && !shouldKeepFullRowInModern) {
                 val key = "${row.addonId}_${row.apiType}_${row.catalogId}"
-                val cachedEntry = truncatedRowCache[key]
+                val cachedEntry = getTruncatedRowCacheEntry(key)
                 if (cachedEntry != null && cachedEntry.sourceRow === row) {
                     cachedEntry.truncatedRow
                 } else {
                     val truncatedRow = row.copy(items = row.items.take(25))
-                    truncatedRowCache[key] = HomeViewModel.TruncatedRowCacheEntry(
-                        sourceRow = row,
-                        truncatedRow = truncatedRow
+                    putTruncatedRowCacheEntry(
+                        key,
+                        HomeViewModel.TruncatedRowCacheEntry(
+                            sourceRow = row,
+                            truncatedRow = truncatedRow
+                        )
                     )
                     truncatedRow
                 }
             } else {
                 val key = "${row.addonId}_${row.apiType}_${row.catalogId}"
-                truncatedRowCache.remove(key)
+                removeTruncatedRowCacheEntry(key)
                 row
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.home
 
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.MetaPreview
 import kotlinx.coroutines.Job
 
@@ -43,6 +44,128 @@ internal fun HomeViewModel.cancelInFlightCatalogLoads() {
     jobsToCancel.forEach { it.cancel() }
 }
 
+private fun HomeViewModel.reindexCatalogRow(
+    key: String,
+    previousRow: CatalogRow?,
+    updatedRow: CatalogRow?
+) {
+    previousRow?.items?.forEach { item ->
+        val keys = catalogItemKeyIndex[item.id] ?: return@forEach
+        keys.remove(key)
+        if (keys.isEmpty()) {
+            catalogItemKeyIndex.remove(item.id)
+        }
+    }
+
+    updatedRow?.items?.forEach { item ->
+        catalogItemKeyIndex.getOrPut(item.id) { LinkedHashSet() }.add(key)
+    }
+}
+
+internal fun HomeViewModel.hasAnyCatalogRows(): Boolean = synchronized(catalogStateLock) {
+    catalogsMap.isNotEmpty()
+}
+
+internal fun HomeViewModel.isCatalogOrderEmpty(): Boolean = synchronized(catalogStateLock) {
+    catalogOrder.isEmpty()
+}
+
+internal fun HomeViewModel.hasCatalogOrderEntries(): Boolean = synchronized(catalogStateLock) {
+    catalogOrder.isNotEmpty()
+}
+
+internal fun HomeViewModel.readCatalogRow(key: String): CatalogRow? = synchronized(catalogStateLock) {
+    catalogsMap[key]
+}
+
+internal fun HomeViewModel.replaceCatalogRow(key: String, row: CatalogRow) {
+    synchronized(catalogStateLock) {
+        val previousRow = catalogsMap.put(key, row)
+        reindexCatalogRow(key, previousRow, row)
+    }
+}
+
+internal inline fun HomeViewModel.updateCatalogRow(
+    key: String,
+    transform: (CatalogRow) -> CatalogRow
+): CatalogRow? {
+    return synchronized(catalogStateLock) {
+        val currentRow = catalogsMap[key] ?: return@synchronized null
+        val updatedRow = transform(currentRow)
+        if (updatedRow != currentRow) {
+            catalogsMap[key] = updatedRow
+            reindexCatalogRow(key, currentRow, updatedRow)
+        }
+        updatedRow
+    }
+}
+
+internal fun HomeViewModel.clearCatalogData() {
+    synchronized(catalogStateLock) {
+        catalogsMap.clear()
+        catalogItemKeyIndex.clear()
+        truncatedRowCache.clear()
+    }
+}
+
+internal fun HomeViewModel.snapshotCatalogKeys(): Set<String> = synchronized(catalogStateLock) {
+    catalogsMap.keys.toSet()
+}
+
+internal fun HomeViewModel.snapshotCatalogState(): Pair<List<String>, Map<String, CatalogRow>> = synchronized(catalogStateLock) {
+    catalogOrder.toList() to catalogsMap.toMap()
+}
+
+internal fun HomeViewModel.findCatalogItemById(itemId: String): MetaPreview? = synchronized(catalogStateLock) {
+    val rowKeys = catalogItemKeyIndex[itemId]?.toList().orEmpty()
+    rowKeys.firstNotNullOfOrNull { key ->
+        catalogsMap[key]?.items?.firstOrNull { it.id == itemId }
+    }
+}
+
+internal inline fun HomeViewModel.updateIndexedCatalogItem(
+    itemId: String,
+    transform: (MetaPreview) -> MetaPreview
+): Boolean {
+    return synchronized(catalogStateLock) {
+        val rowKeys = catalogItemKeyIndex[itemId]?.toList().orEmpty()
+        var changed = false
+
+        rowKeys.forEach { key ->
+            val row = catalogsMap[key] ?: return@forEach
+            val itemIndex = row.items.indexOfFirst { it.id == itemId }
+            if (itemIndex < 0) return@forEach
+
+            val updatedItem = transform(row.items[itemIndex])
+            if (updatedItem == row.items[itemIndex]) return@forEach
+
+            val mutableItems = row.items.toMutableList()
+            mutableItems[itemIndex] = updatedItem
+            catalogsMap[key] = row.copy(items = mutableItems)
+            truncatedRowCache.remove(key)
+            changed = true
+        }
+
+        changed
+    }
+}
+
+internal fun HomeViewModel.getTruncatedRowCacheEntry(key: String): HomeViewModel.TruncatedRowCacheEntry? = synchronized(catalogStateLock) {
+    truncatedRowCache[key]
+}
+
+internal fun HomeViewModel.putTruncatedRowCacheEntry(key: String, entry: HomeViewModel.TruncatedRowCacheEntry) {
+    synchronized(catalogStateLock) {
+        truncatedRowCache[key] = entry
+    }
+}
+
+internal fun HomeViewModel.removeTruncatedRowCacheEntry(key: String) {
+    synchronized(catalogStateLock) {
+        truncatedRowCache.remove(key)
+    }
+}
+
 internal fun HomeViewModel.rebuildCatalogOrder(addons: List<Addon>) {
     val defaultOrder = buildDefaultCatalogOrder(addons)
     val collectionKeys = collectionsCache.map { "collection_${it.id}" }
@@ -59,8 +182,10 @@ internal fun HomeViewModel.rebuildCatalogOrder(addons: List<Addon>) {
     val unsavedCollections = collectionKeys.filterNot { it in savedSet }
     val mergedOrder = savedValid + unsavedCatalogs + unsavedCollections
 
-    catalogOrder.clear()
-    catalogOrder.addAll(mergedOrder)
+    synchronized(catalogStateLock) {
+        catalogOrder.clear()
+        catalogOrder.addAll(mergedOrder)
+    }
 }
 
 private fun HomeViewModel.buildDefaultCatalogOrder(addons: List<Addon>): List<String> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -488,6 +488,7 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
             (_uiState.value.homeLayout != HomeLayout.MODERN || currentTmdbSettings.modernHomeEnabled)
         delay(HomeViewModel.EXTERNAL_META_PREFETCH_ADJACENT_DEBOUNCE_MS)
         if (pendingAdjacentPrefetchItemId != item.id) return@launch
+
         if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) return@launch
 
         try {
@@ -564,18 +565,7 @@ private fun HomeViewModel.updateCatalogItemWithTmdb(itemId: String, enrichment: 
         return merged
     }
 
-    catalogsMap.forEach { (key, row) ->
-        val idx = row.items.indexOfFirst { it.id == itemId }
-        if (idx >= 0) {
-            val merged = mergeItem(row.items[idx])
-            if (merged != row.items[idx]) {
-                val mutableItems = row.items.toMutableList()
-                mutableItems[idx] = merged
-                catalogsMap[key] = row.copy(items = mutableItems)
-                truncatedRowCache.remove(key)
-            }
-        }
-    }
+    updateIndexedCatalogItem(itemId, ::mergeItem)
 
     _uiState.update { state ->
         var changed = false
@@ -598,17 +588,8 @@ private fun HomeViewModel.updateCatalogItemWithTmdb(itemId: String, enrichment: 
 }
 
 internal fun HomeViewModel.updateCatalogItemImdbRating(itemId: String, rating: Float) {
-    catalogsMap.forEach { (key, row) ->
-        val idx = row.items.indexOfFirst { it.id == itemId }
-        if (idx >= 0) {
-            val updated = row.items[idx].copy(imdbRating = rating)
-            if (updated != row.items[idx]) {
-                val mutableItems = row.items.toMutableList()
-                mutableItems[idx] = updated
-                catalogsMap[key] = row.copy(items = mutableItems)
-                truncatedRowCache.remove(key)
-            }
-        }
+    updateIndexedCatalogItem(itemId) { currentItem ->
+        currentItem.copy(imdbRating = rating)
     }
     _uiState.update { state ->
         var changed = false
@@ -647,18 +628,7 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
         trailerYtIds = if (incomingTrailerYtIds.isNotEmpty()) incomingTrailerYtIds else currentItem.trailerYtIds
     )
 
-    catalogsMap.forEach { (key, row) ->
-        val itemIndex = row.items.indexOfFirst { it.id == itemId }
-        if (itemIndex >= 0) {
-            val merged = mergeItem(row.items[itemIndex])
-            if (merged != row.items[itemIndex]) {
-                val mutableItems = row.items.toMutableList()
-                mutableItems[itemIndex] = merged
-                catalogsMap[key] = row.copy(items = mutableItems)
-                truncatedRowCache.remove(key)
-            }
-        }
-    }
+    updateIndexedCatalogItem(itemId, ::mergeItem)
 
     _uiState.update { state ->
         var changed = false
@@ -690,9 +660,7 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
         // Bump version so any in-flight pipeline for this item treats itself as stale
         // and won't overwrite the retry result with a negative cache entry.
         if (activeTrailerPreviewItemId == itemId) trailerPreviewRequestVersion++
-        val currentItem = catalogsMap.values.firstNotNullOfOrNull { row ->
-            row.items.firstOrNull { it.id == itemId }
-        } ?: return
+        val currentItem = findCatalogItemById(itemId) ?: return
         requestTrailerPreviewPipeline(currentItem)
     }
 }


### PR DESCRIPTION
## Summary

- Fix home screen catalog enrichment paths that could mutate shared catalog state while another coroutine was iterating it.
- Move catalog row reads, writes, snapshots, and item updates behind shared helpers so background enrichment and UI presentation use a consistent thread-safe access path.
- Preserve existing home/hero/catalog behavior while preventing the crash reported from production logcat.

## PR type

- Bug fix

## Why

User logcat shows a `java.util.ConcurrentModificationException` on `DefaultDispatcher-worker-14` in the home screen flow:

```text
04-11 12:21:44.635 19143 20393 E AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-14
04-11 12:21:44.635 19143 20393 E AndroidRuntime: Process: com.nuvio.tv, PID: 19143
04-11 12:21:44.635 19143 20393 E AndroidRuntime: java.util.ConcurrentModificationException
04-11 12:21:44.635 19143 20393 E AndroidRuntime: 	at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:760)
04-11 12:21:44.635 19143 20393 E AndroidRuntime: 	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:792)
04-11 12:21:44.635 19143 20393 E AndroidRuntime: 	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:790)
04-11 12:21:44.635 19143 20393 E AndroidRuntime: 	at r9.o.O(SourceFile:28)
04-11 12:21:44.635 19143 20393 E AndroidRuntime: 	at p9.u1.invokeSuspend(SourceFile:853)
```

This points to shared home catalog state being mutated while it was still being iterated during TMDB/meta/rating enrichment. The change makes those catalog updates go through thread-safe helpers and snapshots so the enrichment path no longer mutates a `LinkedHashMap` during iteration.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- A debug build was sent to the user for validation.
- The user tested the debug build and shared a follow-up logcat.
- The crash was not reproduced during this validation.
- ANR events that appeared related to the previously reported crash were also not observed in the latest logcat.

## Screenshots / Video (UI changes only)

None.

## Breaking changes

None.

## Linked issues

None. User-reported crash via logcat.
