### PR TITLE
fix: localization and input-handling bug bundle

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -1101,8 +1101,24 @@ private data class Quintuple<A, B, C, D, E>(
     val fifth: E
 )
 
+// Fallback regions for language codes that don't carry a region tag (e.g. "fr"
+// instead of "fr-FR"). Without this, non-hyphenated locales fall straight through
+// to the US/GB defaults in preferredRegions and users see American ratings.
+private val LANGUAGE_DEFAULT_REGION: Map<String, String> = mapOf(
+    "ar" to "SA", "bg" to "BG", "bs" to "BA", "cs" to "CZ", "da" to "DK",
+    "de" to "DE", "el" to "GR", "es" to "ES", "et" to "EE", "fi" to "FI",
+    "fr" to "FR", "he" to "IL", "hi" to "IN", "hr" to "HR", "hu" to "HU",
+    "id" to "ID", "it" to "IT", "ja" to "JP", "ko" to "KR", "lt" to "LT",
+    "lv" to "LV", "nl" to "NL", "no" to "NO", "pl" to "PL", "pt" to "PT",
+    "ro" to "RO", "ru" to "RU", "sk" to "SK", "sl" to "SI", "sr" to "RS",
+    "sv" to "SE", "th" to "TH", "tr" to "TR", "uk" to "UA", "vi" to "VN",
+    "zh" to "CN"
+)
+
 private fun preferredRegions(normalizedLanguage: String): List<String> {
+    val languageCode = normalizedLanguage.substringBefore("-").lowercase(Locale.US)
     val fromLanguage = normalizedLanguage.substringAfter("-", "").uppercase(Locale.US).takeIf { it.length == 2 }
+        ?: LANGUAGE_DEFAULT_REGION[languageCode]
     return buildList {
         if (!fromLanguage.isNullOrBlank()) add(fromLanguage)
         add("US")

--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
@@ -74,12 +74,6 @@ data class WatchProgress(
         }
         return position.coerceAtLeast(0L)
     }
-
-    /**
-     * Display string for the episode (e.g., "S1E2")
-     */
-    val episodeDisplayString: String?
-        get() = if (season != null && episode != null) "S${season}E${episode}" else null
 }
 
 /**

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -240,8 +240,15 @@ fun ContinueWatchingCard(
 
     val progress = remember(item) { (item as? ContinueWatchingItem.InProgress)?.progress }
     val nextUp = remember(item) { (item as? ContinueWatchingItem.NextUp)?.info }
-    val episodeStr = remember(progress, nextUp) {
-        progress?.episodeDisplayString ?: nextUp?.let { "S${it.season}E${it.episode}" }
+    val cardContext = LocalContext.current
+    val episodeStr = remember(progress, nextUp, cardContext) {
+        val season = progress?.season ?: nextUp?.season
+        val episode = progress?.episode ?: nextUp?.episode
+        if (season != null && episode != null) {
+            cardContext.getString(R.string.season_episode_format, season, episode)
+        } else {
+            null
+        }
     }
     val strAirsDate = stringResource(R.string.cw_airs_date, nextUp?.airDateLabel ?: "")
     val strUpcoming = stringResource(R.string.cw_upcoming)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailViewModel.kt
@@ -21,9 +21,9 @@ class CastDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     val personId: Int = savedStateHandle.get<String>("personId")?.toIntOrNull() ?: 0
-    val personName: String = java.net.URLDecoder.decode(
-        savedStateHandle.get<String>("personName") ?: "", "UTF-8"
-    )
+    val personName: String = (savedStateHandle.get<String>("personName") ?: "").let { raw ->
+        runCatching { java.net.URLDecoder.decode(raw, "UTF-8") }.getOrDefault(raw)
+    }
     private val preferCrew: Boolean = savedStateHandle.get<Boolean>("preferCrew") ?: false
 
     private val _uiState = MutableStateFlow<CastDetailUiState>(CastDetailUiState.Loading)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -284,7 +284,13 @@ internal fun buildContinueWatchingItem(
     val heroPreview = when (item) {
         is ContinueWatchingItem.InProgress -> {
             val isSeries = isSeriesType(item.progress.contentType)
-            val episodeCode = item.progress.episodeDisplayString
+            val s = item.progress.season
+            val e = item.progress.episode
+            val episodeCode = if (s != null && e != null) {
+                context.getString(R.string.season_episode_format, s, e)
+            } else {
+                null
+            }
             val episodeTitle = item.progress.episodeTitle?.takeIf { it.isNotBlank() }?.localizeEpisodeTitle(context)
             val episodeLabel = when {
                 isSeries && episodeCode != null && episodeTitle != null -> "$episodeCode · $episodeTitle"
@@ -312,7 +318,11 @@ internal fun buildContinueWatchingItem(
             )
         }
         is ContinueWatchingItem.NextUp -> {
-            val episodeCode = "S${item.info.season}E${item.info.episode}"
+            val episodeCode = context.getString(
+                R.string.season_episode_format,
+                item.info.season,
+                item.info.episode
+            )
             val episodeTitle = item.info.episodeTitle?.takeIf { it.isNotBlank() }?.localizeEpisodeTitle(context)
             val episodeLabel = if (episodeTitle != null) "$episodeCode · $episodeTitle" else episodeCode
             HeroPreview(
@@ -370,9 +380,21 @@ internal fun buildContinueWatchingItem(
             is ContinueWatchingItem.NextUp -> item.info.name
         },
         subtitle = when (item) {
-            is ContinueWatchingItem.InProgress -> item.progress.episodeDisplayString ?: item.progress.episodeTitle
+            is ContinueWatchingItem.InProgress -> {
+                val ps = item.progress.season
+                val pe = item.progress.episode
+                if (ps != null && pe != null) {
+                    context.getString(R.string.season_episode_format, ps, pe)
+                } else {
+                    item.progress.episodeTitle
+                }
+            }
             is ContinueWatchingItem.NextUp -> {
-                val code = "S${item.info.season}E${item.info.episode}"
+                val code = context.getString(
+                    R.string.season_episode_format,
+                    item.info.season,
+                    item.info.episode
+                )
                 if (item.info.hasAired) {
                     code
                 } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -629,11 +629,11 @@ class LibraryViewModel @Inject constructor(
                     .thenBy { it.id }
             )
             LibrarySortOption.TITLE_ASC -> yearFiltered.sortedWith(
-                compareBy<LibraryEntry> { it.name.ifBlank { it.id }.lowercase(Locale.ROOT) }
+                compareBy<LibraryEntry> { titleSortKey(it.name.ifBlank { it.id }) }
                     .thenBy { it.id }
             )
             LibrarySortOption.TITLE_DESC -> yearFiltered.sortedWith(
-                compareByDescending<LibraryEntry> { it.name.ifBlank { it.id }.lowercase(Locale.ROOT) }
+                compareByDescending<LibraryEntry> { titleSortKey(it.name.ifBlank { it.id }) }
                     .thenBy { it.id }
             )
         }
@@ -678,3 +678,11 @@ class LibraryViewModel @Inject constructor(
         }
     }
 }
+
+// Strip leading English articles ("The", "A", "An") when sorting by title, so
+// "The Walking Dead" sorts under W and not T. Matches how streaming services
+// and most media libraries order titles alphabetically.
+private val LEADING_ARTICLE_REGEX = Regex("^(the|an|a)\\s+", RegexOption.IGNORE_CASE)
+
+private fun titleSortKey(title: String): String =
+    title.trim().replace(LEADING_ARTICLE_REGEX, "").lowercase(Locale.ROOT)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodesSidePanel.kt
@@ -469,7 +469,7 @@ private fun EpisodeItem(
         val s = episode.season
         val e = episode.episode
         if (s != null && e != null) {
-            "S${s.toString().padStart(2, '0')}E${e.toString().padStart(2, '0')}"
+            context.getString(R.string.season_episode_format, s, e)
         } else {
             null
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NextEpisodeCardOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NextEpisodeCardOverlay.kt
@@ -167,8 +167,13 @@ fun NextEpisodeCardOverlay(
                         fontWeight = FontWeight.Medium
                     )
                     Spacer(modifier = Modifier.height(2.dp))
+                    val nextEpisodeCode = stringResource(
+                        R.string.season_episode_format,
+                        nextEpisode.season,
+                        nextEpisode.episode
+                    )
                     Text(
-                        text = "S${nextEpisode.season}E${nextEpisode.episode} • ${nextEpisode.title}",
+                        text = "$nextEpisodeCode • ${nextEpisode.title}",
                         color = Color.White,
                         fontSize = 14.sp,
                         maxLines = 1,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
@@ -195,7 +195,7 @@ private fun PauseMetadataView(
 
             if (!year.isNullOrBlank()) {
                 val episodeLabel = if (type in listOf("series", "tv") && season != null && episode != null) {
-                    " • S${season}E${episode}"
+                    " • " + stringResource(R.string.season_episode_format, season, episode)
                 } else {
                     ""
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
@@ -51,7 +51,11 @@ internal data class PlayerNavigationArgs(
         fun from(savedStateHandle: SavedStateHandle): PlayerNavigationArgs {
             fun decodedOrNull(key: String): String? {
                 val value = savedStateHandle.get<String>(key) ?: return null
-                return if (value.isNotEmpty()) URLDecoder.decode(value, "UTF-8") else null
+                if (value.isEmpty()) return null
+                // Stream metadata occasionally contains stray `%` or malformed escapes
+                // (e.g. via AIOStreams Formatter). Fall back to the raw value rather
+                // than crashing the player on launch.
+                return runCatching { URLDecoder.decode(value, "UTF-8") }.getOrDefault(value)
             }
 
             return PlayerNavigationArgs(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1498,8 +1498,13 @@ private fun PlayerControlsOverlay(
                     )
 
                     if (uiState.currentSeason != null && uiState.currentEpisode != null) {
+                        val seasonEpisodeCode = stringResource(
+                            R.string.season_episode_format,
+                            uiState.currentSeason,
+                            uiState.currentEpisode
+                        )
                         val episodeInfo = buildString {
-                            append("S${uiState.currentSeason}E${uiState.currentEpisode}")
+                            append(seasonEpisodeCode)
                             if (!uiState.currentEpisodeTitle.isNullOrBlank()) {
                                 append(" • ${uiState.currentEpisodeTitle}")
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -114,10 +114,19 @@ internal fun StreamSourcesSidePanel(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Current content info
+            val seasonEpisodeCode = if (uiState.currentSeason != null && uiState.currentEpisode != null) {
+                stringResource(
+                    R.string.season_episode_format,
+                    uiState.currentSeason,
+                    uiState.currentEpisode
+                )
+            } else {
+                null
+            }
             Text(
                 text = buildString {
-                    if (uiState.currentSeason != null && uiState.currentEpisode != null) {
-                        append("S${uiState.currentSeason} E${uiState.currentEpisode}")
+                    if (seasonEpisodeCode != null) {
+                        append(seasonEpisodeCode)
                         if (!uiState.currentEpisodeTitle.isNullOrBlank()) {
                             append(" • ${uiState.currentEpisodeTitle}")
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseViewModel.kt
@@ -31,10 +31,9 @@ class TmdbEntityBrowseViewModel @Inject constructor(
         savedStateHandle.get<String>("entityKind").orEmpty()
     )
     val entityId: Int = savedStateHandle.get<Int>("entityId") ?: 0
-    val entityName: String = URLDecoder.decode(
-        savedStateHandle.get<String>("entityName").orEmpty(),
-        "UTF-8"
-    )
+    val entityName: String = savedStateHandle.get<String>("entityName").orEmpty().let { raw ->
+        runCatching { URLDecoder.decode(raw, "UTF-8") }.getOrDefault(raw)
+    }
     val sourceType: String = savedStateHandle.get<String>("sourceType").orEmpty()
 
     private val _uiState = MutableStateFlow<TmdbEntityBrowseUiState>(TmdbEntityBrowseUiState.Loading)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -930,6 +930,8 @@
     <string name="parental_severity_mild">Mild</string>
     <string name="player_ends_at">Ends at %1$s</string>
     <string name="player_via">via %1$s</string>
+    <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
+    <string name="season_episode_format">S%1$02dE%2$02d</string>
     <string name="player_subtitle_delay">Subtitles Delay</string>
     <string name="player_error_title">Playback Error</string>
     <string name="player_go_back">Go Back</string>


### PR DESCRIPTION
## Summary

Bundle of 4 small uncovered bug fixes that share a defensive-handling-of-locale-and-user-input theme. None overlap with any open PR.

- `#1093` — Age rating falls back to US/GB for bare language codes like `"fr"`
- `#1184` — Player `S`/`E` episode labels are not localizable and inconsistently spaced
- `#1230` — Library alphabetical sort does not ignore leading `The`/`A`/`An`
- `#1275` — Player hard-crashes when a stream URL contains stray `%` characters

## PR type

- Bug fix

## Why

Four independent user-reported bugs, each with a clear reproducer and a localized fix. Bundled into one PR because they share a theme (defensive/correct handling of locale + user input) and because keeping them separate would fragment review for ~50 LoC total.

- **#1093:** Users on non-hyphenated locales (French `"fr"`, German `"de"`, Japanese `"ja"`, etc.) see American `PG-13`/`R` ratings instead of their local certification (French `TP`, etc.). Root cause: `preferredRegions()` uses `substringAfter("-", "")` to extract the region, gets an empty string for bare codes, and falls through to `[US, GB]`. The existing `selectBestLocalizedImagePath` on line 889 of the same file already solved this pattern with a `DEFAULT_LANGUAGE_REGIONS` fallback.
- **#1184:** Player season/episode labels are hardcoded as `"S${s}E${e}"` across the player UI — untranslatable and inconsistently spaced (`StreamSourcesSidePanel` used `"S01 E01"` while everything else used `"S01E01"`).
- **#1230:** Library alphabetical sort puts "The Walking Dead" under T instead of W, creating a giant "The" sub-bucket that's annoying to scroll.
- **#1275:** Movies whose stream metadata contains stray `%` (common with AIOStreams Formatter output) hard-crash the app on player launch via `URLDecoder: Illegal hex characters in escape (%) pattern`.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

**Automated:**
- `./gradlew :app:compileDebugKotlin` passes clean (Windows, AGP as configured). Verified both before and after the merge with `origin/dev`.
- Unit test task (`compileDebugUnitTestKotlin`) fails on `StreamTest.kt:38` (`Unresolved reference 'getStreamUrls'`) — pre-existing on the branch base, unrelated to this PR. Confirmed by stashing my changes and re-running against `b01b03d5`.

**Manual (please verify during review — I do not have a TV test device):**
- Set device locale to French (no region) → open a film with a known French certification → age badge should show French rating (`TP`/`12`), not US `PG-13`
- Play a series episode → verify `S01E02` shows consistently in: play/pause overlay, Sources side panel, Episodes side panel, Next Episode card, Modern Home hero, and Continue Watching cards
- Sort Library alphabetically → "The Walking Dead" sorts under W, not T
- Play a stream whose metadata contains `%` (e.g. AIOStreams-formatted source with `%` in the description) → player starts instead of crashing

## Screenshots / Video (UI changes only)

No new UI. Spacing of existing S/E labels is now consistently `S01E02` (padded, no space) across every visible player surface.

## Breaking changes

None.

- `WatchProgress.episodeDisplayString` property was removed — it had no remaining consumers after this PR's UI updates, and leaving the un-padded `"S${s}E${e}"` getter in place would invite regressing the unified format.
- `season_episode_format` is a new string resource. Translations for it will flow through the normal localization pipeline; no translation PR is bundled here.

## Linked issues

Fixes #1093
Fixes #1184
Fixes #1230
Fixes #1275