### PR TITLE
Add shimmer to Search View

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -81,6 +81,13 @@ object NetworkModule {
             .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor { chain ->
+                val version = BuildConfig.VERSION_NAME.ifBlank { "dev" }
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", "Nuvio/$version")
+                    .build()
+                chain.proceed(request)
+            }
             // Prevent OkHttp from caching error responses (4xx/5xx).
             .addNetworkInterceptor { chain ->
                 val response = chain.proceed(chain.request())

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -265,10 +265,9 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
         }
         lazyLoadRequestedKeys.clear()
 
-        lazyHomeCatalogs.forEach { (addon, catalog) ->
+        (eagerHomeCatalogs + lazyHomeCatalogs).forEach { (addon, catalog) ->
             val key = catalogKey(addonId = addon.id, type = catalog.apiType, catalogId = catalog.id)
             synchronized(catalogStateLock) {
-                pendingLazyCatalogs[key] = addon to catalog
                 placeholderDescriptors.add(
                     HomeViewModel.PlaceholderDescriptor(
                         catalogKey = key,
@@ -284,6 +283,13 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
             }
         }
 
+        lazyHomeCatalogs.forEach { (addon, catalog) ->
+            val key = catalogKey(addonId = addon.id, type = catalog.apiType, catalogId = catalog.id)
+            synchronized(catalogStateLock) {
+                pendingLazyCatalogs[key] = addon to catalog
+            }
+        }
+
         Log.d(HomeViewModel.TAG,
             "Lazy loading: eager=${eagerHomeCatalogs.size} lazy=${lazyHomeCatalogs.size}"
         )
@@ -295,10 +301,8 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
         }
 
         // Immediately schedule an update so placeholder rows appear in the UI
-        // while eager catalogs are still loading.
-        if (lazyHomeCatalogs.isNotEmpty()) {
-            scheduleUpdateCatalogRows()
-        }
+        // while catalogs are still loading.
+        scheduleUpdateCatalogRows()
     } catch (e: Exception) {
         catalogsLoadInProgress = false
         _uiState.update { it.copy(isLoading = false, error = e.message) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -249,6 +250,32 @@ fun SearchScreen(
 
     val trimmedQuery = remember(uiState.query) { uiState.query.trim() }
     val trimmedSubmittedQuery = remember(uiState.submittedQuery) { uiState.submittedQuery.trim() }
+
+    // Stable per-row state maps — mirrors ClassicHomeContent pattern so
+    // CatalogRowSection keeps focus when placeholder→real data transitions.
+    val searchRowStates = remember { mutableMapOf<String, LazyListState>() }
+    val searchRowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val searchRowEntryFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val searchRowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
+
+    // Clean up stale keys when the catalog rows change.
+    val visibleRowKeys = remember(uiState.catalogRows) {
+        uiState.catalogRows.mapTo(mutableSetOf()) {
+            "${it.addonId}_${it.apiType}_${it.catalogId}"
+        }
+    }
+    // Stable list of non-empty catalog rows — mirrors ClassicHomeContent's
+    // visibleHomeRows pattern so the LazyColumn receives a remember'd list.
+    val visibleCatalogRows = remember(uiState.catalogRows) {
+        uiState.catalogRows.filter { it.items.isNotEmpty() }
+    }
+    LaunchedEffect(visibleRowKeys) {
+        searchRowStates.keys.retainAll(visibleRowKeys)
+        searchRowFocusRequesters.keys.retainAll(visibleRowKeys)
+        searchRowEntryFocusRequesters.keys.retainAll(visibleRowKeys)
+        searchRowFocusedItemIndex.keys.retainAll(visibleRowKeys)
+    }
+
     val isDiscoverMode = remember(uiState.discoverEnabled, trimmedSubmittedQuery) {
         uiState.discoverEnabled && trimmedSubmittedQuery.isEmpty()
     }
@@ -530,6 +557,9 @@ fun SearchScreen(
                     }
 
                     uiState.isSearching && uiState.catalogRows.isEmpty() -> {
+                        // Placeholder shimmer rows are emitted by the ViewModel,
+                        // so this branch only fires if search targets haven't
+                        // been resolved yet (very brief).
                         item {
                             Box(
                                 modifier = Modifier
@@ -551,7 +581,7 @@ fun SearchScreen(
                         }
                     }
 
-                    uiState.catalogRows.isEmpty() || uiState.catalogRows.none { it.items.isNotEmpty() } -> {
+                    !uiState.isSearching && (visibleCatalogRows.isEmpty()) -> {
                         item {
                             EmptyScreenState(
                                 title = stringResource(R.string.search_no_results_title),
@@ -562,34 +592,46 @@ fun SearchScreen(
                     }
 
                     else -> {
-                        val visibleCatalogRows = uiState.catalogRows.filter { it.items.isNotEmpty() }
-
                         itemsIndexed(
                             items = visibleCatalogRows,
-                            key = { index, item ->
-                                "${item.addonId}_${item.type}_${item.catalogId}_${trimmedSubmittedQuery}_$index"
-                            }
+                            key = { _, item ->
+                                "${item.addonId}_${item.apiType}_${item.catalogId}"
+                            },
+                            contentType = { _, _ -> "catalog_row" }
                         ) { index, catalogRow ->
-                            val hasEnoughForSeeAll = catalogRow.items.size >= 15
-                            val truncatedRow = if (hasEnoughForSeeAll) {
-                                catalogRow.copy(items = catalogRow.items.take(14))
-                            } else catalogRow
+                            val catalogKey = "${catalogRow.addonId}_${catalogRow.apiType}_${catalogRow.catalogId}"
+                            val isPlaceholder = catalogRow.isLoading &&
+                                catalogRow.items.firstOrNull()?.id?.startsWith("__placeholder_") == true
+                            val hasEnoughForSeeAll = !isPlaceholder && catalogRow.items.size >= 15
+
+                            val listState = searchRowStates.getOrPut(catalogKey) { LazyListState() }
+                            val rowFocusRequester = searchRowFocusRequesters.getOrPut(catalogKey) { FocusRequester() }
+                            val entryFocusRequester = searchRowEntryFocusRequesters.getOrPut(catalogKey) { FocusRequester() }
+
                             CatalogRowSection(
-                                catalogRow = truncatedRow,
+                                catalogRow = catalogRow,
                                 showSeeAll = hasEnoughForSeeAll,
                                 showPosterLabels = uiState.posterLabelsEnabled,
                                 showAddonName = uiState.catalogAddonNameEnabled,
                                 showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,
                                 enableRowFocusRestorer = true,
+                                rowFocusRequester = rowFocusRequester,
+                                entryFocusRequester = entryFocusRequester,
+                                listState = listState,
+                                restorerFocusedIndex = searchRowFocusedItemIndex[catalogKey] ?: -1,
                                 isItemWatched = { item ->
                                     val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)
                                     if (isSeries) item.id in watchedSeriesIds else item.id in watchedMovieIds
                                 },
                                 focusedItemIndex = if (focusResults && index == 0) 0 else -1,
-                                onItemFocused = {
+                                onItemFocused = { itemIndex ->
                                     if (focusResults) {
                                         focusResults = false
                                     }
+                                    // User manually navigated to a row — cancel any
+                                    // pending auto-focus so it doesn't steal focus later.
+                                    pendingFocusMoveToResultsQuery = null
+                                    searchRowFocusedItemIndex[catalogKey] = itemIndex
                                 },
                                 onItemClick = { id, type, addonBaseUrl ->
                                     onNavigateToDetail(id, type, addonBaseUrl)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -16,6 +16,9 @@ import com.nuvio.tv.core.util.filterReleasedItems
 import com.nuvio.tv.core.util.isUnreleased
 import com.nuvio.tv.domain.repository.AddonRepository
 import java.time.LocalDate
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.repository.CatalogRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -340,6 +343,45 @@ class SearchViewModel @Inject constructor(
                 }
             }
 
+            // Emit placeholder rows with shimmer items so the UI shows
+            // skeleton rows immediately instead of a spinner.
+            val placeholderRows = searchTargets.map { (addon, catalog) ->
+                val key = catalogKey(addonId = addon.id, type = catalog.apiType, catalogId = catalog.id)
+                val fakeItems = (0 until 8).map { i ->
+                    MetaPreview(
+                        id = "__placeholder_${key}_$i",
+                        type = ContentType.fromString(catalog.apiType),
+                        rawType = catalog.apiType,
+                        name = " ",
+                        poster = "placeholder://empty",
+                        posterShape = PosterShape.POSTER,
+                        background = null,
+                        logo = null,
+                        description = null,
+                        releaseInfo = " ",
+                        imdbRating = null,
+                        genres = emptyList()
+                    )
+                }
+                CatalogRow(
+                    addonId = addon.id,
+                    addonName = addon.displayName,
+                    addonBaseUrl = addon.baseUrl,
+                    catalogId = catalog.id,
+                    catalogName = catalog.name,
+                    type = ContentType.fromString(catalog.apiType),
+                    rawType = catalog.apiType,
+                    items = fakeItems,
+                    isLoading = true,
+                    hasMore = false,
+                    currentPage = 0,
+                    supportsSkip = false,
+                    skipStep = 0,
+                    extraArgs = emptyMap()
+                )
+            }
+            _uiState.update { it.copy(catalogRows = placeholderRows) }
+
             val jobs = searchTargets.map { (addon, catalog) ->
                 viewModelScope.launch {
                     loadCatalog(addon, catalog, query)
@@ -481,10 +523,27 @@ class SearchViewModel @Inject constructor(
 
     private fun updateCatalogRowsNow() {
         _uiState.update { state ->
-            val orderedRows = catalogOrder.mapNotNull { key -> catalogsMap[key] }
+            val orderedRows = catalogOrder.map { key ->
+                catalogsMap[key]
+                    ?: state.catalogRows.find {
+                        catalogKey(addonId = it.addonId, type = it.rawType, catalogId = it.catalogId) == key
+                    }
+            }.filterNotNull().filter { row ->
+                // Keep placeholder rows (shimmer) and rows with real items.
+                // Drop rows that came back empty from the API.
+                val isPlaceholder = row.isLoading &&
+                    row.items.firstOrNull()?.id?.startsWith("__placeholder_") == true
+                isPlaceholder || row.items.isNotEmpty()
+            }
             val filteredRows = if (hideUnreleasedContent) {
                 val today = LocalDate.now()
-                orderedRows.map { it.filterReleasedItems(today) }
+                orderedRows.map { row ->
+                    if (row.isLoading && row.items.firstOrNull()?.id?.startsWith("__placeholder_") == true) {
+                        row
+                    } else {
+                        row.filterReleasedItems(today)
+                    }
+                }
             } else {
                 orderedRows
             }


### PR DESCRIPTION
## Summary

- Added shimmer placeholder rows to search results, matching the ClassicHomeContent pattern with stable per-row state (listState, focusRequesters, focusRestorer)
- Fixed focus stealing in search - cancels pending auto-focus when user manually navigates to a row
- Added shimmer placeholders for eager catalogs in Modern Home so all rows appear in correct order while loading
- Set OkHttp User-Agent to `Nuvio/<version>` to fix HTTP 403 from Vercel-hosted addons

## PR type

- Bug fix
- Small maintenance improvement

## Why

- Search showed a spinner instead of shimmer, and focus escaped to the search input when placeholder rows transitioned to real data
- Eager catalogs in Modern Home had no placeholder rows, so faster-responding catalogs appeared first and shifted when slower ones loaded
- Vercel bot protection blocked OkHttp's default User-Agent (`okhttp/4.x`) with HTTP 403, breaking addons like mal-stremio

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified search shows shimmer rows that transition to real data without focus loss
- Verified navigating to a lower row then scrolling back doesn't steal focus to first row
- Verified eager catalogs show shimmer in correct order while loading
- Verified mal-stremio addon loads successfully after User-Agent change (confirmed via ADB logcat)

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

Nothing should break

## Linked issues

Found internally/Reported on Discord 
