### PR TITLE
feat: expose rich media metadata to Google Home via MediaSession

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
@@ -1,0 +1,83 @@
+package com.nuvio.tv.ui.screens.player
+
+import android.net.Uri
+import android.util.Log
+import androidx.media3.common.MediaMetadata
+
+/**
+ * Builds a [MediaMetadata] from the current playback information so that
+ * external controllers (Google Home, Wear OS, system media controls) can
+ * display rich "Now Playing" information such as title, subtitle and artwork.
+ */
+internal fun PlayerRuntimeController.buildMediaSessionMetadata(): MediaMetadata {
+    val state = _uiState.value
+    val isSeries = contentType?.lowercase() in listOf("series", "tv")
+
+    // Title: for series use the show name, for movies use the main title.
+    val displayTitle = state.contentName?.takeIf { it.isNotBlank() } ?: state.title
+
+    // Subtitle / artist: for series show "S1:E2 – Episode Title", for movies show the year.
+    val displaySubtitle = if (isSeries) {
+        buildString {
+            val s = state.currentSeason
+            val e = state.currentEpisode
+            if (s != null && e != null) {
+                append("S${s}:E${e}")
+                state.currentEpisodeTitle?.takeIf { it.isNotBlank() }?.let {
+                    append(" – $it")
+                }
+            } else {
+                state.currentEpisodeTitle?.takeIf { it.isNotBlank() }?.let { append(it) }
+            }
+        }.takeIf { it.isNotBlank() }
+    } else {
+        state.releaseYear
+    }
+
+    // Artwork: prefer poster, fall back to backdrop.
+    val artworkUri = (poster?.takeIf { it.isNotBlank() }
+        ?: backdrop?.takeIf { it.isNotBlank() })
+        ?.let { runCatching { Uri.parse(it) }.getOrNull() }
+
+    return MediaMetadata.Builder()
+        .setTitle(displayTitle)
+        .setArtist(displaySubtitle)
+        .setArtworkUri(artworkUri)
+        .setMediaType(
+            if (isSeries) MediaMetadata.MEDIA_TYPE_TV_SHOW
+            else MediaMetadata.MEDIA_TYPE_MOVIE
+        )
+        .build()
+}
+
+/**
+ * Pushes the current media metadata into the active [MediaSession] so that
+ * Google Home and other system surfaces display up-to-date information.
+ *
+ * This should be called:
+ * - Right after the MediaSession is created
+ * - When switching episodes
+ * - When TMDB enrichment updates the title / artwork
+ */
+internal fun PlayerRuntimeController.updateMediaSessionMetadata() {
+    val session = currentMediaSession ?: return
+    val metadata = buildMediaSessionMetadata()
+    try {
+        // Media3 MediaSession reads metadata from the player's current MediaItem.
+        // Setting mediaMetadata on the player propagates to the session automatically.
+        _exoPlayer?.let { player ->
+            val current = player.currentMediaItem ?: return@let
+            val updated = current.buildUpon()
+                .setMediaMetadata(metadata)
+                .build()
+            player.replaceMediaItem(player.currentMediaItemIndex, updated)
+        }
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "MediaSession metadata updated: title=${metadata.title}, " +
+                "artist=${metadata.artist}, artworkUri=${metadata.artworkUri}"
+        )
+    } catch (e: Exception) {
+        Log.w(PlayerRuntimeController.TAG, "Failed to update MediaSession metadata", e)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -68,7 +68,8 @@ internal class PlayerMediaSourceFactory {
         filename: String? = null,
         responseHeaders: Map<String, String> = emptyMap(),
         mimeTypeOverride: String? = null,
-        audioDelayUsProvider: (() -> Long)? = null
+        audioDelayUsProvider: (() -> Long)? = null,
+        mediaMetadata: androidx.media3.common.MediaMetadata? = null
     ): MediaSource {
         val sanitizedHeaders = sanitizeHeaders(headers)
         val httpDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, sanitizedHeaders)
@@ -83,6 +84,7 @@ internal class PlayerMediaSourceFactory {
 
         val mediaItemBuilder = MediaItem.Builder().setUri(url)
         resolvedMimeType?.let(mediaItemBuilder::setMimeType)
+        mediaMetadata?.let(mediaItemBuilder::setMediaMetadata)
 
         if (subtitleConfigurations.isNotEmpty()) {
             mediaItemBuilder.setSubtitleConfigurations(subtitleConfigurations)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -338,6 +338,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     if (canAdvertiseSession()) {
                         currentMediaSession = MediaSession.Builder(context, this).build()
                     }
+                    updateMediaSessionMetadata()
                 } catch (e: Exception) {
                     e.printStackTrace()
                 }
@@ -361,7 +362,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                         filename = currentFilename,
                         responseHeaders = currentStreamResponseHeaders,
                         mimeTypeOverride = currentStreamMimeType,
-                        audioDelayUsProvider = audioDelayUs::get
+                        audioDelayUsProvider = audioDelayUs::get,
+                        mediaMetadata = buildMediaSessionMetadata()
                     )
                 )
                 if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -71,6 +71,9 @@ internal fun PlayerRuntimeController.updateEpisodeDescription() {
         _uiState.update { it.copy(description = overview) }
     }
 
+    // Push episode metadata to the MediaSession so Google Home shows the new episode.
+    updateMediaSessionMetadata()
+
     // Re-enrich from TMDB for the new episode.
     scope.launch {
         enrichDescriptionFromTmdb(contentId, contentType)
@@ -146,6 +149,9 @@ private suspend fun PlayerRuntimeController.enrichDescriptionFromTmdb(id: String
             else state
         }
     }
+
+    // Refresh MediaSession metadata with TMDB-enriched title / artwork.
+    updateMediaSessionMetadata()
 }
 
 internal fun PlayerRuntimeController.recomputeNextEpisode(resetVisibility: Boolean) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -220,6 +220,7 @@ internal fun PlayerRuntimeController.resumeForLifecycle() {
         if (currentMediaSession == null) {
             try {
                 currentMediaSession = androidx.media3.session.MediaSession.Builder(context, player).build()
+                updateMediaSessionMetadata()
             } catch (e: Exception) {
                 e.printStackTrace()
             }


### PR DESCRIPTION
## Summary

Expose rich media metadata (title, artwork, episode info) to Google Home and other system media surfaces via the MediaSession. Previously, playing content in NuvioTV showed a blank "Now Playing" card in Google Home. Now Google Home displays the content title, episode details, and poster artwork.

## PR type

- Small maintenance improvement

## Why

When playing any content, Google Home shows a generic "Now Playing" card with no title, artwork, or episode information. This is because the `MediaSession` was created without any `MediaMetadata` attached to the player's `MediaItem`. External controllers like Google Home read metadata from the session to populate their UI.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual: Verified Google Home displays title, episode info (S1:E2 – Episode Title), and poster artwork when playing series content.
- Manual: Verified Google Home displays movie title, year, and poster when playing movie content.
- Manual: Verified metadata updates correctly when switching episodes mid-playback.
- Manual: Verified metadata refreshes after TMDB enrichment updates title/artwork.
- Manual: Verified metadata persists correctly through lifecycle pause/resume.

## Screenshots / Video (UI changes only)

N/A — changes are on the system media surface (Google Home), not in-app UI.


<img width="1151" height="2560" alt="photo_6025915043179859141_w" src="https://github.com/user-attachments/assets/09a8415f-af27-4302-a8c9-874882386b22" />


## Breaking changes

- None

## Linked issues

- None
