### PR TITLE
fix: keyboard 'Next' action does nothing in integration settings

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/AnimeSkipSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/AnimeSkipSettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,6 +32,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -166,6 +168,7 @@ private fun AnimeSkipClientIdDialog(
                                 event.nativeKeyEvent.action == KeyEvent.ACTION_DOWN
                         },
                     singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
                     textStyle = MaterialTheme.typography.bodyMedium.copy(color = NuvioColors.TextPrimary),
                     cursorBrush = SolidColor(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MDBListSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MDBListSettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,6 +32,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -241,6 +243,7 @@ private fun MDBListApiKeyDialog(
                                 event.nativeKeyEvent.action == KeyEvent.ACTION_DOWN
                         },
                     singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = { keyboardController?.hide() }
                     ),


### PR DESCRIPTION
## Problem
On Fire TV, the on-screen keyboard in MDBList and AnimeSkip integration settings shows a "Next" button that does nothing when pressed. Users expect it to at least close the keyboard.

## Root Cause
Both `MDBListSettingsScreen` and `AnimeSkipSettingsScreen` use `BasicTextField` with a `KeyboardActions(onDone = { ... })` handler but without setting `KeyboardOptions(imeAction = ImeAction.Done)`. Without an explicit IME action, the keyboard defaults to showing "Next" (since the system assumes there might be another field), but there's no `onNext` handler — so pressing it does nothing.

## Fix
Added `keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)` to both text fields. This tells the keyboard to show "Done" instead of "Next", which correctly triggers the existing `onDone` handler that hides the keyboard.

This matches the pattern already used in `InputField.kt` (the reusable input component) which properly sets IME actions.

Fixes #1285