### PR TITLE
Perf profile manager io

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -84,8 +85,8 @@ class ProfileManager @Inject constructor(
         return true
     }
 
-    private suspend fun deleteProfileDataAsync(profileId: Int) {
-        if (profileId == 1) return
+    private suspend fun deleteProfileDataAsync(profileId: Int) = withContext(Dispatchers.IO) {
+        if (profileId == 1) return@withContext
 
         factory.clearProfile(profileId)
 


### PR DESCRIPTION
## Summary

Moved blocking `java.io.File` API calls in `deleteProfileDataAsync` from the caller's context to `Dispatchers.IO` using `withContext(Dispatchers.IO)`.

## PR type

- Small maintenance improvement

## Why

deleteProfileDataAsync` was performing synchronous file deletions and directory recursion. Since it's a `suspend` function, calling it from the Main thread (common in ViewModels) would block the UI, leading to frame drops during profile deletion. This change ensures the function is safer for users.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**


## Testing

Tested deleting a profile in debug build

## Screenshots / Video (UI changes only)

No UI changes visible

## Breaking changes

Nothing is broken from my testing

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1476
