### PR TITLE
Lazy Catalogs loading with shimmer

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -99,7 +99,7 @@ fun CatalogRowSection(
     listState: LazyListState = rememberLazyListState(initialFirstVisibleItemIndex = initialScrollIndex)
 ) {
     fun rowItemFocusKey(index: Int, item: MetaPreview): String {
-        return "${catalogRow.addonId}_${catalogRow.apiType}_${catalogRow.catalogId}_${item.id}"
+        return "${catalogRow.addonId}_${catalogRow.apiType}_${catalogRow.catalogId}_$index"
     }
 
     val seeAllCardShape = RoundedCornerShape(posterCardStyle.cornerRadius)
@@ -111,6 +111,33 @@ fun CatalogRowSection(
     val itemFocusRequestersByKey = remember { mutableMapOf<String, FocusRequester>() }
     var lastRequestedFocusItemKey by remember { mutableStateOf<String?>(null) }
     var lastFocusedItemIndex by remember { mutableIntStateOf(-1) }
+
+    val blockingFocusExit = remember { mutableStateOf(false) }
+    val rowHasFocusRef = remember { mutableStateOf(false) }
+    val firstItemId = catalogRow.items.firstOrNull()?.id
+    val wasPlaceholderRef = remember { mutableStateOf(firstItemId?.startsWith("__placeholder_") == true) }
+    val isNowReal = firstItemId?.startsWith("__placeholder_") != true
+    if (wasPlaceholderRef.value && isNowReal && rowHasFocusRef.value) {
+        blockingFocusExit.value = true
+    }
+    wasPlaceholderRef.value = firstItemId?.startsWith("__placeholder_") == true
+
+    LaunchedEffect(blockingFocusExit.value) {
+        if (!blockingFocusExit.value) return@LaunchedEffect
+        val targetKey = rowItemFocusKey(0, catalogRow.items.firstOrNull() ?: run {
+            blockingFocusExit.value = false
+            return@LaunchedEffect
+        })
+        repeat(15) {
+            val req = itemFocusRequestersByKey[targetKey]
+            if (req != null) {
+                val ok = runCatching { req.requestFocus(); true }.getOrDefault(false)
+                if (ok) { blockingFocusExit.value = false; return@LaunchedEffect }
+            }
+            withFrameNanos { }
+        }
+        blockingFocusExit.value = false
+    }
 
     // When fresh data prepends new items to a row the user hasn't
     // scrolled, snap back to position 0 so the newest content is visible.
@@ -170,7 +197,14 @@ fun CatalogRowSection(
         if (showCatalogTypeSuffix && typeLabel.isNotEmpty()) "$formattedName - $typeLabel" else formattedName
     }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(modifier = modifier.fillMaxWidth().then(
+        if (blockingFocusExit.value) {
+            Modifier.focusProperties {
+                up = FocusRequester.Cancel
+                down = FocusRequester.Cancel
+            }
+        } else Modifier
+    )) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -219,6 +253,7 @@ fun CatalogRowSection(
             state = listState,
             modifier = Modifier
                 .fillMaxWidth()
+                .onFocusChanged { rowHasFocusRef.value = it.hasFocus }
                 .focusRequester(resolvedRowFocusRequester)
                 .focusRestorer(
                     if (enableRowFocusRestorer) {

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -4,6 +4,7 @@ import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.foundation.layout.Box
@@ -24,8 +25,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +40,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -345,7 +352,38 @@ fun ContentCard(
                     .height(baseCardHeight)
                     .clip(cardShape)
             ) {
-                if (!imageUrl.isNullOrBlank()) {
+                val isPlaceholderItem = imageUrl?.startsWith("placeholder://") == true
+                if (isPlaceholderItem) {
+                    val shimmerTransition = rememberInfiniteTransition(label = "classicPlaceholderShimmer")
+                    val shimmerOffset by shimmerTransition.animateFloat(
+                        initialValue = -1f,
+                        targetValue = 2f,
+                        animationSpec = infiniteRepeatable(
+                            animation = tween(durationMillis = 1600, easing = LinearEasing),
+                            repeatMode = RepeatMode.Restart
+                        ),
+                        label = "shimmerOffset"
+                    )
+                    val shimmerBrush = remember(shimmerOffset) {
+                        Brush.linearGradient(
+                            colorStops = arrayOf(
+                                0.0f to Color.Transparent,
+                                0.4f to Color.White.copy(alpha = 0.07f),
+                                0.5f to Color.White.copy(alpha = 0.13f),
+                                0.6f to Color.White.copy(alpha = 0.07f),
+                                1.0f to Color.Transparent
+                            ),
+                            start = Offset(shimmerOffset * 1000f, 0f),
+                            end = Offset((shimmerOffset + 0.6f) * 1000f, 0f)
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(NuvioColors.BackgroundCard)
+                            .background(shimmerBrush)
+                    )
+                } else if (!imageUrl.isNullOrBlank()) {
                     key(scrollPhaseKey) {
                         AsyncImage(
                             model = scrollAwareImageModel,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -17,7 +17,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import kotlinx.coroutines.delay
 
@@ -70,7 +72,8 @@ fun ClassicHomeContent(
     onItemFocus: (MetaPreview) -> Unit = {},
     catalogSeeAllLabel: String? = null,
     onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
-    scrollToTopTrigger: Int = 0
+    scrollToTopTrigger: Int = 0,
+    onRequestLazyCatalogLoad: (String) -> Unit = {}
 ) {
 
     // Nested prefetch: when LazyColumn prefetches a row ahead of scrolling,
@@ -142,6 +145,7 @@ fun ClassicHomeContent(
             when (row) {
                 is HomeRow.Catalog -> "${row.row.addonId}_${row.row.apiType}_${row.row.catalogId}"
                 is HomeRow.CollectionRow -> "collection_${row.collection.id}"
+                is HomeRow.PlaceholderCatalog -> row.catalogKey
             }
         }
     }
@@ -210,6 +214,39 @@ fun ClassicHomeContent(
             LoadingIndicator()
         }
         return
+    }
+
+    // Lazy catalog loading: trigger load after scroll settles
+    val latestOnRequestLazyCatalogLoad = rememberUpdatedState(onRequestLazyCatalogLoad)
+    val latestVisibleHomeRows = rememberUpdatedState(visibleHomeRows)
+    LaunchedEffect(columnListState) {
+        val prefetchAhead = 2
+        snapshotFlow {
+            val scrolling = columnListState.isScrollInProgress
+            val info = columnListState.layoutInfo
+            val firstVisible = info.visibleItemsInfo.firstOrNull()?.index ?: -1
+            val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+            Triple(scrolling, firstVisible, lastVisible)
+        }.collect { (scrolling, firstVisible, lastVisible) ->
+            if (scrolling || lastVisible < 0) return@collect
+            delay(150)
+            if (columnListState.isScrollInProgress) return@collect
+            val rows = latestVisibleHomeRows.value
+            // Offset for hero + CW sections that precede homeRows in LazyColumn
+            val heroOffset = if (uiState.heroSectionEnabled && uiState.heroItems.isNotEmpty()) 1 else 0
+            val cwOffset = if (uiState.continueWatchingItems.isNotEmpty()) 1 else 0
+            val rowsOffset = heroOffset + cwOffset
+            for (idx in firstVisible.coerceAtLeast(0)..(lastVisible + prefetchAhead)) {
+                val rowIdx = idx - rowsOffset
+                val row = rows.getOrNull(rowIdx) ?: continue
+                if (row is HomeRow.Catalog && row.row.isLoading &&
+                    row.row.items.firstOrNull()?.id?.startsWith("__placeholder_") == true
+                ) {
+                    val key = "${row.row.addonId}_${row.row.apiType}_${row.row.catalogId}"
+                    latestOnRequestLazyCatalogLoad.value(key)
+                }
+            }
+        }
     }
 
     CompositionLocalProvider(
@@ -291,6 +328,7 @@ fun ClassicHomeContent(
                     when (row) {
                         is HomeRow.Catalog -> "${row.row.addonId}_${row.row.apiType}_${row.row.catalogId}"
                         is HomeRow.CollectionRow -> "collection_${row.collection.id}"
+                        is HomeRow.PlaceholderCatalog -> row.catalogKey
                     }
                 }
                 val cwDownRequester = firstRowKey?.let { rowEntryFocusRequesters.getOrPut(it) { FocusRequester() } }
@@ -350,14 +388,19 @@ fun ClassicHomeContent(
             items = visibleHomeRows,
             key = { _, item ->
                 when (item) {
-                    is HomeRow.Catalog -> "${item.row.addonId}_${item.row.apiType}_${item.row.catalogId}"
+                    is HomeRow.Catalog -> {
+                        val r = item.row
+                        "${r.addonId}_${r.apiType}_${r.catalogId}"
+                    }
                     is HomeRow.CollectionRow -> "collection_${item.collection.id}"
+                    is HomeRow.PlaceholderCatalog -> item.catalogKey
                 }
             },
             contentType = { _, item ->
                 when (item) {
                     is HomeRow.Catalog -> "catalog_row"
                     is HomeRow.CollectionRow -> "collection_row"
+                    is HomeRow.PlaceholderCatalog -> "catalog_row"
                 }
             }
         ) { index, homeRow ->
@@ -460,6 +503,8 @@ fun ClassicHomeContent(
                         }
                     )
                 }
+
+                is HomeRow.PlaceholderCatalog -> { }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -488,6 +488,9 @@ private fun ClassicHomeRoute(
         },
         onSaveFocusState = { vi, vo, ri, ii, m ->
             viewModel.saveFocusState(vi, vo, ri, ii, m)
+        },
+        onRequestLazyCatalogLoad = remember(viewModel) {
+            { catalogKey: String -> viewModel.requestLazyCatalogLoad(catalogKey) }
         }
     )
 }
@@ -602,7 +605,10 @@ private fun ModernHomeRoute(
             { item -> viewModel.onItemFocus(item) }
         },
         onPreloadAdjacentItem = preloadAdjacentItem,
-        onSaveFocusState = saveModernFocusState
+        onSaveFocusState = saveModernFocusState,
+        onRequestLazyCatalogLoad = remember(viewModel) {
+            { catalogKey: String -> viewModel.requestLazyCatalogLoad(catalogKey) }
+        }
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -113,6 +113,23 @@ sealed class HomeRow {
 
     @Immutable
     data class CollectionRow(val collection: Collection) : HomeRow()
+
+    /**
+     * Placeholder for a catalog row whose data hasn't been fetched yet.
+     * Rendered as a shimmer/skeleton row until the user scrolls near it
+     * and the actual catalog data is loaded on demand.
+     */
+    @Immutable
+    data class PlaceholderCatalog(
+        val catalogKey: String,
+        val addonId: String,
+        val addonName: String,
+        val addonBaseUrl: String,
+        val catalogId: String,
+        val catalogName: String,
+        val apiType: String,
+        val displayTitle: String
+    ) : HomeRow()
 }
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -208,6 +208,23 @@ class HomeViewModel @Inject constructor(
     @Volatile
     internal var startupGracePeriodActive: Boolean = true
     internal var startupAuthNoticeJob: Job? = null
+
+    // Lazy catalog loading
+    internal val eagerCatalogLoadCount: Int = 4
+    internal val lazyLoadRequestedKeys = Collections.synchronizedSet(mutableSetOf<String>())
+    internal val pendingLazyCatalogs = linkedMapOf<String, Pair<Addon, CatalogDescriptor>>()
+    /** All placeholder descriptors for homeRow construction. */
+    internal data class PlaceholderDescriptor(
+        val catalogKey: String,
+        val addonId: String,
+        val addonName: String,
+        val addonBaseUrl: String,
+        val catalogId: String,
+        val catalogName: String,
+        val apiType: String,
+        val displayTitle: String
+    )
+    internal val placeholderDescriptors = mutableListOf<PlaceholderDescriptor>()
     val trailerPreviewUrls: Map<String, String>
         get() = trailerPreviewUrlsState
     val trailerPreviewAudioUrls: Map<String, String>
@@ -577,6 +594,20 @@ class HomeViewModel @Inject constructor(
             delay(debounceMs)
             updateCatalogRows()
         }
+    }
+
+    /**
+     * Called from the UI when a placeholder catalog row becomes visible.
+     */
+    fun requestLazyCatalogLoad(catalogKey: String) {
+        if (!lazyLoadRequestedKeys.add(catalogKey)) return
+        val pair = synchronized(catalogStateLock) {
+            pendingLazyCatalogs.remove(catalogKey)
+        } ?: return
+        val (addon, catalog) = pair
+        val generation = catalogLoadGeneration
+        pendingCatalogLoads = (pendingCatalogLoads + 1)
+        loadCatalogPipeline(addon, catalog, generation)
     }
 
     private suspend fun updateCatalogRows() = updateCatalogRowsPipeline()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -218,7 +218,6 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
         }
 
         val allCatalogsToLoad = catalogsToLoad + heroOnlyCatalogs
-        pendingCatalogLoads = allCatalogsToLoad.size
         if (allCatalogsToLoad.isEmpty()) {
             // No home catalogs and no hero catalogs to load —
             // but collections may still exist to render.
@@ -230,8 +229,75 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
             }
             return
         }
-        allCatalogsToLoad.forEach { (addon, catalog) ->
+
+        // ── Lazy loading: split into eager and deferred ──
+        val heroOnlyKeys = heroOnlyCatalogs.map { (addon, catalog) ->
+            catalogKey(addonId = addon.id, type = catalog.apiType, catalogId = catalog.id)
+        }.toSet()
+
+        // Build display title helper (respects custom titles)
+        val titlesSnapshot = customCatalogTitles
+        val showTypeSuffix = _uiState.value.catalogTypeSuffixEnabled
+        val strTypeMovie = appContext.getString(R.string.type_movie)
+        val strTypeSeries = appContext.getString(R.string.type_series)
+        fun displayTitle(addon: Addon, catalog: CatalogDescriptor): String {
+            val key = catalogKey(addonId = addon.id, type = catalog.apiType, catalogId = catalog.id)
+            val custom = titlesSnapshot[key]
+            val baseName = if (!custom.isNullOrBlank()) custom else catalog.name
+            val catalogName = baseName.replaceFirstChar { it.uppercase() }
+            if (!showTypeSuffix) return catalogName
+            val typeLabel = when (catalog.apiType.lowercase()) {
+                "movie" -> strTypeMovie.ifBlank { catalog.apiType.replaceFirstChar { it.uppercase() } }
+                "series" -> strTypeSeries.ifBlank { catalog.apiType.replaceFirstChar { it.uppercase() } }
+                else -> catalog.apiType.replaceFirstChar { it.uppercase() }
+            }
+            return "$catalogName - $typeLabel"
+        }
+
+        // Determine which home catalogs to load eagerly vs lazily.
+        val eagerHomeCatalogs = catalogsToLoad.take(eagerCatalogLoadCount)
+        val lazyHomeCatalogs = catalogsToLoad.drop(eagerCatalogLoadCount)
+
+        // Build placeholder descriptors for lazy catalogs
+        synchronized(catalogStateLock) {
+            pendingLazyCatalogs.clear()
+            placeholderDescriptors.clear()
+        }
+        lazyLoadRequestedKeys.clear()
+
+        lazyHomeCatalogs.forEach { (addon, catalog) ->
+            val key = catalogKey(addonId = addon.id, type = catalog.apiType, catalogId = catalog.id)
+            synchronized(catalogStateLock) {
+                pendingLazyCatalogs[key] = addon to catalog
+                placeholderDescriptors.add(
+                    HomeViewModel.PlaceholderDescriptor(
+                        catalogKey = key,
+                        addonId = addon.id,
+                        addonName = addon.displayName,
+                        addonBaseUrl = addon.baseUrl,
+                        catalogId = catalog.id,
+                        catalogName = catalog.name,
+                        apiType = catalog.apiType,
+                        displayTitle = displayTitle(addon, catalog)
+                    )
+                )
+            }
+        }
+
+        Log.d(HomeViewModel.TAG,
+            "Lazy loading: eager=${eagerHomeCatalogs.size} lazy=${lazyHomeCatalogs.size}"
+        )
+
+        val eagerCatalogs = eagerHomeCatalogs + heroOnlyCatalogs
+        pendingCatalogLoads = eagerCatalogs.size
+        eagerCatalogs.forEach { (addon, catalog) ->
             loadCatalogPipeline(addon, catalog, generation)
+        }
+
+        // Immediately schedule an update so placeholder rows appear in the UI
+        // while eager catalogs are still loading.
+        if (lazyHomeCatalogs.isNotEmpty()) {
+            scheduleUpdateCatalogRows()
         }
     } catch (e: Exception) {
         catalogsLoadInProgress = false
@@ -316,6 +382,10 @@ internal fun HomeViewModel.loadCatalogPipeline(
                             catalogId = catalog.id
                         )
                         replaceCatalogRow(key, result.data)
+                        // Remove placeholder descriptor now that real data is available
+                        synchronized(catalogStateLock) {
+                            placeholderDescriptors.removeAll { it.catalogKey == key }
+                        }
                         if (!hasCountedCompletion) {
                             pendingCatalogLoads = (pendingCatalogLoads - 1).coerceAtLeast(0)
                             hasCountedCompletion = true
@@ -330,6 +400,15 @@ internal fun HomeViewModel.loadCatalogPipeline(
                         scheduleUpdateCatalogRows()
                     }
                     is NetworkResult.Error -> {
+                        val errorKey = catalogKey(
+                            addonId = addon.id,
+                            type = catalog.apiType,
+                            catalogId = catalog.id
+                        )
+                        // Remove placeholder on error so it doesn't show forever
+                        synchronized(catalogStateLock) {
+                            placeholderDescriptors.removeAll { it.catalogKey == errorKey }
+                        }
                         if (!hasCountedCompletion) {
                             pendingCatalogLoads = (pendingCatalogLoads - 1).coerceAtLeast(0)
                             hasCountedCompletion = true
@@ -548,6 +627,10 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
 
     val computedHomeRows = buildList {
         val displayRowsByKey = displayRows.associateBy { "${it.addonId}_${it.apiType}_${it.catalogId}" }
+        // Build a lookup of placeholder descriptors by key for lazy catalogs
+        val placeholdersByKey = synchronized(catalogStateLock) {
+            placeholderDescriptors.associateBy { it.catalogKey }
+        }
         collectionsCache.forEach { collection ->
             val key = "collection_${collection.id}"
             if (collection.pinToTop && key !in disabledHomeCatalogKeys) {
@@ -565,6 +648,51 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                 val catalogRow = displayRowsByKey[key]
                 if (catalogRow != null && catalogRow.items.isNotEmpty()) {
                     add(HomeRow.Catalog(catalogRow))
+                } else {
+                    val placeholder = placeholdersByKey[key]
+                    if (placeholder != null) {
+                        if (currentLayout == HomeLayout.MODERN) {
+                            add(HomeRow.PlaceholderCatalog(
+                                catalogKey = placeholder.catalogKey,
+                                addonId = placeholder.addonId,
+                                addonName = placeholder.addonName,
+                                addonBaseUrl = placeholder.addonBaseUrl,
+                                catalogId = placeholder.catalogId,
+                                catalogName = placeholder.catalogName,
+                                apiType = placeholder.apiType,
+                                displayTitle = placeholder.displayTitle
+                            ))
+                        } else {
+                            val fakeItems = (0 until 8).map { i ->
+                                MetaPreview(
+                                    id = "__placeholder_${placeholder.catalogKey}_$i",
+                                    type = com.nuvio.tv.domain.model.ContentType.fromString(placeholder.apiType),
+                                    rawType = placeholder.apiType,
+                                    name = " ",
+                                    poster = "placeholder://empty",
+                                    posterShape = com.nuvio.tv.domain.model.PosterShape.POSTER,
+                                    background = null,
+                                    logo = null,
+                                    description = null,
+                                    releaseInfo = " ",
+                                    imdbRating = null,
+                                    genres = emptyList()
+                                )
+                            }
+                            add(HomeRow.Catalog(CatalogRow(
+                                addonId = placeholder.addonId,
+                                addonName = placeholder.addonName,
+                                addonBaseUrl = placeholder.addonBaseUrl,
+                                catalogId = placeholder.catalogId,
+                                catalogName = placeholder.catalogName,
+                                type = com.nuvio.tv.domain.model.ContentType.fromString(placeholder.apiType),
+                                rawType = placeholder.apiType,
+                                items = fakeItems,
+                                isLoading = true,
+                                hasMore = false
+                            )))
+                        }
+                    }
                 }
             }
         }
@@ -628,6 +756,9 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                                 folder = folder
                             ))
                         }
+                    }
+                    is HomeRow.PlaceholderCatalog -> {
+                        // Grid layout: skip placeholders (grid loads all at once)
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -105,7 +105,10 @@ internal fun HomeViewModel.clearCatalogData() {
         catalogsMap.clear()
         catalogItemKeyIndex.clear()
         truncatedRowCache.clear()
+        pendingLazyCatalogs.clear()
+        placeholderDescriptors.clear()
     }
+    lazyLoadRequestedKeys.clear()
 }
 
 internal fun HomeViewModel.snapshotCatalogKeys(): Set<String> = synchronized(catalogStateLock) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -146,7 +146,8 @@ fun ModernHomeContent(
     onItemFocus: (MetaPreview) -> Unit = {},
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
     onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
-    scrollToTopTrigger: Int = 0
+    scrollToTopTrigger: Int = 0,
+    onRequestLazyCatalogLoad: (String) -> Unit = {}
 ) {
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val isSidebarExpanded = LocalSidebarExpanded.current
@@ -257,6 +258,8 @@ fun ModernHomeContent(
     var pendingRowFocusKey by remember { mutableStateOf<String?>(null) }
     var pendingRowFocusIndex by remember { mutableStateOf<Int?>(null) }
     var pendingRowFocusNonce by remember { mutableIntStateOf(0) }
+    // Track row keys that are currently placeholders (empty items + isLoading).
+    val placeholderRowKeysRef = remember { mutableSetOf<String>() }
     var heroItem by remember {
         val initialHero = carouselRows.firstOrNull()?.items?.firstOrNull()?.heroPreview
         mutableStateOf<HeroPreview?>(initialHero)
@@ -335,8 +338,12 @@ fun ModernHomeContent(
         loadMoreRequestedTotals.keys.retainAll(activeRowKeys)
         carouselRows.forEach { row ->
             val rowRequesters = itemFocusRequesters[row.key] ?: return@forEach
-            val allowedKeys = activeItemKeysByRow[row.key] ?: emptySet()
-            rowRequesters.keys.retainAll(allowedKeys)
+            // Prune FocusRequester entries beyond current item count
+            val maxIndex = row.items.size
+            rowRequesters.keys.removeAll { key ->
+                val idx = key.removePrefix("${row.key}_").toIntOrNull()
+                idx != null && idx >= maxIndex
+            }
         }
         if (focusedCatalogSelection?.payload?.itemId !in activeCatalogItemIds) {
             focusedCatalogSelection = null
@@ -378,12 +385,6 @@ fun ModernHomeContent(
         val hadActiveRow = focusHolder.activeRowKey != null
         val existingActive = focusHolder.activeRowKey?.let(rowByKey::get)
         val firstRow = carouselRows.first()
-        // When new rows appear before the auto-selected row (e.g., catalogs
-        // load after collections), move focus to the new first row — but only
-        // if the user hasn't manually navigated away from the initial position.
-        // Detect if the auto-selected row is stale: new rows appeared
-        // above it (e.g., catalogs loaded after collections) and the user
-        // hasn't manually navigated away from the initial selection.
         val userStillOnAutoSelected = initialAutoSelectedKey != null &&
             focusHolder.activeRowKey == initialAutoSelectedKey
         val autoSelectedStale = hadActiveRow && existingActive != null &&
@@ -709,10 +710,8 @@ fun ModernHomeContent(
                     val rowListState = uiCaches.rowListStates[rowKey]
                     val firstVisibleIndex = rowListState?.firstVisibleItemIndex ?: 0
                     val safeIndex = firstVisibleIndex.coerceIn(0, ((row?.items?.size ?: 1) - 1).coerceAtLeast(0))
-                    val itemKey = row?.items?.getOrNull(safeIndex)?.key
-                    if (itemKey != null) {
-                        uiCaches.itemFocusRequesters[rowKey]?.get(itemKey) ?: FocusRequester.Default
-                    } else FocusRequester.Default
+                    val stableKey = "${rowKey}_$safeIndex"
+                    uiCaches.itemFocusRequesters[rowKey]?.get(stableKey) ?: FocusRequester.Default
                 } else FocusRequester.Default
             }
         }
@@ -814,6 +813,33 @@ fun ModernHomeContent(
             }
         }
 
+        // Lazy catalog loading: trigger load after scroll settles
+        val latestOnRequestLazyCatalogLoad = rememberUpdatedState(onRequestLazyCatalogLoad)
+        val latestCarouselRowsForLazy = rememberUpdatedState(carouselRows)
+        LaunchedEffect(verticalRowListState) {
+            val prefetchAheadForLazy = 2
+            snapshotFlow {
+                val scrolling = verticalRowListState.isScrollInProgress
+                val info = verticalRowListState.layoutInfo
+                val firstVisible = info.visibleItemsInfo.firstOrNull()?.index ?: -1
+                val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+                Triple(scrolling, firstVisible, lastVisible)
+            }.collect { (scrolling, firstVisible, lastVisible) ->
+                if (scrolling || lastVisible < 0) return@collect
+                // Small settle delay so rapid D-pad presses don't fire loads
+                delay(150)
+                // Re-check after delay — if scrolling resumed, skip
+                if (verticalRowListState.isScrollInProgress) return@collect
+                val rows = latestCarouselRowsForLazy.value
+                for (idx in firstVisible.coerceAtLeast(0)..(lastVisible + prefetchAheadForLazy)) {
+                    val row = rows.getOrNull(idx) ?: continue
+                    if (row.isLoading && row.items.firstOrNull()?.key?.startsWith("placeholder_") == true) {
+                        latestOnRequestLazyCatalogLoad.value(row.key)
+                    }
+                }
+            }
+        }
+
         CompositionLocalProvider(
             LocalBringIntoViewSpec provides verticalRowBringIntoViewSpec,
             LocalVerticalRowsScrolling provides (uiState.memoryOnlyVerticalScroll && isVerticalRowsScrolling),
@@ -889,9 +915,8 @@ fun ModernHomeContent(
                             else {
                                 val savedIdx = (focusedItemByRow[targetRow.key] ?: 0)
                                     .coerceIn(0, (targetRow.items.size - 1).coerceAtLeast(0))
-                                val targetItemKey = targetRow.items.getOrNull(savedIdx)?.key
-                                if (targetItemKey == null) null
-                                else uiCaches.requesterFor(targetRow.key, targetItemKey)
+                                val targetStableKey = "${targetRow.key}_$savedIdx"
+                                uiCaches.requesterFor(targetRow.key, targetStableKey)
                             }
                         },
                     ),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
@@ -204,6 +204,50 @@ internal fun buildModernHomePresentation(
                     )
                     add(mappedRow)
                 }
+
+                is HomeRow.PlaceholderCatalog -> {
+                    if (catalogRowLimit != null && renderedCatalogRows >= catalogRowLimit) {
+                        return@forEachIndexed
+                    }
+                    renderedCatalogRows++
+                    val fakeItemCount = 8
+                    val fakeItems = (0 until fakeItemCount).map { i ->
+                        val fakeId = "__placeholder_${homeRow.catalogKey}_$i"
+                        ModernCarouselItem(
+                            key = "placeholder_${homeRow.catalogKey}_$i",
+                            title = "",
+                            subtitle = null,
+                            // Dummy URL triggers shimmer instead of MonochromePosterPlaceholder
+                            imageUrl = "placeholder://empty",
+                            heroPreview = HeroPreview(
+                                title = "", logo = null, description = null,
+                                contentTypeText = null, yearText = null, imdbText = null,
+                                genres = emptyList(), poster = null, backdrop = null,
+                                imageUrl = "placeholder://empty"
+                            ),
+                            payload = ModernPayload.Catalog(
+                                focusKey = "placeholder_${homeRow.catalogKey}_$i",
+                                itemId = fakeId,
+                                itemType = homeRow.apiType,
+                                addonBaseUrl = homeRow.addonBaseUrl,
+                                trailerTitle = "",
+                                trailerReleaseInfo = null,
+                                trailerApiType = homeRow.apiType
+                            )
+                        )
+                    }
+                    val placeholderRow = HeroCarouselRow(
+                        key = homeRow.catalogKey,
+                        title = homeRow.displayTitle,
+                        globalRowIndex = index,
+                        catalogId = homeRow.catalogId,
+                        addonId = homeRow.addonId,
+                        apiType = homeRow.apiType,
+                        items = fakeItems,
+                        isLoading = true
+                    )
+                    add(placeholderRow)
+                }
             }
         }
 
@@ -230,6 +274,10 @@ private fun resolveVisibleHomeRows(input: ModernHomePresentationInput): List<Hom
                 }
                 is HomeRow.CollectionRow -> {
                     homeRow.collection.takeIf(Collection::hasVisibleFolders)?.let(HomeRow::CollectionRow)
+                }
+                is HomeRow.PlaceholderCatalog -> {
+                    // Keep placeholder rows as-is — they'll be rendered as shimmer skeletons
+                    homeRow
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -4,9 +4,15 @@ package com.nuvio.tv.ui.screens.home
 
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.ui.draw.clip
@@ -43,6 +49,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -358,7 +366,18 @@ internal fun ModernRowSection(
     val loadMoreRequestedTotals = uiCaches.loadMoreRequestedTotals
 
     val rowKey = row.key
-    Column {
+    // Blocks vertical focus exit during placeholder→data transition.
+    val blockingFocusExit = remember { mutableStateOf(false) }
+    Column(
+        modifier = Modifier.then(
+            if (blockingFocusExit.value) {
+                Modifier.focusProperties {
+                    up = FocusRequester.Cancel
+                    down = FocusRequester.Cancel
+                }
+            } else Modifier
+        )
+    ) {
         val titleMediumStyle = MaterialTheme.typography.titleMedium
         val rowTitleStyle = remember(titleMediumStyle) {
             titleMediumStyle.copy(fontWeight = FontWeight.SemiBold)
@@ -394,6 +413,43 @@ internal fun ModernRowSection(
             }
         }
 
+        // When placeholder items are replaced by real data and this row
+        // is the active row, re-request focus on the first real item.
+        val wasPlaceholderRef = remember { mutableStateOf(row.isLoading && firstItemKey?.startsWith("placeholder_") == true) }
+        val needsFocusRestore = remember { mutableStateOf(false) }
+        val wasPlaceholder = wasPlaceholderRef.value
+        val isNowReal = !row.isLoading || firstItemKey?.startsWith("placeholder_") != true
+        if (wasPlaceholder && isNowReal && isActiveRow) {
+            needsFocusRestore.value = true
+            blockingFocusExit.value = true
+        }
+        wasPlaceholderRef.value = row.isLoading && firstItemKey?.startsWith("placeholder_") == true
+
+        // Restore focus after placeholder→data transition using a retry loop
+        // that starts immediately (no pre-delay) to minimize the visible jump.
+        LaunchedEffect(needsFocusRestore.value, row.key) {
+            if (!needsFocusRestore.value) return@LaunchedEffect
+            needsFocusRestore.value = false
+            if (row.items.isEmpty()) {
+                blockingFocusExit.value = false
+                return@LaunchedEffect
+            }
+            // Use index-based key matching the LazyRow key scheme
+            val targetStableKey = "${row.key}_0"
+            repeat(15) {
+                val requester = uiCaches.itemFocusRequesters[row.key]?.get(targetStableKey)
+                if (requester != null) {
+                    val ok = runCatching { requester.requestFocus(); true }.getOrDefault(false)
+                    if (ok) {
+                        blockingFocusExit.value = false
+                        return@LaunchedEffect
+                    }
+                }
+                withFrameNanos { }
+            }
+            blockingFocusExit.value = false
+        }
+
         val isRowScrollingState = remember(rowListState) {
             derivedStateOf { rowListState.isScrollInProgress }
         }
@@ -412,8 +468,8 @@ internal fun ModernRowSection(
             if (pendingRowFocusKey != row.key) return@LaunchedEffect
             val targetIndex = (pendingRowFocusIndex ?: 0)
                 .coerceIn(0, (row.items.size - 1).coerceAtLeast(0))
-            val targetItemKey = row.items.getOrNull(targetIndex)?.key ?: return@LaunchedEffect
-            val requester = uiCaches.requesterFor(row.key, targetItemKey)
+            val targetStableKey = "${row.key}_$targetIndex"
+            val requester = uiCaches.requesterFor(row.key, targetStableKey)
             var didFocus = false
             var didScrollToTarget = false
             repeat(20) {
@@ -433,11 +489,9 @@ internal fun ModernRowSection(
             if (!didFocus) {
                 val fallbackIndex = rowListState.firstVisibleItemIndex
                     .coerceIn(0, (row.items.size - 1).coerceAtLeast(0))
-                val fallbackItemKey = row.items.getOrNull(fallbackIndex)?.key
+                val fallbackStableKey = "${row.key}_$fallbackIndex"
                 didFocus = runCatching {
-                    if (fallbackItemKey != null) {
-                        uiCaches.requesterFor(row.key, fallbackItemKey).requestFocus()
-                    }
+                    uiCaches.requesterFor(row.key, fallbackStableKey).requestFocus()
                     true
                 }.getOrDefault(false)
             }
@@ -642,22 +696,28 @@ internal fun ModernRowSection(
 
         CompositionLocalProvider(LocalBringIntoViewSpec provides horizontalBringIntoViewSpec) {
             val lastFocusedIdx = focusedItemByRow[rowKey] ?: 0
-            val restoreItemKey = row.items.getOrNull(
-                lastFocusedIdx.coerceIn(0, (row.items.size - 1).coerceAtLeast(0))
-            )?.key
-            val restoreFocusRequester = restoreItemKey?.let {
-                uiCaches.requesterFor(rowKey, it)
-            } ?: FocusRequester.Default
+            val restoreIdx = lastFocusedIdx.coerceIn(0, (row.items.size - 1).coerceAtLeast(0))
+            val restoreStableKey = "${row.key}_$restoreIdx"
+            val restoreFocusRequester = uiCaches.requesterFor(rowKey, restoreStableKey)
 
             LazyRow(
                 state = rowListState,
-                modifier = Modifier.focusRestorer(restoreFocusRequester).focusGroup(),
+                modifier = Modifier
+                    .focusRestorer(restoreFocusRequester)
+                    .focusGroup()
+                    .then(
+                        if (row.isLoading) {
+                            Modifier.onPreviewKeyEvent { event ->
+                                event.type == KeyEventType.KeyDown && event.key == Key.DirectionRight
+                            }
+                        } else Modifier
+                    ),
                 contentPadding = PaddingValues(horizontal = rowStartPadding),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 itemsIndexed(
                     items = row.items,
-                    key = { _, item -> item.key },
+                    key = { index, _ -> "${row.key}_$index" },
                     contentType = { _, item ->
                         when (val payload = item.payload) {
                             is ModernPayload.ContinueWatching -> "modern_cw_card"
@@ -666,7 +726,8 @@ internal fun ModernRowSection(
                         }
                     }
                 ) { index, item ->
-                    val requester = uiCaches.requesterFor(row.key, item.key)
+                    val stableItemKey = "${row.key}_$index"
+                    val requester = uiCaches.requesterFor(row.key, stableItemKey)
                     val isContinueWatchingRow = row.key == MODERN_CONTINUE_WATCHING_ROW_KEY
                     val onFocused = remember(row.key, index, isContinueWatchingRow) {
                         { onRowItemFocused(row.key, index, isContinueWatchingRow) }
@@ -1020,7 +1081,38 @@ private fun ModernCarouselCard(
                 }
 
                 Box(modifier = mediaLayerModifier) {
-                    if (hasImage) {
+                    val isPlaceholderItem = imageUrl?.startsWith("placeholder://") == true
+                    if (isPlaceholderItem) {
+                        // Horizontal sweeping shimmer for placeholder cards
+                        val shimmerTransition = rememberInfiniteTransition(label = "placeholderShimmer")
+                        val shimmerOffset by shimmerTransition.animateFloat(
+                            initialValue = -1f,
+                            targetValue = 2f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(durationMillis = 1600, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart
+                            ),
+                            label = "shimmerOffset"
+                        )
+                        val shimmerBrush = remember(shimmerOffset) {
+                            Brush.linearGradient(
+                                colorStops = arrayOf(
+                                    0.0f to Color.Transparent,
+                                    0.4f to Color.White.copy(alpha = 0.07f),
+                                    0.5f to Color.White.copy(alpha = 0.13f),
+                                    0.6f to Color.White.copy(alpha = 0.07f),
+                                    1.0f to Color.Transparent
+                                ),
+                                start = Offset(shimmerOffset * 1000f, 0f),
+                                end = Offset((shimmerOffset + 0.6f) * 1000f, 0f)
+                            )
+                        }
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(shimmerBrush)
+                        )
+                    } else if (hasImage) {
                         key(scrollPhaseKey) {
                             AsyncImage(
                                 model = scrollAwareImageModel,


### PR DESCRIPTION
## Summary

Lazy catalog loading for the home screen. Instead of fetching all catalog rows on startup, only the first 4 are loaded eagerly. The remaining rows appear as placeholder cards (dark background + sweeping shimmer) and are fetched on-demand when the user scrolls near them. Loading triggers only after scroll settles (150ms debounce) so rapid scrolling doesn't fire unnecessary requests.

Works on both Modern and Classic layouts. Grid layout loads all catalogs eagerly since its flat item grid doesn't map to discrete row-level placeholders.

### How it works

1. `loadAllCatalogsPipeline` splits catalogs into eager (first 4) and lazy (rest)
2. Lazy catalogs get placeholder descriptors stored in `pendingLazyCatalogs`
3. `updateCatalogRowsPipeline` emits `PlaceholderCatalog` (Modern) or `HomeRow.Catalog` with fake items (Classic) for unloaded rows
4. Placeholder cards use `"placeholder://empty"` as image URL which triggers a shimmer overlay instead of the poster fallback
5. A visibility observer on the LazyColumn detects when placeholder rows enter the viewport and calls `requestLazyCatalogLoad`
6. Horizontal D-pad navigation is blocked on placeholder rows (right only - left still reaches the sidebar)
7. LazyRow uses index-based keys so focus is preserved when placeholder items are swapped for real data
8. `focusProperties` temporarily blocks vertical focus exit during the placeholder->data transition to prevent focus jumps

## PR type

- Approved larger change 

## Why

With many addons installed, the home screen fires dozens of concurrent catalog requests on startup. Each arriving catalog triggers a UI state update and presentation rebuild, causing repeated recompositions of the entire home screen. This results in visible jank and frame drops in the seconds after launch as rows keep getting added to the list. Lazy loading defers those requests until the user actually scrolls near them, reducing startup network load and eliminating the post-launch recomposition storm.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual testing on Android TV with 10+ addons (300+ catalog rows)
- Verified eager loading of first 4 catalogs on startup
- Verified lazy loading triggers on scroll settle, not during rapid scroll
- Verified focus preservation on placeholder->data transition (Modern + Classic)
- Verified fast scroll landing on placeholder rows
- Verified left D-pad exits to sidebar from placeholder
- Verified shimmer animation on placeholder cards
- Verified Grid layout still loads all catalogs eagerly

## Screenshots / Video (UI changes only)

https://github.com/user-attachments/assets/c19597f5-e9d9-47a6-8778-106ce3fe5342

## Breaking changes

Nothing should break

## Linked issues

Reported on discord. Now an account with 500 catalogs and 180 items in CW next up seed works just fine
