### PR TITLE
Update sidebar animations

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
 import java.util.Locale
+import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateDp
@@ -1035,14 +1036,17 @@ private fun ModernSidebarScaffold(
         },
         label = "sidebarWidth"
     )
+    val animationDuration = if (sidebarVisible) 400 else 300
+    val animationEasing = if (sidebarVisible) FastOutSlowInEasing else FastOutLinearInEasing
+
     val sidebarSlideX by animateDpAsState(
         targetValue = if (sidebarVisible) 0.dp else (-24).dp,
-        animationSpec = tween(durationMillis = 205, easing = FastOutSlowInEasing),
+        animationSpec = tween(durationMillis = animationDuration, easing = animationEasing),
         label = "sidebarSlideX"
     )
     val sidebarSurfaceAlpha by animateFloatAsState(
         targetValue = if (sidebarVisible) 1f else 0f,
-        animationSpec = tween(durationMillis = 135, easing = FastOutSlowInEasing),
+        animationSpec = tween(durationMillis = animationDuration, easing = animationEasing),
         label = "sidebarSurfaceAlpha"
     )
     val shouldApplySidebarHaze = showSidebar && modernSidebarBlurEnabled && (


### PR DESCRIPTION
## Summary

This PR is to address perceived animation jank by improving upon the existing sidebar animations, by increasing animation slide in duration from 205ms to 400ms and slide out from 135ms to 300ms. Previously, the slide out/close animation seemed choppy.

**Changes:**

- Imported FastOutLinearInEasing. 
- Modified sidebarSlideX and sidebarSurfaceAlpha to dynamically choose duration and easing based on sidebarVisible state.
- Extracted common animation properties into shared variables. 
- Set enter animation to 400ms with FastOutSlowInEasing and exit animation to 300ms with FastOutLinearInEasing.

## PR type

- Small maintenance improvement

## Why

Improve sidebar animation and remove perceived jank.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the **approved** feature request issue below.



## Testing

APK built and tested.

## Screenshots / Video (UI changes only)

I would video but you can't tell the differences really, it is quite subtle. Code wise it's as you see in the commit. 

## Breaking changes

Nothing is broken from my testing, works fine.

## Linked issues

Fixes: https://github.com/NuvioMedia/NuvioTV/issues/1597
