### PR TITLE
perf: optimize PauseOverlayClock to update on minute boundaries

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
@@ -118,8 +118,10 @@ private fun PauseOverlayClock(modifier: Modifier = Modifier) {
 
     LaunchedEffect(Unit) {
         while (true) {
-            nowMillis = System.currentTimeMillis()
-            delay(1_000)
+            val current = System.currentTimeMillis()
+            nowMillis = current
+            val delayMs = (60_000L - (current % 60_000L)).coerceAtLeast(1_000L)
+            delay(delayMs)
         }
     }
 


### PR DESCRIPTION
## Summary

Changed the pause overlay clock from recomposing every second to on the minute boundary only.

## PR type

- Small maintenance improvement

## Why

The PauseOverlayClock was recomposing every 1,000ms using a `delay(1_000)` loop. However, since `DateFormat.getTimeFormat` typically only displays hours and minutes (not seconds), this caused 59 unnecessary recompositions per minute. By calculating the delay until the next minute boundary `(60_000L - (current % 60_000L)).coerceAtLeast(1_000L)`, the component now updates exactly when the visible minute changes, resulting in a ~98.3% reduction in recompositions for the clock UI.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.

## Testing

Tested clock, works fine

## Screenshots / Video (UI changes only)

No UI changes 

## Breaking changes

Nothing is broken from testing.

## Linked issues

No existing issue, as it's an improvement rather than bug fix or feature implementation.
