### PR TITLE
improve sidebar selected item UI 'lag'

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -393,8 +393,14 @@ class MainActivity : ComponentActivity() {
 
                     val startDestination = if (layoutChosen) Screen.Home.route else Screen.LayoutSelection.route
                     val navController = rememberNavController()
+                    var optimisticRoute by remember { mutableStateOf<String?>(null) }
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
-                    val currentRoute = navBackStackEntry?.destination?.route
+                    val actualRoute = navBackStackEntry?.destination?.route
+                    val currentRoute = optimisticRoute ?: actualRoute
+
+                    LaunchedEffect(actualRoute) {
+                        optimisticRoute = null
+                    }
 
                     val view = LocalView.current
                     LaunchedEffect(currentRoute) {
@@ -476,6 +482,7 @@ class MainActivity : ComponentActivity() {
                             activeProfileAvatarImageUrl = activeProfileAvatarImageUrl,
                             showProfileSelector = profiles.size > 1,
                             onSwitchProfile = { hasSelectedProfileThisSession = false },
+                            onNavigate = { optimisticRoute = it },
                             onExitApp = {
                                 finishAffinity()
                                 finishAndRemoveTask()
@@ -496,6 +503,7 @@ class MainActivity : ComponentActivity() {
                             activeProfileAvatarImageUrl = activeProfileAvatarImageUrl,
                             showProfileSelector = profiles.size > 1,
                             onSwitchProfile = { hasSelectedProfileThisSession = false },
+                            onNavigate = { optimisticRoute = it },
                             onExitApp = {
                                 finishAffinity()
                                 finishAndRemoveTask()
@@ -567,6 +575,7 @@ private fun LegacySidebarScaffold(
     activeProfileAvatarImageUrl: String?,
     showProfileSelector: Boolean,
     onSwitchProfile: () -> Unit,
+    onNavigate: (String) -> Unit,
     onExitApp: () -> Unit
 ) {
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -723,6 +732,7 @@ private fun LegacySidebarScaffold(
                                 selected = selectedDrawerRoute == item.route,
                                 expanded = isExpanded,
                                 onClick = {
+                                    onNavigate(item.route)
                                     navigateToDrawerRoute(
                                         navController = navController,
                                         currentRoute = currentRoute,
@@ -894,6 +904,7 @@ private fun ModernSidebarScaffold(
     activeProfileAvatarImageUrl: String?,
     showProfileSelector: Boolean,
     onSwitchProfile: () -> Unit,
+    onNavigate: (String) -> Unit,
     onExitApp: () -> Unit
 ) {
     val showSidebar = currentRoute in rootRoutes
@@ -1215,6 +1226,7 @@ private fun ModernSidebarScaffold(
                         drawerItemFocusRequesters = drawerItemFocusRequesters,
                         onDrawerItemFocused = { focusedDrawerIndex = it },
                         onDrawerItemClick = { targetRoute ->
+                            onNavigate(targetRoute)
                             navigateToDrawerRoute(
                                 navController = navController,
                                 currentRoute = currentRoute,


### PR DESCRIPTION
## Summary

This optimization implements an `optimisticRoute` via `mutableStateOf` within `MainActivity.kt`. It is triggered exactly when a sidebar item is clicked via the new `onNavigate` callback parameter in both `ModernSidebarScaffold` and `LegacySidebarScaffold`. The `optimisticRoute` immediately updates the active UI state so the user sees instant feedback. A subsequent `LaunchedEffect` detects when the `NavController` finishes its transition and safely clears the optimistic state, preventing state desyncs or issues during back navigation.

## PR type

- Small maintenance improvement


## Why

When navigating via the sidebar, the `NavController` took a frame or two to complete its asynchronous transition, leading to a perceived lag in the sidebar UI as it delays updating its highlighted active icon.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**



## Testing

Built apk and tested in app

## Screenshots / Video (UI changes only)

Only changes are in visual feedback, can't capture

## Breaking changes

Nothing broken in UI

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1499
