### PR TITLE
[Internal Engine] Auto Mode - ExoPlayer for TV Show & Movies, MPV for Animes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -253,7 +253,8 @@ enum class PlayerPreference {
 
 enum class InternalPlayerEngine {
     EXOPLAYER,
-    MVP_PLAYER
+    MVP_PLAYER,
+    AUTO
 }
 
 /**

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -252,6 +252,7 @@ class PlayerRuntimeController(
     internal var shouldEnforceAutoplayOnFirstReady = true
     internal var metaVideos: List<Video> = emptyList()
     internal var metaGenres: List<String> = emptyList()
+    internal var metaCountry: String? = null
     internal var nextEpisodeVideo: Video? = null
     internal var userPausedManually = false
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -251,6 +251,7 @@ class PlayerRuntimeController(
     internal var hasRenderedFirstFrame = false
     internal var shouldEnforceAutoplayOnFirstReady = true
     internal var metaVideos: List<Video> = emptyList()
+    internal var metaGenres: List<String> = emptyList()
     internal var nextEpisodeVideo: Video? = null
     internal var userPausedManually = false
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -282,6 +282,7 @@ class PlayerRuntimeController(
     internal var autoSwitchInternalPlayerOnErrorEnabled: Boolean = false
     internal var startupEngineFailoverTriggered: Boolean = false
     internal var runtimeInternalPlayerEngineOverride: InternalPlayerEngine? = null
+    internal var resolvedAutoPlayerEngine: InternalPlayerEngine? = null
     internal var currentInternalPlayerEngine: InternalPlayerEngine = InternalPlayerEngine.EXOPLAYER
     internal var streamAutoPlayModeSetting: StreamAutoPlayMode = StreamAutoPlayMode.MANUAL
     internal var streamAutoPlayNextEpisodeEnabledSetting: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
@@ -20,6 +20,7 @@ internal fun PlayerRuntimeController.maybeAutoSwitchInternalPlayerOnStartupError
     val targetEngine = when (currentInternalPlayerEngine) {
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
+        InternalPlayerEngine.AUTO -> InternalPlayerEngine.EXOPLAYER
     }
     beginSwitchTraceSession(reason = "startup-failover", targetEngine = targetEngine)
     logSwitchTrace(
@@ -67,6 +68,7 @@ internal fun PlayerRuntimeController.switchInternalPlayerEngineManually() {
     val targetEngine = when (currentInternalPlayerEngine) {
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
+        InternalPlayerEngine.AUTO -> InternalPlayerEngine.EXOPLAYER
     }
     beginSwitchTraceSession(reason = "manual-osd", targetEngine = targetEngine)
     val targetEngineLabel = targetEngineLabel(targetEngine)
@@ -135,6 +137,7 @@ private fun PlayerRuntimeController.targetEngineLabel(targetEngine: InternalPlay
     return when (targetEngine) {
         InternalPlayerEngine.EXOPLAYER -> context.getString(R.string.playback_engine_exoplayer)
         InternalPlayerEngine.MVP_PLAYER -> context.getString(R.string.playback_engine_mvplayer)
+        InternalPlayerEngine.AUTO -> context.getString(R.string.playback_player_auto)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
@@ -20,7 +20,7 @@ internal fun PlayerRuntimeController.maybeAutoSwitchInternalPlayerOnStartupError
     val targetEngine = when (currentInternalPlayerEngine) {
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
-        InternalPlayerEngine.AUTO -> InternalPlayerEngine.EXOPLAYER
+        InternalPlayerEngine.AUTO -> if (mpvView != null) InternalPlayerEngine.EXOPLAYER else InternalPlayerEngine.MVP_PLAYER
     }
     beginSwitchTraceSession(reason = "startup-failover", targetEngine = targetEngine)
     logSwitchTrace(
@@ -68,7 +68,7 @@ internal fun PlayerRuntimeController.switchInternalPlayerEngineManually() {
     val targetEngine = when (currentInternalPlayerEngine) {
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
-        InternalPlayerEngine.AUTO -> InternalPlayerEngine.EXOPLAYER
+        InternalPlayerEngine.AUTO -> if (mpvView != null) InternalPlayerEngine.EXOPLAYER else InternalPlayerEngine.MVP_PLAYER
     }
     beginSwitchTraceSession(reason = "manual-osd", targetEngine = targetEngine)
     val targetEngineLabel = targetEngineLabel(targetEngine)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -112,7 +112,9 @@ internal fun PlayerRuntimeController.initializePlayer(
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
                 val isAnime = if (metaGenres.isNotEmpty()) {
-                    metaGenres.any { it.equals("anime", ignoreCase = true) }
+                    metaGenres.any { it.equals("anime", ignoreCase = true) } ||
+                            (metaGenres.any { it.equals("animation", ignoreCase = true) } &&
+                                    metaCountry?.contains("Japan", ignoreCase = true) == true)
                 } else {
                     val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
                     effectiveId.startsWith("kitsu:") ||

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -111,10 +111,6 @@ internal fun PlayerRuntimeController.initializePlayer(
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
-                Log.d("PlayerRuntimeController", "metaGenres: $metaGenres")
-                Log.d("PlayerRuntimeController", "contentId: $contentId")
-                Log.d("PlayerRuntimeController", "currentVideoId: $currentVideoId")
-
                 val isAnime = if (metaGenres.isNotEmpty()) {
                     metaGenres.any { it.equals("anime", ignoreCase = true) }
                 } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -117,8 +117,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
                     effectiveId.startsWith("kitsu:") ||
                         effectiveId.startsWith("mal:") ||
-                        effectiveId.startsWith("anilist:") ||
-                        (currentStreamUrl.contains("/anime/"))
+                        effectiveId.startsWith("anilist:")
                 }
 
                 effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -111,12 +111,15 @@ internal fun PlayerRuntimeController.initializePlayer(
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
-                // Determine if anime
-                val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
-                val isAnime = effectiveId.startsWith("kitsu:") ||
-                              effectiveId.startsWith("mal:") ||
-                              effectiveId.startsWith("anilist:") ||
-                              (currentStreamUrl.contains("/anime/"))
+                val isAnime = if (metaGenres.isNotEmpty()) {
+                    metaGenres.any { it.equals("anime", ignoreCase = true) }
+                } else {
+                    val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
+                    effectiveId.startsWith("kitsu:") ||
+                        effectiveId.startsWith("mal:") ||
+                        effectiveId.startsWith("anilist:") ||
+                        (currentStreamUrl.contains("/anime/"))
+                }
 
                 effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -109,7 +109,17 @@ internal fun PlayerRuntimeController.initializePlayer(
             )
             mpvPreferredAudioLanguages = preferredAudioLanguages
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
-            val effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
+            var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
+            if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
+                // Determine if anime
+                val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
+                val isAnime = effectiveId.startsWith("kitsu:") ||
+                              effectiveId.startsWith("mal:") ||
+                              effectiveId.startsWith("anilist:") ||
+                              (currentStreamUrl.contains("/anime/"))
+
+                effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
+            }
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -111,16 +111,15 @@ internal fun PlayerRuntimeController.initializePlayer(
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
-                val isAnime = if (metaGenres.isNotEmpty()) {
-                    metaGenres.any { it.equals("anime", ignoreCase = true) } ||
-                            (metaGenres.any { it.equals("animation", ignoreCase = true) } &&
-                                    metaCountry?.contains("Japan", ignoreCase = true) == true)
-                } else {
-                    val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
-                    effectiveId.startsWith("kitsu:") ||
-                        effectiveId.startsWith("mal:") ||
-                        effectiveId.startsWith("anilist:")
-                }
+                val hasAnimeGenre = metaGenres.any { it.equals("anime", ignoreCase = true) }
+                val isAnimationFromJapan = (metaGenres.any { it.equals("animation", ignoreCase = true) } &&
+                        metaCountry?.contains("Japan", ignoreCase = true) == true)
+                val hasAnimeId = currentVideoId?.startsWith("kitsu:") == true ||
+                        currentVideoId?.startsWith("mal:") == true ||
+                        currentVideoId?.startsWith("anilist:") == true
+
+                // AIOMetadata usually matches hasAnimeGenre or hasAnimeId, Cinemeta usually matches isAnimationFromJapan
+                val isAnime = hasAnimeGenre || hasAnimeId || isAnimationFromJapan
 
                 effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -111,6 +111,10 @@ internal fun PlayerRuntimeController.initializePlayer(
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
+                Log.d("PlayerRuntimeController", "metaGenres: $metaGenres")
+                Log.d("PlayerRuntimeController", "contentId: $contentId")
+                Log.d("PlayerRuntimeController", "currentVideoId: $currentVideoId")
+
                 val isAnime = if (metaGenres.isNotEmpty()) {
                     metaGenres.any { it.equals("anime", ignoreCase = true) }
                 } else {
@@ -123,6 +127,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                 effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
             }
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
+            if (overrideInternalPlayerEngine == null && playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO) {
+                resolvedAutoPlayerEngine = effectiveInternalPlayerEngine
+            } else if (overrideInternalPlayerEngine != null) {
+                resolvedAutoPlayerEngine = null
+            }
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus
             _uiState.update {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -38,6 +38,7 @@ internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?
 internal fun PlayerRuntimeController.applyMetaDetails(meta: Meta) {
     metaVideos = meta.videos
     metaGenres = meta.genres
+    metaCountry = meta.country
     val description = resolveDescription(meta)
 
     _uiState.update { state ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -37,6 +37,7 @@ internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?
 
 internal fun PlayerRuntimeController.applyMetaDetails(meta: Meta) {
     metaVideos = meta.videos
+    metaGenres = meta.genres
     val description = resolveDescription(meta)
 
     _uiState.update { state ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -188,7 +188,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
         playerSettingsDataStore.playerSettings.collect { settings ->
             val currentState = _uiState.value
             val resolvedInternalPlayerEngine =
-                runtimeInternalPlayerEngineOverride ?: settings.internalPlayerEngine
+                runtimeInternalPlayerEngineOverride ?: resolvedAutoPlayerEngine ?: settings.internalPlayerEngine
             val resolvedAudioAmplificationDb = when {
                 !hasInitializedAudioAmplificationForSession -> {
                     hasInitializedAudioAmplificationForSession = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1124,6 +1124,11 @@ internal fun PlayerRuntimeController.buildStreamInfoData(): StreamInfoData {
             addonSub != null -> context.getString(R.string.stream_info_subtitle_source_addon)
             selectedSubtitle != null -> context.getString(R.string.stream_info_subtitle_source_embedded)
             else -> null
+        },
+        playerEngine = when (currentInternalPlayerEngine) {
+            com.nuvio.tv.data.local.InternalPlayerEngine.EXOPLAYER -> context.getString(R.string.playback_engine_exoplayer)
+            com.nuvio.tv.data.local.InternalPlayerEngine.MVP_PLAYER -> context.getString(R.string.playback_engine_mvplayer)
+            com.nuvio.tv.data.local.InternalPlayerEngine.AUTO -> null
         }
     )
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -307,5 +307,7 @@ data class StreamInfoData(
     val subtitleName: String? = null,
     val subtitleCodec: String? = null,
     val subtitleLanguage: String? = null,
-    val subtitleSource: String? = null
+    val subtitleSource: String? = null,
+    // Player
+    val playerEngine: String? = null
 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -308,6 +308,5 @@ data class StreamInfoData(
     val subtitleCodec: String? = null,
     val subtitleLanguage: String? = null,
     val subtitleSource: String? = null,
-    // Player
     val playerEngine: String? = null
 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
@@ -108,6 +108,10 @@ private fun StreamInfoContent(data: StreamInfoData) {
                 modifier = Modifier.padding(top = 4.dp)
             )
         }
+        if (data.playerEngine != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            InfoItem(label = stringResource(R.string.stream_info_player_engine), value = data.playerEngine)
+        }
         Spacer(modifier = Modifier.height(16.dp))
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -194,6 +194,7 @@ internal fun PlaybackSettingsSections(
         internalEngineLabel = when (playerSettings.internalPlayerEngine) {
             InternalPlayerEngine.EXOPLAYER -> stringResource(R.string.playback_engine_exoplayer)
             InternalPlayerEngine.MVP_PLAYER -> stringResource(R.string.playback_engine_mvplayer)
+            InternalPlayerEngine.AUTO -> stringResource(R.string.playback_player_auto)
         }
     )
 
@@ -848,6 +849,11 @@ private fun InternalPlayerEngineDialog(
             InternalPlayerEngine.MVP_PLAYER,
             stringResource(R.string.playback_engine_mvplayer),
             stringResource(R.string.playback_engine_mvplayer_desc)
+        ),
+        Triple(
+            InternalPlayerEngine.AUTO,
+            stringResource(R.string.playback_player_auto),
+            stringResource(R.string.playback_player_auto_desc)
         )
     )
 

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -1506,4 +1506,6 @@
     <string name="collections_tab_all">Todo</string>
     <string name="collections_tab_combined">Combinado</string>
  
+    <string name="playback_player_auto">Automático (Mejor para el contenido)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Películas y Series · MPV para Anime</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1119,4 +1119,6 @@
     <string name="update_ignore">Ignorovat</string>
     <string name="watchlist_added">Přidáno do watchlistu</string>
     <string name="watchlist_removed">Odstraněno z watchlistu</string>
+    <string name="playback_player_auto">Automaticky (Nejlepší pro obsah)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pro filmy a seriály · MPV pro anime</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1148,4 +1148,6 @@
     <string name="update_ignore">Ignorieren</string>
     <string name="watchlist_added">Zur Beobachtungsliste hinzugefügt</string>
     <string name="watchlist_removed">Aus Beobachtungsliste entfernt</string>
+    <string name="playback_player_auto">Automatisch (Am besten für Inhalt)</string>
+    <string name="playback_player_auto_desc">ExoPlayer für Filme &amp; Serien · MPV für Anime</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1182,4 +1182,6 @@
     <string name="update_ignore">Αγνόηση</string>
     <string name="watchlist_added">Προστέθηκε στη watchlist</string>
     <string name="watchlist_removed">Αφαιρέθηκε από τη watchlist</string>
+    <string name="playback_player_auto">Αυτόματο (Καλύτερο για το περιεχόμενο)</string>
+    <string name="playback_player_auto_desc">ExoPlayer για Ταινίες &amp; Σειρές · MPV για Anime</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1046,4 +1046,6 @@
     <string name="update_downloading_ellipsis">Descargando…</string>
     <string name="watchlist_added">Añadido a lista de deseos</string>
     <string name="watchlist_removed">Eliminado de lista de deseos</string>
+    <string name="playback_player_auto">Automático (Mejor para el contenido)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Películas y Series · MPV para Anime</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1509,4 +1509,6 @@
     <string name="collections_tab_all">Tout</string>
     <string name="collections_tab_combined">Combiné</string>
 
+    <string name="playback_player_auto">Auto (Meilleur pour le contenu)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pour les Films et Séries · MPV pour les Animes</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -998,4 +998,6 @@
     <string name="update_open_settings">सेटिंग्स खोलें</string>
     <string name="update_install">इंस्टॉल</string>
     <string name="update_ignore">नज़रअंदाज़ करें</string>
+    <string name="playback_player_auto">ऑटो (सामग्री के लिए सर्वश्रेष्ठ)</string>
+    <string name="playback_player_auto_desc">ExoPlayer मूवीज़ और टीवी शोज़ के लिए · MPV एनीमे के लिए</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1308,4 +1308,6 @@
     <string name="debug_generate_description">Debug-generato %1$s elemento #%2$d</string>
     <string name="debug_generate_result_failed">Fallito: %1$s</string>
 
+    <string name="playback_player_auto">Automatico (Il migliore per i contenuti)</string>
+    <string name="playback_player_auto_desc">ExoPlayer per Film e Serie TV · MPV per gli Anime</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1034,4 +1034,6 @@
     <string name="sub_mode_effects_gl">Effects OpenGL</string>
     <string name="sub_mode_effects_gl_sub">תמיכת אנימציה באמצעות אפקטי Media3. מהיר יותר מ-Canvas.</string>
     <string name="sub_advanced_section">רינדור כתוביות מתקדם</string>
+    <string name="playback_player_auto">אוטומטי (הטוב ביותר לתוכן)</string>
+    <string name="playback_player_auto_desc">ExoPlayer לסרטים ולתוכניות טלוויזיה · MPV לאנימה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1182,4 +1182,6 @@
     <string name="update_ignore">無視</string>
     <string name="watchlist_added">ウォッチリストに追加しました</string>
     <string name="watchlist_removed">ウォッチリストから削除しました</string>
+    <string name="playback_player_auto">自動（コンテンツに最適化）</string>
+    <string name="playback_player_auto_desc">映画やドラマにはExoPlayer・アニメにはMPV</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1011,4 +1011,6 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="update_ignore">Ignoruoti</string>
     <string name="watchlist_added">Pridėta į žiūrėjimo sąrašą</string>
     <string name="watchlist_removed">Pašalinta iš žiūrėjimo sąrašo</string>
+    <string name="playback_player_auto">Automatiškai (Geriausia turiniui)</string>
+    <string name="playback_player_auto_desc">ExoPlayer filmams ir serialams · MPV animėms</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -870,4 +870,6 @@
     <string name="update_open_settings">Open Instellingen</string>
     <string name="update_install">Installeer</string>
     <string name="update_ignore">Negeer</string>
+    <string name="playback_player_auto">Automatisch (Beste voor inhoud)</string>
+    <string name="playback_player_auto_desc">ExoPlayer voor films en series · MPV voor anime</string>
 </resources>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -1124,4 +1124,6 @@
     <string name="update_ignore">Ignorer</string>
     <string name="watchlist_added">Lagt til ønskelisten</string>
     <string name="watchlist_removed">Fjernet fra ønskelisten</string>
+    <string name="playback_player_auto">Automatisk (Best for innhold)</string>
+    <string name="playback_player_auto_desc">ExoPlayer for filmer og serier · MPV for anime</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1515,4 +1515,6 @@
     <string name="qr_login_signing_in">Logowanie…</string>
     <string name="qr_login_success">Zalogowano pomyślnie</string>
     <string name="qr_login_exchange_failed">Nie udało się dokończyć logowania QR</string>
+    <string name="playback_player_auto">Zalecane (Najlepsze dla treści)</string>
+    <string name="playback_player_auto_desc">ExoPlayer dla filmów i seriali · MPV dla anime</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1509,4 +1509,6 @@
     <string name="collections_tab_all">Tudo</string>
     <string name="collections_tab_combined">Combinado</string>
     
-  </resources>
+      <string name="playback_player_auto">Automático (Melhor para o conteúdo)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Filmes e Séries · MPV para Animes</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1058,4 +1058,6 @@
     <string name="update_ignore">Ignorar</string>
     <string name="watchlist_added">Adicionado à lista de interesses</string>
     <string name="watchlist_removed">Removido da lista de interesses</string>
+    <string name="playback_player_auto">Automático (Melhor para o conteúdo)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Filmes e Séries · MPV para Animes</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -842,4 +842,6 @@
     <string name="update_open_settings">Deschide Setările</string>
     <string name="update_install">Instalează</string>
     <string name="update_ignore">Ignoră</string>
-  </resources>
+      <string name="playback_player_auto">Automat (Cel mai bun pentru conținut)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pentru Filme și Seriale · MPV pentru Anime</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1488,4 +1488,6 @@
     <string name="collections_tab_all">Все</string>
     <string name="collections_tab_combined">Объединенные</string>
 
+    <string name="playback_player_auto">Авто (Лучшее для контента)</string>
+    <string name="playback_player_auto_desc">ExoPlayer для фильмов и сериалов · MPV для аниме</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -739,4 +739,6 @@
     <string name="update_open_settings">Otvoriť nastavenia</string>
     <string name="update_install">Inštalovať</string>
     <string name="update_ignore">Ignorovať</string>
+    <string name="playback_player_auto">Automaticky (Najlepšie pre obsah)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pre filmy a seriály · MPV pre anime</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1418,4 +1418,6 @@
     <string name="collections_card_subtitle">Združite kataloge v mape na začetnem zaslonu</string>
     <string name="collections_tab_all">Vse</string>
     <string name="collections_tab_combined">Združeno</string>															  
-	</resources>
+	    <string name="playback_player_auto">Samodejno (Najboljše za vsebino)</string>
+    <string name="playback_player_auto_desc">ExoPlayer za filme in serije · MPV za anime</string>
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1203,4 +1203,6 @@
     <string name="update_checking">Söker efter uppdateringar…</string>
     <string name="update_download_complete">Nedladdning klar. Redo att installera.</string>
     <string name="update_up_to_date">Systemet är uppdaterat. Senaste ändringarna:</string>
+    <string name="playback_player_auto">Automatiskt (Bäst för innehåll)</string>
+    <string name="playback_player_auto_desc">ExoPlayer för filmer och serier · MPV för anime</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1384,4 +1384,6 @@
     <string name="debug_signin_success">Giriş başarılı</string>
     <string name="debug_generate_description">Hata ayıklama için %1$s öğesi oluşturuldu #%2$d</string>
     <string name="debug_generate_result_failed">Başarısız: %1$s</string>
+    <string name="playback_player_auto">Otomatik (İçerik için en iyisi)</string>
+    <string name="playback_player_auto_desc">Filmler ve Diziler için ExoPlayer · Anime için MPV</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -891,4 +891,6 @@
     <string name="update_open_settings">Mở cài đặt</string>
     <string name="update_install">Cài đặt</string>
     <string name="update_ignore">Bỏ qua</string>
+    <string name="playback_player_auto">Tự động (Tốt nhất cho nội dung)</string>
+    <string name="playback_player_auto_desc">ExoPlayer cho Phim &amp; TV Show · MPV cho Anime</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -947,6 +947,7 @@
     <string name="stream_info_source">Source</string>
     <string name="stream_info_subtitle_source_addon">Addon</string>
     <string name="stream_info_subtitle_source_embedded">Embedded</string>
+    <string name="stream_info_player_engine">Player Engine</string>
 
     <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Sources</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,6 +369,8 @@
     <string name="playback_resolution_matching_sub">Allow display mode changes to match video resolution.</string>
     <string name="playback_player_external_desc">Always open streams in an external app</string>
     <string name="playback_player_ask_desc">Choose the player each time</string>
+    <string name="playback_player_auto">Auto (Best for Content)</string>
+    <string name="playback_player_auto_desc">ExoPlayer for Movies &amp; TV Shows · MPV for Anime</string>
     <string name="playback_engine_exoplayer_desc">Best compatibility with current Nuvio features.</string>
     <string name="playback_engine_mvplayer_desc">Uses libmpv with Nuvio OSD controls. Experimental.</string>
 


### PR DESCRIPTION
## Summary
This PR introduce a third option on "Internal Engine": Auto. The goal is to leverage the best player for each context: ExoPlayer for TV Shows and Movies (HDR and Dolby Vision supported natively), MPV for Animes (Libass supported natively).

To detect if the current content is anime I use three checks:
1. Has genre `anime` (AIOMetadata)
2. Id starts with `mal:`/`kitsu:`/`anilist:` (AIOMetadata)
3. Has genre `animation` and country is `japan` (Cinemeta)
   3.1 This logic is a best effort. I know there are animes from other countries, but I played safe

## PR type

- Small maintenance improvement

## Why

Even though Nuvio has a libass integration with ExoPlayer, it's still not stable - from time to time, I see the subtitle disappearing, probably because of a synchronization issue on buffers.

Instead of trying to fix that, which may take some time and investigation, I tried to use MPV, only to realize it does not have support for DV and HDR.

So, I came to the conclusion: ExoPlayer is the best player for Movies and TV Shows and MPV is the best player for animes, since it comes with libass implemented natively.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

### Setup
- AIOMetadata
  - TheTVDB for Meta provider
  - Anime with Kitsu compatibilty ID
  - Anime with IMDb compatibilty ID
- Cinemeta
- NVIDIA Shield
- Android TV Emulator
- TMDB enhancement enabled and disabled;

### Tests (both with Animes, Movies and TV Show)
1. Selected from Continue Watching
5. Selected from AIOMetadata Catalog
6. Selected from Cinemeta Catalog
7. Tried Engine Switch

I added some logs (not commited) to validate:

```
2026-04-17 20:34:01.237 PlayerViewModel          D  AUTO player: genres=[Fantasy, Drama, Animation, Adventure, Anime], isAnime=true
2026-04-17 20:34:01.237 PlayerViewModel          D  AUTO player selected: MPV_PLAYER
```

## Screenshots / Video (UI changes only)

### Settings page

<img src="https://github.com/user-attachments/assets/e32ec453-fa41-40e6-ac66-2fd722203fd0" width="900" />

### Stream info overlay

Added the "Player Engine" field

<img src="https://github.com/user-attachments/assets/9e9bc313-a4a2-41cd-ae10-6a96cefba51b" width="900"  />

### Engine switch
When anime is detected, we'll use MPV, but if the user clicks on engine switch button, it correctly switch to ExoPlayer.

<img src="https://github.com/user-attachments/assets/ca33ee1f-0714-4806-a5b0-229518b28883"  width="900" />

## Breaking changes

No breaking changes.

## Linked issues

No linked issue.

