### PR TITLE
Memorize last selected profile

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -251,6 +251,7 @@ class MainActivity : ComponentActivity() {
 
             val activeProfileId by profileManager.activeProfileId.collectAsState()
             val profiles by profileManager.profiles.collectAsState()
+            val hasEverSelectedProfile by profileManager.hasEverSelectedProfile.collectAsState()
             val activeProfile = remember(activeProfileId, profiles) {
                 profiles.firstOrNull { it.id == activeProfileId }
             }
@@ -269,6 +270,16 @@ class MainActivity : ComponentActivity() {
             val activeProfileHasPin = remember(activeProfileId, profilePinStates) {
                 profilePinStates[activeProfileId] == true
             }
+
+            LaunchedEffect(hasEverSelectedProfile, activeProfileHasPin) {
+                if (hasEverSelectedProfile && !activeProfileHasPin && !hasSelectedProfileThisSession) {
+                    hasSelectedProfileThisSession = true
+                    if (authManager.authState.value is AuthState.FullAccount) {
+                        startupSyncService.requestSyncNow()
+                    }
+                }
+            }
+
             var avatarCatalog by remember { mutableStateOf(emptyList<com.nuvio.tv.data.remote.supabase.AvatarCatalogItem>()) }
 
             LaunchedEffect(Unit) {

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -252,6 +252,7 @@ class MainActivity : ComponentActivity() {
             val activeProfileId by profileManager.activeProfileId.collectAsState()
             val profiles by profileManager.profiles.collectAsState()
             val hasEverSelectedProfile by profileManager.hasEverSelectedProfile.collectAsState()
+            val rememberLastProfileEnabled by profileManager.rememberLastProfileEnabled.collectAsState()
             val activeProfile = remember(activeProfileId, profiles) {
                 profiles.firstOrNull { it.id == activeProfileId }
             }
@@ -271,8 +272,8 @@ class MainActivity : ComponentActivity() {
                 profilePinStates[activeProfileId] == true
             }
 
-            LaunchedEffect(hasEverSelectedProfile, activeProfileHasPin) {
-                if (hasEverSelectedProfile && !activeProfileHasPin && !hasSelectedProfileThisSession) {
+            LaunchedEffect(hasEverSelectedProfile, activeProfileHasPin, rememberLastProfileEnabled) {
+                if (rememberLastProfileEnabled && hasEverSelectedProfile && !activeProfileHasPin && !hasSelectedProfileThisSession) {
                     hasSelectedProfileThisSession = true
                     if (authManager.authState.value is AuthState.FullAccount) {
                         startupSyncService.requestSyncNow()

--- a/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
@@ -35,6 +35,9 @@ class ProfileManager @Inject constructor(
     val hasEverSelectedProfile: StateFlow<Boolean> = profileDataStore.hasEverSelectedProfile
         .stateIn(scope, SharingStarted.Eagerly, false)
 
+    val rememberLastProfileEnabled: StateFlow<Boolean> = profileDataStore.rememberLastProfileEnabled
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
     val profiles: StateFlow<List<UserProfile>> = profileDataStore.profilesList
         .stateIn(scope, SharingStarted.Eagerly, listOf(
             UserProfile(id = 1, name = "Profile 1", avatarColorHex = "#1E88E5")
@@ -51,6 +54,10 @@ class ProfileManager @Inject constructor(
         if (exists) {
             profileDataStore.setActiveProfile(id)
         }
+    }
+
+    suspend fun setRememberLastProfileEnabled(enabled: Boolean) {
+        profileDataStore.setRememberLastProfileEnabled(enabled)
     }
 
     suspend fun createProfile(

--- a/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
@@ -32,6 +32,9 @@ class ProfileManager @Inject constructor(
         .map { true }
         .stateIn(scope, SharingStarted.Eagerly, false)
 
+    val hasEverSelectedProfile: StateFlow<Boolean> = profileDataStore.hasEverSelectedProfile
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
     val profiles: StateFlow<List<UserProfile>> = profileDataStore.profilesList
         .stateIn(scope, SharingStarted.Eagerly, listOf(
             UserProfile(id = 1, name = "Profile 1", avatarColorHex = "#1E88E5")

--- a/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStore.kt
@@ -29,6 +29,7 @@ class ProfileDataStore @Inject constructor(
     private val profilesJsonKey = stringPreferencesKey("profiles_json")
     private val activeProfileIdKey = intPreferencesKey("active_profile_id")
     private val hasEverSelectedProfileKey = booleanPreferencesKey("profile_has_ever_selected")
+    private val rememberLastProfileEnabledKey = booleanPreferencesKey("remember_last_profile_enabled")
 
     private val profileListType = Types.newParameterizedType(List::class.java, ProfileJson::class.java)
 
@@ -49,10 +50,20 @@ class ProfileDataStore @Inject constructor(
         prefs[hasEverSelectedProfileKey] ?: false
     }
 
+    val rememberLastProfileEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[rememberLastProfileEnabledKey] ?: false
+    }
+
     suspend fun setActiveProfile(id: Int) {
         dataStore.edit { prefs ->
             prefs[activeProfileIdKey] = id
             prefs[hasEverSelectedProfileKey] = true
+        }
+    }
+
+    suspend fun setRememberLastProfileEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[rememberLastProfileEnabledKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStore.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.local
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -27,6 +28,7 @@ class ProfileDataStore @Inject constructor(
 
     private val profilesJsonKey = stringPreferencesKey("profiles_json")
     private val activeProfileIdKey = intPreferencesKey("active_profile_id")
+    private val hasEverSelectedProfileKey = booleanPreferencesKey("profile_has_ever_selected")
 
     private val profileListType = Types.newParameterizedType(List::class.java, ProfileJson::class.java)
 
@@ -43,9 +45,14 @@ class ProfileDataStore @Inject constructor(
         prefs[activeProfileIdKey] ?: 1
     }
 
+    val hasEverSelectedProfile: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[hasEverSelectedProfileKey] ?: false
+    }
+
     suspend fun setActiveProfile(id: Int) {
         dataStore.edit { prefs ->
             prefs[activeProfileIdKey] = id
+            prefs[hasEverSelectedProfileKey] = true
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,6 +76,12 @@ import java.net.URL
 @dagger.hilt.InstallIn(dagger.hilt.components.SingletonComponent::class)
 private interface ClearCwCacheEntryPoint {
     fun cwEnrichmentCache(): com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache
+}
+
+@dagger.hilt.EntryPoint
+@dagger.hilt.InstallIn(dagger.hilt.components.SingletonComponent::class)
+private interface ProfileManagerEntryPoint {
+    fun profileManager(): com.nuvio.tv.core.profile.ProfileManager
 }
 
 private enum class NetworkTestState { Idle, TestingLatency, TestingDownload, Done, Error }
@@ -439,6 +446,28 @@ fun AdvancedSettingsContent(
                                 entryPoint.cwEnrichmentCache().clearAll()
                                 cleared = true
                             }
+                        }
+                    }
+                )
+            }
+        }
+
+        item(key = "remember_last_profile") {
+            val profileManager = remember {
+                dagger.hilt.android.EntryPointAccessors.fromApplication(
+                    context.applicationContext,
+                    ProfileManagerEntryPoint::class.java
+                ).profileManager()
+            }
+            val rememberLastProfileEnabled by profileManager.rememberLastProfileEnabled.collectAsState()
+            SettingsGroupCard(modifier = Modifier.fillMaxWidth()) {
+                SettingsToggleRow(
+                    title = stringResource(R.string.advanced_remember_last_profile),
+                    subtitle = stringResource(R.string.advanced_remember_last_profile_subtitle),
+                    checked = rememberLastProfileEnabled,
+                    onToggle = {
+                        scope.launch {
+                            profileManager.setRememberLastProfileEnabled(!rememberLastProfileEnabled)
                         }
                     }
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -332,6 +332,23 @@ fun AdvancedSettingsContent(
                         )
                     }
                 )
+                val profileManager = remember {
+                    dagger.hilt.android.EntryPointAccessors.fromApplication(
+                        context.applicationContext,
+                        ProfileManagerEntryPoint::class.java
+                    ).profileManager()
+                }
+                val rememberLastProfileEnabled by profileManager.rememberLastProfileEnabled.collectAsState()
+                SettingsToggleRow(
+                    title = stringResource(R.string.advanced_remember_last_profile),
+                    subtitle = stringResource(R.string.advanced_remember_last_profile_subtitle),
+                    checked = rememberLastProfileEnabled,
+                    onToggle = {
+                        scope.launch {
+                            profileManager.setRememberLastProfileEnabled(!rememberLastProfileEnabled)
+                        }
+                    }
+                )
             }
         }
 
@@ -446,28 +463,6 @@ fun AdvancedSettingsContent(
                                 entryPoint.cwEnrichmentCache().clearAll()
                                 cleared = true
                             }
-                        }
-                    }
-                )
-            }
-        }
-
-        item(key = "remember_last_profile") {
-            val profileManager = remember {
-                dagger.hilt.android.EntryPointAccessors.fromApplication(
-                    context.applicationContext,
-                    ProfileManagerEntryPoint::class.java
-                ).profileManager()
-            }
-            val rememberLastProfileEnabled by profileManager.rememberLastProfileEnabled.collectAsState()
-            SettingsGroupCard(modifier = Modifier.fillMaxWidth()) {
-                SettingsToggleRow(
-                    title = stringResource(R.string.advanced_remember_last_profile),
-                    subtitle = stringResource(R.string.advanced_remember_last_profile_subtitle),
-                    checked = rememberLastProfileEnabled,
-                    onToggle = {
-                        scope.launch {
-                            profileManager.setRememberLastProfileEnabled(!rememberLastProfileEnabled)
                         }
                     }
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,6 +310,8 @@
     <string name="advanced_clear_cw_cache">Clear Continue Watching Cache</string>
     <string name="advanced_clear_cw_cache_subtitle">Remove cached thumbnails, titles, and enrichment data for Continue Watching</string>
     <string name="advanced_clear_cw_cache_done">Cache cleared</string>
+    <string name="advanced_remember_last_profile">Remember Last Profile</string>
+    <string name="advanced_remember_last_profile_subtitle">Remember last selected profile at startup</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_subtitle">Developer tools and feature flags</string>
     <string name="settings_plugins_section_subtitle">Manage repositories, providers, and plugin states</string>


### PR DESCRIPTION
## Summary

To memrozie the last selected profile by the user and select it by default on the next application launch. The user can turn this feature on or off in Settings > Advanced. By default it is off.

## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why

To enhance the UX of the application so the user does not have to always select the mostly used profile everytime they launch the application.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)

<!-- Link the approved feature request issue. Delete this section ONLY for small bug fixes. -->
<!-- Example: Approved in #123 -->

## Testing

- Turned this feature off
1. Selected profile 1, then relaunched the app, the profile selection screen appears.
2. Selected profile 2, then relaunched the app, the profile selection screen appears.

- Turned this feature on
1. Selected profile 1, then relaunched the app, the app loads profile 1
2. Selected profile 2, then relaunched the app, the app loads profile 2

## Screenshots / Video (UI changes only)

<img width="967" height="572" alt="image" src="https://github.com/user-attachments/assets/fe8ee35d-ff2d-4098-929f-eb05b8a1b324" />


## Breaking changes

None

## Linked issues

<!-- Example: Fixes #123 -->
