### PR TITLE
Add "Follow addons order" toggle for catalog ordering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Android 11+ fix: SpeechRecognizer not available without this -->
+    <!-- https://stackoverflow.com/questions/64319117/speechrecognizer-not-available-when-targeting-android-11 -->
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServer.kt
@@ -138,6 +138,7 @@ class AddonConfigServer(
             val collectionsRaw = parsed["collections"]
             val collectionsJson = if (collectionsRaw != null) gson.toJson(collectionsRaw) else null
             val disabledCollectionKeys = parseStringList(parsed["disabledCollectionKeys"])
+            val followAddonsOrder = parsed["followAddonsOrder"] as? Boolean
             sanitizePendingAddonChange(
                 mode = webConfigMode,
                 proposedChange = PendingAddonChange(
@@ -145,7 +146,8 @@ class AddonConfigServer(
                     proposedCatalogOrderKeys = catalogOrderKeys,
                     proposedDisabledCatalogKeys = disabledCatalogKeys,
                     proposedCollectionsJson = collectionsJson,
-                    proposedDisabledCollectionKeys = disabledCollectionKeys
+                    proposedDisabledCollectionKeys = disabledCollectionKeys,
+                    proposedFollowAddonsOrder = followAddonsOrder
                 ),
                 currentState = currentPageStateProvider()
             )

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServerModels.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServerModels.kt
@@ -120,7 +120,8 @@ data class PageState(
     val addons: List<AddonInfo>,
     val catalogs: List<CatalogInfo>,
     val collections: List<CollectionInfo> = emptyList(),
-    val disabledCollectionKeys: List<String> = emptyList()
+    val disabledCollectionKeys: List<String> = emptyList(),
+    val followAddonsOrder: Boolean = false
 )
 
 data class PendingAddonChange(
@@ -130,6 +131,7 @@ data class PendingAddonChange(
     val proposedDisabledCatalogKeys: List<String> = emptyList(),
     val proposedCollectionsJson: String? = null,
     val proposedDisabledCollectionKeys: List<String> = emptyList(),
+    val proposedFollowAddonsOrder: Boolean? = null,
     var status: AddonChangeStatus = AddonChangeStatus.PENDING
 )
 

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
@@ -81,6 +81,17 @@ object AddonWebPage {
   <div class="tab-content" id="tab-catalogs">
     <div class="section-block">
       <div class="section-label">${context.getString(R.string.web_home_catalogs)}</div>
+      <div id="followAddonsToggle" class="addon-item" style="border-top:none;padding:0.75rem 0">
+        <div class="catalog-info">
+          <div class="catalog-name">${context.getString(R.string.catalog_order_follow_addons)}</div>
+          <div class="catalog-meta">${context.getString(R.string.catalog_order_follow_addons_desc)}</div>
+        </div>
+        <label class="toggle-switch">
+          <input type="checkbox" id="followAddonsCheckbox" onchange="toggleFollowAddonsOrder()">
+          <span class="toggle-track"></span>
+          <span class="toggle-thumb"></span>
+        </label>
+      </div>
       <div class="add-section" style="display:flex;gap:0.5rem">
         <button class="btn" onclick="enableAllCatalogs()" style="flex:1">${context.getString(R.string.web_btn_enable_all)}</button>
         <button class="btn" onclick="disableAllCatalogs()" style="flex:1">${context.getString(R.string.web_btn_disable_all)}</button>
@@ -1103,6 +1114,7 @@ var originalCollections = [];
 var disabledCollectionKeys = [];
 var originalDisabledCollectionKeys = [];
 var availableCatalogs = [];
+var followAddonsOrder = false;
 var pollTimer = null;
 var pollStartTime = 0;
 var POLL_TIMEOUT = 120000;
@@ -1478,6 +1490,7 @@ async function loadState() {
     catalogs = state.catalogs || [];
     collections = normalizeCollectionsForEditing(state.collections || []);
     disabledCollectionKeys = (state.disabledCollectionKeys || []).slice();
+    followAddonsOrder = state.followAddonsOrder || false;
     originalAddons = JSON.parse(JSON.stringify(addons));
     originalCatalogs = JSON.parse(JSON.stringify(catalogs));
     originalCollections = JSON.parse(JSON.stringify(collections));
@@ -1550,6 +1563,13 @@ function renderCatalogs() {
   if (!list || !empty) return;
   list.innerHTML = '';
 
+  // Render follow addons order toggle
+  var toggleDiv = document.getElementById('followAddonsToggle');
+  if (toggleDiv) {
+    var cb = document.getElementById('followAddonsCheckbox');
+    if (cb) cb.checked = followAddonsOrder;
+  }
+
   if (catalogs.length === 0) {
     empty.style.display = 'block';
     return;
@@ -1567,18 +1587,25 @@ function renderCatalogs() {
     var isCollection = catalog.isCollection || false;
     var typeDisplay = isCollection ? 'Collection' : formatCatalogTitle(catalog.catalogName, catalog.type);
 
+    // In follow addons order mode, disable move buttons for non-collection items
+    var moveDisabled = followAddonsOrder && !isCollection;
+    var upDisabled = isFirst || moveDisabled;
+    var downDisabled = isLast || moveDisabled;
+    var topDisabled = isFirst || moveDisabled;
+    var bottomDisabled = isLast || moveDisabled;
+
     li.innerHTML =
       '<div class="addon-order">' +
-        '<button class="btn-order" onclick="moveCatalogToTop(' + i + ')"' + (isFirst ? ' disabled' : '') + ' title="Send to top">' +
+        '<button class="btn-order" onclick="moveCatalogToTop(' + i + ')"' + (topDisabled ? ' disabled' : '') + ' title="Send to top">' +
           '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 11l-6-6-6 6"/><path d="M18 18l-6-6-6 6"/></svg>' +
         '</button>' +
-        '<button class="btn-order" onclick="moveCatalog(' + i + ',-1)"' + (isFirst ? ' disabled' : '') + ' title="Move up">' +
+        '<button class="btn-order" onclick="moveCatalog(' + i + ',-1)"' + (upDisabled ? ' disabled' : '') + ' title="Move up">' +
           '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 15l-6-6-6 6"/></svg>' +
         '</button>' +
-        '<button class="btn-order" onclick="moveCatalog(' + i + ',1)"' + (isLast ? ' disabled' : '') + ' title="Move down">' +
+        '<button class="btn-order" onclick="moveCatalog(' + i + ',1)"' + (downDisabled ? ' disabled' : '') + ' title="Move down">' +
           '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>' +
         '</button>' +
-        '<button class="btn-order" onclick="moveCatalogToBottom(' + i + ')"' + (isLast ? ' disabled' : '') + ' title="Send to bottom">' +
+        '<button class="btn-order" onclick="moveCatalogToBottom(' + i + ')"' + (bottomDisabled ? ' disabled' : '') + ' title="Send to bottom">' +
           '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l6 6 6-6"/><path d="M6 13l6 6 6-6"/></svg>' +
         '</button>' +
       '</div>' +
@@ -1599,6 +1626,32 @@ function renderCatalogs() {
   });
 }
 
+function toggleFollowAddonsOrder() {
+  followAddonsOrder = !followAddonsOrder;
+  if (followAddonsOrder) {
+    // Reorder: addon catalogs in manifest order, collections keep relative position
+    var addonItems = catalogs.filter(function(c) { return !c.isCollection; });
+    var collectionItems = [];
+    var collectionPositions = [];
+    catalogs.forEach(function(c, i) {
+      if (c.isCollection) {
+        collectionItems.push(c);
+        collectionPositions.push(i);
+      }
+    });
+    // Rebuild: start with addon items in their original manifest order (from server)
+    var manifestAddonOrder = originalCatalogs.filter(function(c) { return !(c.key && c.key.indexOf('collection_') === 0); });
+    var addonByKey = {};
+    addonItems.forEach(function(a) { addonByKey[a.key] = a; });
+    var orderedAddons = manifestAddonOrder.map(function(c) { return addonByKey[c.key]; }).filter(Boolean);
+    // Add any addon items not in manifest (shouldn't happen but safety)
+    addonItems.forEach(function(a) { if (orderedAddons.indexOf(a) < 0) orderedAddons.push(a); });
+    // Place collections at end
+    catalogs = orderedAddons.concat(collectionItems);
+  }
+  renderCatalogs();
+}
+
 function moveAddon(index, direction) {
   if (!allowAddonManagement) return;
   var newIndex = index + direction;
@@ -1610,16 +1663,46 @@ function moveAddon(index, direction) {
 
 function moveCatalog(index, direction) {
   if (!allowCatalogManagement) return;
-  var newIndex = index + direction;
-  if (newIndex < 0 || newIndex >= catalogs.length) return;
-  var item = catalogs.splice(index, 1)[0];
-  catalogs.splice(newIndex, 0, item);
+  var item = catalogs[index];
+  if (!item) return;
+
+  if (followAddonsOrder) {
+    // In follow mode, only collections can move, and they jump between addon blocks
+    if (!item.isCollection) return;
+    var newIndex;
+    if (direction < 0) {
+      // Move up: find start of previous addon block
+      var scanIdx = index - 1;
+      while (scanIdx >= 0 && catalogs[scanIdx].isCollection) scanIdx--;
+      if (scanIdx < 0) return;
+      var targetAddon = catalogs[scanIdx].addonName;
+      while (scanIdx > 0 && !catalogs[scanIdx - 1].isCollection && catalogs[scanIdx - 1].addonName === targetAddon) scanIdx--;
+      newIndex = scanIdx;
+    } else {
+      // Move down: find end of next addon block
+      var scanIdx = index + 1;
+      while (scanIdx < catalogs.length && catalogs[scanIdx].isCollection) scanIdx++;
+      if (scanIdx >= catalogs.length) return;
+      var targetAddon = catalogs[scanIdx].addonName;
+      while (scanIdx < catalogs.length - 1 && !catalogs[scanIdx + 1].isCollection && catalogs[scanIdx + 1].addonName === targetAddon) scanIdx++;
+      newIndex = scanIdx;
+    }
+    if (newIndex === index) return;
+    catalogs.splice(index, 1);
+    catalogs.splice(direction < 0 ? newIndex : newIndex, 0, item);
+  } else {
+    var newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= catalogs.length) return;
+    catalogs.splice(index, 1);
+    catalogs.splice(newIndex, 0, item);
+  }
   renderCatalogs();
 }
 
 function moveCatalogToTop(index) {
   if (!allowCatalogManagement) return;
   if (index <= 0) return;
+  if (followAddonsOrder && !catalogs[index].isCollection) return;
   var item = catalogs.splice(index, 1)[0];
   catalogs.unshift(item);
   renderCatalogs();
@@ -1628,6 +1711,7 @@ function moveCatalogToTop(index) {
 function moveCatalogToBottom(index) {
   if (!allowCatalogManagement) return;
   if (index >= catalogs.length - 1) return;
+  if (followAddonsOrder && !catalogs[index].isCollection) return;
   var item = catalogs.splice(index, 1)[0];
   catalogs.push(item);
   renderCatalogs();
@@ -1749,7 +1833,8 @@ async function saveChanges() {
         catalogOrderKeys: catalogOrderKeys,
         disabledCatalogKeys: disabledCatalogKeys,
         collections: collections,
-        disabledCollectionKeys: disabledCollectionKeys
+        disabledCollectionKeys: disabledCollectionKeys,
+        followAddonsOrder: followAddonsOrder
       })
     }, 8000);
     var data = await res.json();

--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -80,6 +80,7 @@ class LayoutPreferenceDataStore @Inject constructor(
     private val memoryOnlyVerticalScrollKey = booleanPreferencesKey("memory_only_vertical_scroll")
     private val smoothBringIntoViewEnabledKey = booleanPreferencesKey("smooth_bring_into_view_enabled")
     private val fastHorizontalNavigationEnabledKey = booleanPreferencesKey("fast_horizontal_navigation_enabled")
+    private val followAddonsOrderKey = booleanPreferencesKey("follow_addons_order")
 
     private fun <T> profileFlow(extract: (prefs: androidx.datastore.preferences.core.Preferences) -> T): Flow<T> =
         profileManager.activeProfileId.flatMapLatest { pid ->
@@ -252,6 +253,10 @@ class LayoutPreferenceDataStore @Inject constructor(
         prefs[fastHorizontalNavigationEnabledKey] ?: false
     }
 
+    val followAddonsOrder: Flow<Boolean> = profileFlow { prefs ->
+        prefs[followAddonsOrderKey] ?: false
+    }
+
     suspend fun setMemoryOnlyVerticalScroll(enabled: Boolean) {
         store().edit { prefs ->
             prefs[memoryOnlyVerticalScrollKey] = enabled
@@ -267,6 +272,12 @@ class LayoutPreferenceDataStore @Inject constructor(
     suspend fun setFastHorizontalNavigationEnabled(enabled: Boolean) {
         store().edit { prefs ->
             prefs[fastHorizontalNavigationEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setFollowAddonsOrder(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[followAddonsOrderKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerUiState.kt
@@ -35,5 +35,6 @@ data class PendingChangeInfo(
     val proposedCollectionsJson: String? = null,
     val proposedCollectionCount: Int = 0,
     val proposedDisabledCollectionKeys: List<String> = emptyList(),
+    val proposedFollowAddonsOrder: Boolean? = null,
     val isApplying: Boolean = false
 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
@@ -79,6 +79,7 @@ class AddonManagerViewModel @Inject constructor(
     private var logoBytes: ByteArray? = null
     private var homeCatalogOrderKeys: List<String> = emptyList()
     private var disabledHomeCatalogKeys: Set<String> = emptySet()
+    private var followAddonsOrderEnabled: Boolean = false
     private var currentCollections: List<Collection> = emptyList()
 
     init {
@@ -259,12 +260,52 @@ class AddonManagerViewModel @Inject constructor(
                         isDisabled = colKey in disabledHomeCatalogKeys
                     )
                 }
-                // Interleave based on saved order
-                val catalogByKey = (catalogInfos + collectionInfos).associateBy { it.key }
-                val savedOrder = homeCatalogOrderKeys
-                val orderedKeys = savedOrder.filter { it in catalogByKey }
-                val unseenKeys = catalogByKey.keys - orderedKeys.toSet()
-                val unifiedCatalogs = (orderedKeys + unseenKeys).mapNotNull { catalogByKey[it] }
+
+                val unifiedCatalogs: List<CatalogInfo>
+                if (followAddonsOrderEnabled) {
+                    // In follow mode: addon catalogs in manifest order, collections placed by saved position
+                    val addonKeys = catalogInfos.map { it.key }
+                    val collectionKeysSet = collectionInfos.map { it.key }.toSet()
+                    val catalogByKey = (catalogInfos + collectionInfos).associateBy { it.key }
+                    val savedValid = homeCatalogOrderKeys.filter { it in catalogByKey }.distinct()
+
+                    if (savedValid.isNotEmpty()) {
+                        val result = mutableListOf<String>()
+                        var addonPointer = 0
+                        for (savedKey in savedValid) {
+                            if (savedKey in collectionKeysSet) {
+                                result.add(savedKey)
+                            } else {
+                                val targetIdx = addonKeys.indexOf(savedKey)
+                                if (targetIdx >= 0) {
+                                    while (addonPointer <= targetIdx) {
+                                        val ak = addonKeys[addonPointer]
+                                        if (ak !in result) result.add(ak)
+                                        addonPointer++
+                                    }
+                                }
+                            }
+                        }
+                        while (addonPointer < addonKeys.size) {
+                            val ak = addonKeys[addonPointer]
+                            if (ak !in result) result.add(ak)
+                            addonPointer++
+                        }
+                        for (ck in collectionKeysSet) {
+                            if (ck !in result) result.add(ck)
+                        }
+                        unifiedCatalogs = result.mapNotNull { catalogByKey[it] }
+                    } else {
+                        unifiedCatalogs = catalogInfos + collectionInfos
+                    }
+                } else {
+                    // Interleave based on saved order
+                    val catalogByKey = (catalogInfos + collectionInfos).associateBy { it.key }
+                    val savedOrder = homeCatalogOrderKeys
+                    val orderedKeys = savedOrder.filter { it in catalogByKey }
+                    val unseenKeys = catalogByKey.keys - orderedKeys.toSet()
+                    unifiedCatalogs = (orderedKeys + unseenKeys).mapNotNull { catalogByKey[it] }
+                }
 
                 PageState(
                     addons = addons.map { addon ->
@@ -277,7 +318,8 @@ class AddonManagerViewModel @Inject constructor(
                     catalogs = unifiedCatalogs,
                     collections = collectionsToServerFormat(currentCollections),
                     disabledCollectionKeys = disabledHomeCatalogKeys
-                        .filter { it.startsWith("collection_") }
+                        .filter { it.startsWith("collection_") },
+                    followAddonsOrder = followAddonsOrderEnabled
                 )
             },
             onChangeProposed = { change -> handleChangeProposed(change) },
@@ -470,7 +512,8 @@ class AddonManagerViewModel @Inject constructor(
                     collectionsChanged = collectionsChanged,
                     proposedCollectionsJson = proposedCollectionsJson,
                     proposedCollectionCount = proposedCollectionCount,
-                    proposedDisabledCollectionKeys = proposedDisabledCollectionKeys
+                    proposedDisabledCollectionKeys = proposedDisabledCollectionKeys,
+                    proposedFollowAddonsOrder = change.proposedFollowAddonsOrder
                 )
             )
         }
@@ -517,6 +560,10 @@ class AddonManagerViewModel @Inject constructor(
                 val mergedDisabledKeys = nonCollectionDisabledKeys + pending.proposedDisabledCollectionKeys
                 layoutPreferenceDataStore.setDisabledHomeCatalogKeys(mergedDisabledKeys)
                 homeCatalogSettingsSyncService.triggerPush()
+            }
+            // Apply follow addons order change
+            if (pending.proposedFollowAddonsOrder != null) {
+                layoutPreferenceDataStore.setFollowAddonsOrder(pending.proposedFollowAddonsOrder)
             }
             server?.confirmChange(pending.changeId)
 
@@ -585,6 +632,11 @@ class AddonManagerViewModel @Inject constructor(
         viewModelScope.launch {
             layoutPreferenceDataStore.disabledHomeCatalogKeys.collect { keys ->
                 disabledHomeCatalogKeys = keys.toSet()
+            }
+        }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.followAddonsOrder.collect { enabled ->
+                followAddonsOrderEnabled = enabled
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -81,6 +83,33 @@ fun CatalogOrderScreen(
                     style = MaterialTheme.typography.bodyMedium,
                     color = NuvioColors.TextSecondary
                 )
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.catalog_order_follow_addons),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = NuvioColors.TextPrimary
+                        )
+                        Text(
+                            text = stringResource(R.string.catalog_order_follow_addons_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = NuvioColors.TextSecondary
+                        )
+                    }
+                    Switch(
+                        checked = uiState.followAddonsOrder,
+                        onCheckedChange = { viewModel.toggleFollowAddonsOrder(it) },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = NuvioColors.Primary,
+                            checkedTrackColor = NuvioColors.Primary.copy(alpha = 0.5f)
+                        )
+                    )
+                }
             }
 
             when {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -56,11 +56,6 @@ class CatalogOrderViewModel @Inject constructor(
     fun toggleFollowAddonsOrder(enabled: Boolean) {
         viewModelScope.launch {
             layoutPreferenceDataStore.setFollowAddonsOrder(enabled)
-            if (enabled) {
-                // Clear saved order so addon manifest order is used
-                layoutPreferenceDataStore.setHomeCatalogOrderKeys(emptyList())
-                homeCatalogSettingsSyncService.triggerPush()
-            }
         }
     }
 
@@ -276,7 +271,9 @@ class CatalogOrderViewModel @Inject constructor(
                         result.add(ck)
                     }
                 }
-                effectiveOrder = result
+                // Normalize: ensure collections sit at addon block boundaries, not mid-block.
+                // If a collection is between two catalogs of the same addon, push it after that block.
+                effectiveOrder = normalizeCollectionPositions(result, availableMap)
             } else {
                 // No saved order - addon manifest order + collections at end
                 effectiveOrder = addonKeys + collectionKeys.toList()
@@ -325,6 +322,71 @@ class CatalogOrderViewModel @Inject constructor(
                 canMoveDown = canMoveDown
             )
         }
+    }
+
+    /**
+     * Ensures collections are positioned at addon block boundaries.
+     * If a collection ended up between two catalogs of the same addon,
+     * push it to the end of that addon's block.
+     */
+    private fun normalizeCollectionPositions(
+        order: List<String>,
+        availableMap: Map<String, CatalogOrderEntry>
+    ): List<String> {
+        val result = order.toMutableList()
+        var i = 0
+        while (i < result.size) {
+            val key = result[i]
+            if (!key.startsWith("collection_")) {
+                i++
+                continue
+            }
+            // Check if this collection is between catalogs of the same addon
+            val prevAddon = findAddonNameBefore(result, i, availableMap)
+            val nextAddon = findAddonNameAfter(result, i, availableMap)
+            if (prevAddon != null && nextAddon != null && prevAddon == nextAddon) {
+                // Collection is mid-block. Move it after the end of this addon block.
+                result.removeAt(i)
+                var insertPos = i
+                while (insertPos < result.size &&
+                    !result[insertPos].startsWith("collection_") &&
+                    availableMap[result[insertPos]]?.addonName == prevAddon
+                ) {
+                    insertPos++
+                }
+                result.add(insertPos, key)
+                // Don't increment i - re-check this position
+            } else {
+                i++
+            }
+        }
+        return result
+    }
+
+    private fun findAddonNameBefore(
+        order: List<String>,
+        index: Int,
+        availableMap: Map<String, CatalogOrderEntry>
+    ): String? {
+        for (j in index - 1 downTo 0) {
+            if (!order[j].startsWith("collection_")) {
+                return availableMap[order[j]]?.addonName
+            }
+        }
+        return null
+    }
+
+    private fun findAddonNameAfter(
+        order: List<String>,
+        index: Int,
+        availableMap: Map<String, CatalogOrderEntry>
+    ): String? {
+        for (j in index + 1 until order.size) {
+            if (!order[j].startsWith("collection_")) {
+                return availableMap[order[j]]?.addonName
+            }
+        }
+        return null
     }
 
     private fun buildDefaultCatalogEntries(addons: List<Addon>): List<CatalogOrderEntry> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -38,11 +38,30 @@ class CatalogOrderViewModel @Inject constructor(
     }
 
     fun moveUp(key: String) {
-        moveCatalog(key, -1)
+        if (_uiState.value.followAddonsOrder) {
+            moveCollectionBetweenAddons(key, -1)
+        } else {
+            moveCatalog(key, -1)
+        }
     }
 
     fun moveDown(key: String) {
-        moveCatalog(key, 1)
+        if (_uiState.value.followAddonsOrder) {
+            moveCollectionBetweenAddons(key, 1)
+        } else {
+            moveCatalog(key, 1)
+        }
+    }
+
+    fun toggleFollowAddonsOrder(enabled: Boolean) {
+        viewModelScope.launch {
+            layoutPreferenceDataStore.setFollowAddonsOrder(enabled)
+            if (enabled) {
+                // Clear saved order so addon manifest order is used
+                layoutPreferenceDataStore.setHomeCatalogOrderKeys(emptyList())
+                homeCatalogSettingsSyncService.triggerPush()
+            }
+        }
     }
 
     fun toggleCatalogEnabled(disableKey: String) {
@@ -74,6 +93,73 @@ class CatalogOrderViewModel @Inject constructor(
         }
     }
 
+    /**
+     * When followAddonsOrder is enabled, collections jump between addon boundaries.
+     * Moving up means jumping above the previous addon block (all catalogs from one addon).
+     * Moving down means jumping below the next addon block.
+     */
+    private fun moveCollectionBetweenAddons(key: String, direction: Int) {
+        if (!key.startsWith("collection_")) return
+
+        val items = _uiState.value.items
+        val currentIndex = items.indexOfFirst { it.key == key }
+        if (currentIndex == -1) return
+
+        val currentKeys = items.map { it.key }
+
+        val newIndex: Int
+        if (direction < 0) {
+            // Moving up: find the start of the previous addon block
+            // Skip any adjacent collections above
+            var scanIdx = currentIndex - 1
+            while (scanIdx >= 0 && currentKeys[scanIdx].startsWith("collection_")) {
+                scanIdx--
+            }
+            if (scanIdx < 0) return // already at top
+
+            // scanIdx is now pointing at an addon catalog. Find the start of its addon block.
+            val targetAddonName = items[scanIdx].addonName
+            while (scanIdx > 0 && !currentKeys[scanIdx - 1].startsWith("collection_") &&
+                items[scanIdx - 1].addonName == targetAddonName) {
+                scanIdx--
+            }
+            newIndex = scanIdx
+        } else {
+            // Moving down: find the end of the next addon block
+            var scanIdx = currentIndex + 1
+            while (scanIdx < currentKeys.size && currentKeys[scanIdx].startsWith("collection_")) {
+                scanIdx++
+            }
+            if (scanIdx >= currentKeys.size) return // already at bottom
+
+            // scanIdx is now pointing at an addon catalog. Find the end of its addon block.
+            val targetAddonName = items[scanIdx].addonName
+            while (scanIdx < currentKeys.lastIndex && !currentKeys[scanIdx + 1].startsWith("collection_") &&
+                items[scanIdx + 1].addonName == targetAddonName) {
+                scanIdx++
+            }
+            newIndex = scanIdx
+        }
+
+        if (newIndex == currentIndex) return
+
+        val reordered = currentKeys.toMutableList().apply {
+            removeAt(currentIndex)
+            // After removal, if target is after current position, shift index by -1
+            val insertAt = if (direction < 0) {
+                newIndex
+            } else {
+                newIndex // currentIndex < newIndex, after removal target shifts by -1, but we want AFTER the block
+            }
+            add(insertAt, key)
+        }
+
+        viewModelScope.launch {
+            layoutPreferenceDataStore.setHomeCatalogOrderKeys(reordered)
+            homeCatalogSettingsSyncService.triggerPush()
+        }
+    }
+
     private fun observeCatalogs() {
         viewModelScope.launch {
             combine(
@@ -81,21 +167,37 @@ class CatalogOrderViewModel @Inject constructor(
                 collectionsDataStore.collections,
                 layoutPreferenceDataStore.homeCatalogOrderKeys,
                 layoutPreferenceDataStore.disabledHomeCatalogKeys,
-                layoutPreferenceDataStore.customCatalogTitles
-            ) { addons, collections, savedOrderKeys, disabledKeys, customTitles ->
-                buildOrderedCatalogItems(
+                layoutPreferenceDataStore.customCatalogTitles,
+                layoutPreferenceDataStore.followAddonsOrder
+            ) { values ->
+                @Suppress("UNCHECKED_CAST")
+                val addons = values[0] as List<Addon>
+                @Suppress("UNCHECKED_CAST")
+                val collections = values[1] as List<Collection>
+                @Suppress("UNCHECKED_CAST")
+                val savedOrderKeys = values[2] as List<String>
+                @Suppress("UNCHECKED_CAST")
+                val disabledKeys = (values[3] as List<String>).toSet()
+                @Suppress("UNCHECKED_CAST")
+                val customTitles = values[4] as Map<String, String>
+                val followAddons = values[5] as Boolean
+
+                val items = buildOrderedCatalogItems(
                     addons = addons,
                     collections = collections,
                     savedOrderKeys = savedOrderKeys,
-                    disabledKeys = disabledKeys.toSet(),
-                    customTitles = customTitles
+                    disabledKeys = disabledKeys,
+                    customTitles = customTitles,
+                    followAddonsOrder = followAddons
                 )
-            }.collectLatest { orderedItems ->
+                Pair(items, followAddons)
+            }.collectLatest { (orderedItems, followAddons) ->
                 disabledKeysCache = orderedItems.filter { it.isDisabled }.map { it.disableKey }.toSet()
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        items = orderedItems
+                        items = orderedItems,
+                        followAddonsOrder = followAddons
                     )
                 }
             }
@@ -107,7 +209,8 @@ class CatalogOrderViewModel @Inject constructor(
         collections: List<Collection> = emptyList(),
         savedOrderKeys: List<String>,
         disabledKeys: Set<String>,
-        customTitles: Map<String, String> = emptyMap()
+        customTitles: Map<String, String> = emptyMap(),
+        followAddonsOrder: Boolean = false
     ): List<CatalogOrderItem> {
         val defaultEntries = buildDefaultCatalogEntries(addons)
         val collectionEntries = collections.map { collection ->
@@ -123,19 +226,93 @@ class CatalogOrderViewModel @Inject constructor(
         val availableMap = allEntries.associateBy { it.key }
         val defaultOrderKeys = allEntries.map { it.key }
 
-        val savedValid = savedOrderKeys
-            .asSequence()
-            .filter { it in availableMap }
-            .distinct()
-            .toList()
+        val effectiveOrder: List<String>
+        if (followAddonsOrder) {
+            // In follow mode, addon catalogs stay in manifest order.
+            // Collections are positioned based on their relative position in savedOrderKeys.
+            val addonKeys = defaultEntries.map { it.key }
+            val collectionKeys = collectionEntries.map { it.key }.toSet()
 
-        val savedKeySet = savedValid.toSet()
-        val missing = defaultOrderKeys.filterNot { it in savedKeySet }
-        val effectiveOrder = savedValid + missing
+            val savedValid = savedOrderKeys.filter { it in availableMap }.distinct()
+
+            if (savedValid.isNotEmpty()) {
+                // Rebuild order: take saved order but replace addon sequence with manifest order.
+                // Strategy: walk through savedValid, output addon keys in manifest order,
+                // insert collections at their saved positions relative to addon boundaries.
+                val result = mutableListOf<String>()
+                var addonPointer = 0 // pointer into addonKeys (manifest order)
+
+                for (savedKey in savedValid) {
+                    if (savedKey in collectionKeys) {
+                        // Place collection here - but first flush any addon keys up to this point
+                        // that haven't been placed yet
+                        result.add(savedKey)
+                    } else {
+                        // It's an addon catalog key in saved order - advance manifest pointer
+                        // to include all addon keys up to and including this one
+                        val targetManifestIdx = addonKeys.indexOf(savedKey)
+                        if (targetManifestIdx >= 0) {
+                            while (addonPointer <= targetManifestIdx) {
+                                val ak = addonKeys[addonPointer]
+                                if (ak !in result) {
+                                    result.add(ak)
+                                }
+                                addonPointer++
+                            }
+                        }
+                    }
+                }
+                // Append any remaining addon keys not yet placed
+                while (addonPointer < addonKeys.size) {
+                    val ak = addonKeys[addonPointer]
+                    if (ak !in result) {
+                        result.add(ak)
+                    }
+                    addonPointer++
+                }
+                // Append any collections not in savedValid
+                for (ck in collectionKeys) {
+                    if (ck !in result) {
+                        result.add(ck)
+                    }
+                }
+                effectiveOrder = result
+            } else {
+                // No saved order - addon manifest order + collections at end
+                effectiveOrder = addonKeys + collectionKeys.toList()
+            }
+        } else {
+            val savedValid = savedOrderKeys
+                .asSequence()
+                .filter { it in availableMap }
+                .distinct()
+                .toList()
+
+            val savedKeySet = savedValid.toSet()
+            val missing = defaultOrderKeys.filterNot { it in savedKeySet }
+            effectiveOrder = savedValid + missing
+        }
 
         return effectiveOrder.mapIndexedNotNull { index, key ->
             val entry = availableMap[key] ?: return@mapIndexedNotNull null
             val displayName = customTitles[key]?.takeIf { it.isNotBlank() } ?: entry.catalogName
+            val isCollection = key.startsWith("collection_")
+
+            val canMoveUp: Boolean
+            val canMoveDown: Boolean
+            if (followAddonsOrder) {
+                if (isCollection) {
+                    canMoveUp = index > 0
+                    canMoveDown = index < effectiveOrder.lastIndex
+                } else {
+                    canMoveUp = false
+                    canMoveDown = false
+                }
+            } else {
+                canMoveUp = index > 0
+                canMoveDown = index < effectiveOrder.lastIndex
+            }
+
             CatalogOrderItem(
                 key = entry.key,
                 disableKey = entry.disableKey,
@@ -144,8 +321,8 @@ class CatalogOrderViewModel @Inject constructor(
                 typeLabel = entry.typeLabel,
                 isDisabled = entry.disableKey in disabledKeys ||
                     (entry.legacyDisableKey != null && entry.legacyDisableKey in disabledKeys),
-                canMoveUp = index > 0,
-                canMoveDown = index < effectiveOrder.lastIndex
+                canMoveUp = canMoveUp,
+                canMoveDown = canMoveDown
             )
         }
     }
@@ -201,7 +378,8 @@ class CatalogOrderViewModel @Inject constructor(
 
 data class CatalogOrderUiState(
     val isLoading: Boolean = true,
-    val items: List<CatalogOrderItem> = emptyList()
+    val items: List<CatalogOrderItem> = emptyList(),
+    val followAddonsOrder: Boolean = false
 )
 
 data class CatalogOrderItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1467,6 +1467,7 @@ class MetaDetailsViewModel @Inject constructor(
     private fun calculateNextToWatch() {
         val meta = _uiState.value.meta ?: return
         val progressMap = _uiState.value.episodeProgressMap
+        val watchedEpisodes = _uiState.value.watchedEpisodes
         val isSeries = meta.apiType in listOf("series", "tv")
         nextToWatchJob?.cancel()
 
@@ -1525,14 +1526,47 @@ class MetaDetailsViewModel @Inject constructor(
                         .thenByDescending { it.episode ?: 0 }
                 )
                 .firstOrNull()
+            // If progressMap is empty but watchedEpisodes has data (batch mark),
+            // use the highest watched episode as latestSeriesProgress stand-in.
+            val effectiveLatestProgress = latestSeriesProgress ?: run {
+                if (watchedEpisodes.isEmpty()) null
+                else {
+                    val watchedWithTimestamps = watchedItemsPreferences
+                        .getWatchedEpisodesWithTimestamps(_effectiveContentId.value)
+                        .first()
+                    val highest = watchedWithTimestamps.entries
+                        .maxWithOrNull(compareBy<Map.Entry<Pair<Int, Int>, Long>> { it.value }
+                            .thenBy { it.key.first }
+                            .thenBy { it.key.second })
+                    highest?.let { (key, watchedAt) ->
+                        val (s, e) = key
+                        episodePool.firstOrNull { it.season == s && it.episode == e }?.let { video ->
+                            WatchProgress(
+                                contentId = _effectiveContentId.value,
+                                contentType = "series",
+                                name = "",
+                                poster = null, backdrop = null, logo = null,
+                                videoId = video.id,
+                                season = video.season,
+                                episode = video.episode,
+                                episodeTitle = video.title,
+                                position = 1L, duration = 1L,
+                                lastWatched = watchedAt,
+                                progressPercent = 100f
+                            )
+                        }
+                    }
+                }
+            }
             val defaultEpisode = findPreferredDefaultEpisode(meta)?.takeIf { preferred ->
                 episodePool.any { it.id == preferred.id }
             }
 
             val nextToWatch = buildNextToWatchFromLatestProgress(
-                latestProgress = latestSeriesProgress,
+                latestProgress = effectiveLatestProgress,
                 episodes = episodePool,
                 fallbackProgressMap = progressMap,
+                watchedEpisodes = watchedEpisodes,
                 metaId = meta.id,
                 defaultEpisode = defaultEpisode
             )
@@ -1545,6 +1579,7 @@ class MetaDetailsViewModel @Inject constructor(
         latestProgress: WatchProgress?,
         episodes: List<Video>,
         fallbackProgressMap: Map<Pair<Int, Int>, WatchProgress>,
+        watchedEpisodes: Set<Pair<Int, Int>> = emptySet(),
         metaId: String,
         defaultEpisode: Video? = null
     ): NextToWatch {
@@ -1608,7 +1643,13 @@ class MetaDetailsViewModel @Inject constructor(
                 } else if (progress.isCompleted()) {
                     continue
                 }
-            } else {
+            }
+            // Check watchedEpisodes — covers both batch marks and episodes
+            // that haven't propagated to episodeProgressMap yet.
+            if (progress == null && (season to ep) in watchedEpisodes) {
+                continue
+            }
+            if (progress == null) {
                 if (nextUnwatchedEpisode == null) {
                     nextUnwatchedEpisode = episode
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -137,6 +137,7 @@ class HomeViewModel @Inject constructor(
     internal var collectionsCache: List<Collection> = emptyList()
     internal var homeCatalogOrderKeys: List<String> = emptyList()
     internal var disabledHomeCatalogKeys: Set<String> = emptySet()
+    internal var followAddonsOrderEnabled: Boolean = false
     internal var customCatalogTitles: Map<String, String> = emptyMap()
     internal var currentHeroCatalogKeys: List<String> = emptyList()
     internal var catalogUpdateJob: Job? = null
@@ -239,6 +240,7 @@ class HomeViewModel @Inject constructor(
             observeModernHomePresentation()
             observeExternalMetaPrefetchPreference()
             loadHomeCatalogOrderPreference()
+            loadFollowAddonsOrder()
             loadDisabledHomeCatalogPreference()
             loadCustomCatalogTitles()
             observeLibraryState()
@@ -376,6 +378,8 @@ class HomeViewModel @Inject constructor(
     fun preloadAdjacentItem(item: MetaPreview) = preloadAdjacentItemPipeline(item)
 
     private fun loadHomeCatalogOrderPreference() = loadHomeCatalogOrderPreferencePipeline()
+
+    private fun loadFollowAddonsOrder() = loadFollowAddonsOrderPipeline()
 
     private fun loadDisabledHomeCatalogPreference() = loadDisabledHomeCatalogPreferencePipeline()
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -56,6 +56,16 @@ internal fun HomeViewModel.loadHomeCatalogOrderPreferencePipeline() {
     }
 }
 
+internal fun HomeViewModel.loadFollowAddonsOrderPipeline() {
+    viewModelScope.launch {
+        layoutPreferenceDataStore.followAddonsOrder.collectLatest { enabled ->
+            followAddonsOrderEnabled = enabled
+            rebuildCatalogOrder(addonsCache)
+            scheduleUpdateCatalogRows()
+        }
+    }
+}
+
 internal fun HomeViewModel.loadDisabledHomeCatalogPreferencePipeline() {
     viewModelScope.launch {
         layoutPreferenceDataStore.disabledHomeCatalogKeys.collectLatest { keys ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -221,9 +221,13 @@ internal fun HomeViewModel.rebuildCatalogOrder(addons: List<Addon>) {
                 }
             }
 
+            // Normalize: push collections that ended up mid-addon-block to the block boundary
+            val addonKeyToOwner = buildAddonKeyOwnerMap(addons)
+            val normalized = normalizeCollectionBoundaries(result, addonKeyToOwner)
+
             synchronized(catalogStateLock) {
                 catalogOrder.clear()
-                catalogOrder.addAll(result)
+                catalogOrder.addAll(normalized)
             }
         } else {
             // No saved order - manifest order + collections at end
@@ -317,4 +321,61 @@ internal fun MetaPreview.hasHeroArtwork(): Boolean {
 internal fun HomeViewModel.extractYear(releaseInfo: String?): String? {
     if (releaseInfo.isNullOrBlank()) return null
     return Regex("\\b(19|20)\\d{2}\\b").find(releaseInfo)?.value
+}
+
+private fun buildAddonKeyOwnerMap(addons: List<Addon>): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+    addons.forEach { addon ->
+        addon.catalogs.forEach { catalog ->
+            val key = "${addon.id}_${catalog.apiType}_${catalog.id}"
+            map[key] = addon.id
+        }
+    }
+    return map
+}
+
+private fun normalizeCollectionBoundaries(
+    order: List<String>,
+    addonKeyToOwner: Map<String, String>
+): List<String> {
+    val result = order.toMutableList()
+    var i = 0
+    while (i < result.size) {
+        val key = result[i]
+        if (!key.startsWith("collection_")) {
+            i++
+            continue
+        }
+        val prevOwner = findOwnerBefore(result, i, addonKeyToOwner)
+        val nextOwner = findOwnerAfter(result, i, addonKeyToOwner)
+        if (prevOwner != null && nextOwner != null && prevOwner == nextOwner) {
+            // Collection is mid-block, push to end of this addon block
+            result.removeAt(i)
+            var insertPos = i
+            while (insertPos < result.size &&
+                !result[insertPos].startsWith("collection_") &&
+                addonKeyToOwner[result[insertPos]] == prevOwner
+            ) {
+                insertPos++
+            }
+            result.add(insertPos, key)
+        } else {
+            i++
+        }
+    }
+    return result
+}
+
+private fun findOwnerBefore(order: List<String>, index: Int, owners: Map<String, String>): String? {
+    for (j in index - 1 downTo 0) {
+        if (!order[j].startsWith("collection_")) return owners[order[j]]
+    }
+    return null
+}
+
+private fun findOwnerAfter(order: List<String>, index: Int, owners: Map<String, String>): String? {
+    for (j in index + 1 until order.size) {
+        if (!order[j].startsWith("collection_")) return owners[order[j]]
+    }
+    return null
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -174,20 +174,80 @@ internal fun HomeViewModel.rebuildCatalogOrder(addons: List<Addon>) {
     val collectionKeys = collectionsCache.map { "collection_${it.id}" }
     val allAvailable = (defaultOrder + collectionKeys).toSet()
 
-    val savedValid = homeCatalogOrderKeys
-        .asSequence()
-        .filter { it in allAvailable }
-        .distinct()
-        .toList()
+    if (followAddonsOrderEnabled) {
+        // In follow addons order mode, addon catalogs always stay in manifest order.
+        // Collections are positioned based on their relative position in saved order.
+        val savedValid = homeCatalogOrderKeys
+            .asSequence()
+            .filter { it in allAvailable }
+            .distinct()
+            .toList()
 
-    val savedSet = savedValid.toSet()
-    val unsavedCatalogs = defaultOrder.filterNot { it in savedSet }
-    val unsavedCollections = collectionKeys.filterNot { it in savedSet }
-    val mergedOrder = savedValid + unsavedCatalogs + unsavedCollections
+        val collectionKeysSet = collectionKeys.toSet()
 
-    synchronized(catalogStateLock) {
-        catalogOrder.clear()
-        catalogOrder.addAll(mergedOrder)
+        if (savedValid.isNotEmpty()) {
+            val result = mutableListOf<String>()
+            var addonPointer = 0
+
+            for (savedKey in savedValid) {
+                if (savedKey in collectionKeysSet) {
+                    result.add(savedKey)
+                } else {
+                    // Addon catalog - advance manifest pointer to include all up to this one
+                    val targetIdx = defaultOrder.indexOf(savedKey)
+                    if (targetIdx >= 0) {
+                        while (addonPointer <= targetIdx) {
+                            val ak = defaultOrder[addonPointer]
+                            if (ak !in result) {
+                                result.add(ak)
+                            }
+                            addonPointer++
+                        }
+                    }
+                }
+            }
+            // Append remaining addon keys
+            while (addonPointer < defaultOrder.size) {
+                val ak = defaultOrder[addonPointer]
+                if (ak !in result) {
+                    result.add(ak)
+                }
+                addonPointer++
+            }
+            // Append any collections not in saved order
+            for (ck in collectionKeys) {
+                if (ck !in result) {
+                    result.add(ck)
+                }
+            }
+
+            synchronized(catalogStateLock) {
+                catalogOrder.clear()
+                catalogOrder.addAll(result)
+            }
+        } else {
+            // No saved order - manifest order + collections at end
+            synchronized(catalogStateLock) {
+                catalogOrder.clear()
+                catalogOrder.addAll(defaultOrder + collectionKeys)
+            }
+        }
+    } else {
+        val savedValid = homeCatalogOrderKeys
+            .asSequence()
+            .filter { it in allAvailable }
+            .distinct()
+            .toList()
+
+        val savedSet = savedValid.toSet()
+        val unsavedCatalogs = defaultOrder.filterNot { it in savedSet }
+        val unsavedCollections = collectionKeys.filterNot { it in savedSet }
+        val mergedOrder = savedValid + unsavedCatalogs + unsavedCollections
+
+        synchronized(catalogStateLock) {
+            catalogOrder.clear()
+            catalogOrder.addAll(mergedOrder)
+        }
     }
 }
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -634,6 +634,8 @@
     <!-- CatalogOrderScreen -->
     <string name="catalog_order_title">Zmień kolejność katalogów</string>
     <string name="catalog_order_subtitle">Kontroluje kolejność wierszy katalogów na ekranie głównym.</string>
+    <string name="catalog_order_follow_addons">Zachowaj kolejność dodatków</string>
+    <string name="catalog_order_follow_addons_desc">Katalogi ułożone według kolejności z manifestów dodatków. Kolekcje nadal można przesuwać między dodatkami.</string>
     <string name="catalog_order_empty">Brak dostępnych katalogów.</string>
     <string name="catalog_order_disabled_on_home">Wyłączony na ekranie głównym</string>
     <string name="catalog_order_enable">Włącz</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -935,6 +935,8 @@
     <!-- CatalogOrderScreen -->
     <string name="catalog_order_title">Reorder Home Catalogs</string>
     <string name="catalog_order_subtitle">This controls catalog row order on Home (Classic + Modern + Grid).</string>
+    <string name="catalog_order_follow_addons">Follow addons order</string>
+    <string name="catalog_order_follow_addons_desc">Catalogs follow addon manifest order. Collections can still be moved between addons.</string>
     <string name="catalog_order_empty">No home catalogs available yet.</string>
     <string name="catalog_order_disabled_on_home">Disabled on Home</string>
     <string name="catalog_order_enable">Enable</string>


### PR DESCRIPTION
## Summary

Add "Follow addons order" toggle to the Catalog Order screen (TV + QR code Web UI). When enabled, addon catalogs lock to their manifest order (move buttons disabled), while collections can still be repositioned between addon blocks. New catalogs from addon updates automatically appear in their correct manifest position instead of appending to the end.

## PR type

- Approved larger change (link approval below)

## Why

Users who prefer the default addon manifest ordering had no way to "lock" it. Any new catalog added by an addon update would land at the bottom of the list instead of its natural position. This feature gives users a single toggle to enforce manifest order while still allowing flexible collection placement.

Approved internally via direct conversation.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)

Approved in internal discussion (no public issue tracker entry).

## Testing

- Manual: toggled switch on TV CatalogOrderScreen, verified addon catalogs become immovable, collections jump between addon blocks with up/down
- Manual: toggled switch via QR code Web UI, verified same behavior in browser
- Verified new catalogs (simulated by adding addon) appear in manifest position when follow mode is on
- Verified disabling follow mode restores full manual reordering
- Existing unit test `AddonConfigServerTest` passes without changes

## Screenshots / Video (UI changes only)

<img width="724" height="1111" alt="obraz" src="https://github.com/user-attachments/assets/216ec2aa-5518-477c-bb86-f041b6abcf50" />
<img width="4096" height="3072" alt="IMG20260429223438" src="https://github.com/user-attachments/assets/ec7d8e73-a275-4c1d-b578-1092ffaae056" />


## Breaking changes

new preference defaults to `false`, preserving existing behavior.

## Linked issues

approved internally.
