### PR TITLE
fix(player): remove experimental Media3 scheduling optimizations

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -241,7 +241,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                 onPlaybackSpeedAwareAudioOutputProviderCreated = { playbackSpeedAwareAudioOutputProvider = it }
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || forceDv7ToHevc)
-                .enableMediaCodecVideoRendererDurationToProgressUsIfAvailable()
 
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             val buildDefaultPlayer = {
@@ -256,7 +255,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
                     .setReleaseTimeoutMs(3000)
-                    .enableDynamicSchedulingIfAvailable()
                     .build()
             }
 
@@ -267,7 +265,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
                     .setReleaseTimeoutMs(3000)
-                    .enableDynamicSchedulingIfAvailable()
                     .buildWithAssSupportCompat(
                         context = context,
                         renderType = libassRenderType,
@@ -834,30 +831,3 @@ private class SubtitleOffsetRenderer(
     }
 }
 
-private fun DefaultRenderersFactory.enableMediaCodecVideoRendererDurationToProgressUsIfAvailable(): DefaultRenderersFactory {
-    runCatching {
-        javaClass
-            .getMethod("setEnableMediaCodecVideoRendererDurationToProgressUs", java.lang.Boolean.TYPE)
-            .invoke(this, true)
-    }.onFailure {
-        Log.d(
-            PlayerRuntimeController.TAG,
-            "Media3 duration-to-progress optimization unavailable: ${it.message}"
-        )
-    }
-    return this
-}
-
-private fun ExoPlayer.Builder.enableDynamicSchedulingIfAvailable(): ExoPlayer.Builder {
-    runCatching {
-        javaClass
-            .getMethod("experimentalSetDynamicSchedulingEnabled", java.lang.Boolean.TYPE)
-            .invoke(this, true)
-    }.onFailure {
-        Log.d(
-            PlayerRuntimeController.TAG,
-            "Media3 dynamic scheduling unavailable: ${it.message}"
-        )
-    }
-    return this
-}


### PR DESCRIPTION
## Summary

Remove the reflective Media3 scheduling optimizations added during player initialization. This restores the default ExoPlayer timing path while we investigate increased buffering reports on smaller sources.

## PR type

- Bug fix

## Why

Recent playback feedback points to heavier buffering on smaller files after the new Media3 flags were introduced. Both flags are optional and experimental, so reverting them is the safest way to return player timing behavior to the default implementation and verify whether they caused the regression.

These optimizations were originally added in #1335 , and this PR rolls them back because they do not behave reliably on some devices.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manually tested playback after reverting both Media3 flags. Player starts and plays normally again, including the small-source scenarios that were reported as buffering more after the experimental optimizations were added.

## Screenshots / Video (UI changes only)

Not applicable. No UI changes.

## Breaking changes

No breaking changes. This only removes optional experimental playback optimizations and falls back to Media3 defaults.

## Linked issues

Related to #1335 
