### PR TITLE
Fix CW removal, watched badge ID mapping, and profile badge leak

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
@@ -261,5 +261,8 @@ class TmdbService @Inject constructor(
         tmdbToImdbCache[tmdbId] = imdbId
     }
 
+    /** Returns the cached TMDB ID for an IMDB ID without making any network call. */
+    fun cachedTmdbId(imdbId: String): Int? = imdbToTmdbCache[imdbId]
+
     fun apiKey(): String = TMDB_API_KEY
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -228,6 +228,9 @@ class HomeViewModel @Inject constructor(
                     cwEnrichedInProgressOverlay.clear()
                     _uiState.update { it.copy(continueWatchingItems = emptyList()) }
                     loadContinueWatching()
+                    // Clear watched badges so they don't leak between profiles.
+                    watchedSeriesStateHolder.update(emptySet())
+                    _uiState.update { it.copy(movieWatchedStatus = emptyMap()) }
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -741,9 +741,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             (it.info.contentId in allSeedContentIds || isCachedFromDisk) &&
                             it.info.contentId !in recentIds &&
                             it.info.contentId !in inProgressIds &&
-                            // Only apply rejection filter to non-cached items.
-                            // Cached items survive until fresh pipeline replaces them.
-                            (isCachedFromDisk || it.info.contentId !in rejectedByFreshPipeline) &&
+                            // Reject items the fresh pipeline evaluated but produced no
+                            // next-up for (e.g. fully watched series).  Cached-from-disk
+                            // items survive only until the fresh pipeline processes their
+                            // seed — once rejected there, they are removed immediately.
+                            it.info.contentId !in rejectedByFreshPipeline &&
                             // Respect "show unaired" setting for all items including cached.
                             (it.info.hasAired || showUnairedNextUp) &&
                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp &&
@@ -2019,12 +2021,34 @@ private fun HomeViewModel.publishBadgeUpdate(
             allWatched
         }
         .toSet()
+    // Expand IDs: for each fully-watched IMDB ID, also include the
+    // "tmdb:<id>" variant so catalogs that use TMDB IDs get the badge too.
+    val expandedFullyWatched = buildSet {
+        addAll(updatedFullyWatched)
+        for (contentId in updatedFullyWatched) {
+            if (contentId.startsWith("tt")) {
+                tmdbService.cachedTmdbId(contentId)?.let { tmdbId ->
+                    add("tmdb:$tmdbId")
+                }
+            }
+        }
+    }
+    val expandedNotFullyWatched = buildSet {
+        addAll(validatedNotFullyWatched)
+        for (contentId in validatedNotFullyWatched) {
+            if (contentId.startsWith("tt")) {
+                tmdbService.cachedTmdbId(contentId)?.let { tmdbId ->
+                    add("tmdb:$tmdbId")
+                }
+            }
+        }
+    }
     // Merge with persisted badges — don't remove badges we haven't re-validated yet.
     // But DO remove badges for series we've confirmed are NOT fully watched.
     val current = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
-    val merged = (current - validatedNotFullyWatched) + updatedFullyWatched
+    val merged = (current - expandedNotFullyWatched) + expandedFullyWatched
     if (current != merged) {
-        fullyWatchedSeriesIds.updateWithValidation(merged, updatedFullyWatched)
+        fullyWatchedSeriesIds.updateWithValidation(merged, expandedFullyWatched)
     }
 }
 
@@ -2324,6 +2348,18 @@ internal fun HomeViewModel.removeContinueWatchingPipeline(
         return
     }
     viewModelScope.launch {
+        // Optimistic UI: remove the item from the CW list immediately
+        // so the user sees instant feedback while the DataStore write propagates.
+        _uiState.update { state ->
+            state.copy(
+                continueWatchingItems = state.continueWatchingItems.filterNot { item ->
+                    when (item) {
+                        is ContinueWatchingItem.InProgress -> item.progress.contentId == contentId
+                        is ContinueWatchingItem.NextUp -> item.info.contentId == contentId
+                    }
+                }
+            )
+        }
         val targetSeason = if (isNextUp) season else null
         val targetEpisode = if (isNextUp) episode else null
         watchProgressRepository.removeProgress(


### PR DESCRIPTION
## Summary

- Removing an item from Continue Watching now updates the UI immediately (optimistic removal) instead of waiting for the DataStore write to propagate through the pipeline.
- Cached-from-disk next-up items are now properly removed when the fresh CW pipeline rejects them (e.g. after marking a full season as watched). Previously cached items survived indefinitely.
- Watched badge for series now includes the `tmdb:<id>` variant alongside the IMDB ID, so catalogs that use TMDB IDs show the checkmark without needing to visit the detail screen first.
- Watched badges (`movieWatchedStatus` and `fullyWatchedSeriesIds`) are cleared on profile switch to prevent badges from one profile leaking into another.

## PR type

- Bug fix

## Why

- Users reported that removing items from CW was slow or required multiple attempts (especially on Nuvio Sync) because there was no optimistic UI update.
- Marking a full season as watched left stale next-up entries in CW because the disk cache was exempt from the rejection filter.
- Anime series with TMDB-based catalog IDs never showed the watched badge on the home screen, even though the CW pipeline correctly identified them as fully watched - the badge was stored under the IMDB ID only.
- Switching profiles kept the previous profile's watched badges visible until the new profile's data loaded.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Removed item from CW (both Trakt and Nuvio Sync) - verified instant disappearance
- Marked full season as watched - verified next-up entry disappears from CW
- Checked anime series (Frieren, TMDB catalog ID) - verified watched badge appears on home screen without visiting detail
- Switched profiles - verified badges reset and repopulate from new profile data

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break

## Linked issues

Reported on discord 
