### PR TITLE
Adjustments to scroll focus in Modern View

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -106,6 +106,7 @@ import com.nuvio.tv.LocalContentFocusRequester
 import com.nuvio.tv.ui.theme.NuvioColors
 import kotlinx.coroutines.delay
 import android.view.KeyEvent as AndroidKeyEvent
+import kotlin.math.abs
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -865,7 +865,67 @@ fun ModernHomeContent(
                                 onNavigateToFolderDetail = onNavigateToFolderDetail,
                                 onLoadMoreCatalog = onLoadMoreCatalog,
                                 onBackdropInteraction = remember(Unit) { { expansionInteractionNonce++ } },
-                                onExpandedCatalogFocusKeyChange = remember(Unit) { { expandedCatalogFocusKey = it } }
+                                onExpandedCatalogFocusKeyChange = remember(Unit) { { expandedCatalogFocusKey = it } },
+                                onGetVerticalFocusRequester = { sourceIndex, isDown ->
+                                    val currentRows = latestCarouselRows
+                                    val currentRowIndex = currentRows.indexOfFirst { it.key == row.key }
+                                    if (currentRowIndex == -1) return@ModernRowSection FocusRequester.Default
+
+                                    val targetRowIndex = if (isDown) currentRowIndex + 1 else currentRowIndex - 1
+                                    val targetRow = currentRows.getOrNull(targetRowIndex) ?: return@ModernRowSection FocusRequester.Default
+
+                                    if (row.key == "continue_watching") {
+                                        val targetSavedIndex = (focusedItemByRow[targetRow.key] ?: 0)
+                                            .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
+                                        val targetItemKey = targetRow.items.getOrNull(targetSavedIndex)?.key
+
+                                        return@ModernRowSection if (targetItemKey != null) {
+                                            uiCaches.requesterFor(targetRow.key, targetItemKey)
+                                        } else FocusRequester.Default
+                                    }
+
+                                    val currentRowListState = uiCaches.rowListStates[row.key] ?: return@ModernRowSection FocusRequester.Default
+                                    val targetRowListState = uiCaches.rowListStates[targetRow.key] ?: return@ModernRowSection FocusRequester.Default
+
+                                    val sourceItemInfo = currentRowListState.layoutInfo.visibleItemsInfo.find { it.index == sourceIndex }
+                                    val sourceCenter = if (sourceItemInfo != null) {
+                                        val unexpandedWidth = when {
+                                            row.key == "continue_watching" -> continueWatchingCardWidth
+                                            else -> if (useLandscapePosters) landscapeCatalogCardWidth else portraitCatalogCardWidth
+                                        }
+                                        val unexpandedWidthPx = with(localDensity) { unexpandedWidth.roundToPx() }
+                                        sourceItemInfo.offset + (unexpandedWidthPx / 2f)
+                                    } else {
+                                        0f
+                                    }
+
+                                    val targetItems = targetRowListState.layoutInfo.visibleItemsInfo
+                                    if (targetItems.isEmpty()) {
+                                        val targetSavedIndex = (focusedItemByRow[targetRow.key] ?: 0)
+                                            .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
+                                        val targetItemKey = targetRow.items.getOrNull(targetSavedIndex)?.key
+                                        return@ModernRowSection if (targetItemKey != null) {
+                                            uiCaches.requesterFor(targetRow.key, targetItemKey)
+                                        } else FocusRequester.Default
+                                    }
+
+                                    val closestItem = targetItems.minByOrNull { item: androidx.compose.foundation.lazy.LazyListItemInfo ->
+                                        val targetUnexpandedWidth = when {
+                                            targetRow.key == "continue_watching" -> continueWatchingCardWidth
+                                            else -> if (useLandscapePosters) landscapeCatalogCardWidth else portraitCatalogCardWidth
+                                        }
+                                        val targetUnexpandedWidthPx = with(localDensity) { targetUnexpandedWidth.roundToPx() }
+                                        val targetCenter = item.offset + (targetUnexpandedWidthPx / 2f)
+                                        abs(targetCenter - sourceCenter)
+                                    }
+
+                                    val targetItemKey = closestItem?.let { targetRow.items.getOrNull(it.index)?.key }
+                                    if (targetItemKey != null) {
+                                        uiCaches.requesterFor(targetRow.key, targetItemKey)
+                                    } else {
+                                        FocusRequester.Default
+                                    }
+                                }
                             )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.foundation.focusGroup
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
@@ -329,7 +330,8 @@ internal fun ModernRowSection(
     onNavigateToFolderDetail: (String, String) -> Unit,
     onLoadMoreCatalog: (String, String, String) -> Unit,
     onBackdropInteraction: () -> Unit,
-    onExpandedCatalogFocusKeyChange: (String?) -> Unit
+    onExpandedCatalogFocusKeyChange: (String?) -> Unit,
+    onGetVerticalFocusRequester: (index: Int, isDown: Boolean) -> FocusRequester = { _, _ -> FocusRequester.Default }
 ) {
     val focusedItemByRow = uiCaches.focusedItemByRow
     val itemFocusRequesters = uiCaches.itemFocusRequesters
@@ -629,6 +631,10 @@ internal fun ModernRowSection(
                     val onFocused = remember(row.key, index, isContinueWatchingRow) {
                         { onRowItemFocused(row.key, index, isContinueWatchingRow) }
                     }
+                    val verticalFocusModifier = Modifier.focusProperties {
+                        up = onGetVerticalFocusRequester(index, false)
+                        down = onGetVerticalFocusRequester(index, true)
+                    }
 
                     when (val payload = item.payload) {
                         is ModernPayload.ContinueWatching -> {
@@ -640,7 +646,8 @@ internal fun ModernRowSection(
                                 blurUnwatchedEpisodes = blurUnwatchedEpisodes,
                                 onFocused = onFocused,
                                 onContinueWatchingClick = onContinueWatchingClick,
-                                onShowOptions = onContinueWatchingOptions
+                                onShowOptions = onContinueWatchingOptions,
+                                modifier = verticalFocusModifier
                             )
                         }
 
@@ -693,7 +700,8 @@ internal fun ModernRowSection(
                                 onNavigateToFolderDetail = onNavigateToFolderDetail,
                                 onLongPress = onLongPress,
                                 onBackdropInteraction = onBackdropInteraction,
-                                onExpandedCatalogFocusKeyChange = onExpandedCatalogFocusKeyChange
+                                onExpandedCatalogFocusKeyChange = onExpandedCatalogFocusKeyChange,
+                                modifier = verticalFocusModifier
                             )
                         }
                     }


### PR DESCRIPTION
## Summary

Changed the way scrolling calculates the next focused index (e.g., Continue Watching down to catalogs row, and expanded poster up/down to different rows.)

## PR type

- Small maintenance improvement

## Why

Currently when you scroll up/down from an expanded poster, it calculates the next index as the closest point (up or down and to the right). Similar to scrolling down from any index greater than 1 from Continue Watching, instead of scrolling directly down to the previously focused index, it'll scroll down and shoot over right a few indexes.

## Policy check

 - [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.


## Testing

Basic scrolling up, down, left, right between different rows and continue watching indexes with expanded posters to ensure it functions as intended and with expanded posters disabled to ensure that doesn't affect normal use case.

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

None

## Linked issues

None
