### PR TITLE
Adjustments to episode date formatting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -1111,19 +1111,19 @@ private fun formatEpisodeRuntime(runtimeMinutes: Int): String {
 
 private fun formatEpisodeCardDate(isoDate: String): String {
     val locale = Locale.getDefault()
-    val bestPattern = DateFormat.getBestDateTimePattern(locale, "dMMMMy")
-    val outputFormat = SimpleDateFormat(bestPattern, locale)
+    val bestPattern = android.text.format.DateFormat.getBestDateTimePattern(locale, "dMMMMy")
+    val formatter = java.time.format.DateTimeFormatter.ofPattern(bestPattern, locale)
+
     return try {
-        val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-            timeZone = TimeZone.getTimeZone("UTC")
-        }
-        val date = inputFormat.parse(isoDate)
-        date?.let { outputFormat.format(it) }.orEmpty()
+        val localDate = java.time.Instant.parse(isoDate)
+            .atZone(java.time.ZoneOffset.UTC)
+            .toLocalDate()
+
+        formatter.format(localDate)
     } catch (_: Exception) {
         try {
-            val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-            val date = inputFormat.parse(isoDate)
-            date?.let { outputFormat.format(it) }.orEmpty()
+            val localDate = java.time.LocalDate.parse(isoDate.substringBefore('T'))
+            formatter.format(localDate)
         } catch (_: Exception) {
             ""
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2255,9 +2255,7 @@ private fun formatEpisodeAirDateLabel(releaseDate: LocalDate): String {
     val locale = Locale.getDefault()
     val skeleton = if (releaseDate.year == todayLocal.year) "dMMM" else "dMMMy"
     val pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton)
-    return java.text.SimpleDateFormat(pattern, locale).format(
-        java.util.Date(releaseDate.atStartOfDay(java.time.ZoneOffset.UTC).toInstant().toEpochMilli())
-    )
+    return DateTimeFormatter.ofPattern(pattern, locale).format(releaseDate)
 }
 
 private fun resolveNextUpReleaseState(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -34,6 +34,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Collections
@@ -2030,7 +2031,7 @@ private fun HomeViewModel.publishBadgeUpdate(
 private fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
     if (raw.isNullOrBlank()) return null
     val value = raw.trim()
-    val zone = ZoneId.systemDefault()
+    val zone = ZoneOffset.UTC
 
     return runCatching {
         Instant.parse(value).atZone(zone).toLocalDate()
@@ -2050,7 +2051,7 @@ private fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
 private fun parseEpisodeReleaseInstant(raw: String?): Instant? {
     if (raw.isNullOrBlank()) return null
     val value = raw.trim()
-    val zone = ZoneId.systemDefault()
+    val zone = ZoneOffset.UTC
 
     return runCatching {
         Instant.parse(value)


### PR DESCRIPTION
## Summary
Adjusts the way the date for episodes get displayed in Continue Watching and the Details episode section. Ensures the dates are correct in both continue watching and episode section regardless of systems time zone.

## PR type
- Small maintenance improvement

## Why
The current implementation doesn't take into consideration device time zone when displaying the air date in continue watching (gets offset by a few hours if using any GMT -XX:XX, causing it to show the previous date).

## Policy check
 - [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Set to any timezone GMT -XX:XX and you'll see the air date get offset by 1 day. GMT +XX:XX and it displays correct. With proposed changes, correct air date is displayed on both continue watching and episodes section regardless of device time zone.

## Screenshots / Video (UI changes only)
N/A

## Breaking changes
None

## Linked issues
None
