### PR TITLE
fix(tmdb): mock getMovieVideos in fetchEnrichment mapping test

### DIFF
--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -11,6 +11,7 @@ import com.nuvio.tv.data.remote.api.TmdbImagesResponse
 import com.nuvio.tv.data.remote.api.TmdbMovieReleaseDatesResponse
 import com.nuvio.tv.data.remote.api.TmdbNetwork
 import com.nuvio.tv.data.remote.api.TmdbNetworkDetailsResponse
+import com.nuvio.tv.data.remote.api.TmdbVideosResponse
 import com.nuvio.tv.domain.model.ContentType
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -47,6 +48,7 @@ class TmdbMetadataServiceTest {
         coEvery { api.getMovieCredits(any(), any(), any()) } returns Response.success(TmdbCreditsResponse())
         coEvery { api.getMovieImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
         coEvery { api.getMovieReleaseDates(any(), any()) } returns Response.success(TmdbMovieReleaseDatesResponse())
+        coEvery { api.getMovieVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 10))
 
         val service = TmdbMetadataService(api)
 


### PR DESCRIPTION
## Summary

Stub `api.getMovieVideos` in the `fetchEnrichment maps tmdb ids onto production and network companies` case so `TmdbMetadataServiceTest` stops failing with `java.lang.RuntimeException: Method e in android.util.Log not mocked`. Test-only, no production change.

## PR type

- Bug fix

## Why

The MOVIE enrichment path calls `fetchTmdbTrailers`, which in turn calls `api.getMovieVideos`. Because that method was unstubbed, MockK threw `MockKException`. The production code wraps the call in `runCatching { ... }.getOrElse { Log.w(TAG, ...); emptyList() }`, which is fine at runtime, but in JVM unit tests `Log.w(...)` itself throws `RuntimeException: Method w in android.util.Log not mocked`. That bubbles to the outer `catch (e: Exception) { Log.e(TAG, ...) }`, where `Log.e(...)` throws the same "not mocked" error, which is what the test surfaced.

The call path was introduced in commit `6aaa286e` (`feat: adding trailersection`). Stubbing `getMovieVideos` with an empty `TmdbVideosResponse(id = 10)` lets the trailer fetcher take the no-trailers branch and leaves the existing assertions on `productionCompanies` and `networks` unchanged.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A, small bug fix, test-only, no production code changes.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest.fetchEnrichment maps tmdb ids onto production and network companies"` passes. Before this change it failed with `java.lang.RuntimeException: Method e in android.util.Log not mocked`.
- `./gradlew -I .quality/quality.init.gradle.kts qualityChangedLocal` passes clean.
- Test-only change, no on-device testing needed.

## Screenshots / Video (UI changes only)

N/A, no UI change.

## Breaking changes

None.

## Linked issues

None.
