### PR TITLE
Add Reset button and DPAD_CENTER shortcut to clear subtitle delay (fixes #1329)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -813,6 +813,9 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         is PlayerEvent.OnAdjustSubtitleDelay -> {
             adjustSubtitleDelay(event.deltaMs, event.showOverlay)
         }
+        PlayerEvent.OnResetSubtitleDelay -> {
+            adjustSubtitleDelay(-_uiState.value.subtitleDelayMs, true)
+        }
         PlayerEvent.OnShowSpeedDialog -> {
             val state = _uiState.value
             if (state.tunnelingEnabled) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -400,7 +400,10 @@ fun PlayerScreen(
                                     return@onKeyEvent true
                                 }
                                 KeyEvent.KEYCODE_DPAD_CENTER,
-                                KeyEvent.KEYCODE_ENTER,
+                                KeyEvent.KEYCODE_ENTER -> {
+                                    viewModel.onEvent(PlayerEvent.OnResetSubtitleDelay)
+                                    return@onKeyEvent true
+                                }
                                 KeyEvent.KEYCODE_DPAD_UP -> {
                                     return@onKeyEvent true
                                 }
@@ -914,6 +917,9 @@ fun PlayerScreen(
                     subtitleDelayAutoSyncFocused = false
                     subtitleTimingConsumeNextConfirmKeyUp = true
                     viewModel.onEvent(PlayerEvent.OnShowSubtitleTimingDialog)
+                },
+                onResetDelay = {
+                    viewModel.onEvent(PlayerEvent.OnResetSubtitleDelay)
                 }
             )
         }
@@ -2129,7 +2135,8 @@ private fun SubtitleDelayOverlay(
     subtitleDelayMs: Int,
     isAutoSyncButtonFocused: Boolean,
     isSliderFocused: Boolean,
-    onOpenSyncByLine: () -> Unit
+    onOpenSyncByLine: () -> Unit,
+    onResetDelay: () -> Unit = {}
 ) {
     val fraction = ((subtitleDelayMs - SUBTITLE_DELAY_MIN_MS).toFloat() /
         (SUBTITLE_DELAY_MAX_MS - SUBTITLE_DELAY_MIN_MS).toFloat()).coerceIn(0f, 1f)
@@ -2207,24 +2214,42 @@ private fun SubtitleDelayOverlay(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Card(
-            onClick = onOpenSyncByLine,
-            colors = CardDefaults.colors(
-                containerColor = if (isAutoSyncButtonFocused) {
-                    Color.White.copy(alpha = 0.22f)
-                } else {
-                    Color.White.copy(alpha = 0.11f)
-                },
-                focusedContainerColor = Color.White.copy(alpha = 0.22f)
-            ),
-            shape = CardDefaults.shape(RoundedCornerShape(12.dp))
-        ) {
-            Text(
-                text = "Sync Line",
-                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-                color = Color.White,
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
-            )
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Card(
+                onClick = onResetDelay,
+                colors = CardDefaults.colors(
+                    containerColor = Color.White.copy(alpha = 0.11f),
+                    focusedContainerColor = Color.White.copy(alpha = 0.22f)
+                ),
+                shape = CardDefaults.shape(RoundedCornerShape(12.dp))
+            ) {
+                Text(
+                    text = "Reset",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                    color = Color.White,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+                )
+            }
+
+            Card(
+                onClick = onOpenSyncByLine,
+                colors = CardDefaults.colors(
+                    containerColor = if (isAutoSyncButtonFocused) {
+                        Color.White.copy(alpha = 0.22f)
+                    } else {
+                        Color.White.copy(alpha = 0.11f)
+                    },
+                    focusedContainerColor = Color.White.copy(alpha = 0.22f)
+                ),
+                shape = CardDefaults.shape(RoundedCornerShape(12.dp))
+            ) {
+                Text(
+                    text = "Sync Line",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                    color = Color.White,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -223,6 +223,7 @@ sealed class PlayerEvent {
     data object OnShowSubtitleDelayOverlay : PlayerEvent()
     data object OnHideSubtitleDelayOverlay : PlayerEvent()
     data class OnAdjustSubtitleDelay(val deltaMs: Int, val showOverlay: Boolean = true) : PlayerEvent()
+    data object OnResetSubtitleDelay : PlayerEvent()
     data object OnShowSpeedDialog : PlayerEvent()
     data object OnShowMoreDialog : PlayerEvent()
     data object OnDismissMoreDialog : PlayerEvent()


### PR DESCRIPTION
## Summary

Adds a reset-to-zero mechanism for subtitle delay. Users can now clear an auto-sync offset (e.g. +238ms from "Sync by line") via **DPAD_CENTER / Enter** on the delay slider or a new **Reset** button in the subtitle delay overlay.

## PR type

- Bug fix

## Why

After using "Sync by line" to auto-sync subtitles, the delay is set to an arbitrary millisecond value (e.g. +238ms). Since manual adjustment uses 100ms steps, users can never return to exactly 0ms. There's no reset mechanism at all, so an incorrect auto-sync effectively locks the user out of the original subtitle timing.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

<!-- Small bug fix — not applicable. -->

## Testing

- Manually tested on device: opened a video, ran "Sync by line" to produce a non-zero delay (e.g. +238ms), pressed DPAD_CENTER / Enter on the slider → delay returned to 0ms and the overlay refreshed correctly.
- Manually tested the new **Reset** button in the subtitle delay overlay — same behavior as the key binding.
- Verified the existing `adjustSubtitleDelay()` side effects (MPV property update, overlay refresh) still run, since the reset reuses that path by applying the negative of the current delay.

## Screenshots / Video (UI changes only)

<!-- Added a small "Reset" button next to the existing "Sync Line" button in the subtitle delay overlay. Happy to attach a short clip if desired. -->

## Breaking changes

None.

## Linked issues

Fixes #1329
