### PR TITLE
Removed broken focus on episodes and minor visual adjustments

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -510,7 +510,7 @@ fun ContentCard(
                             .padding(end = 8.dp, top = 8.dp)
                             .zIndex(2f)
                             .size(21.dp)
-                            .shadow(10.dp, shape = CircleShape)
+                            .shadow(10.dp, shape = CircleShape, spotColor = Color.Transparent)
                             .background(NuvioColors.Secondary, CircleShape)
                     ) {
                         Icon(

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
@@ -188,7 +188,7 @@ fun GridContentCard(
                             .padding(end = 8.dp, top = 8.dp)
                             .zIndex(2f)
                             .size(21.dp)
-                            .shadow(10.dp, shape = CircleShape)
+                            .shadow(10.dp, shape = CircleShape, spotColor = Color.Transparent)
                             .background(NuvioColors.Secondary, CircleShape)
                     ) {
                         Icon(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.tv.material3.Border
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
@@ -613,7 +614,7 @@ private fun CatalogOrderEntryCard(onClick: () -> Unit) {
                 }
             }
             Icon(
-                imageVector = Icons.Default.ArrowForward,
+                imageVector = Icons.Default.ChevronRight,
                 contentDescription = null,
                 modifier = Modifier.size(20.dp),
                 tint = NuvioColors.TextSecondary
@@ -674,7 +675,7 @@ private fun CollectionsEntryCard(onClick: () -> Unit) {
                 }
             }
             Icon(
-                imageVector = Icons.Default.ArrowForward,
+                imageVector = Icons.Default.ChevronRight,
                 contentDescription = null,
                 modifier = Modifier.size(20.dp),
                 tint = NuvioColors.TextSecondary

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -286,9 +286,6 @@ fun EpisodesRow(
         episodeFocusRequesters.keys.retainAll(episodeIds)
     }
 
-    // Track the last focused episode requester for focus restoration
-    var lastFocusedEpisodeRequester by remember { androidx.compose.runtime.mutableStateOf<FocusRequester?>(null) }
-
     LaunchedEffect(restoreFocusToken, restoreEpisodeId, restoreTargetRequester, dedupedEpisodes) {
         if (restoreFocusToken <= 0 || restoreEpisodeId.isNullOrBlank()) return@LaunchedEffect
         if (dedupedEpisodes.none { it.id == restoreEpisodeId }) return@LaunchedEffect
@@ -297,7 +294,6 @@ fun EpisodesRow(
             val offsetPx = with(density) { (cardMetrics.cardWidth * 2f / 3f - cardMetrics.itemSpacing).roundToPx() }
             lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
         }
-        lastFocusedEpisodeRequester = restoreTargetRequester
         restoreTargetRequester?.requestFocusAfterFrames()
     }
 
@@ -307,18 +303,12 @@ fun EpisodesRow(
         if (index < 0) return@LaunchedEffect
         val offsetPx = with(density) { (cardMetrics.cardWidth * 2f / 3f - cardMetrics.itemSpacing).roundToPx() }
         lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
-        // Reset the focus restorer target so it doesn't point at an off-screen episode
-        // after the list scrolled to a different position.
-        lastFocusedEpisodeRequester = episodeFocusRequesters[scrollToEpisodeId]
         onScrollToEpisodeHandled()
     }
 
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .focusRestorer {
-                lastFocusedEpisodeRequester ?: FocusRequester.Default
-            }
             .onPreviewKeyEvent { event ->
                 val native = event.nativeKeyEvent
                 val isHorizontalKey = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_LEFT ||
@@ -356,7 +346,6 @@ fun EpisodesRow(
             val episodeOnClick = remember(episode.id) { { onEpisodeClick(episode) } }
             val episodeOnLongPress = remember(episode.id) { { optionsEpisode = episode } }
             val episodeOnFocused = remember(episode.id) { {
-                lastFocusedEpisodeRequester = episodeFocusRequester
                 onEpisodeFocused(episode.id)
             } }
             val isRestoreTarget = episode.id == restoreEpisodeId
@@ -819,7 +808,7 @@ private fun EpisodeCard(
                             top = cardMetrics.statusBadgeInset
                         )
                         .size(cardMetrics.statusBadgeSize)
-                        .shadow(10.dp, shape = CircleShape)
+                        .shadow(10.dp, shape = CircleShape, spotColor = Color.Transparent)
                         .background(NuvioColors.Secondary, CircleShape),
                     contentAlignment = Alignment.Center
                 ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -1217,7 +1217,7 @@ private fun ModernCarouselCard(
                             .padding(end = 8.dp, top = 8.dp)
                             .zIndex(2f)
                             .size(21.dp)
-                            .shadow(10.dp, shape = CircleShape)
+                            .shadow(10.dp, shape = CircleShape, spotColor = Color.Transparent)
                             .background(NuvioColors.Secondary, CircleShape)
                     ) {
                         Icon(


### PR DESCRIPTION
## Summary
1. Removed the `lastFocusedEpisodeRequester` from the episodes row
2. Adjusted the watched badge shadow - spotColor set to transparent
3. Changed the catalogs reorder and collections menu icon from arrows to chevron

## PR type
- Bug fix
- Small maintenance improvement

## Why
`lastFocusedEpisodeRequester` was causing index jumps when view was recycled. Default focus does the job with no issues.
The badge shadow was leaving a slight directional shadow; forgot to set spotColor to transparent.
The icon changes in Addons are just to make the menus visually consistent with other menus across the app.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [ ] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [ ] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)
N/A

## Testing
Scrolled horizontally through episode row and then vertically to kick row out of view, swapped seasons doing the same thing then swapping back to previous season. No index jumping and correctly restores previously focused index even after view is no longer visible.

## Screenshots / Video (UI changes only)
**New:**
<img width="1009" height="208" alt="image" src="https://github.com/user-attachments/assets/66efee8f-177d-4fd4-874e-b5964da02626" />
**Old:**
<img width="993" height="210" alt="image" src="https://github.com/user-attachments/assets/acf8e55b-a7c6-45ab-936c-a2d5d954a4c1" />

**New:**
<img width="140" height="203" alt="image" src="https://github.com/user-attachments/assets/1d78fd68-7865-48da-8770-e604bc9f6ab6" />
**Old:**
<img width="145" height="210" alt="image" src="https://github.com/user-attachments/assets/14e17f81-9427-47f4-849d-fbb5eca804b9" /> 


## Breaking changes
None.

## Linked issues
None.
