### PR TITLE
Fix subtitle selection tracking and stream panel focus

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -100,7 +100,21 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                 for (i in 0 until trackGroup.length) {
                     val format = trackGroup.getTrackFormat(i)
                     // Skip addon subtitle tracks — they are managed separately
-                    if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) continue
+                    if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) {
+                        // Detect if ExoPlayer auto-selected an addon track (e.g. via
+                        // preferredTextLanguage) so we can keep selectedAddonSubtitle in sync.
+                        if (trackGroup.isTrackSelected(i)) {
+                            val trackId = format.id ?: ""
+                            val matchedAddon = _uiState.value.addonSubtitles.firstOrNull { subtitle ->
+                                trackId == buildAddonSubtitleTrackId(subtitle)
+                            }
+                            if (matchedAddon != null && _uiState.value.selectedAddonSubtitle?.id != matchedAddon.id) {
+                                _uiState.update { it.copy(selectedAddonSubtitle = matchedAddon, selectedSubtitleTrackIndex = -1) }
+                                if (!autoSubtitleSelected) autoSubtitleSelected = true
+                            }
+                        }
+                        continue
+                    }
                     val isSelected = trackGroup.isTrackSelected(i)
                     if (isSelected) selectedSubtitleIndex = subtitleTracks.size
                     

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.key
@@ -244,6 +245,10 @@ internal fun AddonFilterChips(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
         modifier = Modifier
+            .focusRestorer {
+                val idx = selectedIndex.coerceIn(0, focusRequesters.lastIndex)
+                focusRequesters[idx]
+            }
             .onFocusChanged { chipRowHasFocus = it.hasFocus }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false


### PR DESCRIPTION
## Summary

- When ExoPlayer auto-selects an addon subtitle track via `preferredTextLanguage`, `selectedAddonSubtitle` in UI state is now kept in sync. Previously the overlay showed "None" as selected even though subtitles were visibly active.
- Added `focusRestorer` to the addon filter chips `LazyRow` in `StreamComponents` so that navigating down from the reload/close buttons lands on the currently selected chip instead of a random one.

## PR type

- Bug fix

## Why

Users reported that the subtitle selection overlay always focused on "None" even when a subtitle was automatically loaded at stream start. This happened because `onTracksChanged` skipped addon subtitle tracks without updating `selectedAddonSubtitle`, so the UI had no record of the active selection.

The stream sources side panel had a focus issue - pressing down from the reload button would land on whichever addon chip was geometrically closest rather than the one that was actually selected earlier.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manually tested by:
1. As I could not reproduce the issue I performed only basic smoke tests
2. Opening the stream sources panel and pressing down from reload - verified focus lands on the earlier selected addon chip

## Screenshots / Video (UI changes only)

Behavioral focus fix, no visual changes.

## Breaking changes

Nothing should break

## Linked issues

Reported on discord
