### PR TITLE
fix: recover play button focus after async state updates on detail sc…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1358,6 +1358,20 @@ private fun MetaDetailsContent(
         }
     }
 
+    // Re-request hero focus when late-arriving async state (nextToWatch, mdbListRatings)
+    // causes structural recomposition that invalidates the focus node.
+    LaunchedEffect(nextToWatch, mdbListRatings) {
+        if (
+            initialHeroFocusRequested &&
+            pendingRestoreType == null &&
+            !isTrailerPlaying
+        ) {
+            delay(50)
+            android.util.Log.d("DetailFocus", "Focus recovery after async state update (nextToWatch=$nextToWatch, mdbListRatings=${mdbListRatings != null})")
+            heroPlayFocusRequester.requestFocusAfterFrames()
+        }
+    }
+
     // Pre-compute screen dimensions to avoid BoxWithConstraints subcomposition overhead
     val configuration = LocalConfiguration.current
     val localContext = LocalContext.current


### PR DESCRIPTION
## Summary

Recover play button focus on the detail screen when late-arriving async state updates (`nextToWatch`, `mdbListRatings`) cause structural recomposition that invalidates the focus node.

## PR type

- Bug fix

## Why

When the detail page opens, focus is correctly set on the play button. However, the ViewModel fires several async observers (`calculateNextToWatch`, `loadMDBListRatings`, etc.) that resolve ~100–200ms after the initial focus grant. These state changes trigger structural recomposition inside `AnimatedVisibility` (e.g. play button text changes from "Play" to "Play S2 E3", or `MDBListRatingsRow` becomes visible), which invalidates the existing focus node and causes focus to silently disappear.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manually tested on Android TV device by navigating to detail screens for both movies and series.
- Verified focus stays on the play button after `nextToWatch` and `mdbListRatings` arrive.
- Verified trailer autoplay is not affected (guard: `!isTrailerPlaying`).
- Verified returning from playback with `pendingRestoreType` set does not trigger duplicate focus requests.

## Screenshots / Video (UI changes only)

N/A — no visual change, focus behavior fix only.

## Breaking changes

- None

## Linked issues

- None
