### PR TITLE
fix(detail): keep TMDB Collection tab inline with other integration tabs (refs #1488)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1968,48 +1968,32 @@ private fun PeopleSectionTabs(
 
     val defaultRequester = tabs.first().focusRequester
     val restorerRequester = tabs.firstOrNull { it.tab == activeTab }?.focusRequester ?: defaultRequester
-    val shouldSplitCollection = tabs.size > 3 && tabs.any { it.tab == PeopleSectionTab.COLLECTION }
-    val firstRowTabs = if (shouldSplitCollection) tabs.filterNot { it.tab == PeopleSectionTab.COLLECTION } else tabs
-    val secondRowTabs = if (shouldSplitCollection) tabs.filter { it.tab == PeopleSectionTab.COLLECTION } else emptyList()
 
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 20.dp, start = 48.dp, end = 48.dp)
             .focusRestorer(restorerRequester),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        @Composable
-        fun androidx.compose.foundation.layout.RowScope.renderTabs(items: List<PeopleTabItem>) {
-            items.forEachIndexed { index, item ->
-                if (index > 0) {
-                    Text(
-                        text = "|",
-                        style = MaterialTheme.typography.titleLarge,
-                        color = NuvioColors.TextPrimary.copy(alpha = 0.45f),
-                        modifier = Modifier.padding(horizontal = 10.dp)
-                    )
-                }
-
-                PeopleSectionTabButton(
-                    label = item.label,
-                    selected = activeTab == item.tab,
-                    focusRequester = item.focusRequester,
-                    upFocusRequester = upFocusRequester,
-                    downFocusRequester = if (item.tab == PeopleSectionTab.RATINGS) ratingsDownFocusRequester else null,
-                    onFocused = { onTabFocused(item.tab) }
+        tabs.forEachIndexed { index, item ->
+            if (index > 0) {
+                Text(
+                    text = "|",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = NuvioColors.TextPrimary.copy(alpha = 0.45f),
+                    modifier = Modifier.padding(horizontal = 10.dp)
                 )
             }
-        }
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            renderTabs(firstRowTabs)
-        }
-
-        if (secondRowTabs.isNotEmpty()) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                renderTabs(secondRowTabs)
-            }
+            PeopleSectionTabButton(
+                label = item.label,
+                selected = activeTab == item.tab,
+                focusRequester = item.focusRequester,
+                upFocusRequester = upFocusRequester,
+                downFocusRequester = if (item.tab == PeopleSectionTab.RATINGS) ratingsDownFocusRequester else null,
+                onFocused = { onTabFocused(item.tab) }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Puts the Collection tab back on the same row as Creator & Cast / More Like This / Trailer. Since 0.6.5 it's been rendering in a second row below, which breaks D-pad focus on Android TV — pressing DOWN from any top-row tab skips the Collection tab button and drops you straight into Collection's content.

## PR type

- Bug fix

## Why

Fixes #1488.

The culprit is `6aaa286e` ("feat: adding trailersection"). That commit restructured `PeopleSectionTabs` into a `Column` that splits the row whenever `tabs.size > 3 && COLLECTION is present`. Once Trailer became a regular tab, any movie/show with a Collection hits that condition and Collection gets pushed to its own standalone row. The new row is outside the main tab row's focus group, so D-pad DOWN skips past it.

This PR reverts `PeopleSectionTabs` to the single-Row layout it had before 0.6.5. Nothing else changes.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Opening as a **draft** because I don't have my Android TV set up locally to verify D-pad focus. What I did check:

- Compared against the pre-regression code shape from 0.6.4-beta — same structure.
- All symbols used in the revert are already imported in `MetaDetailsScreen.kt`.
- Diff is 1 file, +17/−33.

I'll mark ready-for-review once I've confirmed on device that:
1. Collection tab button sits inline with the other three.
2. D-pad DOWN from each sibling tab lands on that tab's own content.
3. Phone layout still looks fine (narrow screens rely on the parent `LazyRow` scrolling, which the revert preserves).

@mistersandman-64 — if you've got the Shield Pro handy, a quick sanity check on this would be super helpful.

## Screenshots / Video (UI changes only)

Before is documented by the screenshot on #1488 (Collection button on its own second row).
After should have all four tabs on one row.

Will drop a before/after once tested on device.

## Breaking changes

None.

## Linked issues

Refs #1488. Keeping it as `refs` rather than `fixes` until device verification.