### PR TITLE
fix(tmdb): complete in-flight deferreds on all exit paths

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -17,6 +17,11 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.MetaTrailer
 import com.nuvio.tv.domain.model.PersonDetail
 import com.nuvio.tv.domain.model.PosterShape
+import java.time.LocalDate
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -24,11 +29,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-import java.time.LocalDate
-import java.util.concurrent.ConcurrentHashMap
-import java.util.Locale
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val TAG = "TmdbMetadataService"
 private val TMDB_API_KEY = BuildConfig.TMDB_API_KEY
@@ -172,7 +172,7 @@ class TmdbMetadataService @Inject constructor(
                     }
                 val poster = buildImageUrl(details?.posterPath, size = "w500")
                 val backdrop = buildImageUrl(details?.backdropPath, size = "w1280")
-                
+
                 val collectionId = details?.belongsToCollection?.id
                 val collectionName = details?.belongsToCollection?.name
 
@@ -339,6 +339,9 @@ class TmdbMetadataService @Inject constructor(
                 requestDeferred.complete(null)
                 null
             } finally {
+                if (!requestDeferred.isCompleted) {
+                    requestDeferred.complete(null)
+                }
                 enrichmentInFlight.remove(cacheKey, requestDeferred)
             }
         }
@@ -468,6 +471,9 @@ class TmdbMetadataService @Inject constructor(
             requestDeferred.cancel(e)
             throw e
         } finally {
+            if (!requestDeferred.isCompleted) {
+                requestDeferred.complete(emptyMap())
+            }
             episodeInFlight.remove(cacheKey, requestDeferred)
         }
     }
@@ -607,10 +613,10 @@ class TmdbMetadataService @Inject constructor(
         try {
             val collectionResponse = tmdbApi.getCollectionDetails(collectionId, TMDB_API_KEY, normalizedLanguage).body()
             val rawParts = collectionResponse?.parts.orEmpty()
-            
+
             // Show in release order
             val sortedParts = rawParts.sortedBy { it.releaseDate ?: "9999" }
-            
+
             val includeImageLanguage = buildString {
                 append(normalizedLanguage.substringBefore("-"))
                 append(",")


### PR DESCRIPTION
## Summary

Ensure the dedup `CompletableDeferred` in `TmdbMetadataService.fetchEnrichment` and `fetchEpisodeEnrichment` is always completed before it is removed from the in-flight map, so concurrent callers awaiting on it can never hang.

## PR type

- Bug fix

## Why

Both methods publish a `CompletableDeferred` into their `enrichmentInFlight` / `episodeInFlight` map and later callers dedupe via `existing.await()`. The happy path `complete(...)`s the deferred and `finally { remove() }` tears it down. But `fetchEnrichment` has an early `return@withContext null` branch (triggered when every enrichment field comes back empty) that skips `complete(...)`: the deferred is removed from the map but never completed, leaving any concurrent waiter suspended forever.

Adding `if (!requestDeferred.isCompleted) requestDeferred.complete(...)` inside both `finally` blocks plugs that hole and makes `fetchEpisodeEnrichment` equally defensive against future exit paths that forget to complete. This in practice shouldnt happen in prod as is but again is more defensive than anything.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A, small bug fix.

## Testing

- `./gradlew :app:testDebugUnitTest` passes.
- `./gradlew -I .quality/quality.init.gradle.kts qualityChangedLocal` passes clean.

## Screenshots / Video (UI changes only)

N/A, no UI change.

## Breaking changes

None.

## Linked issues

None.
