### PR TITLE
Cap releaseAlerts to 60 days and use midnight as sort order for them

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2290,11 +2290,27 @@ private fun resolveNextUpReleaseState(
     hasAired: Boolean
 ): NextUpReleaseState {
     val releaseTimestamp = parseEpisodeReleaseInstant(nextReleased)?.toEpochMilli()
+    val nowMs = System.currentTimeMillis()
+    val sixtyDaysMs = 60L * 24 * 60 * 60 * 1000
     val isReleaseAlert = hasAired &&
         releaseTimestamp != null &&
-        releaseTimestamp > seedProgress.lastWatched
+        releaseTimestamp > seedProgress.lastWatched &&
+        // Suppress release alerts for episodes that aired more than 60 days ago —
+        // the user likely abandoned the show.
+        (nowMs - releaseTimestamp) < sixtyDaysMs
+
+    // Use midnight of the release date for sorting instead of the full
+    // timestamp.  Meta sources sometimes report a future hour on the
+    // current day which would pin the alert above freshly-watched items.
+    val releaseDateMidnight = releaseTimestamp?.let { ts ->
+        val localDate = Instant.ofEpochMilli(ts)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate()
+        localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    }
+
     return NextUpReleaseState(
-        sortTimestamp = if (isReleaseAlert) releaseTimestamp else seedProgress.lastWatched,
+        sortTimestamp = if (isReleaseAlert) releaseDateMidnight ?: releaseTimestamp!! else seedProgress.lastWatched,
         releaseTimestamp = releaseTimestamp,
         isReleaseAlert = isReleaseAlert,
         isNewSeasonRelease = isReleaseAlert && seedProgress.season != null && nextSeason != seedProgress.season


### PR DESCRIPTION
## Summary

Two improvements to Continue Watching release alerts:

1. Suppress release alerts for episodes that aired more than 60 days ago - if a user hasn't watched a show in that long, they likely abandoned it.
2. Use midnight of the release date for sort ordering instead of the full timestamp. Meta sources sometimes report a future hour on the current day, which pinned the alert above freshly-watched items for the entire day.

## PR type

- Bug fix
- Small maintenance improvement

## Why

Users complained about getting "New Episode" / "New Season" alerts for shows they watched months ago and abandoned. Additionally, release alerts with future-hour timestamps stayed pinned at the top of CW even after the user watched something else, because the sort timestamp was ahead of `lastWatched`.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manual: verified that a show last watched 90 days ago with a new episode released 70 days ago no longer shows a release alert badge
- Manual: verified that a release alert from today sorts at midnight, so watching something new pushes it below the freshly-watched item
- Manual: verified that a release alert from yesterday still appears with badge

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break

## Linked issues

Reported on Discord 
