### PR TITLE
Improve Trakt Anime Remapper

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -129,6 +129,17 @@ class WatchedSeriesStateHolder @Inject constructor(
     }
 
     /**
+     * Clears all revalidation deadlines, forcing every series to be re-evaluated
+     * on the next CW pipeline cycle. Called when the user manually clears the CW cache.
+     */
+    fun clearValidationState() {
+        revalidateAfterMap = emptyMap()
+        scope.launch {
+            store().edit { prefs -> prefs.remove(REVALIDATE_KEY) }
+        }
+    }
+
+    /**
      * Filters the given set to only those series that need re-validation
      * (past their revalidation deadline or never validated).
      */

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -67,16 +67,16 @@ class TraktEpisodeMappingService @Inject constructor(
         val addonEpisodes = getAddonEpisodes(resolvedContentId, resolvedContentType)
         if (addonEpisodes.isEmpty()) return null
 
-        val addonHasEpisode = addonEpisodes.any {
-            it.season == requestedSeason && it.episode == requestedEpisode
-        }
-        if (addonHasEpisode) {
-            return null
-        }
-
         val showLookupId = resolveShowLookupId(contentId = resolvedContentId, videoId = null) ?: return null
         val traktEpisodes = getTraktEpisodes(showLookupId)
         if (traktEpisodes.isEmpty()) return null
+
+        val addonHasEpisode = addonEpisodes.any {
+            it.season == requestedSeason && it.episode == requestedEpisode
+        }
+        if (addonHasEpisode && hasSameSeasonStructure(addonEpisodes, traktEpisodes)) {
+            return null
+        }
 
         val mapped = reverseRemapEpisodeByTitleOrIndex(
             requestedSeason = requestedSeason,
@@ -90,6 +90,15 @@ class TraktEpisodeMappingService @Inject constructor(
             reverseMappingCache[reverseKey] = mapped
         }
         return mapped
+    }
+
+    private fun hasSameSeasonStructure(
+        addonEpisodes: List<EpisodeMappingEntry>,
+        traktEpisodes: List<EpisodeMappingEntry>
+    ): Boolean {
+        val addonSeasons = addonEpisodes.mapTo(mutableSetOf()) { it.season }
+        val traktSeasons = traktEpisodes.mapTo(mutableSetOf()) { it.season }
+        return addonSeasons == traktSeasons
     }
 
     internal suspend fun getCachedEpisodeMapping(
@@ -126,6 +135,10 @@ class TraktEpisodeMappingService @Inject constructor(
         val showLookupId = resolveShowLookupId(contentId = resolvedContentId, videoId = videoId) ?: return null
         val traktEpisodes = getTraktEpisodes(showLookupId)
         if (traktEpisodes.isEmpty()) return null
+
+        if (hasSameSeasonStructure(addonEpisodes, traktEpisodes)) {
+            return null
+        }
 
         val mapped = remapEpisodeByTitleOrIndex(
             requestedSeason = requestedSeason,

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -2049,14 +2049,65 @@ class TraktProgressService @Inject constructor(
                 )
             )
         )
-        Log.d(TAG, "markSeasonWatchedBatch: ${progressList.size} episodes in ${episodesBySeason.size} season(s)")
         val response = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
             traktApi.addHistory(authHeader, body)
         }
-        Log.d(TAG, "markSeasonWatchedBatch RESPONSE: code=${response?.code()} " +
-            "added=${response?.body()?.added}")
+        val responseBody = response?.body()
         if (response?.isSuccessful != true) {
             throw IllegalStateException("Trakt batch mark watched failed (${response?.code()})")
+        }
+
+        // If Trakt reported "not found" episodes, retry with remapped numbering.
+        val notFoundEpisodes = responseBody?.notFound?.episodes.orEmpty()
+        val notFoundShows = responseBody?.notFound?.shows.orEmpty()
+        val notFoundSeasons = responseBody?.notFound?.seasons.orEmpty()
+        val hasNotFound = notFoundEpisodes.isNotEmpty() || notFoundShows.isNotEmpty() || notFoundSeasons.isNotEmpty()
+        val addedEpisodes = responseBody?.added?.episodes ?: 0
+        val nothingAdded = addedEpisodes == 0 && progressList.isNotEmpty()
+        if (hasNotFound || nothingAdded) {
+            val remappedList = progressList.mapNotNull { progress ->
+                val season = progress.season ?: return@mapNotNull null
+                val episode = progress.episode ?: return@mapNotNull null
+                val remapped = traktEpisodeMappingService.resolveEpisodeMapping(
+                    contentId = progress.contentId,
+                    contentType = progress.contentType,
+                    videoId = progress.videoId,
+                    season = season,
+                    episode = episode
+                ) ?: return@mapNotNull null
+                if (remapped.season == season && remapped.episode == episode) return@mapNotNull null
+                progress.copy(season = remapped.season, episode = remapped.episode)
+            }
+            if (remappedList.isNotEmpty()) {
+                val remappedBySeason = remappedList
+                    .groupBy { it.season!! }
+                    .mapValues { (_, episodes) ->
+                        episodes.map { ep ->
+                            TraktHistoryEpisodeAddDto(
+                                number = ep.episode,
+                                watchedAt = watchedAt
+                            )
+                        }
+                    }
+                val remappedBody = TraktHistoryAddRequestDto(
+                    shows = listOf(
+                        TraktHistoryShowAddDto(
+                            title = first.name.takeIf { it.isNotBlank() },
+                            year = null,
+                            ids = ids,
+                            seasons = remappedBySeason.map { (seasonNumber, episodes) ->
+                                TraktHistorySeasonAddDto(
+                                    number = seasonNumber,
+                                    episodes = episodes
+                                )
+                            }
+                        )
+                    )
+                )
+                val retryResponse = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
+                    traktApi.addHistory(authHeader, remappedBody)
+                }
+            }
         }
         refreshNow()
     }
@@ -2090,11 +2141,67 @@ class TraktProgressService @Inject constructor(
                 )
             )
         )
-        Log.d(TAG, "removeSeasonFromHistoryBatch: ${episodes.size} episodes in ${episodesBySeason.size} season(s)")
         val response = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
             traktApi.removeHistory(authHeader, body)
         }
-        Log.d(TAG, "removeSeasonFromHistoryBatch RESPONSE: code=${response?.code()}")
+        val deleted = response?.body()?.deleted?.episodes ?: 0
+
+        // If nothing was deleted, retry with remapped numbering (anime case)
+        if (deleted == 0 && episodes.isNotEmpty()) {
+            val remappedEpisodes = episodes.mapNotNull { (season, episode) ->
+                val remapped = traktEpisodeMappingService.resolveEpisodeMapping(
+                    contentId = contentId,
+                    contentType = "series",
+                    videoId = null,
+                    season = season,
+                    episode = episode
+                ) ?: return@mapNotNull null
+                if (remapped.season == season && remapped.episode == episode) return@mapNotNull null
+                remapped.season to remapped.episode
+            }
+            if (remappedEpisodes.isNotEmpty()) {
+                val remappedBySeason = remappedEpisodes.groupBy { it.first }
+                val remappedBody = TraktHistoryRemoveRequestDto(
+                    shows = listOf(
+                        TraktHistoryShowRemoveDto(
+                            ids = ids,
+                            seasons = remappedBySeason.map { (seasonNumber, eps) ->
+                                TraktHistorySeasonRemoveDto(
+                                    number = seasonNumber,
+                                    episodes = eps.map { (_, episodeNumber) ->
+                                        TraktHistoryEpisodeRemoveDto(number = episodeNumber)
+                                    }
+                                )
+                            }
+                        )
+                    )
+                )
+                val retryResponse = traktAuthService.executeAuthorizedWriteRequest { authHeader ->
+                    traktApi.removeHistory(authHeader, remappedBody)
+                }
+            }
+        }
+        // Immediately remove episodes from the in-memory cache so UI updates
+        // without waiting for the full Trakt refresh cycle.
+        episodeProgressState.update { current ->
+            val cacheKey = canonicalLookupKey(contentId)
+            val entry = current[cacheKey] ?: return@update current
+            val updatedProgress = entry.progress.toMutableMap().apply {
+                episodes.forEach { (s, e) -> remove(s to e) }
+            }
+            current + (cacheKey to entry.copy(progress = updatedProgress))
+        }
+        // Also remove from watchedShowEpisodesMap so badge evaluation picks up the change.
+        val cacheKey = canonicalLookupKey(contentId)
+        val currentEpisodes = watchedShowEpisodesMap[cacheKey]
+        if (currentEpisodes != null) {
+            val updated = currentEpisodes.toMutableSet().apply {
+                episodes.forEach { remove(it) }
+            }
+            watchedShowEpisodesMap = watchedShowEpisodesMap.toMutableMap().apply {
+                this[cacheKey] = updated
+            }
+        }
         refreshNow()
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -500,12 +500,26 @@ class WatchProgressRepositoryImpl @Inject constructor(
 
     /**
      * Returns per-show watched episodes from the active source.
-     * For Trakt: from /sync/watched/shows response.
+     * For Trakt: merges /sync/watched/shows with local watchedItemsPreferences
+     * (which may contain episodes marked locally but not yet synced to Trakt).
      * For Nuvio sync: from watchedItemsPreferences.
      */
     override suspend fun getWatchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>> {
         return if (shouldUseTraktProgress()) {
-            traktProgressService.getWatchedShowEpisodes()
+            val traktEpisodes = traktProgressService.getWatchedShowEpisodes()
+            val localEpisodes = watchedItemsPreferences.allItems.first()
+                .filter { it.season != null && it.episode != null }
+                .filter { it.contentType.equals("series", ignoreCase = true) || it.contentType.equals("tv", ignoreCase = true) }
+                .groupBy { it.contentId }
+                .mapValues { (_, items) ->
+                    items.map { it.season!! to it.episode!! }.toSet()
+                }
+            // Merge: union of episodes from both sources per content ID
+            val merged = traktEpisodes.toMutableMap()
+            for ((contentId, episodes) in localEpisodes) {
+                merged[contentId] = (merged[contentId] ?: emptySet()) + episodes
+            }
+            merged
         } else {
             watchedItemsPreferences.allItems.first()
                 .filter { it.season != null && it.episode != null }
@@ -571,6 +585,15 @@ class WatchProgressRepositoryImpl @Inject constructor(
         if (shouldUseTraktProgress()) {
             traktProgressService.applyOptimisticProgress(progress)
             watchProgressPreferences.saveProgress(progress)
+            // Mirror to Nuvio Sync so data is ready if user switches source later.
+            if (syncRemote && authManager.isAuthenticated) {
+                syncScope.launch(NonCancellable) {
+                    watchProgressSyncService.pushSingleToRemote(progressKey(progress), progress)
+                        .onFailure { error ->
+                            Log.w(TAG, "Failed single progress push (Trakt mirror); falling back to full sync next cycle", error)
+                        }
+                }
+            }
             return
         }
         watchProgressPreferences.saveProgress(progress)
@@ -784,6 +807,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     watchedAt = System.currentTimeMillis()
                 )
             )
+            // Mirror to Nuvio Sync so data is ready if user switches source later.
+            triggerRemoteSync()
+            triggerWatchedItemsSync()
             return
         }
         watchProgressPreferences.markAsCompleted(progress)
@@ -870,6 +896,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 )
             }
             watchedItemsPreferences.markAsWatchedBatch(watchedItems)
+            // Mirror to Nuvio Sync so data is ready if user switches source later.
+            triggerRemoteSync()
+            triggerWatchedItemsSync()
             return
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -313,6 +313,7 @@ class HomeViewModel @Inject constructor(
         cwEnrichedNextUpOverlay.clear()
         cwEnrichedInProgressOverlay.clear()
         cwLastBadgeEpisodeKeys = emptySet()
+        watchedSeriesStateHolder.clearValidationState()
         _uiState.update { it.copy(continueWatchingItems = emptyList()) }
         // Bump trigger so the pipeline's collectLatest restarts with fresh state.
         cwPipelineRefreshTrigger.value++

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1215,6 +1215,19 @@ private fun resolveVideoForProgress(progress: WatchProgress, meta: CwMetaSummary
     val episode = progress.episode
     if (season != null && episode != null) {
         videos.firstOrNull { it.season == season && it.episode == episode }?.let { return it }
+
+        // Fallback: if not found by season+episode (anime with absolute numbering
+        // on Trakt vs multi-season on addon), try global index matching.
+        val addonSeasons = videos.mapTo(mutableSetOf()) { it.season }
+        if (season == 1 && addonSeasons.size > 1 && episode > 0) {
+            val sorted = videos.sortedWith(
+                compareBy<CwVideoSummary>({ it.season ?: Int.MAX_VALUE }, { it.episode ?: Int.MAX_VALUE })
+            )
+            val globalIndex = episode - 1
+            if (globalIndex in sorted.indices) {
+                return sorted[globalIndex]
+            }
+        }
     }
 
     return null
@@ -1770,7 +1783,8 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         }
         return null
     }
-    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp) ?: run {
+    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp)
+    if (nextVideo == null) {
         debug?.recordNextUpResult(
             progress = progress,
             reason = "no-next-video-after-seed",
@@ -1845,7 +1859,30 @@ private fun resolveNextUpVideoFromMeta(
     val seedEpisode = progress.episode
     if (seedSeason == null || seedEpisode == null) return null
 
-    val watchedIndex = episodes.indexOfFirst { it.season == seedSeason && it.episode == seedEpisode }
+    var watchedIndex = episodes.indexOfFirst { it.season == seedSeason && it.episode == seedEpisode }
+
+    // Fallback: if the seed wasn't found by season+episode
+    if (watchedIndex < 0) {
+        val videoId = progress.videoId.takeIf { it.isNotBlank() }
+        if (videoId != null) {
+            watchedIndex = episodes.indexOfFirst { it.id == videoId }
+        }
+        if (watchedIndex < 0) {
+            // Index-based fallback: treat the seed as the Nth episode overall
+            val addonSeasons = episodes.mapTo(mutableSetOf()) { it.season }
+            if (seedSeason == 1 && addonSeasons.size > 1 && seedEpisode > 0) {
+                val globalIndex = seedEpisode - 1 // 0-based
+                if (globalIndex in episodes.indices) {
+                    watchedIndex = globalIndex
+                    logNextUpDecision(
+                        "remap-index contentId=${progress.contentId} seed=${seedSeason}x${seedEpisode} " +
+                            "-> ${episodes[globalIndex].season}x${episodes[globalIndex].episode} (index=$globalIndex)"
+                    )
+                }
+            }
+        }
+    }
+
     if (watchedIndex < 0) {
         logNextUpDecision(
             "drop contentId=${progress.contentId} name=${progress.name} reason=seed-not-found-in-meta seed=${seedSeason}x${seedEpisode}"
@@ -1854,9 +1891,10 @@ private fun resolveNextUpVideoFromMeta(
     }
 
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
+    val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
         val releaseDate = parseEpisodeReleaseDate(video.released)
-        val isSeasonRollover = video.season != seedSeason
+        val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {
             if (releaseDate == null) {
                 logNextUpDecision(
@@ -2024,9 +2062,6 @@ private suspend fun HomeViewModel.resolveBadgeGroup(group: List<String>) {
     }
     if (!alreadyCached) {
         val episodes = resolveBadgeEpisodes(primaryId, "series")
-        if (episodes == null) {
-        } else {
-        }
         if (group.size > 1) {
             synchronized(cwBadgeEpisodeCache) {
                 for (siblingId in group.drop(1)) {
@@ -2036,7 +2071,6 @@ private suspend fun HomeViewModel.resolveBadgeGroup(group: List<String>) {
                 }
             }
         }
-    } else {
     }
 }
 
@@ -2308,11 +2342,18 @@ private fun HomeViewModel.publishBadgeUpdate(
             } ?: return@filter false
             if (airedEpisodes.isEmpty()) return@filter false
             val watched = allWatchedEpisodes[contentId] ?: return@filter false
+            // Primary check: exact season+episode match
             val allWatched = airedEpisodes.all { it in watched }
-            if (!allWatched && watched.isNotEmpty()) {
+            // Fallback: if exact match fails but the watched count covers all aired
+            // episodes, treat as fully watched. This handles anime where Trakt uses
+            // absolute numbering (S1E1..S1E48) but addon splits into seasons
+            // (S1E1..S1E24, S2E1..S2E24) — the pairs don't match but the counts do.
+            val fullyWatchedByCount = !allWatched &&
+                watched.size >= airedEpisodes.size
+            if (!allWatched && !fullyWatchedByCount && watched.isNotEmpty()) {
                 validatedNotFullyWatched.add(contentId)
             }
-            allWatched
+            allWatched || fullyWatchedByCount
         }
         .toSet()
     // Expand IDs: for each fully-watched IMDB ID, also include the
@@ -2341,8 +2382,6 @@ private fun HomeViewModel.publishBadgeUpdate(
     // But DO remove badges for series we've confirmed are NOT fully watched.
     val current = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
     val merged = (current - expandedNotFullyWatched) + expandedFullyWatched
-    if (updatedFullyWatched.isNotEmpty()) {
-    }
     // Build per-series revalidation deadlines from upcoming season dates.
     // Fully-watched: revalidate at next season premiere or after default TTL.
     // Not-fully-watched: no deadline — status can only change when user watches more.


### PR DESCRIPTION
## Summary

Fix anime episode remapping between Trakt and meta addons, and mirror watch progress to Nuvio Sync when Trakt is the active source.

Key changes:
- Fix reverse episode remapping (Trakt->addon) to detect season structure mismatch instead of naive episode existence check
- Add index-based fallback in CW pipeline when seed episode isn't found in meta (anime absolute numbering)
- Add remap retry to `markSeasonWatchedBatch` and `removeSeasonFromHistoryBatch` when Trakt returns notFound
- Merge local `watchedItemsPreferences` with Trakt data in `getWatchedShowEpisodes()` for badge evaluation
- Add count-based fallback for "fully watched" badge when exact season+episode pairs don't match
- Reset validation state when CW cache is cleared so items reappear
- Immediately update `episodeProgressState` cache after batch remove (instant UI update)
- Mirror watch progress to Nuvio Sync when Trakt is the active CW source

## PR type

- Bug fix

## Why

Anime from Trakt doesn't return seasons the same way meta addons do. Trakt often uses absolute numbering (S1E1..S1E48) or splits anime into separate show entries per season, while addons use multi-season structure. This caused watch progress not syncing, badges disappearing, and CW items lost after restart. Additionally, users couldn't seamlessly switch from Trakt to Nuvio Sync because data wasn't being mirrored.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual testing with tt12343534 - 3 seasons on addon, Trakt splits into separate entries
- Batch mark season: verified remap retry fires and adds episodes to Trakt
- Batch unmark season: verified remap retry and immediate UI cache invalidation
- CW after restart: verified anime items persist via index-based fallback
- Badge persistence: verified "fully watched" badge survives restart with count-based fallback
- CW cache clear: verified validation state reset allows items to reappear
- Nuvio Sync mirror: verified `triggerRemoteSync`/`triggerWatchedItemsSync` called in Trakt path

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break

## Linked issues

Reported on discord
