### PR TITLE
Move FocusManager into separate modifier

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -221,12 +221,16 @@ fun CatalogRowSection(
                 .fillMaxWidth()
                 .focusRequester(resolvedRowFocusRequester)
                 .focusRestorer(
-                    run {
-                        val idx = (if (lastFocusedItemIndex >= 0) lastFocusedItemIndex else restorerFocusedIndex)
-                            .coerceIn(0, (catalogRow.items.size - 1).coerceAtLeast(0))
-                        catalogRow.items.getOrNull(idx)
-                            ?.let { itemFocusRequestersByKey.getOrPut(rowItemFocusKey(idx, it)) { FocusRequester() } }
-                            ?: FocusRequester.Default
+                    if (enableRowFocusRestorer) {
+                        run {
+                            val idx = (if (lastFocusedItemIndex >= 0) lastFocusedItemIndex else restorerFocusedIndex)
+                                .coerceIn(0, (catalogRow.items.size - 1).coerceAtLeast(0))
+                            catalogRow.items.getOrNull(idx)
+                                ?.let { itemFocusRequestersByKey.getOrPut(rowItemFocusKey(idx, it)) { FocusRequester() } }
+                                ?: FocusRequester.Default
+                        }
+                    } else {
+                        FocusRequester.Default
                     }
                 )
                 .focusGroup(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -194,6 +195,7 @@ fun CatalogSeeAllScreen(
                 LazyVerticalGrid(
                     state = gridState,
                     columns = GridCells.Adaptive(minSize = posterCardStyle.width),
+                    modifier = Modifier.dpadRepeatThrottle(),
                     contentPadding = PaddingValues(
                         start = 48.dp,
                         end = 24.dp,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
@@ -132,7 +133,6 @@ fun FolderDetailScreen(
                     onSelectTab = viewModel::selectTab,
                     onNavigateToDetail = onNavigateToDetail,
                     isItemWatched = isItemWatched,
-                    onItemFocus = viewModel::onItemFocused,
                     onLoadMore = { viewModel.loadMoreItems(uiState.selectedTabIndex) },
                     onSaveFocusState = { verticalIndex, verticalOffset, focusedItemKey ->
                         viewModel.saveTabFocusState(
@@ -213,8 +213,7 @@ private fun TabbedGridContent(
     onNavigateToDetail: (String, String, String) -> Unit,
     onSaveFocusState: (Int, Int, String?) -> Unit,
     onLoadMore: () -> Unit = {},
-    isItemWatched: (MetaPreview) -> Boolean = { false },
-    onItemFocus: (MetaPreview) -> Unit = {}
+    isItemWatched: (MetaPreview) -> Boolean = { false }
 ) {
     val tabFocusRequesters = remember(uiState.tabs.size) { uiState.tabs.indices.map { FocusRequester() } }
 
@@ -391,7 +390,8 @@ private fun TabbedGridContent(
                     .fillMaxSize()
                     .focusRestorer {
                         lastFocusedItemKey?.let { itemFocusRequesters[it] } ?: FocusRequester.Default
-                    },
+                    }
+                    .dpadRepeatThrottle(),
                 contentPadding = PaddingValues(
                     start = 48.dp,
                     end = 48.dp,
@@ -412,10 +412,7 @@ private fun TabbedGridContent(
                         posterCardStyle = posterCardStyle,
                         focusRequester = focusReq,
                         isWatched = isItemWatched(item),
-                        onFocus = { focusedItem ->
-                            lastFocusedItemKey = itemKey
-                            onItemFocus(focusedItem)
-                        },
+                        onFocus = { _ -> lastFocusedItemKey = itemKey },
                         onClick = {
                             onNavigateToDetail(
                                 item.id,
@@ -587,7 +584,7 @@ private fun RowsContent(
                             } else {
                                 -1
                             },
-                            restorerFocusedIndex = rowFocusedItemIndex[rowKey] ?: -1,
+                            restorerFocusedIndex = -1,
                             onItemFocused = { itemIndex ->
                                 currentFocusedRowIndex[0] = index
                                 currentFocusedItemIndex[0] = itemIndex

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
+import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.ui.platform.LocalFocusManager
@@ -225,37 +226,7 @@ fun ClassicHomeContent(
             .fillMaxSize()
             .focusRequester(contentFocusRequester)
             .focusRestorer()
-            .onPreviewKeyEvent { event ->
-                val native = event.nativeKeyEvent
-                if (native.action == AndroidKeyEvent.ACTION_DOWN &&
-                    native.repeatCount > 0 &&
-                    (native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_DOWN ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_UP ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_LEFT ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_RIGHT)
-                ) {
-                    val isVertical = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_DOWN ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_UP
-                    val gateMs = if (isVertical) 112L else KEY_REPEAT_THROTTLE_MS
-                    val now = android.os.SystemClock.uptimeMillis()
-                    if (now - lastKeyRepeatTimeRef[0] < gateMs) {
-                        return@onPreviewKeyEvent true // consume — too fast
-                    }
-                    lastKeyRepeatTimeRef[0] = now
-                    val direction = when (native.keyCode) {
-                        AndroidKeyEvent.KEYCODE_DPAD_DOWN -> FocusDirection.Down
-                        AndroidKeyEvent.KEYCODE_DPAD_UP -> FocusDirection.Up
-                        AndroidKeyEvent.KEYCODE_DPAD_LEFT -> FocusDirection.Left
-                        AndroidKeyEvent.KEYCODE_DPAD_RIGHT -> FocusDirection.Right
-                        else -> null
-                    }
-                    if (direction != null) {
-                        focusManager.moveFocus(direction)
-                    }
-                    return@onPreviewKeyEvent true
-                }
-                false
-            },
+            .dpadRepeatThrottle(),
         contentPadding = PaddingValues(top = if (heroVisible) 0.dp else 24.dp, bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(32.dp)
     ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -1,6 +1,5 @@
 package com.nuvio.tv.ui.screens.home
 
-import android.view.KeyEvent as AndroidKeyEvent
 import com.nuvio.tv.LocalContentFocusRequester
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -39,7 +38,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.onPreviewKeyEvent
+import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -72,9 +71,6 @@ import com.nuvio.tv.ui.components.PosterCardStyle
 import com.nuvio.tv.ui.components.collectionFolderCardImageUrl
 import com.nuvio.tv.ui.components.rememberArtworkBackedCardGlow
 import com.nuvio.tv.ui.theme.NuvioColors
-
-/** Minimum interval between processed key repeat events to prevent HWUI overload. */
-private const val KEY_REPEAT_THROTTLE_MS = 80L
 
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -216,7 +212,6 @@ fun GridHomeContent(
     }
 
     // Throttle D-pad key repeats to prevent HWUI overload when a key is held down.
-    val lastKeyRepeatTime = remember { longArrayOf(0L) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         val contentFocusRequester = LocalContentFocusRequester.current
@@ -229,17 +224,7 @@ fun GridHomeContent(
                 .fillMaxSize()
                 .focusRequester(contentFocusRequester)
                 .focusRestorer()
-                .onPreviewKeyEvent { event ->
-                    val native = event.nativeKeyEvent
-                    if (native.action == AndroidKeyEvent.ACTION_DOWN && native.repeatCount > 0) {
-                        val now = System.currentTimeMillis()
-                        if (now - lastKeyRepeatTime[0] < KEY_REPEAT_THROTTLE_MS) {
-                            return@onPreviewKeyEvent true
-                        }
-                        lastKeyRepeatTime[0] = now
-                    }
-                    false
-                },
+                .dpadRepeatThrottle(),
             contentPadding = PaddingValues(
                 start = 48.dp,
                 end = 24.dp,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -107,6 +107,7 @@ import com.nuvio.tv.ui.components.TrailerPlayer
 import com.nuvio.tv.LocalSidebarExpanded
 import com.nuvio.tv.LocalContentFocusRequester
 import com.nuvio.tv.ui.theme.NuvioColors
+import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import kotlinx.coroutines.delay
 import android.view.KeyEvent as AndroidKeyEvent
 import kotlin.math.abs
@@ -268,7 +269,6 @@ fun ModernHomeContent(
     var restoredFromSavedState by remember { mutableStateOf(false) }
     var optionsItem by remember { mutableStateOf<ContinueWatchingItem?>(null) }
     val lastFocusedContinueWatchingIndexRef = remember { java.util.concurrent.atomic.AtomicInteger(-1) }
-    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     val lastHeroNavigationAtMsRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     val heroFocusSettleDelayMsRef = remember { java.util.concurrent.atomic.AtomicLong(MODERN_HERO_FOCUS_DEBOUNCE_MS) }
     var focusedCatalogSelection by remember { mutableStateOf<FocusedCatalogSelection?>(null) }
@@ -829,39 +829,7 @@ fun ModernHomeContent(
                     .graphicsLayer { alpha = trailerContentAlpha }
                     .focusRequester(contentFocusRequester)
                     .focusRestorer { focusRestorerRequester }
-                    .onPreviewKeyEvent { event ->
-                        val native = event.nativeKeyEvent
-                       
-                    
-                        if (native.action == AndroidKeyEvent.ACTION_DOWN &&
-                            native.repeatCount > 0 &&
-                            (native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_DOWN ||
-                                native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_UP ||
-                                native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_LEFT ||
-                                native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_RIGHT)
-                        ) {
-                            val isVertical = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_DOWN ||
-                                native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_UP
-                            val gateMs = if (isVertical) 112L else 80L
-                            val now = android.os.SystemClock.uptimeMillis()
-                            if (now - lastKeyRepeatDispatchRef.get() < gateMs) {
-                                return@onPreviewKeyEvent true // consume, too soon
-                            }
-                            lastKeyRepeatDispatchRef.set(now)
-                            val direction = when (native.keyCode) {
-                                AndroidKeyEvent.KEYCODE_DPAD_DOWN -> FocusDirection.Down
-                                AndroidKeyEvent.KEYCODE_DPAD_UP -> FocusDirection.Up
-                                AndroidKeyEvent.KEYCODE_DPAD_LEFT -> FocusDirection.Left
-                                AndroidKeyEvent.KEYCODE_DPAD_RIGHT -> FocusDirection.Right
-                                else -> null
-                            }
-                            if (direction != null) {
-                                focusManager.moveFocus(direction)
-                            }
-                            return@onPreviewKeyEvent true
-                        }
-                        false
-                    },
+                    .dpadRepeatThrottle(),
                 contentPadding = PaddingValues(bottom = rowsViewportHeight),
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -53,11 +53,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalContext
+import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
@@ -460,42 +459,10 @@ fun SearchScreen(
                 }
             }
         } else {
-            val searchFocusManager = LocalFocusManager.current
-            val searchLastKeyRepeatTimeRef = remember { longArrayOf(0L) }
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .onPreviewKeyEvent { event ->
-                        val native = event.nativeKeyEvent
-                        if (native.action == KeyEvent.ACTION_DOWN &&
-                            native.repeatCount > 0 &&
-                            (native.keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
-                                native.keyCode == KeyEvent.KEYCODE_DPAD_UP ||
-                                native.keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
-                                native.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT)
-                        ) {
-                            val isVertical = native.keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
-                                native.keyCode == KeyEvent.KEYCODE_DPAD_UP
-                            val gateMs = if (isVertical) 112L else 80L
-                            val now = android.os.SystemClock.uptimeMillis()
-                            if (now - searchLastKeyRepeatTimeRef[0] < gateMs) {
-                                return@onPreviewKeyEvent true
-                            }
-                            searchLastKeyRepeatTimeRef[0] = now
-                            val direction = when (native.keyCode) {
-                                KeyEvent.KEYCODE_DPAD_DOWN -> FocusDirection.Down
-                                KeyEvent.KEYCODE_DPAD_UP -> FocusDirection.Up
-                                KeyEvent.KEYCODE_DPAD_LEFT -> FocusDirection.Left
-                                KeyEvent.KEYCODE_DPAD_RIGHT -> FocusDirection.Right
-                                else -> null
-                            }
-                            if (direction != null) {
-                                searchFocusManager.moveFocus(direction)
-                            }
-                            return@onPreviewKeyEvent true
-                        }
-                        false
-                    },
+                    .dpadRepeatThrottle(),
                 contentPadding = PaddingValues(vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {

--- a/app/src/main/java/com/nuvio/tv/ui/util/DpadThrottleModifier.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/DpadThrottleModifier.kt
@@ -1,0 +1,56 @@
+package com.nuvio.tv.ui.util
+
+import android.os.SystemClock
+import android.view.KeyEvent
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalFocusManager
+
+/**
+ * Throttles D-pad key repeats to prevent HWUI overload and focus jank
+ * when a directional key is held down.  Consumes rapid repeats and
+ * manually moves focus at a controlled rate.
+ *
+ * @param horizontalGateMs minimum interval between horizontal repeats
+ * @param verticalGateMs   minimum interval between vertical repeats
+ */
+fun Modifier.dpadRepeatThrottle(
+    horizontalGateMs: Long = 80L,
+    verticalGateMs: Long = 112L
+): Modifier = composed {
+    val focusManager = LocalFocusManager.current
+    val lastRepeatTime = remember { longArrayOf(0L) }
+
+    onPreviewKeyEvent { event ->
+        val native = event.nativeKeyEvent
+        if (native.action == KeyEvent.ACTION_DOWN &&
+            native.repeatCount > 0 &&
+            (native.keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+                native.keyCode == KeyEvent.KEYCODE_DPAD_UP ||
+                native.keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+                native.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT)
+        ) {
+            val isVertical = native.keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+                native.keyCode == KeyEvent.KEYCODE_DPAD_UP
+            val gateMs = if (isVertical) verticalGateMs else horizontalGateMs
+            val now = SystemClock.uptimeMillis()
+            if (now - lastRepeatTime[0] < gateMs) {
+                return@onPreviewKeyEvent true
+            }
+            lastRepeatTime[0] = now
+            val direction = when (native.keyCode) {
+                KeyEvent.KEYCODE_DPAD_DOWN -> FocusDirection.Down
+                KeyEvent.KEYCODE_DPAD_UP -> FocusDirection.Up
+                KeyEvent.KEYCODE_DPAD_LEFT -> FocusDirection.Left
+                KeyEvent.KEYCODE_DPAD_RIGHT -> FocusDirection.Right
+                else -> null
+            }
+            if (direction != null) focusManager.moveFocus(direction)
+            return@onPreviewKeyEvent true
+        }
+        false
+    }
+}


### PR DESCRIPTION
## Summary

Extract duplicated D-pad key repeat throttle into a reusable `Modifier.dpadRepeatThrottle()` extension. The same ~20-line block was copy-pasted across 7 files - now each call site is a single `.dpadRepeatThrottle()`.

## PR type

- Small maintenance improvement

## Why

The identical key repeat throttle logic (intercept held D-pad keys, gate by time interval, manually move focus) was duplicated in ModernHomeContent, ClassicHomeContent, GridHomeContent, SearchScreen, CatalogSeeAllScreen, FolderDetailScreen, and LibraryScreen. Any behavior change required updating all copies.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified D-pad hold scrolling behavior unchanged in Modern home, Classic home, Grid home, Search results, Catalog See All, Folder tabbed grid, and Library
- Verified sidebar is not escaped during fast horizontal scrolling

## Screenshots / Video (UI changes only)

no visual change.

## Breaking changes

Nothing should break

## Linked issues

N/A
