### PR TITLE
Replace downRowFocusRequester and upRowFocusRequester with a correct focusRestorer

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -85,20 +85,17 @@ fun CatalogRowSection(
     modifier: Modifier = Modifier,
     enableRowFocusRestorer: Boolean = true,
     initialScrollIndex: Int = 0,
+    /** Used only for initial focus restore (e.g. returning from detail screen). */
     focusedItemIndex: Int = -1,
+    /** Persisted focus index from parent — used only by focusRestorer to
+     *  survive LazyColumn recycling.  Does NOT trigger a focus request. */
+    restorerFocusedIndex: Int = -1,
     onItemFocused: (itemIndex: Int) -> Unit = {},
     rowFocusRequester: FocusRequester? = null,
     /** FocusRequester that will be attached to the first-or-last-focused card.
      *  Wide elements above (CW, collections) can point their D-pad down here. */
     entryFocusRequester: FocusRequester? = null,
     upFocusRequester: FocusRequester? = null,
-    downRowFocusRequester: FocusRequester? = null,
-    upRowFocusRequester: FocusRequester? = null,
-    /** Entry-point FocusRequester of the row below — attached to the first-or-last-focused card.
-     *  Used by expanded cards to land on the correct card instead of the LazyRow. */
-    downEntryFocusRequester: FocusRequester? = null,
-    /** Entry-point FocusRequester of the row above. */
-    upEntryFocusRequester: FocusRequester? = null,
     listState: LazyListState = rememberLazyListState(initialFirstVisibleItemIndex = initialScrollIndex)
 ) {
     fun rowItemFocusKey(index: Int, item: MetaPreview): String {
@@ -114,7 +111,6 @@ fun CatalogRowSection(
     val itemFocusRequestersByKey = remember { mutableMapOf<String, FocusRequester>() }
     var lastRequestedFocusItemKey by remember { mutableStateOf<String?>(null) }
     var lastFocusedItemIndex by remember { mutableIntStateOf(-1) }
-    var hasExpandedCard by remember { mutableStateOf(false) }
 
     // When fresh data prepends new items to a row the user hasn't
     // scrolled, snap back to position 0 so the newest content is visible.
@@ -224,15 +220,15 @@ fun CatalogRowSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(resolvedRowFocusRequester)
-                .then(
-                    if (hasExpandedCard && (downRowFocusRequester != null || upRowFocusRequester != null)) {
-                        Modifier.focusProperties {
-                            if (downRowFocusRequester != null) down = downRowFocusRequester
-                            if (upRowFocusRequester != null) up = upRowFocusRequester
-                        }
-                    } else Modifier
+                .focusRestorer(
+                    run {
+                        val idx = (if (lastFocusedItemIndex >= 0) lastFocusedItemIndex else restorerFocusedIndex)
+                            .coerceIn(0, (catalogRow.items.size - 1).coerceAtLeast(0))
+                        catalogRow.items.getOrNull(idx)
+                            ?.let { itemFocusRequestersByKey.getOrPut(rowItemFocusKey(idx, it)) { FocusRequester() } }
+                            ?: FocusRequester.Default
+                    }
                 )
-                .focusRestorer()
                 .focusGroup(),
             contentPadding = PaddingValues(start = 48.dp, end = 200.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -269,9 +265,7 @@ fun CatalogRowSection(
                             currentOnItemFocused(index)
                         }
                     },
-                    onBackdropExpandedChanged = { expanded -> hasExpandedCard = expanded },
-                    expandedDownFocusRequester = downEntryFocusRequester,
-                    expandedUpFocusRequester = upEntryFocusRequester,
+                    onBackdropExpandedChanged = null,
                     onClick = { onItemClick(item.id, item.apiType, catalogRow.addonBaseUrl) },
                     onLongPress = { onItemLongPress(item, catalogRow.addonBaseUrl) },
                     modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/components/CollectionRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CollectionRowSection.kt
@@ -74,9 +74,7 @@ fun CollectionRowSection(
     focusedItemIndex: Int = -1,
     onItemFocused: (itemIndex: Int) -> Unit = {},
     onFolderFocused: (collection: Collection, folder: CollectionFolder) -> Unit = { _, _ -> },
-    entryFocusRequester: FocusRequester? = null,
-    downEntryFocusRequester: FocusRequester? = null,
-    upEntryFocusRequester: FocusRequester? = null
+    entryFocusRequester: FocusRequester? = null
 ) {
     val currentOnItemFocused by rememberUpdatedState(onItemFocused)
     val currentOnFolderFocused by rememberUpdatedState(onFolderFocused)
@@ -174,15 +172,8 @@ fun CollectionRowSection(
                 key = { index, folder -> folderFocusKey(index, folder) },
                 contentType = { _, _ -> "collection_folder" }
             ) { index, folder ->
-                val isWide = folder.tileShape != PosterShape.POSTER
                 val targetIndex = if (lastFocusedItemIndex >= 0) lastFocusedItemIndex else 0
                 val isEntryTarget = entryFocusRequester != null && index == targetIndex
-                val wideFocusModifier = if (isWide && (downEntryFocusRequester != null || upEntryFocusRequester != null)) {
-                    Modifier.focusProperties {
-                        if (downEntryFocusRequester != null) down = downEntryFocusRequester
-                        if (upEntryFocusRequester != null) up = upEntryFocusRequester
-                    }
-                } else Modifier
 
                 FolderCard(
                     folder = folder,
@@ -195,9 +186,7 @@ fun CollectionRowSection(
                         }
                         currentOnFolderFocused(collection, folder)
                     },
-                    modifier = wideFocusModifier.then(
-                        if (isEntryTarget) Modifier.focusRequester(entryFocusRequester!!) else Modifier
-                    ),
+                    modifier = if (isEntryTarget) Modifier.focusRequester(entryFocusRequester!!) else Modifier,
                     focusRequester = itemFocusRequesters.getOrPut(
                         folderFocusKey(index, folder)
                     ) { FocusRequester() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -461,6 +461,7 @@ private fun RowsContent(
         initialFirstVisibleItemScrollOffset = focusState.verticalScrollOffset
     )
     val rowStates = remember { mutableMapOf<String, LazyListState>() }
+    val rowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
     val currentFocusedRowIndex = remember { intArrayOf(focusState.focusedRowIndex) }
     val currentFocusedItemIndex = remember { intArrayOf(focusState.focusedItemIndex) }
 
@@ -586,9 +587,11 @@ private fun RowsContent(
                             } else {
                                 -1
                             },
+                            restorerFocusedIndex = rowFocusedItemIndex[rowKey] ?: -1,
                             onItemFocused = { itemIndex ->
                                 currentFocusedRowIndex[0] = index
                                 currentFocusedItemIndex[0] = itemIndex
+                                rowFocusedItemIndex[rowKey] = itemIndex
                             }
                         )
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -126,6 +126,7 @@ fun ClassicHomeContent(
     val rowStates = remember { mutableMapOf<String, LazyListState>() }
     val rowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val rowEntryFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val rowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
 
     var restoringFocus by remember { mutableStateOf(focusState.hasSavedFocus) }
     val heroFocusRequester = remember { FocusRequester() }
@@ -351,23 +352,6 @@ fun ClassicHomeContent(
                 }
             }
         ) { index, homeRow ->
-            val nextRowKey = visibleHomeRows.getOrNull(index + 1)?.let { r ->
-                when (r) {
-                    is HomeRow.Catalog -> "${r.row.addonId}_${r.row.apiType}_${r.row.catalogId}"
-                    is HomeRow.CollectionRow -> "collection_${r.collection.id}"
-                }
-            }
-            val prevRowKey = visibleHomeRows.getOrNull(index - 1)?.let { r ->
-                when (r) {
-                    is HomeRow.Catalog -> "${r.row.addonId}_${r.row.apiType}_${r.row.catalogId}"
-                    is HomeRow.CollectionRow -> "collection_${r.collection.id}"
-                }
-            }
-            val rowDownFocusRequester = nextRowKey?.let { rowFocusRequesters.getOrPut(it) { FocusRequester() } }
-            val rowUpFocusRequester = prevRowKey?.let { rowFocusRequesters.getOrPut(it) { FocusRequester() } }
-            val nextEntryRequester = nextRowKey?.let { rowEntryFocusRequesters.getOrPut(it) { FocusRequester() } }
-            val prevEntryRequester = prevRowKey?.let { rowEntryFocusRequesters.getOrPut(it) { FocusRequester() } }
-
             when (homeRow) {
                 is HomeRow.Catalog -> {
                     val catalogRow = homeRow.row
@@ -425,15 +409,13 @@ fun ClassicHomeContent(
                         listState = listState,
                         enableRowFocusRestorer = true,
                         focusedItemIndex = focusedItemIndex,
-                        downRowFocusRequester = rowDownFocusRequester,
-                        upRowFocusRequester = rowUpFocusRequester,
-                        downEntryFocusRequester = nextEntryRequester,
-                        upEntryFocusRequester = prevEntryRequester,
+                        restorerFocusedIndex = rowFocusedItemIndex[catalogKey] ?: -1,
                         onItemFocused = { itemIndex ->
                             if (restoringFocus) restoringFocus = false
                             currentFocusSnapshot.rowIndex = index
                             currentFocusSnapshot.itemIndex = itemIndex
                             currentFocusSnapshot.rowKey = catalogKey
+                            rowFocusedItemIndex[catalogKey] = itemIndex
                         }
                     )
                 }
@@ -460,13 +442,12 @@ fun ClassicHomeContent(
                         listState = listState,
                         focusedItemIndex = collectionFocusedItemIndex,
                         entryFocusRequester = rowEntryFocusRequesters.getOrPut(collectionKey) { FocusRequester() },
-                        downEntryFocusRequester = nextEntryRequester,
-                        upEntryFocusRequester = prevEntryRequester,
                         onItemFocused = { itemIndex ->
                             if (restoringFocus) restoringFocus = false
                             currentFocusSnapshot.rowIndex = index
                             currentFocusSnapshot.itemIndex = itemIndex
                             currentFocusSnapshot.rowKey = collectionKey
+                            rowFocusedItemIndex[collectionKey] = itemIndex
                         }
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -965,19 +965,7 @@ fun ModernHomeContent(
                                 onNavigateToFolderDetail = onNavigateToFolderDetail,
                                 onLoadMoreCatalog = onLoadMoreCatalog,
                                 onBackdropInteraction = remember(Unit) { { expansionInteractionNonce++ } },
-                                onExpandedCatalogFocusKeyChange = remember(Unit) { { expandedCatalogFocusKey = it } },
-                                onGetVerticalFocusRequester = { _, isDown ->
-                                    val currentRowIndex = rowIndexByKey[row.key] ?: return@ModernRowSection FocusRequester.Default
-                                    val targetRowIndex = if (isDown) currentRowIndex + 1 else currentRowIndex - 1
-                                    val targetRow = latestCarouselRows.getOrNull(targetRowIndex) ?: return@ModernRowSection FocusRequester.Default
-
-                                    val targetSavedIndex = (focusedItemByRow[targetRow.key] ?: 0)
-                                        .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
-                                    val targetItemKey = targetRow.items.getOrNull(targetSavedIndex)?.key
-                                    if (targetItemKey != null) {
-                                        uiCaches.requesterFor(targetRow.key, targetItemKey)
-                                    } else FocusRequester.Default
-                                }
+                                onExpandedCatalogFocusKeyChange = remember(Unit) { { expandedCatalogFocusKey = it } }
                             )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -339,8 +339,7 @@ internal fun ModernRowSection(
     onNavigateToFolderDetail: (String, String) -> Unit,
     onLoadMoreCatalog: (String, String, String) -> Unit,
     onBackdropInteraction: () -> Unit,
-    onExpandedCatalogFocusKeyChange: (String?) -> Unit,
-    onGetVerticalFocusRequester: (index: Int, isDown: Boolean) -> FocusRequester = { _, _ -> FocusRequester.Default }
+    onExpandedCatalogFocusKeyChange: (String?) -> Unit
 ) {
     val focusedItemByRow = uiCaches.focusedItemByRow
     val itemFocusRequesters = uiCaches.itemFocusRequesters
@@ -661,18 +660,7 @@ internal fun ModernRowSection(
                     val onFocused = remember(row.key, index, isContinueWatchingRow) {
                         { onRowItemFocused(row.key, index, isContinueWatchingRow) }
                     }
-                    val hasExpandedCard = expandedCatalogFocusKey != null
                     val isCwPayload = item.payload is ModernPayload.ContinueWatching
-                    val isCollectionPayload = item.payload is ModernPayload.CollectionFolder
-                    val needsVerticalOverride = hasExpandedCard || isCwPayload || isCollectionPayload
-                    val verticalFocusModifier = if (needsVerticalOverride) {
-                        Modifier.focusProperties {
-                            up = onGetVerticalFocusRequester(index, false)
-                            down = onGetVerticalFocusRequester(index, true)
-                        }
-                    } else {
-                        Modifier
-                    }
 
                     when (val payload = item.payload) {
                         is ModernPayload.ContinueWatching -> {
@@ -684,8 +672,7 @@ internal fun ModernRowSection(
                                 blurUnwatchedEpisodes = blurUnwatchedEpisodes,
                                 onFocused = onFocused,
                                 onContinueWatchingClick = onContinueWatchingClick,
-                                onShowOptions = onContinueWatchingOptions,
-                                modifier = verticalFocusModifier
+                                onShowOptions = onContinueWatchingOptions
                             )
                         }
 
@@ -740,8 +727,7 @@ internal fun ModernRowSection(
                                 onBackdropInteraction = onBackdropInteraction,
                                 onExpandedCatalogFocusKeyChange = onExpandedCatalogFocusKeyChange,
                                 enrichedLogoUrl = (payload as? ModernPayload.Catalog)?.itemId?.let { enrichedPreviews[it]?.logo },
-                                enrichedBackdropUrl = (payload as? ModernPayload.Catalog)?.itemId?.let { enrichedPreviews[it]?.backdropUrl },
-                                modifier = verticalFocusModifier
+                                enrichedBackdropUrl = (payload as? ModernPayload.Catalog)?.itemId?.let { enrichedPreviews[it]?.backdropUrl }
                             )
                         }
                     }

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -744,14 +744,6 @@
     <string name="trakt_hide_unaired">Ocultar episodios sin emitir</string>
     <string name="trakt_all_history">Todo el historial</string>
     <string name="trakt_days_format">%1$d días</string>
-    <string name="trakt_cw_window_title">Ventana de Continuar viendo</string>
-    <string name="trakt_cw_window_subtitle">Elige cuánta actividad de Trakt debe aparecer en “Continuar viendo”.</string>
-    <string name="trakt_unaired_dialog_title">Episodios próximos no emitidos</string>
-    <string name="trakt_unaired_dialog_subtitle">Elige si “Continuar viendo” debe incluir episodios próximos antes de su estreno.</string>
-    <string name="trakt_show_unaired">Mostrar episodios no emitidos</string>
-    <string name="trakt_hide_unaired">Ocultar episodios no emitidos</string>
-    <string name="trakt_all_history">Todo el historial</string>
-    <string name="trakt_days_format">%1$d días</string>
 
     <!-- DebugSettingsScreen -->
     <string name="debug_title">Depuración</string>


### PR DESCRIPTION
## Summary

Replace manual `downRowFocusRequester`/`upRowFocusRequester` vertical focus overrides with proper `focusRestorer(lastFocusedRequester)` on all `LazyRow` focus groups. This makes inter-row D-pad navigation consistent across Modern, Classic, Collections, Search, and Folder detail views.

## PR type

- Bug fix
- Small maintenance improvement

## Why

Modern home used `focusRestorer` with a persisted last-focused requester, giving correct focus behavior when navigating between rows. Classic and other views used geometric `focusProperties` overrides (`downRowFocusRequester`, `upRowFocusRequester`, `verticalFocusModifier`) which broke after LazyColumn recycling and behaved inconsistently with expanded poster cards.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified D-pad up/down navigates to last-focused item in target row (not geometric) across all layouts
- Verified focus persists after scrolling far down and back up in Classic (LazyColumn recycling)
- Verified expanded poster cards no longer cause focus to jump to wrong items
- Verified CW, catalog, and collection rows all restore focus correctly
- Verified season tabs in detail screen restore to selected tab
- Verified search results rows restore focus correctly

## Screenshots / Video (UI changes only)

Behavioral fix, no visual change.

## Breaking changes

Nothing should break 

## Linked issues

Nothing reported 
