### PR TITLE
Add build-check GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -38,7 +38,11 @@ jobs:
             printf '%s' "$LOCAL_DEV_PROPERTIES_BASE64" | base64 --decode > local.dev.properties
           fi
 
+      - name: Create CI keystore
+        run: |
+          keytool -genkeypair -keystore nuviotv.jks -alias nuviotv \
+            -keyalg RSA -keysize 2048 -validity 1 \
+            -dname "CN=CI" -storepass 815787 -keypass 815787
+
       - name: Build
-        env:
-          CI_USE_DEBUG_SIGNING: true
         run: ./gradlew assembleFullDebug --no-daemon

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,42 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - master
+
+concurrency:
+  group: build-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Verify build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Prepare local properties
+        env:
+          LOCAL_PROPERTIES_BASE64: ${{ secrets.LOCAL_PROPERTIES_BASE64 }}
+          LOCAL_DEV_PROPERTIES_BASE64: ${{ secrets.LOCAL_DEV_PROPERTIES_BASE64 }}
+        run: |
+          if [ -n "$LOCAL_PROPERTIES_BASE64" ]; then
+            printf '%s' "$LOCAL_PROPERTIES_BASE64" | base64 --decode > local.properties
+          fi
+          if [ -n "$LOCAL_DEV_PROPERTIES_BASE64" ]; then
+            printf '%s' "$LOCAL_DEV_PROPERTIES_BASE64" | base64 --decode > local.dev.properties
+          fi
+
+      - name: Build
+        run: ./gradlew assembleFullDebug --no-daemon

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -39,4 +39,6 @@ jobs:
           fi
 
       - name: Build
+        env:
+          CI_USE_DEBUG_SIGNING: true
         run: ./gradlew assembleFullDebug --no-daemon

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - dev
-      - master
 
 concurrency:
   group: build-check-${{ github.ref }}


### PR DESCRIPTION


## Summary

Runs assembleFullDebug on every PR targeting dev to block merges with build errors.

## PR type
- Improvements


## Why

Merges with build errors have no automated gate - a broken build can land on dev or master unnoticed. 
This workflow adds a required CI check that runs assembleFullDebug on every PR, blocking the merge if the build fails


## Policy check

<!-- Confirm these before requesting review -->
 - [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

Verify workflow

## Screenshots / Video (UI changes only)

<img width="1009" height="286" alt="image" src="https://github.com/user-attachments/assets/ef0431e1-b07c-4513-a976-8c37a36512ae" />


## Breaking changes
None.

## Linked issues
None.
