### PR TITLE
Fix playback resuming in background after codec reclamation (#1560)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -258,6 +258,10 @@ class PlayerRuntimeController(
     internal var nextEpisodeVideo: Video? = null
     internal var userPausedManually = false
 
+    internal var isInBackground: Boolean = false
+    internal var pendingBackgroundCrashRecovery: Boolean = false
+    internal var backgroundCrashSavedPositionMs: Long = 0L
+
     
     internal var skipIntervals: List<SkipInterval> = emptyList()
     internal var skipIntroEnabled: Boolean = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -34,6 +34,7 @@ internal fun PlayerRuntimeController.attemptStartupRecovery(
     if (!isRetryablePlaybackError(error)) return false
     if (startupRetryCount >= MAX_STARTUP_AUTO_RETRIES) return false
 
+    val paused = userPausedManually
     val attempt = startupRetryCount
     startupRetryCount++
 
@@ -57,7 +58,7 @@ internal fun PlayerRuntimeController.attemptStartupRecovery(
         delay(RETRY_DELAY_MS)
 
         releasePlayer(flushPlaybackState = false)
-        initializePlayer(currentStreamUrl, currentHeaders)
+        initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
     }
     return true
 }
@@ -205,6 +206,7 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
     if (!isRetryablePlaybackError(error)) return false
     if (errorRetryCount >= MAX_AUTO_RETRIES) return false
 
+    val paused = userPausedManually
     val attempt = errorRetryCount
     errorRetryCount++
 
@@ -237,13 +239,14 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
                     player.seekTo((savedPosition - 1).coerceAtLeast(0L))
                 }
                 player.prepare()
-                player.playWhenReady = true
+                // Only resume playback if the user hadn't paused.
+                player.playWhenReady = !paused
             } else {
                 releasePlayer(flushPlaybackState = false)
                 if (savedPosition > 0L) {
                     _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
                 }
-                initializePlayer(currentStreamUrl, currentHeaders)
+                initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
             }
         } else {
             // Full teardown — clears any corrupt decoder/internal state.
@@ -251,7 +254,7 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
             if (savedPosition > 0L) {
                 _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
             }
-            initializePlayer(currentStreamUrl, currentHeaders)
+            initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
         }
     }
     return true
@@ -316,7 +319,7 @@ internal fun PlayerRuntimeController.tryAudioTrackPcmFallback(
         player.seekTo(savedPosition)
     }
     player.prepare()
-    player.playWhenReady = true
+    player.playWhenReady = !userPausedManually
 
     return true
 }
@@ -346,6 +349,7 @@ internal fun PlayerRuntimeController.tryDv7HevcFallback(
     hasTriedDv7HevcFallback = true
     forceDv7ToHevc = true
 
+    val paused = userPausedManually
     val savedPosition = _exoPlayer?.currentPosition?.takeIf { it > 0L } ?: 0L
 
     Log.d(
@@ -363,7 +367,7 @@ internal fun PlayerRuntimeController.tryDv7HevcFallback(
         if (savedPosition > 0L) {
             _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
         }
-        initializePlayer(currentStreamUrl, currentHeaders)
+        initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
     }
     return true
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -86,7 +86,8 @@ internal fun PlayerRuntimeController.initializePlayer(
     url: String,
     headers: Map<String, String>,
     overrideInternalPlayerEngine: InternalPlayerEngine? = null,
-    allowEngineFailover: Boolean = true
+    allowEngineFailover: Boolean = true,
+    startPaused: Boolean = false
 ) {
     if (url.isEmpty()) {
         _uiState.update { it.copy(error = context.getString(R.string.player_error_no_stream_url), showLoadingOverlay = false) }
@@ -99,6 +100,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                 startupEngineFailoverTriggered = false
             }
             resetLoadingOverlayForNewStream()
+            if (startPaused) {
+                userPausedManually = true
+                shouldEnforceAutoplayOnFirstReady = false
+            }
             hasTriedAudioPcmFallback = false
             hasTriedDv7HevcFallback = false
             mpvDelayStartAfterAfrSwitch = false
@@ -352,7 +357,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     )
                 )
                 if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }
-                playWhenReady = true
+                playWhenReady = !startPaused
                 prepare()
 
                 addListener(object : Player.Listener {
@@ -466,6 +471,22 @@ internal fun PlayerRuntimeController.initializePlayer(
                             return
                         }
                         val detailedError = error.toDisplayMessage()
+
+                        // If the codec crashed while the app is in the background (e.g. another
+                        // app reclaimed the hardware decoder), don't run the retry chain — each
+                        // retry can further corrupt vendor codec state and may resume playback
+                        // in background. Save position, free resources, and rebuild on resume.
+                        if (isInBackground && isRetryablePlaybackError(error)) {
+                            val savedPosition = currentPosition.takeIf { it > 0L } ?: 0L
+                            backgroundCrashSavedPositionMs = savedPosition
+                            pendingBackgroundCrashRecovery = true
+                            errorRetryJob?.cancel()
+                            errorRetryJob = scope.launch {
+                                releasePlayer(flushPlaybackState = false)
+                            }
+                            return
+                        }
+
                         val responseCode = error.findInvalidResponseCodeException()?.responseCode
                         if (responseCode == 416 && !hasRetriedCurrentStreamAfter416) {
                             retryCurrentStreamFromStartAfter416()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -160,6 +160,22 @@ internal fun PlayerRuntimeController.releaseMpvPlayer() {
 }
 
 internal fun PlayerRuntimeController.pauseForLifecycle() {
+    // Mark we're in background so onPlayerError can defer recovery to onResume.
+    isInBackground = true
+
+    // Release the MediaSession so the system doesn't route media commands
+    // (play/pause, audio focus) to this player while the app is in the background.
+    try {
+        currentMediaSession?.release()
+        currentMediaSession = null
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+
+    // Mark as user-paused so autoplay logic doesn't resume playback.
+    userPausedManually = true
+    shouldEnforceAutoplayOnFirstReady = false
+
     if (isUsingMpvEngine()) {
         mpvView?.setPaused(true)
         stopWatchProgressSaving()
@@ -167,7 +183,48 @@ internal fun PlayerRuntimeController.pauseForLifecycle() {
         _uiState.update { it.copy(isPlaying = false) }
         return
     }
-    _exoPlayer?.pause()
+    _exoPlayer?.let { player ->
+        // Disable automatic audio focus handling so ExoPlayer can't
+        // re-acquire focus and set playWhenReady=true behind our back.
+        player.setAudioAttributes(player.audioAttributes, false)
+        player.playWhenReady = false
+        player.pause()
+    }
+}
+
+internal fun PlayerRuntimeController.resumeForLifecycle() {
+    isInBackground = false
+
+    // If the codec crashed while in background, the player was released to free
+    // resources. Rebuild it now with the saved position so the user comes back
+    // to a clean, paused player ready to play.
+    if (pendingBackgroundCrashRecovery) {
+        pendingBackgroundCrashRecovery = false
+        val savedPosition = backgroundCrashSavedPositionMs
+        backgroundCrashSavedPositionMs = 0L
+        if (savedPosition > 0L) {
+            _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
+        }
+        if (currentStreamUrl.isNotEmpty()) {
+            initializePlayer(currentStreamUrl, currentHeaders, startPaused = true)
+        }
+        return
+    }
+
+    val player = _exoPlayer
+    if (player != null && !isUsingMpvEngine()) {
+        // Restore automatic audio focus handling that was disabled in pauseForLifecycle().
+        player.setAudioAttributes(player.audioAttributes, true)
+
+        // Re-create the MediaSession so media controls work in the foreground.
+        if (currentMediaSession == null) {
+            try {
+                currentMediaSession = androidx.media3.session.MediaSession.Builder(context, player).build()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
 }
 
 internal fun PlayerRuntimeController.updateMpvAvailableTracks() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -218,7 +218,9 @@ fun PlayerScreen(
                     viewModel.pauseForLifecycle()
                 }
                 Lifecycle.Event.ON_RESUME -> {
-                    // Don't auto-resume, let user control
+                    // Re-create the MediaSession so media controls work in foreground.
+                    // Don't auto-resume playback — let the user press play.
+                    viewModel.resumeForLifecycle()
                 }
                 else -> {}
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -122,6 +122,10 @@ class PlayerViewModel @Inject constructor(
         controller.pauseForLifecycle()
     }
 
+    fun resumeForLifecycle() {
+        controller.resumeForLifecycle()
+    }
+
     fun startInitialPlaybackIfNeeded() {
         controller.startInitialPlaybackIfNeeded()
     }


### PR DESCRIPTION
Fixes #1560

Following @skoruppa's suggestion in #1560 to open a PR with this work.

## What actually happens

The issue title mentions "audio focus", but after investigation the real cause is **codec reclamation**, not audio focus management. The chain of events:

1. NuvioTV plays a video and holds an `OMX.*` hardware video decoder slot
2. User pauses, then switches to another app (Aerial Views, YouTube, etc.) that needs a hardware decoder
3. Android's `ResourceManagerService` reclaims NuvioTV's decoder slot for the foreground app
4. NuvioTV's `MediaCodec` throws on the next operation (`IllegalStateException`, sometimes wrapped as `ERROR_RECLAIMED`), bubbled up by ExoPlayer as a `MediaCodecVideoRenderer` error
5. NuvioTV's recovery chain runs and tries to rebuild the player **in the background**, forcing `playWhenReady = true` on every retry
6. That forced playback resume is what causes the player to play in background — audio comes out as the visible symptom

So the real bug is the recovery chain putting the player back into play state while the app is hidden, not audio focus management itself. On hardware where the foreground app keeps using the decoder (e.g. Aerial Views changing clips), the retries also fail in cascade and the user ends up on an `ERROR_CODE_DECODING_FAILED` screen when they come back to the app.

## The fix (two complementary layers)

### Layer 1 - Pause state preservation in the recovery chain

All recovery paths now capture `userPausedManually` before retrying and respect it:

- `attemptAutoRetry()` uses `player.playWhenReady = !paused` instead of `= true`, and passes `startPaused = paused` to `initializePlayer()` on full teardowns
- `attemptStartupRecovery()` and `tryDv7HevcFallback()` follow the same pattern
- `tryAudioTrackPcmFallback()` uses `player.playWhenReady = !userPausedManually`
- `initializePlayer()` accepts a new `startPaused` parameter that, when `true`, keeps `playWhenReady = false`, sets `userPausedManually = true`, and disables `shouldEnforceAutoplayOnFirstReady`
- `pauseForLifecycle()` releases the MediaSession, sets `userPausedManually = true`, and disables auto audio focus handling on the player
- A new `resumeForLifecycle()` re-enables audio focus handling and re-creates the MediaSession when returning to foreground

### Layer 2 - Defer recovery to onResume when crash happens in background

Layer 1 stops the forced playback resume, but the recovery chain itself is still problematic when triggered in the background. While the app is hidden and the foreground app keeps using the hardware decoder, every fresh decoder NuvioTV manages to acquire gets reclaimed again within seconds. The user comes back to a player permanently stuck on `ERROR_CODE_DECODING_FAILED`.

Layer 2 sidesteps this entirely:

- **In `onPlayerError`**: if `isInBackground && isRetryablePlaybackError(error)`, save the playback position, set `pendingBackgroundCrashRecovery = true`, release the player, and skip the recovery chain entirely
- **In `pauseForLifecycle()` / `resumeForLifecycle()`**: toggle `isInBackground` based on the existing Compose lifecycle hooks (`Lifecycle.Event.ON_PAUSE` / `ON_RESUME`)
- **In `resumeForLifecycle()`**: if `pendingBackgroundCrashRecovery` is set, rebuild the entire pipeline via `initializePlayer(..., startPaused = true)` with the saved position restored via `pendingSeekPosition`. The user comes back to a fresh, paused player at the right spot, ready to resume on play

The rebuild happens once, in foreground, when no other app is competing for the decoder, so it actually succeeds. Foreground errors keep using the existing recovery chain, no regression there.

## Files changed (6 files)

- `PlayerRuntimeController.kt`: three new state vars (`isInBackground`, `pendingBackgroundCrashRecovery`, `backgroundCrashSavedPositionMs`)
- `PlayerRuntimeControllerErrorRecovery.kt`: pause-state preservation in `attemptAutoRetry`, `attemptStartupRecovery`, `tryAudioTrackPcmFallback`, `tryDv7HevcFallback`
- `PlayerRuntimeControllerInitialization.kt`: new `startPaused` parameter on `initializePlayer()`, early-return in `onPlayerError` when in background
- `PlayerRuntimeControllerMpv.kt`: enhanced `pauseForLifecycle()`, new `resumeForLifecycle()` with rebuild path
- `PlayerScreen.kt`: calls `viewModel.resumeForLifecycle()` in the Compose `ON_RESUME` handler
- `PlayerViewModel.kt`: exposes `resumeForLifecycle()` as a delegate to the controller

## Tested on

- TCL C735 (Android 11, ARM v7, OMX.MS.AVC.Decoder)
- ExoPlayer engine
- Verified via `adb logcat`: no `Auto-retry` / `Startup recovery` attempts during the background period, no `requestAudioFocus()` while hidden, clean `initializePlayer()` call on resume