### PR TITLE
Introduction of In Memory scroll setting + some bug fixes 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -103,7 +103,7 @@ class NuvioApplication : Application(), ImageLoaderFactory {
             }
             .memoryCache {
                 MemoryCache.Builder(this)
-                    .maxSizePercent(0.25)
+                    .maxSizePercent(0.33)
                     .build()
             }
             .diskCache {

--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -76,6 +76,7 @@ class LayoutPreferenceDataStore @Inject constructor(
     private val modernHeroFullScreenBackdropKey = booleanPreferencesKey("modern_hero_full_screen_backdrop")
     private val hideUnreleasedContentKey = booleanPreferencesKey("hide_unreleased_content")
     private val showFullReleaseDateKey = booleanPreferencesKey("show_full_release_date")
+    private val memoryOnlyVerticalScrollKey = booleanPreferencesKey("memory_only_vertical_scroll")
 
     private fun <T> profileFlow(extract: (prefs: androidx.datastore.preferences.core.Preferences) -> T): Flow<T> =
         profileManager.activeProfileId.flatMapLatest { pid ->
@@ -230,6 +231,16 @@ class LayoutPreferenceDataStore @Inject constructor(
 
     val showFullReleaseDate: Flow<Boolean> = profileFlow { prefs ->
         prefs[showFullReleaseDateKey] ?: true
+    }
+
+    val memoryOnlyVerticalScroll: Flow<Boolean> = profileFlow { prefs ->
+        prefs[memoryOnlyVerticalScrollKey] ?: false
+    }
+
+    suspend fun setMemoryOnlyVerticalScroll(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[memoryOnlyVerticalScrollKey] = enabled
+        }
     }
 
     suspend fun setLayout(layout: HomeLayout) {

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -61,6 +61,12 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import kotlinx.coroutines.delay
 
+/**
+ * When true, vertical scrolling is in progress and image loading should be
+ * restricted to memory cache only (no disk / network) to keep the scroll smooth.
+ */
+val LocalVerticalScrollSuppressImages = androidx.compose.runtime.compositionLocalOf { false }
+
 private const val BACKDROP_ASPECT_RATIO = 16f / 9f
 private const val TRAILER_PREVIEW_REQUEST_FOCUS_DEBOUNCE_MS = 140L
 private val YEAR_REGEX = Regex("""\b(19|20)\d{2}\b""")
@@ -208,6 +214,19 @@ fun ContentCard(
                 .size(width = requestWidthPx, height = requestHeightPx)
                 .build()
         }
+        val isSuppressingImages = LocalVerticalScrollSuppressImages.current
+        val scrollAwareImageModel = if (!isSuppressingImages || imageModel == null) {
+            imageModel
+        } else {
+            remember(imageModel) {
+                (imageModel as? ImageRequest)?.newBuilder()
+                    ?.memoryCachePolicy(coil.request.CachePolicy.ENABLED)
+                    ?.diskCachePolicy(coil.request.CachePolicy.DISABLED)
+                    ?.networkCachePolicy(coil.request.CachePolicy.DISABLED)
+                    ?.build()
+                    ?: imageModel
+            }
+        }
         val logoRequestHeightPx = remember(density) {
             with(density) { 48.dp.roundToPx() }
         }
@@ -309,7 +328,7 @@ fun ContentCard(
             ) {
                 if (!imageUrl.isNullOrBlank()) {
                     AsyncImage(
-                        model = imageModel,
+                        model = scrollAwareImageModel,
                         contentDescription = item.name,
                         modifier = Modifier.fillMaxSize(),
                         placeholder = backgroundPainter,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -114,6 +114,7 @@ fun SeasonTabs(
     val lazyListState = rememberLazyListState()
 
     var suppressFocusSwitch by remember { mutableStateOf(false) }
+    var pendingSeason by remember { mutableStateOf<Int?>(null) }
 
     LaunchedEffect(sortedSeasons, selectedSeason) {
         val selectedIndex = sortedSeasons.indexOf(selectedSeason)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.detail
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.BorderStroke
+import kotlinx.coroutines.delay
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.Canvas
@@ -115,6 +116,12 @@ fun SeasonTabs(
 
     var suppressFocusSwitch by remember { mutableStateOf(false) }
     var pendingSeason by remember { mutableStateOf<Int?>(null) }
+    LaunchedEffect(pendingSeason) {
+        val target = pendingSeason ?: return@LaunchedEffect
+        delay(150)
+        onSeasonSelected(target)
+        pendingSeason = null
+    }
 
     LaunchedEffect(sortedSeasons, selectedSeason) {
         val selectedIndex = sortedSeasons.indexOf(selectedSeason)
@@ -163,7 +170,7 @@ fun SeasonTabs(
                     val nowFocused = it.isFocused
                     isFocused = nowFocused
                     if (nowFocused && !isSelected && !suppressFocusSwitch) {
-                        onSeasonSelected(season)
+                        pendingSeason = season
                     }
                 }
                     .onPreviewKeyEvent { event ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -39,6 +39,7 @@ import com.nuvio.tv.ui.components.CollectionRowSection
 import com.nuvio.tv.ui.components.ContinueWatchingSection
 import com.nuvio.tv.ui.components.HeroCarousel
 import com.nuvio.tv.ui.components.LoadingIndicator
+import com.nuvio.tv.ui.components.LocalVerticalScrollSuppressImages
 import com.nuvio.tv.ui.components.PosterCardStyle
 
 /** Minimum interval between processed key repeat events to prevent HWUI overload. */
@@ -84,6 +85,10 @@ fun ClassicHomeContent(
         initialFirstVisibleItemScrollOffset = focusState.verticalScrollOffset,
         prefetchStrategy = nestedPrefetchStrategy
     )
+    val isVerticalScrolling by remember(columnListState) {
+        androidx.compose.runtime.derivedStateOf { columnListState.isScrollInProgress }
+    }
+    val suppressImages = uiState.memoryOnlyVerticalScroll && isVerticalScrolling
 
     LaunchedEffect(focusState.verticalScrollIndex, focusState.verticalScrollOffset) {
         val targetIndex = focusState.verticalScrollIndex
@@ -191,6 +196,9 @@ fun ClassicHomeContent(
         return
     }
 
+    androidx.compose.runtime.CompositionLocalProvider(
+        LocalVerticalScrollSuppressImages provides suppressImages
+    ) {
     LazyColumn(
         state = columnListState,
         modifier = Modifier
@@ -393,4 +401,5 @@ fun ClassicHomeContent(
             }
         }
     }
+    } // CompositionLocalProvider
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -52,6 +52,7 @@ data class HomeUiState(
     val gridItems: List<GridItem> = emptyList(),
     val hideUnreleasedContent: Boolean = false,
     val showFullReleaseDate: Boolean = true,
+    val memoryOnlyVerticalScroll: Boolean = false,
     val blurUnwatchedEpisodes: Boolean = false,
     val startupAuthNotice: StartupAuthNotice? = null,
     val homeRows: List<HomeRow> = emptyList()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -203,6 +203,7 @@ class HomeViewModel @Inject constructor(
         observeTmdbSettings()
         observeMdbListSettings()
         observeBlurUnwatchedEpisodes()
+        observeMemoryOnlyVerticalScroll()
         observeStartupAuthNotice()
         observeProgressSourceChanges()
         loadContinueWatching()
@@ -264,6 +265,16 @@ class HomeViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .collect { enabled ->
                     _uiState.update { it.copy(blurUnwatchedEpisodes = enabled) }
+                }
+        }
+    }
+
+    private fun observeMemoryOnlyVerticalScroll() {
+        viewModelScope.launch {
+            layoutPreferenceDataStore.memoryOnlyVerticalScroll
+                .distinctUntilChanged()
+                .collect { enabled ->
+                    _uiState.update { it.copy(memoryOnlyVerticalScroll = enabled) }
                 }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -953,7 +953,10 @@ fun ModernHomeContent(
                 .fillMaxWidth(MODERN_HERO_TEXT_WIDTH_FRACTION)
         )
 
-        CompositionLocalProvider(LocalBringIntoViewSpec provides verticalRowBringIntoViewSpec) {
+        CompositionLocalProvider(
+            LocalBringIntoViewSpec provides verticalRowBringIntoViewSpec,
+            LocalVerticalRowsScrolling provides (uiState.memoryOnlyVerticalScroll && isVerticalRowsScrolling)
+        ) {
             LazyColumn(
                 state = verticalRowListState,
                 modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -61,10 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.graphicsLayer
@@ -441,7 +438,6 @@ fun ModernHomeContent(
 
     // Tag JankStats with key UI states so jank reports are actionable.
     val currentView = LocalView.current
-    val focusManager = LocalFocusManager.current
     val metricsHolder = PerformanceMetricsState.getHolderForHierarchy(currentView)
     LaunchedEffect(isVerticalRowsScrolling) {
         metricsHolder.state?.putState("HomeScrolling", isVerticalRowsScrolling.toString())
@@ -970,8 +966,6 @@ fun ModernHomeContent(
                     .focusRestorer { focusRestorerRequester }
                     .onPreviewKeyEvent { event ->
                         val native = event.nativeKeyEvent
-                       
-                    
                         if (native.action == AndroidKeyEvent.ACTION_DOWN &&
                             native.repeatCount > 0 &&
                             (native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_DOWN ||
@@ -987,17 +981,6 @@ fun ModernHomeContent(
                                 return@onPreviewKeyEvent true // consume, too soon
                             }
                             lastKeyRepeatDispatchRef.set(now)
-                            val direction = when (native.keyCode) {
-                                AndroidKeyEvent.KEYCODE_DPAD_DOWN -> FocusDirection.Down
-                                AndroidKeyEvent.KEYCODE_DPAD_UP -> FocusDirection.Up
-                                AndroidKeyEvent.KEYCODE_DPAD_LEFT -> FocusDirection.Left
-                                AndroidKeyEvent.KEYCODE_DPAD_RIGHT -> FocusDirection.Right
-                                else -> null
-                            }
-                            if (direction != null) {
-                                focusManager.moveFocus(direction)
-                            }
-                            return@onPreviewKeyEvent true
                         }
                         false
                     },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -827,13 +827,20 @@ private fun ModernCarouselCard(
     var landscapeLogoLoadFailed by remember(effectiveLogoUrl) { mutableStateOf(false) }
     val shouldPlayTrailerInCard = playTrailerInExpandedCard && !trailerPreviewUrl.isNullOrBlank()
     val isVerticalRowsScrolling = LocalVerticalRowsScrolling.current
-    val imageCacheKey = "${imageUrl}_${requestWidthPx}x${requestHeightPx}"
-    val isImageCached = remember(imageModel) {
-        context.imageLoader.memoryCache?.get(MemoryCache.Key(imageCacheKey)) != null
-    }
 
-    val safeImageModel = if (isVerticalRowsScrolling && !isImageCached) null else imageModel
-    val hasImage = !imageUrl.isNullOrBlank() && safeImageModel != null
+    val scrollAwareImageModel = if (!isVerticalRowsScrolling || imageModel == null) {
+        imageModel
+    } else {
+        remember(imageModel) {
+            (imageModel as? ImageRequest)?.newBuilder()
+                ?.memoryCachePolicy(coil.request.CachePolicy.ENABLED)
+                ?.diskCachePolicy(coil.request.CachePolicy.DISABLED)
+                ?.networkCachePolicy(coil.request.CachePolicy.DISABLED)
+                ?.build()
+                ?: imageModel
+        }
+    }
+    val hasImage = !imageUrl.isNullOrBlank()
     val hasLandscapeLogo =
         (useLandscapeOverlayTreatment || isBackdropExpanded) &&
             !effectiveLogoUrl.isNullOrBlank() &&
@@ -939,7 +946,7 @@ private fun ModernCarouselCard(
                 Box(modifier = mediaLayerModifier) {
                     if (hasImage) {
                         AsyncImage(
-                            model = safeImageModel,
+                            model = scrollAwareImageModel,
                             contentDescription = item.title,
                             modifier = Modifier.fillMaxSize(),
                             placeholder = backgroundPainter,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -100,21 +100,7 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                 for (i in 0 until trackGroup.length) {
                     val format = trackGroup.getTrackFormat(i)
                     // Skip addon subtitle tracks — they are managed separately
-                    if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) {
-                        // Detect if ExoPlayer auto-selected an addon track (e.g. via
-                        // preferredTextLanguage) so we can keep selectedAddonSubtitle in sync.
-                        if (trackGroup.isTrackSelected(i)) {
-                            val trackId = format.id ?: ""
-                            val matchedAddon = _uiState.value.addonSubtitles.firstOrNull { subtitle ->
-                                trackId == buildAddonSubtitleTrackId(subtitle)
-                            }
-                            if (matchedAddon != null && _uiState.value.selectedAddonSubtitle?.id != matchedAddon.id) {
-                                _uiState.update { it.copy(selectedAddonSubtitle = matchedAddon, selectedSubtitleTrackIndex = -1) }
-                                if (!autoSubtitleSelected) autoSubtitleSelected = true
-                            }
-                        }
-                        continue
-                    }
+                    if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) continue
                     val isSelected = trackGroup.isTrackSelected(i)
                     if (isSelected) selectedSubtitleIndex = subtitleTracks.size
                     

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -232,6 +232,12 @@ internal fun AddonFilterChips(
 
 
     val selectedIndex = if (selectedAddon == null) 0 else orderedNames.indexOf(selectedAddon) + 1
+    // Track the focused chip index to handle duplicate addon names correctly.
+    var focusedChipIndex by remember { mutableStateOf(selectedIndex.coerceAtLeast(0)) }
+    LaunchedEffect(selectedAddon, orderedNames) {
+        val idx = if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+        focusedChipIndex = idx
+    }
     LaunchedEffect(selectedAddon) {
         if (selectedIndex >= 0 && selectedIndex < focusRequesters.size) {
             try { focusRequesters[selectedIndex].requestFocus() } catch (_: Exception) {}
@@ -246,7 +252,7 @@ internal fun AddonFilterChips(
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
         modifier = Modifier
             .focusRestorer {
-                val idx = selectedIndex.coerceIn(0, focusRequesters.lastIndex)
+                val idx = focusedChipIndex.coerceIn(0, focusRequesters.lastIndex)
                 focusRequesters[idx]
             }
             .onFocusChanged { chipRowHasFocus = it.hasFocus }
@@ -261,13 +267,13 @@ internal fun AddonFilterChips(
                 }
 
                 val allOptions = listOf<String?>(null) + orderedNames
-                val currentIdx = allOptions.indexOf(selectedAddon)
+                val currentIdx = focusedChipIndex.coerceIn(0, allOptions.lastIndex)
                 when (event.key) {
                     androidx.compose.ui.input.key.Key.DirectionLeft -> {
-                        if (currentIdx > 0) { onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                        if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
                     }
                     androidx.compose.ui.input.key.Key.DirectionRight -> {
-                        if (currentIdx < allOptions.lastIndex) { onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                        if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
                     }
                     else -> false
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -399,6 +399,17 @@ fun LayoutSettingsContent(
                         },
                         onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
                     )
+                    CompactToggleRow(
+                        title = stringResource(R.string.layout_memory_only_scroll),
+                        subtitle = stringResource(R.string.layout_memory_only_scroll_sub),
+                        checked = uiState.memoryOnlyVerticalScroll,
+                        onToggle = {
+                            viewModel.onEvent(
+                                LayoutSettingsEvent.SetMemoryOnlyVerticalScroll(!uiState.memoryOnlyVerticalScroll)
+                            )
+                        },
+                        onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
+                    )
                 }
             }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -45,7 +45,8 @@ data class LayoutSettingsUiState(
     val detailPageTrailerButtonEnabled: Boolean = false,
     val preferExternalMetaAddonDetail: Boolean = false,
     val hideUnreleasedContent: Boolean = false,
-    val showFullReleaseDate: Boolean = true
+    val showFullReleaseDate: Boolean = true,
+    val memoryOnlyVerticalScroll: Boolean = false
 )
 
 data class CatalogInfo(
@@ -82,6 +83,7 @@ sealed class LayoutSettingsEvent {
     data class SetPreferExternalMetaAddonDetail(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetHideUnreleasedContent(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetShowFullReleaseDate(val enabled: Boolean) : LayoutSettingsEvent()
+    data class SetMemoryOnlyVerticalScroll(val enabled: Boolean) : LayoutSettingsEvent()
     data object ResetPosterCardStyle : LayoutSettingsEvent()
 }
 
@@ -240,6 +242,11 @@ class LayoutSettingsViewModel @Inject constructor(
                 updateUiStateIfChanged { it.copy(showFullReleaseDate = enabled) }
             }
         }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.memoryOnlyVerticalScroll.distinctUntilChanged().collectLatest { enabled ->
+                updateUiStateIfChanged { it.copy(memoryOnlyVerticalScroll = enabled) }
+            }
+        }
         loadAvailableCatalogs()
     }
 
@@ -271,6 +278,7 @@ class LayoutSettingsViewModel @Inject constructor(
             is LayoutSettingsEvent.SetPreferExternalMetaAddonDetail -> setPreferExternalMetaAddonDetail(event.enabled)
             is LayoutSettingsEvent.SetHideUnreleasedContent -> setHideUnreleasedContent(event.enabled)
             is LayoutSettingsEvent.SetShowFullReleaseDate -> setShowFullReleaseDate(event.enabled)
+            is LayoutSettingsEvent.SetMemoryOnlyVerticalScroll -> setMemoryOnlyVerticalScroll(event.enabled)
             LayoutSettingsEvent.ResetPosterCardStyle -> resetPosterCardStyle()
         }
     }
@@ -454,6 +462,13 @@ class LayoutSettingsViewModel @Inject constructor(
         if (_uiState.value.showFullReleaseDate == enabled) return
         viewModelScope.launch {
             layoutPreferenceDataStore.setShowFullReleaseDate(enabled)
+        }
+    }
+
+    private fun setMemoryOnlyVerticalScroll(enabled: Boolean) {
+        if (_uiState.value.memoryOnlyVerticalScroll == enabled) return
+        viewModelScope.launch {
+            layoutPreferenceDataStore.setMemoryOnlyVerticalScroll(enabled)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -680,10 +680,6 @@ private fun AddonFilterChips(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
         modifier = Modifier
-            .focusRestorer {
-                val idx = focusedChipIndex.coerceIn(0, focusRequesters.lastIndex)
-                focusRequesters[idx]
-            }
             .onFocusChanged { focusState ->
                 val hasFocus = focusState.hasFocus
                 if (hasFocus && !chipRowHasFocus && isRtl) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -665,20 +665,31 @@ private fun AddonFilterChips(
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val chipMap = sourceChips.associateBy { it.name }
     var chipRowHasFocus by remember { mutableStateOf(false) }
+    // Track the focused chip index to handle duplicate addon names correctly.
+    // indexOf(selectedAddon) would always return the first duplicate.
+    var focusedChipIndex by remember { mutableStateOf(
+        if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+    ) }
+    LaunchedEffect(selectedAddon, orderedNames) {
+        val idx = if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+        focusedChipIndex = idx
+    }
     val scope = rememberCoroutineScope()
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
         modifier = Modifier
+            .focusRestorer {
+                val idx = focusedChipIndex.coerceIn(0, focusRequesters.lastIndex)
+                focusRequesters[idx]
+            }
             .onFocusChanged { focusState ->
                 val hasFocus = focusState.hasFocus
                 if (hasFocus && !chipRowHasFocus && isRtl) {
-                    val selectedIdx = if (selectedAddon == null) 0
-                        else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
                     scope.coroutineLaunch {
                         withFrameNanos {}
-                        focusRequesters.getOrNull(selectedIdx)?.requestFocus()
+                        focusRequesters.getOrNull(focusedChipIndex)?.requestFocus()
                     }
                 }
                 chipRowHasFocus = hasFocus
@@ -694,20 +705,20 @@ private fun AddonFilterChips(
                 }
 
                 val allOptions = listOf<String?>(null) + orderedNames
-                val currentIdx = allOptions.indexOf(selectedAddon)
+                val currentIdx = focusedChipIndex.coerceIn(0, allOptions.lastIndex)
                 when (event.key) {
                     androidx.compose.ui.input.key.Key.DirectionLeft -> {
                         if (isRtl) {
-                            if (currentIdx < allOptions.lastIndex) { onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
                         } else {
-                            if (currentIdx > 0) { onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
                         }
                     }
                     androidx.compose.ui.input.key.Key.DirectionRight -> {
                         if (isRtl) {
-                            if (currentIdx > 0) { onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
                         } else {
-                            if (currentIdx < allOptions.lastIndex) { onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
                         }
                     }
                     else -> false

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -400,6 +400,8 @@
     <string name="layout_preset_balanced">Zrównoważony</string>
     <string name="layout_preset_comfort">Komfortowy</string>
     <string name="layout_preset_large">Duży</string>
+    <string name="layout_memory_only_scroll">Scroll tylko z pamięci</string>
+    <string name="layout_memory_only_scroll_sub">Pomijaj ładowanie nowych obrazków podczas przewijania w pionie.</string>
     <string name="layout_preset_sharp">Ostry</string>
     <string name="layout_preset_subtle">Subtelny</string>
     <string name="layout_preset_classic">Klasyczny</string>
@@ -598,9 +600,11 @@
     <string name="addon_remove">Usuń</string>
     <string name="addon_manage_from_phone_title">Zarządzaj z telefonu</string>
     <string name="addon_manage_from_phone_subtitle">Zeskanuj kod QR, aby zarządzać dodatkami, katalogami i kolekcjami z telefonu</string>
+    <string name="addon_manage_collections_from_phone_subtitle">Zeskanuj kod QR, aby zarządzać kolekcjami z telefonu</string>
     <string name="addon_reorder_title">Zmień kolejność katalogów</string>
     <string name="addon_reorder_subtitle">Kontroluje kolejność wierszy katalogów i kolekcji na ekranie głównym</string>
     <string name="addon_qr_scan_instruction">Zeskanuj telefonem, aby zarządzać dodatkami, katalogami i kolekcjami</string>
+    <string name="addon_qr_collections_scan_instruction">Zeskanuj telefonem, aby zarządzać kolekcjami</string>
     <string name="addon_qr_close">Zamknij</string>
     <string name="addon_confirm_title">Potwierdź zmiany dodatków i katalogów</string>
     <string name="addon_confirm_subtitle">Następujące zmiany zostały wprowadzone z telefonu:</string>
@@ -1475,6 +1479,12 @@
     <string name="collections_editor_placeholder_backdrop">URL obrazu tła (opcjonalnie)</string>
     <string name="collections_editor_placeholder_folder">Nazwa folderu</string>
     <string name="collections_editor_placeholder_gif">URL animowanego GIF (odtwarzany przy zaznaczeniu)</string>
+    <string name="collections_editor_genre_filter">Filtr gatunku</string>
+    <string name="collections_editor_choose_genre">Wybierz</string>
+    <string name="collections_editor_select_genre">Wybierz gatunek</string>
+    <string name="collections_editor_all_genres">Wszystkie gatunki</string>
+    <string name="collections_editor_genre_required">Gatunek wymagany</string>
+    <string name="collections_editor_genre_optional">Filtr gatunku dostępny</string>
     <string name="collections_card_title">Kolekcje</string>
     <string name="collections_card_subtitle">Grupuj katalogi w folderach na ekranie głównym</string>
     <string name="collections_tab_all">Wszystko</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,6 +578,8 @@
     <string name="layout_preset_balanced">Balanced</string>
     <string name="layout_preset_comfort">Comfort</string>
     <string name="layout_preset_large">Large</string>
+    <string name="layout_memory_only_scroll">Memory-Only Vertical Scroll</string>
+    <string name="layout_memory_only_scroll_sub">Skip loading new images while scrolling vertically.</string>
     <string name="layout_preset_sharp">Sharp</string>
     <string name="layout_preset_subtle">Subtle</string>
     <string name="layout_preset_classic">Classic</string>


### PR DESCRIPTION
## Summary

- Memory-only vertical scroll option: new setting in Home Content that restricts image loading to memory cache during vertical scrolling (Modern and Classic layouts. Grid seems to work fine, but the setting can be introduced there as well). Reduces jank on low-end devices. Off by default.
- Coil memory cache increased from 25% to 33% of available RAM for better poster retention.
- Stream sources panel: addon filter chips now track focused index instead of name, fixing navigation when two addons share the same name.
- Season tab debounce: 150ms debounce when scrolling through season tabs in detail screen, preventing unnecessary episode list rebuilds during rapid navigation.
- Added missing Polish translations

## PR type

- Bug fix
- Small maintenance improvement
- Translation update

## Why

- Users on low-end Android TV devices reported jank when scrolling through home screen rows - Coil was starting network/disk requests for every poster during scroll.
- Duplicate addon names in stream sources panel caused navigation to loop back instead of advancing.
- Rapid season tab switching triggered unnecessary episode list rebuilds and thumbnail loading.
- Missing Polish translations 

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Tested memory-only scroll on Modern and Classic layouts - cached posters stay visible during scroll, uncached show placeholder, full loading resumes after scroll stops
- Tested duplicate addon name navigation in stream sources panel
- Tested season tab rapid switching - debounce prevents intermediate rebuilds
- Verified Polish translations 

## Screenshots / Video (UI changes only)

New setting added to the "Home Content" section

## Breaking changes

Nothing should break

## Linked issues

Issues reported on reddit and discord
