### PR TITLE
Fix unlimited addon timeout not working correctly

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1017,7 +1017,6 @@ internal fun PlayerRuntimeController.playNextEpisode() {
                     innerJob.join()
                 }
             } else {
-                timeoutElapsed = true
                 innerJob.join()
             }
 


### PR DESCRIPTION
## Summary

I made the unlimited addon timeout functional by removing one line that made autoselect try too early.

## PR type

- Bug fix

## Why

The unlimited addon timeout option wasn't working correctly. Instead of wating for all addons to return results it tried selecting a stream once one addon has returned its results. Often this lead to either jumping to manual-selection-screen or constant switching between addons.

## Policy check

<!-- Confirm these before requesting review -->
- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [ ] ~If this is a larger or directional change, I linked the issue where it was approved.~

## Testing

Tested on Fire Tv Cube 2nd Gen and in Android Studio (running Android v10).
I tested if autoselect now waits until all addons have returned results.

First tested the option auto-select-first-stream + selected one of my 2 addons to be used, not all addons.
Before it would often jump to manual selection instead of selecting the first stream. This happened because often my 2nd addon was returning results faster than the other one. After the change auto-select-first-stream correctly picks the first stream of my desired addon.

Second test was using the bing group option.
Before auto-select would often switch between addons instead of sticking to the one I manually selected. This in itself wouldn't be a problem if the picked stream was actually the best option, but it mostly wasn't. The addon I originally selected had a better matching stream than the one that got auto-selected. After the change auto-select has so far always sticked to the same addon/picked the best matching stream.

## Breaking changes

None

## Linked issues

Fixes #1075 
