### PR TITLE
Performance Improvments for #1407

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -454,7 +454,13 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
                 }
             }
         } finally {
-            if (_enrichingItemId.value == item.id) setEnrichingItemId(null)
+            if (_enrichingItemId.value == item.id) {
+                scheduleUpdateCatalogRows()
+                withContext(Dispatchers.Main) {
+                    delay(150)
+                }
+                setEnrichingItemId(null)
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -927,8 +927,7 @@ fun ModernHomeContent(
                                 onExpandedCatalogFocusKeyChange = remember(Unit) { { expandedCatalogFocusKey = it } },
                                 onGetVerticalFocusRequester = { sourceIndex, isDown ->
                                     val currentRows = latestCarouselRows
-                                    val currentRowIndex = currentRows.indexOfFirst { it.key == row.key }
-                                    if (currentRowIndex == -1) return@ModernRowSection FocusRequester.Default
+                                    val currentRowIndex = rowIndexByKey[row.key] ?: return@ModernRowSection FocusRequester.Default
 
                                     val targetRowIndex = if (isDown) currentRowIndex + 1 else currentRowIndex - 1
                                     val targetRow = currentRows.getOrNull(targetRowIndex) ?: return@ModernRowSection FocusRequester.Default

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -925,64 +925,17 @@ fun ModernHomeContent(
                                 onLoadMoreCatalog = onLoadMoreCatalog,
                                 onBackdropInteraction = remember(Unit) { { expansionInteractionNonce++ } },
                                 onExpandedCatalogFocusKeyChange = remember(Unit) { { expandedCatalogFocusKey = it } },
-                                onGetVerticalFocusRequester = { sourceIndex, isDown ->
-                                    val currentRows = latestCarouselRows
+                                onGetVerticalFocusRequester = { _, isDown ->
                                     val currentRowIndex = rowIndexByKey[row.key] ?: return@ModernRowSection FocusRequester.Default
-
                                     val targetRowIndex = if (isDown) currentRowIndex + 1 else currentRowIndex - 1
-                                    val targetRow = currentRows.getOrNull(targetRowIndex) ?: return@ModernRowSection FocusRequester.Default
+                                    val targetRow = latestCarouselRows.getOrNull(targetRowIndex) ?: return@ModernRowSection FocusRequester.Default
 
-                                    if (row.key == "continue_watching") {
-                                        val targetSavedIndex = (focusedItemByRow[targetRow.key] ?: 0)
-                                            .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
-                                        val targetItemKey = targetRow.items.getOrNull(targetSavedIndex)?.key
-
-                                        return@ModernRowSection if (targetItemKey != null) {
-                                            uiCaches.requesterFor(targetRow.key, targetItemKey)
-                                        } else FocusRequester.Default
-                                    }
-
-                                    val currentRowListState = uiCaches.rowListStates[row.key] ?: return@ModernRowSection FocusRequester.Default
-                                    val targetRowListState = uiCaches.rowListStates[targetRow.key] ?: return@ModernRowSection FocusRequester.Default
-
-                                    val sourceItemInfo = currentRowListState.layoutInfo.visibleItemsInfo.find { it.index == sourceIndex }
-                                    val sourceCenter = if (sourceItemInfo != null) {
-                                        val unexpandedWidth = when {
-                                            row.key == "continue_watching" -> continueWatchingCardWidth
-                                            else -> if (useLandscapePosters) landscapeCatalogCardWidth else portraitCatalogCardWidth
-                                        }
-                                        val unexpandedWidthPx = with(localDensity) { unexpandedWidth.roundToPx() }
-                                        sourceItemInfo.offset + (unexpandedWidthPx / 2f)
-                                    } else {
-                                        0f
-                                    }
-
-                                    val targetItems = targetRowListState.layoutInfo.visibleItemsInfo
-                                    if (targetItems.isEmpty()) {
-                                        val targetSavedIndex = (focusedItemByRow[targetRow.key] ?: 0)
-                                            .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
-                                        val targetItemKey = targetRow.items.getOrNull(targetSavedIndex)?.key
-                                        return@ModernRowSection if (targetItemKey != null) {
-                                            uiCaches.requesterFor(targetRow.key, targetItemKey)
-                                        } else FocusRequester.Default
-                                    }
-
-                                    val closestItem = targetItems.minByOrNull { item: androidx.compose.foundation.lazy.LazyListItemInfo ->
-                                        val targetUnexpandedWidth = when {
-                                            targetRow.key == "continue_watching" -> continueWatchingCardWidth
-                                            else -> if (useLandscapePosters) landscapeCatalogCardWidth else portraitCatalogCardWidth
-                                        }
-                                        val targetUnexpandedWidthPx = with(localDensity) { targetUnexpandedWidth.roundToPx() }
-                                        val targetCenter = item.offset + (targetUnexpandedWidthPx / 2f)
-                                        abs(targetCenter - sourceCenter)
-                                    }
-
-                                    val targetItemKey = closestItem?.let { targetRow.items.getOrNull(it.index)?.key }
+                                    val targetSavedIndex = (focusedItemByRow[targetRow.key] ?: 0)
+                                        .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
+                                    val targetItemKey = targetRow.items.getOrNull(targetSavedIndex)?.key
                                     if (targetItemKey != null) {
                                         uiCaches.requesterFor(targetRow.key, targetItemKey)
-                                    } else {
-                                        FocusRequester.Default
-                                    }
+                                    } else FocusRequester.Default
                                 }
                             )
                 }


### PR DESCRIPTION
## Summary

Simplify `onGetVerticalFocusRequester` in Modern home layout: replace the expensive pixel-center calculation with a simple `focusedItemByRow` lookup. This make Modern Home behave a bit like Classic View with focus 
## PR type

- Bug fix
- Small maintenance improvement

## Why

The pixel-based vertical focus calculation introduced in #1407 caused noticeable slowdowns during rapid D-pad up/down scrolling - it ran `indexOfFirst` over all rows, accessed `layoutInfo.visibleItemsInfo`, and computed pixel centers for every item in `focusProperties` (which is evaluated eagerly on every recomposition).

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual testing on Android TV: rapid D-pad up/down scrolling through rows is smooth without stutters

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break

## Linked issues

Improves performance for changes from #1407
