### PR TITLE
fix: preserve Trakt comment formatting and add posted date in comment overlay

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
@@ -229,7 +229,7 @@ internal fun stripInlineSpoilerMarkup(comment: String?): String {
     if (comment.isNullOrBlank()) return ""
     return comment
         .replace(INLINE_SPOILER_TAG_REGEX, "")
-    .replace(Regex("[\\t ]+"), " ")
+        .replace(Regex("[\\t ]+"), " ")
         .trim()
 }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
@@ -229,7 +229,7 @@ internal fun stripInlineSpoilerMarkup(comment: String?): String {
     if (comment.isNullOrBlank()) return ""
     return comment
         .replace(INLINE_SPOILER_TAG_REGEX, "")
-        .replace(Regex("\\s+"), " ")
+    .replace(Regex("[\\t ]+"), " ")
         .trim()
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CommentsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CommentsSection.kt
@@ -486,7 +486,7 @@ private fun CommentOverlayContent(
         if (review.review) add(stringResource(R.string.detail_comments_badge_review))
         if (review.hasSpoilerContent) add(stringResource(R.string.detail_comments_badge_spoiler))
         review.rating?.let { add(stringResource(R.string.detail_comments_badge_rating, it)) }
-        formattedCommentDate?.let { add(stringResource(R.string.detail_comments_posted_on, it)) }
+        formattedCommentDate?.let { add(it) }
     }
 
     LaunchedEffect(review.id) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CommentsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CommentsSection.kt
@@ -77,6 +77,12 @@ import com.nuvio.tv.domain.model.TraktCommentReview
 import com.nuvio.tv.ui.theme.NuvioColors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
 @Composable
@@ -473,10 +479,14 @@ private fun CommentOverlayContent(
         review.comment
     }
     val commentStyle = readerCommentStyle(commentText.length)
+    val formattedCommentDate = remember(review.createdAt, review.updatedAt) {
+        formatCommentTimestamp(review.createdAt, review.updatedAt)
+    }
     val overlayLabels = buildList {
         if (review.review) add(stringResource(R.string.detail_comments_badge_review))
         if (review.hasSpoilerContent) add(stringResource(R.string.detail_comments_badge_spoiler))
         review.rating?.let { add(stringResource(R.string.detail_comments_badge_rating, it)) }
+        formattedCommentDate?.let { add(stringResource(R.string.detail_comments_posted_on, it)) }
     }
 
     LaunchedEffect(review.id) {
@@ -635,6 +645,29 @@ private fun readerCommentStyle(length: Int): TextStyle {
         length <= 900 -> typography.titleMedium.copy(fontSize = 18.sp, lineHeight = 23.sp)
         else -> typography.bodyLarge.copy(fontSize = 16.sp, lineHeight = 21.sp)
     }
+}
+
+private fun formatCommentTimestamp(createdAt: String?, updatedAt: String?): String? {
+    val rawTimestamp = createdAt?.trim()?.takeIf { it.isNotBlank() }
+        ?: updatedAt?.trim()?.takeIf { it.isNotBlank() }
+        ?: return null
+
+    val instant = runCatching {
+        if (rawTimestamp.all { it.isDigit() }) {
+            val epoch = rawTimestamp.toLong()
+            val epochMillis = if (epoch < 100_000_000_000L) epoch * 1000L else epoch
+            Instant.ofEpochMilli(epochMillis)
+        } else {
+            runCatching { Instant.parse(rawTimestamp) }.getOrElse {
+                runCatching { OffsetDateTime.parse(rawTimestamp).toInstant() }.getOrElse {
+                    LocalDateTime.parse(rawTimestamp).atZone(ZoneId.systemDefault()).toInstant()
+                }
+            }
+        }
+    }.getOrNull() ?: return null
+
+    val formatter = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())
+    return formatter.format(instant.atZone(ZoneId.systemDefault()))
 }
 
 private fun commentMaxLines(length: Int): Int = when {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,7 +197,6 @@
     <string name="detail_comments_badge_review">Review</string>
     <string name="detail_comments_badge_spoiler">Spoiler</string>
     <string name="detail_comments_badge_rating">%1$d/10</string>
-    <string name="detail_comments_posted_on">Posted %1$s</string>
     <string name="detail_comments_likes">%1$d likes</string>
     <string name="tmdb_entity_kind_company">Production Company</string>
     <string name="tmdb_entity_kind_network">Network</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="detail_comments_badge_review">Review</string>
     <string name="detail_comments_badge_spoiler">Spoiler</string>
     <string name="detail_comments_badge_rating">%1$d/10</string>
+    <string name="detail_comments_posted_on">Posted %1$s</string>
     <string name="detail_comments_likes">%1$d likes</string>
     <string name="tmdb_entity_kind_company">Production Company</string>
     <string name="tmdb_entity_kind_network">Network</string>


### PR DESCRIPTION
## Summary

This PR ships two focused quality-of-life fixes in the trakt comments experience:

- Preserve line breaks in Trakt comments by avoiding broad whitespace flattening.
- Show the comment posted date inline in the existing overlay metadata row.

## PR type

- Small maintenance improvement

## Why

Comment readability was reduced when line breaks were collapsed, especially for longer reviews.
Also, users lacked quick time context while reading a comment in the overlay, making it impossible to distinguish between newer comments and older (possibly outdated) comments
This PR improves readability and context without changing the overall comments flow.

## Policy check

 - [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [X] If this is a larger or directional change, I linked the issue where it was approved.


## Testing

- Manual validation of multiline Trakt comments in trakt comments list cards and comments overlay.
- Confirmed posted date appears inline with existing metadata labels.
- Build passes without errors.

## Screenshots / Video (UI changes only)

The red circle is the new date added. It wasn't there before. Ignore the word "Posted" i removed it after taking the picture as it wasn't necessary, plus this avoids unnecessary translations. Nothing else changes. The red lines indicate the preserved newlines that are in this trakt comment that were being incorrectly removed.

<img width="1140" height="946" alt="image" src="https://github.com/user-attachments/assets/b2b8fc4f-a824-4715-92c5-3a1d7adf608f" />


## Breaking changes

None

## Linked issues

None. I noticed the issue of missing newlines myself and thought it was really hard to read the long reviews. As for the date, it waas just a small QoL addition I thought i'd add to help older titles with big variations in trakt comment dates.