### PR TITLE
fix(player): disable Media3 frame-rate hint to prevent AFR conflict

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -291,6 +291,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
                     .setReleaseTimeoutMs(3000)
+                    .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
                     .build()
             }
 
@@ -301,6 +302,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
                     .setReleaseTimeoutMs(3000)
+                    .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
                     .buildWithAssSupportCompat(
                         context = context,
                         renderType = libassRenderType,


### PR DESCRIPTION
## Summary

Add `C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF` to the main `ExoPlayer.Builder` so `frameRateMatchingMode` is the sole authority for refresh-rate switching. Fixes HDMI blackouts on pause, seek, and source-switch when AFR is `OFF`.

## PR type

- Bug fix

## Why

Two refresh-rate systems run in parallel on the ExoPlayer engine:

1. `FrameRateUtils` sets `preferredDisplayModeId` after detecting the video's frame rate. Gated by `frameRateMatchingMode`.
2. Media3's default `ONLY_IF_SEAMLESS` strategy causes `MediaCodecVideoRenderer` to call `Surface.setFrameRate()` unconditionally, ignoring the user setting.

With AFR `OFF`, `FrameRateUtils` does nothing, so Media3's hint runs alone. It switches the display to match the content rate, then goes stale on pause/seek/source-switch. The system reverts to default, the HDMI link renegotiates, and the screen flashes black.

With AFR `START` or `START_STOP`, `FrameRateUtils` anchors the mode via `preferredDisplayModeId`. Media3's hint still goes stale, but the anchor keeps the display pinned. No flicker. This change only affects the `OFF` path.

`TrailerPlayer.kt:91` already sets `STRATEGY_OFF` for the same reason (commit `7a16f48`). Assuming that the main player builders were missed during this change.

This change makes `frameRateMatchingMode` the single source of truth. MPV is unaffected.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual verification on Raspberry Pi 5 Android TV, ExoPlayer engine, 24fps content:

| Setting | Flicker before fix? | Flicker after fix? |
|---|---|---|
| `OFF` | Yes | No |
| `START` / `START_STOP` | No | No |

Bug is gated by the AFR setting, not the build variant. MPV spot-checked: no flicker.

Build check: `./gradlew :app:assembleFullDebug` clean.

## Screenshots / Video (UI changes only)

None.

## Breaking changes

No code or config breakage. One user-observable change worth a release-note line:

`frameRateMatchingMode = OFF` previously did not fully disable refresh-rate matching. Media3 was still doing its own broken partial matching behind the scenes, which caused the flicker this PR fixes. `OFF` now fully disables all matching. Users who want refresh-rate matching should set AFR to `START` or `START_STOP`.

Suggested release note: "Fixed a bug where AFR set to OFF still triggered broken refresh-rate switching. OFF now fully disables matching. Use START or START_STOP to enable AFR." or something to that effect.

## Linked issues

None.