### PR TITLE
trakt pagination, reuse last link, profile switch CW, collection genre label, subtitle timeout

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
@@ -270,7 +270,9 @@ interface TraktApi {
         @Header("Authorization") authorization: String,
         @Path("id") id: String,
         @Path("list_id") listId: String,
-        @Path("type") type: String
+        @Path("type") type: String,
+        @Query("page") page: Int = 1,
+        @Query("limit") limit: Int = 100
     ): Response<List<TraktListItemDto>>
 
     @POST("users/{id}/lists/{list_id}/items")
@@ -292,7 +294,9 @@ interface TraktApi {
     @GET("sync/watchlist/{type}")
     suspend fun getWatchlist(
         @Header("Authorization") authorization: String,
-        @Path("type") type: String
+        @Path("type") type: String,
+        @Query("page") page: Int = 1,
+        @Query("limit") limit: Int = 100
     ): Response<List<TraktListItemDto>>
 
     @POST("sync/watchlist")

--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -25,7 +25,7 @@ class SubtitleRepositoryImpl @Inject constructor(
 
     companion object {
         private const val TAG = "SubtitleRepository"
-        private const val PER_ADDON_TIMEOUT_MS = 15_000L
+        private const val PER_ADDON_TIMEOUT_MS = 20_000L
     }
 
     override suspend fun getSubtitles(

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -537,25 +537,27 @@ class TraktLibraryService @Inject constructor(
     }
 
     private suspend fun fetchWatchlistEntries(): List<LibraryEntry> {
-        val moviesResponse = traktAuthService.executeAuthorizedRequest { authHeader ->
-            traktApi.getWatchlist(
-                authorization = authHeader,
-                type = "movies"
-            )
-        } ?: throw IllegalStateException("Failed to fetch watchlist movies")
-
-        val showsResponse = traktAuthService.executeAuthorizedRequest { authHeader ->
-            traktApi.getWatchlist(
-                authorization = authHeader,
-                type = "shows"
-            )
-        } ?: throw IllegalStateException("Failed to fetch watchlist shows")
-
-        if (!moviesResponse.isSuccessful || !showsResponse.isSuccessful) {
-            throw IllegalStateException("Failed to fetch watchlist")
+        val movies = fetchAllPages { page ->
+            traktAuthService.executeAuthorizedRequest { authHeader ->
+                traktApi.getWatchlist(
+                    authorization = authHeader,
+                    type = "movies",
+                    page = page
+                )
+            } ?: throw IllegalStateException("Failed to fetch watchlist movies")
         }
 
-        return (moviesResponse.body().orEmpty() + showsResponse.body().orEmpty())
+        val shows = fetchAllPages { page ->
+            traktAuthService.executeAuthorizedRequest { authHeader ->
+                traktApi.getWatchlist(
+                    authorization = authHeader,
+                    type = "shows",
+                    page = page
+                )
+            } ?: throw IllegalStateException("Failed to fetch watchlist shows")
+        }
+
+        return (movies + shows)
             .mapNotNull { mapListItem(listKey = WATCHLIST_KEY, item = it) }
             .sortedWith(
                 compareBy<LibraryEntry> { it.traktRank ?: Int.MAX_VALUE }
@@ -616,20 +618,18 @@ class TraktLibraryService @Inject constructor(
         type: String,
         listKey: String
     ): List<LibraryEntry> {
-        val response = traktAuthService.executeAuthorizedRequest { authHeader ->
-            traktApi.getUserListItems(
-                authorization = authHeader,
-                id = ME_PATH,
-                listId = listIdPath,
-                type = type
-            )
-        } ?: throw IllegalStateException("Failed to fetch list items")
-
-        if (!response.isSuccessful) {
-            throw IllegalStateException("Failed to fetch list items (${response.code()})")
+        val items = fetchAllPages { page ->
+            traktAuthService.executeAuthorizedRequest { authHeader ->
+                traktApi.getUserListItems(
+                    authorization = authHeader,
+                    id = ME_PATH,
+                    listId = listIdPath,
+                    type = type,
+                    page = page
+                )
+            } ?: throw IllegalStateException("Failed to fetch list items")
         }
-        return response.body().orEmpty()
-            .mapNotNull { mapListItem(listKey = listKey, item = it) }
+        return items.mapNotNull { mapListItem(listKey = listKey, item = it) }
     }
 
     private fun mapListTab(dto: TraktListSummaryDto): LibraryListTab? {
@@ -941,6 +941,28 @@ class TraktLibraryService @Inject constructor(
         }
 
         return null
+    }
+
+    /**
+     * Fetches all pages from a paginated Trakt endpoint by reading
+     * X-Pagination-Page-Count from response headers.
+     */
+    private suspend fun <T> fetchAllPages(
+        fetch: suspend (page: Int) -> Response<List<T>>
+    ): List<T> {
+        val allItems = mutableListOf<T>()
+        var currentPage = 1
+        while (true) {
+            val response = fetch(currentPage)
+            if (!response.isSuccessful) {
+                throw IllegalStateException("Trakt paginated fetch failed (${response.code()})")
+            }
+            allItems.addAll(response.body().orEmpty())
+            val pageCount = response.headers()["X-Pagination-Page-Count"]?.toIntOrNull() ?: 1
+            if (currentPage >= pageCount) break
+            currentPage++
+        }
+        return allItems
     }
 
     companion object {

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -231,12 +231,17 @@ class WatchProgressRepositoryImpl @Inject constructor(
         )
     }
 
+    @OptIn(FlowPreview::class)
     private fun useTraktProgressFlow(): Flow<Boolean> {
         return combine(
             traktAuthDataStore.isEffectivelyAuthenticated,
             traktSettingsDataStore.watchProgressSource
         ) { isEffectivelyAuthenticated, source ->
-            isEffectivelyAuthenticated && source == WatchProgressSource.TRAKT
+            source == WatchProgressSource.TRAKT && isEffectivelyAuthenticated
+        }.debounce { useTrakt ->
+            // Debounce only the false -> transition to avoid reacting to transient
+            // auth unavailability during profile switches.  true→ is immediate.
+            if (useTrakt) 0L else 300L
         }.distinctUntilChanged()
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -747,7 +747,8 @@ class FolderDetailViewModel @Inject constructor(
         } else {
             typeLabel
         }
-        val name = source.genre?.takeIf { it.isNotBlank() }?.let { "$baseName · $it" } ?: baseName
+        val effectiveGenre = source.genre?.takeIf { it.isNotBlank() && !it.equals("None", ignoreCase = true) }
+        val name = effectiveGenre?.let { "$baseName · $it" } ?: baseName
         return name to typeLabel
     }
 
@@ -768,7 +769,7 @@ class FolderDetailViewModel @Inject constructor(
     }
 
     private fun buildCatalogExtraArgs(source: AddonCatalogCollectionSource): Map<String, String> {
-        val genre = source.genre?.takeIf { it.isNotBlank() } ?: return emptyMap()
+        val genre = source.genre?.takeIf { it.isNotBlank() && !it.equals("None", ignoreCase = true) } ?: return emptyMap()
         return mapOf("genre" to genre)
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
-private const val STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS = 10_000L
+private const val STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS = 20_000L
 private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
 
 internal data class StartupSubtitlePreparation(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -205,6 +205,7 @@ fun StreamScreen(
         // Torrent streams have url == null but carry an infoHash; navigation
         // builds a torrent:// sentinel URL downstream.
         if (playbackInfo.url != null || (playbackInfo.isTorrent && playbackInfo.infoHash != null)) {
+            viewModel.awaitStreamLinkCacheSave()
             routeAutoPlay(playbackInfo)
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -60,6 +60,7 @@ class StreamScreenViewModel @Inject constructor(
     private var directAutoPlayFlowEnabledForSession = false
     private var streamLoadJob: Job? = null
     private var sourceChipErrorDismissJob: Job? = null
+    private var pendingCacheSaveJob: Job? = null
 
     private val videoId: String = savedStateHandle["videoId"] ?: ""
     private val contentType: String = savedStateHandle["contentType"] ?: ""
@@ -727,7 +728,7 @@ class StreamScreenViewModel @Inject constructor(
 
         val url = playbackInfo.url
         if (!url.isNullOrBlank() && !playbackInfo.isExternal) {
-            viewModelScope.launch {
+            pendingCacheSaveJob = viewModelScope.launch {
                 streamLinkCacheDataStore.save(
                     contentKey = streamCacheKey,
                     url = url,
@@ -742,6 +743,10 @@ class StreamScreenViewModel @Inject constructor(
         }
 
         return playbackInfo
+    }
+
+    suspend fun awaitStreamLinkCacheSave() {
+        pendingCacheSaveJob?.join()
     }
 
     override fun onCleared() {


### PR DESCRIPTION
## Summary

Bundle of bug fixes and small improvements:

1. **Trakt pagination** - Watchlist and personal list endpoints now paginate properly using `X-Pagination-Page-Count` headers instead of silently truncating at the default page size.
2. **Collection "None" genre label** - When a user selects "None" for the genre filter on an embedded catalog source, the tab now shows the catalog name (e.g. "Top") instead of "Top · None". Also prevents sending `genre=None` as an API parameter.
3. **Reuse Last Link not working with auto source selection** - The stream link cache save was fire-and-forget in `viewModelScope`; when `onAutoPlayResolved` popped the StreamScreen (clearing the ViewModel), the save was cancelled before completing. Now awaits the save before navigating away.
4. **Continue Watching empty on secondary profile switch** - After switching profiles in-app, a transient `isEffectivelyAuthenticated = false` emission (while DataStore loads) caused CW to briefly flip to Nuvio Sync (empty). Added a 300ms debounce on the false→ transition so the transient state is ignored.
5. **Subtitle per-addon timeout** - Increased from 15s to 20s. Total startup prefetch timeout increased from 10s to 20s

## PR type

- Bug fix

## Why

- Users with large Trakt watchlists (100+) only saw partial results.
- "None" text appearing on collection folder tabs confused users.
- "Reuse Last Link" never worked when auto source selection was enabled - the cache was never persisted.
- Secondary profile users lost their Continue Watching every time they switched profiles without restarting the app.
- Some subtitle addons (especially on slower connections) were timing out before responding.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Trakt pagination: verified with mock account having 250+ watchlist items; all items now returned across 3 pages.
- Genre "None": confirmed tab shows catalog name only, and no `genre=None` param is sent to addon API.
- Reuse Last Link: played content with auto source selection, quit app, re-opened same content — cached link was used immediately without showing stream picker.
- Subtitle timeout: verified slow addon responses up to 18s are now accepted.

## Screenshots / Video (UI changes only)

Nothing changed

## Breaking changes

Nothing should break

## Linked issues

Reported on Discord
