### PR TITLE
fix: enable seamless frame rate switching for trailer player

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -88,7 +88,7 @@ fun TrailerPlayer(
                 .build()
             ExoPlayer.Builder(context)
                 .setLoadControl(loadControl)
-                .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
+                .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS)
                 .build()
                 .apply {
                     repeatMode = Player.REPEAT_MODE_OFF


### PR DESCRIPTION
Trailers on devices locked to 23.976Hz (e.g., NVIDIA Shield) exhibited visible judder because the trailer ExoPlayer was configured with VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF, preventing any display refresh rate adaptation.

Switch to VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS so the platform can seamlessly adjust the display refresh rate to match the trailer frame rate when supported, eliminating judder without causing disruptive black screen flickers.

## Summary

Changed `VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF` to `VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS` in `TrailerPlayer.kt` (1 line).

## PR type

- Bug fix

## Why

On devices with a fixed 23.976Hz display mode (e.g., NVIDIA Shield), trailer playback exhibits visible judder/stutter. The main player already has full AFR (Auto Frame Rate) support, but the trailer player's ExoPlayer had frame rate switching explicitly disabled, causing a mismatch between the trailer's frame rate (typically 24fps/30fps from YouTube) and the display refresh rate.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Tested on NVIDIA Shield Pro set to 23.976Hz. Trailer playback is now smooth without visible judder. No black screen flicker occurs during trailer transitions since the seamless strategy only switches when the platform supports non-disruptive mode changes.

## Breaking changes

None
