### PR TITLE
Refactor lastFocusedIdx handling in ModernHomeRows

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -693,7 +693,8 @@ internal fun ModernRowSection(
         }
 
         CompositionLocalProvider(LocalBringIntoViewSpec provides horizontalBringIntoViewSpec) {
-            val lastFocusedIdx = focusedItemByRow[rowKey] ?: 0
+            val initialIdx = remember(rowKey) { focusedItemByRow[rowKey] ?: 0 }
+            var lastFocusedIdx by remember { mutableIntStateOf(initialIdx)}
             val restoreIdx = lastFocusedIdx.coerceIn(0, (row.items.size - 1).coerceAtLeast(0))
             val restoreStableKey = "${row.key}_$restoreIdx"
             val restoreFocusRequester = uiCaches.requesterFor(rowKey, restoreStableKey)
@@ -735,7 +736,9 @@ internal fun ModernRowSection(
                     val requester = uiCaches.requesterFor(row.key, stableItemKey)
                     val isContinueWatchingRow = row.key == MODERN_CONTINUE_WATCHING_ROW_KEY
                     val onFocused = remember(row.key, index, isContinueWatchingRow) {
-                        { onRowItemFocused(row.key, index, isContinueWatchingRow) }
+                        { onRowItemFocused(row.key, index, isContinueWatchingRow)
+                            lastFocusedIdx = index
+                            focusedItemByRow[row.key] = index }
                     }
                     val isCwPayload = item.payload is ModernPayload.ContinueWatching
 


### PR DESCRIPTION
## Summary
Updated the row logic to track the user's focus position in real-time. Instead of just setting an initial starting point, the row now continuously updates its "current position" state as the user navigates.

## PR type
- Small maintenance improvement

## Why
Prevent unexpected index jumping when navigating out of sidebar back to content.

## Policy check
- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)
N/A

## Testing
Verified both normal and fast paced vertical/horizontal navigation for both normal and expanded cards function as intended. Tested sidebar-to-content focus (at the start and middle of rows) across CW and category rows.

## Screenshots / Video (UI changes only)
None.

## Breaking changes
None.

## Linked issues
None.
