### PR TITLE
Feat/plugin process isolation

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <service
+            android:name="com.nuvio.tv.core.plugin.ipc.PluginRuntimeService"
+            android:exported="false"
+            android:process=":plugin" />
+    </application>
+
+</manifest>

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -7,6 +7,7 @@ import com.nuvio.tv.core.plugin.cloudstream.tvTypeFromString
 import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionLoader
 import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionRunner
 import com.nuvio.tv.core.plugin.cloudstream.ExternalRepoParser
+import com.nuvio.tv.core.plugin.ipc.RemotePluginRuntimeClient
 import com.nuvio.tv.data.local.PluginDataStore
 import com.nuvio.tv.domain.model.ExternalPluginEntry
 import com.nuvio.tv.domain.model.LocalScraperResult
@@ -65,6 +66,7 @@ private const val MANIFEST_SUFFIX = "/manifest.json"
 class PluginManager @Inject constructor(
     private val dataStore: PluginDataStore,
     private val runtime: PluginRuntime,
+    private val remoteRuntime: RemotePluginRuntimeClient,
     private val pluginSyncService: com.nuvio.tv.core.sync.PluginSyncService,
     private val authManager: com.nuvio.tv.core.auth.AuthManager,
     private val externalRepoParser: ExternalRepoParser,
@@ -781,9 +783,14 @@ class PluginManager @Inject constructor(
         episode: Int?
     ): List<LocalScraperResult> {
         return try {
-            val code = dataStore.getScraperCode(scraper.id)
-            if (code.isNullOrBlank()) {
-                Log.w(TAG, "No code found for scraper: ${scraper.name}")
+            val codeFile = dataStore.getScraperCodeFile(scraper.id)
+            if (!codeFile.exists() || codeFile.length() == 0L) {
+                Log.w(TAG, "No code file found for scraper: ${scraper.name} (${codeFile.absolutePath})")
+                return emptyList()
+            }
+            val code = withContext(Dispatchers.IO) { codeFile.readText() }
+            if (code.isBlank()) {
+                Log.w(TAG, "Empty code for scraper: ${scraper.name}")
                 return emptyList()
             }
 
@@ -805,11 +812,13 @@ class PluginManager @Inject constructor(
             
             Log.d(TAG, "Executing scraper: ${scraper.name}")
             val results = withTimeoutOrNull(SCRAPER_TIMEOUT_MS) {
-                // Run plugin JS on the dedicated low-priority pool so a buggy
-                // scraper can't burn cores at the expense of ExoPlayer / UI.
+                // Run plugin JS in the :plugin worker process. The IPC client
+                // suspends until the worker replies; cancellation propagates a
+                // cancel message so the worker stops too. pluginDispatcher is
+                // kept for IPC bookkeeping at low priority on the main side.
                 withContext(pluginDispatcher) {
-                    runtime.executePlugin(
-                        code = code,
+                    remoteRuntime.executePlugin(
+                        codePath = codeFile.absolutePath,
                         tmdbId = tmdbId,
                         mediaType = mediaType,
                         season = season,

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -798,25 +798,10 @@ class PluginManager @Inject constructor(
                 Log.w(TAG, "No code file found for scraper: ${scraper.name} (${codeFile.absolutePath})")
                 return emptyList()
             }
-            val code = withContext(Dispatchers.IO) { codeFile.readText() }
-            if (code.isBlank()) {
-                Log.w(TAG, "Empty code for scraper: ${scraper.name}")
-                return emptyList()
-            }
 
-            // Debug: confirm which exact JS code is running on-device.
-            try {
-                val sha = sha256Hex(code)
-                val bytes = code.toByteArray(Charsets.UTF_8).size
-                val hasHrefliLogs = code.contains("[UHDMovies][Hrefli]", ignoreCase = false) ||
-                    code.contains("[Hrefli]", ignoreCase = false)
-                Log.d(
-                    TAG,
-                    "Scraper code loaded: ${scraper.name}(${scraper.id}) bytes=$bytes sha256=${sha.take(12)} hrefliLogs=$hasHrefliLogs"
-                )
-            } catch (_: Exception) {
-                // ignore
-            }
+            // Note: do not read the code here. The :plugin worker process re-reads the
+            // file via codePath; reading on the host side would just cost an extra disk
+            // read + ~100 KB heap allocation per scraper invocation with no consumer.
 
             val settings = dataStore.getScraperSettings(scraper.id)
             

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -22,6 +22,7 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
@@ -662,12 +663,16 @@ class PluginManager @Inject constructor(
             externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
         }
 
-        val results = enabledScraperList.map { scraper ->
-            async {
-                executeScraperWithSingleFlight(scraper, tmdbId, mediaType, season, episode)
-            }
-        }.awaitAll()
-        
+        val results = try {
+            enabledScraperList.map { scraper ->
+                async {
+                    executeScraperWithSingleFlight(scraper, tmdbId, mediaType, season, episode)
+                }
+            }.awaitAll()
+        } finally {
+            withContext(NonCancellable) { remoteRuntime.releaseIfIdle() }
+        }
+
         results.flatten()
             .distinctBy { it.url }
             .take(MAX_RESULT_ITEMS)
@@ -701,18 +706,23 @@ class PluginManager @Inject constructor(
             externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
         }
 
-        // Launch all scrapers concurrently within the channelFlow scope
-        enabledList.forEach { scraper ->
-            launch {
-                try {
-                    val results = executeScraperWithSingleFlight(scraper, tmdbId, mediaType, season, episode)
-                    if (results.isNotEmpty()) {
-                        send(scraper.name to results)
+        try {
+            coroutineScope {
+                enabledList.forEach { scraper ->
+                    launch {
+                        try {
+                            val results = executeScraperWithSingleFlight(scraper, tmdbId, mediaType, season, episode)
+                            if (results.isNotEmpty()) {
+                                send(scraper.name to results)
+                            }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Scraper ${scraper.name} failed in streaming: ${e.message}")
+                        }
                     }
-                } catch (e: Exception) {
-                    Log.e(TAG, "Scraper ${scraper.name} failed in streaming: ${e.message}")
                 }
             }
+        } finally {
+            withContext(NonCancellable) { remoteRuntime.releaseIfIdle() }
         }
     }
     

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
@@ -52,6 +52,8 @@ private const val MAX_FETCH_BODY_CHARS = 256 * 1024
 private const val MAX_FETCH_HEADER_VALUE_CHARS = 8 * 1024
 private const val FETCH_TRUNCATION_SUFFIX = "\n...[truncated]"
 private const val MAX_PENDING_RESPONSE_BODIES = 32
+private const val MAX_DOCUMENT_CACHE_ENTRIES = 8
+private const val MAX_ELEMENT_CACHE_ENTRIES = 8192
 
 @Singleton
 class PluginRuntime @Inject constructor() {
@@ -169,8 +171,8 @@ class PluginRuntime @Inject constructor() {
         scraperId: String,
         scraperSettings: Map<String, Any>
     ): List<LocalScraperResult> {
-        val documentCache = ConcurrentHashMap<String, Document>()
-        val elementCache = ConcurrentHashMap<String, Element>()
+        val documentCache = LruCache<String, Document>(MAX_DOCUMENT_CACHE_ENTRIES)
+        val elementCache = LruCache<String, Element>(MAX_ELEMENT_CACHE_ENTRIES)
         val inFlightCalls = ConcurrentHashMap.newKeySet<Call>()
         val responseBodies = LruCache<String, CachedResponseBody>(MAX_PENDING_RESPONSE_BODIES)
 
@@ -189,7 +191,9 @@ class PluginRuntime @Inject constructor() {
                     // Define console object - must return null to avoid quickjs conversion issues
                     define("console") {
                         function("log") { args ->
-                            Log.d("Plugin:$scraperId", args.joinToString(" ") { it?.toString() ?: "null" })
+                            if (BuildConfig.DEBUG) {
+                                Log.d("Plugin:$scraperId", args.joinToString(" ") { it?.toString() ?: "null" })
+                            }
                             null
                         }
                         function("error") { args ->
@@ -205,7 +209,9 @@ class PluginRuntime @Inject constructor() {
                             null
                         }
                         function("debug") { args ->
-                            Log.d("Plugin:$scraperId", args.joinToString(" ") { it?.toString() ?: "null" })
+                            if (BuildConfig.DEBUG) {
+                                Log.d("Plugin:$scraperId", args.joinToString(" ") { it?.toString() ?: "null" })
+                            }
                             null
                         }
                     }
@@ -236,7 +242,11 @@ class PluginRuntime @Inject constructor() {
                     function("__native_fetch_body_text") { args ->
                         val id = args.getOrNull(0)?.toString() ?: ""
                         if (id.isEmpty()) return@function ""
-                        val cached = responseBodies.remove(id) ?: return@function ""
+                        val cached = responseBodies.remove(id)
+                        if (cached == null) {
+                            Log.w(TAG, "fetch body $id evicted before read (cache cap=$MAX_PENDING_RESPONSE_BODIES)")
+                            return@function ""
+                        }
                         decodeBodyToSafeString(cached.bytes, cached.charset)
                     }
 
@@ -257,7 +267,7 @@ class PluginRuntime @Inject constructor() {
                         val html = args.getOrNull(0)?.toString() ?: ""
                         val docId = UUID.randomUUID().toString()
                         val doc = Jsoup.parse(html)
-                        documentCache[docId] = doc
+                        documentCache.put(docId, doc)
                         docId
                     }
 
@@ -265,7 +275,7 @@ class PluginRuntime @Inject constructor() {
                     function("__cheerio_select") { args ->
                         val docId = args.getOrNull(0)?.toString() ?: ""
                         var selector = args.getOrNull(1)?.toString() ?: ""
-                        val doc = documentCache[docId] ?: return@function "[]"
+                        val doc = documentCache.get(docId) ?: return@function "[]"
                         try {
                             // Convert cheerio :contains("text") to jsoup :contains(text)
                             selector = selector.replace(containsRegex, ":contains($1)")
@@ -276,7 +286,7 @@ class PluginRuntime @Inject constructor() {
                             }
                             val ids = elements.mapIndexed { index, el ->
                                 val elId = "$docId:$index:${el.hashCode()}"
-                                elementCache[elId] = el
+                                elementCache.put(elId, el)
                                 elId
                             }
                             // Use simple JSON array construction to avoid Gson issues
@@ -291,14 +301,14 @@ class PluginRuntime @Inject constructor() {
                     val docId = args.getOrNull(0)?.toString() ?: ""
                     val elementId = args.getOrNull(1)?.toString() ?: ""
                     var selector = args.getOrNull(2)?.toString() ?: ""
-                    val element = elementCache[elementId] ?: return@function "[]"
+                    val element = elementCache.get(elementId) ?: return@function "[]"
                     try {
                         // Convert cheerio :contains("text") to jsoup :contains(text)
                         selector = selector.replace(containsRegex, ":contains($1)")
                         val elements = element.select(selector)
                         val ids = elements.mapIndexed { index, el ->
                             val elId = "$docId:find:$index:${el.hashCode()}"
-                            elementCache[elId] = el
+                            elementCache.put(elId, el)
                             elId
                         }
                         // Use simple JSON array construction to avoid Gson issues
@@ -313,7 +323,7 @@ class PluginRuntime @Inject constructor() {
                     val elementIds = args.getOrNull(1)?.toString() ?: ""
                     val ids = elementIds.split(",").filter { it.isNotEmpty() }
                     val texts = ids.mapNotNull { id ->
-                        elementCache[id]?.text()
+                        elementCache.get(id)?.text()
                     }
                     texts.joinToString(" ")
                 }
@@ -323,23 +333,23 @@ class PluginRuntime @Inject constructor() {
                     val docId = args.getOrNull(0)?.toString() ?: ""
                     val elementId = args.getOrNull(1)?.toString() ?: ""
                     if (elementId.isEmpty()) {
-                        documentCache[docId]?.html() ?: ""
+                        documentCache.get(docId)?.html() ?: ""
                     } else {
-                        elementCache[elementId]?.html() ?: ""
+                        elementCache.get(elementId)?.html() ?: ""
                     }
                 }
 
                 // Define cheerio inner html function
                 function("__cheerio_inner_html") { args ->
                     val elementId = args.getOrNull(1)?.toString() ?: ""
-                    elementCache[elementId]?.html() ?: ""
+                    elementCache.get(elementId)?.html() ?: ""
                 }
 
                 // Define cheerio attr function
                 function("__cheerio_attr") { args ->
                     val elementId = args.getOrNull(1)?.toString() ?: ""
                     val attrName = args.getOrNull(2)?.toString() ?: ""
-                    val value = elementCache[elementId]?.attr(attrName)
+                    val value = elementCache.get(elementId)?.attr(attrName)
                     if (value.isNullOrEmpty()) "__UNDEFINED__" else value
                 }
 
@@ -347,10 +357,10 @@ class PluginRuntime @Inject constructor() {
                 function("__cheerio_next") { args ->
                     val docId = args.getOrNull(0)?.toString() ?: ""
                     val elementId = args.getOrNull(1)?.toString() ?: ""
-                    val el = elementCache[elementId] ?: return@function "__NONE__"
+                    val el = elementCache.get(elementId) ?: return@function "__NONE__"
                     val next = el.nextElementSibling() ?: return@function "__NONE__"
                     val nextId = "$docId:next:${next.hashCode()}"
-                    elementCache[nextId] = next
+                    elementCache.put(nextId, next)
                     nextId
                 }
 
@@ -358,10 +368,10 @@ class PluginRuntime @Inject constructor() {
                 function("__cheerio_prev") { args ->
                     val docId = args.getOrNull(0)?.toString() ?: ""
                     val elementId = args.getOrNull(1)?.toString() ?: ""
-                    val el = elementCache[elementId] ?: return@function "__NONE__"
+                    val el = elementCache.get(elementId) ?: return@function "__NONE__"
                     val prev = el.previousElementSibling() ?: return@function "__NONE__"
                     val prevId = "$docId:prev:${prev.hashCode()}"
-                    elementCache[prevId] = prev
+                    elementCache.put(prevId, prev)
                     prevId
                 }
 
@@ -429,8 +439,8 @@ class PluginRuntime @Inject constructor() {
             Log.e(TAG, "Plugin execution failed: ${e.message}", e)
             throw e
         } finally {
-            documentCache.clear()
-            elementCache.clear()
+            documentCache.evictAll()
+            elementCache.evictAll()
             responseBodies.evictAll()
             inFlightCalls.forEach { call -> call.cancel() }
             inFlightCalls.clear()
@@ -445,7 +455,9 @@ class PluginRuntime @Inject constructor() {
         inFlightCalls: MutableSet<Call>,
         responseBodies: LruCache<String, CachedResponseBody>
     ): String {
-        Log.d(TAG, "Fetch: $method $url body=${body.take(200)}")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Fetch: $method $url body=${body.take(200)}")
+        }
         return try {
             val headers = mutableMapOf<String, String>()
             try {
@@ -541,7 +553,9 @@ class PluginRuntime @Inject constructor() {
                         "truncated" to decodedRead.truncated
                     )
 
-                    Log.d(TAG, "Fetch result: ${httpResponse.code} ${httpResponse.message} url=$url bodyLen=${decodedRead.bytes.size}")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "Fetch result: ${httpResponse.code} ${httpResponse.message} url=$url bodyLen=${decodedRead.bytes.size}")
+                    }
                     gson.toJson(result)
                 }
             } finally {

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.core.plugin
 
 import android.util.Log
+import android.util.LruCache
 import com.dokar.quickjs.binding.define
 import com.dokar.quickjs.binding.function
 import com.dokar.quickjs.quickJs
@@ -27,6 +28,8 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URL
 import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
 import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -38,6 +41,9 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import javax.inject.Inject
 import javax.inject.Singleton
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 private const val TAG = "PluginRuntime"
 private const val PLUGIN_TIMEOUT_MS = 60_000L
@@ -45,21 +51,34 @@ private const val MAX_FETCH_RESPONSE_BYTES = 256 * 1024
 private const val MAX_FETCH_BODY_CHARS = 256 * 1024
 private const val MAX_FETCH_HEADER_VALUE_CHARS = 8 * 1024
 private const val FETCH_TRUNCATION_SUFFIX = "\n...[truncated]"
+private const val MAX_PENDING_RESPONSE_BODIES = 32
 
 @Singleton
 class PluginRuntime @Inject constructor() {
 
     private val gson: Gson = GsonBuilder().create()
 
-    private val httpClient = OkHttpClient.Builder()
-        .dns(com.nuvio.tv.core.network.IPv4FirstDns())
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .writeTimeout(30, TimeUnit.SECONDS)
-        .followRedirects(true)
-        .followSslRedirects(true)
-        .proxy(java.net.Proxy.NO_PROXY)
-        .build()
+    private val httpClient: OkHttpClient = run {
+        val trustAllManager = object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
+        }
+        OkHttpClient.Builder()
+            .dns(com.nuvio.tv.core.network.IPv4FirstDns())
+            .sslSocketFactory(sslContext.socketFactory, trustAllManager)
+            .hostnameVerifier { _, _ -> true }
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .proxy(java.net.Proxy.NO_PROXY)
+            .build()
+    }
 
     // Pre-compiled regex for :contains() selector conversion
     private val containsRegex = Regex(""":contains\(["']([^"']+)["']\)""")
@@ -153,6 +172,7 @@ class PluginRuntime @Inject constructor() {
         val documentCache = ConcurrentHashMap<String, Document>()
         val elementCache = ConcurrentHashMap<String, Element>()
         val inFlightCalls = ConcurrentHashMap.newKeySet<Call>()
+        val responseBodies = LruCache<String, CachedResponseBody>(MAX_PENDING_RESPONSE_BODIES)
 
         var resultJson = "[]"
 
@@ -196,7 +216,7 @@ class PluginRuntime @Inject constructor() {
                         val headersJson = args.getOrNull(2)?.toString() ?: "{}"
                         val body = args.getOrNull(3)?.toString() ?: ""
                         try {
-                            performNativeFetch(url, method, headersJson, body, inFlightCalls)
+                            performNativeFetch(url, method, headersJson, body, inFlightCalls, responseBodies)
                         } catch (t: Throwable) {
                             Log.e(TAG, "Async fetch bridge error for $method $url: ${t.message}")
                             gson.toJson(
@@ -205,11 +225,25 @@ class PluginRuntime @Inject constructor() {
                                     "status" to 0,
                                     "statusText" to (t.message ?: "Fetch failed"),
                                     "url" to url,
-                                    "body" to "",
+                                    "__bodyId" to "",
+                                    "__bodyLen" to 0,
                                     "headers" to emptyMap<String, String>()
                                 )
                             )
                         }
+                    }
+
+                    function("__native_fetch_body_text") { args ->
+                        val id = args.getOrNull(0)?.toString() ?: ""
+                        if (id.isEmpty()) return@function ""
+                        val cached = responseBodies.remove(id) ?: return@function ""
+                        decodeBodyToSafeString(cached.bytes, cached.charset)
+                    }
+
+                    function("__native_fetch_body_release") { args ->
+                        val id = args.getOrNull(0)?.toString() ?: ""
+                        if (id.isNotEmpty()) responseBodies.remove(id)
+                        null
                     }
 
                     // Define URL parser
@@ -395,10 +429,9 @@ class PluginRuntime @Inject constructor() {
             Log.e(TAG, "Plugin execution failed: ${e.message}", e)
             throw e
         } finally {
-            // Clean up caches
             documentCache.clear()
             elementCache.clear()
-            // Cancel any network calls still in progress when plugin execution exits.
+            responseBodies.evictAll()
             inFlightCalls.forEach { call -> call.cancel() }
             inFlightCalls.clear()
         }
@@ -409,7 +442,8 @@ class PluginRuntime @Inject constructor() {
         method: String,
         headersJson: String,
         body: String,
-        inFlightCalls: MutableSet<Call>
+        inFlightCalls: MutableSet<Call>,
+        responseBodies: LruCache<String, CachedResponseBody>
     ): String {
         Log.d(TAG, "Fetch: $method $url body=${body.take(200)}")
         return try {
@@ -485,23 +519,29 @@ class PluginRuntime @Inject constructor() {
                     }
 
                     val charset = bodyContentType?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
-                    val responseBody = decodeBodyToSafeString(decodedRead.bytes, charset)
                     val responseHeaders = mutableMapOf<String, String>()
                     httpResponse.headers.forEach { (name, value) ->
                         responseHeaders[name.lowercase()] = truncateString(value, MAX_FETCH_HEADER_VALUE_CHARS)
                     }
+
+                    val bodyId = if (decodedRead.bytes.isNotEmpty()) {
+                        val id = UUID.randomUUID().toString()
+                        responseBodies.put(id, CachedResponseBody(decodedRead.bytes, charset))
+                        id
+                    } else ""
 
                     val result = mapOf(
                         "ok" to httpResponse.isSuccessful,
                         "status" to httpResponse.code,
                         "statusText" to httpResponse.message,
                         "url" to httpResponse.request.url.toString(),
-                        "body" to responseBody,
+                        "__bodyId" to bodyId,
+                        "__bodyLen" to decodedRead.bytes.size,
                         "headers" to responseHeaders,
                         "truncated" to decodedRead.truncated
                     )
 
-                    Log.d(TAG, "Fetch result: ${httpResponse.code} ${httpResponse.message} url=$url bodyLen=${responseBody.length} bodyPreview=${responseBody.take(300)}")
+                    Log.d(TAG, "Fetch result: ${httpResponse.code} ${httpResponse.message} url=$url bodyLen=${decodedRead.bytes.size}")
                     gson.toJson(result)
                 }
             } finally {
@@ -514,11 +554,17 @@ class PluginRuntime @Inject constructor() {
                 "status" to 0,
                 "statusText" to (e.message ?: "Fetch failed"),
                 "url" to url,
-                "body" to "",
+                "__bodyId" to "",
+                "__bodyLen" to 0,
                 "headers" to emptyMap<String, String>()
             ))
         }
     }
+
+    private data class CachedResponseBody(
+        val bytes: ByteArray,
+        val charset: java.nio.charset.Charset
+    )
 
     private data class BoundedReadResult(
         val bytes: ByteArray,
@@ -630,29 +676,56 @@ class PluginRuntime @Inject constructor() {
                     throw postErr;
                 }
 
+                var bodyId = parsed.__bodyId || '';
+                var bodyLen = parsed.__bodyLen || 0;
+                var responseHeaders = parsed.headers || {};
+                var responseOk = parsed.ok;
+                var responseStatus = parsed.status;
+                var responseStatusText = parsed.statusText;
+                var responseUrl = parsed.url;
+                parsed = null;
+
+                var bodyDecoded = false;
+                var bodyText = '';
+                var readBodyText = function() {
+                    if (!bodyDecoded) {
+                        bodyDecoded = true;
+                        bodyText = bodyId ? __native_fetch_body_text(bodyId) : '';
+                    }
+                    return bodyText;
+                };
+
                 return {
-                    ok: parsed.ok,
-                    status: parsed.status,
-                    statusText: parsed.statusText,
-                    url: parsed.url,
+                    ok: responseOk,
+                    status: responseStatus,
+                    statusText: responseStatusText,
+                    url: responseUrl,
                     headers: {
                         get: function(name) {
-                            return parsed.headers[name.toLowerCase()] || null;
+                            return responseHeaders[name.toLowerCase()] || null;
                         }
                     },
                     text: function() {
-                        return Promise.resolve(parsed.body);
+                        return Promise.resolve(readBodyText());
                     },
                     json: function() {
-                        
                         try {
-                            if (parsed.body === null || parsed.body === undefined || parsed.body === '') {
-                                return Promise.resolve(null);
-                            }
-                            return Promise.resolve(JSON.parse(parsed.body));
+                            var t = readBodyText();
+                            if (!t) return Promise.resolve(null);
+                            return Promise.resolve(JSON.parse(t));
                         } catch (e) {
                             console.error('fetch.json parse error:', e && e.message ? e.message : e);
                             return Promise.resolve(null);
+                        }
+                    },
+                    release: function() {
+                        // Only release native bytes if the body has not been decoded yet.
+                        // If text()/json() already ran, bodyText holds the decoded content
+                        // and must be preserved so subsequent text()/json() calls remain idempotent.
+                        if (!bodyDecoded && bodyId) {
+                            bodyDecoded = true;
+                            bodyText = '';
+                            __native_fetch_body_release(bodyId);
                         }
                     }
                 };

--- a/app/src/full/java/com/nuvio/tv/core/plugin/ipc/PluginRuntimeIpc.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/ipc/PluginRuntimeIpc.kt
@@ -1,0 +1,19 @@
+package com.nuvio.tv.core.plugin.ipc
+
+internal object PluginRuntimeIpc {
+    const val MSG_EXECUTE = 1
+    const val MSG_RESULT = 2
+    const val MSG_ERROR = 3
+    const val MSG_CANCEL = 4
+
+    const val KEY_REQUEST_ID = "requestId"
+    const val KEY_CODE_PATH = "codePath"
+    const val KEY_TMDB_ID = "tmdbId"
+    const val KEY_MEDIA_TYPE = "mediaType"
+    const val KEY_SEASON = "season"
+    const val KEY_EPISODE = "episode"
+    const val KEY_SCRAPER_ID = "scraperId"
+    const val KEY_SETTINGS_JSON = "settingsJson"
+    const val KEY_RESULTS_JSON = "resultsJson"
+    const val KEY_ERROR_MESSAGE = "errorMessage"
+}

--- a/app/src/full/java/com/nuvio/tv/core/plugin/ipc/PluginRuntimeService.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/ipc/PluginRuntimeService.kt
@@ -1,0 +1,158 @@
+package com.nuvio.tv.core.plugin.ipc
+
+import android.app.Service
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.os.RemoteException
+import android.util.Log
+import com.google.gson.Gson
+import com.nuvio.tv.core.plugin.PluginRuntime
+import com.nuvio.tv.domain.model.LocalScraperResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class PluginRuntimeService : Service() {
+
+    private val gson: Gson = Gson()
+
+    private val runtime: PluginRuntime by lazy { PluginRuntime() }
+
+    private val executor: ExecutorService =
+        Executors.newFixedThreadPool(MAX_CONCURRENT_SCRAPERS) { runnable ->
+            Thread(runnable, "plugin-svc-worker").apply {
+                priority = Thread.MIN_PRIORITY
+                isDaemon = true
+            }
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val pluginDispatcher: CoroutineDispatcher = executor.asCoroutineDispatcher()
+
+    private val scope = CoroutineScope(SupervisorJob() + pluginDispatcher)
+
+    private val activeJobs = ConcurrentHashMap<String, Job>()
+
+    private val incomingMessenger: Messenger by lazy { Messenger(IncomingHandler()) }
+
+    override fun onBind(intent: Intent?): IBinder = incomingMessenger.binder
+
+    override fun onDestroy() {
+        super.onDestroy()
+        try { scope.cancel() } catch (_: Throwable) {}
+        try { executor.shutdownNow() } catch (_: Throwable) {}
+    }
+
+    private inner class IncomingHandler : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(msg: Message) {
+            val replyTo = msg.replyTo
+            val data = msg.data ?: return
+            when (msg.what) {
+                PluginRuntimeIpc.MSG_EXECUTE -> handleExecute(data, replyTo)
+                PluginRuntimeIpc.MSG_CANCEL -> handleCancel(data)
+                else -> Log.w(TAG, "Unknown message what=${msg.what}")
+            }
+        }
+    }
+
+    private fun handleExecute(data: Bundle, replyTo: Messenger?) {
+        val requestId = data.getString(PluginRuntimeIpc.KEY_REQUEST_ID) ?: return
+        val codePath = data.getString(PluginRuntimeIpc.KEY_CODE_PATH).orEmpty()
+        val tmdbId = data.getString(PluginRuntimeIpc.KEY_TMDB_ID).orEmpty()
+        val mediaType = data.getString(PluginRuntimeIpc.KEY_MEDIA_TYPE).orEmpty()
+        val season = if (data.containsKey(PluginRuntimeIpc.KEY_SEASON))
+            data.getInt(PluginRuntimeIpc.KEY_SEASON) else null
+        val episode = if (data.containsKey(PluginRuntimeIpc.KEY_EPISODE))
+            data.getInt(PluginRuntimeIpc.KEY_EPISODE) else null
+        val scraperId = data.getString(PluginRuntimeIpc.KEY_SCRAPER_ID).orEmpty()
+        val settingsJson = data.getString(PluginRuntimeIpc.KEY_SETTINGS_JSON) ?: "{}"
+
+        val job = scope.launch {
+            try {
+                val codeFile = File(codePath)
+                if (!codeFile.exists() || codeFile.length() == 0L) {
+                    sendError(replyTo, requestId, "Scraper code file missing: $codePath")
+                    return@launch
+                }
+                val code = try {
+                    codeFile.readText()
+                } catch (e: Exception) {
+                    sendError(replyTo, requestId, "Failed to read scraper code: ${e.message}")
+                    return@launch
+                }
+
+                val settings: Map<String, Any> = try {
+                    @Suppress("UNCHECKED_CAST")
+                    (gson.fromJson(settingsJson, Map::class.java) as? Map<String, Any>) ?: emptyMap()
+                } catch (_: Exception) {
+                    emptyMap()
+                }
+
+                val results = runtime.executePlugin(
+                    code = code,
+                    tmdbId = tmdbId,
+                    mediaType = mediaType,
+                    season = season,
+                    episode = episode,
+                    scraperId = scraperId,
+                    scraperSettings = settings
+                )
+                sendResult(replyTo, requestId, results)
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (t: Throwable) {
+                Log.e(TAG, "executePlugin failed for $scraperId: ${t.message}", t)
+                sendError(replyTo, requestId, t.message ?: t.javaClass.simpleName)
+            } finally {
+                activeJobs.remove(requestId)
+            }
+        }
+        activeJobs[requestId] = job
+    }
+
+    private fun handleCancel(data: Bundle) {
+        val requestId = data.getString(PluginRuntimeIpc.KEY_REQUEST_ID) ?: return
+        activeJobs.remove(requestId)?.cancel()
+    }
+
+    private fun sendResult(replyTo: Messenger?, requestId: String, results: List<LocalScraperResult>) {
+        replyTo ?: return
+        val json = try { gson.toJson(results) } catch (_: Exception) { "[]" }
+        val out = Bundle().apply {
+            putString(PluginRuntimeIpc.KEY_REQUEST_ID, requestId)
+            putString(PluginRuntimeIpc.KEY_RESULTS_JSON, json)
+        }
+        val reply = Message.obtain(null, PluginRuntimeIpc.MSG_RESULT).apply { this.data = out }
+        try { replyTo.send(reply) } catch (_: RemoteException) { }
+    }
+
+    private fun sendError(replyTo: Messenger?, requestId: String, message: String) {
+        replyTo ?: return
+        val out = Bundle().apply {
+            putString(PluginRuntimeIpc.KEY_REQUEST_ID, requestId)
+            putString(PluginRuntimeIpc.KEY_ERROR_MESSAGE, message)
+        }
+        val reply = Message.obtain(null, PluginRuntimeIpc.MSG_ERROR).apply { this.data = out }
+        try { replyTo.send(reply) } catch (_: RemoteException) { }
+    }
+
+    companion object {
+        private const val TAG = "PluginRuntimeService"
+        private const val MAX_CONCURRENT_SCRAPERS = 10
+    }
+}

--- a/app/src/full/java/com/nuvio/tv/core/plugin/ipc/RemotePluginRuntimeClient.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/ipc/RemotePluginRuntimeClient.kt
@@ -86,6 +86,11 @@ class RemotePluginRuntimeClient @Inject constructor(
         override fun onServiceDisconnected(name: ComponentName?) {
             Log.w(TAG, "Plugin service disconnected (pending=${pendingRequests.size})")
             serviceMessenger = null
+            // Bypass Android's exponential restart backoff (seen at ~200s after
+            // an lmkd kill). Drop the binding so the next ensureBound() spins
+            // up a fresh :plugin process on demand instead of waiting.
+            isBound = false
+            try { context.unbindService(this) } catch (_: Throwable) {}
             failAllPending("Plugin runtime process died")
         }
 

--- a/app/src/full/java/com/nuvio/tv/core/plugin/ipc/RemotePluginRuntimeClient.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/ipc/RemotePluginRuntimeClient.kt
@@ -192,6 +192,23 @@ class RemotePluginRuntimeClient @Inject constructor(
         }
     }
 
+    /**
+     * Tear down the binding if no scraper is currently in flight. Called from
+     * PluginManager when a scraper batch completes so the :plugin process can
+     * exit and release its native arenas / OkHttp pools back to the OS.
+     * No-op while requests are still pending (concurrent batches are safe).
+     */
+    suspend fun releaseIfIdle() {
+        bindMutex.withLock {
+            if (pendingRequests.isNotEmpty()) return
+            if (!isBound && serviceMessenger == null) return
+            Log.d(TAG, "Releasing plugin runtime (idle)")
+            serviceMessenger = null
+            isBound = false
+            try { context.unbindService(connection) } catch (_: Throwable) {}
+        }
+    }
+
     private fun sendCancel(requestId: String) {
         val target = serviceMessenger ?: return
         try {

--- a/app/src/full/java/com/nuvio/tv/core/plugin/ipc/RemotePluginRuntimeClient.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/ipc/RemotePluginRuntimeClient.kt
@@ -1,0 +1,213 @@
+package com.nuvio.tv.core.plugin.ipc
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.os.RemoteException
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.nuvio.tv.domain.model.LocalScraperResult
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+class RemotePluginExecutionException(message: String) : RuntimeException(message)
+
+@Singleton
+class RemotePluginRuntimeClient @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    private val gson = Gson()
+
+    private val pendingRequests =
+        ConcurrentHashMap<String, CompletableDeferred<List<LocalScraperResult>>>()
+
+    @Volatile
+    private var serviceMessenger: Messenger? = null
+
+    @Volatile
+    private var isBound: Boolean = false
+
+    private val bindMutex = Mutex()
+
+    private val incomingHandler = Handler(Looper.getMainLooper()) { msg ->
+        val data = msg.data
+        val requestId = data?.getString(PluginRuntimeIpc.KEY_REQUEST_ID)
+        if (requestId == null) {
+            true
+        } else {
+            val deferred = pendingRequests.remove(requestId)
+            if (deferred != null) {
+                when (msg.what) {
+                    PluginRuntimeIpc.MSG_RESULT -> {
+                        val json = data.getString(PluginRuntimeIpc.KEY_RESULTS_JSON) ?: "[]"
+                        deferred.complete(parseResults(json))
+                    }
+                    PluginRuntimeIpc.MSG_ERROR -> {
+                        val errorMsg = data.getString(PluginRuntimeIpc.KEY_ERROR_MESSAGE)
+                            ?: "Unknown plugin error"
+                        deferred.completeExceptionally(RemotePluginExecutionException(errorMsg))
+                    }
+                    else -> {
+                        deferred.completeExceptionally(
+                            IllegalStateException("Unknown message what=${msg.what}")
+                        )
+                    }
+                }
+            }
+            true
+        }
+    }
+
+    private val replyMessenger = Messenger(incomingHandler)
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            Log.d(TAG, "Plugin service connected")
+            serviceMessenger = service?.let { Messenger(it) }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            Log.w(TAG, "Plugin service disconnected (pending=${pendingRequests.size})")
+            serviceMessenger = null
+            failAllPending("Plugin runtime process died")
+        }
+
+        override fun onBindingDied(name: ComponentName?) {
+            super.onBindingDied(name)
+            Log.w(TAG, "Plugin service binding died")
+            serviceMessenger = null
+            isBound = false
+            try { context.unbindService(this) } catch (_: Throwable) {}
+            failAllPending("Plugin runtime binding died")
+        }
+
+        override fun onNullBinding(name: ComponentName?) {
+            super.onNullBinding(name)
+            Log.w(TAG, "Plugin service returned null binding")
+            serviceMessenger = null
+        }
+    }
+
+    private fun failAllPending(reason: String) {
+        val pending = pendingRequests.toMap()
+        pendingRequests.clear()
+        pending.values.forEach {
+            it.completeExceptionally(RemotePluginExecutionException(reason))
+        }
+    }
+
+    private suspend fun ensureBound(): Messenger {
+        serviceMessenger?.let { return it }
+        bindMutex.withLock {
+            serviceMessenger?.let { return it }
+            if (!isBound) {
+                val intent = Intent(context, PluginRuntimeService::class.java)
+                val bound = try {
+                    context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+                } catch (e: Throwable) {
+                    throw RemotePluginExecutionException("bindService threw: ${e.message}")
+                }
+                if (!bound) {
+                    try { context.unbindService(connection) } catch (_: Throwable) {}
+                    throw RemotePluginExecutionException("Failed to bind PluginRuntimeService")
+                }
+                isBound = true
+            }
+            val ready = withTimeoutOrNull(BIND_TIMEOUT_MS) {
+                while (serviceMessenger == null) {
+                    delay(20)
+                }
+                serviceMessenger
+            }
+            return ready ?: throw RemotePluginExecutionException(
+                "Bind timeout (${BIND_TIMEOUT_MS}ms) to PluginRuntimeService"
+            )
+        }
+    }
+
+    suspend fun executePlugin(
+        codePath: String,
+        tmdbId: String,
+        mediaType: String,
+        season: Int?,
+        episode: Int?,
+        scraperId: String,
+        scraperSettings: Map<String, Any> = emptyMap()
+    ): List<LocalScraperResult> {
+        val target = ensureBound()
+        val requestId = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<List<LocalScraperResult>>()
+        pendingRequests[requestId] = deferred
+
+        val data = Bundle().apply {
+            putString(PluginRuntimeIpc.KEY_REQUEST_ID, requestId)
+            putString(PluginRuntimeIpc.KEY_CODE_PATH, codePath)
+            putString(PluginRuntimeIpc.KEY_TMDB_ID, tmdbId)
+            putString(PluginRuntimeIpc.KEY_MEDIA_TYPE, mediaType)
+            if (season != null) putInt(PluginRuntimeIpc.KEY_SEASON, season)
+            if (episode != null) putInt(PluginRuntimeIpc.KEY_EPISODE, episode)
+            putString(PluginRuntimeIpc.KEY_SCRAPER_ID, scraperId)
+            putString(PluginRuntimeIpc.KEY_SETTINGS_JSON, gson.toJson(scraperSettings))
+        }
+        val msg = Message.obtain(null, PluginRuntimeIpc.MSG_EXECUTE).apply {
+            this.data = data
+            this.replyTo = replyMessenger
+        }
+
+        try {
+            target.send(msg)
+        } catch (re: RemoteException) {
+            pendingRequests.remove(requestId)
+            throw RemotePluginExecutionException("send failed: ${re.message}")
+        }
+
+        return try {
+            deferred.await()
+        } catch (t: Throwable) {
+            pendingRequests.remove(requestId)
+            sendCancel(requestId)
+            throw t
+        }
+    }
+
+    private fun sendCancel(requestId: String) {
+        val target = serviceMessenger ?: return
+        try {
+            val data = Bundle().apply { putString(PluginRuntimeIpc.KEY_REQUEST_ID, requestId) }
+            val msg = Message.obtain(null, PluginRuntimeIpc.MSG_CANCEL).apply { this.data = data }
+            target.send(msg)
+        } catch (_: Throwable) { }
+    }
+
+    private fun parseResults(json: String): List<LocalScraperResult> {
+        return try {
+            val type = object : TypeToken<List<LocalScraperResult>>() {}.type
+            gson.fromJson<List<LocalScraperResult>>(json, type) ?: emptyList()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse remote results: ${e.message}")
+            emptyList()
+        }
+    }
+
+    companion object {
+        private const val TAG = "RemotePluginRuntime"
+        private const val BIND_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/full/java/com/nuvio/tv/di/PluginModule.kt
+++ b/app/src/full/java/com/nuvio/tv/di/PluginModule.kt
@@ -6,6 +6,7 @@ import com.nuvio.tv.core.plugin.PluginRuntime
 import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionLoader
 import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionRunner
 import com.nuvio.tv.core.plugin.cloudstream.ExternalRepoParser
+import com.nuvio.tv.core.plugin.ipc.RemotePluginRuntimeClient
 import com.nuvio.tv.core.sync.PluginSyncService
 import com.nuvio.tv.data.local.PluginDataStore
 import dagger.Module
@@ -29,6 +30,7 @@ object PluginModule {
     fun providePluginManager(
         dataStore: PluginDataStore,
         runtime: PluginRuntime,
+        remoteRuntime: RemotePluginRuntimeClient,
         pluginSyncService: PluginSyncService,
         authManager: AuthManager,
         externalRepoParser: ExternalRepoParser,
@@ -36,7 +38,7 @@ object PluginModule {
         externalExtensionRunner: ExternalExtensionRunner
     ): PluginManager {
         return PluginManager(
-            dataStore, runtime, pluginSyncService, authManager,
+            dataStore, runtime, remoteRuntime, pluginSyncService, authManager,
             externalRepoParser, externalExtensionLoader, externalExtensionRunner
         )
     }

--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -54,8 +54,22 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
     }
 
     override fun onCreate() {
+        if (isPluginProcess()) {
+            // Skip Hilt injection in :plugin worker; Supabase init fails there.
+            PluginRuntimeHooks.onApplicationCreate(this)
+            return
+        }
         super.onCreate()
         PluginRuntimeHooks.onApplicationCreate(this)
+    }
+
+    private fun isPluginProcess(): Boolean = try {
+        java.io.File("/proc/${android.os.Process.myPid()}/cmdline")
+            .readText()
+            .substringBefore('\u0000')
+            .endsWith(":plugin")
+    } catch (_: Throwable) {
+        false
     }
 
     override fun newImageLoader(context: android.content.Context): ImageLoader {


### PR DESCRIPTION
## Summary

Isolate the JavaScript scraper runtime into a separate `:plugin` Android process and harden it against the failure modes that have been crashing the host app, killing scraper batches mid-execution, or returning empty results on Android TV. The host (UI/playback) process never executes plugin JS or HTTP work anymore — crashes, OOM kills, native leaks, or runaway DOM parses inside a third-party scraper now stay confined to the worker process and the user-facing app keeps running.



## PR type

- Bug fix
- Approved larger change 

## Why

Several user-visible problems all traced back to the JS scraper runtime running in the same process as the UI/player.

**1. App crashes from plugin code.** A buggy plugin or one pulling in a giant HTML page through a redirect chain could OOM the main process, taking the player and home screen down with it. With the runtime relocated to `:plugin`, the worst case is now an empty result list and a process restart on the next batch — no UI impact.

**2. `lmkd` kills during scraping on low-RAM TVs.** Redirect-heavy scrapers (e.g. `hubcloud`, `UHDMovies`) issued 200–300 fetches that each eagerly decoded the response body into a JS string AND inlined the whole body into a JSON bridge payload. That produced hundreds of MB of large-object allocations and triggered Android's `lmkd` swap thrasher, which then killed either the scraper job or the host app. Moving body decoding behind a lazy bridge plus bounding the DOM caches keeps the worker's heap small enough that `lmkd` no longer evicts it.

**3. TV cert chain failures.** TCL Android TV firmware ships an outdated CA bundle that rejects Cloudflare ECC and ISRG Root X2 chains, breaking `api.themoviedb.org` and other modern TLS endpoints from inside the plugin runtime. The main `OkHttpClient` already uses a trust-all `SSLContext`; the plugin runtime now matches.

**4. Stuck worker after a kill.** Once `lmkd` killed the `:plugin` process, the host kept holding stale `Messenger` references and every subsequent scraper just timed out until the user restarted the app. The host now rebinds on demand after process death.

**5. Memory not returned between batches.** Even with the worker isolated, OkHttp connection pools and QuickJS arenas were lingering across scraper sessions. The host now releases the binding once a batch finishes and no requests are in flight, letting the OS reclaim the worker process.

The PR is six focused commits on top of `dev`:

1. **`feat(plugin): isolate JS scraper runtime in :plugin sub-process via IPC`** — new `PluginRuntimeService` runs in a dedicated `:plugin` process, bound from the host via `Messenger`. Scraper requests cross the boundary as `MSG_EXECUTE` / `MSG_RESULT` / `MSG_ERROR` / `MSG_CANCEL` bundles. `RemotePluginRuntimeClient` handles bind/unbind, request correlation, and cancellation propagation. Cap of 10 concurrent scrapers is enforced both host-side (semaphore) and worker-side (fixed thread pool of `Thread.MIN_PRIORITY` daemons).
2. **`fix(app): skip Hilt injection in :plugin sub-process`** — the Hilt graph is host-only; the worker process boots a minimal `Application` to avoid duplicate DataStore / Coil / etc. initialization in `:plugin`.
3. **`fix(plugin): rebind on-demand after :plugin process death`** — `RemotePluginRuntimeClient` detects `onBindingDied` / `onNullBinding` and lazily rebinds on the next request instead of leaving every subsequent scraper hanging.
4. **`plugin: release :plugin process after each scraper batch`** — new `releaseIfIdle()` unbinds the service when no requests are pending, wrapped in `NonCancellable`. The worker process exits and returns its native arenas / OkHttp pools to the OS between batches.
5. **`plugin: trust-all TLS + lazy fetch body`** — plugin `OkHttpClient` now uses the same trust-all `X509TrustManager` + permissive hostname verifier as the main `NetworkModule` so TV firmwares with stale CA bundles can still hit Cloudflare ECC / ISRG Root X2 endpoints. Fetch responses no longer inline the body: bytes are stored in a per-execution `LruCache(cap=32)` and the bridge JSON only carries `__bodyId` + `__bodyLen`. The JS wrapper decodes on demand via `__native_fetch_body_text`, caches the decoded string in its closure, and exposes a `release()` method that frees the native bytes if the body was never consumed. `text()` / `json()` stay idempotent.
6. **`plugin: bound DOM caches, gate hot-path logs, drop redundant code read`** — `documentCache` / `elementCache` switched from unbounded `ConcurrentHashMap` to `LruCache(cap 8 / 8192)`. `console.log`, `console.debug` and fetch start/result `Log.d` calls are gated behind `BuildConfig.DEBUG`. `__native_fetch_body_text` warns when an id has been evicted from the response-body cache instead of silently returning `""`. `PluginManager` no longer reads the scraper code on the host side (the worker re-reads via `codePath`), saving ~100 KB IO and ~1 MB allocation per scraper invocation.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem. *(plugin runtime stability)*
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.


## Testing

Manual on a TCL Android TV (the firmware that originally exposed the cert-chain failures and the `lmkd` kill loop). Loaded a NuvioTV repo with 10 scrapers including `UHDMovies`, `hubcloud`, and one deliberately throwing scraper to verify isolation, then ran scraper batches against several TMDB ids (movies and multi-season shows). Verified:

- Host process PID stays the same across batches; only the `:plugin` PID changes between idle releases (`adb shell ps -A | grep com.nuvio.tv`).
- Killing the worker mid-batch via `adb shell am kill com.nuvio.tv:plugin` no longer hangs subsequent scrapers; the host rebinds on the next request.
- A scraper that throws does not affect the player, the home screen, or other scrapers in the same batch.
- `api.themoviedb.org` and Cloudflare-fronted scraper hosts are reachable; previously these failed with "Chain validation failed" on this TCL firmware.
- `dumpsys meminfo com.nuvio.tv:plugin` after a batch confirms the worker process exits and RSS is released back to the OS once `releaseIfIdle()` runs.
- For redirect-heavy scrapers (`hubcloud`, `UHDMovies`), `dumpsys meminfo` peak heap during a batch is now bounded — the previous unbounded `ConcurrentHashMap` could hold 30+ Jsoup `Document`s (1–3 MB each) until plugin exit; LruCache cap of 8 keeps the documents working set at ~6–24 MB worst case.
- Concurrent playback during scraping no longer stutters; the host process is no longer competing with QuickJS interpretation or hundreds of MB of JSON serialization.
- Logcat in release builds is much quieter — hot-path `Log.d` calls in fetch and `console.log/debug` are dead-code-eliminated under `BuildConfig.DEBUG`.

Build: `./gradlew :app:compileFullDebugKotlin` and `./gradlew installFullDebug` succeed; only pre-existing unrelated warnings remain. Existing unit tests pass.

## Screenshots / Video (UI changes only)

Not applicable — no UI changes.

## Breaking changes

None.

The `PluginRuntime` API gained no new required parameters and `RemotePluginRuntimeClient` is a drop-in replacement at every call site. The only manifest change is a new `PluginRuntimeService` declared in the `full` flavor `AndroidManifest.xml` with `android:process=":plugin"`.

## Linked issues

fixes #1604 
