### PR TITLE
Remove Catalogs Cache

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
@@ -1,9 +1,6 @@
 package com.nuvio.tv.data.repository
 
-import android.content.Context
 import android.util.Log
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.network.safeApiCall
 import com.nuvio.tv.data.mapper.toDomain
@@ -11,32 +8,18 @@ import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.repository.CatalogRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.withContext
-import java.io.File
 import java.net.URLEncoder
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class CatalogRepositoryImpl @Inject constructor(
-    private val api: AddonApi,
-    @ApplicationContext private val context: Context
+    private val api: AddonApi
 ) : CatalogRepository {
     companion object {
         private const val TAG = "CatalogRepository"
-        private const val DISK_CACHE_DIR = "catalog_cache"
-        private const val DISK_CACHE_MAX_AGE_MS = 48L * 60 * 60 * 1000 // 48h
-    }
-
-    private val catalogCache = ConcurrentHashMap<String, CatalogRow>()
-    private val gson = Gson()
-    private val diskCacheDir by lazy {
-        File(context.filesDir, DISK_CACHE_DIR).also { it.mkdirs() }
     }
 
     override fun getCatalog(
@@ -51,30 +34,7 @@ class CatalogRepositoryImpl @Inject constructor(
         extraArgs: Map<String, String>,
         supportsSkip: Boolean
     ): Flow<NetworkResult<CatalogRow>> = flow {
-        val cacheKey = buildCacheKey(
-            addonBaseUrl = addonBaseUrl,
-            addonId = addonId,
-            type = type,
-            catalogId = catalogId,
-            skip = skip,
-            skipStep = skipStep,
-            extraArgs = extraArgs
-        )
-
-        // Emit cached data immediately if available (memory → disk)
-        val cached = catalogCache[cacheKey]
-        if (cached != null) {
-            emit(NetworkResult.Success(cached))
-        } else {
-            val diskCached = loadFromDisk(cacheKey)
-            if (diskCached != null) {
-                catalogCache[cacheKey] = diskCached
-                emit(NetworkResult.Success(diskCached))
-            } else {
-                emit(NetworkResult.Loading)
-            }
-        }
-        val staleData = cached ?: catalogCache[cacheKey]
+        emit(NetworkResult.Loading)
 
         val url = buildCatalogUrl(addonBaseUrl, type, catalogId, skip, extraArgs)
         Log.d(
@@ -111,22 +71,14 @@ class CatalogRepositoryImpl @Inject constructor(
                     skipStep = effectiveSkipStep,
                     extraArgs = extraArgs
                 )
-                catalogCache[cacheKey] = catalogRow
-                saveToDisk(cacheKey, catalogRow)
-                // Only emit fresh data if it differs from cache
-                if (staleData == null || staleData.items != catalogRow.items) {
-                    emit(NetworkResult.Success(catalogRow))
-                }
+                emit(NetworkResult.Success(catalogRow))
             }
             is NetworkResult.Error -> {
                 Log.w(
                     TAG,
                     "Catalog fetch failed addonId=$addonId type=$type catalogId=$catalogId code=${result.code} message=${result.message} url=$url"
                 )
-                // Only emit error if we had no cached data
-                if (staleData == null) {
-                    emit(result)
-                }
+                emit(result)
             }
             NetworkResult.Loading -> { /* Already emitted */ }
         }
@@ -139,8 +91,6 @@ class CatalogRepositoryImpl @Inject constructor(
         skip: Int,
         extraArgs: Map<String, String>
     ): String {
-        // Separate path from query string so the catalog path segment is
-        // inserted before any query parameters (configurable addon URLs).
         val trimmedBase = baseUrl.trimEnd('/')
         val queryStart = trimmedBase.indexOf('?')
         val basePath = if (queryStart >= 0) trimmedBase.substring(0, queryStart).trimEnd('/') else trimmedBase
@@ -156,7 +106,6 @@ class CatalogRepositoryImpl @Inject constructor(
             val allArgs = LinkedHashMap<String, String>()
             allArgs.putAll(extraArgs)
 
-            // For Stremio catalogs, pagination is controlled by `skip` inside extraArgs.
             if (!allArgs.containsKey("skip") && skip > 0) {
                 allArgs["skip"] = skip.toString()
             }
@@ -173,60 +122,5 @@ class CatalogRepositoryImpl @Inject constructor(
 
     private fun encodeArg(value: String): String {
         return URLEncoder.encode(value, "UTF-8").replace("+", "%20")
-    }
-
-    private fun buildCacheKey(
-        addonBaseUrl: String,
-        addonId: String,
-        type: String,
-        catalogId: String,
-        skip: Int,
-        skipStep: Int,
-        extraArgs: Map<String, String>
-    ): String {
-        val normalizedArgs = extraArgs.entries
-            .sortedBy { it.key }
-            .joinToString("&") { "${it.key}=${it.value}" }
-        val normalizedBaseUrl = addonBaseUrl.trim().trimEnd('/').lowercase()
-        return "${normalizedBaseUrl}_${addonId}_${type}_${catalogId}_${skip}_${normalizedArgs}"
-    }
-
-    private fun diskCacheFile(cacheKey: String): File {
-        val safeKey = cacheKey.hashCode().toUInt().toString(16)
-        return File(diskCacheDir, "$safeKey.json")
-    }
-
-    private fun saveToDisk(cacheKey: String, row: CatalogRow) {
-        try {
-            val file = diskCacheFile(cacheKey)
-            val wrapper = mapOf(
-                "key" to cacheKey,
-                "timestamp" to System.currentTimeMillis(),
-                "row" to row
-            )
-            file.writeText(gson.toJson(wrapper))
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to save catalog to disk: ${e.message}")
-        }
-    }
-
-    private suspend fun loadFromDisk(cacheKey: String): CatalogRow? = withContext(Dispatchers.IO) {
-        try {
-            val file = diskCacheFile(cacheKey)
-            if (!file.exists()) return@withContext null
-            val json = file.readText()
-            val mapType = object : TypeToken<Map<String, Any>>() {}.type
-            val wrapper: Map<String, Any> = gson.fromJson(json, mapType)
-            val timestamp = (wrapper["timestamp"] as? Double)?.toLong() ?: return@withContext null
-            if (System.currentTimeMillis() - timestamp > DISK_CACHE_MAX_AGE_MS) {
-                file.delete()
-                return@withContext null
-            }
-            val rowJson = gson.toJson(wrapper["row"])
-            gson.fromJson(rowJson, CatalogRow::class.java)
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to load catalog from disk: ${e.message}")
-            null
-        }
     }
 }

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -191,6 +191,14 @@
     <string name="playback_afr_on_start_stop_sub">Przełącz przy starcie i przywróć przy zatrzymaniu.</string>
     <string name="playback_resolution_matching">Dopasowanie rozdzielczości</string>
     <string name="playback_resolution_matching_sub">Zezwól na zmianę trybu wyświetlania w celu dopasowania rozdzielczości wideo.</string>
+    <string name="playback_resolution_matching_unsupported_sub">Wyświetlacz zgłasza tylko jedną rozdzielczość; dopasowanie może nie mieć efektu.</string>
+    <string name="playback_afr_capability_unsupported_title">Niektóre ustawienia mogą nie działać</string>
+    <string name="playback_afr_capability_both_problem_body">Auto częstotliwość odświeżania i dopasowanie rozdzielczości są włączone, ale wyświetlacz zgłasza tylko jedną częstotliwość odświeżania i jedną rozdzielczość. Żadne z nich może nie zadziałać — zalecane jest wyłączenie obu.</string>
+    <string name="playback_afr_capability_only_afr_unsupported_body">Auto częstotliwość odświeżania jest włączona, ale wyświetlacz zgłasza tylko jedną częstotliwość odświeżania. Przełączanie może nie mieć efektu — zalecane jest wyłączenie.</string>
+    <string name="playback_afr_capability_only_res_unsupported_body">Dopasowanie rozdzielczości jest włączone, ale wyświetlacz zgłasza tylko jedną rozdzielczość. Dopasowanie może nie mieć efektu — zalecane jest wyłączenie.</string>
+    <string name="playback_afr_capability_disable_button">Wyłącz AFR</string>
+    <string name="playback_afr_capability_disable_resolution_button">Wyłącz dopasowanie rozdzielczości</string>
+    <string name="playback_afr_capability_disable_both_button">Wyłącz oba</string>
     <string name="playback_player_external_desc">Zawsze otwieraj strumienie w zewnętrznej aplikacji</string>
     <string name="playback_player_ask_desc">Wybieraj odtwarzacz za każdym razem</string>
 
@@ -1494,6 +1502,10 @@
     <string name="collections_editor_all_genres">Wszystkie gatunki</string>
     <string name="collections_editor_genre_required">Gatunek wymagany</string>
     <string name="collections_editor_genre_optional">Filtr gatunku dostępny</string>
+    <string name="collections_editor_hero_backdrop">Tło hero (Nowoczesny ekran główny)</string>
+    <string name="collections_editor_placeholder_hero_backdrop">URL niestandardowego tła hero (opcjonalnie)</string>
+    <string name="collections_editor_title_logo">Logo tytułu (Nowoczesny ekran główny)</string>
+    <string name="collections_editor_placeholder_title_logo">URL niestandardowego logo tytułu (opcjonalnie)</string>
     <string name="collections_card_title">Kolekcje</string>
     <string name="collections_card_subtitle">Grupuj katalogi w folderach na ekranie głównym</string>
     <string name="collections_tab_all">Wszystko</string>


### PR DESCRIPTION
The Catalog Cache is no longer needed as we now have shimmer placeholders

## Summary

Removed the two-tier catalog cache (in-memory `ConcurrentHashMap` + disk JSON files with 48h TTL) from `CatalogRepositoryImpl`. The flow now simply emits `Loading` -> fetches from API -> emits `Success` or `Error`. The `Context` and `Gson` dependencies were also removed from the constructor since they were only used for caching.

## PR type

- Small maintenance improvement

## Why

The catalog cache was originally added so the home screen could show data instantly while fresh catalogs loaded in the background. Now that we have shimmer loading placeholders, this is no longer necessary. The cache was actively causing issues - when cached data had a different order than freshly fetched data (e.g. catalogs with randomized content), the UI would visibly jump/reshuffle after the network response replaced the stale cache.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified home screen loads catalogs with shimmer shown during loading, then displays fresh data.
- Confirmed no regressions in catalog pagination (load more) flow.
- Confirmed no compile errors after removing `Context`/`Gson` dependencies.

## Screenshots / Video (UI changes only)

no UI changes, shimmer was already implemented.

## Breaking changes

None. Existing disk cache files on user devices will simply be ignored (never read again).

## Linked issues

None