### PR TITLE
CW release alert sorting and home row focus/scroll restoration

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -278,7 +277,6 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 watchedItemsVersion = watchedItemsSize
             )
         }.debounce(CW_PROGRESS_DEBOUNCE_MS).collectLatest { snapshot ->
-            withContext(Dispatchers.Default) {
             val debug = CwDebugSession()
             try {
                 debug.markPhase("filter-snapshot")
@@ -1092,7 +1090,6 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 debug.logSummary(cancelled = true)
                 throw cancelled
             }
-            } // withContext(Dispatchers.Default)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -277,6 +278,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 watchedItemsVersion = watchedItemsSize
             )
         }.debounce(CW_PROGRESS_DEBOUNCE_MS).collectLatest { snapshot ->
+            withContext(Dispatchers.Default) {
             val debug = CwDebugSession()
             try {
                 debug.markPhase("filter-snapshot")
@@ -1090,6 +1092,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 debug.logSummary(cancelled = true)
                 throw cancelled
             }
+            } // withContext(Dispatchers.Default)
         }
     }
 }
@@ -1430,12 +1433,36 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
         .sortedBy { it.first }
         .map { it.second }
 
-    if (enrichedItems == finalItems) return@coroutineScope false
+    // Re-sort if any sortTimestamp changed during enrichment (e.g. release alert
+    // detected after TMDB provided a more accurate release date).
+    val sortChanged = enrichedItems.zip(finalItems).any { (enriched, original) ->
+        val enrichedTs = when (enriched) {
+            is ContinueWatchingItem.InProgress -> enriched.progress.lastWatched
+            is ContinueWatchingItem.NextUp -> enriched.info.sortTimestamp
+        }
+        val originalTs = when (original) {
+            is ContinueWatchingItem.InProgress -> original.progress.lastWatched
+            is ContinueWatchingItem.NextUp -> original.info.sortTimestamp
+        }
+        enrichedTs != originalTs
+    }
+    val sortedEnrichedItems = if (sortChanged) {
+        enrichedItems.sortedByDescending { item ->
+            when (item) {
+                is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
+            }
+        }
+    } else {
+        enrichedItems
+    }
+
+    if (sortedEnrichedItems == finalItems) return@coroutineScope false
 
     // Save enriched next-up info to in-memory overlay so the next CW cycle's
     // cached/partial/normal emissions use enriched data from the start,
     // preventing title/thumbnail flickering between addon and TMDB values.
-    enrichedItems.forEach { item ->
+    sortedEnrichedItems.forEach { item ->
         when (item) {
             is ContinueWatchingItem.NextUp -> {
                 cwEnrichedNextUpOverlay[item.info.contentId] = item.info
@@ -1447,15 +1474,15 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
     }
 
     _uiState.update { state ->
-        if (state.continueWatchingItems == enrichedItems) {
+        if (state.continueWatchingItems == sortedEnrichedItems) {
             state
         } else {
-            state.copy(continueWatchingItems = enrichedItems)
+            state.copy(continueWatchingItems = sortedEnrichedItems)
         }
     }
     persistLocalContinueWatchingMetadata(
         originalItems = finalItems,
-        enrichedItems = enrichedItems
+        enrichedItems = sortedEnrichedItems
     )
     true
 }
@@ -1732,7 +1759,7 @@ private suspend fun HomeViewModel.enrichNextUpItem(
         imdbRating = if (settings.useBasicInfo) tmdbData?.rating?.toFloat() ?: meta.imdbRating ?: item.info.imdbRating else meta.imdbRating ?: item.info.imdbRating,
         genres = meta.genres.take(3).ifEmpty { item.info.genres },
         releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: item.info.releaseInfo,
-        sortTimestamp = item.info.sortTimestamp,
+        sortTimestamp = releaseState.sortTimestamp,
         releaseTimestamp = releaseState.releaseTimestamp,
         isReleaseAlert = releaseState.isReleaseAlert,
         isNewSeasonRelease = releaseState.isNewSeasonRelease,
@@ -2326,11 +2353,13 @@ private fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
     items: List<ContinueWatchingItem>
 ): List<ContinueWatchingItem> {
     if (cwEnrichedNextUpOverlay.isEmpty() && cwEnrichedInProgressOverlay.isEmpty()) return items
-    return items.map { item ->
+    var sortChanged = false
+    val mapped = items.map { item ->
         when (item) {
             is ContinueWatchingItem.NextUp -> {
                 val overlay = cwEnrichedNextUpOverlay[item.info.contentId] ?: return@map item
                 if (overlay.season != item.info.season || overlay.episode != item.info.episode) return@map item
+                if (overlay.sortTimestamp != item.info.sortTimestamp) sortChanged = true
                 item.copy(info = item.info.copy(
                     name = overlay.name.takeIf { it.isNotBlank() } ?: item.info.name,
                     episodeTitle = overlay.episodeTitle ?: item.info.episodeTitle,
@@ -2342,6 +2371,7 @@ private fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
                     imdbRating = overlay.imdbRating ?: item.info.imdbRating,
                     genres = overlay.genres.ifEmpty { item.info.genres },
                     releaseInfo = overlay.releaseInfo ?: item.info.releaseInfo,
+                    sortTimestamp = overlay.sortTimestamp,
                     isReleaseAlert = overlay.isReleaseAlert,
                     isNewSeasonRelease = overlay.isNewSeasonRelease,
                     releaseTimestamp = overlay.releaseTimestamp ?: item.info.releaseTimestamp,
@@ -2368,6 +2398,17 @@ private fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
                 )
             }
         }
+    }
+    // Re-sort if any sortTimestamp was updated by the overlay to maintain correct order.
+    return if (sortChanged) {
+        mapped.sortedByDescending { item ->
+            when (item) {
+                is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
+            }
+        }
+    } else {
+        mapped
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -247,6 +247,17 @@ fun ModernHomeContent(
     val itemFocusRequesters = uiCaches.itemFocusRequesters
     val rowListStates = uiCaches.rowListStates
     val loadMoreRequestedTotals = uiCaches.loadMoreRequestedTotals
+
+    if (focusedItemByRow.isEmpty() && focusState.hasSavedFocus) {
+        val savedRowKey = when {
+            focusState.focusedRowIndex == -1 -> MODERN_CONTINUE_WATCHING_ROW_KEY
+            focusState.focusedRowIndex >= 0 -> rowKeyByGlobalRowIndex[focusState.focusedRowIndex]
+            else -> null
+        }
+        if (savedRowKey != null) {
+            focusedItemByRow[savedRowKey] = focusState.focusedItemIndex.coerceAtLeast(0)
+        }
+    }
     // Holder for hot-path focus tracking — lambdas read through reference, no stale closure
     val focusHolder = remember {
         object {
@@ -541,8 +552,11 @@ fun ModernHomeContent(
             val row = latestActiveRow
             val focusedRowIndex = row?.globalRowIndex ?: 0
             val catalogRowScrollStates = latestCarouselRows
-                .filter { it.globalRowIndex >= 0 }
-                .associate { rowState -> rowState.key to (focusedItemByRow[rowState.key] ?: 0) }
+                .associate { rowState ->
+                    val scrollIndex = rowListStates[rowState.key]?.firstVisibleItemIndex
+                        ?: (focusedItemByRow[rowState.key] ?: 0)
+                    rowState.key to scrollIndex
+                }
 
             onSaveFocusState(
                 latestVerticalRowListState.firstVisibleItemIndex,


### PR DESCRIPTION
## Summary

Fix release alert sorting in Continue Watching and restore row scroll/focus position when returning from detail screens.

**CW sorting:** `sortTimestamp` was not updated during enrichment, so release alert items kept their `lastWatched` value instead of `releaseTimestamp` - causing them to sort incorrectly. The enrichment overlay also didn't propagate `sortTimestamp`, and neither path re-sorted after timestamp changes.

**Row focus restoration:** Catalog and CW row scroll positions were not correctly saved/restored. The CW row was excluded from `catalogRowScrollStates` entirely, and `focusedItemByRow` wasn't seeded during composition — causing `focusRestorer` to always default to item 0 on the first frame.

## PR type

- Bug fix

## Why

1. Release alert items in Continue Watching were not sorting to the front by their premiere timestamp as intended.
2. Navigating to a detail screen and returning would lose the horizontal scroll position - the focused item (especially index 1 or off-screen CW items) would not be restored correctly.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual: Verified release alert items sort by release timestamp after enrichment updates the date.
- Manual: Verified returning from detail with focus on item index 1 in a catalog row correctly restores scroll alignment.
- Manual: Verified returning from detail with focus on CW item 5+ correctly restores scroll position without visible scroll animation.

## Screenshots / Video (UI changes only)

behavioral fix, no visual changes.

## Breaking changes

Nothing should break

## Linked issues

Reported on discord, #1612
