### PR TITLE
fix: remove orphan cs detail_comments_spoiler_hint string

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -193,7 +193,6 @@
     <string name="detail_comments_error">Recenze z Traktu se momentálně nepodařilo načíst.</string>
     <string name="detail_trailer_loading">Načítání traileru...</string>
     <string name="detail_trailer_error">Trailer se momentálně nepodařilo načíst.</string>
-    <string name="detail_comments_spoiler_hint">Recenze obsahuje spoiler. Stiskněte OK pro zobrazení.</string>
     <string name="detail_comments_spoiler_hidden">Recenze se spoilerem. Stiskněte OK pro zobrazení.</string>
     <string name="detail_comments_reveal_spoiler">Zobrazit spoiler</string>
     <string name="detail_comments_reveal_spoiler_hint">Stiskněte OK pro zobrazení spoileru.</string>


### PR DESCRIPTION
## Summary

Remove `detail_comments_spoiler_hint` from `values-cs/strings.xml`. The key does not exist in the default locale or any other locale, and nothing in the codebase references it. It was introduced in #1495 alongside `detail_comments_spoiler_hidden`, which is the key that is actually used.

## PR type

- Bug fix

## Why

Android lint treats `ExtraTranslation` as fatal, so `:app:lintVitalDebug` fails and release assembly is blocked. The orphaned key is also a potential crash risk if anything ever tries to resolve it. `CommentsSection.kt` uses `detail_comments_spoiler_hidden`, and that Czech translation is already present, so removing `detail_comments_spoiler_hint` does not reduce translation coverage.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A - small bug fix.

## Testing

- Reproduced the failure on `34a1d129` with `./gradlew :app:lintVitalDebug`, which fails with `ExtraTranslation` at `values-cs/strings.xml:196`.
- Verified `detail_comments_spoiler_hint` has no references in app sources or any other locale file.
- Confirmed `detail_comments_spoiler_hidden`, which is used in `CommentsSection.kt:259, 477`, remains translated in `values-cs/strings.xml`.
- Re-ran `./gradlew :app:lintVitalDebug` after the change and confirmed it passes.

## Screenshots / Video (UI changes only)

N/A - no UI change.

## Breaking changes

None.

## Linked issues

Regression from #1495.