### PR TITLE
fix: hoist hasSeenAuthQrOnFirstLaunch flow operator into remember

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -227,10 +227,10 @@ class MainActivity : ComponentActivity() {
             var hasSelectedProfileThisSession by rememberSaveable { mutableStateOf(false) }
             var onboardingCompletedThisSession by remember { mutableStateOf(false) }
             var onboardingProfileSyncInProgress by remember { mutableStateOf(false) }
-            val hasSeenAuthQrOnFirstLaunch by appOnboardingDataStore
-                .hasSeenAuthQrOnFirstLaunch
-                .map<Boolean, Boolean?> { it }
-                .collectAsState(initial = null)
+            val hasSeenAuthQrFlow = remember(appOnboardingDataStore) {
+                appOnboardingDataStore.hasSeenAuthQrOnFirstLaunch.map<Boolean, Boolean?> { it }
+            }
+            val hasSeenAuthQrOnFirstLaunch by hasSeenAuthQrFlow.collectAsState(initial = null)
             val authState by authManager.authState.collectAsState()
 
             LaunchedEffect(hasSeenAuthQrOnFirstLaunch, authState) {


### PR DESCRIPTION
## Summary

While working on a feature, I noticed that `appOnboardingDataStore.hasSeenAuthQrOnFirstLaunch.map<Boolean, Boolean?> { it }` was being recreated inside composition in `MainActivity.kt`. This PR moves that expression into `remember(appOnboardingDataStore)` so the resulting `Flow` keeps a stable identity across recompositions. Behavior is preserved, and the existing `Boolean?` typing is preserved.

## PR type

- Bug fix

## Why

While working in this file for a separate feature, this stood out as a recomposition stability issue worth fixing.

The `.map { it }` was being invoked directly inside composition, which allocated a fresh `Flow` on every recomposition. `collectAsState` is implemented via `produceState` keyed on the `Flow` instance, so each new key cancelled the active collection and restarted it with `initial = null` every time recomposition occurred. Effects:

- `hasSeenAuthQrOnFirstLaunch` could momentarily read `null` on recomposition.
- The downstream `LaunchedEffect(hasSeenAuthQrOnFirstLaunch, authState)` could re-key and restart its coroutine repeatedly.
- A repeated `setHasSeenAuthQrOnFirstLaunch(true)` write to DataStore was possible. It is idempotent, but still wasted I/O.

The `== false` guard inside the `LaunchedEffect` masked the worst user-visible symptom, but the root composable still paid the cost of repeated `Flow` allocation, coroutine cancel and restart, and `produceState` re-keying overhead.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A - small bug fix (4 lines changed in 1 file).

## Testing

- Matches the existing `remember(<dataStore>) { ... } / collectAsState(...)` pattern used for `mainUiPrefsFlow` in the same file.
- Manually exercised on-device on a Raspberry Pi 5 running LineageOS Android TV (`com.nuviodebug.com` debug variant): app launched, navigation worked across home -> search -> addon manager, search returned results, nothing crashed.
- The gated `LaunchedEffect` body (the `setHasSeenAuthQrOnFirstLaunch(true)` write) was not exercised end-to-end because `SUPABASE_URL` is empty in this debug environment, so `authState` never transitions to `AuthState.FullAccount`. The change is identity-only and the body is unchanged, so behavior is preserved by construction.

## Screenshots / Video (UI changes only)

N/A - no UI change.

## Breaking changes

None.

## Linked issues

None.