### PR TITLE
Remove reversed predictive search result

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -364,8 +364,7 @@ fun SearchScreen(
     LaunchedEffect(uiState.suggestions) {
         val imm = context.getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as? InputMethodManager
             ?: return@LaunchedEffect
-        val reversed = uiState.suggestions.asReversed()
-        val completions = reversed.mapIndexed { index, name ->
+        val completions = uiState.suggestions.mapIndexed { index, name ->
             CompletionInfo(index.toLong(), index, name)
         }.toTypedArray()
         imm.displayCompletions(view, completions)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -783,7 +783,10 @@ private fun SearchInputField(
                     }
                     false
                 },
-            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+            keyboardOptions = KeyboardOptions.Default.copy(
+                 imeAction = ImeAction.Done,
+                 autoCorrectEnabled = false
+             ),
             keyboardActions = KeyboardActions(
                 onDone = {
                     onSubmit()


### PR DESCRIPTION
## Summary
Currently the most relevant predicted search results in Gboard shows up towards the end of the list, this puts it at the front of the list.

## PR type
- Small maintenance improvement

## Why
Speeds up the search for content by not requiring you to scroll all the way to the end of predictions. From my own experience and some comments I've seen in the Discord, the predictive searches rarely ever show what is being searched and it seems like that's because the results are reversed.

## Policy check
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Searched for multiple shows without completing the entire title before and after changes (e.g., "That time I", "Oshi n"). Both gave me the proper prediction as first result whereas before the edit they showed up at the end of the list.

## Screenshots / Video (UI changes only)
N/A

## Breaking changes
None

## Linked issues
None
