### PR TITLE
fix: allow setting descriptions to wrap instead of truncating

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
@@ -385,7 +385,7 @@ internal fun SettingsToggleRow(
         },
         modifier = modifier
             .fillMaxWidth()
-            .height(62.dp)
+            .heightIn(min = 62.dp)
             .onFocusChanged { state ->
                 val nowFocused = state.isFocused
                 if (isFocused != nowFocused) {
@@ -408,8 +408,8 @@ internal fun SettingsToggleRow(
     ) {
         Row(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 18.dp),
+                .fillMaxWidth()
+                .padding(horizontal = 18.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -427,7 +427,7 @@ internal fun SettingsToggleRow(
                         text = subtitle,
                         style = MaterialTheme.typography.bodySmall,
                         color = NuvioColors.TextSecondary.copy(alpha = contentAlpha),
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
                 }
@@ -500,7 +500,7 @@ internal fun SettingsActionRow(
                         text = subtitle,
                         style = MaterialTheme.typography.bodySmall,
                         color = NuvioColors.TextSecondary.copy(alpha = contentAlpha),
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
                 }


### PR DESCRIPTION
## Summary

Setting descriptions in the Layout, Integration, and Playback categories were being truncated with no way to read the full text. Long descriptions like *"Blur Unwatched in Continue Watching"* stopped mid-sentence. This change lets those descriptions wrap to a second line instead of ellipsizing.

## PR type

- Bug fix

## Why

`SettingsToggleRow` rendered with a fixed `height(62.dp)` and `maxLines = 1` on the subtitle, so text could never wrap. `SettingsActionRow` had the same `maxLines = 1` constraint. Both together hid a significant chunk of copy from users.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual: built the debug APK, opened Settings → Layout / Integration / Playback, confirmed the previously-truncated strings (including *"Blur Unwatched in Continue Watching"* and the TMDB integration subtitles) now wrap to a second line and remain readable. Short descriptions unchanged.

## Screenshots / Video (UI changes only)

Before/after screenshots of the affected toggle rows can be posted on request; the change is a layout-only tweak to two components and does not affect any other screen.

## Breaking changes

None. Rows that fit in one line render identically; only rows whose subtitle previously ellipsized now grow to accommodate up to two lines.

## Linked issues

Fixes #1287

## Detail (unchanged from original description)

**Root Cause**
`SettingsToggleRow` used a fixed \`height(62.dp)\` and \`maxLines = 1\` for subtitles, preventing any text wrapping. \`SettingsActionRow\` had the same \`maxLines = 1\` constraint.

**Fix**
- **\`SettingsToggleRow\`**: Changed from fixed \`height(62.dp)\` to \`heightIn(min = 62.dp)\` so the row can grow when text wraps. Changed inner Row from \`fillMaxSize()\` to \`fillMaxWidth()\` with explicit vertical padding.
- **Both components**: Increased subtitle \`maxLines\` from 1 to 2, allowing descriptions to wrap to a second line before ellipsizing.

This is consistent with how \`SettingsActionRow\` already used \`heightIn(min = 62.dp)\`.