### PR TITLE
Fix/speed dialog current selection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -124,7 +124,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.media3.exoplayer.ExoPlayer
 import io.github.peerless2012.ass.media.widget.AssSubtitleView
-import kotlinx.coroutines.delay
+import kotlin.math.abs
 
 @Composable
 fun PlayerScreen(
@@ -2417,15 +2417,17 @@ private fun SpeedSelectionDialog(
     onSpeedSelected: (Float) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val listState = rememberLazyListState()
+    val selectedIndex = remember(currentSpeed) {
+        PLAYBACK_SPEEDS.indices.minByOrNull { index ->
+            abs(PLAYBACK_SPEEDS[index] - currentSpeed)
+        } ?: 0
+    }
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = selectedIndex)
     val speedFocusRequesters = remember {
         PLAYBACK_SPEEDS.map { FocusRequester() }
     }
 
-    LaunchedEffect(currentSpeed) {
-        val selectedIndex = PLAYBACK_SPEEDS.indexOfFirst { it == currentSpeed }.takeIf { it >= 0 } ?: 0
-        listState.scrollToItem(selectedIndex)
-        delay(120)
+    LaunchedEffect(selectedIndex) {
         runCatching { speedFocusRequesters[selectedIndex].requestFocus() }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -39,6 +39,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
@@ -91,8 +93,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -118,6 +118,8 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.foundation.lazy.rememberLazyListState
+import kotlinx.coroutines.delay
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.media3.exoplayer.ExoPlayer
@@ -2415,6 +2417,18 @@ private fun SpeedSelectionDialog(
     onSpeedSelected: (Float) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val listState = rememberLazyListState()
+    val speedFocusRequesters = remember {
+        PLAYBACK_SPEEDS.map { FocusRequester() }
+    }
+
+    LaunchedEffect(currentSpeed) {
+        val selectedIndex = PLAYBACK_SPEEDS.indexOfFirst { it == currentSpeed }.takeIf { it >= 0 } ?: 0
+        listState.scrollToItem(selectedIndex)
+        delay(120)
+        runCatching { speedFocusRequesters[selectedIndex].requestFocus() }
+    }
+
     Dialog(onDismissRequest = onDismiss) {
         Box(
             modifier = Modifier
@@ -2433,11 +2447,13 @@ private fun SpeedSelectionDialog(
                 )
 
                 LazyColumn(
+                    state = listState,
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(top = 4.dp)
                 ) {
-                    items(PLAYBACK_SPEEDS) { speed ->
+                    itemsIndexed(PLAYBACK_SPEEDS) { index, speed ->
                         SpeedItem(
+                            modifier = Modifier.focusRequester(speedFocusRequesters[index]),
                             speed = speed,
                             isSelected = speed == currentSpeed,
                             onClick = { onSpeedSelected(speed) }
@@ -2520,6 +2536,7 @@ private fun MoreActionItem(
 
 @Composable
 private fun SpeedItem(
+    modifier: Modifier = Modifier,
     speed: Float,
     isSelected: Boolean,
     onClick: () -> Unit
@@ -2528,7 +2545,7 @@ private fun SpeedItem(
 
     Card(
         onClick = onClick,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { isFocused = it.isFocused },
         colors = CardDefaults.colors(


### PR DESCRIPTION
## Summary

Fixes the player playback-speed dialog so it opens at the currently selected speed instead of always starting from the first item (0.5x).

## PR type

- Bug fix

## Why

When users open the speed picker, focus starting at 0.5x makes it slower to confirm or adjust the active speed, especially with remote navigation.
This change improves usability by positioning the list and focus at the current speed on dialog open.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Compilation and install succeed without errors.
- Manually verified by opening the playback speed dialog on several selected speeds and confirming the correct speed index is selected on open.

## Screenshots / Video (UI changes only)

Not changes. This is a focus/initial-selection behavior fix in an existing dialog.

## Breaking changes

No breaking changes.

## Linked issues

No linked issue. I noticed this issue myself.