### PR TITLE
Fix settings subtitles punctuation

### DIFF
--- a/app/src/main/res/values-ar/Strings.xml
+++ b/app/src/main/res/values-ar/Strings.xml
@@ -193,9 +193,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">الحساب</string>
-    <string name="settings_account_subtitle">الحساب وحالة المزامنة.</string>
+    <string name="settings_account_subtitle">الحساب وحالة المزامنة</string>
     <string name="settings_profiles">المستخدمين</string>
-    <string name="settings_profiles_subtitle">إدارة ملفات المستخدمين.</string>
+    <string name="settings_profiles_subtitle">إدارة ملفات المستخدمين</string>
     <string name="settings_layout">واجهة العرض</string>
     <string name="settings_layout_subtitle">تنظيم الواجهة الرئيسية وشكل البطاقات.</string>
     <string name="settings_plugins">الملحقات</string>
@@ -224,8 +224,8 @@
     <string name="network_connection_offline">غير متصل</string>
     <string name="settings_debug">معالجة الأخطاء</string>
     <string name="settings_debug_subtitle">أدوات المطورين والميزات التجريبية.</string>
-    <string name="settings_plugins_section_subtitle">إدارة المستودعات، المصادر، والملحقات.</string>
-    <string name="settings_account_section_subtitle">الحساب وحالة المزامنة.</string>
+    <string name="settings_plugins_section_subtitle">إدارة المستودعات، المصادر، والملحقات</string>
+    <string name="settings_account_section_subtitle">الحساب وحالة المزامنة</string>
     <string name="account_stat_addons">إضافات</string>
     <string name="account_stat_plugins">ملحقات</string>
     <string name="account_stat_library">مكتبة</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -251,9 +251,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Cuenta</string>
-    <string name="settings_account_subtitle">Estado de la cuenta y sincronización.</string>
+    <string name="settings_account_subtitle">Estado de la cuenta y sincronización</string>
     <string name="settings_profiles">Perfiles</string>
-    <string name="settings_profiles_subtitle">Administrar perfiles de usuario.</string>
+    <string name="settings_profiles_subtitle">Administrar perfiles de usuario</string>
     <string name="settings_layout">Diseño</string>
     <string name="settings_layout_subtitle">Estructura de inicio y estilos de pósteres.</string>
     <string name="settings_plugins">Plugins</string>
@@ -282,8 +282,8 @@
     <string name="network_connection_offline">Sin conexión</string>
     <string name="settings_debug">Depuración</string>
     <string name="settings_debug_subtitle">Herramientas de desarrollador y funciones experimentales.</string>
-    <string name="settings_plugins_section_subtitle">Administrar repositorios, proveedores y estado de los plugins.</string>
-    <string name="settings_account_section_subtitle">Estado de la cuenta y sincronización.</string>
+    <string name="settings_plugins_section_subtitle">Administrar repositorios, proveedores y estado de los plugins</string>
+    <string name="settings_account_section_subtitle">Estado de la cuenta y sincronización</string>
     <string name="account_stat_addons">addons</string>
     <string name="account_stat_plugins">plugins</string>
     <string name="account_stat_library">biblioteca</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -180,9 +180,9 @@
     <string name="about_supporters_contributors_subtitle">Veřejné uznání a poděkování</string>
 
     <string name="settings_account">Účet</string>
-    <string name="settings_account_subtitle">Účet a stav synchronizace.</string>
+    <string name="settings_account_subtitle">Účet a stav synchronizace</string>
     <string name="settings_profiles">Profily</string>
-    <string name="settings_profiles_subtitle">Spravovat uživatelské profily.</string>
+    <string name="settings_profiles_subtitle">Spravovat uživatelské profily</string>
     <string name="settings_layout">Rozložení</string>
     <string name="settings_layout_subtitle">Domovská obrazovka a styly posterů.</string>
     <string name="settings_plugins">Pluginy</string>
@@ -211,8 +211,8 @@
     <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Nástroje pro vývojáře a funkční přepínače.</string>
-    <string name="settings_plugins_section_subtitle">Spravovat repozitáře, poskytovatele a stavy pluginů.</string>
-    <string name="settings_account_section_subtitle">Účet a stav synchronizace.</string>
+    <string name="settings_plugins_section_subtitle">Spravovat repozitáře, poskytovatele a stavy pluginů</string>
+    <string name="settings_account_section_subtitle">Účet a stav synchronizace</string>
     <string name="account_stat_addons">doplňky</string>
     <string name="account_stat_plugins">pluginy</string>
     <string name="account_stat_library">knihovna</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -193,9 +193,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Konto</string>
-    <string name="settings_account_subtitle">Konto und Synchronisierungsstatus.</string>
+    <string name="settings_account_subtitle">Konto und Synchronisierungsstatus</string>
     <string name="settings_profiles">Profile</string>
-    <string name="settings_profiles_subtitle">Benutzerprofile verwalten.</string>
+    <string name="settings_profiles_subtitle">Benutzerprofile verwalten</string>
     <string name="settings_layout">Layout</string>
     <string name="settings_layout_subtitle">Startseite-Struktur und Poster-Stile.</string>
     <string name="settings_plugins">Plugins</string>
@@ -224,8 +224,8 @@
 <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Debugging</string>
     <string name="settings_debug_subtitle">Entwicklertools und Feature-Flags.</string>
-    <string name="settings_plugins_section_subtitle">Repositorys, Anbieter und Plugin-Status verwalten.</string>
-    <string name="settings_account_section_subtitle">Konto und Synchronisierungsstatus.</string>
+    <string name="settings_plugins_section_subtitle">Repositorys, Anbieter und Plugin-Status verwalten</string>
+    <string name="settings_account_section_subtitle">Konto und Synchronisierungsstatus</string>
     <string name="account_stat_addons">Add-ons</string>
     <string name="account_stat_plugins">Plugins</string>
     <string name="account_stat_library">Bibliothek</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -193,9 +193,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Λογαριασμός</string>
-    <string name="settings_account_subtitle">Κατάσταση λογαριασμού και συγχρονισμού.</string>
+    <string name="settings_account_subtitle">Κατάσταση λογαριασμού και συγχρονισμού</string>
     <string name="settings_profiles">Προφίλ</string>
-    <string name="settings_profiles_subtitle">Διαχείριση προφίλ χρηστών.</string>
+    <string name="settings_profiles_subtitle">Διαχείριση προφίλ χρηστών</string>
     <string name="settings_layout">Διάταξη</string>
     <string name="settings_layout_subtitle">Δομή αρχικής οθόνης και στυλ αφισών.</string>
     <string name="settings_plugins">Πρόσθετα</string>
@@ -224,8 +224,8 @@
     <string name="network_connection_offline">Εκτός σύνδεσης</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Εργαλεία προγραμματιστή και σημαίες χαρακτηριστικών.</string>
-    <string name="settings_plugins_section_subtitle">Διαχείριση αποθετηρίων, παρόχων και καταστάσεων πρόσθετων.</string>
-    <string name="settings_account_section_subtitle">Κατάσταση λογαριασμού και συγχρονισμού.</string>
+    <string name="settings_plugins_section_subtitle">Διαχείριση αποθετηρίων, παρόχων και καταστάσεων πρόσθετων</string>
+    <string name="settings_account_section_subtitle">Κατάσταση λογαριασμού και συγχρονισμού</string>
     <string name="account_stat_addons">πρόσθετα</string>
     <string name="account_stat_plugins">πρόσθετα</string>
     <string name="account_stat_library">βιβλιοθήκη</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -161,9 +161,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Cuenta</string>
-    <string name="settings_account_subtitle">Estado de la cuenta y sincronización.</string>
+    <string name="settings_account_subtitle">Estado de la cuenta y sincronización</string>
     <string name="settings_profiles">Perfiles</string>
-    <string name="settings_profiles_subtitle">Administra perfiles de usuario.</string>
+    <string name="settings_profiles_subtitle">Administra perfiles de usuario</string>
     <string name="settings_layout">Diseño</string>
     <string name="settings_layout_subtitle">Estructura del inicio y estilos de pósters.</string>
     <string name="settings_plugins">Complementos</string>
@@ -175,8 +175,8 @@
     <string name="settings_about_subtitle">Versión y políticas.</string>
     <string name="settings_debug">Depuración</string>
     <string name="settings_debug_subtitle">Herramientas de desarrollador y marcas de características.</string>
-    <string name="settings_plugins_section_subtitle">Administra repositorios, proveedores y estados de complementos.</string>
-    <string name="settings_account_section_subtitle">Estado de la cuenta y sincronización.</string>
+    <string name="settings_plugins_section_subtitle">Administra repositorios, proveedores y estados de complementos</string>
+    <string name="settings_account_section_subtitle">Estado de la cuenta y sincronización</string>
     <string name="account_stat_addons">complementos</string>
     <string name="account_stat_plugins">complementos</string>
     <string name="account_stat_library">biblioteca</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -193,9 +193,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Compte</string>
-    <string name="settings_account_subtitle">Compte et état de la synchronisation.</string>
+    <string name="settings_account_subtitle">Compte et état de la synchronisation</string>
     <string name="settings_profiles">Profils</string>
-    <string name="settings_profiles_subtitle">Gérer les profils utilisateurs.</string>
+    <string name="settings_profiles_subtitle">Gérer les profils utilisateurs</string>
     <string name="settings_layout">Disposition</string>
     <string name="settings_layout_subtitle">Structure de l\'accueil et styles d\'affiches.</string>
     <string name="settings_plugins">Plugins</string>
@@ -224,8 +224,8 @@
     <string name="network_connection_offline">Hors ligne</string>
     <string name="settings_debug">Débogage</string>
     <string name="settings_debug_subtitle">Outils développeur et options expérimentales.</string>
-    <string name="settings_plugins_section_subtitle">Gérer les dépôts, fournisseurs et états des plugins.</string>
-    <string name="settings_account_section_subtitle">Compte et état de la synchronisation.</string>
+    <string name="settings_plugins_section_subtitle">Gérer les dépôts, fournisseurs et états des plugins</string>
+    <string name="settings_account_section_subtitle">Compte et état de la synchronisation</string>
     <string name="account_stat_addons">addons</string>
     <string name="account_stat_plugins">plugins</string>
     <string name="account_stat_library">bibliothèque</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -193,9 +193,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Fiók</string>
-    <string name="settings_account_subtitle">Fiókadatok és szinkronizálási állapot.</string>
+    <string name="settings_account_subtitle">Fiókadatok és szinkronizálási állapot</string>
     <string name="settings_profiles">Profilok</string>
-    <string name="settings_profiles_subtitle">Felhasználói profilok kezelése.</string>
+    <string name="settings_profiles_subtitle">Felhasználói profilok kezelése</string>
     <string name="settings_layout">Elrendezés</string>
     <string name="settings_layout_subtitle">Kezdőlap szerkezete és poszter stílusok.</string>
     <string name="settings_plugins">Beépülő modulok</string>
@@ -224,8 +224,8 @@
     <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Hibakeresés</string>
     <string name="settings_debug_subtitle">Fejlesztői eszközök és tesztfunkciók.</string>
-    <string name="settings_plugins_section_subtitle">Tárhelyek, szolgáltatók és beépülő modulok kezelése.</string>
-    <string name="settings_account_section_subtitle">Fiók és szinkronizálási állapot.</string>
+    <string name="settings_plugins_section_subtitle">Tárhelyek, szolgáltatók és beépülő modulok kezelése</string>
+    <string name="settings_account_section_subtitle">Fiók és szinkronizálási állapot</string>
     <string name="account_stat_addons">bővítmény</string>
     <string name="account_stat_plugins">beépülő modul</string>
     <string name="account_stat_library">könyvtár</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -193,9 +193,9 @@
     
     <!-- SettingsScreen categories -->
     <string name="settings_account">Account</string>
-    <string name="settings_account_subtitle">Stato dell\'account e della sincronizzazione.</string>
+    <string name="settings_account_subtitle">Stato dell\'account e della sincronizzazione</string>
     <string name="settings_profiles">Profili</string>
-    <string name="settings_profiles_subtitle">Gestisci i profili utente.</string>
+    <string name="settings_profiles_subtitle">Gestisci i profili utente</string>
     <string name="settings_layout">Layout</string>
     <string name="settings_layout_subtitle">Struttura della home e stili delle locandine.</string>
     <string name="settings_plugins">Plugin</string>
@@ -224,8 +224,8 @@
     <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Strumenti per sviluppatori e feature flags.</string>
-    <string name="settings_plugins_section_subtitle">Gestisci repository, provider e stato dei plugin.</string>
-    <string name="settings_account_section_subtitle">Stato dell\'account e della sincronizzazione.</string>
+    <string name="settings_plugins_section_subtitle">Gestisci repository, provider e stato dei plugin</string>
+    <string name="settings_account_section_subtitle">Stato dell\'account e della sincronizzazione</string>
     <string name="account_stat_addons">addon</string>
     <string name="account_stat_plugins">plugin</string>
     <string name="account_stat_library">libreria</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -167,9 +167,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">חשבון</string>
-    <string name="settings_account_subtitle">מצב חשבון וסנכרון.</string>
+    <string name="settings_account_subtitle">מצב חשבון וסנכרון</string>
     <string name="settings_profiles">פרופילים</string>
-    <string name="settings_profiles_subtitle">ניהול פרופילי משתמש.</string>
+    <string name="settings_profiles_subtitle">ניהול פרופילי משתמש</string>
     <string name="settings_layout">פריסה</string>
     <string name="settings_layout_subtitle">מבנה בית וסגנונות פוסטרים.</string>
     <string name="settings_plugins">תוספים</string>
@@ -198,8 +198,8 @@
     <string name="network_connection_offline">אין חיבור</string>
     <string name="settings_debug">ניפוי שגיאות</string>
     <string name="settings_debug_subtitle">כלי מפתחים ודגלי פיצ׳רים.</string>
-    <string name="settings_plugins_section_subtitle">ניהול מאגרים, ספקים ומצבי תוספים.</string>
-    <string name="settings_account_section_subtitle">מצב חשבון וסנכרון.</string>
+    <string name="settings_plugins_section_subtitle">ניהול מאגרים, ספקים ומצבי תוספים</string>
+    <string name="settings_account_section_subtitle">מצב חשבון וסנכרון</string>
     <string name="account_stat_addons">תוספים</string>
     <string name="account_stat_plugins">פלאגינים</string>
     <string name="account_stat_library">ספרייה</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -164,9 +164,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Paskyra</string>
-    <string name="settings_account_subtitle">Paskyros ir sinchronizavimo būsena.</string>
+    <string name="settings_account_subtitle">Paskyros ir sinchronizavimo būsena</string>
     <string name="settings_profiles">Profiliai</string>
-    <string name="settings_profiles_subtitle">Valdyti naudotojų profilius.</string>
+    <string name="settings_profiles_subtitle">Valdyti naudotojų profilius</string>
     <string name="settings_layout">Išdėstymas</string>
     <string name="settings_layout_subtitle">Pradinio ekrano struktūra ir plakatų stiliai.</string>
     <string name="settings_plugins">Įskiepiai</string>
@@ -178,8 +178,8 @@
     <string name="settings_about_subtitle">Versija ir politika.</string>
     <string name="settings_debug">Derinimas (Debug)</string>
     <string name="settings_debug_subtitle">Kūrėjo įrankiai ir funkcijų vėliavėlės.</string>
-    <string name="settings_plugins_section_subtitle">Valdyti repozitorijas, teikėjus ir įskiepių būsenas.</string>
-    <string name="settings_account_section_subtitle">Paskyros ir sinchronizavimo būsena.</string>
+    <string name="settings_plugins_section_subtitle">Valdyti repozitorijas, teikėjus ir įskiepių būsenas</string>
+    <string name="settings_account_section_subtitle">Paskyros ir sinchronizavimo būsena</string>
     <string name="account_stat_addons">priedai</string>
     <string name="account_stat_plugins">įskiepiai</string>
     <string name="account_stat_library">biblioteka</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -122,9 +122,9 @@
 
 <!-- SettingsScreen categories -->
 <string name="settings_account">Account</string>
-<string name="settings_account_subtitle">Account- en synchronisatiestatus.</string>
+<string name="settings_account_subtitle">Account- en synchronisatiestatus</string>
 <string name="settings_profiles">Profielen</string>
-<string name="settings_profiles_subtitle">Beheer gebruikersprofielen.</string>
+<string name="settings_profiles_subtitle">Beheer gebruikersprofielen</string>
 <string name="settings_layout">Indeling</string>
 <string name="settings_layout_subtitle">Startpagina-indeling en posterstijlen.</string>
 <string name="settings_plugins">Plugins</string>
@@ -136,8 +136,8 @@
 <string name="settings_about_subtitle">Versie en beleid.</string>
 <string name="settings_debug">Debug</string>
 <string name="settings_debug_subtitle">Ontwikkelaarstools en feature flags.</string>
-<string name="settings_plugins_section_subtitle">Beheer repositories, providers en pluginstatussen.</string>
-<string name="settings_account_section_subtitle">Account- en synchronisatiestatus.</string>
+<string name="settings_plugins_section_subtitle">Beheer repositories, providers en pluginstatussen</string>
+<string name="settings_account_section_subtitle">Account- en synchronisatiestatus</string>
 <string name="account_stat_addons">addons</string>
 <string name="account_stat_plugins">plugins</string>
 <string name="account_stat_library">bibliotheek</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -191,9 +191,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Konto</string>
-    <string name="settings_account_subtitle">Kontostatus og synkroniseringsstatus.</string>
+    <string name="settings_account_subtitle">Kontostatus og synkroniseringsstatus</string>
     <string name="settings_profiles">Profiler</string>
-    <string name="settings_profiles_subtitle">Administrer brukerprofiler.</string>
+    <string name="settings_profiles_subtitle">Administrer brukerprofiler</string>
     <string name="settings_layout">Oppsett</string>
     <string name="settings_layout_subtitle">Hjemmestruktur og plakatstiler.</string>
     <string name="settings_plugins">Programtillegg</string>
@@ -222,8 +222,8 @@
     <string name="network_connection_offline">Frakoblet</string>
     <string name="settings_debug">Feilsøking</string>
     <string name="settings_debug_subtitle">Utviklerverktøy og funksjonsflagg.</string>
-    <string name="settings_plugins_section_subtitle">Administrer lagrer, leverandører og programtilleggstilstander.</string>
-    <string name="settings_account_section_subtitle">Kontostatus og synkroniseringsstatus.</string>
+    <string name="settings_plugins_section_subtitle">Administrer lagrer, leverandører og programtilleggstilstander</string>
+    <string name="settings_account_section_subtitle">Kontostatus og synkroniseringsstatus</string>
     <string name="account_stat_addons">tillegg</string>
     <string name="account_stat_plugins">programtillegg</string>
     <string name="account_stat_library">bibliotek</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -123,9 +123,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Konto</string>
-    <string name="settings_account_subtitle">Status konta i synchronizacji.</string>
+    <string name="settings_account_subtitle">Status konta i synchronizacji</string>
     <string name="settings_profiles">Profile</string>
-    <string name="settings_profiles_subtitle">Zarządzaj profilami użytkowników.</string>
+    <string name="settings_profiles_subtitle">Zarządzaj profilami użytkowników</string>
     <string name="settings_layout">Układ</string>
     <string name="settings_layout_subtitle">Struktura strony głównej i style kart.</string>
     <string name="settings_plugins">Wtyczki</string>
@@ -137,8 +137,8 @@
     <string name="settings_about_subtitle">Wersja i polityki.</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Narzędzia deweloperskie i flagi funkcji.</string>
-    <string name="settings_plugins_section_subtitle">Zarządzaj repozytoriami, dostawcami i stanami wtyczek.</string>
-    <string name="settings_account_section_subtitle">Status konta i synchronizacji.</string>
+    <string name="settings_plugins_section_subtitle">Zarządzaj repozytoriami, dostawcami i stanami wtyczek</string>
+    <string name="settings_account_section_subtitle">Status konta i synchronizacji</string>
     <string name="account_stat_addons">dodatki</string>
     <string name="account_stat_plugins">wtyczki</string>
     <string name="account_stat_library">biblioteka</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -250,9 +250,9 @@
         
     <!-- SettingsScreen categories -->
     <string name="settings_account">Conta</string>
-    <string name="settings_account_subtitle">Status da conta e sincronização.</string>
+    <string name="settings_account_subtitle">Status da conta e sincronização</string>
     <string name="settings_profiles">Perfis</string>
-    <string name="settings_profiles_subtitle">Gerenciar perfis de usuário.</string>
+    <string name="settings_profiles_subtitle">Gerenciar perfis de usuário</string>
     <string name="settings_layout">Layout</string>
     <string name="settings_layout_subtitle">Estrutura da home e estilo dos pôsteres.</string>
     <string name="settings_plugins">Plugins</string>
@@ -281,8 +281,8 @@
     <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Depuração</string>
     <string name="settings_debug_subtitle">Ferramentas de desenvolvedor e recursos avançados.</string>
-    <string name="settings_plugins_section_subtitle">Gerenciar repositórios, provedores e extensões.</string>
-    <string name="settings_account_section_subtitle">Status da conta e sincronização.</string>
+    <string name="settings_plugins_section_subtitle">Gerenciar repositórios, provedores e extensões</string>
+    <string name="settings_account_section_subtitle">Status da conta e sincronização</string>
     <string name="account_stat_addons">addons</string>
     <string name="account_stat_plugins">plugins</string>
     <string name="account_stat_library">biblioteca</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -170,9 +170,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Conta</string>
-    <string name="settings_account_subtitle">Estado da conta e sincronização.</string>
+    <string name="settings_account_subtitle">Estado da conta e sincronização</string>
     <string name="settings_profiles">Perfis</string>
-    <string name="settings_profiles_subtitle">Gerir perfis de utilizador.</string>
+    <string name="settings_profiles_subtitle">Gerir perfis de utilizador</string>
     <string name="settings_layout">Layout</string>
     <string name="settings_layout_subtitle">Estrutura do ecrã inicial e estilos de póster.</string>
     <string name="settings_plugins">Plugins</string>
@@ -201,8 +201,8 @@
     <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Ferramentas de programador e feature flags.</string>
-    <string name="settings_plugins_section_subtitle">Gerir repositórios, fornecedores e estado dos plugins.</string>
-    <string name="settings_account_section_subtitle">Estado da conta e sincronização.</string>
+    <string name="settings_plugins_section_subtitle">Gerir repositórios, fornecedores e estado dos plugins</string>
+    <string name="settings_account_section_subtitle">Estado da conta e sincronização</string>
     <string name="account_stat_addons">addons</string>
     <string name="account_stat_plugins">plugins</string>
     <string name="account_stat_library">biblioteca</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -116,9 +116,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Cont</string>
-    <string name="settings_account_subtitle">Starea contului și sincronizării.</string>
+    <string name="settings_account_subtitle">Starea contului și sincronizării</string>
     <string name="settings_profiles">Profile</string>
-    <string name="settings_profiles_subtitle">Gestionează profilurile utilizatorilor.</string>
+    <string name="settings_profiles_subtitle">Gestionează profilurile utilizatorilor</string>
     <string name="settings_layout">Aranjament</string>
     <string name="settings_layout_subtitle">Structura paginii principale și stilurile afișajului.</string>
     <string name="settings_plugins">Plugin-uri</string>
@@ -130,8 +130,8 @@
     <string name="settings_about_subtitle">Versiune și politici.</string>
     <string name="settings_debug">Depanare</string>
     <string name="settings_debug_subtitle">Instrumente pentru dezvoltatori și steaguri de funcționalitate.</string>
-    <string name="settings_plugins_section_subtitle">Gestionează depozitele, furnizorii și stările pluginurilor.</string>
-    <string name="settings_account_section_subtitle">Statutul contului și sincronizării.</string>
+    <string name="settings_plugins_section_subtitle">Gestionează depozitele, furnizorii și stările pluginurilor</string>
+    <string name="settings_account_section_subtitle">Statutul contului și sincronizării</string>
     <string name="account_stat_addons">add-on-uri</string>
     <string name="account_stat_plugins">pluginuri</string>
     <string name="account_stat_library">bibliotecă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -250,9 +250,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Аккаунт</string>
-    <string name="settings_account_subtitle">Статус аккаунта и синхронизации.</string>
+    <string name="settings_account_subtitle">Статус аккаунта и синхронизации</string>
     <string name="settings_profiles">Профили</string>
-    <string name="settings_profiles_subtitle">Управление профилями пользователей.</string>
+    <string name="settings_profiles_subtitle">Управление профилями пользователей</string>
     <string name="settings_layout">Интерфейс</string>
     <string name="settings_layout_subtitle">Структура главного экрана и стиль постеров.</string>
     <string name="settings_plugins">Плагины</string>
@@ -281,8 +281,8 @@
     <string name="network_connection_offline">Не в сети</string>
     <string name="settings_debug">Отладка</string>
     <string name="settings_debug_subtitle">Инструменты разработчика и скрытые функции.</string>
-    <string name="settings_plugins_section_subtitle">Управление репозиториями, провайдерами и состоянием плагинов.</string>
-    <string name="settings_account_section_subtitle">Аккаунт и статус синхронизации.</string>
+    <string name="settings_plugins_section_subtitle">Управление репозиториями, провайдерами и состоянием плагинов</string>
+    <string name="settings_account_section_subtitle">Аккаунт и статус синхронизации</string>
     <string name="account_stat_addons">аддоны</string>
     <string name="account_stat_plugins">плагины</string>
     <string name="account_stat_library">библиотека</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -87,9 +87,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Účet</string>
-    <string name="settings_account_subtitle">Účet a stav synchronizácie.</string>
+    <string name="settings_account_subtitle">Účet a stav synchronizácie</string>
     <string name="settings_profiles">Profily</string>
-    <string name="settings_profiles_subtitle">Spravovať používateľské profily.</string>
+    <string name="settings_profiles_subtitle">Spravovať používateľské profily</string>
     <string name="settings_layout">Rozloženie</string>
     <string name="settings_layout_subtitle">Domáca obrazovka a štýly posterov.</string>
     <string name="settings_plugins">Pluginy</string>
@@ -101,8 +101,8 @@
     <string name="settings_about_subtitle">Verzia a zásady.</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Nástroje pre vývojárov a funkčné prepínače.</string>
-    <string name="settings_plugins_section_subtitle">Spravovať repozitáre, poskytovateľov a stavy pluginov.</string>
-    <string name="settings_account_section_subtitle">Účet a stav synchronizácie.</string>
+    <string name="settings_plugins_section_subtitle">Spravovať repozitáre, poskytovateľov a stavy pluginov</string>
+    <string name="settings_account_section_subtitle">Účet a stav synchronizácie</string>
     <string name="settings_integrations_section">Integrácie</string>
     <string name="settings_integrations_section_subtitle">Vyberte nastavenia TMDB alebo MDBList</string>
     <string name="settings_tmdb_subtitle">Ovládanie obohatenia metadát</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -238,9 +238,9 @@
     <string name="about_supporters_contributors_subtitle">Javne zahvale in zasluge pri projektu</string>																				   
     <!-- SettingsScreen categories -->
     <string name="settings_account">Račun</string>
-    <string name="settings_account_subtitle">Stanje računa in sinhronizacije.</string>
+    <string name="settings_account_subtitle">Stanje računa in sinhronizacije</string>
     <string name="settings_profiles">Profili</string>
-    <string name="settings_profiles_subtitle">Upravljajte uporabniške profile.</string>
+    <string name="settings_profiles_subtitle">Upravljajte uporabniške profile</string>
     <string name="settings_layout">Postavitev</string>
     <string name="settings_layout_subtitle">Struktura domačega zaslona in slogi plakatov.</string>
     <string name="settings_plugins">Vtičniki</string>
@@ -269,8 +269,8 @@
     <string name="network_connection_offline">Brez povezave</string>
     <string name="settings_debug">Odpravljanje napak</string>
     <string name="settings_debug_subtitle">Razvojna orodja in zastavice funkcij.</string>																  
-    <string name="settings_plugins_section_subtitle">Upravljanje repozitorijev, ponudnikov in stanj vtičnikov.</string>
-    <string name="settings_account_section_subtitle">Stanje računa in sinhronizacije.</string>
+    <string name="settings_plugins_section_subtitle">Upravljanje repozitorijev, ponudnikov in stanj vtičnikov</string>
+    <string name="settings_account_section_subtitle">Stanje računa in sinhronizacije</string>
 	<string name="account_stat_addons">dodatki</string>
     <string name="account_stat_plugins">vtičniki</string>
     <string name="account_stat_library">knjižnica</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -167,9 +167,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Konto</string>
-    <string name="settings_account_subtitle">Konto och synkroniseringsstatus.</string>
+    <string name="settings_account_subtitle">Konto och synkroniseringsstatus</string>
     <string name="settings_profiles">Profiler</string>
-    <string name="settings_profiles_subtitle">Hantera användarprofiler.</string>
+    <string name="settings_profiles_subtitle">Hantera användarprofiler</string>
     <string name="settings_layout">Layout</string>
     <string name="settings_layout_subtitle">Hemstruktur och affischstilar.</string>
     <string name="settings_plugins">Plugins</string>
@@ -181,8 +181,8 @@
     <string name="settings_about_subtitle">Version och policyer.</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Utvecklarverktyg och funktionsflaggor.</string>
-    <string name="settings_plugins_section_subtitle">Hantera arkiv, leverantörer, och plugin-status.</string>
-    <string name="settings_account_section_subtitle">Konto och synkroniseringsstatus.</string>
+    <string name="settings_plugins_section_subtitle">Hantera arkiv, leverantörer, och plugin-status</string>
+    <string name="settings_account_section_subtitle">Konto och synkroniseringsstatus</string>
     <string name="account_stat_addons">tillägg</string>
     <string name="account_stat_plugins">plugins</string>
     <string name="account_stat_library">bibliotek</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -230,9 +230,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Hesap</string>
-    <string name="settings_account_subtitle">Hesap ve senkronizasyon durumu.</string>
+    <string name="settings_account_subtitle">Hesap ve senkronizasyon durumu</string>
     <string name="settings_profiles">Profiller</string>
-    <string name="settings_profiles_subtitle">Kullanıcı profillerini yönetin.</string>
+    <string name="settings_profiles_subtitle">Kullanıcı profillerini yönetin</string>
     <string name="settings_layout">Düzen</string>
     <string name="settings_layout_subtitle">Ana sayfa düzeni ve poster stilleri.</string>
     <string name="settings_plugins">Uzantılar</string>
@@ -261,8 +261,8 @@
     <string name="network_connection_offline">Çevrimdışı</string>
     <string name="settings_debug">Hata Ayıklama</string>
     <string name="settings_debug_subtitle">Geliştirici araçları ve özellik bayrakları.</string>
-    <string name="settings_plugins_section_subtitle">Depoları, sağlayıcıları ve eklenti durumlarını yönetin.</string>
-    <string name="settings_account_section_subtitle">Hesap ve senkronizasyon durumu.</string>
+    <string name="settings_plugins_section_subtitle">Depoları, sağlayıcıları ve eklenti durumlarını yönetin</string>
+    <string name="settings_account_section_subtitle">Hesap ve senkronizasyon durumu</string>
     <string name="account_stat_addons">eklentiler</string>
     <string name="account_stat_plugins">uzantılar</string>
     <string name="account_stat_library">kütüphane</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -122,9 +122,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Tài khoản</string>
-    <string name="settings_account_subtitle">Tài khoản và trạng thái đồng bộ.</string>
+    <string name="settings_account_subtitle">Tài khoản và trạng thái đồng bộ</string>
     <string name="settings_profiles">Hồ sơ</string>
-    <string name="settings_profiles_subtitle">Quản lý hồ sơ người dùng.</string>
+    <string name="settings_profiles_subtitle">Quản lý hồ sơ người dùng</string>
     <string name="settings_layout">Bố cục</string>
     <string name="settings_layout_subtitle">Cấu trúc màn hình chính và kiểu poster.</string>
     <string name="settings_plugins">Plugin</string>
@@ -136,8 +136,8 @@
     <string name="settings_about_subtitle">Phiên bản và điều khoản.</string>
     <string name="settings_debug">Gỡ lỗi</string>
     <string name="settings_debug_subtitle">Công cụ nhà phát triển và cờ tính năng.</string>
-    <string name="settings_plugins_section_subtitle">Quản lý kho lưu trữ, nhà cung cấp và trạng thái plugin.</string>
-    <string name="settings_account_section_subtitle">Tài khoản và trạng thái đồng bộ.</string>
+    <string name="settings_plugins_section_subtitle">Quản lý kho lưu trữ, nhà cung cấp và trạng thái plugin</string>
+    <string name="settings_account_section_subtitle">Tài khoản và trạng thái đồng bộ</string>
     <string name="account_stat_addons">addon</string>
     <string name="account_stat_plugins">plugin</string>
     <string name="account_stat_library">thư viện</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -251,9 +251,9 @@
 
     <!-- SettingsScreen categories -->
     <string name="settings_account">Account</string>
-    <string name="settings_account_subtitle">Account and sync status.</string>
+    <string name="settings_account_subtitle">Account and sync status</string>
     <string name="settings_profiles">Profiles</string>
-    <string name="settings_profiles_subtitle">Manage user profiles.</string>
+    <string name="settings_profiles_subtitle">Manage user profiles</string>
     <string name="settings_layout">Layout</string>
     <string name="settings_layout_subtitle">Home structure and poster styles.</string>
     <string name="settings_plugins">Plugins</string>
@@ -282,8 +282,8 @@
     <string name="network_connection_offline">Offline</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Developer tools and feature flags.</string>
-    <string name="settings_plugins_section_subtitle">Manage repositories, providers, and plugin states.</string>
-    <string name="settings_account_section_subtitle">Account and sync status.</string>
+    <string name="settings_plugins_section_subtitle">Manage repositories, providers, and plugin states</string>
+    <string name="settings_account_section_subtitle">Account and sync status</string>
     <string name="account_stat_addons">addons</string>
     <string name="account_stat_plugins">plugins</string>
     <string name="account_stat_library">library</string>


### PR DESCRIPTION
## Summary

Fixes the trailing full stop punctuation at the end of the subtitle text for the Plugins, Account, and Profiles pages in the settings screen. All string resource files (including localized translations) have been updated accordingly.

## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why

Some settings subtitles had full stops, others did not. Updated for consistency

## Policy check

<!-- Confirm these before requesting review -->
 - [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

Only strings are updated so it is fine to merge if in agreement

## Screenshots / Video (UI changes only)

The only change is in the strings, examples here:

<img width="472" height="154" alt="image" src="https://github.com/user-attachments/assets/90095fa3-1fa8-4df3-9ef7-b204fe192005" />


## Breaking changes

None, strings changes only

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1360
