### PR TITLE
feat(tmdb): deduplicate concurrent in-flight API requests

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -15,6 +15,8 @@ import com.nuvio.tv.domain.model.MetaCompany
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PersonDetail
 import com.nuvio.tv.domain.model.PosterShape
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -36,6 +38,8 @@ class TmdbMetadataService @Inject constructor(
     // In-memory caches
     private val enrichmentCache = ConcurrentHashMap<String, TmdbEnrichment>()
     private val episodeCache = ConcurrentHashMap<String, Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
+    private val enrichmentInFlight = ConcurrentHashMap<String, CompletableDeferred<TmdbEnrichment?>>()
+    private val episodeInFlight = ConcurrentHashMap<String, CompletableDeferred<Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>>()
     private val personCache = ConcurrentHashMap<String, PersonDetail>()
     private val moreLikeThisCache = ConcurrentHashMap<String, List<MetaPreview>>()
     private val entityHeaderCache = ConcurrentHashMap<String, TmdbEntityHeader>()
@@ -51,8 +55,13 @@ class TmdbMetadataService @Inject constructor(
             val normalizedLanguage = normalizeTmdbLanguage(language)
             val cacheKey = "$tmdbId:${contentType.name}:$normalizedLanguage"
             enrichmentCache[cacheKey]?.let { return@withContext it }
+            enrichmentInFlight[cacheKey]?.let { return@withContext it.await() }
 
             val numericId = tmdbId.toIntOrNull() ?: return@withContext null
+            val requestDeferred = CompletableDeferred<TmdbEnrichment?>()
+            enrichmentInFlight.putIfAbsent(cacheKey, requestDeferred)?.let { existing ->
+                return@withContext existing.await()
+            }
             val tmdbType = when (contentType) {
                 ContentType.SERIES, ContentType.TV -> "tv"
                 else -> "movie"
@@ -294,10 +303,17 @@ class TmdbMetadataService @Inject constructor(
                     collectionName = collectionName
                 )
                 enrichmentCache[cacheKey] = enrichment
+                requestDeferred.complete(enrichment)
                 enrichment
+            } catch (e: CancellationException) {
+                requestDeferred.cancel(e)
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch TMDB enrichment: ${e.message}", e)
+                requestDeferred.complete(null)
                 null
+            } finally {
+                enrichmentInFlight.remove(cacheKey, requestDeferred)
             }
         }
 
@@ -309,27 +325,41 @@ class TmdbMetadataService @Inject constructor(
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val cacheKey = "$tmdbId:${seasonNumbers.sorted().joinToString(",")}:$normalizedLanguage"
         episodeCache[cacheKey]?.let { return@withContext it }
+        episodeInFlight[cacheKey]?.let { return@withContext it.await() }
 
         val numericId = tmdbId.toIntOrNull() ?: return@withContext emptyMap()
+        val requestDeferred = CompletableDeferred<Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
+        episodeInFlight.putIfAbsent(cacheKey, requestDeferred)?.let { existing ->
+            return@withContext existing.await()
+        }
         val result = mutableMapOf<Pair<Int, Int>, TmdbEpisodeEnrichment>()
 
-        seasonNumbers.distinct().forEach { season ->
-            try {
-                val response = tmdbApi.getTvSeasonDetails(numericId, season, TMDB_API_KEY, normalizedLanguage)
-                val episodes = response.body()?.episodes.orEmpty()
-                episodes.forEach { ep ->
-                    val epNum = ep.episodeNumber ?: return@forEach
-                    result[season to epNum] = ep.toEnrichment()
+        try {
+            seasonNumbers.distinct().forEach { season ->
+                try {
+                    val response = tmdbApi.getTvSeasonDetails(numericId, season, TMDB_API_KEY, normalizedLanguage)
+                    val episodes = response.body()?.episodes.orEmpty()
+                    episodes.forEach { ep ->
+                        val epNum = ep.episodeNumber ?: return@forEach
+                        result[season to epNum] = ep.toEnrichment()
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to fetch TMDB season $season: ${e.message}")
                 }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to fetch TMDB season $season: ${e.message}")
             }
-        }
 
-        if (result.isNotEmpty()) {
-            episodeCache[cacheKey] = result
+            val finalResult = result.toMap()
+            if (finalResult.isNotEmpty()) {
+                episodeCache[cacheKey] = finalResult
+            }
+            requestDeferred.complete(finalResult)
+            finalResult
+        } catch (e: CancellationException) {
+            requestDeferred.cancel(e)
+            throw e
+        } finally {
+            episodeInFlight.remove(cacheKey, requestDeferred)
         }
-        result
     }
 
     suspend fun fetchMoreLikeThis(

--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
@@ -3,6 +3,8 @@ package com.nuvio.tv.core.tmdb
 import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.data.remote.api.TmdbApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -27,6 +29,9 @@ class TmdbService @Inject constructor(
     
     // Cache: TMDB ID -> IMDB ID  
     private val tmdbToImdbCache = ConcurrentHashMap<Int, String>()
+
+    private val imdbToTmdbInFlight = ConcurrentHashMap<String, CompletableDeferred<Int?>>()
+    private val tmdbToImdbInFlight = ConcurrentHashMap<String, CompletableDeferred<String?>>()
     
     // Mutex for thread-safe cache operations
     private val cacheMutex = Mutex()
@@ -51,6 +56,13 @@ class TmdbService @Inject constructor(
             return@withContext cached
         }
         
+        val normalizedType = normalizeMediaType(mediaType)
+        val requestKey = "$imdbId:$normalizedType"
+        val requestDeferred = CompletableDeferred<Int?>()
+        imdbToTmdbInFlight.putIfAbsent(requestKey, requestDeferred)?.let { existing ->
+            return@withContext existing.await()
+        }
+
         try {
             Log.d(TAG, "Looking up TMDB ID for IMDB: $imdbId (type: $mediaType)")
             
@@ -62,13 +74,17 @@ class TmdbService @Inject constructor(
             
             if (!response.isSuccessful) {
                 Log.e(TAG, "TMDB API error: ${response.code()} - ${response.message()}")
+                requestDeferred.complete(null)
                 return@withContext null
             }
             
-            val body = response.body() ?: return@withContext null
+            val body = response.body()
+            if (body == null) {
+                requestDeferred.complete(null)
+                return@withContext null
+            }
             
             // Determine which results to use based on media type
-            val normalizedType = normalizeMediaType(mediaType)
             val result = when (normalizedType) {
                 "movie" -> body.movieResults?.firstOrNull()
                 "tv", "series" -> body.tvResults?.firstOrNull()
@@ -83,16 +99,25 @@ class TmdbService @Inject constructor(
                     imdbToTmdbCache[imdbId] = found.id
                     tmdbToImdbCache[found.id] = imdbId
                 }
-                
+
+                requestDeferred.complete(found.id)
+                 
                 return@withContext found.id
             }
             
             Log.w(TAG, "No TMDB result found for IMDB: $imdbId")
+            requestDeferred.complete(null)
             null
             
+        } catch (e: CancellationException) {
+            requestDeferred.cancel(e)
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error looking up TMDB ID for $imdbId: ${e.message}", e)
+            requestDeferred.complete(null)
             null
+        } finally {
+            imdbToTmdbInFlight.remove(requestKey, requestDeferred)
         }
     }
     
@@ -110,10 +135,16 @@ class TmdbService @Inject constructor(
             return@withContext cached
         }
         
+        val normalizedType = normalizeMediaType(mediaType)
+        val requestKey = "$tmdbId:$normalizedType"
+        val requestDeferred = CompletableDeferred<String?>()
+        tmdbToImdbInFlight.putIfAbsent(requestKey, requestDeferred)?.let { existing ->
+            return@withContext existing.await()
+        }
+
         try {
             Log.d(TAG, "Looking up IMDB ID for TMDB: $tmdbId (type: $mediaType)")
             
-            val normalizedType = normalizeMediaType(mediaType)
             val response = when (normalizedType) {
                 "movie" -> tmdbApi.getMovieExternalIds(tmdbId, TMDB_API_KEY)
                 "tv", "series" -> tmdbApi.getTvExternalIds(tmdbId, TMDB_API_KEY)
@@ -122,10 +153,15 @@ class TmdbService @Inject constructor(
             
             if (!response.isSuccessful) {
                 Log.e(TAG, "TMDB API error: ${response.code()} - ${response.message()}")
+                requestDeferred.complete(null)
                 return@withContext null
             }
             
-            val body = response.body() ?: return@withContext null
+            val body = response.body()
+            if (body == null) {
+                requestDeferred.complete(null)
+                return@withContext null
+            }
             
             body.imdbId?.let { imdbId ->
                 Log.d(TAG, "Found IMDB ID: $imdbId for TMDB: $tmdbId")
@@ -135,16 +171,25 @@ class TmdbService @Inject constructor(
                     tmdbToImdbCache[tmdbId] = imdbId
                     imdbToTmdbCache[imdbId] = tmdbId
                 }
-                
+
+                requestDeferred.complete(imdbId)
+                 
                 return@withContext imdbId
             }
             
             Log.w(TAG, "No IMDB ID found for TMDB: $tmdbId")
+            requestDeferred.complete(null)
             null
             
+        } catch (e: CancellationException) {
+            requestDeferred.cancel(e)
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error looking up IMDB ID for $tmdbId: ${e.message}", e)
+            requestDeferred.complete(null)
             null
+        } finally {
+            tmdbToImdbInFlight.remove(requestKey, requestDeferred)
         }
     }
     
@@ -203,6 +248,8 @@ class TmdbService @Inject constructor(
     fun clearCache() {
         imdbToTmdbCache.clear()
         tmdbToImdbCache.clear()
+        imdbToTmdbInFlight.clear()
+        tmdbToImdbInFlight.clear()
         Log.d(TAG, "Cache cleared")
     }
     

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -14,8 +14,12 @@ import com.nuvio.tv.data.remote.api.TmdbNetworkDetailsResponse
 import com.nuvio.tv.domain.model.ContentType
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -55,6 +59,51 @@ class TmdbMetadataServiceTest {
         assertNotNull(enrichment)
         assertEquals(55, enrichment?.productionCompanies?.firstOrNull()?.tmdbId)
         assertEquals(77, enrichment?.networks?.firstOrNull()?.tmdbId)
+    }
+
+    @Test
+    fun `fetchEnrichment deduplicates concurrent requests for same key`() = runTest {
+        val api = mockk<TmdbApi>()
+        val gate = CompletableDeferred<Unit>()
+        var detailsCalls = 0
+        var creditsCalls = 0
+        var imagesCalls = 0
+        var releaseCalls = 0
+
+        coEvery { api.getMovieDetails(any(), any(), any()) } coAnswers {
+            detailsCalls += 1
+            gate.await()
+            Response.success(TmdbDetailsResponse(id = 10, title = "Movie"))
+        }
+        coEvery { api.getMovieCredits(any(), any(), any()) } coAnswers {
+            creditsCalls += 1
+            Response.success(TmdbCreditsResponse())
+        }
+        coEvery { api.getMovieImages(any(), any(), any()) } coAnswers {
+            imagesCalls += 1
+            Response.success(TmdbImagesResponse())
+        }
+        coEvery { api.getMovieReleaseDates(any(), any()) } coAnswers {
+            releaseCalls += 1
+            Response.success(TmdbMovieReleaseDatesResponse())
+        }
+
+        val service = TmdbMetadataService(api)
+
+        val first = async { service.fetchEnrichment(tmdbId = "10", contentType = ContentType.MOVIE, language = "en") }
+        val second = async { service.fetchEnrichment(tmdbId = "10", contentType = ContentType.MOVIE, language = "en") }
+
+        yield()
+        assertEquals(1, detailsCalls)
+
+        gate.complete(Unit)
+        val results = awaitAll(first, second)
+
+        assertEquals(1, detailsCalls)
+        assertEquals(1, creditsCalls)
+        assertEquals(1, imagesCalls)
+        assertEquals(1, releaseCalls)
+        assertEquals(results[0], results[1])
     }
 
     @Test


### PR DESCRIPTION
## Summary

Deduplicate concurrent in-flight TMDB API requests using `CompletableDeferred`-based request coalescing. When multiple coroutines request the same TMDB lookup (e.g. IMDB→TMDB, TMDB→IMDB, enrichment, episode metadata) simultaneously, only the first coroutine performs the actual network call. All subsequent callers await the same `CompletableDeferred` and receive the cached result once it completes.

## PR type

- Small maintenance improvement

## Why

During app startup and content browsing, the same TMDB metadata can be requested concurrently by multiple UI components or prefetch tasks. Without deduplication, each concurrent request fires a separate API call — this was causing repeated TMDB timeout errors observed in `adb logcat` logs, as identical requests piled up and exhausted connection resources. The duplicate calls also waste network bandwidth and hit TMDB rate limits faster. This change ensures at most one network call per unique lookup key is in-flight at any time, eliminating the timeout issue.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- **Unit test added:** `TmdbMetadataServiceTest.fetchEnrichment deduplicates concurrent requests for same key` — launches two async `fetchEnrichment` calls against the same key with a gate-controlled mock, asserts only 1 API call per endpoint and both callers receive the same result.
- **Manual testing:**
  - Verified on debug build that enrichment network calls are not duplicated during rapid navigation between content detail screens.
  - Switching TMDB language back and forth updates metadata noticeably faster; deduplication prevents redundant fetches when the same key is requested by multiple components during a language change.
  - MetaDetails screen renders enriched data (cast, ratings, networks) correctly after the change — no regressions observed.
  - Reviewed `adb logcat` output: no TMDB timeout or rate-limit error logs were present during extended browsing sessions.

## Screenshots / Video (UI changes only)

- No UI changes.

## Breaking changes

- None

## Linked issues

- None — Internal performance optimization.
