### PR TITLE
Update playback icon

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.GridView
@@ -144,7 +145,7 @@ private fun rememberSettingsSectionSpecs() = listOf(
     SettingsSectionSpec(
         category = SettingsCategory.PLAYBACK,
         title = stringResource(R.string.settings_playback),
-        icon = Icons.Default.Settings,
+        icon = Icons.Rounded.PlayArrow,
         subtitle = stringResource(R.string.settings_playback_subtitle),
         destination = SettingsSectionDestination.Inline
     ),


### PR DESCRIPTION
## Summary

Updated playback icon in settings to use material library playback icon, same as the mobile app

## PR type

- Small maintenance improvement

## Why

Using wrong icon, brings it in line with mobile app

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the **approved** feature request issue below.


## Testing

It's only an icon change, but I tested the UI change
## Screenshots / Video (UI changes only)

It's only an icon change, I forgot to grab one, out the house now!

## Breaking changes

Nothing is broken, no changes that affect major code, it's an icon replacement.


## Linked issues

Fixes: https://github.com/NuvioMedia/NuvioTV/issues/1544
