### PR TITLE
Home performance, CW/Trakt stability, debrid stream fixes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -74,6 +74,17 @@ object NetworkModule {
             .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
+            // Prevent OkHttp from caching error responses (4xx/5xx).
+            .addNetworkInterceptor { chain ->
+                val response = chain.proceed(chain.request())
+                if (!response.isSuccessful) {
+                    response.newBuilder()
+                        .header("Cache-Control", "no-store")
+                        .build()
+                } else {
+                    response
+                }
+            }
             .addInterceptor(HttpLoggingInterceptor().apply {
                 level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
                         else HttpLoggingInterceptor.Level.NONE

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -194,57 +196,74 @@ class StartupSyncService @Inject constructor(
                     }
             }
 
-            pluginManager.isSyncingFromRemote = true
-            try {
-                val remotePlugins = pluginSyncService.getRemoteRepoUrls().getOrElse { throw it }
-                pluginManager.reconcileWithRemoteRepoUrls(
-                    remotePlugins = remotePlugins,
-                    removeMissingLocal = true
-                )
-                Log.d(TAG, "Pulled ${remotePlugins.size} plugin repos from remote for profile $profileId")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to pull plugins from remote, keeping local cache", e)
-            } finally {
-                pluginManager.isSyncingFromRemote = false
-                pluginManager.flushPendingSync()
-            }
+            // Run independent syncs in parallel to reduce total startup time.
+            // Plugins, addons, collections, and home catalog settings don't depend on each other.
+            coroutineScope {
+                val pluginJob = async {
+                    pluginManager.isSyncingFromRemote = true
+                    try {
+                        val remotePlugins = pluginSyncService.getRemoteRepoUrls().getOrElse { throw it }
+                        pluginManager.reconcileWithRemoteRepoUrls(
+                            remotePlugins = remotePlugins,
+                            removeMissingLocal = true
+                        )
+                        Log.d(TAG, "Pulled ${remotePlugins.size} plugin repos from remote for profile $profileId")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to pull plugins from remote, keeping local cache", e)
+                    } finally {
+                        pluginManager.isSyncingFromRemote = false
+                        pluginManager.flushPendingSync()
+                    }
+                }
 
-            addonRepository.isSyncingFromRemote = true
-            try {
-                val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
-                addonRepository.reconcileWithRemoteAddonUrls(
-                    remoteUrls = remoteAddonUrls,
-                    removeMissingLocal = true
-                )
-                Log.d(TAG, "Pulled ${remoteAddonUrls.size} addons from remote for profile $profileId")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to pull addons from remote, keeping local cache", e)
-            } finally {
-                addonRepository.isSyncingFromRemote = false
-            }
+                val addonJob = async {
+                    addonRepository.isSyncingFromRemote = true
+                    try {
+                        val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
+                        addonRepository.reconcileWithRemoteAddonUrls(
+                            remoteUrls = remoteAddonUrls,
+                            removeMissingLocal = true
+                        )
+                        Log.d(TAG, "Pulled ${remoteAddonUrls.size} addons from remote for profile $profileId")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to pull addons from remote, keeping local cache", e)
+                    } finally {
+                        addonRepository.isSyncingFromRemote = false
+                    }
+                }
 
-            try {
-                collectionSyncService.pullFromRemote()
-                    .onSuccess { applied ->
-                        Log.d(TAG, "Collections pull completed for profile $profileId (applied=$applied)")
+                val collectionJob = async {
+                    try {
+                        collectionSyncService.pullFromRemote()
+                            .onSuccess { applied ->
+                                Log.d(TAG, "Collections pull completed for profile $profileId (applied=$applied)")
+                            }
+                            .onFailure { e ->
+                                Log.e(TAG, "Failed to pull collections from remote, keeping local", e)
+                            }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to pull collections from remote", e)
                     }
-                    .onFailure { e ->
-                        Log.e(TAG, "Failed to pull collections from remote, keeping local", e)
-                    }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to pull collections from remote", e)
-            }
+                }
 
-            try {
-                homeCatalogSettingsSyncService.pullFromRemote()
-                    .onSuccess { applied ->
-                        Log.d(TAG, "Home catalog settings pull completed for profile $profileId (applied=$applied)")
+                val homeCatalogJob = async {
+                    try {
+                        homeCatalogSettingsSyncService.pullFromRemote()
+                            .onSuccess { applied ->
+                                Log.d(TAG, "Home catalog settings pull completed for profile $profileId (applied=$applied)")
+                            }
+                            .onFailure { e ->
+                                Log.e(TAG, "Failed to pull home catalog settings from remote, keeping local", e)
+                            }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to pull home catalog settings from remote", e)
                     }
-                    .onFailure { e ->
-                        Log.e(TAG, "Failed to pull home catalog settings from remote, keeping local", e)
-                    }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to pull home catalog settings from remote", e)
+                }
+
+                pluginJob.await()
+                addonJob.await()
+                collectionJob.await()
+                homeCatalogJob.await()
             }
 
             val isTraktConnected = traktAuthDataStore.isEffectivelyAuthenticated.first()

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -211,7 +211,10 @@ class MetaRepositoryImpl @Inject constructor(
                                 }
                                 Log.d(TAG, "Meta response was null addonId=${addon.id} type=$candidateType id=$id")
                             }
-                            else -> { /* try next */ }
+                            is NetworkResult.Error -> {
+                                /* try next */
+                            }
+                            NetworkResult.Loading -> { /* try next */ }
                         }
                     }
                     null

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -28,6 +28,9 @@ class TraktEpisodeMappingService @Inject constructor(
     private val addonEpisodesCache = mutableMapOf<String, List<EpisodeMappingEntry>>()
     private val traktEpisodesCache = mutableMapOf<String, List<EpisodeMappingEntry>>()
     private val reverseMappingCache = mutableMapOf<String, EpisodeMappingEntry>()
+    // In-flight dedup: prevents multiple concurrent coroutines from fetching
+    // the same show's addon episodes simultaneously.
+    private val addonEpisodesInFlight = mutableMapOf<String, kotlinx.coroutines.CompletableDeferred<List<EpisodeMappingEntry>>>()
 
     internal suspend fun prefetchEpisodeMapping(
         contentId: String?,
@@ -63,6 +66,13 @@ class TraktEpisodeMappingService @Inject constructor(
 
         val addonEpisodes = getAddonEpisodes(resolvedContentId, resolvedContentType)
         if (addonEpisodes.isEmpty()) return null
+
+        val addonHasEpisode = addonEpisodes.any {
+            it.season == requestedSeason && it.episode == requestedEpisode
+        }
+        if (addonHasEpisode) {
+            return null
+        }
 
         val showLookupId = resolveShowLookupId(contentId = resolvedContentId, videoId = null) ?: return null
         val traktEpisodes = getTraktEpisodes(showLookupId)
@@ -137,18 +147,49 @@ class TraktEpisodeMappingService @Inject constructor(
         contentType: String
     ): List<EpisodeMappingEntry> {
         val cacheKey = addonEpisodesCacheKey(contentId, contentType)
+
+        // Fast path: cache hit
         cacheMutex.withLock {
             addonEpisodesCache[cacheKey]?.let { return it }
         }
 
-        val meta = fetchSeriesMeta(contentId, contentType) ?: return emptyList()
-        val addonEpisodes = meta.videos.toEpisodeMappingEntries()
-        if (addonEpisodes.isEmpty()) return emptyList()
-
-        cacheMutex.withLock {
-            addonEpisodesCache[cacheKey] = addonEpisodes
+        // Dedup: if another coroutine is already fetching this show, await its result.
+        val existingDeferred = cacheMutex.withLock { addonEpisodesInFlight[cacheKey] }
+        if (existingDeferred != null) {
+            return try { existingDeferred.await() } catch (_: Exception) { emptyList() }
         }
-        return addonEpisodes
+
+        // Register ourselves as the in-flight fetcher.
+        val deferred = kotlinx.coroutines.CompletableDeferred<List<EpisodeMappingEntry>>()
+        val weOwn = cacheMutex.withLock {
+            // Double-check: cache or another flight may have appeared while we waited.
+            addonEpisodesCache[cacheKey]?.let { return it }
+            if (addonEpisodesInFlight.containsKey(cacheKey)) {
+                false
+            } else {
+                addonEpisodesInFlight[cacheKey] = deferred
+                true
+            }
+        }
+        if (!weOwn) {
+            val other = cacheMutex.withLock { addonEpisodesInFlight[cacheKey] }
+            return try { other?.await() ?: emptyList() } catch (_: Exception) { emptyList() }
+        }
+
+        return try {
+            val meta = fetchSeriesMeta(contentId, contentType)
+            val addonEpisodes = meta?.videos?.toEpisodeMappingEntries() ?: emptyList()
+            if (addonEpisodes.isNotEmpty()) {
+                cacheMutex.withLock { addonEpisodesCache[cacheKey] = addonEpisodes }
+            }
+            deferred.complete(addonEpisodes)
+            addonEpisodes
+        } catch (e: Exception) {
+            deferred.completeExceptionally(e)
+            emptyList()
+        } finally {
+            cacheMutex.withLock { addonEpisodesInFlight.remove(cacheKey) }
+        }
     }
 
     private suspend fun getTraktEpisodes(showLookupId: String): List<EpisodeMappingEntry> {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -851,20 +851,23 @@ class TraktProgressService @Inject constructor(
         if (!force && !hasActivityChanged()) {
             return
         }
-        // Load dropped shows first so all downstream flows emit pre-filtered data.
-        ensureHiddenProgressShows(force = force)
 
-        if ((force || watchedMoviesStale) && hasLoadedWatchedMovies) {
-            getWatchedMoviesSnapshot(forceRefresh = true)
-        }
-
-        val needSeedsRefresh = force ||
-            (watchedShowSeedsStale && hasLoadedWatchedShowSeeds)
         coroutineScope {
+            val hiddenDeferred = async { ensureHiddenProgressShows(force = force) }
+
+            if ((force || watchedMoviesStale) && hasLoadedWatchedMovies) {
+                launch { getWatchedMoviesSnapshot(forceRefresh = true) }
+            }
+
+            val needSeedsRefresh = force ||
+                (watchedShowSeedsStale && hasLoadedWatchedShowSeeds)
             val progressDeferred = async { fetchAllProgressSnapshot(force = force) }
             val seedsDeferred = if (needSeedsRefresh) {
                 async { getWatchedShowSeedsSnapshot(forceRefresh = true) }
             } else null
+
+            // Wait for hidden shows before emitting progress so filters apply.
+            hiddenDeferred.await()
 
             val snapshot = progressDeferred.await()
             seedsDeferred?.await()
@@ -1430,14 +1433,21 @@ class TraktProgressService @Inject constructor(
         val (recentCompletedEpisodes, inProgressMovies, inProgressEpisodes) = coroutineScope {
             val historyDeferred = async { fetchRecentEpisodeHistorySnapshot() }
             val moviesDeferred = async {
-                getPlayback("movies", force = force, startAt = playbackStartAt)
-                    .mapNotNull { mapPlaybackMovie(it) }
+                val playback = getPlayback("movies", force = force, startAt = playbackStartAt)
+                playback.map { item -> async { mapPlaybackMovie(item) } }
+                    .awaitAll()
+                    .filterNotNull()
             }
             val episodesDeferred = async {
-                getPlayback("episodes", force = force, startAt = playbackStartAt)
-                    .mapNotNull { mapPlaybackEpisode(it, applyAddonRemap = true) }
+                val playback = getPlayback("episodes", force = force, startAt = playbackStartAt)
+                playback.map { item -> async { mapPlaybackEpisode(item, applyAddonRemap = true) } }
+                    .awaitAll()
+                    .filterNotNull()
             }
-            Triple(historyDeferred.await(), moviesDeferred.await(), episodesDeferred.await())
+            val history = historyDeferred.await()
+            val movies = moviesDeferred.await()
+            val episodes = episodesDeferred.await()
+            Triple(history, movies, episodes)
         }
 
         inProgressEpisodes.take(5).forEach { p ->
@@ -1513,7 +1523,9 @@ class TraktProgressService @Inject constructor(
             val items = response.body().orEmpty()
             if (items.isEmpty()) break
 
+            // Filter items first (cheap), then map in parallel (expensive).
             var shouldStop = false
+            val candidateItems = mutableListOf<TraktUserEpisodeHistoryItemDto>()
             for (item in items) {
                 val contentId = normalizeContentId(item.show?.ids)
                 if (contentId.isBlank()) continue
@@ -1525,11 +1537,22 @@ class TraktProgressService @Inject constructor(
                     continue
                 }
 
-                val mapped = mapEpisodeHistoryItem(item, applyAddonRemap = true) ?: continue
-                results.putIfAbsent(mapped.contentId, mapped)
-                if (results.size >= maxRecentEpisodeHistoryEntries) {
+                candidateItems.add(item)
+                if (results.size + candidateItems.size >= maxRecentEpisodeHistoryEntries) {
                     shouldStop = true
-                    continue
+                    break
+                }
+            }
+
+            // Map candidates in parallel to speed up videoId resolution.
+            if (candidateItems.isNotEmpty()) {
+                val mapped = coroutineScope {
+                    candidateItems.map { item ->
+                        async { mapEpisodeHistoryItem(item, applyAddonRemap = true) }
+                    }.awaitAll()
+                }
+                mapped.filterNotNull().forEach { progress ->
+                    results.putIfAbsent(progress.contentId, progress)
                 }
             }
 
@@ -1807,7 +1830,7 @@ class TraktProgressService @Inject constructor(
         episode: Int,
         episodeTitle: String?
     ): EpisodeMappingEntry? {
-        return runCatching {
+        return try {
             traktEpisodeMappingService.resolveAddonEpisodeMapping(
                 contentId = contentId,
                 contentType = "series",
@@ -1815,7 +1838,7 @@ class TraktProgressService @Inject constructor(
                 episode = episode,
                 episodeTitle = episodeTitle
             )
-        }.getOrElse { error ->
+        } catch (error: Exception) {
             Log.w(
                 TAG,
                 "resolveAddonEpisodeProgress failed for $contentId s=$season e=$episode",
@@ -1830,34 +1853,21 @@ class TraktProgressService @Inject constructor(
         season: Int,
         episode: Int
     ): String {
-        if (!hasLoadedRemoteProgress.value) {
-            return "$contentId:$season:$episode"
-        }
         val key = "$contentId:$season:$episode"
         episodeVideoIdCache[key]?.let { return it }
 
-        val candidates = buildList {
-            add(contentId)
-            if (contentId.startsWith("tmdb:")) add(contentId.substringAfter(':'))
-            if (contentId.startsWith("trakt:")) add(contentId.substringAfter(':'))
-        }.distinct()
-
-        for (candidate in candidates) {
-            for (type in listOf("series", "tv")) {
-                val result = withTimeoutOrNull(2500) {
-                    metaRepository.getMetaFromAllAddons(type = type, id = candidate)
-                        .first { it !is NetworkResult.Loading }
-                } ?: continue
-
-                val meta = (result as? NetworkResult.Success)?.data ?: continue
-                val videoId = meta.videos.firstOrNull {
-                    it.season == season && it.episode == episode
-                }?.id
-
-                if (!videoId.isNullOrBlank()) {
-                    episodeVideoIdCache[key] = videoId
-                    return videoId
-                }
+        // Check if metadata is already cached (from a previous hydrateMetadata cycle).
+        // If so, resolve videoId from it without a network call.
+        val existingMeta = metadataState.value[contentId]
+        if (existingMeta != null) {
+            val episodeMeta = existingMeta.episodes.entries.firstOrNull {
+                it.key.first == season && it.key.second == episode
+            }
+            // Use the video ID pattern that matches addon meta structure
+            val videoId = episodeMeta?.let { "$contentId:${it.key.first}:${it.key.second}" }
+            if (videoId != null) {
+                episodeVideoIdCache[key] = videoId
+                return videoId
             }
         }
 

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -28,9 +28,11 @@ data class Stream(
     fun getStreamUrl(): String? = url ?: externalUrl
 
     /**
-     * Returns true if this is a torrent stream
+     * Returns true if this is a torrent-only stream (no HTTP URL available).
+     * When both infoHash and url are present (e.g. debrid cached torrents),
+     * the HTTP url is preferred and this returns false.
      */
-    fun isTorrent(): Boolean = infoHash != null
+    fun isTorrent(): Boolean = infoHash != null && url.isNullOrBlank()
 
     /**
      * Returns true if this is a YouTube stream

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -461,6 +461,11 @@ fun NuvioNavHost(
                 onStreamSelected = { playbackInfo ->
                     val streamUrl = playbackInfo.url
                         ?: if (playbackInfo.isTorrent) "torrent://${playbackInfo.infoHash}" else null
+                    // When both url and infoHash are present (debrid cached torrent),
+                    // prefer the HTTP url and don't pass infoHash — avoids starting
+                    // TorrServer for a stream that's already available via HTTP.
+                    val effectiveInfoHash = if (playbackInfo.url != null) null else playbackInfo.infoHash
+                    val effectiveFileIdx = if (playbackInfo.url != null) null else playbackInfo.fileIdx
                     streamUrl?.let { url ->
                         navController.navigate(
                             Screen.Player.createRoute(
@@ -490,8 +495,8 @@ fun NuvioNavHost(
                                 addonName = playbackInfo.addonName,
                                 addonLogo = playbackInfo.addonLogo,
                                 streamDescription = playbackInfo.streamDescription,
-                                infoHash = playbackInfo.infoHash,
-                                fileIdx = playbackInfo.fileIdx,
+                                infoHash = effectiveInfoHash,
+                                fileIdx = effectiveFileIdx,
                                 sources = playbackInfo.sources,
                                 contentLanguage = playbackInfo.contentLanguage
                             )
@@ -501,6 +506,8 @@ fun NuvioNavHost(
                 onAutoPlayResolved = { playbackInfo ->
                     val autoPlayUrl = playbackInfo.url
                         ?: if (playbackInfo.isTorrent) "torrent://${playbackInfo.infoHash}" else null
+                    val effectiveInfoHash = if (playbackInfo.url != null) null else playbackInfo.infoHash
+                    val effectiveFileIdx = if (playbackInfo.url != null) null else playbackInfo.fileIdx
                     autoPlayUrl?.let { url ->
                         navController.navigate(
                             Screen.Player.createRoute(
@@ -530,8 +537,8 @@ fun NuvioNavHost(
                                 addonName = playbackInfo.addonName,
                                 addonLogo = playbackInfo.addonLogo,
                                 streamDescription = playbackInfo.streamDescription,
-                                infoHash = playbackInfo.infoHash,
-                                fileIdx = playbackInfo.fileIdx,
+                                infoHash = effectiveInfoHash,
+                                fileIdx = effectiveFileIdx,
                                 sources = playbackInfo.sources,
                                 contentLanguage = playbackInfo.contentLanguage
                             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,7 +60,7 @@ private data class HomePosterOptionsTarget(
     val addonBaseUrl: String
 )
 
-private const val HOME_STARTUP_CW_GATE_TIMEOUT_MS = 5_000L
+private const val HOME_STABLE_GATE_TIMEOUT_MS = 3_000L
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -91,46 +92,59 @@ fun HomeScreen(
     val hasCatalogContent = uiState.catalogRows.any { it.items.isNotEmpty() }
     val hasCollectionContent = uiState.homeRows.any { it is HomeRow.CollectionRow }
     val hasHeroContent = uiState.heroItems.isNotEmpty()
-    var hasEnteredCatalogContent by rememberSaveable { mutableStateOf(false) }
     var showHomeContentWithAnimation by rememberSaveable { mutableStateOf(false) }
-    var hasReleasedStartupCwGate by rememberSaveable { mutableStateOf(false) }
-    var startupCwGateTimedOut by rememberSaveable { mutableStateOf(false) }
     var hasShownInitialHomeContent by rememberSaveable { mutableStateOf(false) }
+    // Once we've shown stable home content, never go back to loading gate.
+    var homeStableGateReleased by rememberSaveable { mutableStateOf(false) }
+    // Track that catalog loading has started at least once (isLoading went true→false).
+    var catalogLoadingStarted by rememberSaveable { mutableStateOf(false) }
     var posterOptionsTarget by remember { mutableStateOf<HomePosterOptionsTarget?>(null) }
 
     // Stable lambdas — captured via rememberUpdatedState so they never cause
     // downstream recomposition when uiState changes.
     val latestMovieWatchedStatus by rememberUpdatedState(uiState.movieWatchedStatus)
     val latestPosterOptionsTarget by rememberUpdatedState(posterOptionsTarget)
-    val isCatalogItemWatched: (MetaPreview) -> Boolean = remember(uiState.movieWatchedStatus) {
+    val isCatalogItemWatched: (MetaPreview) -> Boolean = remember(Unit) {
         { item -> latestMovieWatchedStatus[homeItemStatusKey(item.id, item.apiType)] == true }
     }
     val onCatalogItemLongPress: (MetaPreview, String) -> Unit = remember(Unit) {
         { item, addonBaseUrl -> posterOptionsTarget = HomePosterOptionsTarget(item, addonBaseUrl) }
     }
 
-    LaunchedEffect(hasCatalogContent, hasCollectionContent, hasHeroContent) {
-        if (hasCatalogContent || hasCollectionContent || hasHeroContent) {
-            hasEnteredCatalogContent = true
+    LaunchedEffect(uiState.isLoading, hasCatalogContent, hasCollectionContent, hasHeroContent) {
+        Log.d("HomeGate", "isLoading=${uiState.isLoading} hasCatalog=$hasCatalogContent hasCollection=$hasCollectionContent hasHero=$hasHeroContent gateReleased=$homeStableGateReleased catalogLoadStarted=$catalogLoadingStarted addons=${uiState.installedAddonsCount} catalogRows=${uiState.catalogRows.size} homeRows=${uiState.homeRows.size} cwItems=${uiState.continueWatchingItems.size}")
+        // Track that catalog loading pipeline has started.
+        if (uiState.isLoading && uiState.installedAddonsCount > 0) {
+            catalogLoadingStarted = true
+        }
+        // Wait until catalog loading has completed (started AND finished) with content.
+        if (!homeStableGateReleased &&
+            catalogLoadingStarted &&
+            !uiState.isLoading &&
+            (hasCatalogContent || hasCollectionContent || hasHeroContent)
+        ) {
+            Log.d("HomeGate", "Gate releasing: settle delay 200ms")
+            delay(200)
+            homeStableGateReleased = true
+            Log.d("HomeGate", "Gate RELEASED via content+loading done")
         }
     }
 
     LaunchedEffect(Unit) {
-        delay(HOME_STARTUP_CW_GATE_TIMEOUT_MS)
-        startupCwGateTimedOut = true
-    }
-
-    LaunchedEffect(uiState.continueWatchingItems.isNotEmpty(), startupCwGateTimedOut, uiState.isLoading) {
-        if (!hasReleasedStartupCwGate &&
-            (uiState.continueWatchingItems.isNotEmpty() || startupCwGateTimedOut || !uiState.isLoading)
-        ) {
-            hasReleasedStartupCwGate = true
+        // Give the addon pipeline time to start (local DataStore read + emission).
+        // If after that window the pipeline still hasn't started and no addons
+        // are known, the user genuinely has no addons — release the gate.
+        delay(300)
+        if (!homeStableGateReleased && !catalogLoadingStarted && uiState.installedAddonsCount == 0) {
+            homeStableGateReleased = true
+            Log.d("HomeGate", "Gate RELEASED: no addons after 300ms")
         }
-    }
-
-    LaunchedEffect(showHomeContentWithAnimation) {
-        if (showHomeContentWithAnimation) {
-            hasShownInitialHomeContent = true
+        // Safety timeout for everything else.
+        delay(HOME_STABLE_GATE_TIMEOUT_MS - 300)
+        Log.d("HomeGate", "Timeout reached (${HOME_STABLE_GATE_TIMEOUT_MS}ms)")
+        if (!homeStableGateReleased) {
+            homeStableGateReleased = true
+            Log.d("HomeGate", "Gate RELEASED via timeout")
         }
     }
 
@@ -158,6 +172,7 @@ fun HomeScreen(
 
         when {
             uiState.isLoading && !hasAnyContent -> {
+                Log.d("HomeGate", "BRANCH: loading+noContent")
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
@@ -213,23 +228,10 @@ fun HomeScreen(
             }
 
             else -> {
-                val shouldShowLoadingGate =
-                    !hasReleasedStartupCwGate ||
-                        (uiState.isLoading &&
-                            !hasEnteredCatalogContent &&
-                            !hasCatalogContent &&
-                            !hasCollectionContent &&
-                            !hasHeroContent)
-                LaunchedEffect(shouldShowLoadingGate) {
-                    if (shouldShowLoadingGate) {
-                        showHomeContentWithAnimation = false
-                    } else {
-                        // Flip on the next frame so AnimatedVisibility can run enter transition.
-                        kotlinx.coroutines.yield()
-                        showHomeContentWithAnimation = true
-                    }
-                }
-                if (shouldShowLoadingGate) {
+                Log.d("HomeGate", "BRANCH: else — gateReleased=$homeStableGateReleased showAnim=$showHomeContentWithAnimation hasShown=$hasShownInitialHomeContent")
+                // On first launch, wait for stable content before revealing home.
+                // Once released, never go back to loading (homeStableGateReleased is rememberSaveable).
+                if (!homeStableGateReleased) {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -237,16 +239,38 @@ fun HomeScreen(
                         LoadingIndicator()
                     }
                 } else {
+                    // Flip showHomeContentWithAnimation on the next frame so
+                    // AnimatedVisibility can run its enter transition.
+                    LaunchedEffect(Unit) {
+                        if (!showHomeContentWithAnimation) {
+                            kotlinx.coroutines.yield()
+                            showHomeContentWithAnimation = true
+                        }
+                    }
+                    LaunchedEffect(showHomeContentWithAnimation) {
+                        if (showHomeContentWithAnimation) {
+                            hasShownInitialHomeContent = true
+                        }
+                    }
+                    // Keep loading visible during the single-frame gap before animation starts.
+                    if (!showHomeContentWithAnimation) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            LoadingIndicator()
+                        }
+                    }
                     AnimatedVisibility(
                         visible = showHomeContentWithAnimation,
                         enter = if (hasShownInitialHomeContent) {
+                            EnterTransition.None
+                        } else {
                             fadeIn(animationSpec = tween(320)) +
                                 slideInVertically(
                                     initialOffsetY = { it / 24 },
                                     animationSpec = tween(320)
                                 )
-                        } else {
-                            EnterTransition.None
                         }
                     ) {
                         when (uiState.homeLayout) {
@@ -517,7 +541,8 @@ private fun ModernHomeRoute(
             { item -> viewModel.onItemFocus(item) }
         },
         onPreloadAdjacentItem = preloadAdjacentItem,
-        onSaveFocusState = saveModernFocusState
+        onSaveFocusState = saveModernFocusState,
+        rowBuildCache = viewModel.modernCarouselRowBuildCache
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -60,7 +60,7 @@ private data class HomePosterOptionsTarget(
     val addonBaseUrl: String
 )
 
-private const val HOME_STABLE_GATE_TIMEOUT_MS = 4_000L
+private const val HOME_STABLE_GATE_TIMEOUT_MS = 5_000L
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -2,10 +2,10 @@ package com.nuvio.tv.ui.screens.home
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
+import android.util.Log
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -60,7 +60,7 @@ private data class HomePosterOptionsTarget(
     val addonBaseUrl: String
 )
 
-private const val HOME_STABLE_GATE_TIMEOUT_MS = 3_000L
+private const val HOME_STABLE_GATE_TIMEOUT_MS = 4_000L
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -86,6 +86,7 @@ fun HomeScreen(
     onNavigateToFolderDetail: (String, String) -> Unit = { _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val initialCwResolved by viewModel.initialCwResolved.collectAsStateWithLifecycle()
     val effectiveAutoplayEnabled by viewModel.effectiveAutoplayEnabled.collectAsStateWithLifecycle(
         initialValue = false
     )
@@ -111,40 +112,34 @@ fun HomeScreen(
         { item, addonBaseUrl -> posterOptionsTarget = HomePosterOptionsTarget(item, addonBaseUrl) }
     }
 
-    LaunchedEffect(uiState.isLoading, hasCatalogContent, hasCollectionContent, hasHeroContent) {
-        Log.d("HomeGate", "isLoading=${uiState.isLoading} hasCatalog=$hasCatalogContent hasCollection=$hasCollectionContent hasHero=$hasHeroContent gateReleased=$homeStableGateReleased catalogLoadStarted=$catalogLoadingStarted addons=${uiState.installedAddonsCount} catalogRows=${uiState.catalogRows.size} homeRows=${uiState.homeRows.size} cwItems=${uiState.continueWatchingItems.size}")
-        // Track that catalog loading pipeline has started.
-        if (uiState.isLoading && uiState.installedAddonsCount > 0) {
+    LaunchedEffect(uiState.isLoading, hasCatalogContent, hasCollectionContent, hasHeroContent, initialCwResolved) {
+        // Track that addons are known (even if isLoading flipped too fast to catch).
+        if (uiState.installedAddonsCount > 0) {
             catalogLoadingStarted = true
         }
-        // Wait until catalog loading has completed (started AND finished) with content.
+        // Wait until catalog loading has completed with content AND the CW
+        // pipeline has completed its first emission.
         if (!homeStableGateReleased &&
             catalogLoadingStarted &&
             !uiState.isLoading &&
-            (hasCatalogContent || hasCollectionContent || hasHeroContent)
+            initialCwResolved &&
+            // When addons are installed, require at least one catalog row.
+            (hasCatalogContent || uiState.installedAddonsCount == 0)
         ) {
-            Log.d("HomeGate", "Gate releasing: settle delay 200ms")
-            delay(200)
+            Log.d("HomeGate", "RELEASE: catalogs=$hasCatalogContent cwResolved=$initialCwResolved cwItems=${uiState.continueWatchingItems.size} addons=${uiState.installedAddonsCount}")
             homeStableGateReleased = true
-            Log.d("HomeGate", "Gate RELEASED via content+loading done")
         }
     }
 
     LaunchedEffect(Unit) {
-        // Give the addon pipeline time to start (local DataStore read + emission).
-        // If after that window the pipeline still hasn't started and no addons
-        // are known, the user genuinely has no addons — release the gate.
-        delay(300)
-        if (!homeStableGateReleased && !catalogLoadingStarted && uiState.installedAddonsCount == 0) {
-            homeStableGateReleased = true
-            Log.d("HomeGate", "Gate RELEASED: no addons after 300ms")
-        }
-        // Safety timeout for everything else.
-        delay(HOME_STABLE_GATE_TIMEOUT_MS - 300)
-        Log.d("HomeGate", "Timeout reached (${HOME_STABLE_GATE_TIMEOUT_MS}ms)")
+        // Safety timeout — if catalogs and CW haven't loaded within this
+        // window, show whatever is available.  Covers edge cases like
+        // clean cache (addons loading from remote sync) and users with
+        // no addons at all.
+        delay(HOME_STABLE_GATE_TIMEOUT_MS)
         if (!homeStableGateReleased) {
+            Log.d("HomeGate", "RELEASE timeout: isLoading=${uiState.isLoading} cwResolved=$initialCwResolved catalogs=$hasCatalogContent cwItems=${uiState.continueWatchingItems.size}")
             homeStableGateReleased = true
-            Log.d("HomeGate", "Gate RELEASED via timeout")
         }
     }
 
@@ -172,7 +167,6 @@ fun HomeScreen(
 
         when {
             uiState.isLoading && !hasAnyContent -> {
-                Log.d("HomeGate", "BRANCH: loading+noContent")
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
@@ -182,28 +176,40 @@ fun HomeScreen(
             }
 
             uiState.error == "No addons installed" && uiState.catalogRows.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = stringResource(R.string.home_no_addons),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = NuvioColors.TextSecondary
-                    )
+                if (!homeStableGateReleased) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        LoadingIndicator()
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(R.string.home_no_addons),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = NuvioColors.TextSecondary
+                        )
+                    }
                 }
             }
 
             uiState.error == "No catalog addons installed" && uiState.catalogRows.isEmpty() && !hasCollectionContent && !hasHeroContent -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = stringResource(R.string.home_no_catalog_addons),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = NuvioColors.TextSecondary
-                    )
+                if (!homeStableGateReleased) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        LoadingIndicator()
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(R.string.home_no_catalog_addons),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = NuvioColors.TextSecondary
+                        )
+                    }
                 }
             }
 
@@ -215,20 +221,30 @@ fun HomeScreen(
             }
 
             !uiState.isLoading && !hasAnyContent -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = stringResource(R.string.web_no_catalogs),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = NuvioColors.TextSecondary
-                    )
+                // Don't show "no catalogs" until the stable gate has released —
+                // addons may still be loading from remote after a cache clear.
+                if (!homeStableGateReleased) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        LoadingIndicator()
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(R.string.web_no_catalogs),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = NuvioColors.TextSecondary
+                        )
+                    }
                 }
             }
 
             else -> {
-                Log.d("HomeGate", "BRANCH: else — gateReleased=$homeStableGateReleased showAnim=$showHomeContentWithAnimation hasShown=$hasShownInitialHomeContent")
                 // On first launch, wait for stable content before revealing home.
                 // Once released, never go back to loading (homeStableGateReleased is rememberSaveable).
                 if (!homeStableGateReleased) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -92,6 +92,9 @@ class HomeViewModel @Inject constructor(
 
     internal val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+    /** True once the CW pipeline has completed its first emission (items or empty). */
+    internal val _initialCwResolved = MutableStateFlow(false)
+    val initialCwResolved: StateFlow<Boolean> = _initialCwResolved.asStateFlow()
     val effectiveAutoplayEnabled = playerSettingsDataStore.playerSettings
         .map(StreamAutoPlayPolicy::isEffectivelyEnabled)
         .distinctUntilChanged()
@@ -201,6 +204,7 @@ class HomeViewModel @Inject constructor(
         observeMdbListSettings()
         observeBlurUnwatchedEpisodes()
         observeStartupAuthNotice()
+        observeProgressSourceChanges()
         loadContinueWatching()
         observeCollections()
         observeInstalledAddons()
@@ -223,6 +227,7 @@ class HomeViewModel @Inject constructor(
                     cwEnrichedNextUpOverlay.clear()
                     cwEnrichedInProgressOverlay.clear()
                     _uiState.update { it.copy(continueWatchingItems = emptyList()) }
+                    loadContinueWatching()
                 }
             }
         }
@@ -292,6 +297,38 @@ class HomeViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .collectLatest { settings ->
                     currentMdbListSettings = settings
+                }
+        }
+    }
+
+    /**
+     * When the watch-progress source changes (e.g. Trakt login/logout, or
+     * switching between Trakt and Nuvio Sync), clear the CW disk cache and
+     * in-memory state so items from the old source don't leak into the new one.
+     */
+    private fun observeProgressSourceChanges() {
+        viewModelScope.launch {
+            var previousSource: com.nuvio.tv.data.local.WatchProgressSource? = null
+            traktSettingsDataStore.watchProgressSource
+                .distinctUntilChanged()
+                .collect { source ->
+                    if (previousSource != null && previousSource != source) {
+                        // Source changed — clear CW caches to prevent mixing.
+                        cwMetaCache.clear()
+                        cwEnrichedNextUpOverlay.clear()
+                        cwEnrichedInProgressOverlay.clear()
+                        discoveredOlderNextUpItems.clear()
+                        cwLastProcessedNextUpContentIds.clear()
+                        _uiState.update { it.copy(continueWatchingItems = emptyList()) }
+                        // Clear disk cache for current profile.
+                        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                            runCatching { cwEnrichmentCache.saveNextUpSnapshot(emptyList()) }
+                            runCatching { cwEnrichmentCache.saveInProgressSnapshot(emptyList()) }
+                        }
+                        // Reload CW from fresh source.
+                        loadContinueWatching()
+                    }
+                    previousSource = source
                 }
         }
     }
@@ -437,6 +474,7 @@ class HomeViewModel @Inject constructor(
                         state.copy(continueWatchingItems = items)
                     } else state
                 }
+                _initialCwResolved.value = true
             }
         }
         loadContinueWatchingPipeline()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -12,8 +12,10 @@ import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.domain.model.skipStep
 import com.nuvio.tv.domain.model.supportsExtra
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import com.nuvio.tv.domain.model.MetaPreview
@@ -30,10 +32,12 @@ private data class CatalogUpdateResult(
     val fullRows: List<CatalogRow>
 )
 
+@OptIn(FlowPreview::class)
 internal fun HomeViewModel.observeCollectionsPipeline() {
     viewModelScope.launch {
         collectionsDataStore.collections
             .distinctUntilChanged()
+            .debounce(300)
             .collectLatest { collections ->
                 collectionsCache = collections
                 rebuildCatalogOrder(addonsCache)
@@ -94,6 +98,7 @@ internal fun HomeViewModel.observeTmdbSettingsPipeline() {
     }
 }
 
+@OptIn(FlowPreview::class)
 internal fun HomeViewModel.observeInstalledAddonsPipeline() {
     viewModelScope.launch {
         addonRepository.getInstalledAddons()
@@ -123,7 +128,14 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
     val generation = catalogLoadGeneration
     cancelInFlightCatalogLoads()
 
-    _uiState.update { it.copy(isLoading = true, error = null, installedAddonsCount = addons.size) }
+    // On reload (not first load), keep existing UI data visible while new
+    // catalogs load in the background to avoid a flash of empty content.
+    val isReload = _uiState.value.catalogRows.isNotEmpty() || _uiState.value.homeRows.isNotEmpty()
+    if (!isReload) {
+        _uiState.update { it.copy(isLoading = true, error = null, installedAddonsCount = addons.size) }
+    } else {
+        _uiState.update { it.copy(error = null, installedAddonsCount = addons.size) }
+    }
     synchronized(catalogStateLock) {
         catalogOrder.clear()
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -424,12 +424,6 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             nextUpItems = cachedNextUpItems
                         )
                     )
-                    _uiState.update { state ->                        if (state.continueWatchingItems == initialItems) {
-                            state
-                        } else {
-                            state.copy(continueWatchingItems = initialItems)
-                        }
-                    }
                     _uiState.update { state ->
                         if (state.continueWatchingItems == initialItems) {
                             state
@@ -1057,6 +1051,9 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
     val mergeMutex = Mutex()
     val nextUpByContent = linkedMapOf<String, ContinueWatchingItem.NextUp>()
     val processedContentIds = Collections.synchronizedSet(mutableSetOf<String>())
+    val resolvedSinceLastPublish = java.util.concurrent.atomic.AtomicInteger(0)
+    // Batch partial updates: publish every N resolved items instead of after each one.
+    val partialPublishBatchSize = (latestCompletedBySeries.size / 3).coerceIn(2, 8)
 
     val jobs = latestCompletedBySeries.map { progress ->
         launch(Dispatchers.IO) {
@@ -1070,11 +1067,17 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
                     logNextUpDecision("drop contentId=${progress.contentId} name=${progress.name} reason=buildNextUpItem-null")
                     return@withPermit
                 }
+                val shouldPublish: Boolean
                 val partialItems = mergeMutex.withLock {
                     nextUpByContent[progress.contentId] = nextUp
-                    nextUpByContent.values.toList()
+                    val count = resolvedSinceLastPublish.incrementAndGet()
+                    shouldPublish = count >= partialPublishBatchSize
+                    if (shouldPublish) resolvedSinceLastPublish.set(0)
+                    if (shouldPublish) nextUpByContent.values.toList() else emptyList()
                 }
-                onPartialUpdate(partialItems)
+                if (shouldPublish) {
+                    onPartialUpdate(partialItems)
+                }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -387,6 +387,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     if (inProgressOnly.any { it.progress.contentId == cached.contentId }) return@mapNotNull null
                     // Skip dismissed items
                     if (nextUpDismissKey(cached.contentId, cached.seedSeason, cached.seedEpisode) in dismissedNextUp) return@mapNotNull null
+                    // Respect "show unaired" setting
+                    if (!cached.hasAired && !showUnairedNextUp) return@mapNotNull null
                     ContinueWatchingItem.NextUp(
                         info = NextUpInfo(
                             contentId = cached.contentId,
@@ -741,6 +743,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             // Only apply rejection filter to non-cached items.
                             // Cached items survive until fresh pipeline replaces them.
                             (isCachedFromDisk || it.info.contentId !in rejectedByFreshPipeline) &&
+                            // Respect "show unaired" setting for all items including cached.
+                            (it.info.hasAired || showUnairedNextUp) &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&
                             !watchProgressRepository.isDroppedShow(it.info.contentId)
                         pass

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -431,6 +431,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             state.copy(continueWatchingItems = initialItems)
                         }
                     }
+                    _initialCwResolved.value = true
                     debug.recordInitialRendered(
                         count = initialItems.size,
                         elapsedMs = SystemClock.elapsedRealtime() - cycleStartMs
@@ -643,7 +644,37 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                                 nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
                                         }
                                         if (newItems.isEmpty()) return@update state
-                                        state.copy(continueWatchingItems = state.continueWatchingItems + newItems)
+                                        val merged = (state.continueWatchingItems + newItems)
+                                            .sortedByDescending { item ->
+                                                when (item) {
+                                                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                                                    is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
+                                                }
+                                            }
+                                        state.copy(continueWatchingItems = merged)
+                                    }
+                                    // Persist updated CW snapshot
+                                    viewModelScope.launch(Dispatchers.IO) {
+                                        val currentItems = _uiState.value.continueWatchingItems
+                                        val brokenUrls = com.nuvio.tv.ui.components.brokenImageUrls
+                                        val nextUpSnap = currentItems.mapNotNull { item ->
+                                            val nu = item as? ContinueWatchingItem.NextUp ?: return@mapNotNull null
+                                            val info = nu.info
+                                            com.nuvio.tv.data.local.CachedNextUpItem(
+                                                contentId = info.contentId, contentType = info.contentType, name = info.name,
+                                                poster = info.poster, backdrop = info.backdrop, logo = info.logo,
+                                                videoId = info.videoId, season = info.season, episode = info.episode,
+                                                episodeTitle = info.episodeTitle, episodeDescription = info.episodeDescription,
+                                                thumbnail = info.thumbnail?.takeIf { it !in brokenUrls },
+                                                released = info.released, hasAired = info.hasAired, airDateLabel = info.airDateLabel,
+                                                lastWatched = info.lastWatched, imdbRating = info.imdbRating, genres = info.genres,
+                                                releaseInfo = info.releaseInfo, sortTimestamp = info.sortTimestamp,
+                                                releaseTimestamp = info.releaseTimestamp, isReleaseAlert = info.isReleaseAlert,
+                                                isNewSeasonRelease = info.isNewSeasonRelease, seedSeason = info.seedSeason,
+                                                seedEpisode = info.seedEpisode, contentLanguage = info.contentLanguage
+                                            )
+                                        }
+                                        runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap) }
                                     }
                                 }
                             }
@@ -657,9 +688,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     discoveredOlderNextUpItems.toList()
                 }
                 // Preserve cached next-up items from disk until async inject re-verifies them.
-                // For Trakt: only release alerts. For Nuvio Sync: all items.
                 val cachedOlderNextUp = cachedNextUp
-                    .filter { if (useTraktProgress) it.isReleaseAlert else true }
                     .map { cached ->
                         ContinueWatchingItem.NextUp(
                             info = NextUpInfo(
@@ -704,13 +733,17 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val olderToInclude = (persistedOlderItems + cachedOlderNextUp)
                     .distinctBy { it.info.contentId }
                     .filter {
-                        (if (useTraktProgress) it.info.isReleaseAlert else true) &&
-                            it.info.contentId in allSeedContentIds &&
+                        val isCachedFromDisk = cachedOlderNextUp.any { c -> c.info.contentId == it.info.contentId }
+                        val pass =
+                            (it.info.contentId in allSeedContentIds || isCachedFromDisk) &&
                             it.info.contentId !in recentIds &&
                             it.info.contentId !in inProgressIds &&
-                            it.info.contentId !in rejectedByFreshPipeline &&
+                            // Only apply rejection filter to non-cached items.
+                            // Cached items survive until fresh pipeline replaces them.
+                            (isCachedFromDisk || it.info.contentId !in rejectedByFreshPipeline) &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&
                             !watchProgressRepository.isDroppedShow(it.info.contentId)
+                        pass
                     }
                 val allNextUpItems = nextUpItems + olderToInclude
                 val normalItems = applyContinueWatchingEnrichmentOverlay(
@@ -747,6 +780,13 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     count = normalItems.size,
                     elapsedMs = SystemClock.elapsedRealtime() - cycleStartMs
                 )
+                // Signal that the first CW cycle completed (items or confirmed empty).
+                if (!_initialCwResolved.value) {
+                    val hasRealData = normalItems.isNotEmpty() || !useTraktProgress || items.isNotEmpty()
+                    if (hasRealData) {
+                        _initialCwResolved.value = true
+                    }
+                }
 
                 // Save lightweight CW snapshot to disk immediately so cache stays fresh
                 // even if enrichment is cancelled by collectLatest.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -222,6 +222,7 @@ internal fun HomeViewModel.observeLayoutPreferencesPipeline() {
     }
 }
 
+@OptIn(FlowPreview::class)
 internal fun HomeViewModel.observeModernHomePresentationPipeline() {
     viewModelScope.launch {
         uiState
@@ -235,6 +236,7 @@ internal fun HomeViewModel.observeModernHomePresentationPipeline() {
                 )
             }
             .distinctUntilChanged()
+            .debounce(80)
             .collectLatest { input ->
                 val shouldWarmStart = uiState.value.modernHomePresentation.rows.isEmpty()
                 val visibleCatalogRowCount = input.catalogRows.count { it.items.isNotEmpty() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -146,7 +146,8 @@ fun ModernHomeContent(
     onNavigateToFolderDetail: (String, String) -> Unit = { _, _ -> },
     onItemFocus: (MetaPreview) -> Unit = {},
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
-    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit
+    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
+    rowBuildCache: ModernCarouselRowBuildCache = remember { ModernCarouselRowBuildCache() }
 ) {
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val isSidebarExpanded = LocalSidebarExpanded.current
@@ -196,7 +197,6 @@ fun ModernHomeContent(
     val strUpcoming = stringResource(R.string.cw_upcoming)
     val strTypeMovie = stringResource(R.string.type_movie)
     val strTypeSeries = stringResource(R.string.type_series)
-    val rowBuildCache = remember { ModernCarouselRowBuildCache() }
     val context = LocalContext.current
     val carouselRows = remember(
         uiState.continueWatchingItems,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -174,16 +174,16 @@ internal class ModernHomeUiCaches {
 }
 
 @Stable
-internal class ModernCarouselRowBuildCache {
+class ModernCarouselRowBuildCache {
     var continueWatchingItems: List<ContinueWatchingItem> = emptyList()
     var continueWatchingTitle: String = ""
     var continueWatchingAirsDateTemplate: String = ""
     var continueWatchingUpcomingLabel: String = ""
     var continueWatchingUseLandscapePosters: Boolean = false
     var continueWatchingRow: HeroCarouselRow? = null
-    val catalogRows = mutableMapOf<String, ModernCatalogRowBuildCacheEntry>()
+    internal val catalogRows = mutableMapOf<String, ModernCatalogRowBuildCacheEntry>()
     // per-item cache: rowKey -> (itemId -> cached carousel item + source MetaPreview)
-    val catalogItemCache = mutableMapOf<String, MutableMap<String, CachedCarouselItem>>()
+    internal val catalogItemCache = mutableMapOf<String, MutableMap<String, CachedCarouselItem>>()
 }
 
 internal data class CachedCarouselItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -677,6 +677,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(stream: Stream, force
         stopTorrentStream()
         switchToEpisodeStreamCommon(stream, forcedTargetVideo)
         launchTorrentSourceStream(stream, infoHash, loadSavedProgress = true)
+        persistTorrentStreamForReuse(stream)
         return
     }
 


### PR DESCRIPTION
## Summary

Home screen performance improvements, CW (Continue Watching) stability fixes for Trakt users, debrid stream handling, and several related bug fixes.

**Home startup:**
- Loading gate waits for catalogs + CW before revealing home
- Startup sync (plugins, addons, collections, catalog settings) runs in parallel instead of sequentially
- `ModernCarouselRowBuildCache` persisted in ViewModel - eliminates full carousel rebuild on back navigation from details
- Presentation pipeline debounced (80ms) to reduce redundant rebuilds
- Collections observer debounced (300ms)
- Catalog reload no longer resets UI to loading when content is already visible

**CW Trakt performance (~10s -> ~4s first fetch):**
- Hidden shows, progress, seeds and watched movies fetched in parallel
- History and playback items mapped concurrently (async/awaitAll)
- In-flight dedup in `getAddonEpisodes` - prevents duplicate meta fetches for the same show
- `resolveEpisodeVideoId` no longer makes network calls - uses cached meta or returns fallback
- Fast path in `resolveAddonEpisodeMapping` - skips Trakt API call when addon already has the episode

**CW stability (no more jumping items):**
- Cached next-up items from disk survive merge-lightweight until fresh pipeline replaces them
- Older seeds injection inserts at sorted position instead of appending to end
- Disk persistence after older seeds injection - release alerts survive app restart
- Duplicate `_uiState.update` in initial CW render removed
- Batched partial updates in `buildLightweightNextUpItems` (~4 emissions instead of ~32)
- Unaired next-up items now filtered by `showUnairedNextUp` setting in both cached and older-to-include paths

**Profile switch / Trakt login:**
- CW disk cache reloaded on profile switch (fixes: CW disappears after switching profiles)
- CW disk + memory cache cleared on watch progress source change (Trakt <-> Nuvio Sync) - prevents mixing items
- `initialCwResolved` signal ensures gate waits for CW pipeline before showing home

**Debrid / torrent stream handling:**
- `Stream.isTorrent()` now returns `false` when both `url` and `infoHash` are present - debrid cached torrents play via HTTP instead of starting TorrServer
- NuvioNavHost strips `infoHash`/`fileIdx` from navigation args when HTTP URL is available
- Fixes binge/next-episode auto-play for debrid streams

**Other fixes:**
- HTTP cache: network interceptor prevents caching of error responses (4xx/5xx) - fixes stale 404 causing fallback to wrong addon
- `isCatalogItemWatched` lambda stabilized (`remember(Unit)`) to prevent cascading recomposition
- `switchToEpisodeStream` now persists torrent stream for reuse link
- `ModernCarouselRowBuildCache` visibility fixed for benchmark build

## PR type

- Bug fix
- Small maintenance improvement

## Why

Users reported sluggish home screen after v0.6. Investigation revealed cascading recomposition from startup sync, CW pipeline emitting too many intermediate states, and carousel rebuild on every navigation. Trakt users additionally experienced ~10s delay for in-progress items and jumping CW positions. User of addons that provided both url and infoHash had streams incorrectly routed through TorrServer

## Testing

- Manual testing on TCL TV
- Verified: home loads behind loading gate, CW items stable on startup, no jumping after Trakt refresh
- Verified: profile switch reloads CW correctly, source change clears stale items
- Verified: debrid streams (Corsaro) play via HTTP, not TorrServer
- Verified: return from details is instant (no animation, no rebuild)
- Verified: clean cache start shows loading until catalogs + CW ready

## Breaking changes

Nothing should break 

## Linked issues

Most of the issues reported on discord 
