### PR TITLE
NonCancellable Nuvio Sync push, scope vertical focus override to expanded cards only

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -94,7 +96,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
         syncJob?.cancel()
         syncJob = syncScope.launch {
             delay(2000)
-            watchProgressSyncService.pushToRemote()
+            withContext(NonCancellable) {
+                watchProgressSyncService.pushToRemote()
+            }
         }
     }
 
@@ -105,7 +109,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
         watchedItemsSyncJob?.cancel()
         watchedItemsSyncJob = syncScope.launch {
             delay(2000)
-            watchedItemsSyncService.pushToRemote()
+            withContext(NonCancellable) {
+                watchedItemsSyncService.pushToRemote()
+            }
         }
     }
 
@@ -562,7 +568,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
         watchProgressPreferences.saveProgress(progress)
 
         if (syncRemote && authManager.isAuthenticated) {
-            syncScope.launch {
+            syncScope.launch(NonCancellable) {
                 watchProgressSyncService.pushSingleToRemote(progressKey(progress), progress)
                     .onFailure { error ->
                         Log.w(TAG, "Failed single progress push; falling back to full sync next cycle", error)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -631,9 +631,14 @@ internal fun ModernRowSection(
                     val onFocused = remember(row.key, index, isContinueWatchingRow) {
                         { onRowItemFocused(row.key, index, isContinueWatchingRow) }
                     }
-                    val verticalFocusModifier = Modifier.focusProperties {
-                        up = onGetVerticalFocusRequester(index, false)
-                        down = onGetVerticalFocusRequester(index, true)
+                    val hasExpandedCard = expandedCatalogFocusKey != null
+                    val verticalFocusModifier = if (hasExpandedCard) {
+                        Modifier.focusProperties {
+                            up = onGetVerticalFocusRequester(index, false)
+                            down = onGetVerticalFocusRequester(index, true)
+                        }
+                    } else {
+                        Modifier
                     }
 
                     when (val payload = item.payload) {


### PR DESCRIPTION
## Summary

Two fixes:

1. Make Nuvio Sync watch progress and watched items push operations non-cancellable, matching the existing Trakt fix. When the app is closed shortly after watching an episode, the sync push now completes instead of being silently cancelled

2. Only apply custom vertical focus (`focusProperties` up/down override) when a poster card is expanded. In normal state, Compose handles D-pad up/down navigation naturally. 

## PR type

- Bug fix

## Why

1. Users reported that watched episodes disappeared from the Continue Watching list after leaving and returning to the app. The debounced sync push (2s delay) was being cancelled on app close, so progress never reached Supabase.

2. The `focusProperties` override from #1407 was applied unconditionally to every row item, which caused broken `LazyRow` scroll behavior when the target row was still loading. The fix from #1407 is only needed when a card is expanded (wider than normal), so we now gate it on `expandedCatalogFocusKey != null`.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: watched an episode, immediately closed the app, reopened - episode appears in Continue Watching
- Manual: rapid D-pad scroll down to a loading row, then scroll right - row scrolls correctly
- Manual: expanded poster, press down - focus lands on correct item in row below (fix from #1407 preserved)

## Screenshots / Video (UI changes only)

Nothing changed 

## Breaking changes

Nothing should break

## Linked issues

Fixes regression from #1407
