### PR TITLE
fix(tmdb): inject IO dispatcher to unblock dedup test

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -17,18 +17,19 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.MetaTrailer
 import com.nuvio.tv.domain.model.PersonDetail
 import com.nuvio.tv.domain.model.PosterShape
+import java.time.LocalDate
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-import java.time.LocalDate
-import java.util.concurrent.ConcurrentHashMap
-import java.util.Locale
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val TAG = "TmdbMetadataService"
 private val TMDB_API_KEY = BuildConfig.TMDB_API_KEY
@@ -36,9 +37,13 @@ private const val TMDB_TRAILER_FALLBACK_LANGUAGE = "en-US"
 private val YOUTUBE_VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
 
 @Singleton
-class TmdbMetadataService @Inject constructor(
-    private val tmdbApi: TmdbApi
+class TmdbMetadataService(
+    private val tmdbApi: TmdbApi,
+    private val ioDispatcher: CoroutineDispatcher
 ) {
+    @Inject
+    constructor(tmdbApi: TmdbApi) : this(tmdbApi, Dispatchers.IO)
+
     // In-memory caches
     private val enrichmentCache = ConcurrentHashMap<String, TmdbEnrichment>()
     private val episodeCache = ConcurrentHashMap<String, Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
@@ -55,7 +60,7 @@ class TmdbMetadataService @Inject constructor(
         contentType: ContentType,
         language: String = "en"
     ): TmdbEnrichment? =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val normalizedLanguage = normalizeTmdbLanguage(language)
             val cacheKey = "$tmdbId:${contentType.name}:$normalizedLanguage"
             enrichmentCache[cacheKey]?.let { return@withContext it }
@@ -172,7 +177,7 @@ class TmdbMetadataService @Inject constructor(
                     }
                 val poster = buildImageUrl(details?.posterPath, size = "w500")
                 val backdrop = buildImageUrl(details?.backdropPath, size = "w1280")
-                
+
                 val collectionId = details?.belongsToCollection?.id
                 val collectionName = details?.belongsToCollection?.name
 
@@ -431,7 +436,7 @@ class TmdbMetadataService @Inject constructor(
         tmdbId: String,
         seasonNumbers: List<Int>,
         language: String = "en"
-    ): Map<Pair<Int, Int>, TmdbEpisodeEnrichment> = withContext(Dispatchers.IO) {
+    ): Map<Pair<Int, Int>, TmdbEpisodeEnrichment> = withContext(ioDispatcher) {
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val cacheKey = "$tmdbId:${seasonNumbers.sorted().joinToString(",")}:$normalizedLanguage"
         episodeCache[cacheKey]?.let { return@withContext it }
@@ -477,7 +482,7 @@ class TmdbMetadataService @Inject constructor(
         contentType: ContentType,
         language: String = "en",
         maxItems: Int = 12
-    ): List<MetaPreview> = withContext(Dispatchers.IO) {
+    ): List<MetaPreview> = withContext(ioDispatcher) {
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val cacheKey = "$tmdbId:${contentType.name}:$normalizedLanguage:more_like"
         moreLikeThisCache[cacheKey]?.let { return@withContext it }
@@ -599,7 +604,7 @@ class TmdbMetadataService @Inject constructor(
     suspend fun fetchMovieCollection(
         collectionId: Int,
         language: String = "en"
-    ): List<MetaPreview> = withContext(Dispatchers.IO) {
+    ): List<MetaPreview> = withContext(ioDispatcher) {
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val cacheKey = "$collectionId:$normalizedLanguage:collection"
         collectionCache[cacheKey]?.let { return@withContext it }
@@ -607,10 +612,10 @@ class TmdbMetadataService @Inject constructor(
         try {
             val collectionResponse = tmdbApi.getCollectionDetails(collectionId, TMDB_API_KEY, normalizedLanguage).body()
             val rawParts = collectionResponse?.parts.orEmpty()
-            
+
             // Show in release order
             val sortedParts = rawParts.sortedBy { it.releaseDate ?: "9999" }
-            
+
             val includeImageLanguage = buildString {
                 append(normalizedLanguage.substringBefore("-"))
                 append(",")
@@ -666,7 +671,7 @@ class TmdbMetadataService @Inject constructor(
         sourceType: String,
         fallbackName: String? = null,
         language: String = "en"
-    ): TmdbEntityBrowseData? = withContext(Dispatchers.IO) {
+    ): TmdbEntityBrowseData? = withContext(ioDispatcher) {
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val normalizedSourceType = normalizeEntitySourceType(sourceType)
         val cacheKey = "${entityKind.routeValue}:$entityId:$normalizedSourceType:$normalizedLanguage"
@@ -1009,7 +1014,7 @@ class TmdbMetadataService @Inject constructor(
         preferCrewCredits: Boolean? = null,
         language: String = "en"
     ): PersonDetail? =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val normalizedLanguage = normalizeTmdbLanguage(language)
             val cacheKey = "$personId:${preferCrewCredits?.toString() ?: "auto"}:$normalizedLanguage"
             personCache[cacheKey]?.let { return@withContext it }

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -11,6 +11,7 @@ import com.nuvio.tv.data.remote.api.TmdbImagesResponse
 import com.nuvio.tv.data.remote.api.TmdbMovieReleaseDatesResponse
 import com.nuvio.tv.data.remote.api.TmdbNetwork
 import com.nuvio.tv.data.remote.api.TmdbNetworkDetailsResponse
+import com.nuvio.tv.data.remote.api.TmdbVideosResponse
 import com.nuvio.tv.domain.model.ContentType
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -18,8 +19,9 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -73,7 +75,7 @@ class TmdbMetadataServiceTest {
         coEvery { api.getMovieDetails(any(), any(), any()) } coAnswers {
             detailsCalls += 1
             gate.await()
-            Response.success(TmdbDetailsResponse(id = 10, title = "Movie"))
+            Response.success(TmdbDetailsResponse(id = 10, title = "Movie", overview = "Synopsis"))
         }
         coEvery { api.getMovieCredits(any(), any(), any()) } coAnswers {
             creditsCalls += 1
@@ -87,13 +89,14 @@ class TmdbMetadataServiceTest {
             releaseCalls += 1
             Response.success(TmdbMovieReleaseDatesResponse())
         }
+        coEvery { api.getMovieVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 10))
 
-        val service = TmdbMetadataService(api)
+        val service = TmdbMetadataService(api, StandardTestDispatcher(testScheduler))
 
         val first = async { service.fetchEnrichment(tmdbId = "10", contentType = ContentType.MOVIE, language = "en") }
         val second = async { service.fetchEnrichment(tmdbId = "10", contentType = ContentType.MOVIE, language = "en") }
 
-        yield()
+        advanceUntilIdle()
         assertEquals(1, detailsCalls)
 
         gate.complete(Unit)


### PR DESCRIPTION
## Summary

Inject a `CoroutineDispatcher` into `TmdbMetadataService` so the dedup unit test can drive it with `StandardTestDispatcher` + `advanceUntilIdle()` instead of a non-deterministic `yield()` on `Dispatchers.IO`. Production wiring is unchanged: a secondary `@Inject constructor(tmdbApi: TmdbApi)` still defaults to `Dispatchers.IO`.

## PR type

- Bug fix

## Why

The existing `fetchEnrichment dedupes concurrent callers` test is flaky. The service dispatches onto `Dispatchers.IO`, so `yield()` inside `runTest` cannot drain the real IO thread pool to a deterministic point: the `assertEquals(1, detailsCalls)` assertion sometimes runs before the first coroutine has even entered the mocked call. Making the dispatcher injectable lets the test pass `StandardTestDispatcher(testScheduler)` and use `advanceUntilIdle()` for a deterministic suspension point.

The test mocks also gain `overview = "Synopsis"` and a `getMovieVideos` stub so the first call exercises the happy path through `requestDeferred.complete(enrichment)` rather than the empty-enrichment early return.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A, small bug fix.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest"` passes deterministically across repeated runs.
- `./gradlew -I .quality/quality.init.gradle.kts qualityChangedLocal` passes clean.

## Screenshots / Video (UI changes only)

N/A, no UI change.

## Breaking changes

None. Hilt still binds `TmdbMetadataService` via the `@Inject constructor(tmdbApi: TmdbApi)` secondary constructor; the two-arg primary constructor is an internal test seam.

## Linked issues

None.
