### PR TITLE
Fix modern home performance regression

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -563,8 +563,7 @@ private fun ModernHomeRoute(
             { item -> viewModel.onItemFocus(item) }
         },
         onPreloadAdjacentItem = preloadAdjacentItem,
-        onSaveFocusState = saveModernFocusState,
-        rowBuildCache = viewModel.modernCarouselRowBuildCache
+        onSaveFocusState = saveModernFocusState
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -228,6 +228,7 @@ internal fun HomeViewModel.observeModernHomePresentationPipeline() {
         uiState
             .map { state ->
                 ModernHomePresentationInput(
+                    homeRows = state.homeRows,
                     catalogRows = state.catalogRows,
                     continueWatchingItems = state.continueWatchingItems,
                     useLandscapePosters = state.modernLandscapePostersEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -91,10 +91,8 @@ import coil.compose.AsyncImage
 import coil.decode.SvgDecoder
 import coil.imageLoader
 import coil.request.ImageRequest
-import com.nuvio.tv.domain.model.CatalogRow
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.ContinueWatchingCard
@@ -143,8 +141,7 @@ fun ModernHomeContent(
     onNavigateToFolderDetail: (String, String) -> Unit = { _, _ -> },
     onItemFocus: (MetaPreview) -> Unit = {},
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
-    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
-    rowBuildCache: ModernCarouselRowBuildCache = remember { ModernCarouselRowBuildCache() }
+    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit
 ) {
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val isSidebarExpanded = LocalSidebarExpanded.current
@@ -164,198 +161,20 @@ fun ModernHomeContent(
     val effectiveExpandEnabled =
         (uiState.focusedPosterBackdropExpandEnabled && expandControlAvailable) ||
             landscapeExpandedCardMode
-    val showCatalogTypeSuffixInModern = uiState.catalogTypeSuffixEnabled
-    val showFullReleaseDate = uiState.showFullReleaseDate
     val shouldActivateFocusedPosterFlow =
         effectiveExpandEnabled ||
             (effectiveAutoplayEnabled &&
                 trailerPlaybackTarget == FocusedPosterTrailerPlaybackTarget.HERO_MEDIA)
-    val visibleHomeRows = remember(uiState.homeRows, uiState.catalogRows) {
-        if (uiState.homeRows.isNotEmpty()) {
-            val latestCatalogByKey = uiState.catalogRows.associateBy { catalogRowKey(it) }
-            uiState.homeRows.map { homeRow ->
-                when (homeRow) {
-                    is HomeRow.Catalog -> {
-                        val latest = latestCatalogByKey[catalogRowKey(homeRow.row)]
-                        if (latest != null && latest !== homeRow.row) HomeRow.Catalog(latest) else homeRow
-                    }
-                    else -> homeRow
-                }
-            }
-        } else {
-            uiState.catalogRows.filter { it.items.isNotEmpty() }.map { HomeRow.Catalog(it) }
-        }
-    }
-    val visibleCatalogRows = remember(visibleHomeRows) {
-        visibleHomeRows.filterIsInstance<HomeRow.Catalog>().map { it.row }
-    }
-    val strContinueWatching = stringResource(R.string.continue_watching)
-    val strAirsDate = stringResource(R.string.cw_airs_date)
-    val strUpcoming = stringResource(R.string.cw_upcoming)
-    val strTypeMovie = stringResource(R.string.type_movie)
-    val strTypeSeries = stringResource(R.string.type_series)
-    val context = LocalContext.current
-    val carouselRows = remember(
-        uiState.continueWatchingItems,
-        visibleHomeRows,
-        useLandscapePosters,
-        showCatalogTypeSuffixInModern,
-        strTypeMovie,
-        strTypeSeries
-    ) {
-        buildList {
-            val activeCatalogKeys = LinkedHashSet<String>(visibleCatalogRows.size)
-            if (uiState.continueWatchingItems.isNotEmpty()) {
-                val reuseContinueWatchingRow =
-                    rowBuildCache.continueWatchingRow != null &&
-                        rowBuildCache.continueWatchingItems == uiState.continueWatchingItems &&
-                        rowBuildCache.continueWatchingTitle == strContinueWatching &&
-                        rowBuildCache.continueWatchingAirsDateTemplate == strAirsDate &&
-                        rowBuildCache.continueWatchingUpcomingLabel == strUpcoming &&
-                        rowBuildCache.continueWatchingUseLandscapePosters == useLandscapePosters
-                val continueWatchingRow = if (reuseContinueWatchingRow) {
-                    checkNotNull(rowBuildCache.continueWatchingRow)
-                } else {
-                    HeroCarouselRow(
-                        key = "continue_watching",
-                        title = strContinueWatching,
-                        globalRowIndex = -1,
-                        items = uiState.continueWatchingItems.map { item ->
-                            buildContinueWatchingItem(
-                                item = item,
-                                useLandscapePosters = useLandscapePosters,
-                                airsDateTemplate = strAirsDate,
-                                upcomingLabel = strUpcoming,
-                                context = context
-                            )
-                        }
-                    )
-                }
-                rowBuildCache.continueWatchingItems = uiState.continueWatchingItems
-                rowBuildCache.continueWatchingTitle = strContinueWatching
-                rowBuildCache.continueWatchingAirsDateTemplate = strAirsDate
-                rowBuildCache.continueWatchingUpcomingLabel = strUpcoming
-                rowBuildCache.continueWatchingUseLandscapePosters = useLandscapePosters
-                rowBuildCache.continueWatchingRow = continueWatchingRow
-                add(continueWatchingRow)
-            } else {
-                rowBuildCache.continueWatchingItems = emptyList()
-                rowBuildCache.continueWatchingRow = null
-            }
-
-            visibleHomeRows.forEachIndexed { index, homeRow ->
-                when (homeRow) {
-                    is HomeRow.Catalog -> {
-                        val row = homeRow.row
-                        val rowKey = catalogRowKey(row)
-                        activeCatalogKeys += rowKey
-                        val cached = rowBuildCache.catalogRows[rowKey]
-                        val canReuseMappedRow =
-                            cached != null &&
-                                cached.source == row &&
-                                cached.useLandscapePosters == useLandscapePosters &&
-                                cached.showCatalogTypeSuffix == showCatalogTypeSuffixInModern
-
-                        val mappedRow = if (canReuseMappedRow) {
-                            val cachedMappedRow = checkNotNull(cached).mappedRow
-                            if (cachedMappedRow.globalRowIndex == index) {
-                                cachedMappedRow
-                            } else {
-                                cachedMappedRow.copy(globalRowIndex = index)
-                            }
-                        } else {
-                            val rowItemOccurrenceCounts = mutableMapOf<String, Int>()
-                            val rowItemCache = rowBuildCache.catalogItemCache.getOrPut(rowKey) { mutableMapOf() }
-                            HeroCarouselRow(
-                                key = rowKey,
-                                title = catalogRowTitle(
-                                    row = row,
-                                    showCatalogTypeSuffix = showCatalogTypeSuffixInModern,
-                                    strTypeMovie = strTypeMovie,
-                                    strTypeSeries = strTypeSeries
-                                ),
-                                globalRowIndex = index,
-                                catalogId = row.catalogId,
-                                addonId = row.addonId,
-                                apiType = row.apiType,
-                                supportsSkip = row.supportsSkip,
-                                hasMore = row.hasMore,
-                                isLoading = row.isLoading,
-                                items = row.items.map { item ->
-                                    val occurrence = rowItemOccurrenceCounts.getOrDefault(item.id, 0)
-                                    rowItemOccurrenceCounts[item.id] = occurrence + 1
-                                    val cacheKey = "${item.id}_$occurrence"
-                                    val cachedItem = rowItemCache[cacheKey]
-                                    if (cachedItem != null &&
-                                        cachedItem.source == item &&
-                                        cachedItem.useLandscapePosters == useLandscapePosters &&
-                                        cachedItem.showFullReleaseDate == showFullReleaseDate
-                                    ) {
-                                        cachedItem.carouselItem
-                                    } else {
-                                        val built = buildCatalogItem(
-                                            item = item,
-                                            row = row,
-                                            useLandscapePosters = useLandscapePosters,
-                                            occurrence = occurrence,
-                                            strTypeMovie = strTypeMovie,
-                                            strTypeSeries = strTypeSeries,
-                                            showFullReleaseDate = showFullReleaseDate
-                                        )
-                                        rowItemCache[cacheKey] = CachedCarouselItem(
-                                            source = item,
-                                            useLandscapePosters = useLandscapePosters,
-                                            showFullReleaseDate = showFullReleaseDate,
-                                            carouselItem = built
-                                        )
-                                        built
-                                    }
-                                }
-                            )
-                        }
-
-                        rowBuildCache.catalogRows[rowKey] = ModernCatalogRowBuildCacheEntry(
-                            source = row,
-                            useLandscapePosters = useLandscapePosters,
-                            showCatalogTypeSuffix = showCatalogTypeSuffixInModern,
-                            mappedRow = mappedRow
-                        )
-                        add(mappedRow)
-                    }
-
-                    is HomeRow.CollectionRow -> {
-                        val collection = homeRow.collection
-                        val occurrenceCounts = mutableMapOf<String, Int>()
-                        add(
-                            HeroCarouselRow(
-                                key = "collection_${collection.id}",
-                                title = collection.title,
-                                globalRowIndex = index,
-                                items = collection.folders.map { folder ->
-                                    val occurrence = occurrenceCounts.getOrDefault(folder.id, 0)
-                                    occurrenceCounts[folder.id] = occurrence + 1
-                                    buildCollectionFolderItem(
-                                        collection = collection,
-                                        folder = folder,
-                                        useLandscapePosters = useLandscapePosters,
-                                        occurrence = occurrence
-                                    )
-                                }
-                            )
-                        )
-                    }
-                }
-            }
-            rowBuildCache.catalogRows.keys.retainAll(activeCatalogKeys)
-            rowBuildCache.catalogItemCache.keys.retainAll(activeCatalogKeys)
-        }
-    }
+    val presentation = uiState.modernHomePresentation
+    val carouselRows = presentation.rows
 
     // Show spinner when collections are ready but catalogs haven't arrived
     // yet — prevents collections from grabbing focus before catalogs
     // appear above them.  Only waits when addons are installed (meaning
     // catalogs are expected to load).
-    val hasCollections = visibleHomeRows.any { it is HomeRow.CollectionRow }
+    val hasCollections = remember(uiState.homeRows) {
+        uiState.homeRows.any { it is HomeRow.CollectionRow }
+    }
     val hasCatalogs = uiState.catalogRows.isNotEmpty()
     if (hasCollections && !hasCatalogs && uiState.installedAddonsCount > 0 && uiState.isLoading) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -379,47 +198,7 @@ fun ModernHomeContent(
         }
         return
     }
-    val carouselLookups = remember(carouselRows) {
-        val rowIndexByKey = LinkedHashMap<String, Int>(carouselRows.size)
-        val rowByKey = LinkedHashMap<String, HeroCarouselRow>(carouselRows.size)
-        val rowKeyByGlobalRowIdx = LinkedHashMap<Int, String>(carouselRows.size)
-        val firstHeroPreviewByRowMap = LinkedHashMap<String, HeroPreview>(carouselRows.size)
-        val fallbackBackdropByRowMap = LinkedHashMap<String, String>(carouselRows.size)
-        val activeRowKeys = LinkedHashSet<String>(carouselRows.size)
-        val activeItemKeysByRow = LinkedHashMap<String, Set<String>>(carouselRows.size)
-        val activeCatalogItemIds = LinkedHashSet<String>()
-
-        carouselRows.forEachIndexed { index, row ->
-            rowIndexByKey[row.key] = index
-            rowByKey[row.key] = row
-            rowKeyByGlobalRowIdx[row.globalRowIndex] = row.key
-            activeRowKeys += row.key
-
-            row.items.firstOrNull()?.heroPreview?.let { firstHeroPreviewByRowMap[row.key] = it }
-            row.items.firstNotNullOfOrNull { it.heroPreview.backdrop }?.let { fallbackBackdropByRowMap[row.key] = it }
-
-            val itemKeys = LinkedHashSet<String>(row.items.size)
-            row.items.forEach { item ->
-                itemKeys += item.key
-                val payload = item.payload
-                if (payload is ModernPayload.Catalog) {
-                    activeCatalogItemIds += payload.itemId
-                }
-            }
-            activeItemKeysByRow[row.key] = itemKeys
-        }
-
-        CarouselRowLookups(
-            rowIndexByKey = rowIndexByKey,
-            rowByKey = rowByKey,
-            rowKeyByGlobalRowIndex = rowKeyByGlobalRowIdx,
-            firstHeroPreviewByRow = firstHeroPreviewByRowMap,
-            fallbackBackdropByRow = fallbackBackdropByRowMap,
-            activeRowKeys = activeRowKeys,
-            activeItemKeysByRow = activeItemKeysByRow,
-            activeCatalogItemIds = activeCatalogItemIds
-        )
-    }
+    val carouselLookups = presentation.lookups
     val rowIndexByKey = carouselLookups.rowIndexByKey
     val rowByKey = carouselLookups.rowByKey
     val rowKeyByGlobalRowIndex = carouselLookups.rowKeyByGlobalRowIndex

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -160,6 +160,12 @@ internal data class ModernCatalogRowBuildCacheEntry(
     val mappedRow: HeroCarouselRow
 )
 
+internal data class ModernCollectionRowBuildCacheEntry(
+    val source: Collection,
+    val useLandscapePosters: Boolean,
+    val mappedRow: HeroCarouselRow
+)
+
 @Stable
 internal class ModernHomeUiCaches {
     val focusedItemByRow = mutableMapOf<String, Int>()
@@ -182,6 +188,7 @@ class ModernCarouselRowBuildCache {
     var continueWatchingUseLandscapePosters: Boolean = false
     var continueWatchingRow: HeroCarouselRow? = null
     internal val catalogRows = mutableMapOf<String, ModernCatalogRowBuildCacheEntry>()
+    internal val collectionRows = mutableMapOf<String, ModernCollectionRowBuildCacheEntry>()
     // per-item cache: rowKey -> (itemId -> cached carousel item + source MetaPreview)
     internal val catalogItemCache = mutableMapOf<String, MutableMap<String, CachedCarouselItem>>()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import androidx.compose.runtime.Immutable
 import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.Collection
 
 @Immutable
 internal data class ModernHomePresentationInput(
+    val homeRows: List<HomeRow>,
     val catalogRows: List<CatalogRow>,
     val continueWatchingItems: List<ContinueWatchingItem>,
     val useLandscapePosters: Boolean,
@@ -20,11 +22,7 @@ internal fun buildModernHomePresentation(
     context: Context,
     maxCatalogRows: Int? = null
 ): ModernHomePresentationState {
-    val visibleCatalogRows = input.catalogRows.filter { it.items.isNotEmpty() }
-    val catalogRowsToRender = maxCatalogRows
-        ?.coerceAtLeast(0)
-        ?.let(visibleCatalogRows::take)
-        ?: visibleCatalogRows
+    val visibleHomeRows = resolveVisibleHomeRows(input)
     val strContinueWatching = context.getString(R.string.continue_watching)
     val strAirsDate = context.getString(R.string.cw_airs_date)
     val strUpcoming = context.getString(R.string.cw_upcoming)
@@ -32,7 +30,10 @@ internal fun buildModernHomePresentation(
     val strTypeSeries = context.getString(R.string.type_series)
 
     val rows = buildList {
-        val activeCatalogKeys = LinkedHashSet<String>(catalogRowsToRender.size)
+        val activeCatalogKeys = LinkedHashSet<String>()
+        val activeCollectionKeys = LinkedHashSet<String>()
+        val catalogRowLimit = maxCatalogRows?.coerceAtLeast(0)
+        var renderedCatalogRows = 0
 
         if (input.continueWatchingItems.isNotEmpty()) {
             val reuseContinueWatchingRow =
@@ -72,92 +73,178 @@ internal fun buildModernHomePresentation(
             cache.continueWatchingRow = null
         }
 
-        catalogRowsToRender.forEachIndexed { index, row ->
-            val rowKey = catalogRowKey(row)
-            activeCatalogKeys += rowKey
-            val cached = cache.catalogRows[rowKey]
-            val canReuseMappedRow =
-                cached != null &&
-                    cached.source == row &&
-                    cached.useLandscapePosters == input.useLandscapePosters &&
-                    cached.showCatalogTypeSuffix == input.showCatalogTypeSuffix
-
-            val mappedRow = if (canReuseMappedRow) {
-                val cachedMappedRow = checkNotNull(cached).mappedRow
-                if (cachedMappedRow.globalRowIndex == index) {
-                    cachedMappedRow
-                } else {
-                    cachedMappedRow.copy(globalRowIndex = index)
-                }
-            } else {
-                val rowItemOccurrenceCounts = mutableMapOf<String, Int>()
-                val rowItemCache = cache.catalogItemCache.getOrPut(rowKey) { mutableMapOf() }
-                HeroCarouselRow(
-                    key = rowKey,
-                    title = catalogRowTitle(
-                        row = row,
-                        showCatalogTypeSuffix = input.showCatalogTypeSuffix,
-                        strTypeMovie = strTypeMovie,
-                        strTypeSeries = strTypeSeries
-                    ),
-                    globalRowIndex = index,
-                    catalogId = row.catalogId,
-                    addonId = row.addonId,
-                    apiType = row.apiType,
-                    supportsSkip = row.supportsSkip,
-                    hasMore = row.hasMore,
-                    isLoading = row.isLoading,
-                    items = row.items.map { item ->
-                        val occurrence = rowItemOccurrenceCounts.getOrDefault(item.id, 0)
-                        rowItemOccurrenceCounts[item.id] = occurrence + 1
-                        val cacheKey = "${item.id}_$occurrence"
-                        val cachedItem = rowItemCache[cacheKey]
-                        if (cachedItem != null &&
-                            cachedItem.source == item &&
-                            cachedItem.useLandscapePosters == input.useLandscapePosters &&
-                            cachedItem.showFullReleaseDate == input.showFullReleaseDate
-                        ) {
-                            cachedItem.carouselItem
-                        } else {
-                            val built = buildCatalogItem(
-                                item = item,
-                                row = row,
-                                useLandscapePosters = input.useLandscapePosters,
-                                occurrence = occurrence,
-                                strTypeMovie = strTypeMovie,
-                                strTypeSeries = strTypeSeries,
-                                showFullReleaseDate = input.showFullReleaseDate,
-                                previousCachedItem = cachedItem?.carouselItem
-                            )
-                            rowItemCache[cacheKey] = CachedCarouselItem(
-                                source = item,
-                                useLandscapePosters = input.useLandscapePosters,
-                                showFullReleaseDate = input.showFullReleaseDate,
-                                carouselItem = built
-                            )
-                            built
-                        }
+        visibleHomeRows.forEachIndexed { index, homeRow ->
+            when (homeRow) {
+                is HomeRow.Catalog -> {
+                    val row = homeRow.row
+                    if (catalogRowLimit != null && renderedCatalogRows >= catalogRowLimit) {
+                        return@forEachIndexed
                     }
-                )
-            }
+                    renderedCatalogRows++
+                    val rowKey = catalogRowKey(row)
+                    activeCatalogKeys += rowKey
+                    val cached = cache.catalogRows[rowKey]
+                    val canReuseMappedRow =
+                        cached != null &&
+                            cached.source == row &&
+                            cached.useLandscapePosters == input.useLandscapePosters &&
+                            cached.showCatalogTypeSuffix == input.showCatalogTypeSuffix
 
-            cache.catalogRows[rowKey] = ModernCatalogRowBuildCacheEntry(
-                source = row,
-                useLandscapePosters = input.useLandscapePosters,
-                showCatalogTypeSuffix = input.showCatalogTypeSuffix,
-                mappedRow = mappedRow
-            )
-            add(mappedRow)
+                    val mappedRow = if (canReuseMappedRow) {
+                        val cachedMappedRow = checkNotNull(cached).mappedRow
+                        if (cachedMappedRow.globalRowIndex == index) {
+                            cachedMappedRow
+                        } else {
+                            cachedMappedRow.copy(globalRowIndex = index)
+                        }
+                    } else {
+                        val rowItemOccurrenceCounts = mutableMapOf<String, Int>()
+                        val rowItemCache = cache.catalogItemCache.getOrPut(rowKey) { mutableMapOf() }
+                        HeroCarouselRow(
+                            key = rowKey,
+                            title = catalogRowTitle(
+                                row = row,
+                                showCatalogTypeSuffix = input.showCatalogTypeSuffix,
+                                strTypeMovie = strTypeMovie,
+                                strTypeSeries = strTypeSeries
+                            ),
+                            globalRowIndex = index,
+                            catalogId = row.catalogId,
+                            addonId = row.addonId,
+                            apiType = row.apiType,
+                            supportsSkip = row.supportsSkip,
+                            hasMore = row.hasMore,
+                            isLoading = row.isLoading,
+                            items = row.items.map { item ->
+                                val occurrence = rowItemOccurrenceCounts.getOrDefault(item.id, 0)
+                                rowItemOccurrenceCounts[item.id] = occurrence + 1
+                                val cacheKey = "${item.id}_$occurrence"
+                                val cachedItem = rowItemCache[cacheKey]
+                                if (cachedItem != null &&
+                                    cachedItem.source == item &&
+                                    cachedItem.useLandscapePosters == input.useLandscapePosters &&
+                                    cachedItem.showFullReleaseDate == input.showFullReleaseDate
+                                ) {
+                                    cachedItem.carouselItem
+                                } else {
+                                    val built = buildCatalogItem(
+                                        item = item,
+                                        row = row,
+                                        useLandscapePosters = input.useLandscapePosters,
+                                        occurrence = occurrence,
+                                        strTypeMovie = strTypeMovie,
+                                        strTypeSeries = strTypeSeries,
+                                        showFullReleaseDate = input.showFullReleaseDate,
+                                        previousCachedItem = cachedItem?.carouselItem
+                                    )
+                                    rowItemCache[cacheKey] = CachedCarouselItem(
+                                        source = item,
+                                        useLandscapePosters = input.useLandscapePosters,
+                                        showFullReleaseDate = input.showFullReleaseDate,
+                                        carouselItem = built
+                                    )
+                                    built
+                                }
+                            }
+                        )
+                    }
+
+                    cache.catalogRows[rowKey] = ModernCatalogRowBuildCacheEntry(
+                        source = row,
+                        useLandscapePosters = input.useLandscapePosters,
+                        showCatalogTypeSuffix = input.showCatalogTypeSuffix,
+                        mappedRow = mappedRow
+                    )
+                    add(mappedRow)
+                }
+
+                is HomeRow.CollectionRow -> {
+                    if (catalogRowLimit != null && renderedCatalogRows >= catalogRowLimit) {
+                        return@forEachIndexed
+                    }
+                    val collection = homeRow.collection
+                    val rowKey = collectionRowKey(collection)
+                    activeCollectionKeys += rowKey
+                    val cached = cache.collectionRows[rowKey]
+                    val canReuseMappedRow =
+                        cached != null &&
+                            cached.source == collection &&
+                            cached.useLandscapePosters == input.useLandscapePosters
+
+                    val mappedRow = if (canReuseMappedRow) {
+                        val cachedMappedRow = checkNotNull(cached).mappedRow
+                        if (cachedMappedRow.globalRowIndex == index) {
+                            cachedMappedRow
+                        } else {
+                            cachedMappedRow.copy(globalRowIndex = index)
+                        }
+                    } else {
+                        val occurrenceCounts = mutableMapOf<String, Int>()
+                        HeroCarouselRow(
+                            key = rowKey,
+                            title = collection.title,
+                            globalRowIndex = index,
+                            items = collection.folders.map { folder ->
+                                val occurrence = occurrenceCounts.getOrDefault(folder.id, 0)
+                                occurrenceCounts[folder.id] = occurrence + 1
+                                buildCollectionFolderItem(
+                                    collection = collection,
+                                    folder = folder,
+                                    useLandscapePosters = input.useLandscapePosters,
+                                    occurrence = occurrence
+                                )
+                            }
+                        )
+                    }
+
+                    cache.collectionRows[rowKey] = ModernCollectionRowBuildCacheEntry(
+                        source = collection,
+                        useLandscapePosters = input.useLandscapePosters,
+                        mappedRow = mappedRow
+                    )
+                    add(mappedRow)
+                }
+            }
         }
 
         cache.catalogRows.keys.retainAll(activeCatalogKeys)
         cache.catalogItemCache.keys.retainAll(activeCatalogKeys)
+        cache.collectionRows.keys.retainAll(activeCollectionKeys)
     }
 
     return ModernHomePresentationState(
         rows = rows,
         lookups = buildCarouselRowLookups(rows)
     )
+}
+
+private fun resolveVisibleHomeRows(input: ModernHomePresentationInput): List<HomeRow> {
+    if (input.homeRows.isNotEmpty()) {
+        val latestCatalogByKey = input.catalogRows.associateBy(::catalogRowKey)
+        return input.homeRows.mapNotNull { homeRow ->
+            when (homeRow) {
+                is HomeRow.Catalog -> {
+                    val latest = latestCatalogByKey[catalogRowKey(homeRow.row)] ?: homeRow.row
+                    latest.takeIf { it.items.isNotEmpty() }?.let(HomeRow::Catalog)
+                }
+                is HomeRow.CollectionRow -> {
+                    homeRow.collection.takeIf(Collection::hasVisibleFolders)?.let(HomeRow::CollectionRow)
+                }
+            }
+        }
+    }
+
+    return input.catalogRows
+        .filter { it.items.isNotEmpty() }
+        .map(HomeRow::Catalog)
+}
+
+private fun collectionRowKey(collection: Collection): String {
+    return "collection_${collection.id}"
+}
+
+private fun Collection.hasVisibleFolders(): Boolean {
+    return folders.isNotEmpty()
 }
 
 internal fun buildCarouselRowLookups(carouselRows: List<HeroCarouselRow>): CarouselRowLookups {


### PR DESCRIPTION
## Summary

- Move modern home row mapping and lookup building out of `ModernHomeContent` and into the presentation pipeline.
- Reuse precomputed presentation rows in the UI instead of rebuilding carousel rows during composition.
- Keep continue watching, catalog rows, collection rows, and focus lookups intact while reducing duplicate work on the home screen.

## PR type

- Bug fix

## Why

The modern home screen was rebuilding row presentation data inside Compose even though similar mapping was already available from the presentation pipeline. That duplicate work increases allocations and raises the risk of jank during recomposition, especially on Android TV home navigation. This change makes the presentation layer the single source of truth so the UI only consumes prepared rows and lookups.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual testing completed on the modern home screen.
- Verified initial load, continue watching rendering, catalog rows, collection rows, focus restore, and general home navigation after the refactor.
- Verified the UI still consumes precomputed presentation rows and preserves hero/trailer behavior during navigation.

## Screenshots / Video (UI changes only)

None. This change is performance-focused and does not intentionally alter UI design.

## Breaking changes

None.

## Linked issues

None.
