### PR TITLE
fix: keep Modern home hero backdrop fade on cache hits

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/AlwaysCrossfadeTransitionFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/AlwaysCrossfadeTransitionFactory.kt
@@ -1,0 +1,44 @@
+package com.nuvio.tv.ui.screens.home
+
+import coil.drawable.CrossfadeDrawable
+import coil.request.ImageResult
+import coil.request.SuccessResult
+import coil.transition.CrossfadeTransition
+import coil.transition.Transition
+import coil.transition.TransitionTarget
+
+internal class AlwaysCrossfadeTransitionFactory @JvmOverloads constructor(
+    private val durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION,
+    private val preferExactIntrinsicSize: Boolean = false
+) : Transition.Factory {
+
+    init {
+        require(durationMillis > 0) { "durationMillis must be > 0." }
+    }
+
+    override fun create(target: TransitionTarget, result: ImageResult): Transition {
+        return if (result is SuccessResult) {
+            CrossfadeTransition(
+                target = target,
+                result = result,
+                durationMillis = durationMillis,
+                preferExactIntrinsicSize = preferExactIntrinsicSize
+            )
+        } else {
+            Transition.Factory.NONE.create(target, result)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is AlwaysCrossfadeTransitionFactory &&
+            durationMillis == other.durationMillis &&
+            preferExactIntrinsicSize == other.preferExactIntrinsicSize
+    }
+
+    override fun hashCode(): Int {
+        var result = durationMillis
+        result = 31 * result + preferExactIntrinsicSize.hashCode()
+        return result
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -114,11 +114,18 @@ internal fun ModernHeroMediaLayer(
     // so Coil crossfade starts with the final URL, not an intermediate one.
     var stableBackdrop by remember { mutableStateOf(heroBackdrop) }
     if (!enrichmentActive) stableBackdrop = heroBackdrop
+    val heroBackdropTransitionFactory = remember { AlwaysCrossfadeTransitionFactory(durationMillis = 400) }
 
-    val imageModel = remember(localContext, stableBackdrop, requestWidthPx, requestHeightPx) {
+    val imageModel = remember(
+        localContext,
+        stableBackdrop,
+        requestWidthPx,
+        requestHeightPx,
+        heroBackdropTransitionFactory
+    ) {
         ImageRequest.Builder(localContext)
             .data(stableBackdrop)
-            .crossfade(400)
+            .transitionFactory(heroBackdropTransitionFactory)
             .size(width = requestWidthPx, height = requestHeightPx)
             .build()
     }


### PR DESCRIPTION
## Summary

Replace `crossfade(400)` with a custom `AlwaysCrossfadeTransitionFactory` on the Modern Home hero backdrop so the fade-in animation plays even on Coil memory-cache hits.

## PR type

- Bug fix

## Why

Coil's built-in `crossfade()` skips the transition when the image is served from the memory cache (`isSampled = false`). On the Modern Home screen this causes the hero backdrop to pop in instantly after the first load — breaking the smooth fade effect users expect when swiping between hero items.

`AlwaysCrossfadeTransitionFactory` forces `CrossfadeTransition` for every `SuccessResult`, regardless of cache status.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: installed debug build on physical Android TV device, navigated to Modern Home, swiped through hero items multiple times. Verified crossfade animation plays consistently on every backdrop change (first load and subsequent cache hits).

## Screenshots / Video (UI changes only)

N/A — animation behavior, no layout change.

## Breaking changes

- None

## Linked issues

- None
