### PR TITLE
Fix player aspect ratio mode behavior

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -20,6 +20,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     private var hasQueuedInitialMedia = false
     private var lastMediaRequestKey: String? = null
     private var hardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE
+    private var currentAspectMode: AspectMode = AspectMode.ORIGINAL
+    private var pendingAspectRetryCount = 0
+    private val aspectReapplyRunnable = Runnable {
+        applyAspectModeInternal(currentAspectMode, allowRetry = true)
+    }
 
     fun ensureInitialized() {
         if (initialized) return
@@ -48,6 +53,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         }
         lastMediaRequestKey = requestKey
         applyDefaultTrackSelectionForNewLoad()
+        scheduleAspectModeRefresh(resetRetryCount = true)
     }
 
     fun setMediaUsingLoadfile(url: String, headers: Map<String, String>) {
@@ -63,6 +69,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         hasQueuedInitialMedia = true
         lastMediaRequestKey = requestKey
         applyDefaultTrackSelectionForNewLoad()
+        scheduleAspectModeRefresh(resetRetryCount = true)
     }
 
     private fun ensureSurfaceAttachedIfAlreadyAvailable() {
@@ -190,34 +197,52 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     }
 
     fun applyAspectMode(mode: AspectMode) {
-        when (mode) {
-            AspectMode.ORIGINAL -> {
-                scaleX = 1.0f
-                scaleY = 1.0f
-            }
+        currentAspectMode = mode
+        pendingAspectRetryCount = 0
+        removeCallbacks(aspectReapplyRunnable)
+        applyAspectModeInternal(mode, allowRetry = true)
+    }
 
-            AspectMode.FULL_SCREEN -> applyCoverAspectScale()
-
-            AspectMode.SLIGHT_ZOOM -> {
-                scaleX = 1.15f
-                scaleY = 1.15f
-            }
-
-            AspectMode.CINEMA_ZOOM -> {
-                scaleX = 1.33f
-                scaleY = 1.33f
-            }
-
-            AspectMode.VERTICAL_STRETCH -> {
-                scaleX = 1.0f
-                scaleY = 1.33f
-            }
-
-            AspectMode.HORIZONTAL_STRETCH -> {
-                scaleX = 1.3333f
-                scaleY = 1.0f
-            }
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (w == oldw && h == oldh) return
+        pendingAspectRetryCount = 0
+        removeCallbacks(aspectReapplyRunnable)
+        post {
+            applyAspectModeInternal(currentAspectMode, allowRetry = true)
         }
+    }
+
+    private fun applyAspectModeInternal(mode: AspectMode, allowRetry: Boolean) {
+        val viewAspect = readViewAspectRatio(width, height)
+        val videoAspect = readVideoAspectRatio()
+        val scale = resolveAspectScale(
+            mode = mode,
+            viewAspect = viewAspect,
+            videoAspect = videoAspect
+        )
+        scaleX = scale.scaleX
+        scaleY = scale.scaleY
+        if (
+            allowRetry &&
+            aspectModeNeedsVideoAspect(mode) &&
+            (viewAspect <= 0f || videoAspect == null || videoAspect <= 0f)
+        ) {
+            scheduleAspectModeRefresh(resetRetryCount = false)
+        }
+    }
+
+    private fun scheduleAspectModeRefresh(resetRetryCount: Boolean) {
+        if (resetRetryCount) {
+            pendingAspectRetryCount = 0
+        }
+        removeCallbacks(aspectReapplyRunnable)
+        if (pendingAspectRetryCount >= MAX_ASPECT_RETRY_COUNT) {
+            return
+        }
+        val delayMs = if (pendingAspectRetryCount == 0) 0L else ASPECT_RETRY_DELAY_MS
+        pendingAspectRetryCount += 1
+        postDelayed(aspectReapplyRunnable, delayMs)
     }
 
     fun applySubtitleStyle(style: SubtitleStyleSettings) {
@@ -440,6 +465,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     fun releasePlayer() {
         if (!initialized) return
+        removeCallbacks(aspectReapplyRunnable)
         runCatching { destroy() }
             .onFailure { Log.w(TAG, "Failed to destroy libmpv view cleanly: ${it.message}") }
         initialized = false
@@ -561,6 +587,8 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         private const val TAG = "NuvioMpvSurfaceView"
         private const val MPV_COVER_FALLBACK_SCALE = 1.15f
         private const val MPV_MAX_VOLUME_PERCENT = 400.0
+        private const val ASPECT_RETRY_DELAY_MS = 120L
+        private const val MAX_ASPECT_RETRY_COUNT = 10
         private const val SUBTITLE_VERTICAL_OFFSET_MIN = -20
         private const val SUBTITLE_VERTICAL_OFFSET_MAX = 50
         private const val MPV_SUB_POS_AT_BOTTOM = 103.4

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
@@ -11,6 +11,7 @@ import com.nuvio.tv.R
 enum class AspectMode(@StringRes val labelResId: Int) {
     ORIGINAL(R.string.player_aspect_fit),
     FULL_SCREEN(R.string.player_aspect_crop),
+    STRETCH(R.string.player_aspect_stretch),
     SLIGHT_ZOOM(R.string.player_aspect_mode_slight_zoom),
     CINEMA_ZOOM(R.string.player_aspect_mode_cinema_zoom),
     VERTICAL_STRETCH(R.string.player_aspect_fit_height),
@@ -25,6 +26,96 @@ internal fun nextAspectMode(current: AspectMode): AspectMode {
 
 internal fun aspectModeLabel(mode: AspectMode, getString: (Int) -> String): String =
     getString(mode.labelResId)
+
+internal data class AspectScale(val scaleX: Float, val scaleY: Float)
+
+internal fun aspectModeNeedsVideoAspect(mode: AspectMode): Boolean {
+    return when (mode) {
+        AspectMode.FULL_SCREEN,
+        AspectMode.STRETCH,
+        AspectMode.VERTICAL_STRETCH,
+        AspectMode.HORIZONTAL_STRETCH -> true
+
+        AspectMode.ORIGINAL,
+        AspectMode.SLIGHT_ZOOM,
+        AspectMode.CINEMA_ZOOM -> false
+    }
+}
+
+internal fun readViewAspectRatio(width: Int, height: Int): Float {
+    return if (width > 0 && height > 0) {
+        width.toFloat() / height.toFloat()
+    } else {
+        0f
+    }
+}
+
+internal fun readExoVideoAspectRatio(playerView: PlayerView): Float? {
+    val videoSize = playerView.player?.videoSize
+    return if ((videoSize?.height ?: 0) > 0) {
+        ((videoSize?.width ?: 0).toFloat() * (videoSize?.pixelWidthHeightRatio ?: 1f)) /
+            videoSize!!.height.toFloat()
+    } else {
+        null
+    }
+}
+
+internal fun resolveAspectScale(mode: AspectMode, viewAspect: Float, videoAspect: Float?): AspectScale {
+    if (viewAspect <= 0f) {
+        return AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+    }
+
+    return when (mode) {
+        AspectMode.ORIGINAL -> AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+
+        AspectMode.FULL_SCREEN -> {
+            val safeVideoAspect = videoAspect?.takeIf { it > 0f }
+                ?: return AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+            val uniformScale = if (safeVideoAspect > viewAspect) {
+                safeVideoAspect / viewAspect
+            } else {
+                viewAspect / safeVideoAspect
+            }
+            AspectScale(scaleX = uniformScale, scaleY = uniformScale)
+        }
+
+        AspectMode.STRETCH -> {
+            val safeVideoAspect = videoAspect?.takeIf { it > 0f }
+                ?: return AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+            if (safeVideoAspect > viewAspect) {
+                AspectScale(scaleX = 1.0f, scaleY = safeVideoAspect / viewAspect)
+            } else {
+                AspectScale(scaleX = viewAspect / safeVideoAspect, scaleY = 1.0f)
+            }
+        }
+
+        AspectMode.SLIGHT_ZOOM -> AspectScale(scaleX = 1.15f, scaleY = 1.15f)
+
+        AspectMode.CINEMA_ZOOM -> AspectScale(scaleX = 1.33f, scaleY = 1.33f)
+
+        AspectMode.VERTICAL_STRETCH -> {
+            val safeVideoAspect = videoAspect?.takeIf { it > 0f }
+                ?: return AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+            if (safeVideoAspect > viewAspect) {
+                val uniformScale = safeVideoAspect / viewAspect
+                AspectScale(scaleX = uniformScale, scaleY = uniformScale)
+            } else {
+                AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+            }
+        }
+
+        AspectMode.HORIZONTAL_STRETCH -> {
+            val safeVideoAspect = videoAspect?.takeIf { it > 0f }
+                ?: return AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+            if (safeVideoAspect < viewAspect) {
+                val uniformScale = viewAspect / safeVideoAspect
+                AspectScale(scaleX = uniformScale, scaleY = uniformScale)
+            } else {
+                AspectScale(scaleX = 1.0f, scaleY = 1.0f)
+            }
+        }
+    }
+}
 
 internal fun applyExoAspectMode(playerView: PlayerView, mode: AspectMode) {
     val contentFrame = playerView.findViewById<View>(androidx.media3.ui.R.id.exo_content_frame)
@@ -50,63 +141,13 @@ internal fun applyAspectMode(playerView: PlayerView, mode: AspectMode) {
 }
 
 private fun applyAspectScale(playerView: PlayerView, targetView: View, mode: AspectMode) {
-    when (mode) {
-        AspectMode.ORIGINAL -> {
-            targetView.scaleX = 1.0f
-            targetView.scaleY = 1.0f
-        }
-
-        AspectMode.FULL_SCREEN -> applyCoverAspectScale(playerView, targetView)
-
-        AspectMode.SLIGHT_ZOOM -> {
-            targetView.scaleX = 1.15f
-            targetView.scaleY = 1.15f
-        }
-
-        AspectMode.CINEMA_ZOOM -> {
-            targetView.scaleX = 1.33f
-            targetView.scaleY = 1.33f
-        }
-
-        AspectMode.VERTICAL_STRETCH -> {
-            targetView.scaleX = 1.0f
-            targetView.scaleY = 1.33f
-        }
-
-        AspectMode.HORIZONTAL_STRETCH -> {
-            targetView.scaleX = 1.3333f
-            targetView.scaleY = 1.0f
-        }
-    }
-}
-
-private fun applyCoverAspectScale(playerView: PlayerView, targetView: View) {
-    val videoSize = playerView.player?.videoSize
-    val videoAspect = if ((videoSize?.height ?: 0) > 0) {
-        ((videoSize?.width ?: 0).toFloat() * (videoSize?.pixelWidthHeightRatio ?: 1f)) /
-            videoSize!!.height.toFloat()
-    } else {
-        0f
-    }
-
-    val viewAspect = if (playerView.width > 0 && playerView.height > 0) {
-        playerView.width.toFloat() / playerView.height.toFloat()
-    } else {
-        0f
-    }
-
-    if (videoAspect > 0f && viewAspect > 0f) {
-        if (videoAspect > viewAspect) {
-            targetView.scaleX = 1.0f
-            targetView.scaleY = videoAspect / viewAspect
-        } else {
-            targetView.scaleX = viewAspect / videoAspect
-            targetView.scaleY = 1.0f
-        }
-    } else {
-        targetView.scaleX = 1.0f
-        targetView.scaleY = 1.0f
-    }
+    val scale = resolveAspectScale(
+        mode = mode,
+        viewAspect = readViewAspectRatio(playerView.width, playerView.height),
+        videoAspect = readExoVideoAspectRatio(playerView)
+    )
+    targetView.scaleX = scale.scaleX
+    targetView.scaleY = scale.scaleY
 }
 
 private fun resolveVideoSurfaceView(playerView: PlayerView): View? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -7,6 +7,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
 import android.view.KeyEvent
+import android.view.View
 import androidx.annotation.RawRes
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -1149,6 +1150,7 @@ private fun MpvPlayerSurface(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val latestAspectMode by rememberUpdatedState(aspectMode)
     val mpvView = remember(context) {
         NuvioMpvSurfaceView(context)
     }
@@ -1162,6 +1164,16 @@ private fun MpvPlayerSurface(
         viewModel.attachMpvView(mpvView)
         onDispose {
             viewModel.attachMpvView(null)
+        }
+    }
+
+    DisposableEffect(mpvView) {
+        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            mpvView.applyAspectMode(latestAspectMode)
+        }
+        mpvView.addOnLayoutChangeListener(listener)
+        onDispose {
+            mpvView.removeOnLayoutChangeListener(listener)
         }
     }
 
@@ -1232,22 +1244,32 @@ private fun ExoPlayerSurface(
         val listener = object : androidx.media3.common.Player.Listener {
             override fun onVideoSizeChanged(videoSize: androidx.media3.common.VideoSize) {
                 playerView.post {
-                    playerView.applyExoAspectModeIfNeeded(latestAspectMode)
+                    playerView.applyExoAspectMode(latestAspectMode)
                 }
             }
 
             override fun onRenderedFirstFrame() {
                 playerView.post {
-                    playerView.applyExoAspectModeIfNeeded(latestAspectMode)
+                    playerView.applyExoAspectMode(latestAspectMode)
                 }
             }
         }
         player.addListener(listener)
         playerView.post {
-            playerView.applyExoAspectModeIfNeeded(latestAspectMode)
+            playerView.applyExoAspectMode(latestAspectMode)
         }
         onDispose {
             player.removeListener(listener)
+        }
+    }
+
+    DisposableEffect(playerView) {
+        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            playerView.applyExoAspectMode(latestAspectMode)
+        }
+        playerView.addOnLayoutChangeListener(listener)
+        onDispose {
+            playerView.removeOnLayoutChangeListener(listener)
         }
     }
 
@@ -1259,7 +1281,7 @@ private fun ExoPlayerSurface(
     }
 
     LaunchedEffect(playerView, aspectMode) {
-        playerView.applyExoAspectModeIfNeeded(aspectMode)
+        playerView.applyExoAspectMode(aspectMode)
     }
 
     LaunchedEffect(playerView, player, useLibass, libassRenderType) {
@@ -1283,10 +1305,7 @@ private fun PlayerView.enableComposeSurfaceSyncWorkaroundIfAvailable() {
     }
 }
 
-private fun PlayerView.applyExoAspectModeIfNeeded(mode: AspectMode) {
-    if (getTag(R.id.player_view_aspect_mode_tag) == mode) {
-        return
-    }
+private fun PlayerView.applyExoAspectMode(mode: AspectMode) {
     setTag(R.id.player_view_aspect_mode_tag, mode)
     applyExoAspectMode(this, mode)
 }


### PR DESCRIPTION
## Summary

Fix player aspect ratio mode behavior across MPV and ExoPlayer.

This PR adds back a proper `Stretch` mode, fixes `Crop` so it fills the screen by cropping instead of behaving like stretch, and updates `Fit Height` / `Fit Width` scaling so they recalculate against the current video and view aspect ratio. It also reapplies aspect scaling when layout or video size changes so the selected mode persists correctly across content changes.

## PR type

- Bug fix

## Why

Tester feedback showed that several aspect modes were not behaving as labeled:

- `Crop` could behave like stretch and appear not to persist correctly between videos.
- The old full-picture `Stretch` behavior was missing.
- `Fit Height` could still leave small black bars because it used a fixed scale instead of content-aware scaling.

This change makes the aspect modes match user expectation and ensures dynamic modes are reapplied when playback state, layout, or media changes.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual testing:

- Verified `Crop` now fills the screen by cropping while keeping aspect ratio.
- Verified `Stretch` is available again and fills the screen without preserving aspect ratio.
- Verified `Fit Height` removes the remaining top/bottom bars for relevant content.
- Verified aspect mode is reapplied after video size/layout changes in both MPV and ExoPlayer paths.
- Verified the selected aspect mode remains persisted across content changes.

## Breaking changes

- None

## Linked issues

- None
