### PR TITLE
fix: wait for resolved profile before rendering home

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import java.io.File
 import javax.inject.Inject
@@ -25,6 +26,10 @@ class ProfileManager @Inject constructor(
 
     val activeProfileId: StateFlow<Int> = profileDataStore.activeProfileId
         .stateIn(scope, SharingStarted.Eagerly, 1)
+
+    val activeProfileReady: StateFlow<Boolean> = profileDataStore.activeProfileId
+        .map { true }
+        .stateIn(scope, SharingStarted.Eagerly, false)
 
     val profiles: StateFlow<List<UserProfile>> = profileDataStore.profilesList
         .stateIn(scope, SharingStarted.Eagerly, listOf(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -93,6 +93,10 @@ fun HomeScreen(
     val hasCatalogContent = uiState.catalogRows.any { it.items.isNotEmpty() }
     val hasCollectionContent = uiState.homeRows.any { it is HomeRow.CollectionRow }
     val hasHeroContent = uiState.heroItems.isNotEmpty()
+    val modernPresentationReady =
+        uiState.homeLayout != HomeLayout.MODERN ||
+            uiState.modernHomePresentation.rows.isNotEmpty() ||
+            (uiState.heroSectionEnabled && hasHeroContent && !hasCatalogContent && !hasCollectionContent)
     var showHomeContentWithAnimation by rememberSaveable { mutableStateOf(false) }
     var hasShownInitialHomeContent by rememberSaveable { mutableStateOf(false) }
     // Once we've shown stable home content, never go back to loading gate.
@@ -118,7 +122,14 @@ fun HomeScreen(
         { item, addonBaseUrl -> posterOptionsTarget = HomePosterOptionsTarget(item, addonBaseUrl) }
     }
 
-    LaunchedEffect(uiState.isLoading, hasCatalogContent, hasCollectionContent, hasHeroContent, initialCwResolved) {
+    LaunchedEffect(
+        uiState.isLoading,
+        hasCatalogContent,
+        hasCollectionContent,
+        hasHeroContent,
+        initialCwResolved,
+        modernPresentationReady
+    ) {
         // Track that addons are known (even if isLoading flipped too fast to catch).
         if (uiState.installedAddonsCount > 0) {
             catalogLoadingStarted = true
@@ -129,6 +140,7 @@ fun HomeScreen(
             catalogLoadingStarted &&
             !uiState.isLoading &&
             initialCwResolved &&
+            modernPresentationReady &&
             // When addons are installed, require at least one catalog row.
             (hasCatalogContent || uiState.installedAddonsCount == 0)
         ) {
@@ -172,6 +184,15 @@ fun HomeScreen(
             hasCollectionContent
 
         when {
+            !uiState.layoutPreferencesReady -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LoadingIndicator()
+                }
+            }
+
             uiState.isLoading && !hasAnyContent -> {
                 Box(
                     modifier = Modifier.fillMaxSize(),
@@ -254,6 +275,13 @@ fun HomeScreen(
                 // On first launch, wait for stable content before revealing home.
                 // Once released, never go back to loading (homeStableGateReleased is rememberSaveable).
                 if (!homeStableGateReleased) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        LoadingIndicator()
+                    }
+                } else if (!modernPresentationReady) {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -16,6 +16,7 @@ data class HomeUiState(
     val catalogRows: List<CatalogRow> = emptyList(),
     val continueWatchingItems: List<ContinueWatchingItem> = emptyList(),
     val isLoading: Boolean = true,
+    val layoutPreferencesReady: Boolean = false,
     val error: String? = null,
     val selectedItemId: String? = null,
     val installedAddonsCount: Int = 0,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -192,25 +192,27 @@ class HomeViewModel @Inject constructor(
         get() = trailerPreviewAudioUrlsState
 
     init {
-        watchedSeriesStateHolder.loadFromDisk()
-        observeLayoutPreferences()
-        observeModernHomePresentation()
-        observeExternalMetaPrefetchPreference()
-        loadHomeCatalogOrderPreference()
-        loadDisabledHomeCatalogPreference()
-        loadCustomCatalogTitles()
-        observeLibraryState()
-        observeTmdbSettings()
-        observeMdbListSettings()
-        observeBlurUnwatchedEpisodes()
-        observeMemoryOnlyVerticalScroll()
         observeStartupAuthNotice()
-        observeProgressSourceChanges()
-        loadContinueWatching()
-        observeCollections()
-        observeInstalledAddons()
-        // Clear CW state when profile changes so items don't leak between profiles.
         viewModelScope.launch {
+            profileManager.activeProfileReady.first { it }
+            watchedSeriesStateHolder.loadFromDisk()
+            observeLayoutPreferences()
+            observeModernHomePresentation()
+            observeExternalMetaPrefetchPreference()
+            loadHomeCatalogOrderPreference()
+            loadDisabledHomeCatalogPreference()
+            loadCustomCatalogTitles()
+            observeLibraryState()
+            observeTmdbSettings()
+            observeMdbListSettings()
+            observeBlurUnwatchedEpisodes()
+            observeMemoryOnlyVerticalScroll()
+            observeProgressSourceChanges()
+            loadContinueWatching()
+            observeCollections()
+            observeInstalledAddons()
+
+            // Clear CW state when profile changes so items don't leak between profiles.
             var previousProfileId = profileManager.activeProfileId.value
             profileManager.activeProfileId.collect { newId ->
                 if (newId != previousProfileId) {
@@ -227,7 +229,12 @@ class HomeViewModel @Inject constructor(
                     cwLastProcessedNextUpContentIds.clear()
                     cwEnrichedNextUpOverlay.clear()
                     cwEnrichedInProgressOverlay.clear()
-                    _uiState.update { it.copy(continueWatchingItems = emptyList()) }
+                    _uiState.update {
+                        it.copy(
+                            continueWatchingItems = emptyList(),
+                            layoutPreferencesReady = false
+                        )
+                    }
                     loadContinueWatching()
                     // Clear watched badges so they don't leak between profiles.
                     watchedSeriesStateHolder.update(emptySet())

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -188,6 +188,7 @@ internal fun HomeViewModel.observeLayoutPreferencesPipeline() {
                 }
                 _uiState.update {
                     it.copy(
+                        layoutPreferencesReady = true,
                         homeLayout = prefs.layout,
                         heroCatalogKeys = prefs.heroCatalogKeys,
                         heroSectionEnabled = prefs.heroSectionEnabled,


### PR DESCRIPTION
## Summary

That does not just create a visual flash. Even when the wrong layout is not visibly shown, the app still does work for two layouts in sequence in the background: first for the temporary layout, then again for the actual resolved layout. This adds unnecessary startup cost and slows down initial app launch.

- Prevents Home from briefly rendering the wrong layout during cold start.
- Waits for the active profile and layout preferences to resolve before Home content is allowed to render.
- Avoids doing startup work twice when Modern Home is selected.

## PR type

- Bug fix

## Why

When Modern Home is selected, the app can briefly render another layout first during cold start. This happens because Home starts building UI from a temporary default profile/layout before the real active profile is loaded from datastore.

That does not just create a visual flash. It also adds unnecessary startup cost because the app begins work for the wrong layout first, then repeats layout-dependent work again once the real profile and preferences arrive.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Ran `./gradlew :app:compileDebugKotlin`
- Manually verified the Home startup flow to ensure Home waits for resolved profile/layout state before rendering.
- Confirmed the incorrect temporary layout is no longer shown first when Modern Home is selected.

## Screenshots / Video (UI changes only)

- Problem 

https://github.com/user-attachments/assets/7fe90289-3150-4795-ac83-597aeeba5f9b


## Breaking changes

- None

## Linked issues

- None
