### PR TITLE
Optimize home placeholder shimmer

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -248,6 +248,14 @@ fun CatalogRowSection(
             }
         }
 
+        val usesPlaceholderShimmer = catalogRow.isLoading &&
+            catalogRow.items.firstOrNull()?.poster?.startsWith("placeholder://") == true
+        val placeholderShimmerOffsetState = if (usesPlaceholderShimmer) {
+            rememberPlaceholderShimmerOffsetState(label = "classicPlaceholderShimmer")
+        } else {
+            null
+        }
+
         CompositionLocalProvider(LocalBringIntoViewSpec provides horizontalBringIntoViewSpec) {
         LazyRow(
             state = listState,
@@ -289,6 +297,7 @@ fun CatalogRowSection(
                     item = item,
                     posterCardStyle = posterCardStyle,
                     showLabels = showPosterLabels,
+                    placeholderShimmerOffsetState = placeholderShimmerOffsetState,
                     focusedPosterBackdropExpandEnabled = focusedPosterBackdropExpandEnabled,
                     focusedPosterBackdropExpandDelaySeconds = focusedPosterBackdropExpandDelaySeconds,
                     focusedPosterBackdropTrailerEnabled = focusedPosterBackdropTrailerEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -19,19 +19,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,7 +36,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -90,6 +85,7 @@ fun ContentCard(
     focusRequester: FocusRequester? = null,
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
     showLabels: Boolean = true,
+    placeholderShimmerOffsetState: State<Float>? = null,
     focusedPosterBackdropExpandEnabled: Boolean = false,
     focusedPosterBackdropExpandDelaySeconds: Int = 3,
     focusedPosterBackdropTrailerEnabled: Boolean = false,
@@ -354,34 +350,17 @@ fun ContentCard(
             ) {
                 val isPlaceholderItem = imageUrl?.startsWith("placeholder://") == true
                 if (isPlaceholderItem) {
-                    val shimmerTransition = rememberInfiniteTransition(label = "classicPlaceholderShimmer")
-                    val shimmerOffset by shimmerTransition.animateFloat(
-                        initialValue = -1f,
-                        targetValue = 2f,
-                        animationSpec = infiniteRepeatable(
-                            animation = tween(durationMillis = 1600, easing = LinearEasing),
-                            repeatMode = RepeatMode.Restart
-                        ),
-                        label = "shimmerOffset"
-                    )
-                    val shimmerBrush = remember(shimmerOffset) {
-                        Brush.linearGradient(
-                            colorStops = arrayOf(
-                                0.0f to Color.Transparent,
-                                0.4f to Color.White.copy(alpha = 0.07f),
-                                0.5f to Color.White.copy(alpha = 0.13f),
-                                0.6f to Color.White.copy(alpha = 0.07f),
-                                1.0f to Color.Transparent
-                            ),
-                            start = Offset(shimmerOffset * 1000f, 0f),
-                            end = Offset((shimmerOffset + 0.6f) * 1000f, 0f)
+                    val effectivePlaceholderShimmerOffsetState =
+                        placeholderShimmerOffsetState ?: rememberPlaceholderShimmerOffsetState(
+                            label = "classicPlaceholderShimmer"
                         )
-                    }
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(NuvioColors.BackgroundCard)
-                            .background(shimmerBrush)
+                            .placeholderCardShimmer(
+                                shimmerOffsetState = effectivePlaceholderShimmerOffsetState,
+                                backgroundColor = NuvioColors.BackgroundCard
+                            )
                     )
                 } else if (!imageUrl.isNullOrBlank()) {
                     key(scrollPhaseKey) {

--- a/app/src/main/java/com/nuvio/tv/ui/components/PlaceholderShimmer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/PlaceholderShimmer.kt
@@ -1,0 +1,59 @@
+package com.nuvio.tv.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+private const val PLACEHOLDER_SHIMMER_DISTANCE_PX = 1000f
+private const val PLACEHOLDER_SHIMMER_WIDTH_FRACTION = 0.6f
+private val PLACEHOLDER_SHIMMER_COLOR_STOPS = arrayOf(
+    0.0f to Color.Transparent,
+    0.4f to Color.White.copy(alpha = 0.07f),
+    0.5f to Color.White.copy(alpha = 0.13f),
+    0.6f to Color.White.copy(alpha = 0.07f),
+    1.0f to Color.Transparent
+)
+
+@Composable
+fun rememberPlaceholderShimmerOffsetState(label: String): State<Float> {
+    val shimmerTransition = rememberInfiniteTransition(label = label)
+    return shimmerTransition.animateFloat(
+        initialValue = -1f,
+        targetValue = 2f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1600, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmerOffset"
+    )
+}
+
+fun Modifier.placeholderCardShimmer(
+    shimmerOffsetState: State<Float>,
+    backgroundColor: Color? = null
+): Modifier = drawWithCache {
+    onDrawBehind {
+        backgroundColor?.let { drawRect(color = it) }
+        val shimmerOffset = shimmerOffsetState.value
+        drawRect(
+            brush = Brush.linearGradient(
+                colorStops = PLACEHOLDER_SHIMMER_COLOR_STOPS,
+                start = Offset(shimmerOffset * PLACEHOLDER_SHIMMER_DISTANCE_PX, 0f),
+                end = Offset(
+                    (shimmerOffset + PLACEHOLDER_SHIMMER_WIDTH_FRACTION) * PLACEHOLDER_SHIMMER_DISTANCE_PX,
+                    0f
+                )
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -4,13 +4,7 @@ package com.nuvio.tv.ui.screens.home
 
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -37,6 +31,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -49,7 +44,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
@@ -97,7 +91,9 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.ContinueWatchingCard
 import com.nuvio.tv.ui.components.MonochromePosterPlaceholder
 import com.nuvio.tv.ui.components.TrailerPlayer
+import com.nuvio.tv.ui.components.placeholderCardShimmer
 import com.nuvio.tv.ui.components.rememberArtworkBackedCardGlow
+import com.nuvio.tv.ui.components.rememberPlaceholderShimmerOffsetState
 import com.nuvio.tv.LocalSidebarExpanded
 import com.nuvio.tv.ui.theme.NuvioColors
 import kotlin.math.abs
@@ -174,6 +170,7 @@ private fun ModernCatalogRowItem(
     requester: FocusRequester,
     useLandscapePosters: Boolean,
     showLabels: Boolean,
+    placeholderShimmerOffsetState: State<Float>?,
     posterCardCornerRadius: Dp,
     portraitCatalogCardWidth: Dp,
     portraitCatalogCardHeight: Dp,
@@ -272,6 +269,7 @@ private fun ModernCatalogRowItem(
         item = item,
         useLandscapeOverlayTreatment = useLandscapePosters,
         showLabels = showLabels,
+        placeholderShimmerOffsetState = placeholderShimmerOffsetState,
         cardCornerRadius = posterCardCornerRadius,
         cardWidth = cardMetrics.width,
         cardHeight = cardMetrics.height,
@@ -699,6 +697,13 @@ internal fun ModernRowSection(
             val restoreIdx = lastFocusedIdx.coerceIn(0, (row.items.size - 1).coerceAtLeast(0))
             val restoreStableKey = "${row.key}_$restoreIdx"
             val restoreFocusRequester = uiCaches.requesterFor(rowKey, restoreStableKey)
+            val usesPlaceholderShimmer = row.isLoading &&
+                row.items.firstOrNull()?.imageUrl?.startsWith("placeholder://") == true
+            val placeholderShimmerOffsetState = if (usesPlaceholderShimmer) {
+                rememberPlaceholderShimmerOffsetState(label = "placeholderShimmer")
+            } else {
+                null
+            }
 
             LazyRow(
                 state = rowListState,
@@ -773,6 +778,7 @@ internal fun ModernRowSection(
                                 requester = requester,
                                 useLandscapePosters = useLandscapePosters,
                                 showLabels = showLabels,
+                                placeholderShimmerOffsetState = placeholderShimmerOffsetState,
                                 posterCardCornerRadius = posterCardCornerRadius,
                                 portraitCatalogCardWidth = portraitCatalogCardWidth,
                                 portraitCatalogCardHeight = portraitCatalogCardHeight,
@@ -816,6 +822,7 @@ private fun ModernCarouselCard(
     item: ModernCarouselItem,
     useLandscapeOverlayTreatment: Boolean,
     showLabels: Boolean,
+    placeholderShimmerOffsetState: State<Float>? = null,
     cardCornerRadius: Dp,
     cardWidth: Dp,
     cardHeight: Dp,
@@ -1084,33 +1091,14 @@ private fun ModernCarouselCard(
                     val isPlaceholderItem = imageUrl?.startsWith("placeholder://") == true
                     if (isPlaceholderItem) {
                         // Horizontal sweeping shimmer for placeholder cards
-                        val shimmerTransition = rememberInfiniteTransition(label = "placeholderShimmer")
-                        val shimmerOffset by shimmerTransition.animateFloat(
-                            initialValue = -1f,
-                            targetValue = 2f,
-                            animationSpec = infiniteRepeatable(
-                                animation = tween(durationMillis = 1600, easing = LinearEasing),
-                                repeatMode = RepeatMode.Restart
-                            ),
-                            label = "shimmerOffset"
-                        )
-                        val shimmerBrush = remember(shimmerOffset) {
-                            Brush.linearGradient(
-                                colorStops = arrayOf(
-                                    0.0f to Color.Transparent,
-                                    0.4f to Color.White.copy(alpha = 0.07f),
-                                    0.5f to Color.White.copy(alpha = 0.13f),
-                                    0.6f to Color.White.copy(alpha = 0.07f),
-                                    1.0f to Color.Transparent
-                                ),
-                                start = Offset(shimmerOffset * 1000f, 0f),
-                                end = Offset((shimmerOffset + 0.6f) * 1000f, 0f)
+                        val effectivePlaceholderShimmerOffsetState =
+                            placeholderShimmerOffsetState ?: rememberPlaceholderShimmerOffsetState(
+                                label = "placeholderShimmer"
                             )
-                        }
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .background(shimmerBrush)
+                                .placeholderCardShimmer(effectivePlaceholderShimmerOffsetState)
                         )
                     } else if (hasImage) {
                         key(scrollPhaseKey) {


### PR DESCRIPTION
## Summary

- Add a shared placeholder shimmer helper for home loading cards.
- Reuse one shimmer animation state per loading row in both modern and classic home instead of creating one infinite animation per placeholder card.
- Preserve the existing shimmer timing, sweep range, color stops, and visual behavior.

## PR type

- Small maintenance improvement

## Why

Home placeholder rows can show several shimmer cards at once. Previously, each placeholder card owned its own infinite shimmer animation, which increased Compose animation and invalidation overhead when multiple loading rows were visible. Sharing the same shimmer offset per row keeps the UI looking the same while reducing unnecessary per-card animation work.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

Not required; this is a small focused maintenance/performance optimization.

## Testing

- `./gradlew.bat :app:compileDebugKotlin` passed.
- `./gradlew installDebug` completed successfully locally.

## Screenshots / Video (UI changes only)

Not included; this change intentionally preserves the existing shimmer appearance.

## Breaking changes

No breaking behavior, configuration, API, or schema changes are introduced.

## Linked issues

No linked issue; local performance maintenance change for home placeholder loading.
