### PR TITLE
Add automatic skip options for detected segments

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -255,10 +255,10 @@ enum class AutoSkipSegmentType(val storedValue: String) {
         fun fromStoredValue(value: String): AutoSkipSegmentType? =
             values().firstOrNull { it.storedValue == value }
 
-        fun fromSkipIntervalType(type: String): AutoSkipSegmentType? = when (type.lowercase()) {
-            "op", "mixed-op", "intro" -> INTRO
+        fun fromSkipIntervalType(type: String): AutoSkipSegmentType? = when (type.trim().lowercase()) {
+            "op", "opening", "mixed-op", "intro" -> INTRO
             "recap" -> RECAP
-            "ed", "mixed-ed", "outro" -> OUTRO
+            "ed", "ending", "mixed-ed", "outro", "credits" -> OUTRO
             else -> null
         }
     }

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -177,6 +177,7 @@ data class PlayerSettings(
     val pauseOverlayEnabled: Boolean = true,
     val osdClockEnabled: Boolean = true,
     val skipIntroEnabled: Boolean = true,
+    val autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet(),
     // Dolby Vision Profile 7 → HEVC fallback (requires forked ExoPlayer)
     val mapDV7ToHevc: Boolean = false,
     val mpvHardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE,
@@ -245,6 +246,24 @@ enum class MpvHardwareDecodeMode {
     DISABLED
 }
 
+enum class AutoSkipSegmentType(val storedValue: String) {
+    INTRO("intro"),
+    RECAP("recap"),
+    OUTRO("outro");
+
+    companion object {
+        fun fromStoredValue(value: String): AutoSkipSegmentType? =
+            values().firstOrNull { it.storedValue == value }
+
+        fun fromSkipIntervalType(type: String): AutoSkipSegmentType? = when (type.lowercase()) {
+            "op", "mixed-op", "intro" -> INTRO
+            "recap" -> RECAP
+            "ed", "mixed-ed", "outro" -> OUTRO
+            else -> null
+        }
+    }
+}
+
 enum class PlayerPreference {
     INTERNAL,
     EXTERNAL,
@@ -308,6 +327,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val pauseOverlayEnabledKey = booleanPreferencesKey("pause_overlay_enabled")
     private val osdClockEnabledKey = booleanPreferencesKey("osd_clock_enabled")
     private val skipIntroEnabledKey = booleanPreferencesKey("skip_intro_enabled")
+    private val autoSkipSegmentTypesKey = stringSetPreferencesKey("auto_skip_segment_types")
     private val mapDV7ToHevcKey = booleanPreferencesKey("map_dv7_to_hevc")
     private val mpvHardwareDecodeModeKey = stringPreferencesKey("mpv_hardware_decode_mode")
     private val frameRateMatchingKey = booleanPreferencesKey("frame_rate_matching")
@@ -458,6 +478,10 @@ class PlayerSettingsDataStore @Inject constructor(
                 pauseOverlayEnabled = prefs[pauseOverlayEnabledKey] ?: true,
                 osdClockEnabled = prefs[osdClockEnabledKey] ?: true,
                 skipIntroEnabled = prefs[skipIntroEnabledKey] ?: true,
+                autoSkipSegmentTypes = prefs[autoSkipSegmentTypesKey]
+                    ?.mapNotNull(AutoSkipSegmentType::fromStoredValue)
+                    ?.toSet()
+                    ?: emptySet(),
                 mapDV7ToHevc = prefs[mapDV7ToHevcKey] ?: false,
                 mpvHardwareDecodeMode = parseMpvHardwareDecodeMode(prefs[mpvHardwareDecodeModeKey]),
                 frameRateMatchingMode = prefs[frameRateMatchingModeKey]?.let {
@@ -648,6 +672,17 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setSkipIntroEnabled(enabled: Boolean) {
         store().edit { prefs ->
             prefs[skipIntroEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setAutoSkipSegmentTypeEnabled(segmentType: AutoSkipSegmentType, enabled: Boolean) {
+        store().edit { prefs ->
+            val current = prefs[autoSkipSegmentTypesKey]
+                ?.mapNotNull(AutoSkipSegmentType::fromStoredValue)
+                ?.toSet()
+                ?: emptySet()
+            val updated = if (enabled) current + segmentType else current - segmentType
+            prefs[autoSkipSegmentTypesKey] = updated.map { it.storedValue }.toSet()
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.torrent.TorrentService
+import com.nuvio.tv.data.local.AutoSkipSegmentType
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.MpvHardwareDecodeMode
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
@@ -265,7 +266,9 @@ class PlayerRuntimeController(
     
     internal var skipIntervals: List<SkipInterval> = emptyList()
     internal var skipIntroEnabled: Boolean = true
+    internal var autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet()
     internal var skipIntroFetchedKey: String? = null
+    internal var lastAutoSkippedIntervalKey: String? = null
     internal var lastActiveSkipType: String? = null
     internal var autoSubtitleSelected: Boolean = false
     internal var lastSubtitlePreferredLanguage: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -2,6 +2,8 @@ package com.nuvio.tv.ui.screens.player
 
 import com.nuvio.tv.R
 import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.data.local.AutoSkipSegmentType
+import com.nuvio.tv.data.repository.SkipInterval
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Stream
@@ -345,6 +347,7 @@ internal fun PlayerRuntimeController.showStreamSourceIndicator(stream: Stream) {
 
 internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) {
     if (skipIntervals.isEmpty()) {
+        lastAutoSkippedIntervalKey = null
         if (_uiState.value.activeSkipInterval != null) {
             _uiState.update { it.copy(activeSkipInterval = null) }
         }
@@ -364,11 +367,25 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
             lastActiveSkipType = active.type
             _uiState.update { it.copy(activeSkipInterval = active, skipIntervalDismissed = false) }
         }
+        val segmentType = AutoSkipSegmentType.fromSkipIntervalType(active.type)
+        val activeKey = active.autoSkipKey()
+        if (
+            segmentType != null &&
+            segmentType in autoSkipSegmentTypes &&
+            lastAutoSkippedIntervalKey != activeKey
+        ) {
+            lastAutoSkippedIntervalKey = activeKey
+            skipActiveInterval()
+        }
     } else if (currentActive != null) {
         
+        lastAutoSkippedIntervalKey = null
         _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = false) }
     }
 }
+
+private fun SkipInterval.autoSkipKey(): String =
+    "$provider:$type:$startTime:$endTime"
 
 internal fun PlayerRuntimeController.tryShowParentalGuide() {
     val state = _uiState.value

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -375,7 +375,7 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
             lastAutoSkippedIntervalKey != activeKey
         ) {
             lastAutoSkippedIntervalKey = activeKey
-            skipActiveInterval()
+            skipInterval(active)
         }
     } else if (currentActive != null) {
         

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -298,10 +298,12 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
 
             val wasEnabled = skipIntroEnabled
             skipIntroEnabled = settings.skipIntroEnabled
+            autoSkipSegmentTypes = settings.autoSkipSegmentTypes
             if (!skipIntroEnabled) {
                 if (skipIntervals.isNotEmpty() || _uiState.value.activeSkipInterval != null) {
                     skipIntervals = emptyList()
                     skipIntroFetchedKey = null
+                    lastAutoSkippedIntervalKey = null
                     _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = true) }
                 }
             } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -17,6 +17,20 @@ import kotlinx.coroutines.launch
 internal const val AUDIO_AMPLIFICATION_MIN_DB = 0
 internal const val AUDIO_AMPLIFICATION_MAX_DB = 10
 
+internal fun PlayerRuntimeController.skipActiveInterval(): Boolean {
+    val interval = _uiState.value.activeSkipInterval ?: return false
+    val duration = currentPlaybackDurationMs().takeIf { it > 0 } ?: Long.MAX_VALUE
+    val seekMs = if (interval.endTime == Double.MAX_VALUE) {
+        duration
+    } else {
+        (interval.endTime * 1000).toLong()
+    }
+    seekPlaybackTo(seekMs.coerceAtMost(duration))
+    scheduleProgressSyncAfterSeek()
+    _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = true) }
+    return true
+}
+
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
     gainAudioProcessor.setGainDb(clampedDb)
@@ -978,14 +992,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             cancelPauseOverlay()
         }
         PlayerEvent.OnSkipIntro -> {
-            _uiState.value.activeSkipInterval?.let { interval ->
-                val duration = currentPlaybackDurationMs().takeIf { it > 0 } ?: Long.MAX_VALUE
-                val seekMs = if (interval.endTime == Double.MAX_VALUE) duration
-                             else (interval.endTime * 1000).toLong()
-                seekPlaybackTo(seekMs.coerceAtMost(duration))
-                scheduleProgressSyncAfterSeek()
-                _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = true) }
-            }
+            skipActiveInterval()
         }
         PlayerEvent.OnDismissSkipIntro -> {
             _uiState.update { it.copy(skipIntervalDismissed = true) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.media3.common.Player
 import com.nuvio.tv.R
 import com.nuvio.tv.data.local.SubtitleStyleSettings
+import com.nuvio.tv.data.repository.SkipInterval
 import com.nuvio.tv.data.repository.TraktScrobbleItem
 import com.nuvio.tv.data.repository.extractYear
 import com.nuvio.tv.data.repository.parseContentIds
@@ -18,7 +19,10 @@ internal const val AUDIO_AMPLIFICATION_MIN_DB = 0
 internal const val AUDIO_AMPLIFICATION_MAX_DB = 10
 
 internal fun PlayerRuntimeController.skipActiveInterval(): Boolean {
-    val interval = _uiState.value.activeSkipInterval ?: return false
+    return skipInterval(_uiState.value.activeSkipInterval ?: return false)
+}
+
+internal fun PlayerRuntimeController.skipInterval(interval: SkipInterval): Boolean {
     val duration = currentPlaybackDurationMs().takeIf { it > 0 } ?: Long.MAX_VALUE
     val seekMs = if (interval.endTime == Double.MAX_VALUE) {
         duration

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
@@ -229,9 +229,9 @@ fun SkipIntroButton(
 }
 
 @Composable
-private fun getSkipLabel(type: String?): String = when (type) {
-    "op", "mixed-op", "intro" -> stringResource(R.string.skip_intro)
-    "ed", "mixed-ed", "outro" -> stringResource(R.string.skip_ending)
+private fun getSkipLabel(type: String?): String = when (type?.trim()?.lowercase()) {
+    "op", "opening", "mixed-op", "intro" -> stringResource(R.string.skip_intro)
+    "ed", "ending", "mixed-ed", "outro", "credits" -> stringResource(R.string.skip_ending)
     "recap" -> stringResource(R.string.skip_recap)
     else -> stringResource(R.string.skip_generic)
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -251,6 +251,9 @@ fun PlaybackSettingsContent(
                 onSetPauseOverlayEnabled = { enabled -> coroutineScope.launch { viewModel.setPauseOverlayEnabled(enabled) } },
                 onSetOsdClockEnabled = { enabled -> coroutineScope.launch { viewModel.setOsdClockEnabled(enabled) } },
                 onSetSkipIntroEnabled = { enabled -> coroutineScope.launch { viewModel.setSkipIntroEnabled(enabled) } },
+                onSetAutoSkipSegmentTypeEnabled = { segmentType, enabled ->
+                    coroutineScope.launch { viewModel.setAutoSkipSegmentTypeEnabled(segmentType, enabled) }
+                },
                 onSetFrameRateMatchingMode = { mode -> coroutineScope.launch { viewModel.setFrameRateMatchingMode(mode) } },
                 onSetResolutionMatchingEnabled = { enabled ->
                     coroutineScope.launch { viewModel.setResolutionMatchingEnabled(enabled) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PauseCircle
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
@@ -62,6 +63,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
+import com.nuvio.tv.data.local.AutoSkipSegmentType
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.PlayerPreference
@@ -132,6 +134,7 @@ internal fun PlaybackSettingsSections(
     onSetPauseOverlayEnabled: (Boolean) -> Unit,
     onSetOsdClockEnabled: (Boolean) -> Unit,
     onSetSkipIntroEnabled: (Boolean) -> Unit,
+    onSetAutoSkipSegmentTypeEnabled: (AutoSkipSegmentType, Boolean) -> Unit,
     onSetFrameRateMatchingMode: (FrameRateMatchingMode) -> Unit,
     onSetResolutionMatchingEnabled: (Boolean) -> Unit,
     onDisableAfrAndResolution: () -> Unit,
@@ -155,6 +158,7 @@ internal fun PlaybackSettingsSections(
 ) {
     var generalExpanded by rememberSaveable { mutableStateOf(false) }
     var afrExpanded by rememberSaveable { mutableStateOf(false) }
+    var autoSkipExpanded by rememberSaveable { mutableStateOf(false) }
     var streamExpanded by rememberSaveable { mutableStateOf(false) }
     var audioTrailerExpanded by rememberSaveable { mutableStateOf(false) }
     var subtitlesExpanded by rememberSaveable { mutableStateOf(false) }
@@ -162,6 +166,7 @@ internal fun PlaybackSettingsSections(
 
     val defaultGeneralHeaderFocus = remember { FocusRequester() }
     val afrHeaderFocus = remember { FocusRequester() }
+    val autoSkipHeaderFocus = remember { FocusRequester() }
     val streamHeaderFocus = remember { FocusRequester() }
     val audioTrailerHeaderFocus = remember { FocusRequester() }
     val subtitlesHeaderFocus = remember { FocusRequester() }
@@ -238,6 +243,11 @@ internal fun PlaybackSettingsSections(
     LaunchedEffect(generalExpanded, focusedSection) {
         if (!generalExpanded && focusedSection == PlaybackSection.GENERAL) {
             generalHeaderFocus.requestFocus()
+        }
+    }
+    LaunchedEffect(autoSkipExpanded, focusedSection) {
+        if (!autoSkipExpanded && focusedSection == PlaybackSection.GENERAL) {
+            autoSkipHeaderFocus.requestFocus()
         }
     }
     LaunchedEffect(streamExpanded, focusedSection) {
@@ -324,6 +334,62 @@ internal fun PlaybackSettingsSections(
                     onFocused = { focusedSection = PlaybackSection.GENERAL },
                     enabled = !generalUi.isExternalPlayer
                 )
+            }
+
+            item(key = "general_auto_skip_header") {
+                PlaybackSectionHeader(
+                    title = stringResource(R.string.playback_auto_skip_segments),
+                    description = stringResource(R.string.playback_auto_skip_segments_sub),
+                    expanded = autoSkipExpanded,
+                    onToggle = { autoSkipExpanded = !autoSkipExpanded },
+                    focusRequester = autoSkipHeaderFocus,
+                    onFocused = { focusedSection = PlaybackSection.GENERAL },
+                    enabled = !generalUi.isExternalPlayer && playerSettings.skipIntroEnabled
+                )
+            }
+
+            if (autoSkipExpanded) {
+                item(key = "general_auto_skip_intro") {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.SkipNext,
+                        title = stringResource(R.string.auto_skip_intro),
+                        subtitle = stringResource(R.string.auto_skip_intro_sub),
+                        isChecked = AutoSkipSegmentType.INTRO in playerSettings.autoSkipSegmentTypes,
+                        onCheckedChange = {
+                            onSetAutoSkipSegmentTypeEnabled(AutoSkipSegmentType.INTRO, it)
+                        },
+                        onFocused = { focusedSection = PlaybackSection.GENERAL },
+                        enabled = !generalUi.isExternalPlayer && playerSettings.skipIntroEnabled
+                    )
+                }
+
+                item(key = "general_auto_skip_recap") {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.SkipNext,
+                        title = stringResource(R.string.auto_skip_recap),
+                        subtitle = stringResource(R.string.auto_skip_recap_sub),
+                        isChecked = AutoSkipSegmentType.RECAP in playerSettings.autoSkipSegmentTypes,
+                        onCheckedChange = {
+                            onSetAutoSkipSegmentTypeEnabled(AutoSkipSegmentType.RECAP, it)
+                        },
+                        onFocused = { focusedSection = PlaybackSection.GENERAL },
+                        enabled = !generalUi.isExternalPlayer && playerSettings.skipIntroEnabled
+                    )
+                }
+
+                item(key = "general_auto_skip_outro") {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.SkipNext,
+                        title = stringResource(R.string.auto_skip_outro),
+                        subtitle = stringResource(R.string.auto_skip_outro_sub),
+                        isChecked = AutoSkipSegmentType.OUTRO in playerSettings.autoSkipSegmentTypes,
+                        onCheckedChange = {
+                            onSetAutoSkipSegmentTypeEnabled(AutoSkipSegmentType.OUTRO, it)
+                        },
+                        onFocused = { focusedSection = PlaybackSection.GENERAL },
+                        enabled = !generalUi.isExternalPlayer && playerSettings.skipIntroEnabled
+                    )
+                }
             }
 
             item(key = "general_afr_header") {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamAutoPlaySource
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
+import com.nuvio.tv.data.local.AutoSkipSegmentType
 import com.nuvio.tv.data.local.MpvHardwareDecodeMode
 import com.nuvio.tv.data.local.SubtitleOrganizationMode
 import com.nuvio.tv.data.local.TrailerSettings
@@ -122,6 +123,10 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setSkipIntroEnabled(enabled: Boolean) {
         playerSettingsDataStore.setSkipIntroEnabled(enabled)
+    }
+
+    suspend fun setAutoSkipSegmentTypeEnabled(segmentType: AutoSkipSegmentType, enabled: Boolean) {
+        playerSettingsDataStore.setAutoSkipSegmentTypeEnabled(segmentType, enabled)
     }
 
     suspend fun setFrameRateMatchingMode(mode: FrameRateMatchingMode) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,14 @@
     <string name="playback_osd_clock">OSD Clock</string>
     <string name="playback_skip_intro">Skip Intro</string>
     <string name="playback_skip_intro_sub">Use introdb.app to detect intros and recaps.</string>
+    <string name="playback_auto_skip_segments">Automatic Skipping</string>
+    <string name="playback_auto_skip_segments_sub">Choose which segments skip automatically.</string>
+    <string name="auto_skip_intro">Intro / Opening</string>
+    <string name="auto_skip_intro_sub">Skip intros and anime openings automatically.</string>
+    <string name="auto_skip_recap">Recap</string>
+    <string name="auto_skip_recap_sub">Skip recap segments automatically.</string>
+    <string name="auto_skip_outro">Outro / Ending</string>
+    <string name="auto_skip_outro_sub">Skip outros and anime endings automatically.</string>
     <string name="playback_auto_frame_rate">Auto Frame Rate &amp; Resolution</string>
     <string name="playback_section_player">Player &amp; Stream Selection</string>
     <string name="playback_section_player_desc">Player preference, auto-play, and source filtering.</string>


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->

## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why
Users now have to press a button to skip segments (intro, recap and outro). This addition will allow users to chose per segment if they want to keep skipping manually or skip automatically.
<!-- Why this change is needed. Link bug/issue/context. -->

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)


## Testing
<!-- What you tested and how (manual + automated). -->
Tested manually. With Anime Skip and IntroDB
## Screenshots / Video (UI changes only)
<img width="1430" height="824" alt="image" src="https://github.com/user-attachments/assets/a89d40ce-da79-4a44-9656-c3eedd797ba1" />
<img width="1431" height="802" alt="image" src="https://github.com/user-attachments/assets/43345a0b-f24b-4dcf-9e81-11229008a16f" />

<!-- If UI changed, add before/after screenshots or a short clip. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None -->
None
## Linked issues

<!-- Example: Fixes #123 -->
Fixes https://github.com/NuvioMedia/NuvioTV/issues/1585