### PR TITLE
Remove periods from refresh addons subtitles

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
@@ -127,7 +127,7 @@ fun AddonManagerScreen(
         stringResource(R.string.addon_qr_scan_instruction)
     }
 
-    val defaultRefreshAddonsSubtitle = "Pull latest addon changes for current profile."
+    val defaultRefreshAddonsSubtitle = "Pull latest addon changes for current profile"
     var refreshAddonsSubtitle by remember {
         mutableStateOf(defaultRefreshAddonsSubtitle)
     }
@@ -366,7 +366,7 @@ fun AddonManagerScreen(
                     subtitle = refreshAddonsSubtitle,
                     onClick = {
                         viewModel.requestAddonSyncNow()
-                        refreshAddonsSubtitle = "Addons refreshed just now."
+                        refreshAddonsSubtitle = "Addons refreshed just now"
                     }
                 )
             }


### PR DESCRIPTION
## Summary

Removes trailing periods from the Refresh Addons subtitles so they match the existing Addons screen row style.

## PR type

Small UI text consistency cleanup.

## Why

Existing Addons screen subtitles do not use trailing periods, so this keeps the new Refresh Addons row consistent with the surrounding UI.

## Policy check

- This PR is cosmetic-only / UI text consistency.
- This PR is small in scope and focused on one issue.

## Testing

Text-only change. Confirmed diff only removes trailing periods from the Refresh Addons subtitles.

## Screenshots / Video (UI changes only)

Not needed for this text-only consistency cleanup.

## Breaking changes

None.

## Linked issues

None.