### PR TITLE
Fix original audio language resolution for CW and detail screen playback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
@@ -85,6 +85,85 @@ data class Meta(
     }
 }
 
+/**
+ * Resolves the original content language as an ISO 639-1 code.
+ * Falls back to [country]-based inference when [Meta.language] is absent.
+ */
+fun Meta.resolveContentLanguage(): String? {
+    normalizeLanguageCode(language)?.let { return it }
+    countryToLanguageCode(country)?.let { return it }
+    return null
+}
+
+/** Normalize a language string (full name, ISO 639-2/3, etc.) to ISO 639-1 when possible. */
+internal fun normalizeLanguageCode(language: String?): String? {
+    val normalized = language?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return null
+    if (normalized.length == 2) return normalized
+    return LANGUAGE_NORMALIZATION_MAP[normalized] ?: normalized
+}
+
+/** Best-effort mapping from country name/code to ISO 639-1 primary language. */
+internal fun countryToLanguageCode(country: String?): String? {
+    val normalized = country?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return null
+    return COUNTRY_TO_LANGUAGE_MAP[normalized]
+}
+
+private val LANGUAGE_NORMALIZATION_MAP = mapOf(
+    // ISO 639-2 / 639-3
+    "jpn" to "ja", "kor" to "ko", "zho" to "zh", "chi" to "zh",
+    "fra" to "fr", "fre" to "fr", "deu" to "de", "ger" to "de",
+    "ita" to "it", "spa" to "es", "por" to "pt", "rus" to "ru",
+    "hin" to "hi", "tur" to "tr", "pol" to "pl", "nld" to "nl",
+    "dut" to "nl", "swe" to "sv", "nor" to "no", "dan" to "da",
+    "fin" to "fi", "tha" to "th", "ara" to "ar", "heb" to "he",
+    "ces" to "cs", "cze" to "cs", "ron" to "ro", "rum" to "ro",
+    "hun" to "hu", "ukr" to "uk", "ell" to "el", "gre" to "el",
+    "eng" to "en", "vie" to "vi", "ind" to "id", "msa" to "ms",
+    "may" to "ms", "tam" to "ta", "tel" to "te", "ben" to "bn",
+    // Full names
+    "japanese" to "ja", "korean" to "ko", "chinese" to "zh",
+    "mandarin" to "zh", "cantonese" to "zh", "french" to "fr",
+    "german" to "de", "italian" to "it", "spanish" to "es",
+    "portuguese" to "pt", "russian" to "ru", "hindi" to "hi",
+    "turkish" to "tr", "polish" to "pl", "dutch" to "nl",
+    "swedish" to "sv", "norwegian" to "no", "danish" to "da",
+    "finnish" to "fi", "thai" to "th", "arabic" to "ar",
+    "hebrew" to "he", "czech" to "cs", "romanian" to "ro",
+    "hungarian" to "hu", "ukrainian" to "uk", "greek" to "el",
+    "english" to "en", "vietnamese" to "vi", "indonesian" to "id",
+    "malay" to "ms", "tamil" to "ta", "telugu" to "te",
+    "bengali" to "bn"
+)
+
+private val COUNTRY_TO_LANGUAGE_MAP = mapOf(
+    // ISO 3166-1 alpha-2
+    "jp" to "ja", "kr" to "ko", "cn" to "zh", "tw" to "zh",
+    "fr" to "fr", "de" to "de", "it" to "it", "es" to "es",
+    "pt" to "pt", "br" to "pt", "ru" to "ru", "in" to "hi",
+    "tr" to "tr", "pl" to "pl", "nl" to "nl", "se" to "sv",
+    "no" to "no", "dk" to "da", "fi" to "fi", "th" to "th",
+    "il" to "he", "cz" to "cs", "ro" to "ro", "hu" to "hu",
+    "ua" to "uk", "gr" to "el",
+    // ISO 3166-1 alpha-3
+    "jpn" to "ja", "kor" to "ko", "chn" to "zh", "twn" to "zh",
+    "fra" to "fr", "deu" to "de", "ita" to "it", "esp" to "es",
+    "prt" to "pt", "bra" to "pt", "rus" to "ru", "ind" to "hi",
+    "tur" to "tr", "pol" to "pl", "nld" to "nl", "swe" to "sv",
+    "nor" to "no", "dnk" to "da", "fin" to "fi", "tha" to "th",
+    "isr" to "he", "cze" to "cs", "rou" to "ro", "hun" to "hu",
+    "ukr" to "uk", "grc" to "el",
+    // Common full names
+    "japan" to "ja", "south korea" to "ko", "korea" to "ko",
+    "china" to "zh", "taiwan" to "zh", "france" to "fr",
+    "germany" to "de", "italy" to "it", "spain" to "es",
+    "portugal" to "pt", "brazil" to "pt", "russia" to "ru",
+    "india" to "hi", "turkey" to "tr", "poland" to "pl",
+    "netherlands" to "nl", "sweden" to "sv", "norway" to "no",
+    "denmark" to "da", "finland" to "fi", "thailand" to "th",
+    "israel" to "he", "romania" to "ro", "hungary" to "hu",
+    "ukraine" to "uk", "greece" to "el"
+)
+
 @Immutable
 data class MetaCastMember(
     val name: String,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -96,6 +96,7 @@ import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaCastMember
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.resolveContentLanguage
 import com.nuvio.tv.domain.model.MDBListRatings
 import com.nuvio.tv.domain.model.NextToWatch
 import com.nuvio.tv.domain.model.TraktCommentReview
@@ -455,7 +456,7 @@ fun MetaDetailsScreen(
                             null,
                             null,
                             video.runtime,
-                            meta.language
+                            meta.resolveContentLanguage()
                         )
                     },
                     onEpisodeManualPlayClick = { video ->
@@ -473,7 +474,7 @@ fun MetaDetailsScreen(
                             null,
                             null,
                             video.runtime,
-                            meta.language
+                            meta.resolveContentLanguage()
                         )
                     },
                     onPlayClick = { videoId ->
@@ -491,7 +492,7 @@ fun MetaDetailsScreen(
                             genresString,
                             yearString,
                             null,
-                            meta.language
+                            meta.resolveContentLanguage()
                         )
                     },
                     onPlayManuallyClick = { videoId ->
@@ -509,7 +510,7 @@ fun MetaDetailsScreen(
                             genresString,
                             yearString,
                             null,
-                            meta.language
+                            meta.resolveContentLanguage()
                         )
                     },
                     showManualPlayOption = effectiveAutoplayEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -10,6 +10,8 @@ import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.model.normalizeLanguageCode
+import com.nuvio.tv.domain.model.countryToLanguageCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
@@ -71,6 +73,8 @@ internal data class CwMetaSummary(
     val genres: List<String>,
     val releaseInfo: String?,
     val imdbRating: Float?,
+    val language: String?,
+    val country: String?,
     val videos: List<CwVideoSummary>
 ) {
     fun watchableEpisodes(): List<CwVideoSummary> {
@@ -119,6 +123,8 @@ private fun Meta.toCwSummary(): CwMetaSummary = CwMetaSummary(
     genres = genres,
     releaseInfo = releaseInfo,
     imdbRating = imdbRating,
+    language = language,
+    country = country,
     videos = videos.map { v ->
         CwVideoSummary(
             id = v.id,
@@ -1366,7 +1372,10 @@ private suspend fun HomeViewModel.enrichInProgressItem(
         episodeImdbRating = if (settings.useBasicInfo) imdbRating else meta.imdbRating,
         genres = genres,
         releaseInfo = releaseInfo,
-        contentLanguage = tmdbData?.contentLanguage ?: item.contentLanguage
+        contentLanguage = tmdbData?.contentLanguage
+            ?: normalizeLanguageCode(meta.language)
+            ?: countryToLanguageCode(meta.country)
+            ?: item.contentLanguage
     )
 }
 
@@ -1447,7 +1456,10 @@ private suspend fun HomeViewModel.enrichNextUpItem(
         releaseTimestamp = releaseState.releaseTimestamp,
         isReleaseAlert = releaseState.isReleaseAlert,
         isNewSeasonRelease = releaseState.isNewSeasonRelease,
-        contentLanguage = tmdbData?.contentLanguage ?: item.info.contentLanguage
+        contentLanguage = tmdbData?.contentLanguage
+            ?: normalizeLanguageCode(meta.language)
+            ?: countryToLanguageCode(meta.country)
+            ?: item.info.contentLanguage
     )
     if (shouldTraceNextUpSeries(progressSeed)) {
         logNextUpDecision(


### PR DESCRIPTION
## Summary

Resolve original content language from addon meta `language` and `country` fields so the player can select the correct audio track even when TMDB enrichment is disabled.

Previously `contentLanguage` was only populated by TMDB enrichment. When CW enrichment was off, the player received `null` and fell back to device/secondary language instead of original.

Changes:
- Add `Meta.resolveContentLanguage()` with fallback chain: `language` -> `country` -> `null`, normalizing ISO 639-2/3 codes and full names to ISO 639-1
- Detail screen now uses `meta.resolveContentLanguage()` instead of raw `meta.language`
- CW enrichment applies the same `normalizeLanguageCode` / `countryToLanguageCode` fallback from addon meta

## PR type

- Bug fix

## Why

Users with "Preferred audio: Original" and TMDB CW enrichment disabled reported that anime/foreign content played in English instead of the original language. The player had no `contentLanguage` to resolve "Original" and fell back to device language.

Also fixes stale next-up items persisting in CW after unmarking all watched episodes of a series.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Anime with TMDB CW enrichment disabled: play from CW -> audio correctly selects Japanese
- Anime from detail screen with addon meta `country: "jpn"`, no `language` field -> player selects Japanese
- TMDB enrichment enabled: still uses TMDB language (no regression)
- Tested both ExoPlayer and mpv engine paths

## Screenshots / Video (UI changes only)

No changes

## Breaking changes

Nothing should break 

## Linked issues

Reported on discord 
