### PR TITLE
Fix catalog order crash, detail focus loss, collection logos, and release dates

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -334,36 +334,33 @@ class CatalogOrderViewModel @Inject constructor(
         availableMap: Map<String, CatalogOrderEntry>
     ): List<String> {
         val result = order.toMutableList()
-        var i = 0
-        while (i < result.size) {
-            val key = result[i]
-            if (!key.startsWith("collection_")) {
-                i++
-                continue
-            }
-            // Check if this collection is between catalogs of the same addon
-            val prevAddon = findAddonNameBefore(result, i, availableMap)
-            val nextAddon = findAddonNameAfter(result, i, availableMap)
-            if (prevAddon != null && nextAddon != null && prevAddon == nextAddon) {
-                // Collection is mid-block. Move it after the end of this addon block.
-                result.removeAt(i)
-                var insertPos = i
-                while (insertPos < result.size &&
-                    !result[insertPos].startsWith("collection_") &&
-                    availableMap[result[insertPos]]?.addonName == prevAddon
-                ) {
-                    insertPos++
+        var changed = true
+        while (changed) {
+            changed = false
+            var i = 0
+            while (i < result.size) {
+                val key = result[i]
+                if (!key.startsWith("collection_")) {
+                    i++
+                    continue
                 }
-                if (insertPos == i) {
-                    // Would re-insert at same position — skip to avoid infinite loop
-                    result.add(i, key)
+                val prevAddon = findAddonNameBefore(result, i, availableMap)
+                val nextAddon = findAddonNameAfter(result, i, availableMap)
+                if (prevAddon != null && nextAddon != null && prevAddon == nextAddon) {
+                    result.removeAt(i)
+                    var insertPos = i
+                    while (insertPos < result.size &&
+                        !result[insertPos].startsWith("collection_") &&
+                        availableMap[result[insertPos]]?.addonName == prevAddon
+                    ) {
+                        insertPos++
+                    }
+                    result.add(insertPos, key)
+                    if (insertPos != i) changed = true
                     i++
                 } else {
-                    result.add(insertPos, key)
-                    // Don't increment i - re-check this position
+                    i++
                 }
-            } else {
-                i++
             }
         }
         return result

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -354,8 +354,14 @@ class CatalogOrderViewModel @Inject constructor(
                 ) {
                     insertPos++
                 }
-                result.add(insertPos, key)
-                // Don't increment i - re-check this position
+                if (insertPos == i) {
+                    // Would re-insert at same position — skip to avoid infinite loop
+                    result.add(i, key)
+                    i++
+                } else {
+                    result.add(insertPos, key)
+                    // Don't increment i - re-check this position
+                }
             } else {
                 i++
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -921,18 +921,10 @@ private fun formatMDBListRating(provider: String, rating: Double): String {
     }
 }
 
-private val DETAIL_YEAR_RANGE_REGEX = Regex("""^((19|20)\d{2})\s*[-–]\s*((19|20)\d{2})?$""")
 
 private fun formatYearRange(releaseInfo: String?): String? {
     if (releaseInfo.isNullOrBlank()) return null
-    val trimmed = releaseInfo.trim()
-    val match = DETAIL_YEAR_RANGE_REGEX.find(trimmed)
-    if (match != null) {
-        val startYear = match.groupValues[1]
-        val endYear = match.groupValues[3]
-        return if (endYear.isNotBlank()) "$startYear–$endYear" else startYear
-    }
-    return Regex("""\b(19|20)\d{2}\b""").find(trimmed)?.value ?: trimmed
+    return releaseInfo.trim()
 }
 
 private fun formatRuntime(runtime: String): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -168,18 +168,10 @@ private fun resolveDetailReturnEpisodeFocusTarget(
 
 private const val USER_INTERACTION_DISPATCH_DEBOUNCE_MS = 120L
 
-private val DETAIL_YEAR_RANGE_REGEX = Regex("""^((19|20)\d{2})\s*[-–]\s*((19|20)\d{2})?$""")
 
 private fun formatDetailYearRange(releaseInfo: String?): String? {
     if (releaseInfo.isNullOrBlank()) return null
-    val trimmed = releaseInfo.trim()
-    val match = DETAIL_YEAR_RANGE_REGEX.find(trimmed)
-    if (match != null) {
-        val startYear = match.groupValues[1]
-        val endYear = match.groupValues[3]
-        return if (endYear.isNotBlank()) "$startYear–$endYear" else startYear
-    }
-    return Regex("""\b(19|20)\d{2}\b""").find(trimmed)?.value ?: trimmed
+    return releaseInfo.trim()
 }
 
 private fun applyDither(bmp: android.graphics.Bitmap) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -726,6 +726,18 @@ class MetaDetailsViewModel @Inject constructor(
         // Fire all independent async jobs immediately — they run in parallel.
         loadMoreLikeThisAsync(meta)
         val enriched = enrichMeta(meta)
+
+        // Pre-compute nextToWatch before applyMeta so the PlayButton text is stable
+        // from the first composition — prevents focus invalidation from late recomposition.
+        val progressMap = watchProgressRepository
+            .getAllEpisodeProgress(_effectiveContentId.value)
+            .first()
+        val watchedEpisodes = watchedItemsPreferences
+            .getWatchedEpisodesForContent(_effectiveContentId.value)
+            .first()
+        val precomputedNextToWatch = computeNextToWatch(enriched, progressMap, watchedEpisodes)
+        updateNextToWatch(precomputedNextToWatch)
+
         applyMeta(enriched)
         // Episode ratings and MDBList are independent — launch both without waiting.
         loadEpisodeRatingsAsync(enriched)
@@ -1468,111 +1480,111 @@ class MetaDetailsViewModel @Inject constructor(
         val meta = _uiState.value.meta ?: return
         val progressMap = _uiState.value.episodeProgressMap
         val watchedEpisodes = _uiState.value.watchedEpisodes
-        val isSeries = meta.apiType in listOf("series", "tv")
         nextToWatchJob?.cancel()
 
         nextToWatchJob = viewModelScope.launch {
-            if (!isSeries) {
-                // For movies, check if there's an in-progress watch
-                val progress = watchProgressRepository.getProgress(_effectiveContentId.value).first()
-                val nextToWatch = if (progress != null && shouldResumeProgress(progress)) {
-                    NextToWatch(
-                        watchProgress = progress,
-                        isResume = true,
-                        nextVideoId = meta.id,
-                        nextSeason = null,
-                        nextEpisode = null,
-                        displayText = context.getString(R.string.detail_btn_resume)
-                    )
-                } else {
-                    NextToWatch(
-                        watchProgress = null,
-                        isResume = false,
-                        nextVideoId = meta.id,
-                        nextSeason = null,
-                        nextEpisode = null,
-                        displayText = context.getString(R.string.detail_btn_play)
-                    )
-                }
-                updateNextToWatch(nextToWatch)
-                return@launch
-            }
+            val nextToWatch = computeNextToWatch(meta, progressMap, watchedEpisodes)
+            updateNextToWatch(nextToWatch)
+        }
+    }
 
-            val allEpisodes = meta.videos
-                .filter { it.season != null && it.episode != null }
-                .filter { it.available != false }
-                .sortedWith(compareBy({ it.season }, { it.episode }))
+    private suspend fun computeNextToWatch(
+        meta: Meta,
+        progressMap: Map<Pair<Int, Int>, WatchProgress> = emptyMap(),
+        watchedEpisodes: Set<Pair<Int, Int>> = emptySet()
+    ): NextToWatch {
+        val isSeries = meta.apiType in listOf("series", "tv")
 
-            if (allEpisodes.isEmpty()) {
-                updateNextToWatch(
-                    NextToWatch(
-                        watchProgress = null,
-                        isResume = false,
-                        nextVideoId = meta.id,
-                        nextSeason = null,
-                        nextEpisode = null,
-                        displayText = context.getString(R.string.detail_btn_play)
-                    )
+        if (!isSeries) {
+            val progress = watchProgressRepository.getProgress(_effectiveContentId.value).first()
+            return if (progress != null && shouldResumeProgress(progress)) {
+                NextToWatch(
+                    watchProgress = progress,
+                    isResume = true,
+                    nextVideoId = meta.id,
+                    nextSeason = null,
+                    nextEpisode = null,
+                    displayText = context.getString(R.string.detail_btn_resume)
                 )
-                return@launch
-            }
-
-            val nonSpecialEpisodes = allEpisodes.filter { (it.season ?: 0) > 0 }
-            val episodePool = if (nonSpecialEpisodes.isNotEmpty()) nonSpecialEpisodes else allEpisodes
-            val latestSeriesProgress = progressMap.values
-                .sortedWith(
-                    compareByDescending<WatchProgress> { it.lastWatched }
-                        .thenByDescending { it.season ?: 0 }
-                        .thenByDescending { it.episode ?: 0 }
+            } else {
+                NextToWatch(
+                    watchProgress = null,
+                    isResume = false,
+                    nextVideoId = meta.id,
+                    nextSeason = null,
+                    nextEpisode = null,
+                    displayText = context.getString(R.string.detail_btn_play)
                 )
-                .firstOrNull()
-            // If progressMap is empty but watchedEpisodes has data (batch mark),
-            // use the highest watched episode as latestSeriesProgress stand-in.
-            val effectiveLatestProgress = latestSeriesProgress ?: run {
-                if (watchedEpisodes.isEmpty()) null
-                else {
-                    val watchedWithTimestamps = watchedItemsPreferences
-                        .getWatchedEpisodesWithTimestamps(_effectiveContentId.value)
-                        .first()
-                    val highest = watchedWithTimestamps.entries
-                        .maxWithOrNull(compareBy<Map.Entry<Pair<Int, Int>, Long>> { it.value }
-                            .thenBy { it.key.first }
-                            .thenBy { it.key.second })
-                    highest?.let { (key, watchedAt) ->
-                        val (s, e) = key
-                        episodePool.firstOrNull { it.season == s && it.episode == e }?.let { video ->
-                            WatchProgress(
-                                contentId = _effectiveContentId.value,
-                                contentType = "series",
-                                name = "",
-                                poster = null, backdrop = null, logo = null,
-                                videoId = video.id,
-                                season = video.season,
-                                episode = video.episode,
-                                episodeTitle = video.title,
-                                position = 1L, duration = 1L,
-                                lastWatched = watchedAt,
-                                progressPercent = 100f
-                            )
-                        }
+            }
+        }
+
+        val allEpisodes = meta.videos
+            .filter { it.season != null && it.episode != null }
+            .filter { it.available != false }
+            .sortedWith(compareBy({ it.season }, { it.episode }))
+
+        if (allEpisodes.isEmpty()) {
+            return NextToWatch(
+                watchProgress = null,
+                isResume = false,
+                nextVideoId = meta.id,
+                nextSeason = null,
+                nextEpisode = null,
+                displayText = context.getString(R.string.detail_btn_play)
+            )
+        }
+
+        val nonSpecialEpisodes = allEpisodes.filter { (it.season ?: 0) > 0 }
+        val episodePool = if (nonSpecialEpisodes.isNotEmpty()) nonSpecialEpisodes else allEpisodes
+        val latestSeriesProgress = progressMap.values
+            .sortedWith(
+                compareByDescending<WatchProgress> { it.lastWatched }
+                    .thenByDescending { it.season ?: 0 }
+                    .thenByDescending { it.episode ?: 0 }
+            )
+            .firstOrNull()
+        val effectiveLatestProgress = latestSeriesProgress ?: run {
+            if (watchedEpisodes.isEmpty()) null
+            else {
+                val watchedWithTimestamps = watchedItemsPreferences
+                    .getWatchedEpisodesWithTimestamps(_effectiveContentId.value)
+                    .first()
+                val highest = watchedWithTimestamps.entries
+                    .maxWithOrNull(compareBy<Map.Entry<Pair<Int, Int>, Long>> { it.value }
+                        .thenBy { it.key.first }
+                        .thenBy { it.key.second })
+                highest?.let { (key, watchedAt) ->
+                    val (s, e) = key
+                    episodePool.firstOrNull { it.season == s && it.episode == e }?.let { video ->
+                        WatchProgress(
+                            contentId = _effectiveContentId.value,
+                            contentType = "series",
+                            name = "",
+                            poster = null, backdrop = null, logo = null,
+                            videoId = video.id,
+                            season = video.season,
+                            episode = video.episode,
+                            episodeTitle = video.title,
+                            position = 1L, duration = 1L,
+                            lastWatched = watchedAt,
+                            progressPercent = 100f
+                        )
                     }
                 }
             }
-            val defaultEpisode = findPreferredDefaultEpisode(meta)?.takeIf { preferred ->
-                episodePool.any { it.id == preferred.id }
-            }
-
-            val nextToWatch = buildNextToWatchFromLatestProgress(
-                latestProgress = effectiveLatestProgress,
-                episodes = episodePool,
-                fallbackProgressMap = progressMap,
-                watchedEpisodes = watchedEpisodes,
-                metaId = meta.id,
-                defaultEpisode = defaultEpisode
-            )
-
-            updateNextToWatch(nextToWatch)
         }
+        val defaultEpisode = findPreferredDefaultEpisode(meta)?.takeIf { preferred ->
+            episodePool.any { it.id == preferred.id }
+        }
+
+        return buildNextToWatchFromLatestProgress(
+            latestProgress = effectiveLatestProgress,
+            episodes = episodePool,
+            fallbackProgressMap = progressMap,
+            watchedEpisodes = watchedEpisodes,
+            metaId = meta.id,
+            defaultEpisode = defaultEpisode
+        )
     }
 
     private fun buildNextToWatchFromLatestProgress(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -125,9 +125,10 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
     forceReload: Boolean = false
 ) {
     val signature = buildHomeCatalogLoadSignature(addons)
+    val hasActiveLoads = synchronized(activeCatalogLoadJobs) { activeCatalogLoadJobs.any { it.isActive } }
     if (!forceReload &&
         signature == activeCatalogLoadSignature &&
-        (catalogsLoadInProgress || hasAnyCatalogRows())
+        (hasActiveLoads || hasAnyCatalogRows())
     ) {
         return
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -358,7 +358,14 @@ private fun normalizeCollectionBoundaries(
             ) {
                 insertPos++
             }
-            result.add(insertPos, key)
+            if (insertPos == i) {
+                // Would re-insert at same position — skip to avoid infinite loop
+                result.add(i, key)
+                i++
+            } else {
+                result.add(insertPos, key)
+                // Don't increment i — check the new element at position i
+            }
         } else {
             i++
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -339,35 +339,34 @@ private fun normalizeCollectionBoundaries(
     addonKeyToOwner: Map<String, String>
 ): List<String> {
     val result = order.toMutableList()
-    var i = 0
-    while (i < result.size) {
-        val key = result[i]
-        if (!key.startsWith("collection_")) {
-            i++
-            continue
-        }
-        val prevOwner = findOwnerBefore(result, i, addonKeyToOwner)
-        val nextOwner = findOwnerAfter(result, i, addonKeyToOwner)
-        if (prevOwner != null && nextOwner != null && prevOwner == nextOwner) {
-            // Collection is mid-block, push to end of this addon block
-            result.removeAt(i)
-            var insertPos = i
-            while (insertPos < result.size &&
-                !result[insertPos].startsWith("collection_") &&
-                addonKeyToOwner[result[insertPos]] == prevOwner
-            ) {
-                insertPos++
+    var changed = true
+    while (changed) {
+        changed = false
+        var i = 0
+        while (i < result.size) {
+            val key = result[i]
+            if (!key.startsWith("collection_")) {
+                i++
+                continue
             }
-            if (insertPos == i) {
-                // Would re-insert at same position — skip to avoid infinite loop
-                result.add(i, key)
+            val prevOwner = findOwnerBefore(result, i, addonKeyToOwner)
+            val nextOwner = findOwnerAfter(result, i, addonKeyToOwner)
+            if (prevOwner != null && nextOwner != null && prevOwner == nextOwner) {
+                // Collection is mid-block, push to end of this addon block
+                result.removeAt(i)
+                var insertPos = i
+                while (insertPos < result.size &&
+                    !result[insertPos].startsWith("collection_") &&
+                    addonKeyToOwner[result[insertPos]] == prevOwner
+                ) {
+                    insertPos++
+                }
+                result.add(insertPos, key)
+                if (insertPos != i) changed = true
                 i++
             } else {
-                result.add(insertPos, key)
-                // Don't increment i — check the new element at position i
+                i++
             }
-        } else {
-            i++
         }
     }
     return result

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -18,7 +18,6 @@ import com.nuvio.tv.R
 import com.nuvio.tv.ui.components.formatContinueWatchingProgressLabel
 
 internal val YEAR_REGEX = Regex("""\b(19|20)\d{2}\b""")
-internal val YEAR_RANGE_REGEX = Regex("""^((19|20)\d{2})\s*[-–]\s*((19|20)\d{2})?$""")
 internal const val MODERN_HERO_TEXT_WIDTH_FRACTION = 0.42f
 internal const val MODERN_HERO_MEDIA_WIDTH_FRACTION = 0.72f
 internal const val MODERN_TRAILER_OVERSCAN_ZOOM = 1.35f
@@ -584,15 +583,7 @@ internal fun extractYear(releaseInfo: String?): String? {
 
 internal fun extractYearOrRange(releaseInfo: String?): String? {
     if (releaseInfo.isNullOrBlank()) return null
-    val trimmed = releaseInfo.trim()
-    val match = YEAR_RANGE_REGEX.find(trimmed)
-    if (match != null) {
-        val startYear = match.groupValues[1]
-        val endYear = match.groupValues[3]
-        // "2022-2025" → "2022–2025", but "2024-" → "2024"
-        return if (endYear.isNotBlank()) "$startYear–$endYear" else startYear
-    }
-    return YEAR_REGEX.find(trimmed)?.value
+    return releaseInfo.trim()
 }
 
 @Volatile

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -1023,6 +1023,7 @@ private fun ModernCarouselCard(
     val hasImage = !imageUrl.isNullOrBlank()
     val hasLandscapeLogo =
         (useLandscapeOverlayTreatment || isBackdropExpanded) &&
+            !isCollectionFolder &&
             !effectiveLogoUrl.isNullOrBlank() &&
             !landscapeLogoLoadFailed
     var longPressTriggered by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary

Four bug fixes:

1. **Infinite loop + incorrect placement when using "Follow Addons Order" for catalogs** - `normalizeCollectionBoundaries` and `normalizeCollectionPositions` could enter an infinite loop when a collection couldn't be moved, and with multiple collections mid-block only one was correctly repositioned. Fixed with multi-pass approach that repeats until all collections are at addon block boundaries.

2. **Release date trailing dash removed** - Dates like `"2025-"` were being parsed and stripped to just `"2025"`. Now `releaseInfo` is displayed as-is.

3. **Collection cards showing clearLogo in horizontal poster mode** - When landscape posters were enabled globally, collection folder cards incorrectly displayed a logo overlay even though they use their own defined poster shape.

4. **Play button losing focus on movie detail screen** - `calculateNextToWatch` resolved asynchronously after the UI rendered, causing a recomposition that invalidated the focus node. Now `nextToWatch` is pre-computed before `applyMeta` so the PlayButton text is stable from the first composition.

## PR type

- Bug fix

## Why

- ANR/crash reports from users enabling the "Follow Addons Order" catalog setting
- User feedback that release dates lost their trailing dash
- Visual bug with logos appearing on collection cards in horizontal mode
- Focus disappearing from Play button on movie details (TV remote UX regression)

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Tested "Follow Addons Order" toggle on/off with collections present - no freeze
- Tested catalog order editing screen with collections - no freeze
- Verified release dates display as-is (e.g. `"2025-"` shows `"2025-"`)
- Verified collection cards in horizontal poster mode no longer show logo overlay
- Verified movie detail screen: Play button gets focus and keeps it after mdbListRatings and moreLikeThis load
- Verified series detail screen: Play button text shows correct episode immediately without flashing

## Screenshots / Video (UI changes only)

Nothing changed - bugfixes 

## Breaking changes

Nothing should break

## Linked issues

reported via user feedback channels.
