### PR TITLE
Fix focus restore, discovery scroll, collection black screen, and TMDB rating guard

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.ui.screens.collection
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -21,9 +22,13 @@ import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.ui.screens.home.GridItem
 import com.nuvio.tv.ui.screens.home.HomeRow
 import com.nuvio.tv.ui.screens.home.HomeUiState
+import com.nuvio.tv.ui.screens.home.ModernCarouselRowBuildCache
+import com.nuvio.tv.ui.screens.home.ModernHomePresentationInput
+import com.nuvio.tv.ui.screens.home.buildModernHomePresentation
 import com.nuvio.tv.ui.screens.home.homeItemStatusKey
 import com.nuvio.tv.domain.repository.CatalogRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -84,6 +89,7 @@ data class FolderDetailGridFocusState(
 
 @HiltViewModel
 class FolderDetailViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     savedStateHandle: SavedStateHandle,
     private val collectionsDataStore: CollectionsDataStore,
     private val addonRepository: AddonRepository,
@@ -117,6 +123,7 @@ class FolderDetailViewModel @Inject constructor(
     val trailerPreviewAudioUrls: StateFlow<Map<String, String>> = _trailerPreviewAudioUrls.asStateFlow()
     private val trailerPreviewLoadingIds = mutableSetOf<String>()
     private val trailerPreviewNegativeCache = mutableSetOf<String>()
+    private val modernCarouselRowBuildCache = ModernCarouselRowBuildCache()
     private var activeTrailerPreviewItemId: String? = null
     private var trailerPreviewRequestVersion: Long = 0L
 
@@ -322,8 +329,27 @@ class FolderDetailViewModel @Inject constructor(
         }
 
         val anyLoading = sourceTabs.any { it.isLoading }
+
+        // Build modern presentation so ModernHomeContent has carousel rows to render.
+        val modernPresentation = _uiState.value.let { s ->
+            if (s.homeLayout == HomeLayout.MODERN) {
+                buildModernHomePresentation(
+                    input = ModernHomePresentationInput(
+                        homeRows = homeRows,
+                        catalogRows = loadedRows,
+                        continueWatchingItems = emptyList(),
+                        useLandscapePosters = s.modernLandscapePostersEnabled,
+                        showCatalogTypeSuffix = s.catalogTypeSuffixEnabled,
+                        showFullReleaseDate = s.showFullReleaseDate
+                    ),
+                    cache = modernCarouselRowBuildCache,
+                    context = appContext
+                )
+            } else null
+        }
+
         _uiState.update { s ->
-            s.copy(followLayoutHomeState = HomeUiState(
+            val homeState = HomeUiState(
                 catalogRows = loadedRows,
                 homeRows = homeRows,
                 gridItems = gridItems,
@@ -347,7 +373,12 @@ class FolderDetailViewModel @Inject constructor(
                 hideUnreleasedContent = s.hideUnreleasedContent,
                 showFullReleaseDate = s.showFullReleaseDate,
                 movieWatchedStatus = s.movieWatchedStatus
-            ))
+            )
+            s.copy(followLayoutHomeState = if (modernPresentation != null) {
+                homeState.copy(modernHomePresentation = modernPresentation)
+            } else {
+                homeState
+            })
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CompanyLogosSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CompanyLogosSection.kt
@@ -62,7 +62,8 @@ fun CompanyLogosSection(
 
     LaunchedEffect(restoreCompanyId, restoreFocusToken) {
         if (restoreFocusToken <= 0 || restoreCompanyId == null) return@LaunchedEffect
-        val targetRequester = focusRequesters[restoreCompanyId] ?: return@LaunchedEffect
+        val targetRequester = focusRequesters[restoreCompanyId]
+        if (targetRequester == null) return@LaunchedEffect
         repeat(2) { withFrameNanos { } }
         runCatching { targetRequester.requestFocus() }
         onRestoreFocusHandled()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -272,6 +272,9 @@ fun EpisodesRow(
         episodeFocusRequesters.keys.retainAll(episodeIds)
     }
 
+    // Track the last focused episode requester for focus restoration
+    var lastFocusedEpisodeRequester by remember { androidx.compose.runtime.mutableStateOf<FocusRequester?>(null) }
+
     LaunchedEffect(restoreFocusToken, restoreEpisodeId, restoreTargetRequester, dedupedEpisodes) {
         if (restoreFocusToken <= 0 || restoreEpisodeId.isNullOrBlank()) return@LaunchedEffect
         if (dedupedEpisodes.none { it.id == restoreEpisodeId }) return@LaunchedEffect
@@ -280,6 +283,7 @@ fun EpisodesRow(
             val offsetPx = with(density) { (cardMetrics.cardWidth * 2f / 3f - cardMetrics.itemSpacing).roundToPx() }
             lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
         }
+        lastFocusedEpisodeRequester = restoreTargetRequester
         restoreTargetRequester?.requestFocusAfterFrames()
     }
 
@@ -289,16 +293,18 @@ fun EpisodesRow(
         if (index < 0) return@LaunchedEffect
         val offsetPx = with(density) { (cardMetrics.cardWidth * 2f / 3f - cardMetrics.itemSpacing).roundToPx() }
         lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
+        // Reset the focus restorer target so it doesn't point at an off-screen episode
+        // after the list scrolled to a different position.
+        lastFocusedEpisodeRequester = episodeFocusRequesters[scrollToEpisodeId]
         onScrollToEpisodeHandled()
     }
-
-    // Track the last focused episode requester for focus restoration
-    var lastFocusedEpisodeRequester by remember { androidx.compose.runtime.mutableStateOf<FocusRequester?>(null) }
 
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .focusRestorer { lastFocusedEpisodeRequester ?: FocusRequester.Default }
+            .focusRestorer {
+                lastFocusedEpisodeRequester ?: FocusRequester.Default
+            }
             .onPreviewKeyEvent { event ->
                 val native = event.nativeKeyEvent
                 val isHorizontalKey = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_LEFT ||

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -840,9 +840,10 @@ private fun MetaDetailsContent(
     var pendingRestoreCollectionItemId by rememberSaveable { mutableStateOf<String?>(null) }
     var pendingRestoreCompanyId by rememberSaveable { mutableStateOf<Int?>(null) }
     var restoreFocusToken by rememberSaveable { mutableIntStateOf(0) }
+    var companyRestoreToken by rememberSaveable { mutableIntStateOf(0) }
     var initialHeroFocusRequested by rememberSaveable(meta.id) { mutableStateOf(false) }
     var showHeroPlayOptionsDialog by rememberSaveable(meta.id) { mutableStateOf(false) }
-    var initialDetailReturnFocusHandled by remember(
+    var initialDetailReturnFocusHandled by rememberSaveable(
         meta.id,
         detailReturnEpisodeFocusRequest?.season,
         detailReturnEpisodeFocusRequest?.episode
@@ -859,6 +860,7 @@ private fun MetaDetailsContent(
         pendingRestoreMoreLikeItemId = null
         pendingRestoreCollectionItemId = null
         pendingRestoreCompanyId = null
+        companyRestoreToken = 0
     }
 
     fun markHeroRestore() {
@@ -926,7 +928,11 @@ private fun MetaDetailsContent(
     ) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME && pendingRestoreType != null) {
+                android.util.Log.d("DetailFocus", "ON_RESUME: restoreFocusToken++ pendingRestoreType=$pendingRestoreType")
                 restoreFocusToken += 1
+                if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) {
+                    companyRestoreToken += 1
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -943,6 +949,7 @@ private fun MetaDetailsContent(
         episodeProgressMap,
         watchedEpisodes
     ) {
+        android.util.Log.d("DetailFocus", "ReturnEpisodeFocus LE fired: handled=$initialDetailReturnFocusHandled request=${detailReturnEpisodeFocusRequest?.season}/${detailReturnEpisodeFocusRequest?.episode} pendingRestore=$pendingRestoreType")
         if (initialDetailReturnFocusHandled) return@LaunchedEffect
         if (!isSeries) {
             initialDetailReturnFocusHandled = true
@@ -972,6 +979,7 @@ private fun MetaDetailsContent(
         initialHeroFocusRequested = true
         markEpisodeRestore(targetEpisode.id)
         if (seasons.isNotEmpty()) {
+            android.util.Log.d("DetailFocus", "ReturnEpisodeFocus: scrollToItem(2)")
             // Ensure the episodes row is composed before requesting focus on a card.
             listState.scrollToItem(2)
             delay(32)
@@ -1218,6 +1226,7 @@ private fun MetaDetailsContent(
             pendingRestoreEpisodeId == null &&
             !isTrailerPlaying
         ) {
+            android.util.Log.d("DetailFocus", "Hero auto-focus LE: requesting hero focus")
             repeat(3) {
                 if (initialHeroFocusRequested) return@repeat
                 heroPlayFocusRequester.requestFocusAfterFrames()
@@ -1416,6 +1425,7 @@ private fun MetaDetailsContent(
                         isTrailerPlaying = isTrailerPlaying,
                         playButtonFocusRequester = heroPlayFocusRequester,
                         onHeroActionFocused = {
+                            android.util.Log.d("DetailFocus", "onHeroActionFocused: scrolling to top, listState.firstVisible=${listState.firstVisibleItemIndex}")
                             if (listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0) {
                                 coroutineScope.launch {
                                     listState.animateScrollToItem(0)
@@ -1479,7 +1489,9 @@ private fun MetaDetailsContent(
                             onEpisodeFocused = { episodeId ->
                                 lastFocusedEpisodeIdBySeason[selectedSeason] = episodeId
                             },
-                            scrollToEpisodeId = if (nextToWatchScrolledSeasons[selectedSeason] != true && pendingRestoreType != RestoreTarget.EPISODE) {
+                            scrollToEpisodeId = if (lastFocusedEpisodeIdBySeason[selectedSeason] != null) {
+                                null
+                            } else if (nextToWatchScrolledSeasons[selectedSeason] != true && pendingRestoreType != RestoreTarget.EPISODE) {
                                 val ntwId = nextToWatch?.nextVideoId
                                     ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
                                 if (ntwId != null) {
@@ -1639,7 +1651,7 @@ private fun MetaDetailsContent(
                         CompanyLogosSection(
                             title = stringResource(R.string.detail_section_network),
                             companies = meta.networks,
-                            restoreCompanyId = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
+                            restoreCompanyId = if (companyRestoreToken > 0 && pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
                             restoreFocusToken = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) restoreFocusToken else 0,
                             onRestoreFocusHandled = { clearPendingRestore() },
                             onCompanyClick = { company ->
@@ -1657,7 +1669,7 @@ private fun MetaDetailsContent(
                         CompanyLogosSection(
                             title = stringResource(R.string.detail_section_production),
                             companies = meta.productionCompanies,
-                            restoreCompanyId = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
+                            restoreCompanyId = if (companyRestoreToken > 0 && pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
                             restoreFocusToken = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) restoreFocusToken else 0,
                             onRestoreFocusHandled = { clearPendingRestore() },
                             onCompanyClick = { company ->
@@ -1675,7 +1687,7 @@ private fun MetaDetailsContent(
                         CompanyLogosSection(
                             title = stringResource(R.string.detail_section_production),
                             companies = meta.productionCompanies,
-                            restoreCompanyId = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
+                            restoreCompanyId = if (companyRestoreToken > 0 && pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
                             restoreFocusToken = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) restoreFocusToken else 0,
                             onRestoreFocusHandled = { clearPendingRestore() },
                             onCompanyClick = { company ->
@@ -1693,7 +1705,7 @@ private fun MetaDetailsContent(
                         CompanyLogosSection(
                             title = stringResource(R.string.detail_section_network),
                             companies = meta.networks,
-                            restoreCompanyId = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
+                            restoreCompanyId = if (companyRestoreToken > 0 && pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) pendingRestoreCompanyId else null,
                             restoreFocusToken = if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) restoreFocusToken else 0,
                             onRestoreFocusHandled = { clearPendingRestore() },
                             onCompanyClick = { company ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1097,7 +1097,7 @@ class MetaDetailsViewModel @Inject constructor(
         }
 
         // Store TMDB rating separately so it can be shown with its own icon on the details screen.
-        if (enrichment?.rating != null) {
+        if (enrichment?.rating != null && settings.useBasicInfo) {
             _uiState.update { it.copy(tmdbRating = enrichment.rating.toFloat()) }
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -87,6 +87,7 @@ fun DiscoverScreen(
                 firstItemFocusRequester = discoverFirstItemFocusRequester,
                 focusedItemIndex = discoverFocusedItemIndex,
                 shouldRestoreFocusedItem = restoreDiscoverFocus,
+                blockFilterFocus = restoreDiscoverFocus || pendingDiscoverRestoreOnResume,
                 onRestoreFocusedItemHandled = { restoreDiscoverFocus = false },
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
                     pendingDiscoverRestoreOnResume = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -77,6 +78,7 @@ internal fun DiscoverSection(
     firstItemFocusRequester: FocusRequester,
     focusedItemIndex: Int,
     shouldRestoreFocusedItem: Boolean,
+    blockFilterFocus: Boolean = false,
     onRestoreFocusedItemHandled: () -> Unit,
     onNavigateToDetail: (String, String, String) -> Unit,
     onDiscoverItemFocused: (Int) -> Unit,
@@ -129,7 +131,8 @@ internal fun DiscoverSection(
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             DiscoverDropdownPicker(
-                modifier = Modifier.weight(1f).focusRequester(filterFocusRequester),
+                modifier = Modifier.weight(1f)
+                    .focusRequester(filterFocusRequester),
                 title = stringResource(R.string.discover_filter_type),
                 value = selectedTypeLabel,
                 selectedValue = uiState.selectedDiscoverType,
@@ -144,7 +147,8 @@ internal fun DiscoverSection(
                 onSelect = { option ->
                     onSelectType(option.value)
                     expandedPicker = null
-                }
+                },
+                blockFocus = blockFilterFocus
             )
 
             DiscoverDropdownPicker(
@@ -160,7 +164,8 @@ internal fun DiscoverSection(
                 onSelect = { option ->
                     onSelectCatalog(option.value)
                     expandedPicker = null
-                }
+                },
+                blockFocus = blockFilterFocus
             )
 
             DiscoverDropdownPicker(
@@ -179,7 +184,8 @@ internal fun DiscoverSection(
                 onSelect = { option ->
                     onSelectGenre(option.value.takeUnless { it == "__default__" })
                     expandedPicker = null
-                }
+                },
+                blockFocus = blockFilterFocus
             )
         }
 
@@ -270,7 +276,8 @@ private fun DiscoverDropdownPicker(
     expanded: Boolean,
     options: List<DiscoverOption>,
     onExpandedChange: (Boolean) -> Unit,
-    onSelect: (DiscoverOption) -> Unit
+    onSelect: (DiscoverOption) -> Unit,
+    blockFocus: Boolean = false
 ) {
     var isFocused by remember { mutableStateOf(false) }
     var anchorSize by remember { mutableStateOf(IntSize.Zero) }
@@ -284,7 +291,11 @@ private fun DiscoverDropdownPicker(
                 .onSizeChanged { anchorSize = it }
                 .onFocusChanged { state ->
                     isFocused = state.isFocused
-                },
+                }
+                .then(
+                    if (blockFocus) Modifier.focusProperties { canFocus = false }
+                    else Modifier
+                ),
             shape = CardDefaults.shape(shape = RoundedCornerShape(14.dp)),
             colors = CardDefaults.colors(
                 containerColor = NuvioColors.BackgroundCard,
@@ -406,6 +417,7 @@ private data class DiscoverOption(
     val value: String
 )
 
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 internal fun DiscoverGrid(
     items: List<MetaPreview>,
@@ -429,9 +441,13 @@ internal fun DiscoverGrid(
     val gridState = rememberLazyGridState()
     var pendingFocusOnNewItemIndex by remember { mutableStateOf<Int?>(null) }
 
-    // Scroll to top when the filter combination changes.
+    // Scroll to top only when the filter combination actually changes (not on initial composition / back navigation).
+    var previousFilterKey by remember { mutableStateOf(filterKey) }
     LaunchedEffect(filterKey) {
-        gridState.scrollToItem(0, 0)
+        if (filterKey != previousFilterKey) {
+            gridState.scrollToItem(0, 0)
+            previousFilterKey = filterKey
+        }
     }
     var localRestoreFocusedItemIndex by remember { mutableStateOf(-1) }
     var localShouldRestoreFocusedItem by remember { mutableStateOf(false) }
@@ -504,10 +520,19 @@ internal fun DiscoverGrid(
         }
     }
 
+    // Per-item FocusRequesters for focusRestorer on the grid.
+    // Pre-create the requester for the focused item so focusRestorer can use it
+    // even before the grid items are composed (first return from navigation).
+    val itemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
+    val focusedItemRequester = remember(focusedItemIndex) {
+        itemFocusRequesters.getOrPut(focusedItemIndex) { FocusRequester() }
+    }
+
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Adaptive(minSize = adaptiveStyle.width),
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize()
+            .focusRestorer { focusedItemRequester },
         contentPadding = PaddingValues(bottom = 32.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -517,10 +542,11 @@ internal fun DiscoverGrid(
             key = { index, item -> item.id.ifEmpty { "discover_$index" } },
             contentType = { _, _ -> "content_card" }
         ) { index, item ->
+            val itemFocusReq = remember(index) { itemFocusRequesters.getOrPut(index) { FocusRequester() } }
             val focusReq = when {
                 effectiveShouldRestoreFocusedItem && index == effectiveFocusedItemIndex -> restoreFocusRequester
                 focusResults && index == 0 -> firstItemFocusRequester
-                else -> null
+                else -> itemFocusReq
             }
             GridContentCard(
                 item = item,
@@ -532,7 +558,9 @@ internal fun DiscoverGrid(
                 },
                 modifier = Modifier.width(adaptiveStyle.width),
                 focusRequester = focusReq,
-                onFocused = { onItemFocused(index) }
+                onFocused = {
+                    onItemFocused(index)
+                }
             )
         }
 


### PR DESCRIPTION
## Summary

Multiple bug fixes for 0.6.4:
- Fix Discovery scroll-to-top when returning from details (filter state preserved)
- Fix Discovery focus jumping to filters instead of staying on poster when returning from details
- Fix Discovery focus restoring to first item in row instead of the exact item
- Gate TMDB rating display behind "basic information" setting
- Fix black screen when opening collection folders with "follow home" layout in modern home
- Fix episode list scrolling to beginning when returning from streams (first season, unwatched series)
- Fix focus restoring to episodes instead of cast/network/production section after returning from person/entity screen
- Fix `initialDetailReturnFocusHandled` being lost on navigation (changed from `remember` to `rememberSaveable`)
- Fix premature `clearPendingRestore` for company/network sections triggering false restore before ON_RESUME

## PR type

- Bug fix

## Why

Several regressions introduced in 0.6.4, including focus management bugs from commit 1790961a and missing guards on TMDB data display. Collection folders in modern home were showing black screen due to missing `modernHomePresentation` build in `FolderDetailViewModel`.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual testing on Android TV device:
- Discovery: navigate to detail and back - scroll position and focus preserved on correct poster
- Discovery: filter changes still scroll to top correctly
- Details: open unwatched series S01, scroll to episode 6, enter streams, back - episode list stays in place
- Details: click cast member, back - focus returns to cast member
- Details: click network/production company, back - focus returns to correct company
- Details: TMDB rating hidden when "basic information" setting is off
- Collections: open folder with "follow home" layout in modern home - content renders correctly

## Screenshots / Video (UI changes only)

no visual changes.

## Breaking changes

Nothing should break

## Linked issues

Reported on Reddit and Discord
