### PR TITLE
Fix prevent backdrop crossfade backward navigation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -114,18 +114,25 @@ internal fun ModernHeroMediaLayer(
     // so Coil crossfade starts with the final URL, not an intermediate one.
     var stableBackdrop by remember { mutableStateOf(heroBackdrop) }
     if (!enrichmentActive) stableBackdrop = heroBackdrop
-    val heroBackdropTransitionFactory = remember { AlwaysCrossfadeTransitionFactory(durationMillis = 400) }
+
+    
+    val lastBackdropRef = remember { java.util.concurrent.atomic.AtomicReference<String?>(null) }
 
     val imageModel = remember(
         localContext,
         stableBackdrop,
         requestWidthPx,
-        requestHeightPx,
-        heroBackdropTransitionFactory
+        requestHeightPx
     ) {
+        val prev = lastBackdropRef.getAndSet(stableBackdrop)
+        val isBackdropChange = prev != null && prev != stableBackdrop
+
         ImageRequest.Builder(localContext)
             .data(stableBackdrop)
-            .transitionFactory(heroBackdropTransitionFactory)
+            .transitionFactory(
+                if (isBackdropChange) AlwaysCrossfadeTransitionFactory(durationMillis = 400)
+                else coil.transition.Transition.Factory.NONE
+            )
             .size(width = requestWidthPx, height = requestHeightPx)
             .build()
     }


### PR DESCRIPTION
## Summary

Skip prevent crossfade on backward navigation

## PR type

- Bug fix

## Why

When returning from `MetaDetails`, the `AsyncImage` reinstantiates and loads the home backdrop from `MEMORY_CACHE`. With the previous behavior in `AlwaysCrossfadeTransitionFactory`, this caused an unwanted crossfade effect because it faded in an already available cached image from scratch (where `target.drawable` was null). This PR adds a check to skip crossfade if there's no pre-existing drawable and the source is memory cache.

## Policy check

 - [x] This PR is not cosmetic-only, unless it is a translation PR.
 - [x] This PR does not add a new major feature without prior approval.
 - [x] This PR is small in scope and focused on one problem.
 - [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Manually verified:
- Scrolling `ModernHomeHero` horizontally still applies the crossfade transition properly on cached hits.
- Pressing back from `MetaDetails` directly loads the cached backdrop without crossfade, fixing the flash.

## Screenshots / Video (UI changes only)

None.
## Breaking changes

None.

## Linked issues

Fixes #1412
