### PR TITLE
Fix unused imports modernsidebar

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,11 +31,6 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin


### PR DESCRIPTION
## Summary

Removed unused imports from 'ModernSidebarBlurPanel.kt':
- androidx.compose.foundation.interaction.MutableInteractionSource
- androidx.compose.foundation.focusable
- androidx.compose.ui.input.key.KeyEventType
- androidx.compose.ui.input.key.onPreviewKeyEvent
- androidx.compose.ui.input.key.type
- androidx.compose.ui.input.key.Key
- androidx.compose.ui.input.key.key

## PR type

- Small maintenance improvement


## Why

Improving code maintainability and readability by cleaning up dead code references.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the **approved** feature request issue below.


## Testing

No change to feature upon testing

## Screenshots / Video (UI changes only)

Nothing changed in UI

## Breaking changes

Nothing broken in UI or from testing

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1478
