### PR TITLE
Perf: Enable asynchronous subtitle parsing in ExoPlayer

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -104,24 +104,28 @@ internal class PlayerMediaSourceFactory {
         return when {
             isHls && !forceDefaultFactory -> HlsMediaSource.Factory(httpDataSourceFactory)
                 .setAllowChunklessPreparation(true)
-                .apply {
-                    customSubtitleParserFactory?.let { parserFactory ->
-                        setSubtitleParserFactory(parserFactory)
-                    }
-                }
+                .applySubtitleParserFactory(customSubtitleParserFactory)
                 .createMediaSource(mediaItem)
             isDash && !forceDefaultFactory -> DashMediaSource.Factory(httpDataSourceFactory)
-                .apply {
-                    customSubtitleParserFactory?.let { parserFactory ->
-                        setSubtitleParserFactory(parserFactory)
-                    }
-                }
+                .applySubtitleParserFactory(customSubtitleParserFactory)
                 .createMediaSource(mediaItem)
             else -> defaultFactory.createMediaSource(mediaItem)
         }
     }
 
     fun shutdown() = Unit
+
+    private fun HlsMediaSource.Factory.applySubtitleParserFactory(
+        subtitleParserFactory: SubtitleParser.Factory?
+    ): HlsMediaSource.Factory = apply {
+        subtitleParserFactory?.let(::setSubtitleParserFactory)
+    }
+
+    private fun DashMediaSource.Factory.applySubtitleParserFactory(
+        subtitleParserFactory: SubtitleParser.Factory?
+    ): DashMediaSource.Factory = apply {
+        subtitleParserFactory?.let(::setSubtitleParserFactory)
+    }
 
     companion object {
         private const val PROBE_TIMEOUT_MS = 4000

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -94,7 +94,7 @@ internal class PlayerMediaSourceFactory {
                 setSubtitleParserFactory(parserFactory)
             }
         }
-        val forceDefaultFactory = customExtractorsFactory != null || customSubtitleParserFactory != null
+        val forceDefaultFactory = customExtractorsFactory != null
 
         // Sidecar subtitles are more reliable through DefaultMediaSourceFactory.
         if (subtitleConfigurations.isNotEmpty()) {
@@ -104,8 +104,18 @@ internal class PlayerMediaSourceFactory {
         return when {
             isHls && !forceDefaultFactory -> HlsMediaSource.Factory(httpDataSourceFactory)
                 .setAllowChunklessPreparation(true)
+                .apply {
+                    customSubtitleParserFactory?.let { parserFactory ->
+                        setSubtitleParserFactory(parserFactory)
+                    }
+                }
                 .createMediaSource(mediaItem)
             isDash && !forceDefaultFactory -> DashMediaSource.Factory(httpDataSourceFactory)
+                .apply {
+                    customSubtitleParserFactory?.let { parserFactory ->
+                        setSubtitleParserFactory(parserFactory)
+                    }
+                }
                 .createMediaSource(mediaItem)
             else -> defaultFactory.createMediaSource(mediaItem)
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -243,12 +243,13 @@ internal fun PlayerRuntimeController.initializePlayer(
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || forceDv7ToHevc)
 
+            mediaSourceFactory.configureSubtitleParsing(
+                extractorsFactory = extractorsFactory,
+                subtitleParserFactory = DefaultSubtitleParserFactory()
+            )
+
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             val buildDefaultPlayer = {
-                mediaSourceFactory.configureSubtitleParsing(
-                    extractorsFactory = null,
-                    subtitleParserFactory = DefaultSubtitleParserFactory()
-                )
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)
                     .setTrackSelector(trackSelector!!)
@@ -831,4 +832,3 @@ private class SubtitleOffsetRenderer(
         super.render(adjustedPositionUs, elapsedRealtimeUs)
     }
 }
-

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -28,6 +28,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.text.TextOutput
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.text.DefaultSubtitleParserFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
 import androidx.media3.extractor.ts.TsExtractor
 import androidx.media3.session.MediaSession
@@ -246,7 +247,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             val buildDefaultPlayer = {
                 mediaSourceFactory.configureSubtitleParsing(
                     extractorsFactory = null,
-                    subtitleParserFactory = null
+                    subtitleParserFactory = DefaultSubtitleParserFactory()
                 )
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)


### PR DESCRIPTION
## Summary

Updates PlayerRuntimeControllerInitialization to use `DefaultSubtitleParserFactory` instead of `null` when configuring subtitle parsing on `DefaultMediaSourceFactory`. This delegates text extraction to a background thread instead of the playback/rendering thread, which significantly reduces UI stutter and improves playback startup times, especially for large, text-heavy subtitle files (like those found in certain streaming setups as reported on Reddit.

## PR type

- Bug fix

## Why

Reddit users had reported lag when playback starts

## Policy check

<!-- Confirm these before requesting review -->
 - [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

I am unable to build an apk at the moment due to my setup environment, but the idea makes sense in principle. If someone can provide an APK, I am happy to test.

## Screenshots / Video (UI changes only)

<img width="692" height="212" alt="image" src="https://github.com/user-attachments/assets/3fb5dfba-3572-4c90-bb3d-edb11c7dfd42" />


## Breaking changes

Shouldn't be any as far as I know, so marking this as none.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1428
