### PR TITLE
Add support for "other" type content with inline meta streams

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -102,7 +102,22 @@ class StreamRepositoryImpl @Inject constructor(
                                             )
                                         )
                                     } else {
-                                        attemptedFailures += buildMissingStreamFailure(addon)
+                                        // Stream endpoint returned empty - try inline
+                                        // streams from meta response as fallback.
+                                        val inlineStreams = fetchInlineStreamsFromMeta(
+                                            addon, type, videoId
+                                        )
+                                        if (inlineStreams.isNotEmpty()) {
+                                            resultChannel.send(
+                                                AddonStreams(
+                                                    addonName = addon.displayName,
+                                                    addonLogo = addon.logo,
+                                                    streams = inlineStreams
+                                                )
+                                            )
+                                        } else {
+                                            attemptedFailures += buildMissingStreamFailure(addon)
+                                        }
                                     }
                                 }
                                 is NetworkResult.Error -> {
@@ -351,6 +366,58 @@ class StreamRepositoryImpl @Inject constructor(
         return resources.any { resource ->
             resource.name == "stream" && 
             (resource.types.isEmpty() || resource.types.contains(type))
+        }
+    }
+
+    /**
+     * Fetch meta for the given content and extract inline streams from the
+     * matching video entry.  Returns an empty list when the addon doesn't
+     * support meta or the video has no inline streams.
+     */
+    private suspend fun fetchInlineStreamsFromMeta(
+        addon: Addon,
+        type: String,
+        videoId: String
+    ): List<Stream> {
+        // For inline streams the meta is fetched using the content-level ID
+        // (everything before the video-specific suffix).  For "other" type
+        // the videoId IS the content ID; for series it is contentId:S:E.
+        val contentId = videoId.substringBefore(":")
+            .takeIf { it.isNotBlank() }
+            ?: videoId
+        // Reconstruct a content-level ID that keeps the addon-specific prefix.
+        // e.g. "realdebrid:ABC:3" → "realdebrid:ABC"
+        val metaId = run {
+            val parts = videoId.split(":")
+            // Drop trailing numeric segment(s) that represent video index
+            val contentParts = parts.dropLastWhile { it.toIntOrNull() != null }
+            if (contentParts.isNotEmpty()) contentParts.joinToString(":") else videoId
+        }
+        val cleanBaseUrl = addon.baseUrl.trimEnd('/')
+        val queryStart = cleanBaseUrl.indexOf('?')
+        val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
+        val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
+        val encodedType = encodePathSegment(type)
+        val encodedMetaId = encodePathSegment(metaId)
+        val metaUrl = "$basePath/meta/$encodedType/$encodedMetaId.json$baseQuery"
+        Log.d(TAG, "Fetching inline streams via meta type=$type metaId=$metaId videoId=$videoId url=$metaUrl")
+        return try {
+            when (val result = safeApiCall { api.getMeta(metaUrl) }) {
+                is NetworkResult.Success -> {
+                    val metaDto = result.data.meta ?: return emptyList()
+                    val matchingVideo = metaDto.videos?.firstOrNull { it.id == videoId }
+                    val streams = matchingVideo?.streams
+                        ?.mapNotNull { it.toDomain(addon.displayName, addon.logo) }
+                        ?: emptyList()
+                    Log.d(TAG, "Inline streams from meta: addon=${addon.displayName} videoId=$videoId found=${streams.size}")
+                    streams
+                }
+                else -> emptyList()
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.w(TAG, "Failed to fetch inline streams from meta for ${addon.displayName}: ${e.message}")
+            emptyList()
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -232,7 +232,9 @@ fun HeroContentSection(
                     ) {
                         PlayButton(
                             text = nextToWatch?.displayText ?: when {
-                                nextEpisode != null -> stringResource(R.string.hero_play_episode, nextEpisode.season ?: 0, nextEpisode.episode ?: 0)
+                                nextEpisode != null && nextEpisode.season != null && nextEpisode.episode != null ->
+                                    stringResource(R.string.hero_play_episode, nextEpisode.season, nextEpisode.episode)
+                                nextEpisode != null -> stringResource(R.string.hero_play)
                                 else -> stringResource(R.string.hero_play)
                             },
                             onClick = onPlayClick,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1436,7 +1436,9 @@ private fun MetaDetailsContent(
             }
 
             // Season tabs and episodes for series
-            if (isSeries && seasons.isNotEmpty()) {
+            val showSeasonTabs = isSeries && seasons.isNotEmpty() && !(seasons.size == 1 && meta.apiType.equals("other", ignoreCase = true))
+            val showEpisodesRow = isSeries && seasons.isNotEmpty()
+            if (showSeasonTabs) {
                 item(key = "season_tabs", contentType = "season_tabs") {
                     Box(modifier = Modifier.bringIntoViewResponder(noVerticalScrollResponder)) {
                         SeasonTabs(
@@ -1450,6 +1452,8 @@ private fun MetaDetailsContent(
                         )
                     }
                 }
+            }
+            if (showEpisodesRow) {
                 item(key = "episodes_$selectedSeason", contentType = "episodes") {
                     Box(modifier = Modifier.bringIntoViewResponder(noVerticalScrollResponder)) {
                         EpisodesRow(
@@ -1468,7 +1472,7 @@ private fun MetaDetailsContent(
                             isSeasonFullyWatched = isSeasonFullyWatched(selectedSeason),
                             selectedSeason = selectedSeason,
                             onMarkPreviousEpisodesWatched = onMarkPreviousEpisodesWatched,
-                            upFocusRequester = selectedSeasonFocusRequester,
+                            upFocusRequester = if (showSeasonTabs) selectedSeasonFocusRequester else heroPlayFocusRequester,
                             downFocusRequester = episodesDownFocusRequester,
                             episodeFocusRequesters = seasonEpisodeFocusRequesters,
                             restoreEpisodeId = if (pendingRestoreType == RestoreTarget.EPISODE) pendingRestoreEpisodeId else null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -361,7 +361,29 @@ class MetaDetailsViewModel @Inject constructor(
         if (itemType.lowercase() == "movie") return
         viewModelScope.launch {
             _effectiveContentId.flatMapLatest { cid ->
-                watchProgressRepository.getAllEpisodeProgress(cid)
+                if (itemType.equals("other", ignoreCase = true)) {
+                    // For "other" type, videos lack season/episode.
+                    // Build progress map by matching video IDs to their
+                    // position in the meta video list.
+                    watchProgressRepository.allProgress.map { allProgress ->
+                        val meta = _uiState.value.meta
+                        val videos = meta?.videos ?: emptyList()
+                        val progressByVideoId = allProgress
+                            .filter { it.contentId == cid }
+                            .associateBy { it.videoId }
+                        val result = mutableMapOf<Pair<Int, Int>, WatchProgress>()
+                        videos.forEachIndexed { index, video ->
+                            val progress = progressByVideoId[video.id]
+                            if (progress != null) {
+                                // Use synthetic season=1, episode=index+1 as key
+                                result[1 to (index + 1)] = progress
+                            }
+                        }
+                        result as Map<Pair<Int, Int>, WatchProgress>
+                    }
+                } else {
+                    watchProgressRepository.getAllEpisodeProgress(cid)
+                }
             }
                 .distinctUntilChanged()
                 .collectLatest { progressMap ->
@@ -1211,9 +1233,12 @@ class MetaDetailsViewModel @Inject constructor(
         val filtered = videos.filter { it.season == season }
         if (filtered.isNotEmpty()) return filtered.sortedBy { it.episode }
         // Fallback: if no videos match the season (e.g. "other" type with
-        // null seasons), return all videos assigned to the virtual season.
+        // null seasons), return all videos with synthetic season/episode
+        // numbers so the episode UI can track watched state.
         if (videos.isNotEmpty() && videos.all { it.season == null }) {
-            return videos
+            return videos.mapIndexed { index, video ->
+                video.copy(season = 1, episode = index + 1)
+            }
         }
         return emptyList()
     }
@@ -1602,8 +1627,11 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun toggleEpisodeWatched(video: Video) {
         val meta = _uiState.value.meta ?: return
-        val season = video.season ?: return
-        val episode = video.episode ?: return
+        val season = video.season
+        val episode = video.episode
+        // For "other" type content, videos may lack season/episode.
+        // Use video ID as the key instead.
+        val isOtherType = season == null || episode == null
         val pendingKey = episodePendingKey(video)
         if (_uiState.value.episodeWatchedPendingKeys.contains(pendingKey)) return
 
@@ -1612,11 +1640,18 @@ class MetaDetailsViewModel @Inject constructor(
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKey)
             }
 
-            val isWatched = _uiState.value.episodeProgressMap[season to episode]?.isCompleted() == true
-                || _uiState.value.watchedEpisodes.contains(season to episode)
+            val isWatched = if (!isOtherType) {
+                _uiState.value.episodeProgressMap[season!! to episode!!]?.isCompleted() == true
+                    || _uiState.value.watchedEpisodes.contains(season to episode)
+            } else {
+                // For "other" type, check by video ID in progress map values
+                _uiState.value.episodeProgressMap.values.any {
+                    it.videoId == video.id && it.isCompleted()
+                }
+            }
             runCatching {
                 if (isWatched) {
-                    watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = resolveFallbackVideoId(), season = season, episode = episode)
+                    watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = video.id, season = season, episode = episode)
                     showMessage(context.getString(R.string.detail_episode_marked_unwatched))
                 } else {
                     watchProgressRepository.markAsCompleted(buildCompletedEpisodeProgress(meta, video))

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -574,6 +574,11 @@ class MetaDetailsViewModel @Inject constructor(
             .mapNotNull { it.season }
             .distinct()
             .sorted()
+            .ifEmpty {
+                // For "other" type content videos lack season/episode numbers.  
+                // Treat them as a single virtual season so the episodes UI can display them.
+                if (meta.videos.isNotEmpty()) listOf(1) else emptyList()
+            }
 
         val defaultEpisodeSeason = findPreferredDefaultEpisode(meta)?.season
         // Prefer addon-specified default episode season, otherwise first regular season (> 0), fallback to season 0 (specials)
@@ -1203,9 +1208,14 @@ class MetaDetailsViewModel @Inject constructor(
     }
 
     private fun getEpisodesForSeason(videos: List<Video>, season: Int): List<Video> {
-        return videos
-            .filter { it.season == season }
-            .sortedBy { it.episode }
+        val filtered = videos.filter { it.season == season }
+        if (filtered.isNotEmpty()) return filtered.sortedBy { it.episode }
+        // Fallback: if no videos match the season (e.g. "other" type with
+        // null seasons), return all videos assigned to the virtual season.
+        if (videos.isNotEmpty() && videos.all { it.season == null }) {
+            return videos
+        }
+        return emptyList()
     }
 
     private fun reevaluateSeriesWatchedBadge() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1627,11 +1627,8 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun toggleEpisodeWatched(video: Video) {
         val meta = _uiState.value.meta ?: return
-        val season = video.season
-        val episode = video.episode
-        // For "other" type content, videos may lack season/episode.
-        // Use video ID as the key instead.
-        val isOtherType = season == null || episode == null
+        val season = video.season ?: return
+        val episode = video.episode ?: return
         val pendingKey = episodePendingKey(video)
         if (_uiState.value.episodeWatchedPendingKeys.contains(pendingKey)) return
 
@@ -1640,15 +1637,8 @@ class MetaDetailsViewModel @Inject constructor(
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKey)
             }
 
-            val isWatched = if (!isOtherType) {
-                _uiState.value.episodeProgressMap[season!! to episode!!]?.isCompleted() == true
-                    || _uiState.value.watchedEpisodes.contains(season to episode)
-            } else {
-                // For "other" type, check by video ID in progress map values
-                _uiState.value.episodeProgressMap.values.any {
-                    it.videoId == video.id && it.isCompleted()
-                }
-            }
+            val isWatched = _uiState.value.episodeProgressMap[season to episode]?.isCompleted() == true
+                || _uiState.value.watchedEpisodes.contains(season to episode)
             runCatching {
                 if (isWatched) {
                     watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = video.id, season = season, episode = episode)
@@ -1673,7 +1663,13 @@ class MetaDetailsViewModel @Inject constructor(
     fun isSeasonFullyWatched(season: Int): Boolean {
         val state = _uiState.value
         val meta = state.meta ?: return false
-        val episodes = meta.videos.filter { it.season == season && it.episode != null }
+        // For "other" type, use episodesForSeason which has synthetic season/episode.
+        // For regular series, use meta.videos to support checking any season.
+        val episodes = if (meta.apiType.equals("other", ignoreCase = true)) {
+            state.episodesForSeason.filter { it.season == season && it.episode != null }
+        } else {
+            meta.videos.filter { it.season == season && it.episode != null }
+        }
         if (episodes.isEmpty()) return false
         return episodes.all { video ->
             val s = video.season ?: return@all false
@@ -1687,7 +1683,11 @@ class MetaDetailsViewModel @Inject constructor(
         val meta = _uiState.value.meta ?: return
         suppressSeasonAutoSwitch = true
         viewModelScope.launch {
-            val episodes = meta.videos.filter { it.season == season && it.episode != null }
+            val episodes = if (meta.apiType.equals("other", ignoreCase = true)) {
+                _uiState.value.episodesForSeason.filter { it.season == season && it.episode != null }
+            } else {
+                meta.videos.filter { it.season == season && it.episode != null }
+            }
             val unwatched = episodes.filter { video ->
                 val s = video.season!!
                 val e = video.episode!!
@@ -1723,7 +1723,11 @@ class MetaDetailsViewModel @Inject constructor(
         val meta = _uiState.value.meta ?: return
         suppressSeasonAutoSwitch = true
         viewModelScope.launch {
-            val episodes = meta.videos.filter { it.season == season && it.episode != null }
+            val episodes = if (meta.apiType.equals("other", ignoreCase = true)) {
+                _uiState.value.episodesForSeason.filter { it.season == season && it.episode != null }
+            } else {
+                meta.videos.filter { it.season == season && it.episode != null }
+            }
             val watched = episodes.filter { video ->
                 val s = video.season!!
                 val e = video.episode!!
@@ -1764,8 +1768,14 @@ class MetaDetailsViewModel @Inject constructor(
         val targetEpisode = video.episode ?: return
 
         viewModelScope.launch {
-            val previous = meta.videos.filter { v ->
-                v.season == targetSeason && v.episode != null && v.episode < targetEpisode
+            val previous = if (meta.apiType.equals("other", ignoreCase = true)) {
+                _uiState.value.episodesForSeason.filter { v ->
+                    v.season == targetSeason && v.episode != null && v.episode < targetEpisode
+                }
+            } else {
+                meta.videos.filter { v ->
+                    v.season == targetSeason && v.episode != null && v.episode < targetEpisode
+                }
             }
             val unwatched = previous.filter { v ->
                 val s = v.season!!

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NextEpisodeCardOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NextEpisodeCardOverlay.kt
@@ -168,7 +168,11 @@ fun NextEpisodeCardOverlay(
                     )
                     Spacer(modifier = Modifier.height(2.dp))
                     Text(
-                        text = "S${nextEpisode.season}E${nextEpisode.episode} • ${nextEpisode.title}",
+                        text = if (nextEpisode.isOtherType) {
+                            nextEpisode.title
+                        } else {
+                            "S${nextEpisode.season}E${nextEpisode.episode} • ${nextEpisode.title}"
+                        },
                         color = Color.White,
                         fontSize = 14.sp,
                         maxLines = 1,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -150,7 +150,7 @@ private suspend fun PlayerRuntimeController.enrichDescriptionFromTmdb(id: String
 
 internal fun PlayerRuntimeController.recomputeNextEpisode(resetVisibility: Boolean) {
     val normalizedType = contentType?.lowercase()
-    if (normalizedType !in listOf("series", "tv")) {
+    if (normalizedType !in listOf("series", "tv", "other")) {
         nextEpisodeVideo = null
         _uiState.update {
             it.copy(
@@ -160,6 +160,50 @@ internal fun PlayerRuntimeController.recomputeNextEpisode(resetVisibility: Boole
                 nextEpisodeAutoPlaySearching = false,
                 nextEpisodeAutoPlaySourceName = null,
                 nextEpisodeAutoPlayCountdownSec = null
+            )
+        }
+        return
+    }
+
+    // For "other" type, videos lack season/episode - resolve next by
+    // position in the video list using the current video ID.
+    if (normalizedType == "other") {
+        val currentId = currentVideoId
+        val idx = if (currentId != null) metaVideos.indexOfFirst { it.id == currentId } else -1
+        val resolvedNext = if (idx >= 0 && idx < metaVideos.size - 1) metaVideos[idx + 1] else null
+        nextEpisodeVideo = resolvedNext
+        if (resolvedNext == null) {
+            _uiState.update {
+                it.copy(
+                    nextEpisode = null,
+                    showNextEpisodeCard = false,
+                    nextEpisodeCardDismissed = false,
+                    nextEpisodeAutoPlaySearching = false,
+                    nextEpisodeAutoPlaySourceName = null,
+                    nextEpisodeAutoPlayCountdownSec = null
+                )
+            }
+            return
+        }
+        val nextInfo = NextEpisodeInfo(
+            videoId = resolvedNext.id,
+            season = resolvedNext.season ?: 1,
+            episode = resolvedNext.episode ?: (idx + 2),
+            title = resolvedNext.title,
+            thumbnail = resolvedNext.thumbnail,
+            overview = resolvedNext.overview,
+            released = resolvedNext.released,
+            hasAired = true,
+            unairedMessage = null,
+            isOtherType = true
+        )
+        _uiState.update { state ->
+            val sameEpisode = state.nextEpisode?.videoId == nextInfo.videoId
+            val shouldResetVisibility = resetVisibility || !sameEpisode
+            state.copy(
+                nextEpisode = nextInfo,
+                showNextEpisodeCard = if (shouldResetVisibility) false else state.showNextEpisodeCard,
+                nextEpisodeCardDismissed = if (shouldResetVisibility) false else state.nextEpisodeCardDismissed
             )
         }
         return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -190,7 +190,8 @@ data class NextEpisodeInfo(
     val overview: String?,
     val released: String?,
     val hasAired: Boolean,
-    val unairedMessage: String?
+    val unairedMessage: String?,
+    val isOtherType: Boolean = false
 )
 
 data class SubtitleSyncCue(


### PR DESCRIPTION
## Summary

Add support for `other` type content. Addons with `other` types provide files via inline streams in meta response rather than the standard `/stream/` endpoint.

Changes:
- Detail screen: display videos without season/episode as a file list (virtual season, no season tabs)
- Stream loading: when `/stream/` returns empty, fall back to inline `videos[].streams` from meta response
- Player: resolve next file by position in video list for `other` type, enabling auto-play next
- UI: show file title instead of "S1E2" in next episode card and hero play button for `other` type

## PR type

- Bug fix

## Why

Users with "video files" store addons reported that `other` type content couldn't be played. The addon provides streams inline in the meta response, but our app only checked the `/stream/` endpoint which returned empty. Additionally, the detail screen treated `other` as a movie (no file list), and the player had no next-file navigation.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Install addon with `other` type catalog
- Open content from RD store catalog -> detail screen shows file list
- Click a file -> streams load via inline meta fallback -> playback starts
- Playback ends -> next file card appears with file title (not "S1E2") -> auto-play advances to next file
- Standard series/movie playback unaffected (no regression)

## Screenshots / Video (UI changes only)

file list reuses existing episode card UI.

## Breaking changes

nothing should break - now type supported

## Linked issues

Reported on Discord
