### PR TITLE
fix: use full timestamp for new episode/season release alert timing

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1668,7 +1668,7 @@ private suspend fun HomeViewModel.enrichNextUpItem(
         ?: item.info.released
     val releaseDate = parseEpisodeReleaseDate(released)
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
-    val hasAired = releaseDate?.let { !it.isAfter(todayLocal) } ?: item.info.hasAired
+    val hasAired = hasEpisodeAired(released, fallback = item.info.hasAired)
     val releaseState = resolveNextUpReleaseState(
         seedProgress = progressSeed,
         nextSeason = video?.season ?: item.info.season,
@@ -1823,8 +1823,11 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
             ),
         episodeTitle = nextVideo.title?.takeIf { it.isNotBlank() },
         released = nextVideo.released?.trim()?.takeIf { it.isNotBlank() },
-        hasAired = nextVideo.released?.let(::parseEpisodeReleaseDate)?.let { !it.isAfter(LocalDate.now(ZoneId.systemDefault())) } ?: true,
-        airDateLabel = nextVideo.released?.let(::parseEpisodeReleaseDate)?.takeIf { it.isAfter(LocalDate.now(ZoneId.systemDefault())) }?.let(::formatEpisodeAirDateLabel),
+        hasAired = hasEpisodeAired(nextVideo.released, fallback = true),
+        airDateLabel = nextVideo.released?.let(::parseEpisodeReleaseDate)?.let { releaseDate ->
+            if (hasEpisodeAired(nextVideo.released, fallback = true)) null
+            else formatEpisodeAirDateLabel(releaseDate)
+        },
         lastWatched = progress.lastWatched
     )
     debug?.recordNextUpResult(
@@ -2443,6 +2446,18 @@ private fun parseEpisodeReleaseInstant(raw: String?): Instant? {
     }.getOrNull()
 }
 
+/**
+ * Determines whether an episode has actually aired by comparing the full release
+ * instant (including time-of-day when available) against the current moment.
+ * If the raw string only contains a date (no time component), falls back to
+ * date-only comparison (start of day UTC) so episodes without a known air time
+ * are still treated as aired once the calendar date arrives.
+ */
+private fun hasEpisodeAired(raw: String?, fallback: Boolean = true): Boolean {
+    val instant = parseEpisodeReleaseInstant(raw) ?: return fallback
+    return !instant.isAfter(Instant.now())
+}
+
 private suspend fun HomeViewModel.resolveContinueWatchingTmdbData(
     progress: WatchProgress,
     meta: CwMetaSummary,
@@ -2650,18 +2665,7 @@ private fun resolveNextUpReleaseState(
         // the user likely abandoned the show.
         (nowMs - releaseTimestamp) < sixtyDaysMs
 
-    // Use midnight of the release date for sorting instead of the full
-    // timestamp.  Meta sources sometimes report a future hour on the
-    // current day which would pin the alert above freshly-watched items.
-    val releaseDateMidnight = releaseTimestamp?.let { ts ->
-        val localDate = Instant.ofEpochMilli(ts)
-            .atZone(ZoneId.systemDefault())
-            .toLocalDate()
-        localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-    }
-
     return NextUpReleaseState(
-        sortTimestamp = if (isReleaseAlert) releaseDateMidnight ?: releaseTimestamp!! else seedProgress.lastWatched,
         releaseTimestamp = releaseTimestamp,
         isReleaseAlert = isReleaseAlert,
         isNewSeasonRelease = isReleaseAlert && seedProgress.season != null && nextSeason != seedProgress.season

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2666,6 +2666,7 @@ private fun resolveNextUpReleaseState(
         (nowMs - releaseTimestamp) < sixtyDaysMs
 
     return NextUpReleaseState(
+        sortTimestamp = if (isReleaseAlert) releaseTimestamp!! else seedProgress.lastWatched,
         releaseTimestamp = releaseTimestamp,
         isReleaseAlert = isReleaseAlert,
         isNewSeasonRelease = isReleaseAlert && seedProgress.season != null && nextSeason != seedProgress.season


### PR DESCRIPTION
## Summary

Fix "New Episode" / "New Season" badge appearing before the episode has actually aired. Previously only the date was compared (ignoring time-of-day), so episodes scheduled for later in the day would show the release alert prematurely. Now the full release timestamp (including hour) is used to determine aired status. Also fixes sort order - release alerts now sort by actual release time instead of midnight, so they appear above items watched before the episode aired.

## PR type

- Bug fix

## Why

Users reported seeing "New Episode" alerts for episodes that hadn't actually been released yet. The root cause was that `hasAired` compared only `LocalDate` (day granularity) against today's date - any episode releasing today was treated as already aired regardless of the actual air time. This caused premature badge display and incorrect CW row ordering.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified with a mock episode released string containing a future hour on today's date (`2026-04-29T20:00:00Z`) — badge shows "Upcoming" before 20:00 UTC and "New Episode" after.
- Verified date-only strings (`2026-04-29`) behave as before (aired at start of day UTC).
- Verified sort order: alert with timestamp 15:00 sorts above items watched at 10:00 but below items watched at 16:00.

## Screenshots / Video (UI changes only)

no visual changes, only timing logic for when existing badges appear.

## Breaking changes

Nothing should break

## Linked issues

Reported on discord
