### PR TITLE
Standardise series/episode formatting

### DIFF
--- a/app/src/main/res/values-ar/Strings.xml
+++ b/app/src/main/res/values-ar/Strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">المخرج: %1$s</string>
     <string name="hero_writer">الكاتب: %1$s</string>
     <string name="hero_play">تشغيل</string>
-    <string name="hero_play_episode">تشغيل S%1$d, E%2$d</string>
+    <string name="hero_play_episode">تشغيل S%1$d E%2$d</string>
     <string name="hero_add_to_library">إضافة للمكتبة</string>
     <string name="hero_remove_from_library">إزالة من المكتبة</string>
     <string name="hero_mark_watched">تحديد كمشاهد</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">تشغيل</string>
     <string name="detail_btn_resume">استئناف</string>
-    <string name="detail_btn_play_episode">تشغيل S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">استئناف S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">التالي S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">تشغيل S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">استئناف S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">التالي S%1$d E%2$d</string>
     <string name="detail_tab_cast">المؤلف وطاقم العمل</string>
     <string name="cast_role_creator">المؤلف</string>
     <string name="cast_role_director">المخرج</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Director: %1$s</string>
     <string name="hero_writer">Escritor: %1$s</string>
     <string name="hero_play">Reproducir</string>
-    <string name="hero_play_episode">Reproducir T%1$d, E%2$d</string>
+    <string name="hero_play_episode">Reproducir T%1$d E%2$d</string>
     <string name="hero_add_to_library">Agregar a la biblioteca</string>
     <string name="hero_remove_from_library">Eliminar de la biblioteca</string>
     <string name="hero_mark_watched">Marcar como visto</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Reproducir</string>
     <string name="detail_btn_resume">Reanudar</string>
-    <string name="detail_btn_play_episode">Reproducir T%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Reanudar T%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Siguiente T%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Reproducir T%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Reanudar T%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Siguiente T%1$d E%2$d</string>
     <string name="detail_tab_cast">Creadores y Elenco</string>
     <string name="cast_role_creator">Creador</string>
     <string name="cast_role_director">Director</string>
@@ -938,7 +938,7 @@
     <string name="player_ends_at">Termina a las %1$s</string>
     <string name="player_via">vía %1$s</string>
     <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
-    <string name="season_episode_format">T%1$02dE%2$02d</string>
+    <string name="season_episode_format">T%1$d E%2$d</string>
     <string name="player_subtitle_delay">Retraso de Subtítulos</string>
     <string name="player_error_title">Error de Reproducción</string>
     <string name="player_go_back">Volver</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Režiser: %1$s</string>
     <string name="hero_writer">Scenarist: %1$s</string>
     <string name="hero_play">Pusti</string>
-    <string name="hero_play_episode">Pusti S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Pusti S%1$d E%2$d</string>
     <string name="hero_add_to_library">Dodaj u biblioteku</string>
     <string name="hero_remove_from_library">Ukloni iz biblioteke</string>
     <string name="hero_mark_watched">Označi kao odgledano</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Pusti</string>
     <string name="detail_btn_resume">Nastavi</string>
-    <string name="detail_btn_play_episode">Pusti S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Nastavi S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Sljedeća S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Pusti S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Nastavi S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Sljedeća S%1$d E%2$d</string>
     <string name="detail_tab_cast">Kreator i Glumci</string>
     <string name="cast_role_creator">Kreator</string>
     <string name="cast_role_director">Režiser</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Režisér: %1$s</string>
     <string name="hero_writer">Scenárista: %1$s</string>
     <string name="hero_play">Přehrát</string>
-    <string name="hero_play_episode">Přehrát S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Přehrát S%1$d E%2$d</string>
     <string name="hero_add_to_library">Přidat do knihovny</string>
     <string name="hero_remove_from_library">Odebrat z knihovny</string>
     <string name="hero_mark_watched">Označit jako zhlédnuté</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Přehrát</string>
     <string name="detail_btn_resume">Pokračovat</string>
-    <string name="detail_btn_play_episode">Přehrát S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Pokračovat S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Další S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Přehrát S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Pokračovat S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Další S%1$d E%2$d</string>
     <string name="detail_tab_cast">Tvůrci a obsazení</string>
     <string name="cast_role_creator">Tvůrce</string>
     <string name="cast_role_director">Režisér</string>
@@ -934,7 +934,7 @@
     <string name="player_ends_at">Konec v %1$s</string>
     <string name="player_via">přes %1$s</string>
     <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
-    <string name="season_episode_format">S%1$02dE%2$02d</string>
+    <string name="season_episode_format">S%1$d E%2$d</string>
     <string name="player_subtitle_delay">Zpoždění titulků</string>
     <string name="player_error_title">Chyba přehrávání</string>
     <string name="player_go_back">Zpět</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -73,7 +73,7 @@
     <string name="hero_director">Regisseur: %1$s</string>
     <string name="hero_writer">Autor: %1$s</string>
     <string name="hero_play">Abspielen</string>
-    <string name="hero_play_episode">Spiel S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Spiel S%1$d E%2$d</string>
     <string name="hero_add_to_library">Zur Bibliothek hinzufügen</string>
     <string name="hero_remove_from_library">Aus Bibliothek entfernen</string>
     <string name="hero_mark_watched">Als gesehen markieren</string>
@@ -115,9 +115,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Abspielen</string>
     <string name="detail_btn_resume">Fortsetzen</string>
-    <string name="detail_btn_play_episode">S%1$dE%2$d abspielen</string>
-    <string name="detail_btn_resume_episode">S%1$dE%2$d fortsetzen</string>
-    <string name="detail_btn_next_episode">Nächste S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">S%1$d E%2$d abspielen</string>
+    <string name="detail_btn_resume_episode">S%1$d E%2$d fortsetzen</string>
+    <string name="detail_btn_next_episode">Nächste S%1$d E%2$d</string>
     <string name="detail_tab_cast">Schöpfer und Besetzung</string>
     <string name="cast_role_creator">Schöpfer</string>
     <string name="cast_role_director">Regisseur</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -73,7 +73,7 @@
     <string name="hero_director">Σκηνοθέτης: %1$s</string>
     <string name="hero_writer">Σεναριογράφος: %1$s</string>
     <string name="hero_play">Αναπαραγωγή</string>
-    <string name="hero_play_episode">Αναπαραγωγή S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Αναπαραγωγή S%1$d E%2$d</string>
     <string name="hero_add_to_library">Προσθήκη στη βιβλιοθήκη</string>
     <string name="hero_remove_from_library">Αφαίρεση από τη βιβλιοθήκη</string>
     <string name="hero_mark_watched">Επισήμανση ως προβληθέν</string>
@@ -115,9 +115,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Αναπαραγωγή</string>
     <string name="detail_btn_resume">Συνέχεια</string>
-    <string name="detail_btn_play_episode">Αναπαραγωγή S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Συνέχεια S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Επόμενο S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Αναπαραγωγή S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Συνέχεια S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Επόμενο S%1$d E%2$d</string>
     <string name="detail_tab_cast">Δημιουργοί και ηθοποιοί</string>
     <string name="cast_role_creator">Δημιουργός</string>
     <string name="cast_role_director">Σκηνοθέτης</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,7 +74,7 @@
     <string name="hero_director">Director: %1$s</string>
     <string name="hero_writer">Guionista: %1$s</string>
     <string name="hero_play">Reproducir</string>
-    <string name="hero_play_episode">Reproducir T%1$d, E%2$d</string>
+    <string name="hero_play_episode">Reproducir T%1$d E%2$d</string>
     <string name="hero_add_to_library">Añadir a biblioteca</string>
     <string name="hero_remove_from_library">Eliminar de biblioteca</string>
     <string name="hero_mark_watched">Marcar como visto</string>
@@ -116,9 +116,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Reproducir</string>
     <string name="detail_btn_resume">Reanudar</string>
-    <string name="detail_btn_play_episode">Reproducir T%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Reanudar T%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Siguiente T%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Reproducir T%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Reanudar T%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Siguiente T%1$d E%2$d</string>
     <string name="detail_tab_cast">Creador y elenco</string>
     <string name="cast_role_creator">Creador</string>
     <string name="cast_role_director">Director</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Réalisateur : %1$s</string>
     <string name="hero_writer">Scénariste : %1$s</string>
     <string name="hero_play">Regarder</string>
-    <string name="hero_play_episode">Regarder S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Regarder S%1$d E%2$d</string>
     <string name="hero_add_to_library">Ajouter à la bibliothèque</string>
     <string name="hero_remove_from_library">Retirer de la bibliothèque</string>
     <string name="hero_mark_watched">Marquer comme vu</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Regarder</string>
     <string name="detail_btn_resume">Reprendre</string>
-    <string name="detail_btn_play_episode">Regarder S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Reprendre S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Suivant S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Regarder S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Reprendre S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Suivant S%1$d E%2$d</string>
     <string name="detail_tab_cast">Créateur et distribution</string>
     <string name="cast_role_creator">Créateur</string>
     <string name="cast_role_director">Réalisateur</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -65,7 +65,7 @@
     <string name="hero_director">निर्देशक: %1$s</string>
     <string name="hero_writer">लेखक: %1$s</string>
     <string name="hero_play">चलाएँ</string>
-    <string name="hero_play_episode">चलाएँ S%1$d, E%2$d</string>
+    <string name="hero_play_episode">चलाएँ S%1$d E%2$d</string>
     <string name="hero_add_to_library">लाइब्रेरी में जोड़ें</string>
     <string name="hero_remove_from_library">लाइब्रेरी से हटाएँ</string>
     <string name="hero_mark_watched">देख लिया</string>
@@ -107,9 +107,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">चलाएँ</string>
     <string name="detail_btn_resume">जारी रखें</string>
-    <string name="detail_btn_play_episode">चलाएँ S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">जारी रखें S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">अगला S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">चलाएँ S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">जारी रखें S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">अगला S%1$d E%2$d</string>
     <string name="detail_tab_cast">क्रिएटर और कास्ट</string>
     <string name="cast_role_creator">क्रिएटर</string>
     <string name="cast_role_director">डायरेक्टर</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Rendező: %1$s</string>
     <string name="hero_writer">Író: %1$s</string>
     <string name="hero_play">Lejátszás</string>
-    <string name="hero_play_episode">Lejátszás S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Lejátszás S%1$d E%2$d</string>
     <string name="hero_add_to_library">Hozzáadás a könyvtárhoz</string>
     <string name="hero_remove_from_library">Eltávolítás a könyvtárból</string>
     <string name="hero_mark_watched">Megjelölés megnézettként</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -73,7 +73,7 @@
     <string name="hero_director">Regista: %1$s</string>
     <string name="hero_writer">Sceneggiatore: %1$s</string>
     <string name="hero_play">Riproduci</string>
-    <string name="hero_play_episode">Riproduci S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Riproduci S%1$d E%2$d</string>
     <string name="hero_add_to_library">Aggiungi alla libreria</string>
     <string name="hero_remove_from_library">Rimuovi dalla libreria</string>
     <string name="hero_mark_watched">Segna come visto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -115,9 +115,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">再生</string>
     <string name="detail_btn_resume">再開</string>
-    <string name="detail_btn_play_episode">S%1$dE%2$d を再生</string>
-    <string name="detail_btn_resume_episode">S%1$dE%2$d を再開</string>
-    <string name="detail_btn_next_episode">次 S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">S%1$d E%2$d を再生</string>
+    <string name="detail_btn_resume_episode">S%1$d E%2$d を再開</string>
+    <string name="detail_btn_next_episode">次 S%1$d E%2$d</string>
     <string name="detail_tab_cast">キャストとスタッフ</string>
     <string name="cast_role_creator">制作者</string>
     <string name="cast_role_director">監督</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -107,9 +107,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Leisti</string>
     <string name="detail_btn_resume">Tęsti</string>
-    <string name="detail_btn_play_episode">Leisti S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Tęsti S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Kitas S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Leisti S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Tęsti S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Kitas S%1$d E%2$d</string>
     <string name="detail_tab_cast">Kūrėjai ir aktoriai</string>
     <string name="cast_role_creator">Kūrėjas</string>
     <string name="cast_role_director">Režisierius</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -36,7 +36,7 @@
     <string name="hero_director">Regisseur: %1$s</string>
     <string name="hero_writer">Schrijver: %1$s</string>
     <string name="hero_play">Afspelen</string>
-    <string name="hero_play_episode">Speel S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Speel S%1$d E%2$d</string>
     <string name="hero_add_to_library">Voeg toe aan bibliotheek</string>
     <string name="hero_remove_from_library">Verwijder uit bibliotheek</string>
     <string name="hero_mark_watched">Markeer als bekeken</string>
@@ -77,9 +77,9 @@
 <!-- MetaDetailsScreen -->
 <string name="detail_btn_play">Afspelen</string>
 <string name="detail_btn_resume">Hervatten</string>
-<string name="detail_btn_play_episode">Speel S%1$dE%2$d</string>
-<string name="detail_btn_resume_episode">Hervat S%1$dE%2$d</string>
-<string name="detail_btn_next_episode">Volgende S%1$dE%2$d</string>
+<string name="detail_btn_play_episode">Speel S%1$d E%2$d</string>
+<string name="detail_btn_resume_episode">Hervat S%1$d E%2$d</string>
+<string name="detail_btn_next_episode">Volgende S%1$d E%2$d</string>
 <string name="detail_tab_cast">Maker en cast</string>
 <string name="cast_role_creator">Maker</string>
 <string name="cast_role_director">Regisseur</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -73,7 +73,7 @@
     <string name="hero_director">Regissør: %1$s</string>
     <string name="hero_writer">Skribent: %1$s</string>
     <string name="hero_play">Spill av</string>
-    <string name="hero_play_episode">Spill av S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Spill av S%1$d E%2$d</string>
     <string name="hero_add_to_library">Legg til i biblioteket</string>
     <string name="hero_remove_from_library">Fjern fra biblioteket</string>
     <string name="hero_mark_watched">Merk som sett</string>
@@ -115,9 +115,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Spill av</string>
     <string name="detail_btn_resume">Gjenoppta</string>
-    <string name="detail_btn_play_episode">Spill av S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Gjenoppta S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Neste S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Spill av S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Gjenoppta S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Neste S%1$d E%2$d</string>
     <string name="detail_tab_cast">Forfatter og skuespillere</string>
     <string name="cast_role_creator">Forfatter</string>
     <string name="cast_role_director">Regissør</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -34,7 +34,7 @@
     <string name="hero_director">Reżyser: %1$s</string>
     <string name="hero_writer">Scenarzysta: %1$s</string>
     <string name="hero_play">Odtwórz</string>
-    <string name="hero_play_episode">Odtwórz S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Odtwórz S%1$d E%2$d</string>
     <string name="hero_add_to_library">Dodaj do biblioteki</string>
     <string name="hero_remove_from_library">Usuń z biblioteki</string>
     <string name="hero_mark_watched">Oznacz jako obejrzane</string>
@@ -76,9 +76,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Odtwórz</string>
     <string name="detail_btn_resume">Wznów</string>
-    <string name="detail_btn_play_episode">Odtwórz S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Wznów S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Następny S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Odtwórz S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Wznów S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Następny S%1$d E%2$d</string>
     <string name="detail_tab_cast">Twórcy i obsada</string>
     <string name="cast_role_creator">Twórca</string>
     <string name="cast_role_director">Reżyser</string>
@@ -1538,7 +1538,7 @@
     <string name="profile_pin_current_required">Ten profil ma już PIN. Wprowadź aktualny PIN, aby go zmienić.</string>
     <string name="profile_pin_overlay_delete_verify_heading">Wprowadź aktualny PIN, aby usunąć %1$s.</string>
     <string name="profile_pin_overlay_delete_verify_support">Wprowadź aktualny 4-cyfrowy PIN przed usunięciem tego profilu.</string>
-    <string name="season_episode_format">S%1$02dE%2$02d</string>
+    <string name="season_episode_format">S%1$d E%2$d</string>
     <string name="stream_info_player_engine">Silnik odtwarzacza</string>
     <string name="tmdb_trailers_subtitle">Kandydaci na zwiastuny z filmów TMDB dla sekcji zwiastunów</string>
     <string name="tmdb_trailers_title">Zwiastuny</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Direção: %1$s</string>
     <string name="hero_writer">Roteiro: %1$s</string>
     <string name="hero_play">Assistir</string>
-    <string name="hero_play_episode">Assistir: T%1$d:E%2$d</string>
+    <string name="hero_play_episode">Assistir: T%1$d E%2$d</string>
     <string name="hero_add_to_library">Adicionar à Biblioteca</string>
     <string name="hero_remove_from_library">Remover da Biblioteca</string>
     <string name="hero_mark_watched">Marcar como assistido</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Assistir</string>
     <string name="detail_btn_resume">Continuar</string>
-    <string name="detail_btn_play_episode">Assistir T%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Continuar T%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Próximo T%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Assistir T%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Continuar T%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Próximo T%1$d E%2$d</string>
     <string name="detail_tab_cast">Elenco e Criação</string>
     <string name="cast_role_creator">Criação</string>
     <string name="cast_role_director">Direção</string>
@@ -946,7 +946,7 @@
     <string name="player_ends_at">Termina às %1$s</string>
     <string name="player_via"> %1$s</string>
     <!-- Código de temporada/episódio mostrado na interface do player (ex.: T01E02). %1$d = temporada, %2$d = episódio. -->
-    <string name="season_episode_format">T%1$02dE%2$02d</string>
+    <string name="season_episode_format">T%1$d E%2$d</string>
     <string name="player_subtitle_delay">Atraso da legenda</string>
     <string name="player_error_title">Erro de Reprodução</string>
     <string name="player_go_back">Voltar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -71,7 +71,7 @@
     <string name="hero_director">Diretor: %1$s</string>
     <string name="hero_writer">Argumentista: %1$s</string>
     <string name="hero_play">Reproduzir</string>
-    <string name="hero_play_episode">Reproduzir T%1$d, E%2$d</string>
+    <string name="hero_play_episode">Reproduzir T%1$d E%2$d</string>
     <string name="hero_add_to_library">Adicionar à biblioteca</string>
     <string name="hero_remove_from_library">Remover da biblioteca</string>
     <string name="hero_mark_watched">Marcar como visto</string>
@@ -113,9 +113,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Reproduzir</string>
     <string name="detail_btn_resume">Retomar</string>
-    <string name="detail_btn_play_episode">Reproduzir T%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Retomar T%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Seguinte T%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Reproduzir T%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Retomar T%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Seguinte T%1$d E%2$d</string>
     <string name="detail_tab_cast">Criador e Elenco</string>
     <string name="cast_role_creator">Criador</string>
     <string name="cast_role_director">Diretor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -35,7 +35,7 @@
     <string name="hero_director">Director: %1$s</string>
     <string name="hero_writer">Scriitor: %1$s</string>
     <string name="hero_play">Redă</string>
-    <string name="hero_play_episode">Redă S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Redă S%1$d E%2$d</string>
     <string name="hero_add_to_library">Adaugă în bibliotecă</string>
     <string name="hero_remove_from_library">Elimină din bibliotecă</string>
     <string name="hero_mark_watched">Marchează ca vizionat</string>
@@ -76,9 +76,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Redă</string>
     <string name="detail_btn_resume">Continuă</string>
-    <string name="detail_btn_play_episode">Redă S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Continuă S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Următorul S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Redă S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Continuă S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Următorul S%1$d E%2$d</string>
     <string name="detail_tab_cast">Creator și Distribuție</string>
     <string name="cast_role_creator">Creator</string>
     <string name="cast_role_director">Regizor</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Režisér: %1$s</string>
     <string name="hero_writer">Scenár: %1$s</string>
     <string name="hero_play">Prehrať</string>
-    <string name="hero_play_episode">Prehrať S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Prehrať S%1$d E%2$d</string>
     <string name="hero_add_to_library">Pridať do knižnice</string>
     <string name="hero_remove_from_library">Odstrániť z knižnice</string>
     <string name="hero_mark_watched">Označiť ako videné</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Prehrať</string>
     <string name="detail_btn_resume">Pokračovať</string>
-    <string name="detail_btn_play_episode">Prehrať S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Pokračovať S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Ďalší S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Prehrať S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Pokračovať S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Ďalší S%1$d E%2$d</string>
     <string name="detail_tab_cast">Tvorcovia a herci</string>
     <string name="cast_role_creator">Tvorca</string>
     <string name="cast_role_director">Režisér</string>
@@ -944,7 +944,7 @@
     <string name="parental_severity_mild">Mierné</string>
     <string name="player_ends_at">Končí o: %1$s</string>
     <string name="player_via">cez %1$s</string>
-    <string name="season_episode_format">S%1$02dE%2$02d</string>
+    <string name="season_episode_format">S%1$d E%2$d</string>
     <string name="player_subtitle_delay">Oneskorenie titulkov</string>
     <string name="player_error_title">Chyba prehrávania</string>
     <string name="player_go_back">Späť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -125,7 +125,7 @@
     <string name="hero_director">Režiser: %1$s</string>
     <string name="hero_writer">Scenarist: %1$s</string>
     <string name="hero_play">Predvajaj</string>
-    <string name="hero_play_episode">Predvajaj S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Predvajaj S%1$d E%2$d</string>
     <string name="hero_add_to_library">Dodaj v knjižnico</string>
     <string name="hero_remove_from_library">Odstrani iz knjižnice</string>
     <string name="hero_mark_watched">Označi kot ogledano</string>
@@ -164,9 +164,9 @@
 	<!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Predvajaj</string>
     <string name="detail_btn_resume">Nadaljuj</string>
-    <string name="detail_btn_play_episode">Predvajaj S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Nadaljuj S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Naslednja S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Predvajaj S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Nadaljuj S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Naslednja S%1$d E%2$d</string>
     <string name="detail_tab_cast">Ustvarjalci in zasedba</string>
     <string name="cast_role_creator">Ustvarjalec</string>
     <string name="cast_role_director">Režiser</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -68,7 +68,7 @@
     <string name="hero_director">Regissör: %1$s</string>
     <string name="hero_writer">Skribent: %1$s</string>
     <string name="hero_play">Spela</string>
-    <string name="hero_play_episode">Spela S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Spela S%1$d E%2$d</string>
     <string name="hero_add_to_library">Lägg till i biblioteket</string>
     <string name="hero_remove_from_library">Ta bort från biblioteket</string>
     <string name="hero_mark_watched">Markera som sedd</string>
@@ -110,9 +110,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Spela</string>
     <string name="detail_btn_resume">Återuppta</string>
-    <string name="detail_btn_play_episode">Spela S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Återuppta S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Nästa S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Spela S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Återuppta S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Nästa S%1$d E%2$d</string>
     <string name="detail_tab_cast">Skapare och medverkande</string>
     <string name="cast_role_creator">Medverkande</string>
     <string name="cast_role_director">Regissör</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -130,7 +130,7 @@
     <string name="hero_director">Yönetmen: %1$s</string>
     <string name="hero_writer">Yazar: %1$s</string>
     <string name="hero_play">Oynat</string>
-    <string name="hero_play_episode">Oynat S%1$d, B%2$d</string>
+    <string name="hero_play_episode">Oynat S%1$d B%2$d</string>
     <string name="hero_add_to_library">Kütüphaneye ekle</string>
     <string name="hero_remove_from_library">Kütüphaneden kaldır</string>
     <string name="hero_mark_watched">İzlendi olarak işaretle</string>
@@ -172,9 +172,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Oynat</string>
     <string name="detail_btn_resume">Devam Et</string>
-    <string name="detail_btn_play_episode">Oynat S%1$dB%2$d</string>
-    <string name="detail_btn_resume_episode">Devam Et S%1$dB%2$d</string>
-    <string name="detail_btn_next_episode">Sıradaki S%1$dB%2$d</string>
+    <string name="detail_btn_play_episode">Oynat S%1$d B%2$d</string>
+    <string name="detail_btn_resume_episode">Devam Et S%1$d B%2$d</string>
+    <string name="detail_btn_next_episode">Sıradaki S%1$d B%2$d</string>
     <string name="detail_tab_cast">Oyuncular</string>
     <string name="cast_role_creator">Yapımcı</string>
     <string name="cast_role_director">Yönetmen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="hero_director">Director: %1$s</string>
     <string name="hero_writer">Writer: %1$s</string>
     <string name="hero_play">Play</string>
-    <string name="hero_play_episode">Play S%1$d, E%2$d</string>
+    <string name="hero_play_episode">Play S%1$d E%2$d</string>
     <string name="hero_add_to_library">Add to library</string>
     <string name="hero_remove_from_library">Remove from library</string>
     <string name="hero_mark_watched">Mark as watched</string>
@@ -173,9 +173,9 @@
     <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Play</string>
     <string name="detail_btn_resume">Resume</string>
-    <string name="detail_btn_play_episode">Play S%1$dE%2$d</string>
-    <string name="detail_btn_resume_episode">Resume S%1$dE%2$d</string>
-    <string name="detail_btn_next_episode">Next S%1$dE%2$d</string>
+    <string name="detail_btn_play_episode">Play S%1$d E%2$d</string>
+    <string name="detail_btn_resume_episode">Resume S%1$d E%2$d</string>
+    <string name="detail_btn_next_episode">Next S%1$d E%2$d</string>
     <string name="detail_tab_cast">Creator and Cast</string>
     <string name="cast_role_creator">Creator</string>
     <string name="cast_role_director">Director</string>
@@ -949,7 +949,7 @@
     <string name="player_ends_at">Ends at %1$s</string>
     <string name="player_via">via %1$s</string>
     <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
-    <string name="season_episode_format">S%1$02dE%2$02d</string>
+    <string name="season_episode_format">S%1$d E%2$d</string>
     <string name="player_subtitle_delay">Subtitles Delay</string>
     <string name="player_error_title">Playback Error</string>
     <string name="player_go_back">Go Back</string>


### PR DESCRIPTION
## Summary

Standardises the text used to indicate the series and episode numbers across the app to uniformly use the format 'SX EY' (e.g., S1 E3, with a space and no leading zeros or commas). It replaces inconsistent instances such as S1E3, S01E03, and their localized variants (like T1E3 or S1 B3) in strings.xml to ensure a consistent user experience.

## PR type

- Small maintenance improvement

## Why

Previously the details, continue watching and play buttons had different usage of this. Continue watching had S01E01, in details play/next button had S1E1 and the results page of an episode had S1 E1

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.

## Testing

Tested APK and the areas aforementioned.

## Screenshots / Video (UI changes only)

Before:
<img width="1368" height="1929" alt="IMG_5588" src="https://github.com/user-attachments/assets/7ecc188d-8f16-4420-a6a0-82707e54f84d" />
<img width="1442" height="1335" alt="IMG_5589" src="https://github.com/user-attachments/assets/3ed96ef0-20ad-4298-b32c-9241cc5b50cf" />

After:
<img width="3072" height="4080" alt="PXL_20260426_082442656 MP" src="https://github.com/user-attachments/assets/c7824ca9-e296-4b89-955f-86f386c49c0c" />
<img width="4080" height="3072" alt="PXL_20260426_082432832 MP" src="https://github.com/user-attachments/assets/f792c62d-0a0b-4a6a-bf1d-2779d565d2c8" />


## Breaking changes

Nothing broken, verified this by testing app

## Linked issues

Addresses: https://github.com/NuvioMedia/NuvioTV/issues/1537
