### PR TITLE
feat: add movie budget and revenue details tmdb

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -300,7 +300,9 @@ class TmdbMetadataService @Inject constructor(
                     countries = countries,
                     language = language,
                     collectionId = collectionId,
-                    collectionName = collectionName
+                    collectionName = collectionName,
+                    budget = details?.budget,
+                    revenue = details?.revenue
                 )
                 enrichmentCache[cacheKey] = enrichment
                 requestDeferred.complete(enrichment)
@@ -1145,7 +1147,9 @@ data class TmdbEnrichment(
     val countries: List<String>?,
     val language: String?,
     val collectionId: Int?,
-    val collectionName: String?
+    val collectionName: String?,
+    val budget: Long?,
+    val revenue: Long?
 )
 
 data class TmdbEpisodeEnrichment(

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -242,6 +242,8 @@ data class TmdbDetailsResponse(
     @Json(name = "poster_path") val posterPath: String? = null,
     @Json(name = "last_air_date") val lastAirDate: String? = null,
     @Json(name = "status") val status: String? = null,
+    @Json(name = "budget") val budget: Long? = null,
+    @Json(name = "revenue") val revenue: Long? = null,
     @Json(name = "belongs_to_collection") val belongsToCollection: TmdbCollectionSummary? = null
 )
 

--- a/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
@@ -44,7 +44,9 @@ data class Meta(
     val hasLandscapePoster: Boolean? = null,
     val hasLogo: Boolean? = null,
     val hasLinks: Boolean? = null,
-    val hasVideos: Boolean? = null
+    val hasVideos: Boolean? = null,
+    val budget: Long? = null,
+    val revenue: Long? = null
 ) {
     val apiType: String
         get() = type.toApiString(rawType)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -322,6 +322,50 @@ fun HeroContentSection(
                     }
 
                     MetaInfoRow(meta = meta, hideImdbRating = hideMetaInfoImdb, showFullReleaseDate = showFullReleaseDate)
+
+                    if (meta.budget != null && meta.budget > 0) {
+                        val formatCurrency = remember {
+                            { amount: Long ->
+                                when {
+                                    amount >= 1_000_000_000 -> "\$${String.format(java.util.Locale.US, "%.1f", amount / 1_000_000_000.0)}B"
+                                    amount >= 1_000_000 -> "\$${String.format(java.util.Locale.US, "%.0f", amount / 1_000_000.0)}M"
+                                    else -> java.text.NumberFormat.getCurrencyInstance(java.util.Locale.US).apply { maximumFractionDigits = 0 }.format(amount)
+                                }
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(24.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column {
+                                Text(
+                                    text = "Budget",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = NuvioTheme.extendedColors.textSecondary
+                                )
+                                Text(
+                                    text = formatCurrency(meta.budget),
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = NuvioColors.TextPrimary
+                                )
+                            }
+                            if (meta.revenue != null && meta.revenue > 0) {
+                                Column {
+                                    Text(
+                                        text = "Revenue",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = NuvioTheme.extendedColors.textSecondary
+                                    )
+                                    Text(
+                                        text = formatCurrency(meta.revenue),
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = NuvioColors.TextPrimary
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -625,6 +669,7 @@ private fun MetaInfoRow(
     val secondaryItems = remember(runtimeText, meta.country, meta.language) {
         buildList<String> {
             runtimeText?.takeIf { it.isNotBlank() }?.let { add(it) }
+
             meta.country?.trim()?.takeIf { it.isNotBlank() }?.let { add(normalizeCountryLabel(it)) }
             meta.language?.trim()?.takeIf { it.isNotBlank() }?.let { add(it.uppercase()) }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1100,7 +1100,9 @@ class MetaDetailsViewModel @Inject constructor(
                 status = enrichment.status ?: updated.status,
                 ageRating = enrichment.ageRating ?: updated.ageRating,
                 country = enrichment.countries?.joinToString(", ") ?: updated.country,
-                language = enrichment.language ?: updated.language
+                language = enrichment.language ?: updated.language,
+                budget = enrichment.budget ?: updated.budget,
+                revenue = enrichment.revenue ?: updated.revenue
             )
         }
 


### PR DESCRIPTION
## Summary

- Add movie budget and revenue details above creator and cast at the bottom of the other tmdb details.

## PR type

- Small maintenance improvement

## Why

- It was missing and its a small improvement to the details.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Build completed successfully and tested.

## Screenshots / Video (UI changes only)

- Screenshot from bluestacks. Looks the same on tv.  

<img width="2470" height="1059" alt="Screenshot (16)" src="https://github.com/user-attachments/assets/4faba8f4-c23b-4f30-b345-0e0846a46f2e" />

## Breaking changes

None.
 
## Linked issues

 None.
