### PR TITLE
Update Integration settings strings

### DIFF
--- a/app/src/main/res/values-ar/Strings.xml
+++ b/app/src/main/res/values-ar/Strings.xml
@@ -290,7 +290,7 @@
     <string name="account_stat_progress">مستوى المشاهدة</string>
     <string name="account_stat_watched">تمت المشاهدة</string>
     <string name="settings_integrations_section">الخدمات المرتبطة</string>
-    <string name="settings_integrations_section_subtitle">ضبط إعدادات TMDB أو MDBList</string>
+    <string name="settings_integrations_section_subtitle">إدارة عمليات التكامل المتاحة</string>
     <string name="settings_tmdb_subtitle">عناصر التحكم في إثراء البيانات الوصفية</string>
     <string name="settings_mdblist_subtitle">مصادر التقييمات الخارجية</string>
     <string name="settings_animeskip_subtitle">مواقيت تخطي مقدمة/نهاية الأنمي</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -267,7 +267,7 @@
     <string name="settings_layout_subtitle">Estructura de inicio y estilos de pósteres</string>
     <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Repositorios y proveedores</string>
-    <string name="settings_integration">Integración</string>
+    <string name="settings_integration">Integraciones</string>
     <string name="settings_playback">Reproducción</string>
     <string name="settings_playback_subtitle">Reproductor, subtítulos y auto-reproducción</string>
     <string name="settings_trakt_subtitle">Abrir pantalla de conexión con Trakt</string>
@@ -299,7 +299,7 @@
     <string name="account_stat_progress">progreso</string>
     <string name="account_stat_watched">vistos</string>
     <string name="settings_integrations_section">Integraciones</string>
-    <string name="settings_integrations_section_subtitle">Elegir configuraciones de TMDB o MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gestionar integraciones disponibles</string>
     <string name="settings_tmdb_subtitle">Controles de enriquecimiento de metadatos</string>
     <string name="settings_mdblist_subtitle">Proveedores de calificaciones externos</string>
     <string name="settings_animeskip_subtitle">Marcas de tiempo para omitir intro/outro de anime</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -299,7 +299,7 @@
     <string name="account_stat_progress">napredak</string>
     <string name="account_stat_watched">odgledano</string>
     <string name="settings_integrations_section">Integracije</string>
-    <string name="settings_integrations_section_subtitle">Upravljanje dostupnim integracijama</string>
+    <string name="settings_integrations_section_subtitle">Upravljajte dostupnim integracijama</string>
     <string name="settings_tmdb_subtitle">Kontrole za obogaćivanje metapodataka</string>
     <string name="settings_mdblist_subtitle">Vanjski provajderi ocjena</string>
     <string name="settings_animeskip_subtitle">Vremenske oznake za preskakanje anime uvoda/odjave</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -228,7 +228,7 @@
     <string name="account_stat_progress">postup</string>
     <string name="account_stat_watched">zhlédnuto</string>
     <string name="settings_integrations_section">Integrace</string>
-    <string name="settings_integrations_section_subtitle">Vyberte TMDB nebo MDBList</string>
+    <string name="settings_integrations_section_subtitle">Spravujte dostupné integrace</string>
     <string name="settings_tmdb_subtitle">Ovládání obohacení metadat</string>
     <string name="settings_mdblist_subtitle">Externí poskytovatelé hodnocení</string>
     <string name="settings_animeskip_subtitle">Anime intro/outro časy pro přeskočení</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -209,7 +209,7 @@
     <string name="settings_layout_subtitle">Startseite-Struktur und Poster-Stile</string>
     <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Repositorys und Anbieter</string>
-    <string name="settings_integration">Integration</string>
+    <string name="settings_integration">Integrationen</string>
     <string name="settings_playback">Wiedergabe</string>
     <string name="settings_playback_subtitle">Player, Untertitel und automatische Wiedergabe</string>
     <string name="settings_trakt_subtitle">Trakt-Verbindungsbildschirm öffnen</string>
@@ -241,7 +241,7 @@
     <string name="account_stat_progress">Fortschritt</string>
     <string name="account_stat_watched">angesehen</string>
     <string name="settings_integrations_section">Integrationen</string>
-    <string name="settings_integrations_section_subtitle">TMDB oder MDBList auswählen</string>
+    <string name="settings_integrations_section_subtitle">Verwalten Sie verfügbare Integrationen</string>
     <string name="settings_tmdb_subtitle">Steuerelemente zur Anreicherung von Metadaten</string>
     <string name="settings_mdblist_subtitle">Externe Bewertungsanbieter</string>
     <string name="settings_animeskip_subtitle">Zeitstempel zum Überspringen von Anime-Intro/Outro</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -209,7 +209,7 @@
     <string name="settings_layout_subtitle">Δομή αρχικής οθόνης και στυλ αφισών</string>
     <string name="settings_plugins">Πρόσθετα</string>
     <string name="settings_plugins_subtitle">Αποθετήρια και πάροχοι</string>
-    <string name="settings_integration">Ενσωμάτωση</string>
+    <string name="settings_integration">Ενσωματώσεις</string>
     <string name="settings_playback">Αναπαραγωγή</string>
     <string name="settings_playback_subtitle">Πρόγραμμα αναπαραγωγής, υπότιτλοι και αυτόματη αναπαραγωγή</string>
     <string name="settings_trakt_subtitle">Άνοιγμα οθόνης σύνδεσης Trakt</string>
@@ -241,7 +241,7 @@
     <string name="account_stat_progress">πρόοδος</string>
     <string name="account_stat_watched">προβληθέντα</string>
     <string name="settings_integrations_section">Ενσωματώσεις</string>
-    <string name="settings_integrations_section_subtitle">Επιλέξτε TMDB ή MDBList</string>
+    <string name="settings_integrations_section_subtitle">Διαχειριστείτε τις διαθέσιμες ενσωματώσεις</string>
     <string name="settings_tmdb_subtitle">Έλεγχοι εμπλουτισμού μεταδεδομένων</string>
     <string name="settings_mdblist_subtitle">Εξωτερικοί πάροχοι βαθμολογιών</string>
     <string name="settings_animeskip_subtitle">Χρονοσήμανση παράλειψης intro/outro anime</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -168,7 +168,7 @@
     <string name="settings_layout_subtitle">Estructura del inicio y estilos de pósters</string>
     <string name="settings_plugins">Complementos</string>
     <string name="settings_plugins_subtitle">Repositorios y proveedores</string>
-    <string name="settings_integration">Integración</string>
+    <string name="settings_integration">Integraciones</string>
     <string name="settings_playback">Reproducción</string>
     <string name="settings_playback_subtitle">Reproductor, subtítulos y reproducción automática</string>
     <string name="settings_trakt_subtitle">Abre la pantalla de conexión de Trakt</string>
@@ -183,7 +183,7 @@
     <string name="account_stat_progress">progreso</string>
     <string name="account_stat_watched">visto</string>
     <string name="settings_integrations_section">Integraciones</string>
-    <string name="settings_integrations_section_subtitle">Elige configuración de TMDB o MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gestionar integraciones disponibles</string>
     <string name="settings_tmdb_subtitle">Controles de enriquecimiento de metadatos</string>
     <string name="settings_mdblist_subtitle">Proveedores de calificaciones externas</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -267,7 +267,7 @@
     <string name="settings_layout_subtitle">Structure de l\'accueil et styles d\'affiches</string>
     <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Dépôts et fournisseurs</string>
-    <string name="settings_integration">Intégration</string>
+    <string name="settings_integration">Intégrations</string>
     <string name="settings_playback">Lecture</string>
     <string name="settings_playback_subtitle">Lecteur, sous-titres et lecture automatique</string>
     <string name="settings_trakt_subtitle">Ouvrir l\'écran de connexion Trakt</string>
@@ -299,7 +299,7 @@
     <string name="account_stat_progress">progression</string>
     <string name="account_stat_watched">vus</string>
     <string name="settings_integrations_section">Intégrations</string>
-    <string name="settings_integrations_section_subtitle">Paramètres TMDB ou MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gérer les intégrations disponibles</string>
     <string name="settings_tmdb_subtitle">Contrôles d\'enrichissement des métadonnées</string>
     <string name="settings_mdblist_subtitle">Fournisseurs de notes externes</string>
     <string name="settings_animeskip_subtitle">Horodatages pour passer les intros/outros d\'animés</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -195,7 +195,7 @@
     <string name="account_stat_progress">प्रोग्रेस</string>
     <string name="account_stat_watched">देखा गया</string>
     <string name="settings_integrations_section">इंटीग्रेशन</string>
-    <string name="settings_integrations_section_subtitle">TMDB या MDBList चुनें</string>
+    <string name="settings_integrations_section_subtitle">उपलब्ध एकीकरण प्रबंधित करें</string>
     <string name="settings_tmdb_subtitle">मेटाडेटा एनरिचमेंट कंट्रोल</string>
     <string name="settings_mdblist_subtitle">बाहरी रेटिंग प्रोवाइडर्स</string>
     <string name="settings_animeskip_subtitle">एनीमे इंट्रो/आउट्रो स्किप टाइमस्टैम्प</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -200,7 +200,7 @@
     <string name="settings_layout_subtitle">Kezdőlap szerkezete és poszter stílusok</string>
     <string name="settings_plugins">Beépülő modulok</string>
     <string name="settings_plugins_subtitle">Tárhelyek és szolgáltatók</string>
-    <string name="settings_integration">Integráció</string>
+    <string name="settings_integration">Integrációk</string>
     <string name="settings_playback">Lejátszás</string>
     <string name="settings_playback_subtitle">Lejátszó, feliratok és automatikus lejátszás</string>
     <string name="settings_trakt_subtitle">Trakt kapcsolat beállítása</string>
@@ -232,7 +232,7 @@
     <string name="account_stat_progress">folyamatban</string>
     <string name="account_stat_watched">megnézve</string>
     <string name="settings_integrations_section">Integrációk</string>
-    <string name="settings_integrations_section_subtitle">TMDB vagy MDBList beállítások</string>
+    <string name="settings_integrations_section_subtitle">Az elérhető integrációk kezelése</string>
     <string name="settings_tmdb_subtitle">Metaadat-bővítési beállítások</string>
     <string name="settings_mdblist_subtitle">Külső értékelési szolgáltatók</string>
     <string name="settings_animeskip_subtitle">Anime intro/outro átugrási időbélyegek</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -209,7 +209,7 @@
     <string name="settings_layout_subtitle">Struttura della home e stili delle locandine</string>
     <string name="settings_plugins">Plugin</string>
     <string name="settings_plugins_subtitle">Repository e provider</string>
-    <string name="settings_integration">Integrazione</string>
+    <string name="settings_integration">Integrazioni</string>
     <string name="settings_playback">Riproduzione</string>
     <string name="settings_playback_subtitle">Player, sottotitoli e riproduzione automatica</string>
     <string name="settings_trakt_subtitle">Apri la schermata di login su Trakt</string>
@@ -241,7 +241,7 @@
     <string name="account_stat_progress">progresso</string>
     <string name="account_stat_watched">guardato</string>
     <string name="settings_integrations_section">Integrazioni</string>
-    <string name="settings_integrations_section_subtitle">Scegli le impostazioni TMDB o MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gestisci le integrazioni disponibili</string>
     <string name="settings_tmdb_subtitle">Controlli per l\'arricchimento dei metadati</string>
     <string name="settings_mdblist_subtitle">Provider esterni per le valutazioni</string>
     <string name="settings_animeskip_subtitle">Salta inizio/fine Anime</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -183,7 +183,7 @@
     <string name="settings_layout_subtitle">מבנה בית וסגנונות פוסטרים</string>
     <string name="settings_plugins">תוספים</string>
     <string name="settings_plugins_subtitle">מאגרים וספקים</string>
-    <string name="settings_integration">שילוב</string>
+    <string name="settings_integration">שילובים</string>
     <string name="settings_playback">הפעלה</string>
     <string name="settings_playback_subtitle">נגן, כתוביות והפעלה אוטומטית</string>
     <string name="settings_trakt_subtitle">פתח מסך חיבור Trakt</string>
@@ -215,7 +215,7 @@
     <string name="account_stat_progress">התקדמות</string>
     <string name="account_stat_watched">נצפה</string>
     <string name="settings_integrations_section">שילובים</string>
-    <string name="settings_integrations_section_subtitle">בחר TMDB או MDBList</string>
+    <string name="settings_integrations_section_subtitle">נהל אינטגרציות זמינות</string>
     <string name="settings_tmdb_subtitle">בקרות העשרת מטה-דאטה</string>
     <string name="settings_mdblist_subtitle">ספקי דירוג חיצוניים</string>
     <string name="settings_animeskip_subtitle">חותמות זמן לדילוג על הקדמות/סיומות אנימה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -242,7 +242,7 @@
     <string name="account_stat_progress">進行状況</string>
     <string name="account_stat_watched">視聴済み</string>
     <string name="settings_integrations_section">連携</string>
-    <string name="settings_integrations_section_subtitle">TMDBまたはMDBListの設定</string>
+    <string name="settings_integrations_section_subtitle">利用可能な統合を管理する</string>
     <string name="settings_tmdb_subtitle">メタデータ補完の設定</string>
     <string name="settings_mdblist_subtitle">外部評価プロバイダー</string>
     <string name="settings_animeskip_subtitle">アニメのイントロ/アウトロスキップのタイムスタンプ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -180,7 +180,7 @@
     <string name="settings_layout_subtitle">Pradinio ekrano struktūra ir plakatų stiliai</string>
     <string name="settings_plugins">Įskiepiai</string>
     <string name="settings_plugins_subtitle">Repozitorijos ir teikėjai</string>
-    <string name="settings_integration">Integracija</string>
+    <string name="settings_integration">Integracijos</string>
     <string name="settings_playback">Atkūrimas</string>
     <string name="settings_playback_subtitle">Grotuvas, subtitrai ir automatinis paleidimas</string>
     <string name="settings_trakt_subtitle">Atidaryti „Trakt“ ryšio ekraną</string>
@@ -195,7 +195,7 @@
     <string name="account_stat_progress">pažanga</string>
     <string name="account_stat_watched">žiūrėta</string>
     <string name="settings_integrations_section">Integracijos</string>
-    <string name="settings_integrations_section_subtitle">Pasirinkite TMDB arba MDBList</string>
+    <string name="settings_integrations_section_subtitle">Tvarkykite galimas integracijas</string>
     <string name="settings_tmdb_subtitle">Metaduomenų praturtinimo valdikliai</string>
     <string name="settings_mdblist_subtitle">Išoriniai įvertinimų teikėjai</string>
     <string name="settings_animeskip_subtitle">„Anime Skip“ intro/outro praleidimo laiko žymos</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -144,7 +144,7 @@
 <string name="account_stat_progress">voortgang</string>
 <string name="account_stat_watched">bekeken</string>
 <string name="settings_integrations_section">Integraties</string>
-<string name="settings_integrations_section_subtitle">Kies TMDB of MDBList</string>
+<string name="settings_integrations_section_subtitle">Beheer beschikbare integraties</string>
 <string name="settings_tmdb_subtitle">Instellingen voor metadata-verrijking</string>
 <string name="settings_mdblist_subtitle">Externe beoordelingsproviders</string>
 <string name="settings_animeskip_subtitle">Tijdstempels voor intro-/outro-overslaan bij anime</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -207,7 +207,7 @@
     <string name="settings_layout_subtitle">Hjemmestruktur og plakatstiler</string>
     <string name="settings_plugins">Programtillegg</string>
     <string name="settings_plugins_subtitle">Arkiver og leverandører</string>
-    <string name="settings_integration">Integrasjon</string>
+    <string name="settings_integration">Integrasjoner</string>
     <string name="settings_playback">Avspilling</string>
     <string name="settings_playback_subtitle">Spiller, undertekster og autoavspilling</string>
     <string name="settings_trakt_subtitle">Åpne tilkoblingsside for Trakt</string>
@@ -239,7 +239,7 @@
     <string name="account_stat_progress">progresjon</string>
     <string name="account_stat_watched">sett</string>
     <string name="settings_integrations_section">Integrasjoner</string>
-    <string name="settings_integrations_section_subtitle">Velg TMDB eller MDBList</string>
+    <string name="settings_integrations_section_subtitle">Administrer tilgjengelige integrasjoner</string>
     <string name="settings_tmdb_subtitle">Kontroller for metadataberikelse</string>
     <string name="settings_mdblist_subtitle">Eksterne vurderingsleverandører</string>
     <string name="settings_animeskip_subtitle">Tidsmerker for anime intro/outro</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -145,7 +145,7 @@
     <string name="account_stat_progress">postęp</string>
     <string name="account_stat_watched">obejrzane</string>
     <string name="settings_integrations_section">Integracje</string>
-    <string name="settings_integrations_section_subtitle">Wybierz ustawienia TMDB lub MDBList</string>
+    <string name="settings_integrations_section_subtitle">Zarządzaj dostępnymi integracjami</string>
     <string name="settings_tmdb_subtitle">Kontrolki wzbogacania metadanych</string>
     <string name="settings_mdblist_subtitle">Zewnętrzni dostawcy ocen</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -299,7 +299,7 @@
     <string name="account_stat_progress">progresso</string>
     <string name="account_stat_watched">assistidos</string>
     <string name="settings_integrations_section">Integrações</string>
-    <string name="settings_integrations_section_subtitle">Configurar TMDB ou MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gerenciar integrações disponíveis</string>
     <string name="settings_tmdb_subtitle">Enriquecimento de metadados</string>
     <string name="settings_mdblist_subtitle">Provedores de avaliações externas</string>
     <string name="settings_animeskip_subtitle">Pular introduções/créditos de animes</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -186,7 +186,7 @@
     <string name="settings_layout_subtitle">Estrutura do ecrã inicial e estilos de póster</string>
     <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Repositórios e fornecedores</string>
-    <string name="settings_integration">Integração</string>
+    <string name="settings_integration">Integrações</string>
     <string name="settings_playback">Reprodução</string>
     <string name="settings_playback_subtitle">Reprodutor, legendas e reprodução automática</string>
     <string name="settings_trakt_subtitle">Abrir ecrã de ligação ao Trakt</string>
@@ -218,7 +218,7 @@
     <string name="account_stat_progress">progresso</string>
     <string name="account_stat_watched">vistos</string>
     <string name="settings_integrations_section">Integrações</string>
-    <string name="settings_integrations_section_subtitle">Escolher TMDB ou MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gerenciar integrações disponíveis</string>
     <string name="settings_tmdb_subtitle">Controlos de enriquecimento de metadados</string>
     <string name="settings_mdblist_subtitle">Fornecedores externos de classificações</string>
     <string name="settings_animeskip_subtitle">Tempos de salto para intros/outros de Anime</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -123,7 +123,7 @@
     <string name="settings_layout_subtitle">Structura paginii principale și stilurile afișajului</string>
     <string name="settings_plugins">Plugin-uri</string>
     <string name="settings_plugins_subtitle">Depozite și furnizori</string>
-    <string name="settings_integration">Integrare</string>
+    <string name="settings_integration">Integrări</string>
     <string name="settings_playback">Redare</string>
     <string name="settings_playback_subtitle">Player, subtitrări și redare automată</string>
     <string name="settings_trakt_subtitle">Deschide ecranul de conectare Trakt</string>
@@ -138,7 +138,7 @@
     <string name="account_stat_progress">progres</string>
     <string name="account_stat_watched">vizionate</string>
     <string name="settings_integrations_section">Integrări</string>
-    <string name="settings_integrations_section_subtitle">Alege setările TMDB sau MDBList</string>
+    <string name="settings_integrations_section_subtitle">Gestionați integrările disponibile</string>
     <string name="settings_tmdb_subtitle">Controale de îmbogățire a metadatelor</string>
     <string name="settings_mdblist_subtitle">Furnizori externi de evaluări</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -298,7 +298,7 @@
     <string name="account_stat_progress">прогресс</string>
     <string name="account_stat_watched">просмотрено</string>
     <string name="settings_integrations_section">Интеграции</string>
-    <string name="settings_integrations_section_subtitle">Выберите TMDB или MDBList</string>
+    <string name="settings_integrations_section_subtitle">Управление доступными интеграциями</string>
     <string name="settings_tmdb_subtitle">Настройки обогащения метаданными</string>
     <string name="settings_mdblist_subtitle">Провайдеры внешних рейтингов</string>
     <string name="settings_animeskip_subtitle">Таймкоды пропуска интро/аутро для аниме</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -94,7 +94,7 @@
     <string name="settings_layout_subtitle">Domáca obrazovka a štýly posterov</string>
     <string name="settings_plugins">Pluginy</string>
     <string name="settings_plugins_subtitle">Repozitáre a poskytovatelia</string>
-    <string name="settings_integration">Integrácia</string>
+    <string name="settings_integration">Integrácie</string>
     <string name="settings_playback">Prehrávanie</string>
     <string name="settings_playback_subtitle">Prehrávač, titulky a automatické prehrávanie</string>
     <string name="settings_trakt_subtitle">Otvoriť obrazovku pripojenia Trakt</string>
@@ -104,7 +104,7 @@
     <string name="settings_plugins_section_subtitle">Spravovať repozitáre, poskytovateľov a stavy pluginov</string>
     <string name="settings_account_section_subtitle">Účet a stav synchronizácie</string>
     <string name="settings_integrations_section">Integrácie</string>
-    <string name="settings_integrations_section_subtitle">Vyberte nastavenia TMDB alebo MDBList</string>
+    <string name="settings_integrations_section_subtitle">Spravujte dostupné integrácie</string>
     <string name="settings_tmdb_subtitle">Ovládanie obohatenia metadát</string>
     <string name="settings_mdblist_subtitle">Externí poskytovatelia hodnotení</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -254,7 +254,7 @@
     <string name="settings_layout_subtitle">Struktura domačega zaslona in slogi plakatov</string>
     <string name="settings_plugins">Vtičniki</string>
     <string name="settings_plugins_subtitle">Repozitoriji in ponudniki</string>
-    <string name="settings_integration">Integracija</string>
+    <string name="settings_integration">Integracije</string>
     <string name="settings_playback">Predvajanje</string>
     <string name="settings_playback_subtitle">Predvajalnik, podnapisi in samodejno predvajanje</string>
     <string name="settings_trakt_subtitle">Odpri zaslon za povezavo s Trakt</string>
@@ -286,7 +286,7 @@
     <string name="account_stat_progress">napredek</string>
     <string name="account_stat_watched">ogledano</string>													
 	<string name="settings_integrations_section">Integracije</string>
-    <string name="settings_integrations_section_subtitle">Izberite nastavitve za TMDB ali MDBList</string>
+    <string name="settings_integrations_section_subtitle">Upravljajte razpoložljive integracije</string>
     <string name="settings_tmdb_subtitle">Kontrole za obogatitev metapodatkov</string>
     <string name="settings_mdblist_subtitle">Zunanji ponudniki ocen</string>
     <string name="settings_animeskip_subtitle">Časovni žigi za preskok anime uvoda/odjave</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -198,7 +198,7 @@
     <string name="account_stat_progress">pågående</string>
     <string name="account_stat_watched">sedd</string>
     <string name="settings_integrations_section">Integrationer</string>
-    <string name="settings_integrations_section_subtitle">Välj TMDB eller MDBList inställningar</string>
+    <string name="settings_integrations_section_subtitle">Hantera tillgängliga integrationer</string>
     <string name="settings_tmdb_subtitle">Metadataberikning</string>
     <string name="settings_mdblist_subtitle">Externa betygsläggare</string>
     <string name="settings_animeskip_subtitle">Tidsstämplar för att hoppa över anime-intro/outro</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -246,7 +246,7 @@
     <string name="settings_layout_subtitle">Ana sayfa düzeni ve poster stilleri</string>
     <string name="settings_plugins">Uzantılar</string>
     <string name="settings_plugins_subtitle">Depolar ve sağlayıcılar</string>
-    <string name="settings_integration">Entegrasyon</string>
+    <string name="settings_integration">Entegrasyonlar</string>
     <string name="settings_playback">Oynatma</string>
     <string name="settings_playback_subtitle">Oynatıcı, altyazılar ve otomatik oynatma</string>
     <string name="settings_trakt_subtitle">Trakt bağlantı ekranını aç</string>
@@ -278,7 +278,7 @@
     <string name="account_stat_progress">ilerleme</string>
     <string name="account_stat_watched">izlenen</string>
     <string name="settings_integrations_section">Entegrasyonlar</string>
-    <string name="settings_integrations_section_subtitle">TMDB veya MDBList ayarlarını seçin</string>
+    <string name="settings_integrations_section_subtitle">Mevcut entegrasyonları yönetin</string>
     <string name="settings_tmdb_subtitle">Meta veri zenginleştirme kontrolleri</string>
     <string name="settings_mdblist_subtitle">Harici değerlendirme sağlayıcıları</string>
     <string name="settings_animeskip_subtitle">Anime jeneriklerini (intro/outro) otomatik atlama ayarları</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -144,7 +144,7 @@
     <string name="account_stat_progress">tiến độ</string>
     <string name="account_stat_watched">đã xem</string>
     <string name="settings_integrations_section">Tích hợp</string>
-    <string name="settings_integrations_section_subtitle">Chọn TMDB hoặc MDBList</string>
+    <string name="settings_integrations_section_subtitle">Quản lý tích hợp có sẵn</string>
     <string name="settings_tmdb_subtitle">Tuỳ chỉnh bổ sung metadata</string>
     <string name="settings_mdblist_subtitle">Nhà cung cấp xếp hạng bên ngoài</string>
     <string name="settings_animeskip_subtitle">Dấu thời gian bỏ qua intro/outro anime</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,7 +269,7 @@
     <string name="settings_layout_subtitle">Home structure and poster styles</string>
     <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Repositories and providers</string>
-    <string name="settings_integration">Integration</string>
+    <string name="settings_integration">Integrations</string>
     <string name="settings_playback">Playback</string>
     <string name="settings_playback_subtitle">Player, subtitles, and auto-play</string>
     <string name="settings_trakt_subtitle">Open Trakt connection screen</string>


### PR DESCRIPTION
## Summary

This PR updates the settings list Integration page strings to use plurals ("Integrations") and a more generic subtitle ("Manage available integrations") across all supported translations. This is necessary because the integrations page supports more than just TMDB or MDBList, and previous commit did not updates translations correctly.

## PR type

- Small maintenance improvement

## Why

Corrects grammar and updates translations

## Policy check

<!-- Confirm these before requesting review -->
 - [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Checked translation strings and how this is applied across app

## Screenshots / Video (UI changes only)

<img width="289" height="62" alt="image" src="https://github.com/user-attachments/assets/2a8de0c9-b39f-4dfb-abdc-960c7fa73d0c" />


## Breaking changes

Nothing is broken, this is purely a wording update.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1423
