### PR TITLE
Optimize player startup loading

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -137,7 +137,7 @@ data class SubtitleStyleSettings(
 data class BufferSettings(
     val minBufferMs: Int = 50_000,
     val maxBufferMs: Int = 50_000,
-    val bufferForPlaybackMs: Int = 2_500,
+    val bufferForPlaybackMs: Int = 1_000,
     val bufferForPlaybackAfterRebufferMs: Int = 5_000,
     val targetBufferSizeMb: Int = 0, // 0 = ExoPlayer default
     val backBufferDurationMs: Int = 0,
@@ -521,7 +521,7 @@ class PlayerSettingsDataStore @Inject constructor(
                 bufferSettings = BufferSettings(
                     minBufferMs = prefs[minBufferMsKey] ?: 50_000,
                     maxBufferMs = prefs[maxBufferMsKey] ?: 50_000,
-                    bufferForPlaybackMs = prefs[bufferForPlaybackMsKey] ?: 2_500,
+                    bufferForPlaybackMs = prefs[bufferForPlaybackMsKey] ?: 1_000,
                     bufferForPlaybackAfterRebufferMs = prefs[bufferForPlaybackAfterRebufferMsKey] ?: 5_000,
                     targetBufferSizeMb = prefs[targetBufferSizeMbKey] ?: 0,
                     backBufferDurationMs = prefs[backBufferDurationMsKey] ?: 0,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -177,12 +177,18 @@ internal fun PlayerRuntimeController.initializePlayer(
                 }
                 return@launch
             }
-            resolveCurrentStreamMimeType(
-                url = url,
-                headers = headers
-            )
+            val streamMimeTypeJob = async {
+                resolveCurrentStreamMimeType(
+                    url = url,
+                    headers = headers
+                )
+            }
             mpvInitializationInProgress = false
-            val startupSubtitlePreparation = prepareStreamStartSubtitles(playerSettings, showLoadingStatus)
+            val startupSubtitlePreparationJob = async {
+                prepareStreamStartSubtitles(playerSettings, showLoadingStatus)
+            }
+            streamMimeTypeJob.await()
+            val startupSubtitlePreparation = startupSubtitlePreparationJob.await()
             afrJob.await()
             requestedUseLibassByUser = playerSettings.useLibass
             val useLibass = when {
@@ -198,17 +204,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     libassRenderType = playerSettings.libassRenderType
                 )
             }
-            val loadControl = run {
-                DefaultLoadControl.Builder()
-                    .setTargetBufferBytes(100 * 1024 * 1024)
-                    .setBufferDurationsMs(
-                        DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-                        70_000,
-                        DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-                        5_000
-                    )
-                    .build()
-            }
+            val loadControl = buildLoadControl(playerSettings)
 
             
             trackSelector = DefaultTrackSelector(context).apply {
@@ -584,6 +580,36 @@ internal fun resolveDeviceAudioLanguages(): List<String> {
     }
 }
 
+@androidx.annotation.OptIn(UnstableApi::class)
+private fun buildLoadControl(playerSettings: PlayerSettings): DefaultLoadControl {
+    val bufferSettings = playerSettings.bufferSettings
+    val minBufferMs = bufferSettings.minBufferMs.coerceIn(5_000, 120_000)
+    val maxBufferMs = bufferSettings.maxBufferMs.coerceIn(minBufferMs, 120_000)
+    val bufferForPlaybackMs = bufferSettings.bufferForPlaybackMs.coerceIn(1_000, 30_000)
+    val bufferForPlaybackAfterRebufferMs = bufferSettings.bufferForPlaybackAfterRebufferMs.coerceIn(1_000, 60_000)
+    val targetBufferBytes = bufferSettings.targetBufferSizeMb
+        .takeIf { it > 0 }
+        ?.let { (it.toLong() * 1024L * 1024L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt() }
+
+    return DefaultLoadControl.Builder()
+        .setBufferDurationsMs(
+            minBufferMs,
+            maxBufferMs,
+            bufferForPlaybackMs,
+            bufferForPlaybackAfterRebufferMs
+        )
+        .setBackBuffer(
+            bufferSettings.backBufferDurationMs.coerceIn(0, 120_000),
+            bufferSettings.retainBackBufferFromKeyframe
+        )
+        .apply {
+            if (targetBufferBytes != null) {
+                setTargetBufferBytes(targetBufferBytes)
+            }
+        }
+        .build()
+}
+
 internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
     mode: AddonSubtitleStartupMode,
     preferredLanguage: String,
@@ -630,6 +656,7 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
 
     val fetchedSubtitles = withTimeoutOrNull(STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS) {
         fetchAddonSubtitlesNow(
+            computeHash = false,
             onProgress = if (showLoadingStatus) { completed, total, addonName ->
                 val msg = if (completed == 0) {
                     context.getString(R.string.player_loading_subtitles_from, total)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -656,7 +656,6 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
 
     val fetchedSubtitles = withTimeoutOrNull(STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS) {
         fetchAddonSubtitlesNow(
-            computeHash = false,
             onProgress = if (showLoadingStatus) { completed, total, addonName ->
                 val msg = if (completed == 0) {
                     context.getString(R.string.player_loading_subtitles_from, total)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -29,7 +29,8 @@ internal fun PlayerRuntimeController.buildSubtitleFetchRequest(): SubtitleFetchR
 }
 
 internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
-    onProgress: ((completed: Int, total: Int, addonName: String?) -> Unit)? = null
+    onProgress: ((completed: Int, total: Int, addonName: String?) -> Unit)? = null,
+    computeHash: Boolean = true
 ): List<Subtitle> {
     val request = buildSubtitleFetchRequest() ?: return emptyList()
     val installedAddonOrder = addonRepository.getInstalledAddons().firstOrNull()
@@ -38,7 +39,7 @@ internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
     _uiState.update { it.copy(installedSubtitleAddonOrder = installedAddonOrder) }
 
     // Compute hash lazily for providers that support OpenSubtitles-style matching.
-    if (currentVideoHash == null && currentStreamUrl.isNotBlank()) {
+    if (computeHash && currentVideoHash == null && currentStreamUrl.isNotBlank()) {
         val result = OpenSubtitlesHasher.compute(currentStreamUrl, currentHeaders)
         if (result != null) {
             currentVideoHash = result.hash


### PR DESCRIPTION
## Summary

- Optimized ExoPlayer startup setup by running stream MIME detection and startup subtitle preparation concurrently instead of serializing both pre-playback tasks.
- Kept the existing 10 second startup subtitle prefetch timeout, but skipped OpenSubtitles hash calculation during the startup prefetch path so extra stream `HEAD` / range requests do not add blocking work before playback preparation.
- Preserved the existing full addon subtitle fetch behavior outside startup, including hash calculation when subtitles are fetched normally after player setup.
- Replaced hardcoded ExoPlayer `DefaultLoadControl` values with the `BufferSettings` values loaded through `PlayerSettingsDataStore`.
- Applied the buffer values loaded from `PlayerSettingsDataStore` for min buffer, max buffer, initial playback buffer, rebuffer playback buffer, target buffer size, back buffer duration, and keyframe back-buffer retention.
- Lowered the default initial playback buffer threshold in `BufferSettings` from 2500ms to 1000ms so fresh installs can start playback sooner.

## PR type

- Small maintenance improvement

## Why

Player startup was doing multiple pre-playback tasks in sequence before preparing playback. In addition, ExoPlayer was using hardcoded load control values instead of the `BufferSettings` values loaded by `PlayerSettingsDataStore`, so DataStore-backed buffer defaults and saved values were not reflected in the actual `DefaultLoadControl` configuration.

This change reduces unnecessary serialized startup work while keeping the existing subtitle timeout behavior intact. It also applies the DataStore-backed buffer values to ExoPlayer and lowers the default initial playback buffer threshold, which makes playback start sooner in practice.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)

Not required; this is a small focused maintenance optimization for player startup latency.

## Testing

- Ran `./gradlew.bat :app:compileDebugKotlin` successfully.
- Ran `./gradlew installDebug` successfully.
- Manually tested playback startup and confirmed the player opens faster.

## Screenshots / Video (UI changes only)



| `main`  | `debug`  |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/6c052959-eeec-4cd5-a0a9-d2e23c781542" width="300" /> | <video src="https://github.com/user-attachments/assets/f753f0e2-3d5a-4d36-8551-15e8af0145f1" width="300" /> |




*For my tests, I specifically picked the slowest loading source on my end*




## Breaking changes

None.

## Linked issues

Relates to #1365
Relates to #1428
