### PR TITLE
fix(trakt): fix anime episode remap and TMDB→IMDB resolution for watch history sync

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -96,9 +96,13 @@ class TraktEpisodeMappingService @Inject constructor(
         addonEpisodes: List<EpisodeMappingEntry>,
         traktEpisodes: List<EpisodeMappingEntry>
     ): Boolean {
-        val addonSeasons = addonEpisodes.mapTo(mutableSetOf()) { it.season }
-        val traktSeasons = traktEpisodes.mapTo(mutableSetOf()) { it.season }
-        return addonSeasons == traktSeasons
+        // Compare per-season episode counts, not just the set of season numbers.
+        // Anime often uses the same season numbers in both sources but with completely
+        // different episode distributions (e.g. One Piece has seasons 1-24 in both
+        // AIOMetadata and Trakt but with different episode counts per season).
+        val addonPerSeason = addonEpisodes.groupBy { it.season }.mapValues { it.value.size }
+        val traktPerSeason = traktEpisodes.groupBy { it.season }.mapValues { it.value.size }
+        return addonPerSeason == traktPerSeason
     }
 
     internal suspend fun getCachedEpisodeMapping(
@@ -117,7 +121,8 @@ class TraktEpisodeMappingService @Inject constructor(
         contentType: String?,
         videoId: String?,
         season: Int?,
-        episode: Int?
+        episode: Int?,
+        episodeTitle: String? = null
     ): EpisodeMappingEntry? {
         val key = cacheKey(contentId, contentType, videoId, season, episode) ?: return null
         cacheMutex.withLock {
@@ -144,7 +149,7 @@ class TraktEpisodeMappingService @Inject constructor(
             requestedSeason = requestedSeason,
             requestedEpisode = requestedEpisode,
             requestedVideoId = videoId,
-            requestedTitle = null,
+            requestedTitle = episodeTitle,
             addonEpisodes = addonEpisodes,
             traktEpisodes = traktEpisodes
         ) ?: return null

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -2383,7 +2383,8 @@ class TraktProgressService @Inject constructor(
             contentType = progress.contentType,
             videoId = progress.videoId,
             season = progress.season,
-            episode = progress.episode
+            episode = progress.episode,
+            episodeTitle = progress.episodeTitle
         )
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -2258,7 +2258,7 @@ class TraktProgressService @Inject constructor(
         refreshNow()
     }
 
-    private fun buildHistoryAddRequest(
+    private suspend fun buildHistoryAddRequest(
         progress: WatchProgress,
         title: String?,
         year: Int?
@@ -2307,14 +2307,23 @@ class TraktProgressService @Inject constructor(
         }
     }
 
-    private fun resolveHistoryIds(progress: WatchProgress): TraktIdsDto {
-        val contentIds = toTraktIds(parseContentIds(progress.contentId))
+    private suspend fun resolveHistoryIds(progress: WatchProgress): TraktIdsDto {
+        val contentIds = enrichWithImdb(toTraktIds(parseContentIds(progress.contentId)), progress.contentType)
         if (contentIds.hasAnyId()) return contentIds
 
-        val videoIds = toTraktIds(parseContentIds(progress.videoId))
+        val videoIds = enrichWithImdb(toTraktIds(parseContentIds(progress.videoId)), progress.contentType)
         if (videoIds.hasAnyId()) return videoIds
 
         return contentIds
+    }
+
+    // Trakt reliably finds shows/movies by IMDB ID; TMDB links are community-contributed
+    // and often missing for anime. Resolve TMDB → IMDB before sending history requests
+    // so Trakt can match the content even when the TMDB link isn't set up in its DB.
+    private suspend fun enrichWithImdb(ids: TraktIdsDto, contentType: String): TraktIdsDto {
+        if (ids.tmdb == null || !ids.imdb.isNullOrBlank()) return ids
+        val imdb = tmdbService.tmdbToImdb(ids.tmdb, contentType) ?: return ids
+        return ids.copy(imdb = imdb)
     }
 
     private suspend fun attemptEpisodeRemapHistoryAdd(


### PR DESCRIPTION
Closes #1693

## Summary

**Problem:** Marking anime episodes as watched on Trakt fails with "Failed to mark watched on Trakt (201)" for series where the Stremio addon (e.g. AIOMetadata) uses different season/episode numbering than Trakt's TVDB-based database. Tested with One Piece (`tt0388629`), which is confirmed in Trakt's database but not findable at the addon's season/episode coordinates.

**Fix 1 — episode remap season structure check (`TraktEpisodeMappingService`)**

`hasSameSeasonStructure()` previously compared only the *set* of season numbers between the addon episode list and Trakt's episode list. For One Piece, both sources have seasons 1–24, so the check concluded the structures matched and skipped the remap entirely — even though episode counts per season differ significantly. The fix compares per-season episode counts instead, correctly identifying the structural mismatch and allowing the remap to fire.

**Fix 2 — episode title threading (`TraktEpisodeMappingService` + `TraktProgressService`)**

`resolveEpisodeMapping()` passed `requestedTitle = null` to `remapEpisodeByTitleOrIndex()`, disabling title-based episode matching even when `WatchProgress.episodeTitle` was available. The fix threads the episode title through `resolveCanonicalEpisodeMapping()` → `resolveEpisodeMapping()` → `remapEpisodeByTitleOrIndex()` so title-based matching can fire as the primary strategy before falling back to index-based matching.

**Fix 3 — TMDB → IMDB resolution for `/sync/history` requests (`TraktProgressService`)**

When a content ID is TMDB-only (e.g. `tmdb:12345`), `resolveHistoryIds()` now calls `tmdbService.tmdbToImdb()` to resolve an IMDB ID before sending the history request. Trakt's IMDB links are maintained far more comprehensively than its TMDB links, so this improves match rates for any content identified by TMDB ID.

## Test plan

- [x] One Piece S23E3 and S23E4 (`tt0388629`) marked as watched successfully — confirmed in Trakt history
- [x] Error toast no longer shown for anime episodes with numbering mismatch
- [x] Remap fires: second `/sync/history` request observed in logs after initial `not_found` response
- [x] Non-anime series with matching numbering unaffected (remap returns null when `hasSameSeasonStructure` is true)
- [x] TMDB-only content IDs correctly resolved to IMDB before Trakt requests