### PR TITLE
fix: improve plugin card focus feedback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginScreen.kt
@@ -5,8 +5,10 @@ package com.nuvio.tv.ui.screens.plugin
 import android.graphics.Bitmap
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -57,6 +59,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -995,13 +998,34 @@ private fun RepositoryCard(
     val enabledCount = repoScrapers.count { it.enabled }
     val allEnabled = repoScrapers.isNotEmpty() && enabledCount == repoScrapers.size
     val anyEnabled = enabledCount > 0
+    var isToggleFocused by remember { mutableStateOf(false) }
+    var isRefreshFocused by remember { mutableStateOf(false) }
+    var isRemoveFocused by remember { mutableStateOf(false) }
+    val isCardFocused = isToggleFocused || isRefreshFocused || isRemoveFocused
+    val cardBorderColor by animateColorAsState(
+        targetValue = if (isCardFocused) NuvioColors.FocusRing else Color.Transparent,
+        label = "repositoryCardBorder"
+    )
+    val cardScale by animateFloatAsState(
+        targetValue = if (isCardFocused) 1.01f else 1f,
+        label = "repositoryCardScale"
+    )
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
+            .graphicsLayer {
+                scaleX = cardScale
+                scaleY = cardScale
+            }
             .background(
                 color = NuvioColors.BackgroundCard,
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(18.dp)
+            )
+            .border(
+                width = if (isCardFocused) 2.dp else 0.dp,
+                color = cardBorderColor,
+                shape = RoundedCornerShape(18.dp)
             )
     ) {
         Row(
@@ -1037,6 +1061,7 @@ private fun RepositoryCard(
                 if (repoScrapers.isNotEmpty()) {
                     Surface(
                         onClick = { onToggleAll(!anyEnabled) },
+                        modifier = Modifier.onFocusChanged { isToggleFocused = it.isFocused },
                         colors = ClickableSurfaceDefaults.colors(
                             containerColor = NuvioColors.Surface,
                             focusedContainerColor = NuvioColors.FocusBackground
@@ -1075,6 +1100,7 @@ private fun RepositoryCard(
                 Button(
                     onClick = onRefresh,
                     enabled = !isLoading,
+                    modifier = Modifier.onFocusChanged { isRefreshFocused = it.isFocused },
                     colors = ButtonDefaults.colors(
                         containerColor = NuvioColors.Surface,
                         contentColor = NuvioColors.TextSecondary,
@@ -1092,6 +1118,7 @@ private fun RepositoryCard(
                 Button(
                     onClick = onRemove,
                     enabled = !isLoading,
+                    modifier = Modifier.onFocusChanged { isRemoveFocused = it.isFocused },
                     colors = ButtonDefaults.colors(
                         containerColor = NuvioColors.Surface,
                         contentColor = NuvioColors.TextSecondary,
@@ -1121,6 +1148,17 @@ private fun ScraperCard(
     isReadOnly: Boolean = false
 ) {
     var showResults by remember { mutableStateOf(false) }
+    var isTestFocused by remember { mutableStateOf(false) }
+    var isToggleFocused by remember { mutableStateOf(false) }
+    val isCardFocused = isTestFocused || isToggleFocused
+    val cardBorderColor by animateColorAsState(
+        targetValue = if (isCardFocused) NuvioColors.FocusRing else Color.Transparent,
+        label = "scraperCardBorder"
+    )
+    val cardScale by animateFloatAsState(
+        targetValue = if (isCardFocused) 1.01f else 1f,
+        label = "scraperCardScale"
+    )
 
     LaunchedEffect(testResults, testDiagnostics) {
         showResults = testResults != null || testDiagnostics != null
@@ -1130,9 +1168,18 @@ private fun ScraperCard(
     Box(
         modifier = Modifier
             .fillMaxWidth()
+            .graphicsLayer {
+                scaleX = cardScale
+                scaleY = cardScale
+            }
             .background(
                 color = NuvioColors.BackgroundCard,
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(18.dp)
+            )
+            .border(
+                width = if (isCardFocused) 2.dp else 0.dp,
+                color = cardBorderColor,
+                shape = RoundedCornerShape(18.dp)
             )
     ) {
         Column(
@@ -1179,6 +1226,7 @@ private fun ScraperCard(
                     Button(
                         onClick = onTest,
                         enabled = !isTesting && scraper.enabled,
+                        modifier = Modifier.onFocusChanged { isTestFocused = it.isFocused },
                         colors = ButtonDefaults.colors(
                             containerColor = NuvioColors.Surface,
                             contentColor = NuvioColors.TextPrimary,
@@ -1202,14 +1250,36 @@ private fun ScraperCard(
 
                     // Enable toggle
                     if (!isReadOnly) {
-                        Switch(
-                            checked = scraper.enabled,
-                            onCheckedChange = onToggle,
-                            colors = SwitchDefaults.colors(
-                                checkedThumbColor = NuvioColors.Secondary,
-                                checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f)
-                            )
-                        )
+                        Surface(
+                            onClick = { onToggle(!scraper.enabled) },
+                            modifier = Modifier.onFocusChanged { isToggleFocused = it.isFocused },
+                            colors = ClickableSurfaceDefaults.colors(
+                                containerColor = NuvioColors.Surface,
+                                focusedContainerColor = NuvioColors.FocusBackground
+                            ),
+                            border = ClickableSurfaceDefaults.border(
+                                focusedBorder = Border(
+                                    border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                                    shape = RoundedCornerShape(12.dp)
+                                )
+                            ),
+                            shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+                            scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Switch(
+                                    checked = scraper.enabled,
+                                    onCheckedChange = null,
+                                    colors = SwitchDefaults.colors(
+                                        checkedThumbColor = NuvioColors.Secondary,
+                                        checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f)
+                                    )
+                                )
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Improve focus feedback on Plugin screen cards (RepositoryCard & ScraperCard) for D-pad / remote navigation. When any interactive element inside a card receives focus, the parent card now shows a visible border highlight and a subtle scale animation, making it clear which card is active.

Additionally, the ScraperCard toggle `Switch` has been wrapped in a focusable `Surface` so that it is properly reachable and operable via D-pad.

## PR type

- Bug fix

## Why

On Android TV, navigating through the Plugin screen with a remote/D-pad gave no visual indication of which repository or scraper card was currently focused. Users could not tell where the cursor was, leading to confusion and accidental actions. This change brings the Plugin screen in line with the focus-feedback standards used elsewhere in the app.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- **Manual:** Navigated all interactive elements on the Plugin screen using D-pad on AVD (API 30). Confirmed:
  - RepositoryCard border + scale animation appears when any child (toggle-all, refresh, remove) is focused.
  - ScraperCard border + scale animation appears when test button or enable toggle is focused.
  - ScraperCard Switch is now D-pad focusable and toggleable via the wrapping `Surface`.
  - Focus ring uses `NuvioColors.FocusRing` and matches the app's existing focus style.
  - No visual glitches on focus enter/exit transitions.

## Screenshots / Video (UI changes only)


### Main (Before)

https://github.com/user-attachments/assets/f2d8f40c-12cc-405f-9aa1-6cb6d4c7d47c

### Debug (After)

 https://github.com/user-attachments/assets/fb3b7e72-e508-486a-a9fc-57e77f1f8fad







## Breaking changes

- None

## Linked issues

- none
