### PR TITLE
fix: rethrow CancellationException in safeApiCall to prevent infinite…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/network/SafeApiCall.kt
+++ b/app/src/main/java/com/nuvio/tv/core/network/SafeApiCall.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.core.network
 
 import retrofit2.Response
+import kotlinx.coroutines.CancellationException
 
 suspend fun <T> safeApiCall(apiCall: suspend () -> Response<T>): NetworkResult<T> {
     return try {
@@ -12,6 +13,8 @@ suspend fun <T> safeApiCall(apiCall: suspend () -> Response<T>): NetworkResult<T
         } else {
             NetworkResult.Error(response.message(), response.code())
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         NetworkResult.Error(e.message ?: "Unknown error occurred")
     }


### PR DESCRIPTION
## Summary

Fixes the "Flow was aborted" error loop in `AddonRepositoryImpl` which was causing severe performance issues, UI stuttering, and logcat spam ("DefaultDispatch expire").

By explicitly catching and rethrowing `CancellationException` in `safeApiCall`, we ensure that cancelled coroutines (e.g., when the UI unmounts or state changes) do not falsely trigger a `NetworkResult.Error`. This prevents the addon sync mechanism from getting stuck in an infinite retry loop that previously starved the CPU and blocked ExoPlayer rendering threads.

## PR type

- Bug fix

## Why

The NuvioTV app was experiencing random frame drops and stuttering in ExoPlayer, along with thousands of log warnings (`DefaultDispatch expire X lines` and `Failed to fetch addon manifest`). This was traced to `AddonRepositoryImpl` aggressively fetching 20+ addon manifests in a tight loop because `CancellationException`s were swallowed, preventing the `lastManifestRefreshTime` from updating and tricking the system into thinking the cache was constantly stale.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.


## Testing

Manually tested on device/emulator. Compiled and ran the app, verified that:
1. The `DefaultDispatch expire` and `Flow was aborted` warnings are no longer spamming logcat.
2. ExoPlayer playback is smooth without CPU starvation related frame drops.
3. CPU usage has normalized.

## Screenshots / Video (UI changes only)

- None

## Breaking changes

- None

## Linked issues
[nuvio_firestick_log.txt](https://github.com/user-attachments/files/26947104/nuvio_firestick_log.txt)
