### PR TITLE
Push not aired watching items to the end of continue watching section

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1408,7 +1408,13 @@ internal fun mergeContinueWatchingItems(
             contentId.isBlank() || seen.add(contentId)
         }
 
-    return result
+    val upcoming = result.filterIsInstance<ContinueWatchingItem.NextUp>()
+        .filter { !it.info.hasAired }
+        .sortedBy { it.info.releaseTimestamp ?: Long.MAX_VALUE }
+    val rest = result.filter { item ->
+        item !is ContinueWatchingItem.NextUp || item.info.hasAired
+    }
+    return rest + upcoming
 }
 
 private suspend fun HomeViewModel.buildNextUpItem(


### PR DESCRIPTION
## Summary

The Continue Watching section may contain a mix of currently watching items and upcoming (not yet aired) entries. This PR moves the not-yet-aired items to the end of the list and sorts them by how soon they will be available. This improves the selection of the next watchable item, since not-yet-aired items are not playable yet.

## PR type
- Small maintenance improvement

## Why

The not aired items will not have any streams to start playing. So there will be no point from having them infront of the list until they get aired.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)

<!-- Link the approved feature request issue. Delete this section ONLY for small bug fixes. -->
<!-- Example: Approved in #123 -->

## Testing

- Have a list of continue to watch that contains a mix of: not finished items, finished items with next available episodes, and finished items with upcoming (not aired) items.
- The not aired items are pushed to the last of the list.

## Screenshots / Video (UI changes only)

<!-- If UI changed, add before/after screenshots or a short clip. -->

## Breaking changes

None

## Linked issues

<!-- Example: Fixes #123 -->
