### PR TITLE
Persist player aspect mode preference

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/DeviceLocalPlayerPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/DeviceLocalPlayerPreferences.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.nuvio.tv.ui.screens.player.AspectMode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Device-local player preferences that are NOT tied to any profile.
+ * These values stay on the device and are never synced across devices or profiles.
+ *
+ * Currently stores:
+ *  - aspectMode  (player aspect ratio mode)
+ */
+@Singleton
+class DeviceLocalPlayerPreferences @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val store: DataStore<Preferences> = PreferenceDataStoreFactory.create {
+        context.preferencesDataStoreFile("device_local_player_prefs")
+    }
+
+    private val aspectModeKey = stringPreferencesKey("aspect_mode")
+
+    val aspectMode: Flow<AspectMode> = store.data.map { prefs ->
+        prefs[aspectModeKey]?.let {
+            runCatching { AspectMode.valueOf(it) }.getOrDefault(AspectMode.ORIGINAL)
+        } ?: AspectMode.ORIGINAL
+    }
+
+    suspend fun setAspectMode(mode: AspectMode) {
+        store.edit { prefs ->
+            prefs[aspectModeKey] = mode.name
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.ui.screens.player.AspectMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -199,7 +200,8 @@ data class PlayerSettings(
     val streamReuseLastLinkCacheHours: Int = 24,
     val subtitleOrganizationMode: SubtitleOrganizationMode = SubtitleOrganizationMode.NONE,
     val addonSubtitleStartupMode: AddonSubtitleStartupMode = AddonSubtitleStartupMode.ALL_SUBTITLES,
-    val resizeMode: Int = 0
+    val resizeMode: Int = 0,
+    val aspectMode: AspectMode = AspectMode.ORIGINAL
 )
 
 enum class StreamAutoPlayMode {
@@ -330,6 +332,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val subtitleOrganizationModeKey = stringPreferencesKey("subtitle_organization_mode")
     private val addonSubtitleStartupModeKey = stringPreferencesKey("addon_subtitle_startup_mode")
     private val resizeModeKey = intPreferencesKey("resize_mode")
+    private val aspectModeKey = stringPreferencesKey("aspect_mode")
 
     // Subtitle style settings keys
     private val subtitlePreferredLanguageKey = stringPreferencesKey("subtitle_preferred_language")
@@ -502,6 +505,9 @@ class PlayerSettingsDataStore @Inject constructor(
                 subtitleOrganizationMode = parseSubtitleOrganizationMode(prefs[subtitleOrganizationModeKey]),
                 addonSubtitleStartupMode = parseAddonSubtitleStartupMode(prefs[addonSubtitleStartupModeKey]),
                 resizeMode = (prefs[resizeModeKey] ?: 0).coerceIn(0, 4),
+                aspectMode = prefs[aspectModeKey]?.let {
+                    runCatching { AspectMode.valueOf(it) }.getOrDefault(AspectMode.ORIGINAL)
+                } ?: AspectMode.ORIGINAL,
                 subtitleStyle = SubtitleStyleSettings(
                     preferredLanguage = normalizeSelectableLanguageCode(
                         prefs[subtitlePreferredLanguageKey] ?: "en"
@@ -787,6 +793,12 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setResizeMode(mode: Int) {
         store().edit { prefs ->
             prefs[resizeModeKey] = mode.coerceIn(0, 4)
+        }
+    }
+
+    suspend fun setAspectMode(mode: AspectMode) {
+        store().edit { prefs ->
+            prefs[aspectModeKey] = mode.name
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -9,7 +9,6 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
-import com.nuvio.tv.ui.screens.player.AspectMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -200,8 +199,7 @@ data class PlayerSettings(
     val streamReuseLastLinkCacheHours: Int = 24,
     val subtitleOrganizationMode: SubtitleOrganizationMode = SubtitleOrganizationMode.NONE,
     val addonSubtitleStartupMode: AddonSubtitleStartupMode = AddonSubtitleStartupMode.ALL_SUBTITLES,
-    val resizeMode: Int = 0,
-    val aspectMode: AspectMode = AspectMode.ORIGINAL
+    val resizeMode: Int = 0
 )
 
 enum class StreamAutoPlayMode {
@@ -332,7 +330,6 @@ class PlayerSettingsDataStore @Inject constructor(
     private val subtitleOrganizationModeKey = stringPreferencesKey("subtitle_organization_mode")
     private val addonSubtitleStartupModeKey = stringPreferencesKey("addon_subtitle_startup_mode")
     private val resizeModeKey = intPreferencesKey("resize_mode")
-    private val aspectModeKey = stringPreferencesKey("aspect_mode")
 
     // Subtitle style settings keys
     private val subtitlePreferredLanguageKey = stringPreferencesKey("subtitle_preferred_language")
@@ -505,9 +502,6 @@ class PlayerSettingsDataStore @Inject constructor(
                 subtitleOrganizationMode = parseSubtitleOrganizationMode(prefs[subtitleOrganizationModeKey]),
                 addonSubtitleStartupMode = parseAddonSubtitleStartupMode(prefs[addonSubtitleStartupModeKey]),
                 resizeMode = (prefs[resizeModeKey] ?: 0).coerceIn(0, 4),
-                aspectMode = prefs[aspectModeKey]?.let {
-                    runCatching { AspectMode.valueOf(it) }.getOrDefault(AspectMode.ORIGINAL)
-                } ?: AspectMode.ORIGINAL,
                 subtitleStyle = SubtitleStyleSettings(
                     preferredLanguage = normalizeSelectableLanguageCode(
                         prefs[subtitlePreferredLanguageKey] ?: "en"
@@ -796,11 +790,7 @@ class PlayerSettingsDataStore @Inject constructor(
         }
     }
 
-    suspend fun setAspectMode(mode: AspectMode) {
-        store().edit { prefs ->
-            prefs[aspectModeKey] = mode.name
-        }
-    }
+
 
     private fun parseSubtitleOrganizationMode(value: String?): SubtitleOrganizationMode {
         return when (value) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.MpvHardwareDecodeMode
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
+import com.nuvio.tv.data.local.DeviceLocalPlayerPreferences
 import com.nuvio.tv.data.local.StreamLinkCacheDataStore
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.repository.ParentalGuideRepository
@@ -52,6 +53,7 @@ class PlayerRuntimeController(
     internal val traktEpisodeMappingService: TraktEpisodeMappingService,
     internal val skipIntroRepository: SkipIntroRepository,
     internal val playerSettingsDataStore: PlayerSettingsDataStore,
+    internal val deviceLocalPlayerPreferences: DeviceLocalPlayerPreferences,
     internal val streamLinkCacheDataStore: StreamLinkCacheDataStore,
     internal val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     internal val watchedItemsPreferences: com.nuvio.tv.data.local.WatchedItemsPreferences,
@@ -367,6 +369,7 @@ class PlayerRuntimeController(
         observeBlurUnwatchedEpisodes()
         observeEpisodeWatchProgress()
         observeTorrentSettings()
+        observeDeviceLocalAspectMode()
     }
 
     private fun observeTorrentSettings() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -113,12 +113,13 @@ internal fun PlayerRuntimeController.initializePlayer(
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus
+            val deviceAspectMode = deviceLocalPlayerPreferences.aspectMode.first()
             _uiState.update {
                 it.copy(
                     internalPlayerEngine = effectiveInternalPlayerEngine,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
                     resizeMode = playerSettings.resizeMode,
-                    aspectMode = playerSettings.aspectMode,
+                    aspectMode = deviceAspectMode,
                     tunnelingEnabled = playerSettings.tunnelingEnabled,
                     loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_detecting_format) else null
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -118,6 +118,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     internalPlayerEngine = effectiveInternalPlayerEngine,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
                     resizeMode = playerSettings.resizeMode,
+                    aspectMode = playerSettings.aspectMode,
                     tunnelingEnabled = playerSettings.tunnelingEnabled,
                     loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_detecting_format) else null
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -202,6 +202,13 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                 else -> currentState.audioAmplificationDb
             }
 
+            if (currentState.aspectMode != settings.aspectMode) {
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "Aspect mode restored from settings: ${currentState.aspectMode} -> ${settings.aspectMode}"
+                )
+            }
+
             _uiState.update { state ->
                 val shouldShowOverlay = if (settings.loadingOverlayEnabled && !hasRenderedFirstFrame) {
                     true
@@ -219,6 +226,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     osdClockEnabled = settings.osdClockEnabled,
                     internalPlayerEngine = resolvedInternalPlayerEngine,
                     frameRateMatchingMode = settings.frameRateMatchingMode,
+                    aspectMode = settings.aspectMode,
                     tunnelingEnabled = settings.tunnelingEnabled,
                     persistAudioAmplification = settings.persistAudioAmplification,
                     audioAmplificationDb = resolvedAudioAmplificationDb

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 internal data class SubtitleFetchRequest(
     val type: String,
@@ -202,12 +203,6 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                 else -> currentState.audioAmplificationDb
             }
 
-            if (currentState.aspectMode != settings.aspectMode) {
-                Log.d(
-                    PlayerRuntimeController.TAG,
-                    "Aspect mode restored from settings: ${currentState.aspectMode} -> ${settings.aspectMode}"
-                )
-            }
 
             _uiState.update { state ->
                 val shouldShowOverlay = if (settings.loadingOverlayEnabled && !hasRenderedFirstFrame) {
@@ -226,7 +221,6 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     osdClockEnabled = settings.osdClockEnabled,
                     internalPlayerEngine = resolvedInternalPlayerEngine,
                     frameRateMatchingMode = settings.frameRateMatchingMode,
-                    aspectMode = settings.aspectMode,
                     tunnelingEnabled = settings.tunnelingEnabled,
                     persistAudioAmplification = settings.persistAudioAmplification,
                     audioAmplificationDb = resolvedAudioAmplificationDb
@@ -455,5 +449,22 @@ internal fun PlayerRuntimeController.retryCurrentStreamFromStartAfter416() {
                 )
             }
         }
+    }
+}
+
+internal fun PlayerRuntimeController.observeDeviceLocalAspectMode() {
+    scope.launch {
+        deviceLocalPlayerPreferences.aspectMode
+            .distinctUntilChanged()
+            .collect { mode ->
+                val currentState = _uiState.value
+                if (currentState.aspectMode != mode) {
+                    Log.d(
+                        PlayerRuntimeController.TAG,
+                        "Aspect mode restored from device-local prefs: ${currentState.aspectMode} -> $mode"
+                    )
+                    _uiState.update { it.copy(aspectMode = mode) }
+                }
+            }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1065,7 +1065,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
             scope.launch {
                 Log.d(PlayerRuntimeController.TAG, "Persisting aspect mode: $newMode")
-                playerSettingsDataStore.setAspectMode(newMode)
+                deviceLocalPlayerPreferences.setAspectMode(newMode)
             }
             hideAspectRatioIndicatorJob?.cancel()
             hideAspectRatioIndicatorJob = scope.launch {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1055,13 +1055,17 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
             val newMode = nextAspectMode(state.aspectMode)
             val label = aspectModeLabel(newMode, context::getString)
-            Log.d("PlayerViewModel", "Aspect mode toggled: ${state.aspectMode} -> $newMode ($label)")
+            Log.d(PlayerRuntimeController.TAG, "Aspect mode toggled by user: ${state.aspectMode} -> $newMode ($label)")
             _uiState.update {
                 it.copy(
                     aspectMode = newMode,
                     showAspectRatioIndicator = true,
                     aspectRatioIndicatorText = label
                 )
+            }
+            scope.launch {
+                Log.d(PlayerRuntimeController.TAG, "Persisting aspect mode: $newMode")
+                playerSettingsDataStore.setAspectMode(newMode)
             }
             hideAspectRatioIndicatorJob?.cancel()
             hideAspectRatioIndicatorJob = scope.launch {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -9,6 +9,7 @@ import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.torrent.TorrentService
 import com.nuvio.tv.core.torrent.TorrentSettings
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
+import com.nuvio.tv.data.local.DeviceLocalPlayerPreferences
 import com.nuvio.tv.data.local.StreamLinkCacheDataStore
 import com.nuvio.tv.data.repository.ParentalGuideRepository
 import com.nuvio.tv.data.repository.SkipIntroRepository
@@ -40,6 +41,7 @@ class PlayerViewModel @Inject constructor(
     private val traktEpisodeMappingService: TraktEpisodeMappingService,
     private val skipIntroRepository: SkipIntroRepository,
     private val playerSettingsDataStore: PlayerSettingsDataStore,
+    private val deviceLocalPlayerPreferences: DeviceLocalPlayerPreferences,
     private val streamLinkCacheDataStore: StreamLinkCacheDataStore,
     private val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     private val watchedItemsPreferences: com.nuvio.tv.data.local.WatchedItemsPreferences,
@@ -65,6 +67,7 @@ class PlayerViewModel @Inject constructor(
         traktEpisodeMappingService = traktEpisodeMappingService,
         skipIntroRepository = skipIntroRepository,
         playerSettingsDataStore = playerSettingsDataStore,
+        deviceLocalPlayerPreferences = deviceLocalPlayerPreferences,
         streamLinkCacheDataStore = streamLinkCacheDataStore,
         layoutPreferenceDataStore = layoutPreferenceDataStore,
         watchedItemsPreferences = watchedItemsPreferences,


### PR DESCRIPTION
## Summary
~~Persist the player's selected aspect mode across playback sessions. Add debug logs for aspect mode toggle, save, and restore flow.~~

Persist the player's selected aspect mode across playback sessions using **device-local storage** instead of profile-based DataStore. This ensures each device keeps its own aspect ratio preference independently — no cross-device or cross-profile sync. Add debug logs for aspect mode toggle, save, and restore flow.

## PR type
- Small maintenance improvement

## Why
~~Users want the selected aspect ratio to stay the same until they change it again.~~

Users want the selected aspect ratio to stay the same until they change it again. Per review feedback, aspect mode is now stored in a dedicated `DeviceLocalPlayerPreferences` DataStore (`device_local_player_prefs`) that is **not** tied to any profile and never synced to cloud. This way, different devices can have different aspect ratio preferences without interfering with each other.



## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Tested locally by changing aspect ratio during playback, closing the player, and reopening playback. Confirmed that the selected aspect mode is restored and stays unchanged until the user switches it again. Aspect mode is now stored per-device and does not sync across profiles.

## Screenshots / Video (UI changes only)
None.

## Breaking changes
None.

## Linked issues
#1433 
