### PR TITLE
Fix stretch aspect recentering on playback reopen

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.ui.screens.player
 
+import android.graphics.Rect
 import android.view.SurfaceView
 import android.view.TextureView
 import android.view.View
@@ -121,33 +122,68 @@ internal fun applyExoAspectMode(playerView: PlayerView, mode: AspectMode) {
     val contentFrame = playerView.findViewById<View>(androidx.media3.ui.R.id.exo_content_frame)
     val surfaceView = resolveVideoSurfaceView(playerView)
     val targetView = contentFrame ?: surfaceView ?: playerView
+    val viewAspect = readViewAspectRatio(playerView.width, playerView.height)
+    val videoAspect = readExoVideoAspectRatio(playerView)
 
-    playerView.scaleX = 1.0f
-    playerView.scaleY = 1.0f
-    contentFrame?.scaleX = 1.0f
-    contentFrame?.scaleY = 1.0f
-    surfaceView?.scaleX = 1.0f
-    surfaceView?.scaleY = 1.0f
+    resetAspectTransform(playerView)
+    contentFrame?.let(::resetAspectTransform)
+    surfaceView?.let(::resetAspectTransform)
 
-    applyAspectScale(playerView, targetView, mode)
+    applyAspectScale(targetView, mode, viewAspect, videoAspect)
+    centerTargetInPlayer(playerView, targetView)
 }
 
 internal fun applyAspectMode(playerView: PlayerView, mode: AspectMode) {
     val targetView = resolveVideoSurfaceView(playerView) ?: playerView
-    playerView.scaleX = 1.0f
-    playerView.scaleY = 1.0f
+    val viewAspect = readViewAspectRatio(playerView.width, playerView.height)
+    val videoAspect = readExoVideoAspectRatio(playerView)
+    resetAspectTransform(playerView)
 
-    applyAspectScale(playerView, targetView, mode)
+    applyAspectScale(targetView, mode, viewAspect, videoAspect)
 }
 
-private fun applyAspectScale(playerView: PlayerView, targetView: View, mode: AspectMode) {
+private fun applyAspectScale(targetView: View, mode: AspectMode, viewAspect: Float, videoAspect: Float?) {
     val scale = resolveAspectScale(
         mode = mode,
-        viewAspect = readViewAspectRatio(playerView.width, playerView.height),
-        videoAspect = readExoVideoAspectRatio(playerView)
+        viewAspect = viewAspect,
+        videoAspect = videoAspect
     )
     targetView.scaleX = scale.scaleX
     targetView.scaleY = scale.scaleY
+}
+
+private fun resetAspectTransform(view: View) {
+    view.scaleX = 1.0f
+    view.scaleY = 1.0f
+    view.translationX = 0.0f
+    view.translationY = 0.0f
+    if (view.width > 0) {
+        view.pivotX = view.width / 2.0f
+    }
+    if (view.height > 0) {
+        view.pivotY = view.height / 2.0f
+    }
+}
+
+private fun centerTargetInPlayer(playerView: PlayerView, targetView: View) {
+    if (
+        targetView === playerView ||
+        playerView.width <= 0 ||
+        playerView.height <= 0 ||
+        targetView.width <= 0 ||
+        targetView.height <= 0
+    ) {
+        return
+    }
+
+    val targetRect = Rect(0, 0, targetView.width, targetView.height)
+    playerView.offsetDescendantRectToMyCoords(targetView, targetRect)
+    val playerCenterX = playerView.width / 2.0f
+    val playerCenterY = playerView.height / 2.0f
+    val targetCenterX = targetRect.left + targetRect.width() / 2.0f
+    val targetCenterY = targetRect.top + targetRect.height() / 2.0f
+    targetView.translationX = playerCenterX - targetCenterX
+    targetView.translationY = playerCenterY - targetCenterY
 }
 
 private fun resolveVideoSurfaceView(playerView: PlayerView): View? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
@@ -142,6 +142,20 @@ internal fun applyAspectMode(playerView: PlayerView, mode: AspectMode) {
     applyAspectScale(targetView, mode, viewAspect, videoAspect)
 }
 
+internal fun addExoAspectLayoutChangeListener(
+    playerView: PlayerView,
+    listener: View.OnLayoutChangeListener
+): () -> Unit {
+    val targets = linkedSetOf<View>()
+    targets.add(playerView)
+    playerView.findViewById<View>(androidx.media3.ui.R.id.exo_content_frame)?.let(targets::add)
+    resolveVideoSurfaceView(playerView)?.let(targets::add)
+    targets.forEach { it.addOnLayoutChangeListener(listener) }
+    return {
+        targets.forEach { it.removeOnLayoutChangeListener(listener) }
+    }
+}
+
 private fun applyAspectScale(targetView: View, mode: AspectMode, viewAspect: Float, videoAspect: Float?) {
     val scale = resolveAspectScale(
         mode = mode,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1264,11 +1264,13 @@ private fun ExoPlayerSurface(
 
     DisposableEffect(playerView) {
         val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            playerView.applyExoAspectMode(latestAspectMode)
+            playerView.post {
+                playerView.applyExoAspectMode(latestAspectMode)
+            }
         }
-        playerView.addOnLayoutChangeListener(listener)
+        val removeListener = addExoAspectLayoutChangeListener(playerView, listener)
         onDispose {
-            playerView.removeOnLayoutChangeListener(listener)
+            removeListener()
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes persisted Stretch mode reopening or switching streams into a letterboxed, top-shifted layout on affected media.
- Resets stale `PlayerView`, content frame, and video surface transforms before applying the custom aspect scale.
- Recenters the scaled video target inside `PlayerView` so the custom Stretch mode is applied from the correct position.

## PR type

- Bug fix

## Why

Some streams can leave the Media3 content frame in a stale fitted/top-aligned layout after exiting playback and reopening the stream, or after selecting another stream. When the saved Stretch mode is applied again, the app can scale that already shifted target instead of starting from a clean centered state, making the video appear letterboxed and pushed to the top of the screen.

This keeps the existing custom aspect-scaling approach, but normalizes the view transforms and center position before each Exo aspect application.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below. Not applicable; this is a small focused bug fix.

## Testing

- Tester reproduced the error scenario from the main version on the debug build and confirmed that the issue is resolved

## Screenshots / Video (UI changes only)

Not included. This is a playback layout fix; visual verification should use the affected Stretch reopen/switch-stream scenario.

## Breaking changes

No breaking behavior, configuration, schema, or dependency changes are expected.

## Linked issues

No linked GitHub issue. Reported on Discord from the test build and v0.6.7 as a reproducible Stretch mode reopen/switch-stream playback bug.
