### PR TITLE
fix: persist subtitle delay + harden Trakt device auth

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
@@ -25,6 +25,9 @@ class TrackPreferenceDataStore @Inject constructor(
         private const val AUDIO_LANG = "audio_lang"
         private const val AUDIO_NAME = "audio_name"
         private const val AUDIO_TRACK_ID = "audio_track_id"
+        // Keyed per-videoId (not per-contentId) so that a delay calibrated for
+        // one episode is not blindly reapplied to the next episode where it is
+        // almost certainly wrong.
         private const val SUB_DELAY_MS = "sub_delay_ms"
     }
 
@@ -33,8 +36,8 @@ class TrackPreferenceDataStore @Inject constructor(
     private fun key(field: String, contentId: String) =
         stringPreferencesKey("$field|$contentId")
 
-    private fun intKey(field: String, contentId: String) =
-        intPreferencesKey("$field|$contentId")
+    private fun intKey(field: String, id: String) =
+        intPreferencesKey("$field|$id")
 
     suspend fun save(contentId: String, pref: PersistedTrackPreference) {
         store().edit { prefs ->
@@ -52,9 +55,6 @@ class TrackPreferenceDataStore @Inject constructor(
             set(AUDIO_LANG, pref.audioLanguage)
             set(AUDIO_NAME, pref.audioName)
             set(AUDIO_TRACK_ID, pref.audioTrackId)
-            val delayKey = intKey(SUB_DELAY_MS, contentId)
-            val delay = pref.subtitleDelayMs
-            if (delay != null && delay != 0) prefs[delayKey] = delay else prefs.remove(delayKey)
         }
     }
 
@@ -64,13 +64,11 @@ class TrackPreferenceDataStore @Inject constructor(
         val audioLang = prefs[key(AUDIO_LANG, contentId)]
         val audioName = prefs[key(AUDIO_NAME, contentId)]
         val audioTrackId = prefs[key(AUDIO_TRACK_ID, contentId)]
-        val subtitleDelayMs = prefs[intKey(SUB_DELAY_MS, contentId)]
         if (
             subType == null &&
             audioLang == null &&
             audioName == null &&
-            audioTrackId == null &&
-            subtitleDelayMs == null
+            audioTrackId == null
         ) return null
         return PersistedTrackPreference(
             subtitleType = subType,
@@ -82,9 +80,26 @@ class TrackPreferenceDataStore @Inject constructor(
             addonSubtitleAddonName = prefs[key(SUB_ADDON_NAME, contentId)],
             audioLanguage = audioLang,
             audioName = audioName,
-            audioTrackId = audioTrackId,
-            subtitleDelayMs = subtitleDelayMs
+            audioTrackId = audioTrackId
         )
+    }
+
+    /**
+     * Subtitle delay is persisted separately from audio/subtitle track selection
+     * because it has different locality: tracks sensibly apply to every episode
+     * of a series (same preferred language), but a delay calibrated against one
+     * release/encode rarely transfers to the next episode. Keying by videoId
+     * scopes the delay to exactly the video it was synced against. See #1063.
+     */
+    suspend fun saveSubtitleDelayMs(videoId: String, delayMs: Int?) {
+        store().edit { prefs ->
+            val k = intKey(SUB_DELAY_MS, videoId)
+            if (delayMs != null && delayMs != 0) prefs[k] = delayMs else prefs.remove(k)
+        }
+    }
+
+    suspend fun loadSubtitleDelayMs(videoId: String): Int? {
+        return store().data.first()[intKey(SUB_DELAY_MS, videoId)]
     }
 }
 
@@ -98,8 +113,7 @@ data class PersistedTrackPreference(
     val addonSubtitleAddonName: String?,
     val audioLanguage: String?,
     val audioName: String?,
-    val audioTrackId: String?,
-    val subtitleDelayMs: Int? = null
+    val audioTrackId: String?
 )
 
 internal fun PersistedTrackPreference.toTrackPreference(): com.nuvio.tv.ui.screens.player.PlayerRuntimeController.TrackPreference? {

--- a/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.local
 
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
 import kotlinx.coroutines.flow.first
@@ -24,12 +25,16 @@ class TrackPreferenceDataStore @Inject constructor(
         private const val AUDIO_LANG = "audio_lang"
         private const val AUDIO_NAME = "audio_name"
         private const val AUDIO_TRACK_ID = "audio_track_id"
+        private const val SUB_DELAY_MS = "sub_delay_ms"
     }
 
     private fun store() = factory.get(profileManager.activeProfileId.value, FEATURE)
 
     private fun key(field: String, contentId: String) =
         stringPreferencesKey("$field|$contentId")
+
+    private fun intKey(field: String, contentId: String) =
+        intPreferencesKey("$field|$contentId")
 
     suspend fun save(contentId: String, pref: PersistedTrackPreference) {
         store().edit { prefs ->
@@ -47,6 +52,9 @@ class TrackPreferenceDataStore @Inject constructor(
             set(AUDIO_LANG, pref.audioLanguage)
             set(AUDIO_NAME, pref.audioName)
             set(AUDIO_TRACK_ID, pref.audioTrackId)
+            val delayKey = intKey(SUB_DELAY_MS, contentId)
+            val delay = pref.subtitleDelayMs
+            if (delay != null && delay != 0) prefs[delayKey] = delay else prefs.remove(delayKey)
         }
     }
 
@@ -56,7 +64,14 @@ class TrackPreferenceDataStore @Inject constructor(
         val audioLang = prefs[key(AUDIO_LANG, contentId)]
         val audioName = prefs[key(AUDIO_NAME, contentId)]
         val audioTrackId = prefs[key(AUDIO_TRACK_ID, contentId)]
-        if (subType == null && audioLang == null && audioName == null && audioTrackId == null) return null
+        val subtitleDelayMs = prefs[intKey(SUB_DELAY_MS, contentId)]
+        if (
+            subType == null &&
+            audioLang == null &&
+            audioName == null &&
+            audioTrackId == null &&
+            subtitleDelayMs == null
+        ) return null
         return PersistedTrackPreference(
             subtitleType = subType,
             subtitleLanguage = prefs[key(SUB_LANG, contentId)],
@@ -67,7 +82,8 @@ class TrackPreferenceDataStore @Inject constructor(
             addonSubtitleAddonName = prefs[key(SUB_ADDON_NAME, contentId)],
             audioLanguage = audioLang,
             audioName = audioName,
-            audioTrackId = audioTrackId
+            audioTrackId = audioTrackId,
+            subtitleDelayMs = subtitleDelayMs
         )
     }
 }
@@ -82,7 +98,8 @@ data class PersistedTrackPreference(
     val addonSubtitleAddonName: String?,
     val audioLanguage: String?,
     val audioName: String?,
-    val audioTrackId: String?
+    val audioTrackId: String?,
+    val subtitleDelayMs: Int? = null
 )
 
 internal fun PersistedTrackPreference.toTrackPreference(): com.nuvio.tv.ui.screens.player.PlayerRuntimeController.TrackPreference? {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
@@ -124,12 +124,54 @@ class TraktAuthService @Inject constructor(
             return Result.failure(IllegalStateException("Missing TRAKT credentials"))
         }
 
-        val response = try {
+        // Reuse an existing, still-valid device flow if one is already active.
+        // This avoids re-hitting /oauth/device/code (which is tightly rate-limited
+        // by Trakt) when the user navigates back to the login screen or taps the
+        // Connect button twice in a row — see issue #1197.
+        val state = getCurrentAuthState()
+        val existingExpiresAt = state.expiresAt
+        val existingCode = state.deviceCode
+        if (
+            !existingCode.isNullOrBlank() &&
+            existingExpiresAt != null &&
+            System.currentTimeMillis() < existingExpiresAt
+        ) {
+            return Result.success(
+                TraktDeviceCodeResponseDto(
+                    deviceCode = existingCode,
+                    userCode = state.userCode.orEmpty(),
+                    verificationUrl = state.verificationUrl.orEmpty(),
+                    expiresIn = ((existingExpiresAt - System.currentTimeMillis()) / 1000L)
+                        .coerceAtLeast(0L)
+                        .toInt(),
+                    interval = state.pollInterval ?: 5
+                )
+            )
+        }
+
+        // Issue a request, auto-retrying once on a transient 429 using the
+        // Retry-After header when the server supplies a short back-off.
+        suspend fun requestOnce(): Response<TraktDeviceCodeResponseDto> =
             traktApi.requestDeviceCode(
                 TraktDeviceCodeRequestDto(clientId = BuildConfig.TRAKT_CLIENT_ID)
             )
+
+        var response = try {
+            requestOnce()
         } catch (e: IOException) {
             return Result.failure(IllegalStateException("Network error, please try again"))
+        }
+
+        if (response.code() == 429) {
+            val retryAfterSeconds = response.headers()["Retry-After"]?.toLongOrNull()
+            if (retryAfterSeconds != null && retryAfterSeconds in 1L..10L) {
+                delay(retryAfterSeconds * 1000L)
+                response = try {
+                    requestOnce()
+                } catch (e: IOException) {
+                    return Result.failure(IllegalStateException("Network error, please try again"))
+                }
+            }
         }
 
         val body = response.body()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -450,7 +450,9 @@ internal fun PlayerRuntimeController.adjustSubtitleDelay(deltaMs: Int, showOverl
             .buildUpon()
             .build()
     }
-    
+    // Remember the delay so it survives to the next session (issue #1063).
+    persistTrackPreference()
+
     if (!showOverlay || keepInlineInSubtitleOverlay) {
         hideSubtitleDelayOverlayJob?.cancel()
         hideSubtitleDelayOverlayJob = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -22,27 +22,34 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
         refreshScrobbleItem()
         if (persistedTrackPreference == null) {
             contentId?.let { id ->
-                val loadedRaw = trackPreferenceDataStore.load(id)
-                val loaded = loadedRaw?.toTrackPreference()
+                val loaded = trackPreferenceDataStore.load(id)?.toTrackPreference()
                 logSwitchTrace(
                     stage = "track-pref-load",
                     message = "contentId=$id loadedAudio=${loaded?.audio?.language}/${loaded?.audio?.name} " +
-                        "loadedSubtitle=${loaded?.subtitle?.javaClass?.simpleName ?: "none"} " +
-                        "loadedSubtitleDelayMs=${loadedRaw?.subtitleDelayMs}"
+                        "loadedSubtitle=${loaded?.subtitle?.javaClass?.simpleName ?: "none"}"
                 )
                 Log.d(
                     PlayerRuntimeController.TAG,
                     "TRACK_PREF load: contentId=$id S${currentSeason}E${currentEpisode} " +
-                        "result=${if (loadedRaw == null) "null (no saved preference)" else "audio=${loaded?.audio?.language}/${loaded?.audio?.name} subtitle=${loaded?.subtitle?.javaClass?.simpleName} subtitleDelayMs=${loadedRaw.subtitleDelayMs}"}"
+                        "result=${if (loaded == null) "null (no saved preference)" else "audio=${loaded.audio?.language}/${loaded.audio?.name} subtitle=${loaded.subtitle?.javaClass?.simpleName}"}"
                 )
                 persistedTrackPreference = loaded
-                // Apply persisted subtitle delay BEFORE initializePlayer — the
-                // renderers factory snapshots subtitleDelayUs from this value.
-                loadedRaw?.subtitleDelayMs?.takeIf { it != 0 }?.let { delayMs ->
-                    subtitleDelayUs.set(delayMs.toLong() * 1000L)
-                    _uiState.update { it.copy(subtitleDelayMs = delayMs) }
-                }
             } ?: Log.d(PlayerRuntimeController.TAG, "TRACK_PREF load: skipped (contentId is null)")
+            // Subtitle delay is keyed per-videoId, so it is loaded separately
+            // from the track selection above. This happens before
+            // initializePlayer() because the renderers factory snapshots
+            // subtitleDelayUs from _uiState.value.subtitleDelayMs on build.
+            currentVideoId?.takeIf { it.isNotBlank() }?.let { vid ->
+                val savedDelayMs = trackPreferenceDataStore.loadSubtitleDelayMs(vid)
+                if (savedDelayMs != null && savedDelayMs != 0) {
+                    subtitleDelayUs.set(savedDelayMs.toLong() * 1000L)
+                    _uiState.update { it.copy(subtitleDelayMs = savedDelayMs) }
+                    Log.d(
+                        PlayerRuntimeController.TAG,
+                        "TRACK_PREF load: restored subtitleDelayMs=$savedDelayMs for videoId=$vid"
+                    )
+                }
+            }
         } else {
             Log.d(
                 PlayerRuntimeController.TAG,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import com.nuvio.tv.data.local.toTrackPreference
 
@@ -21,18 +22,26 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
         refreshScrobbleItem()
         if (persistedTrackPreference == null) {
             contentId?.let { id ->
-                val loaded = trackPreferenceDataStore.load(id)?.toTrackPreference()
+                val loadedRaw = trackPreferenceDataStore.load(id)
+                val loaded = loadedRaw?.toTrackPreference()
                 logSwitchTrace(
                     stage = "track-pref-load",
                     message = "contentId=$id loadedAudio=${loaded?.audio?.language}/${loaded?.audio?.name} " +
-                        "loadedSubtitle=${loaded?.subtitle?.javaClass?.simpleName ?: "none"}"
+                        "loadedSubtitle=${loaded?.subtitle?.javaClass?.simpleName ?: "none"} " +
+                        "loadedSubtitleDelayMs=${loadedRaw?.subtitleDelayMs}"
                 )
                 Log.d(
                     PlayerRuntimeController.TAG,
                     "TRACK_PREF load: contentId=$id S${currentSeason}E${currentEpisode} " +
-                        "result=${if (loaded == null) "null (no saved preference)" else "audio=${loaded.audio?.language}/${loaded.audio?.name} subtitle=${loaded.subtitle?.javaClass?.simpleName}"}"
+                        "result=${if (loadedRaw == null) "null (no saved preference)" else "audio=${loaded?.audio?.language}/${loaded?.audio?.name} subtitle=${loaded?.subtitle?.javaClass?.simpleName} subtitleDelayMs=${loadedRaw.subtitleDelayMs}"}"
                 )
                 persistedTrackPreference = loaded
+                // Apply persisted subtitle delay BEFORE initializePlayer — the
+                // renderers factory snapshots subtitleDelayUs from this value.
+                loadedRaw?.subtitleDelayMs?.takeIf { it != 0 }?.let { delayMs ->
+                    subtitleDelayUs.set(delayMs.toLong() * 1000L)
+                    _uiState.update { it.copy(subtitleDelayMs = delayMs) }
+                }
             } ?: Log.d(PlayerRuntimeController.TAG, "TRACK_PREF load: skipped (contentId is null)")
         } else {
             Log.d(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
@@ -76,6 +76,8 @@ internal fun PlayerRuntimeController.applySubtitleAutoSyncCue(cueStartTimeMs: Lo
             subtitleAutoSyncError = null
         )
     }
+    // Remember the delay so it survives to the next session (issue #1063).
+    persistTrackPreference()
     refreshActiveSubtitleTrackAfterTimingChange()
     scheduleHideSubtitleDelayOverlay()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -580,14 +580,13 @@ private fun PlayerRuntimeController.currentTrackPreferenceForPersistence(): Play
 internal fun PlayerRuntimeController.persistTrackPreference() {
     val id = contentId ?: return
     // Use the currently-effective preference (remembered OR previously persisted)
-    // so that a delay-only change doesn't wipe a previously-saved track selection.
+    // so that a delay-only change does not wipe a previously-saved track selection.
     // For the resume-from-CW case, rememberedTrackPreference is null for the fresh
-    // session — falling through to persistedTrackPreference preserves the user's
-    // earlier audio/subtitle choices. See issue #1063 (and thanks Copilot).
+    // session, and falling through to persistedTrackPreference preserves the user's
+    // earlier audio/subtitle choices. See issue #1063.
     val pref = currentTrackPreferenceForPersistence()
     val audio = pref.audio
     val subtitle = pref.subtitle
-    val currentDelayMs = _uiState.value.subtitleDelayMs
     val persisted = com.nuvio.tv.data.local.PersistedTrackPreference(
         subtitleType = when (subtitle) {
             is PlayerRuntimeController.RememberedSubtitleSelection.Internal -> "INTERNAL"
@@ -607,10 +606,20 @@ internal fun PlayerRuntimeController.persistTrackPreference() {
         addonSubtitleAddonName = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Addon)?.addonName,
         audioLanguage = audio?.language,
         audioName = audio?.name,
-        audioTrackId = audio?.trackId,
-        subtitleDelayMs = currentDelayMs.takeIf { it != 0 }
+        audioTrackId = audio?.trackId
     )
     scope.launch { trackPreferenceDataStore.save(id, persisted) }
+    // Subtitle delay is keyed per-videoId (not per-contentId) because a delay
+    // calibrated against one episode release rarely applies to the next
+    // episode. Scoping it to the exact video prevents cross-episode leakage.
+    // See issue #1063 discussion.
+    val vid = currentVideoId?.takeIf { it.isNotBlank() }
+    if (vid != null) {
+        val currentDelayMs = _uiState.value.subtitleDelayMs
+        scope.launch {
+            trackPreferenceDataStore.saveSubtitleDelayMs(vid, currentDelayMs.takeIf { it != 0 })
+        }
+    }
 }
 
 internal fun PlayerRuntimeController.captureCurrentAudioSelectionForSubtitleRefresh(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -579,10 +579,12 @@ private fun PlayerRuntimeController.currentTrackPreferenceForPersistence(): Play
 
 internal fun PlayerRuntimeController.persistTrackPreference() {
     val id = contentId ?: return
-    // Use an empty preference when only the subtitle delay has changed (no track
-    // has been explicitly selected yet). Without this we'd early-return and the
-    // delay would never be persisted — see issue #1063.
-    val pref = rememberedTrackPreference ?: PlayerRuntimeController.TrackPreference()
+    // Use the currently-effective preference (remembered OR previously persisted)
+    // so that a delay-only change doesn't wipe a previously-saved track selection.
+    // For the resume-from-CW case, rememberedTrackPreference is null for the fresh
+    // session — falling through to persistedTrackPreference preserves the user's
+    // earlier audio/subtitle choices. See issue #1063 (and thanks Copilot).
+    val pref = currentTrackPreferenceForPersistence()
     val audio = pref.audio
     val subtitle = pref.subtitle
     val currentDelayMs = _uiState.value.subtitleDelayMs

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -579,9 +579,13 @@ private fun PlayerRuntimeController.currentTrackPreferenceForPersistence(): Play
 
 internal fun PlayerRuntimeController.persistTrackPreference() {
     val id = contentId ?: return
-    val pref = rememberedTrackPreference ?: return
+    // Use an empty preference when only the subtitle delay has changed (no track
+    // has been explicitly selected yet). Without this we'd early-return and the
+    // delay would never be persisted — see issue #1063.
+    val pref = rememberedTrackPreference ?: PlayerRuntimeController.TrackPreference()
     val audio = pref.audio
     val subtitle = pref.subtitle
+    val currentDelayMs = _uiState.value.subtitleDelayMs
     val persisted = com.nuvio.tv.data.local.PersistedTrackPreference(
         subtitleType = when (subtitle) {
             is PlayerRuntimeController.RememberedSubtitleSelection.Internal -> "INTERNAL"
@@ -601,7 +605,8 @@ internal fun PlayerRuntimeController.persistTrackPreference() {
         addonSubtitleAddonName = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Addon)?.addonName,
         audioLanguage = audio?.language,
         audioName = audio?.name,
-        audioTrackId = audio?.trackId
+        audioTrackId = audio?.trackId,
+        subtitleDelayMs = currentDelayMs.takeIf { it != 0 }
     )
     scope.launch { trackPreferenceDataStore.save(id, persisted) }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -167,10 +167,13 @@ class TraktViewModel @Inject constructor(
 
         // Guard against rapid re-entry — each double-tap would otherwise fire a
         // fresh /oauth/device/code request and can trip Trakt's rate limiter (#1197).
+        // Flip isLoading synchronously here, before the launch, so two main-thread
+        // clicks can't both observe isLoading == false and start parallel
+        // coroutines (thanks Copilot).
         if (_uiState.value.isLoading) return
+        _uiState.update { it.copy(isLoading = true, errorMessage = null, statusMessage = null) }
 
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, errorMessage = null, statusMessage = null) }
             val result = traktAuthService.startDeviceAuth()
             _uiState.update { state ->
                 if (result.isSuccess) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -165,6 +165,10 @@ class TraktViewModel @Inject constructor(
             return
         }
 
+        // Guard against rapid re-entry — each double-tap would otherwise fire a
+        // fresh /oauth/device/code request and can trip Trakt's rate limiter (#1197).
+        if (_uiState.value.isLoading) return
+
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null, statusMessage = null) }
             val result = traktAuthService.startDeviceAuth()


### PR DESCRIPTION
## Summary

Two independent persistence / auth bugs bundled under a shared theme: user-set state was silently thrown away between sessions or re-requested unnecessarily, causing surprising behavior on the next interaction.

- **Fixes #1063**: subtitle delay resets to `0` when resuming from Continue Watching
- **Fixes #1197**: Trakt login fails with `"Trakt is rate limiting requests"` on first connect

## PR type

- Bug fix

## Why

**#1063:** `PersistedTrackPreference` persisted subtitle type, language, name, and audio track selection but had no field for the subtitle delay offset. Once the player closed, the delay lived only in `PlayerUiState` and was lost. Users who set a `-4500ms` delay on S01E01 of a show would resume the next episode from Continue Watching and find their delay silently reset to `0`.

The delay is persisted at a finer granularity than track selection: audio/subtitle track is keyed by `contentId` (series level) because preferred language is consistent across episodes, but the delay is keyed by `videoId` (episode level) because a sync offset is tied to a specific release/encode and rarely transfers to the next episode. This avoids silently applying a stale delay to a fresh episode.

**#1197:** Two compounding problems made first-time Trakt login brittle:
1. `onConnectClick()` had no re-entry guard. Rapid taps queued multiple parallel `/oauth/device/code` requests, and Trakt's anti-abuse rate limiter treats repeated device-code requests from the same IP harshly.
2. `startDeviceAuth()` did not reuse an already-active device flow. If the user navigated away from the login screen and came back, it re-hit `/oauth/device/code` for no reason.
3. No auto-retry on transient 429 with a short `Retry-After`, even when Trakt explicitly asked us to wait a few seconds.

The device-token polling loop already honors `slow_down` per RFC 8628, so it is not touched.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

**Automated**
- `./gradlew :app:compileDebugKotlin` passes clean against latest `origin/dev` with no new warnings.

**Manual (please verify during review)**

#1063:
- Open a series episode, set subtitle delay to e.g. `-4500ms`, close the player. Reopen the same episode from Continue Watching: delay should still be `-4500ms`.
- Use the "Sync by line" auto-sync feature to compute a delay automatically: same scenario should persist.
- A delay of exactly `0ms` should NOT create a DataStore entry (the int key is only written when `delay != 0` and is removed otherwise).
- Adjusting only the subtitle delay on resume must not wipe a previously-saved audio/subtitle track selection (verified by using `currentTrackPreferenceForPersistence()` as the base).
- Start a different episode of the same series after setting a delay on the first: delay should start at `0`, not inherit the previous episode's offset.

#1197:
- On a fresh Trakt account: Settings -> Trakt -> tap **Connect** multiple times in rapid succession: no duplicate `/oauth/device/code` requests fire; the button is idempotent while `isLoading`.
- Start the device flow, navigate away from the login screen, navigate back: polling should resume against the existing device code (no new device-code request).
- If Trakt returns a transient 429 with `Retry-After <= 10s`, `startDeviceAuth()` waits that long and retries once before surfacing an error to the user.

## Screenshots / Video (UI changes only)

No new UI.

## Breaking changes

None.

- New `sub_delay_ms|<videoId>` entries in the profile-scoped track-preference DataStore. Nothing else reads this key, so missing values simply load as `null` and default to `0ms`.
- `PersistedTrackPreference` shape unchanged from what was on `dev` before this PR.

## Linked issues

Fixes #1063
Fixes #1197