### PR TITLE
Fix RTL subtitle punctuation placement bug for Media3 1.8.x 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -807,20 +807,22 @@ private class CueNormalizingTextOutput(
 ) : TextOutput {
 
     override fun onCues(cueGroup: CueGroup) {
-        if (!shouldNormalizeCuePositionProvider()) {
-            delegate.onCues(cueGroup)
-            return
+        val processed = cueGroup.cues.map { cue ->
+            var c = fixRtlCueText(cue)
+            if (shouldNormalizeCuePositionProvider()) c = normalizeCuePosition(c)
+            c
         }
-        delegate.onCues(CueGroup(cueGroup.cues.map(::normalizeCuePosition), cueGroup.presentationTimeUs))
+        delegate.onCues(CueGroup(processed, cueGroup.presentationTimeUs))
     }
 
     @Deprecated("Uses the deprecated Media3 callback for text outputs.")
     override fun onCues(cues: List<Cue>) {
-        if (!shouldNormalizeCuePositionProvider()) {
-            delegate.onCues(cues)
-            return
+        val processed = cues.map { cue ->
+            var c = fixRtlCueText(cue)
+            if (shouldNormalizeCuePositionProvider()) c = normalizeCuePosition(c)
+            c
         }
-        delegate.onCues(cues.map(::normalizeCuePosition))
+        delegate.onCues(processed)
     }
 
     private fun normalizeCuePosition(cue: Cue): Cue {
@@ -831,6 +833,43 @@ private class CueNormalizingTextOutput(
             .setLine(Cue.DIMEN_UNSET, Cue.TYPE_UNSET)
             .setLineAnchor(Cue.TYPE_UNSET)
             .build()
+    }
+
+    private fun fixRtlCueText(cue: Cue): Cue {
+        val text = cue.text ?: return cue
+        if (!containsRtlChars(text)) return cue
+        val original = text.toString()
+        val fixed = original.split('\n').joinToString("\n") { line ->
+            moveLeadingRtlPunctuationToEnd(line)
+        }
+        if (fixed == original) return cue
+        return cue.buildUpon().setText(android.text.SpannableString(fixed)).build()
+    }
+
+    // In RTL subtitle files punctuation is stored at the logical start of the string,
+    // which should visually appear at the right (end) in RTL. Since SubtitlePainter
+    // renders LTR, we physically move the punctuation to the end of each line.
+    private fun moveLeadingRtlPunctuationToEnd(line: String): String {
+        if (line.isEmpty()) return line
+        var end = 0
+        while (end < line.length && line[end] in RTL_PUNCTUATION) end++
+        if (end == 0) return line
+        val punct = line.substring(0, end)
+        val rest = line.substring(end)
+        return "$rest$punct"
+    }
+
+    private fun containsRtlChars(text: CharSequence): Boolean {
+        for (ch in text) {
+            val d = Character.getDirectionality(ch)
+            if (d == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
+                d == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC) return true
+        }
+        return false
+    }
+
+    companion object {
+        private val RTL_PUNCTUATION = setOf('.', ',', '?', '!', '-', ':', ';', '…', ')', '(')
     }
 }
 


### PR DESCRIPTION
## Summary

 - RTL subtitle files (Hebrew, Arabic, etc.) store punctuation at the logical start of strings, which should visually appear on the right side of the sentence                                                                                                                                                     
  - Media3 1.8.x SubtitlePainter uses the old StaticLayout constructor which ignores BiDi direction markers, causing punctuation to render on the wrong (left) side
  - Fixed by physically relocating leading punctuation to the end of each cue line when RTL characters are detected, bypassing the broken BiDi rendering entirel

## PR type
- Bug fix


## Why

The project was downgraded from Media3 1.10.x to 1.8.x. The older SubtitlePainter uses a deprecated StaticLayout constructor that ignores Unicode BiDi direction markers (\u200F), so RTL paragraph direction is never established. As a result, punctuation stored at the logical start of RTL subtitle strings  
  renders on the left side of the screen instead of the right.


## Policy check

<!-- Confirm these before requesting review -->
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

  - Enabled AI Translation toggle and verified all sub-options appear/hide correctly                                                                                                                                                
  - Confirmed toggle off hides all AI options including hearing impaired filter                                                                                                                                                     
  - Played content with English built-in subtitles — translation appeared live in Hebrew                                                                                                                                            
  - Verified AI loading badge shows during translation and disappears after                                                                                                                                                         
  - Verified success/error toast on first batch result                                                                                                                                                                              
  - Tested QR code key entry flow via phone browser                                                                                                                                                                                 
  - Tested invalid/missing API key — error toast shown, fallback to original subtitle                                                                                                                                               
  - Confirmed feature is off by default for new users

## Screenshots / Video (UI changes only)

Hebrew:
<img width="494" height="146" alt="image" src="https://github.com/user-attachments/assets/265652d6-8434-46b0-b06f-b4419b75dca8" />


English:
<img width="399" height="115" alt="image" src="https://github.com/user-attachments/assets/2d405422-b871-4142-b606-7a42d8b5e1c5" />


## Breaking changes
None.

## Linked issues
None.