### PR TITLE
WIP feat/stereo downmix & night mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -167,6 +167,7 @@ data class PlayerSettings(
     // Audio settings
     val decoderPriority: Int = 1, // EXTENSION_RENDERER_MODE_ON (0=off, 1=on, 2=prefer)
     val tunnelingEnabled: Boolean = false,
+    val forceStereoDownmix: Boolean = false,
     val skipSilence: Boolean = false,
     val audioAmplificationDb: Int = 0,
     val persistAudioAmplification: Boolean = false,
@@ -299,6 +300,7 @@ class PlayerSettingsDataStore @Inject constructor(
     // Audio settings keys
     private val decoderPriorityKey = intPreferencesKey("decoder_priority")
     private val tunnelingEnabledKey = booleanPreferencesKey("tunneling_enabled")
+    private val forceStereoDownmixKey = booleanPreferencesKey("force_stereo_downmix")
     private val skipSilenceKey = booleanPreferencesKey("skip_silence")
     private val audioAmplificationDbKey = intPreferencesKey("audio_amplification_db")
     private val persistAudioAmplificationKey = booleanPreferencesKey("persist_audio_amplification")
@@ -444,6 +446,7 @@ class PlayerSettingsDataStore @Inject constructor(
                 } ?: LibassRenderType.OVERLAY_OPEN_GL,
                 decoderPriority = prefs[decoderPriorityKey] ?: 1,
                 tunnelingEnabled = prefs[tunnelingEnabledKey] ?: false,
+                forceStereoDownmix = prefs[forceStereoDownmixKey] ?: false,
                 skipSilence = prefs[skipSilenceKey] ?: false,
                 audioAmplificationDb = (prefs[audioAmplificationDbKey] ?: 0).coerceIn(
                     AUDIO_AMPLIFICATION_DB_MIN,
@@ -585,6 +588,12 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setTunnelingEnabled(enabled: Boolean) {
         store().edit { prefs ->
             prefs[tunnelingEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setForceStereoDownmix(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[forceStereoDownmixKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -171,6 +171,7 @@ data class PlayerSettings(
     val skipSilence: Boolean = false,
     val audioAmplificationDb: Int = 0,
     val persistAudioAmplification: Boolean = false,
+    val nightMode: Boolean = false,
     val rememberAudioDelayPerDevice: Boolean = true,
     val preferredAudioLanguage: String = AudioLanguageOption.DEVICE,
     val secondaryPreferredAudioLanguage: String? = null,
@@ -304,6 +305,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val skipSilenceKey = booleanPreferencesKey("skip_silence")
     private val audioAmplificationDbKey = intPreferencesKey("audio_amplification_db")
     private val persistAudioAmplificationKey = booleanPreferencesKey("persist_audio_amplification")
+    private val nightModeKey = booleanPreferencesKey("night_mode")
     private val rememberAudioDelayPerDeviceKey = booleanPreferencesKey("remember_audio_delay_per_device")
     private val preferredAudioLanguageKey = stringPreferencesKey("preferred_audio_language")
     private val secondaryPreferredAudioLanguageKey = stringPreferencesKey("secondary_preferred_audio_language")
@@ -453,6 +455,7 @@ class PlayerSettingsDataStore @Inject constructor(
                     AUDIO_AMPLIFICATION_DB_MAX
                 ),
                 persistAudioAmplification = prefs[persistAudioAmplificationKey] ?: false,
+                nightMode = prefs[nightModeKey] ?: false,
                 rememberAudioDelayPerDevice = prefs[rememberAudioDelayPerDeviceKey] ?: true,
                 preferredAudioLanguage = normalizeSelectableLanguageCode(
                     prefs[preferredAudioLanguageKey] ?: AudioLanguageOption.DEVICE
@@ -612,15 +615,30 @@ class PlayerSettingsDataStore @Inject constructor(
         }
     }
 
-    suspend fun setPersistAudioAmplification(enabled: Boolean, dbToPersist: Int? = null) {
+    suspend fun setPersistAudioAmplification(
+        enabled: Boolean,
+        dbToPersist: Int? = null,
+        nightModeToPersist: Boolean? = null
+    ) {
         store().edit { prefs ->
             prefs[persistAudioAmplificationKey] = enabled
-            if (enabled && dbToPersist != null) {
-                prefs[audioAmplificationDbKey] = dbToPersist.coerceIn(
-                    AUDIO_AMPLIFICATION_DB_MIN,
-                    AUDIO_AMPLIFICATION_DB_MAX
-                )
+            if (enabled) {
+                if (dbToPersist != null) {
+                    prefs[audioAmplificationDbKey] = dbToPersist.coerceIn(
+                        AUDIO_AMPLIFICATION_DB_MIN,
+                        AUDIO_AMPLIFICATION_DB_MAX
+                    )
+                }
+                if (nightModeToPersist != null) {
+                    prefs[nightModeKey] = nightModeToPersist
+                }
             }
+        }
+    }
+
+    suspend fun setNightMode(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[nightModeKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -59,10 +59,12 @@ internal fun AudioSelectionOverlay(
     audioAmplificationDb: Int,
     isAmplificationAvailable: Boolean,
     persistAmplification: Boolean,
+    forceStereoDownmixActive: Boolean,
     onTrackSelected: (Int) -> Unit,
     onAudioDelayChange: (Int) -> Unit,
     onAmplificationChange: (Int) -> Unit,
     onPersistAmplificationChange: (Boolean) -> Unit,
+    onForceStereoDownmixChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -72,6 +74,7 @@ internal fun AudioSelectionOverlay(
     val ampMinusFocusRequester = remember { FocusRequester() }
     val ampPlusFocusRequester = remember { FocusRequester() }
     val persistFocusRequester = remember { FocusRequester() }
+    val downmixFocusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
     val currentDelayMs = audioDelayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
     val canDecreaseDelay = currentDelayMs > AUDIO_DELAY_MIN_MS
@@ -152,15 +155,18 @@ internal fun AudioSelectionOverlay(
                         audioAmplificationDb = audioAmplificationDb,
                         isAmplificationAvailable = isAmplificationAvailable,
                         persistAmplification = persistAmplification,
+                        forceStereoDownmixActive = forceStereoDownmixActive,
                         delayMinusFocusRequester = delayMinusFocusRequester,
                         delayPlusFocusRequester = delayPlusFocusRequester,
                         ampMinusFocusRequester = ampMinusFocusRequester,
                         ampPlusFocusRequester = ampPlusFocusRequester,
                         persistFocusRequester = persistFocusRequester,
+                        downmixFocusRequester = downmixFocusRequester,
                         leftFocusRequester = tracksFocusRequester,
                         onAudioDelayChange = onAudioDelayChange,
                         onAmplificationChange = onAmplificationChange,
-                        onPersistAmplificationChange = onPersistAmplificationChange
+                        onPersistAmplificationChange = onPersistAmplificationChange,
+                        onForceStereoDownmixChange = onForceStereoDownmixChange
                     )
                 }
             }
@@ -315,15 +321,18 @@ private fun AudioControlsContent(
     audioAmplificationDb: Int,
     isAmplificationAvailable: Boolean,
     persistAmplification: Boolean,
+    forceStereoDownmixActive: Boolean,
     delayMinusFocusRequester: FocusRequester,
     delayPlusFocusRequester: FocusRequester,
     ampMinusFocusRequester: FocusRequester,
     ampPlusFocusRequester: FocusRequester,
     persistFocusRequester: FocusRequester,
+    downmixFocusRequester: FocusRequester,
     leftFocusRequester: FocusRequester,
     onAudioDelayChange: (Int) -> Unit,
     onAmplificationChange: (Int) -> Unit,
-    onPersistAmplificationChange: (Boolean) -> Unit
+    onPersistAmplificationChange: (Boolean) -> Unit,
+    onForceStereoDownmixChange: (Boolean) -> Unit
 ) {
     val currentDelayMs = audioDelayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
     val canDecreaseDelay = currentDelayMs > AUDIO_DELAY_MIN_MS
@@ -450,6 +459,7 @@ private fun AudioControlsContent(
                     .focusProperties {
                         left = persistLeftFocusRequester
                         up = firstAmpFocusRequester
+                        down = downmixFocusRequester
                     },
                 colors = CardDefaults.colors(
                     containerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent,
@@ -476,6 +486,44 @@ private fun AudioControlsContent(
                     },
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (persistAmplification) NuvioColors.OnSecondary else Color.White,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+                )
+            }
+
+            Card(
+                onClick = { onForceStereoDownmixChange(!forceStereoDownmixActive) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(downmixFocusRequester)
+                    .focusProperties {
+                        left = persistLeftFocusRequester
+                        up = persistFocusRequester
+                    },
+                colors = CardDefaults.colors(
+                    containerColor = if (forceStereoDownmixActive) NuvioColors.Secondary else Color.Transparent,
+                    focusedContainerColor = if (forceStereoDownmixActive) NuvioColors.Secondary else Color.Transparent
+                ),
+                shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+                border = CardDefaults.border(
+                    border = Border(
+                        border = BorderStroke(2.dp, Color.Transparent),
+                        shape = RoundedCornerShape(12.dp)
+                    ),
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                ),
+                scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+            ) {
+                Text(
+                    text = if (forceStereoDownmixActive) {
+                        stringResource(R.string.audio_force_downmix_session_on)
+                    } else {
+                        stringResource(R.string.audio_force_downmix_session_off)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (forceStereoDownmixActive) NuvioColors.OnSecondary else Color.White,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -62,11 +62,13 @@ internal fun AudioSelectionOverlay(
     isAmplificationAvailable: Boolean,
     persistAmplification: Boolean,
     forceStereoDownmixActive: Boolean,
+    nightModeActive: Boolean,
     onTrackSelected: (Int) -> Unit,
     onAudioDelayChange: (Int) -> Unit,
     onAmplificationChange: (Int) -> Unit,
     onPersistAmplificationChange: (Boolean) -> Unit,
     onForceStereoDownmixChange: (Boolean) -> Unit,
+    onNightModeChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -77,6 +79,7 @@ internal fun AudioSelectionOverlay(
     val ampPlusFocusRequester = remember { FocusRequester() }
     val persistFocusRequester = remember { FocusRequester() }
     val downmixFocusRequester = remember { FocusRequester() }
+    val nightModeFocusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
     val currentDelayMs = audioDelayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
     val canDecreaseDelay = currentDelayMs > AUDIO_DELAY_MIN_MS
@@ -163,17 +166,20 @@ internal fun AudioSelectionOverlay(
                         isAmplificationAvailable = isAmplificationAvailable,
                         persistAmplification = persistAmplification,
                         forceStereoDownmixActive = forceStereoDownmixActive,
+                        nightModeActive = nightModeActive,
                         delayMinusFocusRequester = delayMinusFocusRequester,
                         delayPlusFocusRequester = delayPlusFocusRequester,
                         ampMinusFocusRequester = ampMinusFocusRequester,
                         ampPlusFocusRequester = ampPlusFocusRequester,
                         persistFocusRequester = persistFocusRequester,
                         downmixFocusRequester = downmixFocusRequester,
+                        nightModeFocusRequester = nightModeFocusRequester,
                         leftFocusRequester = tracksFocusRequester,
                         onAudioDelayChange = onAudioDelayChange,
                         onAmplificationChange = onAmplificationChange,
                         onPersistAmplificationChange = onPersistAmplificationChange,
-                        onForceStereoDownmixChange = onForceStereoDownmixChange
+                        onForceStereoDownmixChange = onForceStereoDownmixChange,
+                        onNightModeChange = onNightModeChange
                     )
                 }
             }
@@ -329,17 +335,20 @@ private fun AudioControlsContent(
     isAmplificationAvailable: Boolean,
     persistAmplification: Boolean,
     forceStereoDownmixActive: Boolean,
+    nightModeActive: Boolean,
     delayMinusFocusRequester: FocusRequester,
     delayPlusFocusRequester: FocusRequester,
     ampMinusFocusRequester: FocusRequester,
     ampPlusFocusRequester: FocusRequester,
     persistFocusRequester: FocusRequester,
     downmixFocusRequester: FocusRequester,
+    nightModeFocusRequester: FocusRequester,
     leftFocusRequester: FocusRequester,
     onAudioDelayChange: (Int) -> Unit,
     onAmplificationChange: (Int) -> Unit,
     onPersistAmplificationChange: (Boolean) -> Unit,
-    onForceStereoDownmixChange: (Boolean) -> Unit
+    onForceStereoDownmixChange: (Boolean) -> Unit,
+    onNightModeChange: (Boolean) -> Unit
 ) {
     val currentDelayMs = audioDelayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
     val canDecreaseDelay = currentDelayMs > AUDIO_DELAY_MIN_MS
@@ -383,6 +392,11 @@ private fun AudioControlsContent(
         stringResource(R.string.audio_force_downmix_session_on)
     } else {
         stringResource(R.string.audio_force_downmix_session_off)
+    }
+    val nightModeLabel = if (nightModeActive) {
+        stringResource(R.string.audio_night_mode_session_on)
+    } else {
+        stringResource(R.string.audio_night_mode_session_off)
     }
 
     val amplificationHelperText = when {
@@ -512,6 +526,7 @@ private fun AudioControlsContent(
                     .focusProperties {
                         left = persistLeftFocusRequester
                         up = persistFocusRequester
+                        down = nightModeFocusRequester
                     },
                 colors = CardDefaults.colors(
                     containerColor = if (forceStereoDownmixActive) NuvioColors.Secondary else Color.Transparent,
@@ -534,6 +549,40 @@ private fun AudioControlsContent(
                     text = downmixLabel,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (forceStereoDownmixActive) NuvioColors.OnSecondary else Color.White,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+                )
+            }
+
+            Card(
+                onClick = { onNightModeChange(!nightModeActive) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(nightModeFocusRequester)
+                    .focusProperties {
+                        left = persistLeftFocusRequester
+                        up = downmixFocusRequester
+                    },
+                colors = CardDefaults.colors(
+                    containerColor = if (nightModeActive) NuvioColors.Secondary else Color.Transparent,
+                    focusedContainerColor = if (nightModeActive) NuvioColors.Secondary else Color.Transparent
+                ),
+                shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+                border = CardDefaults.border(
+                    border = Border(
+                        border = BorderStroke(2.dp, Color.Transparent),
+                        shape = RoundedCornerShape(12.dp)
+                    ),
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                ),
+                scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+            ) {
+                Text(
+                    text = nightModeLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (nightModeActive) NuvioColors.OnSecondary else Color.White,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -61,13 +61,11 @@ internal fun AudioSelectionOverlay(
     audioAmplificationDb: Int,
     isAmplificationAvailable: Boolean,
     persistAmplification: Boolean,
-    forceStereoDownmixActive: Boolean,
     nightModeActive: Boolean,
     onTrackSelected: (Int) -> Unit,
     onAudioDelayChange: (Int) -> Unit,
     onAmplificationChange: (Int) -> Unit,
     onPersistAmplificationChange: (Boolean) -> Unit,
-    onForceStereoDownmixChange: (Boolean) -> Unit,
     onNightModeChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
@@ -78,7 +76,6 @@ internal fun AudioSelectionOverlay(
     val ampMinusFocusRequester = remember { FocusRequester() }
     val ampPlusFocusRequester = remember { FocusRequester() }
     val persistFocusRequester = remember { FocusRequester() }
-    val downmixFocusRequester = remember { FocusRequester() }
     val nightModeFocusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
     val currentDelayMs = audioDelayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
@@ -165,20 +162,17 @@ internal fun AudioSelectionOverlay(
                         audioAmplificationDb = audioAmplificationDb,
                         isAmplificationAvailable = isAmplificationAvailable,
                         persistAmplification = persistAmplification,
-                        forceStereoDownmixActive = forceStereoDownmixActive,
                         nightModeActive = nightModeActive,
                         delayMinusFocusRequester = delayMinusFocusRequester,
                         delayPlusFocusRequester = delayPlusFocusRequester,
                         ampMinusFocusRequester = ampMinusFocusRequester,
                         ampPlusFocusRequester = ampPlusFocusRequester,
                         persistFocusRequester = persistFocusRequester,
-                        downmixFocusRequester = downmixFocusRequester,
                         nightModeFocusRequester = nightModeFocusRequester,
                         leftFocusRequester = tracksFocusRequester,
                         onAudioDelayChange = onAudioDelayChange,
                         onAmplificationChange = onAmplificationChange,
                         onPersistAmplificationChange = onPersistAmplificationChange,
-                        onForceStereoDownmixChange = onForceStereoDownmixChange,
                         onNightModeChange = onNightModeChange
                     )
                 }
@@ -334,20 +328,17 @@ private fun AudioControlsContent(
     audioAmplificationDb: Int,
     isAmplificationAvailable: Boolean,
     persistAmplification: Boolean,
-    forceStereoDownmixActive: Boolean,
     nightModeActive: Boolean,
     delayMinusFocusRequester: FocusRequester,
     delayPlusFocusRequester: FocusRequester,
     ampMinusFocusRequester: FocusRequester,
     ampPlusFocusRequester: FocusRequester,
     persistFocusRequester: FocusRequester,
-    downmixFocusRequester: FocusRequester,
     nightModeFocusRequester: FocusRequester,
     leftFocusRequester: FocusRequester,
     onAudioDelayChange: (Int) -> Unit,
     onAmplificationChange: (Int) -> Unit,
     onPersistAmplificationChange: (Boolean) -> Unit,
-    onForceStereoDownmixChange: (Boolean) -> Unit,
     onNightModeChange: (Boolean) -> Unit
 ) {
     val currentDelayMs = audioDelayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
@@ -387,11 +378,6 @@ private fun AudioControlsContent(
         stringResource(R.string.audio_mix_persist_on)
     } else {
         stringResource(R.string.audio_mix_persist_off)
-    }
-    val downmixLabel = if (forceStereoDownmixActive) {
-        stringResource(R.string.audio_force_downmix_session_on)
-    } else {
-        stringResource(R.string.audio_force_downmix_session_off)
     }
     val nightModeLabel = if (nightModeActive) {
         stringResource(R.string.audio_night_mode_session_on)
@@ -466,7 +452,7 @@ private fun AudioControlsContent(
                 minusLeftFocusRequester = leftFocusRequester,
                 plusLeftFocusRequester = ampPlusLeftFocusRequester,
                 upFocusRequester = firstDelayFocusRequester,
-                downFocusRequester = persistFocusRequester,
+                downFocusRequester = nightModeFocusRequester,
                 onDecrease = {
                     val nextDb = currentDb - 1
                     onAmplificationChange(nextDb)
@@ -484,83 +470,14 @@ private fun AudioControlsContent(
             )
 
             Card(
-                onClick = { onPersistAmplificationChange(!persistAmplification) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(persistFocusRequester)
-                    .focusProperties {
-                        left = persistLeftFocusRequester
-                        up = firstAmpFocusRequester
-                        down = downmixFocusRequester
-                    },
-                colors = CardDefaults.colors(
-                    containerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent,
-                    focusedContainerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent
-                ),
-                shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-                border = CardDefaults.border(
-                    border = Border(
-                        border = BorderStroke(2.dp, Color.Transparent),
-                        shape = RoundedCornerShape(12.dp)
-                    ),
-                    focusedBorder = Border(
-                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                ),
-                scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
-            ) {
-                Text(
-                    text = persistLabel,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (persistAmplification) NuvioColors.OnSecondary else Color.White,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
-                )
-            }
-
-            Card(
-                onClick = { onForceStereoDownmixChange(!forceStereoDownmixActive) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(downmixFocusRequester)
-                    .focusProperties {
-                        left = persistLeftFocusRequester
-                        up = persistFocusRequester
-                        down = nightModeFocusRequester
-                    },
-                colors = CardDefaults.colors(
-                    containerColor = if (forceStereoDownmixActive) NuvioColors.Secondary else Color.Transparent,
-                    focusedContainerColor = if (forceStereoDownmixActive) NuvioColors.Secondary else Color.Transparent
-                ),
-                shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-                border = CardDefaults.border(
-                    border = Border(
-                        border = BorderStroke(2.dp, Color.Transparent),
-                        shape = RoundedCornerShape(12.dp)
-                    ),
-                    focusedBorder = Border(
-                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                ),
-                scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
-            ) {
-                Text(
-                    text = downmixLabel,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (forceStereoDownmixActive) NuvioColors.OnSecondary else Color.White,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
-                )
-            }
-
-            Card(
                 onClick = { onNightModeChange(!nightModeActive) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(nightModeFocusRequester)
                     .focusProperties {
                         left = persistLeftFocusRequester
-                        up = downmixFocusRequester
+                        up = firstAmpFocusRequester
+                        down = persistFocusRequester
                     },
                 colors = CardDefaults.colors(
                     containerColor = if (nightModeActive) NuvioColors.Secondary else Color.Transparent,
@@ -583,6 +500,40 @@ private fun AudioControlsContent(
                     text = nightModeLabel,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (nightModeActive) NuvioColors.OnSecondary else Color.White,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+                )
+            }
+
+            Card(
+                onClick = { onPersistAmplificationChange(!persistAmplification) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(persistFocusRequester)
+                    .focusProperties {
+                        left = persistLeftFocusRequester
+                        up = nightModeFocusRequester
+                    },
+                colors = CardDefaults.colors(
+                    containerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent,
+                    focusedContainerColor = if (persistAmplification) NuvioColors.Secondary else Color.Transparent
+                ),
+                shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+                border = CardDefaults.border(
+                    border = Border(
+                        border = BorderStroke(2.dp, Color.Transparent),
+                        shape = RoundedCornerShape(12.dp)
+                    ),
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                ),
+                scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+            ) {
+                Text(
+                    text = persistLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (persistAmplification) NuvioColors.OnSecondary else Color.White,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -367,6 +367,17 @@ private fun AudioControlsContent(
         else -> leftFocusRequester
     }
 
+    val persistLabel = if (persistAmplification) {
+        stringResource(R.string.audio_mix_persist_on)
+    } else {
+        stringResource(R.string.audio_mix_persist_off)
+    }
+    val downmixLabel = if (forceStereoDownmixActive) {
+        stringResource(R.string.audio_force_downmix_session_on)
+    } else {
+        stringResource(R.string.audio_force_downmix_session_off)
+    }
+
     val amplificationHelperText = when {
         !isAmplificationAvailable -> stringResource(R.string.audio_mix_unavailable)
         persistAmplification -> stringResource(
@@ -479,11 +490,7 @@ private fun AudioControlsContent(
                 scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
             ) {
                 Text(
-                    text = if (persistAmplification) {
-                        stringResource(R.string.audio_mix_persist_on)
-                    } else {
-                        stringResource(R.string.audio_mix_persist_off)
-                    },
+                    text = persistLabel,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (persistAmplification) NuvioColors.OnSecondary else Color.White,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
@@ -517,11 +524,7 @@ private fun AudioControlsContent(
                 scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
             ) {
                 Text(
-                    text = if (forceStereoDownmixActive) {
-                        stringResource(R.string.audio_force_downmix_session_on)
-                    } else {
-                        stringResource(R.string.audio_force_downmix_session_off)
-                    },
+                    text = downmixLabel,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (forceStereoDownmixActive) NuvioColors.OnSecondary else Color.White,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -149,7 +151,12 @@ internal fun AudioSelectionOverlay(
                         onTrackSelected = onTrackSelected
                     )
                 }
-                Column(modifier = Modifier.width(286.dp)) {
+                Column(
+                    modifier = Modifier
+                        .width(286.dp)
+                        .heightIn(max = 620.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     AudioControlsContent(
                         audioDelayMs = audioDelayMs,
                         audioAmplificationDb = audioAmplificationDb,
@@ -395,8 +402,8 @@ private fun AudioControlsContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 8.dp, bottom = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(18.dp)
+            .padding(top = 4.dp, bottom = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         AdjustmentSection(
             title = stringResource(R.string.audio_delay_label),
@@ -432,7 +439,7 @@ private fun AudioControlsContent(
 
         Column(
             modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             AdjustmentSection(
                 title = stringResource(R.string.audio_mix_label),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/CenterChannelGainAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/CenterChannelGainAudioProcessor.kt
@@ -17,7 +17,7 @@ internal class CenterChannelGainAudioProcessor : BaseAudioProcessor() {
     private var gainScale: Float = 1f
 
     fun setGainDb(db: Int) {
-        val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+        val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_CENTER_MAX_DB)
         gainDb = clampedDb
         gainScale = if (clampedDb == 0) 1f else 10.0.pow(clampedDb / 20.0).toFloat()
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/CenterChannelGainAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/CenterChannelGainAudioProcessor.kt
@@ -1,0 +1,122 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+internal class CenterChannelGainAudioProcessor : BaseAudioProcessor() {
+
+    @Volatile
+    private var gainDb: Int = 0
+
+    @Volatile
+    private var gainScale: Float = 1f
+
+    fun setGainDb(db: Int) {
+        val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+        gainDb = clampedDb
+        gainScale = if (clampedDb == 0) 1f else 10.0.pow(clampedDb / 20.0).toFloat()
+    }
+
+    override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        if (inputAudioFormat.channelCount < 3) {
+            return AudioProcessor.AudioFormat.NOT_SET
+        }
+        return when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT,
+            C.ENCODING_PCM_FLOAT -> inputAudioFormat
+            else -> AudioProcessor.AudioFormat.NOT_SET
+        }
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        if (!inputBuffer.hasRemaining()) return
+
+        val inputSize = inputBuffer.remaining()
+        val outputBuffer = replaceOutputBuffer(inputSize)
+        val scale = gainScale
+
+        if (scale == 1f) {
+            outputBuffer.put(inputBuffer)
+            outputBuffer.flip()
+            return
+        }
+
+        val channelCount = inputAudioFormat.channelCount
+        val centerIndex = CENTER_CHANNEL_INDEX
+
+        when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT -> processPcm16(inputBuffer, outputBuffer, scale, channelCount, centerIndex)
+            C.ENCODING_PCM_FLOAT -> processPcmFloat(inputBuffer, outputBuffer, scale, channelCount, centerIndex)
+            else -> outputBuffer.put(inputBuffer)
+        }
+
+        outputBuffer.flip()
+    }
+
+    private fun processPcm16(
+        inputBuffer: ByteBuffer,
+        outputBuffer: ByteBuffer,
+        scale: Float,
+        channelCount: Int,
+        centerIndex: Int
+    ) {
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+
+        val frameBytes = channelCount * 2
+        while (inputBuffer.remaining() >= frameBytes) {
+            for (channel in 0 until channelCount) {
+                val sample = inputBuffer.short.toInt()
+                val outSample = if (channel == centerIndex) {
+                    (sample * scale)
+                        .roundToInt()
+                        .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+                } else {
+                    sample
+                }
+                outputBuffer.putShort(outSample.toShort())
+            }
+        }
+
+        if (inputBuffer.hasRemaining()) {
+            outputBuffer.put(inputBuffer)
+        }
+    }
+
+    private fun processPcmFloat(
+        inputBuffer: ByteBuffer,
+        outputBuffer: ByteBuffer,
+        scale: Float,
+        channelCount: Int,
+        centerIndex: Int
+    ) {
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+
+        val frameBytes = channelCount * 4
+        while (inputBuffer.remaining() >= frameBytes) {
+            for (channel in 0 until channelCount) {
+                val sample = inputBuffer.float
+                val outSample = if (channel == centerIndex) {
+                    (sample * scale).coerceIn(-1f, 1f)
+                } else {
+                    sample
+                }
+                outputBuffer.putFloat(outSample)
+            }
+        }
+
+        if (inputBuffer.hasRemaining()) {
+            outputBuffer.put(inputBuffer)
+        }
+    }
+
+    companion object {
+        private const val CENTER_CHANNEL_INDEX = 2
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.PI
 import kotlin.math.cos
+import kotlin.math.exp
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sin
@@ -15,6 +16,24 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
 
     @Volatile
     private var enabled: Boolean = false
+
+    @Volatile
+    private var compressionEnabled: Boolean = false
+
+    @Volatile
+    private var compressionThresholdFraction: Float = 1f
+
+    @Volatile
+    private var compressionMaxGain: Float = 1f
+
+    private var attackCoeff: Float = 0f
+    private var releaseCoeff: Float = 0f
+    private var gainSmoothCoeff: Float = 0f
+
+    private var stereoMidEnvelope: Float = 0f
+    private var stereoMidGain: Float = 1f
+    private var multichannelFcEnvelope: Float = 0f
+    private var multichannelFcGain: Float = 1f
 
     private var hpfStage1: Array<BiquadState> = emptyArray()
     private var hpfStage2: Array<BiquadState> = emptyArray()
@@ -28,15 +47,76 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         enabled = on
     }
 
+    fun setDialogIsolationDb(extraDb: Float) {
+        val amp = (extraDb * 0.5f).coerceIn(0f, AMP_RANGE_DB)
+        if (amp <= 0f) {
+            compressionEnabled = false
+            compressionThresholdFraction = 1f
+            compressionMaxGain = 1f
+            return
+        }
+        val ampNorm = amp / AMP_RANGE_DB
+        val thresholdDb =
+            COMP_THRESHOLD_HIGH_DB + ampNorm * (COMP_THRESHOLD_LOW_DB - COMP_THRESHOLD_HIGH_DB)
+        val maxBoostDb = ampNorm * COMP_MAX_BOOST_DB
+        compressionThresholdFraction = 10f.pow(thresholdDb / 20f)
+        compressionMaxGain = 10f.pow(maxBoostDb / 20f)
+        compressionEnabled = true
+    }
+
     override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
         return when (inputAudioFormat.encoding) {
             C.ENCODING_PCM_16BIT,
             C.ENCODING_PCM_FLOAT -> {
-                configureHpf(inputAudioFormat.sampleRate.toFloat(), inputAudioFormat.channelCount)
+                val sampleRate = inputAudioFormat.sampleRate.toFloat()
+                configureHpf(sampleRate, inputAudioFormat.channelCount)
+                configureCompressor(sampleRate)
                 inputAudioFormat
             }
             else -> AudioProcessor.AudioFormat.NOT_SET
         }
+    }
+
+    private fun configureCompressor(sampleRate: Float) {
+        attackCoeff = exp(-1f / (sampleRate * COMP_ATTACK_SECONDS))
+        releaseCoeff = exp(-1f / (sampleRate * COMP_RELEASE_SECONDS))
+        gainSmoothCoeff = exp(-1f / (sampleRate * COMP_GAIN_SMOOTH_SECONDS))
+        stereoMidEnvelope = 0f
+        stereoMidGain = 1f
+        multichannelFcEnvelope = 0f
+        multichannelFcGain = 1f
+    }
+
+    private fun updateStereoMidGain(mid: Float, fullScale: Float): Float {
+        if (!compressionEnabled) return MID_GAIN
+        val absMid = if (mid < 0f) -mid else mid
+        val coeff = if (absMid > stereoMidEnvelope) attackCoeff else releaseCoeff
+        stereoMidEnvelope = absMid + coeff * (stereoMidEnvelope - absMid)
+        val thresholdSamples = compressionThresholdFraction * fullScale
+        val noiseFloor = NOISE_FLOOR_FRACTION * fullScale
+        val rawGain = when {
+            stereoMidEnvelope < noiseFloor -> 1f
+            stereoMidEnvelope >= thresholdSamples -> 1f
+            else -> (thresholdSamples / stereoMidEnvelope).coerceAtMost(compressionMaxGain)
+        }
+        stereoMidGain = rawGain + gainSmoothCoeff * (stereoMidGain - rawGain)
+        return stereoMidGain * MID_GAIN
+    }
+
+    private fun updateMultichannelFcGain(fc: Float, fullScale: Float): Float {
+        if (!compressionEnabled) return MID_GAIN
+        val absFc = if (fc < 0f) -fc else fc
+        val coeff = if (absFc > multichannelFcEnvelope) attackCoeff else releaseCoeff
+        multichannelFcEnvelope = absFc + coeff * (multichannelFcEnvelope - absFc)
+        val thresholdSamples = compressionThresholdFraction * fullScale
+        val noiseFloor = NOISE_FLOOR_FRACTION * fullScale
+        val rawGain = when {
+            multichannelFcEnvelope < noiseFloor -> 1f
+            multichannelFcEnvelope >= thresholdSamples -> 1f
+            else -> (thresholdSamples / multichannelFcEnvelope).coerceAtMost(compressionMaxGain)
+        }
+        multichannelFcGain = rawGain + gainSmoothCoeff * (multichannelFcGain - rawGain)
+        return multichannelFcGain * MID_GAIN
     }
 
     private fun configureHpf(sampleRate: Float, channelCount: Int) {
@@ -122,12 +202,13 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     }
 
     private fun processStereoPcm16(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer) {
+        val fullScale = SHORT_FULL_SCALE
         while (inputBuffer.remaining() >= 4) {
             val l = inputBuffer.short.toFloat()
             val r = inputBuffer.short.toFloat()
             val mid = (l + r) * 0.5f
             val side = (l - r) * 0.5f * SIDE_GAIN
-            val midBoost = mid * MID_GAIN
+            val midBoost = mid * updateStereoMidGain(mid, fullScale)
             val preL = midBoost + side
             val preR = midBoost - side
             val filtL = applyShelf(0, preL)
@@ -141,12 +222,13 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     }
 
     private fun processStereoPcmFloat(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer) {
+        val fullScale = FLOAT_FULL_SCALE
         while (inputBuffer.remaining() >= 8) {
             val l = inputBuffer.float
             val r = inputBuffer.float
             val mid = (l + r) * 0.5f
             val side = (l - r) * 0.5f * SIDE_GAIN
-            val midBoost = mid * MID_GAIN
+            val midBoost = mid * updateStereoMidGain(mid, fullScale)
             val preL = midBoost + side
             val preR = midBoost - side
             val filtL = applyShelf(0, preL)
@@ -165,11 +247,12 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val frameBytes = channelCount * 2
         val centerIndex = if (channelCount >= 3) 2 else -1
         val lfeIndex = if (channelCount >= 4) 3 else -1
+        val fullScale = SHORT_FULL_SCALE
         while (inputBuffer.remaining() >= frameBytes) {
             for (channel in 0 until channelCount) {
                 val sample = inputBuffer.short.toFloat()
                 val scale = when (channel) {
-                    centerIndex -> MID_GAIN
+                    centerIndex -> updateMultichannelFcGain(sample, fullScale)
                     lfeIndex -> LFE_GAIN
                     else -> NON_CENTER_GAIN
                 }
@@ -191,11 +274,12 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val frameBytes = channelCount * 4
         val centerIndex = if (channelCount >= 3) 2 else -1
         val lfeIndex = if (channelCount >= 4) 3 else -1
+        val fullScale = FLOAT_FULL_SCALE
         while (inputBuffer.remaining() >= frameBytes) {
             for (channel in 0 until channelCount) {
                 val sample = inputBuffer.float
                 val scale = when (channel) {
-                    centerIndex -> MID_GAIN
+                    centerIndex -> updateMultichannelFcGain(sample, fullScale)
                     lfeIndex -> LFE_GAIN
                     else -> NON_CENTER_GAIN
                 }
@@ -224,5 +308,16 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         private val SIDE_GAIN = 10f.pow(SIDE_ATTENUATION_DB / 20f)
         private val NON_CENTER_GAIN = 10f.pow(NON_CENTER_ATTENUATION_DB / 20f)
         private val LFE_GAIN = 10f.pow(LFE_ATTENUATION_DB / 20f)
+
+        private const val AMP_RANGE_DB = 10f
+        private const val COMP_THRESHOLD_HIGH_DB = -12f
+        private const val COMP_THRESHOLD_LOW_DB = -36f
+        private const val COMP_MAX_BOOST_DB = 18f
+        private const val COMP_ATTACK_SECONDS = 0.010f
+        private const val COMP_RELEASE_SECONDS = 0.200f
+        private const val COMP_GAIN_SMOOTH_SECONDS = 0.020f
+        private const val NOISE_FLOOR_FRACTION = 0.0005f
+        private const val SHORT_FULL_SCALE = 32768f
+        private const val FLOAT_FULL_SCALE = 1f
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
@@ -214,11 +214,11 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     }
 
     companion object {
-        private const val MID_BOOST_DB = 9f
+        private const val MID_BOOST_DB = 0f
         private const val SIDE_ATTENUATION_DB = -60f
         private const val NON_CENTER_ATTENUATION_DB = -48f
         private const val LFE_ATTENUATION_DB = -80f
-        private const val HPF_CUTOFF_HZ = 130f
+        private const val HPF_CUTOFF_HZ = 60f
         private const val HPF_Q = 0.7071f
         private val MID_GAIN = 10f.pow(MID_BOOST_DB / 20f)
         private val SIDE_GAIN = 10f.pow(SIDE_ATTENUATION_DB / 20f)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
@@ -26,6 +26,21 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     @Volatile
     private var compressionMaxGain: Float = 1f
 
+    @Volatile
+    private var peakLimitFraction: Float = 1f
+
+    @Volatile
+    private var peakMinGain: Float = 1f
+
+    @Volatile
+    private var midStaticGain: Float = MID_GAIN
+
+    @Volatile
+    private var currentSideGain: Float = SIDE_GAIN_MIN
+
+    @Volatile
+    private var currentNonCenterGain: Float = NON_CENTER_GAIN_MIN
+
     private var attackCoeff: Float = 0f
     private var releaseCoeff: Float = 0f
     private var gainSmoothCoeff: Float = 0f
@@ -43,24 +58,62 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     private var hpfA1: Float = 0f
     private var hpfA2: Float = 0f
 
+    private var mudStates: Array<BiquadState> = emptyArray()
+
+    @Volatile
+    private var mudB0: Float = 1f
+
+    @Volatile
+    private var mudB1: Float = 0f
+
+    @Volatile
+    private var mudB2: Float = 0f
+
+    @Volatile
+    private var mudA1: Float = 0f
+
+    @Volatile
+    private var mudA2: Float = 0f
+
+    private var cachedSampleRate: Float = 0f
+
     fun setEnabled(on: Boolean) {
         enabled = on
     }
 
     fun setDialogIsolationDb(extraDb: Float) {
         val amp = (extraDb * 0.5f).coerceIn(0f, AMP_RANGE_DB)
+        val ampNorm = amp / AMP_RANGE_DB
+        val sideDb =
+            SIDE_ATTENUATION_MIN_DB + ampNorm * (SIDE_ATTENUATION_MAX_DB - SIDE_ATTENUATION_MIN_DB)
+        val nonCenterDb = NON_CENTER_ATTENUATION_MIN_DB +
+            ampNorm * (NON_CENTER_ATTENUATION_MAX_DB - NON_CENTER_ATTENUATION_MIN_DB)
+        val mudCutDb = MUD_CUT_MIN_DB + ampNorm * (MUD_CUT_MAX_DB - MUD_CUT_MIN_DB)
+        currentSideGain = 10f.pow(sideDb / 20f)
+        currentNonCenterGain = 10f.pow(nonCenterDb / 20f)
+        updateMudCoefficients(mudCutDb)
         if (amp <= 0f) {
             compressionEnabled = false
             compressionThresholdFraction = 1f
             compressionMaxGain = 1f
+            peakLimitFraction = 1f
+            peakMinGain = 1f
+            midStaticGain = MID_GAIN
             return
         }
-        val ampNorm = amp / AMP_RANGE_DB
         val thresholdDb =
             COMP_THRESHOLD_HIGH_DB + ampNorm * (COMP_THRESHOLD_LOW_DB - COMP_THRESHOLD_HIGH_DB)
         val maxBoostDb = ampNorm * COMP_MAX_BOOST_DB
+        val staticBoostDb = MID_STATIC_BOOST_MIN_DB +
+            ampNorm * (MID_STATIC_BOOST_MAX_DB - MID_STATIC_BOOST_MIN_DB)
+        val peakThresholdDb =
+            PEAK_THRESHOLD_HIGH_DB + ampNorm * (PEAK_THRESHOLD_LOW_DB - PEAK_THRESHOLD_HIGH_DB)
+        val peakMaxAttenDb = ampNorm * PEAK_MAX_ATTEN_DB
         compressionThresholdFraction = 10f.pow(thresholdDb / 20f)
         compressionMaxGain = 10f.pow(maxBoostDb / 20f)
+        peakLimitFraction = 10f.pow(peakThresholdDb / 20f)
+        peakMinGain = 10f.pow(-peakMaxAttenDb / 20f)
+        midStaticGain = 10f.pow((MID_BOOST_DB + staticBoostDb) / 20f)
         compressionEnabled = true
     }
 
@@ -69,12 +122,60 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
             C.ENCODING_PCM_16BIT,
             C.ENCODING_PCM_FLOAT -> {
                 val sampleRate = inputAudioFormat.sampleRate.toFloat()
+                cachedSampleRate = sampleRate
                 configureHpf(sampleRate, inputAudioFormat.channelCount)
                 configureCompressor(sampleRate)
+                configureMud(inputAudioFormat.channelCount)
                 inputAudioFormat
             }
             else -> AudioProcessor.AudioFormat.NOT_SET
         }
+    }
+
+    private fun configureMud(channelCount: Int) {
+        mudStates = Array(channelCount) { BiquadState() }
+        // Coefficients will be updated on next setDialogIsolationDb call; default unity passthrough.
+        mudB0 = 1f
+        mudB1 = 0f
+        mudB2 = 0f
+        mudA1 = 0f
+        mudA2 = 0f
+    }
+
+    private fun updateMudCoefficients(gainDb: Float) {
+        val sampleRate = cachedSampleRate
+        if (sampleRate <= 0f) return
+        if (gainDb >= 0f) {
+            mudB0 = 1f
+            mudB1 = 0f
+            mudB2 = 0f
+            mudA1 = 0f
+            mudA2 = 0f
+            return
+        }
+        val a = 10f.pow(gainDb / 40f)
+        val w0 = 2.0 * PI * MUD_FREQ_HZ / sampleRate
+        val cosW0 = cos(w0).toFloat()
+        val sinW0 = sin(w0).toFloat()
+        val alpha = sinW0 / (2f * MUD_Q)
+        val a0 = 1f + alpha / a
+        mudB0 = (1f + alpha * a) / a0
+        mudB1 = (-2f * cosW0) / a0
+        mudB2 = (1f - alpha * a) / a0
+        mudA1 = (-2f * cosW0) / a0
+        mudA2 = (1f - alpha / a) / a0
+    }
+
+    private fun applyMud(channel: Int, input: Float): Float {
+        if (channel >= mudStates.size) return input
+        val state = mudStates[channel]
+        val y = mudB0 * input + mudB1 * state.x1 + mudB2 * state.x2 -
+            mudA1 * state.y1 - mudA2 * state.y2
+        state.x2 = state.x1
+        state.x1 = input
+        state.y2 = state.y1
+        state.y1 = y
+        return y
     }
 
     private fun configureCompressor(sampleRate: Float) {
@@ -93,14 +194,18 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val coeff = if (absMid > stereoMidEnvelope) attackCoeff else releaseCoeff
         stereoMidEnvelope = absMid + coeff * (stereoMidEnvelope - absMid)
         val thresholdSamples = compressionThresholdFraction * fullScale
+        val peakSamples = peakLimitFraction * fullScale
         val noiseFloor = NOISE_FLOOR_FRACTION * fullScale
         val rawGain = when {
             stereoMidEnvelope < noiseFloor -> 1f
-            stereoMidEnvelope >= thresholdSamples -> 1f
-            else -> (thresholdSamples / stereoMidEnvelope).coerceAtMost(compressionMaxGain)
+            stereoMidEnvelope < thresholdSamples ->
+                (thresholdSamples / stereoMidEnvelope).coerceAtMost(compressionMaxGain)
+            stereoMidEnvelope > peakSamples ->
+                (peakSamples / stereoMidEnvelope).coerceAtLeast(peakMinGain)
+            else -> 1f
         }
         stereoMidGain = rawGain + gainSmoothCoeff * (stereoMidGain - rawGain)
-        return stereoMidGain * MID_GAIN
+        return stereoMidGain * midStaticGain
     }
 
     private fun updateMultichannelFcGain(fc: Float, fullScale: Float): Float {
@@ -109,14 +214,18 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val coeff = if (absFc > multichannelFcEnvelope) attackCoeff else releaseCoeff
         multichannelFcEnvelope = absFc + coeff * (multichannelFcEnvelope - absFc)
         val thresholdSamples = compressionThresholdFraction * fullScale
+        val peakSamples = peakLimitFraction * fullScale
         val noiseFloor = NOISE_FLOOR_FRACTION * fullScale
         val rawGain = when {
             multichannelFcEnvelope < noiseFloor -> 1f
-            multichannelFcEnvelope >= thresholdSamples -> 1f
-            else -> (thresholdSamples / multichannelFcEnvelope).coerceAtMost(compressionMaxGain)
+            multichannelFcEnvelope < thresholdSamples ->
+                (thresholdSamples / multichannelFcEnvelope).coerceAtMost(compressionMaxGain)
+            multichannelFcEnvelope > peakSamples ->
+                (peakSamples / multichannelFcEnvelope).coerceAtLeast(peakMinGain)
+            else -> 1f
         }
         multichannelFcGain = rawGain + gainSmoothCoeff * (multichannelFcGain - rawGain)
-        return multichannelFcGain * MID_GAIN
+        return multichannelFcGain * midStaticGain
     }
 
     private fun configureHpf(sampleRate: Float, channelCount: Int) {
@@ -203,16 +312,19 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
 
     private fun processStereoPcm16(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer) {
         val fullScale = SHORT_FULL_SCALE
+        val sideGain = currentSideGain
         while (inputBuffer.remaining() >= 4) {
             val l = inputBuffer.short.toFloat()
             val r = inputBuffer.short.toFloat()
             val mid = (l + r) * 0.5f
-            val side = (l - r) * 0.5f * SIDE_GAIN
+            val side = (l - r) * 0.5f * sideGain
             val midBoost = mid * updateStereoMidGain(mid, fullScale)
             val preL = midBoost + side
             val preR = midBoost - side
-            val filtL = applyShelf(0, preL)
-            val filtR = applyShelf(1, preR)
+            val hpL = applyShelf(0, preL)
+            val hpR = applyShelf(1, preR)
+            val filtL = applyMud(0, hpL)
+            val filtR = applyMud(1, hpR)
             val newL = filtL.coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat())
             val newR = filtR.coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat())
             outputBuffer.putShort(newL.roundToInt().toShort())
@@ -223,16 +335,19 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
 
     private fun processStereoPcmFloat(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer) {
         val fullScale = FLOAT_FULL_SCALE
+        val sideGain = currentSideGain
         while (inputBuffer.remaining() >= 8) {
             val l = inputBuffer.float
             val r = inputBuffer.float
             val mid = (l + r) * 0.5f
-            val side = (l - r) * 0.5f * SIDE_GAIN
+            val side = (l - r) * 0.5f * sideGain
             val midBoost = mid * updateStereoMidGain(mid, fullScale)
             val preL = midBoost + side
             val preR = midBoost - side
-            val filtL = applyShelf(0, preL)
-            val filtR = applyShelf(1, preR)
+            val hpL = applyShelf(0, preL)
+            val hpR = applyShelf(1, preR)
+            val filtL = applyMud(0, hpL)
+            val filtR = applyMud(1, hpR)
             outputBuffer.putFloat(filtL.coerceIn(-1f, 1f))
             outputBuffer.putFloat(filtR.coerceIn(-1f, 1f))
         }
@@ -248,16 +363,22 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val centerIndex = if (channelCount >= 3) 2 else -1
         val lfeIndex = if (channelCount >= 4) 3 else -1
         val fullScale = SHORT_FULL_SCALE
+        val nonCenterGain = currentNonCenterGain
         while (inputBuffer.remaining() >= frameBytes) {
             for (channel in 0 until channelCount) {
                 val sample = inputBuffer.short.toFloat()
                 val scale = when (channel) {
                     centerIndex -> updateMultichannelFcGain(sample, fullScale)
                     lfeIndex -> LFE_GAIN
-                    else -> NON_CENTER_GAIN
+                    else -> nonCenterGain
                 }
                 val scaled = sample * scale
-                val filtered = applyShelf(channel, scaled)
+                val hpFiltered = applyShelf(channel, scaled)
+                val filtered = if (channel == centerIndex) {
+                    applyMud(channel, hpFiltered)
+                } else {
+                    hpFiltered
+                }
                 val amplified = filtered
                     .coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat())
                 outputBuffer.putShort(amplified.roundToInt().toShort())
@@ -275,15 +396,21 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val centerIndex = if (channelCount >= 3) 2 else -1
         val lfeIndex = if (channelCount >= 4) 3 else -1
         val fullScale = FLOAT_FULL_SCALE
+        val nonCenterGain = currentNonCenterGain
         while (inputBuffer.remaining() >= frameBytes) {
             for (channel in 0 until channelCount) {
                 val sample = inputBuffer.float
                 val scale = when (channel) {
                     centerIndex -> updateMultichannelFcGain(sample, fullScale)
                     lfeIndex -> LFE_GAIN
-                    else -> NON_CENTER_GAIN
+                    else -> nonCenterGain
                 }
-                val filtered = applyShelf(channel, sample * scale)
+                val hpFiltered = applyShelf(channel, sample * scale)
+                val filtered = if (channel == centerIndex) {
+                    applyMud(channel, hpFiltered)
+                } else {
+                    hpFiltered
+                }
                 outputBuffer.putFloat(filtered.coerceIn(-1f, 1f))
             }
         }
@@ -299,20 +426,31 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
 
     companion object {
         private const val MID_BOOST_DB = 0f
-        private const val SIDE_ATTENUATION_DB = -60f
-        private const val NON_CENTER_ATTENUATION_DB = -48f
+        private const val SIDE_ATTENUATION_MIN_DB = -12f
+        private const val SIDE_ATTENUATION_MAX_DB = -60f
+        private const val NON_CENTER_ATTENUATION_MIN_DB = -12f
+        private const val NON_CENTER_ATTENUATION_MAX_DB = -48f
         private const val LFE_ATTENUATION_DB = -80f
         private const val HPF_CUTOFF_HZ = 60f
         private const val HPF_Q = 0.7071f
         private val MID_GAIN = 10f.pow(MID_BOOST_DB / 20f)
-        private val SIDE_GAIN = 10f.pow(SIDE_ATTENUATION_DB / 20f)
-        private val NON_CENTER_GAIN = 10f.pow(NON_CENTER_ATTENUATION_DB / 20f)
+        private val SIDE_GAIN_MIN = 10f.pow(SIDE_ATTENUATION_MIN_DB / 20f)
+        private val NON_CENTER_GAIN_MIN = 10f.pow(NON_CENTER_ATTENUATION_MIN_DB / 20f)
         private val LFE_GAIN = 10f.pow(LFE_ATTENUATION_DB / 20f)
 
         private const val AMP_RANGE_DB = 10f
         private const val COMP_THRESHOLD_HIGH_DB = -12f
-        private const val COMP_THRESHOLD_LOW_DB = -36f
-        private const val COMP_MAX_BOOST_DB = 18f
+        private const val COMP_THRESHOLD_LOW_DB = -30f
+        private const val COMP_MAX_BOOST_DB = 24f
+        private const val MID_STATIC_BOOST_MIN_DB = 0f
+        private const val MID_STATIC_BOOST_MAX_DB = 0f
+        private const val PEAK_THRESHOLD_HIGH_DB = -3f
+        private const val PEAK_THRESHOLD_LOW_DB = -12f
+        private const val PEAK_MAX_ATTEN_DB = 18f
+        private const val MUD_FREQ_HZ = 250f
+        private const val MUD_Q = 1.0f
+        private const val MUD_CUT_MIN_DB = -2f
+        private const val MUD_CUT_MAX_DB = -8f
         private const val COMP_ATTACK_SECONDS = 0.010f
         private const val COMP_RELEASE_SECONDS = 0.200f
         private const val COMP_GAIN_SMOOTH_SECONDS = 0.020f

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
@@ -1,0 +1,228 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+internal class NightModeAudioProcessor : BaseAudioProcessor() {
+
+    @Volatile
+    private var enabled: Boolean = false
+
+    private var hpfStage1: Array<BiquadState> = emptyArray()
+    private var hpfStage2: Array<BiquadState> = emptyArray()
+    private var hpfB0: Float = 0f
+    private var hpfB1: Float = 0f
+    private var hpfB2: Float = 0f
+    private var hpfA1: Float = 0f
+    private var hpfA2: Float = 0f
+
+    fun setEnabled(on: Boolean) {
+        enabled = on
+    }
+
+    override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        return when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT,
+            C.ENCODING_PCM_FLOAT -> {
+                configureHpf(inputAudioFormat.sampleRate.toFloat(), inputAudioFormat.channelCount)
+                inputAudioFormat
+            }
+            else -> AudioProcessor.AudioFormat.NOT_SET
+        }
+    }
+
+    private fun configureHpf(sampleRate: Float, channelCount: Int) {
+        val w0 = 2.0 * PI * HPF_CUTOFF_HZ / sampleRate
+        val cosW0 = cos(w0).toFloat()
+        val sinW0 = sin(w0).toFloat()
+        val alpha = sinW0 / (2f * HPF_Q)
+        val a0 = 1f + alpha
+        hpfB0 = ((1f + cosW0) / 2f) / a0
+        hpfB1 = -(1f + cosW0) / a0
+        hpfB2 = ((1f + cosW0) / 2f) / a0
+        hpfA1 = (-2f * cosW0) / a0
+        hpfA2 = (1f - alpha) / a0
+        hpfStage1 = Array(channelCount) { BiquadState() }
+        hpfStage2 = Array(channelCount) { BiquadState() }
+    }
+
+    private fun applyShelf(channel: Int, input: Float): Float {
+        val stage1 = hpfStage1[channel]
+        val y1 = hpfB0 * input + hpfB1 * stage1.x1 + hpfB2 * stage1.x2 -
+            hpfA1 * stage1.y1 - hpfA2 * stage1.y2
+        stage1.x2 = stage1.x1
+        stage1.x1 = input
+        stage1.y2 = stage1.y1
+        stage1.y1 = y1
+
+        val stage2 = hpfStage2[channel]
+        val y2 = hpfB0 * y1 + hpfB1 * stage2.x1 + hpfB2 * stage2.x2 -
+            hpfA1 * stage2.y1 - hpfA2 * stage2.y2
+        stage2.x2 = stage2.x1
+        stage2.x1 = y1
+        stage2.y2 = stage2.y1
+        stage2.y1 = y2
+        return y2
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        if (!inputBuffer.hasRemaining()) return
+
+        val inputSize = inputBuffer.remaining()
+        val outputBuffer = replaceOutputBuffer(inputSize)
+
+        if (!enabled) {
+            outputBuffer.put(inputBuffer)
+            outputBuffer.flip()
+            return
+        }
+
+        val channelCount = inputAudioFormat.channelCount
+        when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT -> processPcm16(inputBuffer, outputBuffer, channelCount)
+            C.ENCODING_PCM_FLOAT -> processPcmFloat(inputBuffer, outputBuffer, channelCount)
+            else -> outputBuffer.put(inputBuffer)
+        }
+
+        outputBuffer.flip()
+    }
+
+    private fun processPcm16(
+        inputBuffer: ByteBuffer,
+        outputBuffer: ByteBuffer,
+        channelCount: Int
+    ) {
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+        when (channelCount) {
+            2 -> processStereoPcm16(inputBuffer, outputBuffer)
+            else -> processMultichannelPcm16(inputBuffer, outputBuffer, channelCount)
+        }
+    }
+
+    private fun processPcmFloat(
+        inputBuffer: ByteBuffer,
+        outputBuffer: ByteBuffer,
+        channelCount: Int
+    ) {
+        inputBuffer.order(ByteOrder.nativeOrder())
+        outputBuffer.order(ByteOrder.nativeOrder())
+        when (channelCount) {
+            2 -> processStereoPcmFloat(inputBuffer, outputBuffer)
+            else -> processMultichannelPcmFloat(inputBuffer, outputBuffer, channelCount)
+        }
+    }
+
+    private fun processStereoPcm16(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer) {
+        while (inputBuffer.remaining() >= 4) {
+            val l = inputBuffer.short.toFloat()
+            val r = inputBuffer.short.toFloat()
+            val mid = (l + r) * 0.5f
+            val side = (l - r) * 0.5f * SIDE_GAIN
+            val midBoost = mid * MID_GAIN
+            val preL = midBoost + side
+            val preR = midBoost - side
+            val filtL = applyShelf(0, preL)
+            val filtR = applyShelf(1, preR)
+            val newL = filtL.coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat())
+            val newR = filtR.coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat())
+            outputBuffer.putShort(newL.roundToInt().toShort())
+            outputBuffer.putShort(newR.roundToInt().toShort())
+        }
+        if (inputBuffer.hasRemaining()) outputBuffer.put(inputBuffer)
+    }
+
+    private fun processStereoPcmFloat(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer) {
+        while (inputBuffer.remaining() >= 8) {
+            val l = inputBuffer.float
+            val r = inputBuffer.float
+            val mid = (l + r) * 0.5f
+            val side = (l - r) * 0.5f * SIDE_GAIN
+            val midBoost = mid * MID_GAIN
+            val preL = midBoost + side
+            val preR = midBoost - side
+            val filtL = applyShelf(0, preL)
+            val filtR = applyShelf(1, preR)
+            outputBuffer.putFloat(filtL.coerceIn(-1f, 1f))
+            outputBuffer.putFloat(filtR.coerceIn(-1f, 1f))
+        }
+        if (inputBuffer.hasRemaining()) outputBuffer.put(inputBuffer)
+    }
+
+    private fun processMultichannelPcm16(
+        inputBuffer: ByteBuffer,
+        outputBuffer: ByteBuffer,
+        channelCount: Int
+    ) {
+        val frameBytes = channelCount * 2
+        val centerIndex = if (channelCount >= 3) 2 else -1
+        val lfeIndex = if (channelCount >= 4) 3 else -1
+        while (inputBuffer.remaining() >= frameBytes) {
+            for (channel in 0 until channelCount) {
+                val sample = inputBuffer.short.toFloat()
+                val scale = when (channel) {
+                    centerIndex -> MID_GAIN
+                    lfeIndex -> LFE_GAIN
+                    else -> NON_CENTER_GAIN
+                }
+                val scaled = sample * scale
+                val filtered = applyShelf(channel, scaled)
+                val amplified = filtered
+                    .coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat())
+                outputBuffer.putShort(amplified.roundToInt().toShort())
+            }
+        }
+        if (inputBuffer.hasRemaining()) outputBuffer.put(inputBuffer)
+    }
+
+    private fun processMultichannelPcmFloat(
+        inputBuffer: ByteBuffer,
+        outputBuffer: ByteBuffer,
+        channelCount: Int
+    ) {
+        val frameBytes = channelCount * 4
+        val centerIndex = if (channelCount >= 3) 2 else -1
+        val lfeIndex = if (channelCount >= 4) 3 else -1
+        while (inputBuffer.remaining() >= frameBytes) {
+            for (channel in 0 until channelCount) {
+                val sample = inputBuffer.float
+                val scale = when (channel) {
+                    centerIndex -> MID_GAIN
+                    lfeIndex -> LFE_GAIN
+                    else -> NON_CENTER_GAIN
+                }
+                val filtered = applyShelf(channel, sample * scale)
+                outputBuffer.putFloat(filtered.coerceIn(-1f, 1f))
+            }
+        }
+        if (inputBuffer.hasRemaining()) outputBuffer.put(inputBuffer)
+    }
+
+    private class BiquadState {
+        var x1: Float = 0f
+        var x2: Float = 0f
+        var y1: Float = 0f
+        var y2: Float = 0f
+    }
+
+    companion object {
+        private const val MID_BOOST_DB = 9f
+        private const val SIDE_ATTENUATION_DB = -60f
+        private const val NON_CENTER_ATTENUATION_DB = -48f
+        private const val LFE_ATTENUATION_DB = -80f
+        private const val HPF_CUTOFF_HZ = 130f
+        private const val HPF_Q = 0.7071f
+        private val MID_GAIN = 10f.pow(MID_BOOST_DB / 20f)
+        private val SIDE_GAIN = 10f.pow(SIDE_ATTENUATION_DB / 20f)
+        private val NON_CENTER_GAIN = 10f.pow(NON_CENTER_ATTENUATION_DB / 20f)
+        private val LFE_GAIN = 10f.pow(LFE_ATTENUATION_DB / 20f)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NightModeAudioProcessor.kt
@@ -41,6 +41,12 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     @Volatile
     private var currentNonCenterGain: Float = NON_CENTER_GAIN_MIN
 
+    @Volatile
+    private var currentLfeGain: Float = LFE_GAIN_MIN
+
+    @Volatile
+    private var currentHpfCutoffHz: Float = HPF_CUTOFF_MAX_HZ
+
     private var attackCoeff: Float = 0f
     private var releaseCoeff: Float = 0f
     private var gainSmoothCoeff: Float = 0f
@@ -89,9 +95,16 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         val nonCenterDb = NON_CENTER_ATTENUATION_MIN_DB +
             ampNorm * (NON_CENTER_ATTENUATION_MAX_DB - NON_CENTER_ATTENUATION_MIN_DB)
         val mudCutDb = MUD_CUT_MIN_DB + ampNorm * (MUD_CUT_MAX_DB - MUD_CUT_MIN_DB)
+        val lfeDb = LFE_ATTENUATION_MIN_DB + ampNorm * (LFE_ATTENUATION_MAX_DB - LFE_ATTENUATION_MIN_DB)
+        val hpfHz = HPF_CUTOFF_MAX_HZ + ampNorm * (HPF_CUTOFF_MIN_HZ - HPF_CUTOFF_MAX_HZ)
+
         currentSideGain = 10f.pow(sideDb / 20f)
         currentNonCenterGain = 10f.pow(nonCenterDb / 20f)
+        currentLfeGain = 10f.pow(lfeDb / 20f)
+        currentHpfCutoffHz = hpfHz
+
         updateMudCoefficients(mudCutDb)
+        updateHpfCoefficients(hpfHz)
         if (amp <= 0f) {
             compressionEnabled = false
             compressionThresholdFraction = 1f
@@ -228,8 +241,10 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         return multichannelFcGain * midStaticGain
     }
 
-    private fun configureHpf(sampleRate: Float, channelCount: Int) {
-        val w0 = 2.0 * PI * HPF_CUTOFF_HZ / sampleRate
+    private fun updateHpfCoefficients(cutoffHz: Float) {
+        val sampleRate = cachedSampleRate
+        if (sampleRate <= 0f) return
+        val w0 = 2.0 * PI * cutoffHz / sampleRate
         val cosW0 = cos(w0).toFloat()
         val sinW0 = sin(w0).toFloat()
         val alpha = sinW0 / (2f * HPF_Q)
@@ -239,6 +254,10 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         hpfB2 = ((1f + cosW0) / 2f) / a0
         hpfA1 = (-2f * cosW0) / a0
         hpfA2 = (1f - alpha) / a0
+    }
+
+    private fun configureHpf(sampleRate: Float, channelCount: Int) {
+        updateHpfCoefficients(currentHpfCutoffHz)
         hpfStage1 = Array(channelCount) { BiquadState() }
         hpfStage2 = Array(channelCount) { BiquadState() }
     }
@@ -369,7 +388,7 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
                 val sample = inputBuffer.short.toFloat()
                 val scale = when (channel) {
                     centerIndex -> updateMultichannelFcGain(sample, fullScale)
-                    lfeIndex -> LFE_GAIN
+                    lfeIndex -> currentLfeGain
                     else -> nonCenterGain
                 }
                 val scaled = sample * scale
@@ -402,7 +421,7 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
                 val sample = inputBuffer.float
                 val scale = when (channel) {
                     centerIndex -> updateMultichannelFcGain(sample, fullScale)
-                    lfeIndex -> LFE_GAIN
+                    lfeIndex -> currentLfeGain
                     else -> nonCenterGain
                 }
                 val hpFiltered = applyShelf(channel, sample * scale)
@@ -427,16 +446,18 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
     companion object {
         private const val MID_BOOST_DB = 0f
         private const val SIDE_ATTENUATION_MIN_DB = -12f
-        private const val SIDE_ATTENUATION_MAX_DB = -60f
+        private const val SIDE_ATTENUATION_MAX_DB = 0f
         private const val NON_CENTER_ATTENUATION_MIN_DB = -12f
-        private const val NON_CENTER_ATTENUATION_MAX_DB = -48f
-        private const val LFE_ATTENUATION_DB = -80f
-        private const val HPF_CUTOFF_HZ = 60f
+        private const val NON_CENTER_ATTENUATION_MAX_DB = 0f
+        private const val LFE_ATTENUATION_MIN_DB = -80f
+        private const val LFE_ATTENUATION_MAX_DB = 0f
+        private const val HPF_CUTOFF_MAX_HZ = 60f
+        private const val HPF_CUTOFF_MIN_HZ = 20f
         private const val HPF_Q = 0.7071f
         private val MID_GAIN = 10f.pow(MID_BOOST_DB / 20f)
         private val SIDE_GAIN_MIN = 10f.pow(SIDE_ATTENUATION_MIN_DB / 20f)
         private val NON_CENTER_GAIN_MIN = 10f.pow(NON_CENTER_ATTENUATION_MIN_DB / 20f)
-        private val LFE_GAIN = 10f.pow(LFE_ATTENUATION_DB / 20f)
+        private val LFE_GAIN_MIN = 10f.pow(LFE_ATTENUATION_MIN_DB / 20f)
 
         private const val AMP_RANGE_DB = 10f
         private const val COMP_THRESHOLD_HIGH_DB = -12f
@@ -447,10 +468,10 @@ internal class NightModeAudioProcessor : BaseAudioProcessor() {
         private const val PEAK_THRESHOLD_HIGH_DB = -3f
         private const val PEAK_THRESHOLD_LOW_DB = -12f
         private const val PEAK_MAX_ATTEN_DB = 18f
-        private const val MUD_FREQ_HZ = 250f
+        private const val MUD_FREQ_HZ = 200f
         private const val MUD_Q = 1.0f
-        private const val MUD_CUT_MIN_DB = -2f
-        private const val MUD_CUT_MAX_DB = -8f
+        private const val MUD_CUT_MIN_DB = -5f
+        private const val MUD_CUT_MAX_DB = 0f
         private const val COMP_ATTACK_SECONDS = 0.010f
         private const val COMP_RELEASE_SECONDS = 0.200f
         private const val COMP_GAIN_SMOOTH_SECONDS = 0.020f

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
@@ -9,7 +9,8 @@ import androidx.media3.exoplayer.audio.ForwardingAudioSink
 
 internal class PlaybackSpeedAwareAudioSink(
     sink: AudioSink,
-    private val forceStereoDownmixProvider: () -> Boolean = { false }
+    private val forceStereoDownmixProvider: () -> Boolean = { false },
+    private val nightModeProvider: () -> Boolean = { false }
 ) : ForwardingAudioSink(sink) {
 
     @Volatile
@@ -74,6 +75,7 @@ internal class PlaybackSpeedAwareAudioSink(
     private fun shouldRejectDirectPlayback(format: Format): Boolean {
         if (!isEncodedSurroundFormat(format)) return false
         return forceStereoDownmixProvider() ||
+            nightModeProvider() ||
             forcePcmForCurrentSession ||
             playbackSpeed != 1f
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
@@ -67,6 +67,10 @@ internal class PlaybackSpeedAwareAudioSink(
         return shouldRejectDirectPlayback(format)
     }
 
+    fun notifyAudioCapabilitiesChanged() {
+        listener?.onAudioCapabilitiesChanged()
+    }
+
     private fun shouldRejectDirectPlayback(format: Format): Boolean {
         if (!isEncodedSurroundFormat(format)) return false
         return forceStereoDownmixProvider() ||

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
@@ -8,7 +8,8 @@ import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.ForwardingAudioSink
 
 internal class PlaybackSpeedAwareAudioSink(
-    sink: AudioSink
+    sink: AudioSink,
+    private val forceStereoDownmixProvider: () -> Boolean = { false }
 ) : ForwardingAudioSink(sink) {
 
     @Volatile
@@ -67,11 +68,14 @@ internal class PlaybackSpeedAwareAudioSink(
     }
 
     private fun shouldRejectDirectPlayback(format: Format): Boolean {
-        return requiresPcmForSpeed(format) && (forcePcmForCurrentSession || playbackSpeed != 1f)
+        if (!isEncodedSurroundFormat(format)) return false
+        return forceStereoDownmixProvider() ||
+            forcePcmForCurrentSession ||
+            playbackSpeed != 1f
     }
 
     private fun markPcmFallbackIfNeeded(format: Format?, speed: Float): Boolean {
-        if (format == null || speed == 1f || !requiresPcmForSpeed(format)) {
+        if (format == null || speed == 1f || !isEncodedSurroundFormat(format)) {
             return false
         }
         val wasForcingPcm = forcePcmForCurrentSession
@@ -83,7 +87,7 @@ internal class PlaybackSpeedAwareAudioSink(
         return speed.takeIf { it > 0f } ?: 1f
     }
 
-    private fun requiresPcmForSpeed(format: Format): Boolean {
+    private fun isEncodedSurroundFormat(format: Format): Boolean {
         val mimeType = format.sampleMimeType
         if (mimeType != null && (
                 mimeType == MimeTypes.AUDIO_E_AC3 ||

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -329,6 +329,7 @@ class PlayerRuntimeController(
     internal var hasRetriedCurrentStreamAfter416: Boolean = false
     internal var isReleasingPlayer: Boolean = false
     internal var cachedDecoderPriority: Int = 1
+    internal var cachedForceStereoDownmix: Boolean = false
     internal var hasTriedAudioPcmFallback: Boolean = false
     internal var hasTriedDv7HevcFallback: Boolean = false
     internal var forceDv7ToHevc: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -312,6 +312,7 @@ class PlayerRuntimeController(
     
     internal val gainAudioProcessor = GainAudioProcessor()
     internal val centerChannelGainAudioProcessor = CenterChannelGainAudioProcessor()
+    internal val nightModeAudioProcessor = NightModeAudioProcessor()
     internal var trackSelector: DefaultTrackSelector? = null
     internal var currentMediaSession: MediaSession? = null
     internal var mpvView: NuvioMpvSurfaceView? = null
@@ -333,6 +334,9 @@ class PlayerRuntimeController(
     internal var cachedForceStereoDownmix: Boolean = false
     internal var sessionForceStereoDownmixOverride: Boolean? = null
     internal var sessionForceStereoDownmixOverrideUrl: String? = null
+    internal var cachedNightMode: Boolean = false
+    internal var sessionNightModeOverride: Boolean? = null
+    internal var sessionNightModeOverrideUrl: String? = null
     internal var hasTriedAudioPcmFallback: Boolean = false
     internal var hasTriedDv7HevcFallback: Boolean = false
     internal var forceDv7ToHevc: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -311,6 +311,7 @@ class PlayerRuntimeController(
     internal var lastBufferLogTimeMs: Long = 0L
     
     internal val gainAudioProcessor = GainAudioProcessor()
+    internal val centerChannelGainAudioProcessor = CenterChannelGainAudioProcessor()
     internal var trackSelector: DefaultTrackSelector? = null
     internal var currentMediaSession: MediaSession? = null
     internal var mpvView: NuvioMpvSurfaceView? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -330,6 +330,8 @@ class PlayerRuntimeController(
     internal var isReleasingPlayer: Boolean = false
     internal var cachedDecoderPriority: Int = 1
     internal var cachedForceStereoDownmix: Boolean = false
+    internal var sessionForceStereoDownmixOverride: Boolean? = null
+    internal var sessionForceStereoDownmixOverrideUrl: String? = null
     internal var hasTriedAudioPcmFallback: Boolean = false
     internal var hasTriedDv7HevcFallback: Boolean = false
     internal var forceDv7ToHevc: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -821,11 +821,60 @@ private class SubtitleOffsetRenderersFactory(
         enableAudioTrackPlaybackParams: Boolean
     ): AudioSink {
         val channelMixing = ToggleableChannelMixingAudioProcessor(forceStereoDownmixProvider)
-        for (inputChannels in 1..6) {
-            channelMixing.putChannelMixingMatrix(
-                ChannelMixingMatrix.createForConstantPower(inputChannels, 2)
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                1, 2,
+                floatArrayOf(
+                    1.0f,
+                    1.0f
+                )
             )
-        }
+        )
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                2, 2,
+                floatArrayOf(
+                    1.0f, 0.0f,
+                    0.0f, 1.0f
+                )
+            )
+        )
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                3, 2,
+                floatArrayOf(
+                    1.0f, 0.0f, 0.7071f,
+                    0.0f, 1.0f, 0.7071f
+                )
+            )
+        )
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                4, 2,
+                floatArrayOf(
+                    1.0f, 0.0f, 0.7071f, 0.0f,
+                    0.0f, 1.0f, 0.0f, 0.7071f
+                )
+            )
+        )
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                5, 2,
+                floatArrayOf(
+                    1.0f, 0.0f, 0.7071f, 0.7071f, 0.0f,
+                    0.0f, 1.0f, 0.7071f, 0.0f, 0.7071f
+                )
+            )
+        )
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                6, 2,
+                floatArrayOf(
+                    1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f,
+                    0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f
+                )
+            )
+        )
         channelMixing.putChannelMixingMatrix(
             ChannelMixingMatrix(
                 7,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -126,6 +126,15 @@ internal fun PlayerRuntimeController.initializePlayer(
             cachedForceStereoDownmix =
                 sessionForceStereoDownmixOverride ?: playerSettings.forceStereoDownmix
             _uiState.update { it.copy(forceStereoDownmixActive = cachedForceStereoDownmix) }
+            if (sessionNightModeOverrideUrl != null &&
+                sessionNightModeOverrideUrl != url
+            ) {
+                sessionNightModeOverride = null
+                sessionNightModeOverrideUrl = null
+            }
+            cachedNightMode = sessionNightModeOverride ?: false
+            nightModeAudioProcessor.setEnabled(cachedNightMode)
+            _uiState.update { it.copy(nightModeActive = cachedNightMode) }
             val preferredAudioLanguages = resolvePreferredAudioLanguages(
                 preferredAudioLanguage = playerSettings.preferredAudioLanguage,
                 secondaryPreferredAudioLanguage = playerSettings.secondaryPreferredAudioLanguage,
@@ -286,6 +295,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 },
                 gainAudioProcessor = gainAudioProcessor,
                 centerChannelGainAudioProcessor = centerChannelGainAudioProcessor,
+                nightModeAudioProcessor = nightModeAudioProcessor,
                 playbackSpeedProvider = { _uiState.value.playbackSpeed },
                 forceStereoDownmixProvider = { cachedForceStereoDownmix },
                 onPlaybackSpeedAwareAudioSinkCreated = { playbackSpeedAwareAudioSink = it }
@@ -810,6 +820,7 @@ private class SubtitleOffsetRenderersFactory(
     private val shouldNormalizeCuePositionProvider: () -> Boolean,
     private val gainAudioProcessor: GainAudioProcessor,
     private val centerChannelGainAudioProcessor: CenterChannelGainAudioProcessor,
+    private val nightModeAudioProcessor: NightModeAudioProcessor,
     private val playbackSpeedProvider: () -> Float,
     private val forceStereoDownmixProvider: () -> Boolean,
     private val onPlaybackSpeedAwareAudioSinkCreated: (PlaybackSpeedAwareAudioSink) -> Unit
@@ -898,6 +909,7 @@ private class SubtitleOffsetRenderersFactory(
         val audioProcessors: Array<AudioProcessor> = arrayOf(
             centerChannelGainAudioProcessor,
             channelMixing,
+            nightModeAudioProcessor,
             gainAudioProcessor
         )
         val baseAudioSink = DefaultAudioSink.Builder(context)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -846,7 +846,10 @@ private class SubtitleOffsetRenderersFactory(
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
             .setAudioProcessors(audioProcessors)
             .build()
-        val playbackSpeedAwareAudioSink = PlaybackSpeedAwareAudioSink(baseAudioSink)
+        val playbackSpeedAwareAudioSink = PlaybackSpeedAwareAudioSink(
+            sink = baseAudioSink,
+            forceStereoDownmixProvider = forceStereoDownmixProvider
+        )
         playbackSpeedAwareAudioSink.setInitialPlaybackSpeed(playbackSpeedProvider())
         onPlaybackSpeedAwareAudioSinkCreated(playbackSpeedAwareAudioSink)
         return playbackSpeedAwareAudioSink

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -817,6 +817,26 @@ private class SubtitleOffsetRenderersFactory(
                     ChannelMixingMatrix.createForConstantPower(inputChannels, 2)
                 )
             }
+            channelMixing.putChannelMixingMatrix(
+                ChannelMixingMatrix(
+                    7,
+                    2,
+                    floatArrayOf(
+                        1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f, 0.7071f,
+                        0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f, 0.7071f
+                    )
+                )
+            )
+            channelMixing.putChannelMixingMatrix(
+                ChannelMixingMatrix(
+                    8,
+                    2,
+                    floatArrayOf(
+                        1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f, 0.7071f, 0.0f,
+                        0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f, 0.0f, 0.7071f
+                    )
+                )
+            )
             arrayOf(channelMixing, gainAudioProcessor)
         } else {
             arrayOf(gainAudioProcessor)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -285,6 +285,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         PlayerSubtitleUtils.mimeTypeFromUrl(selectedAddonSubtitle.url) == MimeTypes.TEXT_VTT
                 },
                 gainAudioProcessor = gainAudioProcessor,
+                centerChannelGainAudioProcessor = centerChannelGainAudioProcessor,
                 playbackSpeedProvider = { _uiState.value.playbackSpeed },
                 forceStereoDownmixProvider = { cachedForceStereoDownmix },
                 onPlaybackSpeedAwareAudioSinkCreated = { playbackSpeedAwareAudioSink = it }
@@ -808,6 +809,7 @@ private class SubtitleOffsetRenderersFactory(
     private val audioDelayUsProvider: () -> Long,
     private val shouldNormalizeCuePositionProvider: () -> Boolean,
     private val gainAudioProcessor: GainAudioProcessor,
+    private val centerChannelGainAudioProcessor: CenterChannelGainAudioProcessor,
     private val playbackSpeedProvider: () -> Float,
     private val forceStereoDownmixProvider: () -> Boolean,
     private val onPlaybackSpeedAwareAudioSinkCreated: (PlaybackSpeedAwareAudioSink) -> Unit
@@ -844,7 +846,11 @@ private class SubtitleOffsetRenderersFactory(
                 )
             )
         )
-        val audioProcessors: Array<AudioProcessor> = arrayOf(channelMixing, gainAudioProcessor)
+        val audioProcessors: Array<AudioProcessor> = arrayOf(
+            centerChannelGainAudioProcessor,
+            channelMixing,
+            gainAudioProcessor
+        )
         val baseAudioSink = DefaultAudioSink.Builder(context)
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -13,6 +13,9 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.ChannelMixingAudioProcessor
+import androidx.media3.common.audio.ChannelMixingMatrix
 import androidx.media3.common.text.Cue
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
@@ -114,6 +117,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 applyStoredAudioDelayForCurrentRouteIfEnabled()
             }
             cachedDecoderPriority = playerSettings.decoderPriority
+            cachedForceStereoDownmix = playerSettings.forceStereoDownmix
             val preferredAudioLanguages = resolvePreferredAudioLanguages(
                 preferredAudioLanguage = playerSettings.preferredAudioLanguage,
                 secondaryPreferredAudioLanguage = playerSettings.secondaryPreferredAudioLanguage,
@@ -274,6 +278,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 },
                 gainAudioProcessor = gainAudioProcessor,
                 playbackSpeedProvider = { _uiState.value.playbackSpeed },
+                forceStereoDownmixProvider = { cachedForceStereoDownmix },
                 onPlaybackSpeedAwareAudioSinkCreated = { playbackSpeedAwareAudioSink = it }
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || forceDv7ToHevc)
@@ -796,6 +801,7 @@ private class SubtitleOffsetRenderersFactory(
     private val shouldNormalizeCuePositionProvider: () -> Boolean,
     private val gainAudioProcessor: GainAudioProcessor,
     private val playbackSpeedProvider: () -> Float,
+    private val forceStereoDownmixProvider: () -> Boolean,
     private val onPlaybackSpeedAwareAudioSinkCreated: (PlaybackSpeedAwareAudioSink) -> Unit
 ) : DefaultRenderersFactory(context) {
 
@@ -804,10 +810,21 @@ private class SubtitleOffsetRenderersFactory(
         enableFloatOutput: Boolean,
         enableAudioTrackPlaybackParams: Boolean
     ): AudioSink {
+        val audioProcessors: Array<AudioProcessor> = if (forceStereoDownmixProvider()) {
+            val channelMixing = ChannelMixingAudioProcessor()
+            for (inputChannels in 1..6) {
+                channelMixing.putChannelMixingMatrix(
+                    ChannelMixingMatrix.createForConstantPower(inputChannels, 2)
+                )
+            }
+            arrayOf(channelMixing, gainAudioProcessor)
+        } else {
+            arrayOf(gainAudioProcessor)
+        }
         val baseAudioSink = DefaultAudioSink.Builder(context)
-            .setEnableFloatOutput(enableFloatOutput)
+            .setEnableFloatOutput(enableFloatOutput && !forceStereoDownmixProvider())
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
-            .setAudioProcessors(arrayOf(gainAudioProcessor))
+            .setAudioProcessors(audioProcessors)
             .build()
         val playbackSpeedAwareAudioSink = PlaybackSpeedAwareAudioSink(baseAudioSink)
         playbackSpeedAwareAudioSink.setInitialPlaybackSpeed(playbackSpeedProvider())

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -117,7 +117,15 @@ internal fun PlayerRuntimeController.initializePlayer(
                 applyStoredAudioDelayForCurrentRouteIfEnabled()
             }
             cachedDecoderPriority = playerSettings.decoderPriority
-            cachedForceStereoDownmix = playerSettings.forceStereoDownmix
+            if (sessionForceStereoDownmixOverrideUrl != null &&
+                sessionForceStereoDownmixOverrideUrl != url
+            ) {
+                sessionForceStereoDownmixOverride = null
+                sessionForceStereoDownmixOverrideUrl = null
+            }
+            cachedForceStereoDownmix =
+                sessionForceStereoDownmixOverride ?: playerSettings.forceStereoDownmix
+            _uiState.update { it.copy(forceStereoDownmixActive = cachedForceStereoDownmix) }
             val preferredAudioLanguages = resolvePreferredAudioLanguages(
                 preferredAudioLanguage = playerSettings.preferredAudioLanguage,
                 secondaryPreferredAudioLanguage = playerSettings.secondaryPreferredAudioLanguage,
@@ -810,37 +818,33 @@ private class SubtitleOffsetRenderersFactory(
         enableFloatOutput: Boolean,
         enableAudioTrackPlaybackParams: Boolean
     ): AudioSink {
-        val audioProcessors: Array<AudioProcessor> = if (forceStereoDownmixProvider()) {
-            val channelMixing = ChannelMixingAudioProcessor()
-            for (inputChannels in 1..6) {
-                channelMixing.putChannelMixingMatrix(
-                    ChannelMixingMatrix.createForConstantPower(inputChannels, 2)
-                )
-            }
+        val channelMixing = ToggleableChannelMixingAudioProcessor(forceStereoDownmixProvider)
+        for (inputChannels in 1..6) {
             channelMixing.putChannelMixingMatrix(
-                ChannelMixingMatrix(
-                    7,
-                    2,
-                    floatArrayOf(
-                        1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f, 0.7071f,
-                        0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f, 0.7071f
-                    )
-                )
+                ChannelMixingMatrix.createForConstantPower(inputChannels, 2)
             )
-            channelMixing.putChannelMixingMatrix(
-                ChannelMixingMatrix(
-                    8,
-                    2,
-                    floatArrayOf(
-                        1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f, 0.7071f, 0.0f,
-                        0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f, 0.0f, 0.7071f
-                    )
-                )
-            )
-            arrayOf(channelMixing, gainAudioProcessor)
-        } else {
-            arrayOf(gainAudioProcessor)
         }
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                7,
+                2,
+                floatArrayOf(
+                    1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f, 0.7071f,
+                    0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f, 0.7071f
+                )
+            )
+        )
+        channelMixing.putChannelMixingMatrix(
+            ChannelMixingMatrix(
+                8,
+                2,
+                floatArrayOf(
+                    1.0f, 0.0f, 0.7071f, 0.5f, 0.7071f, 0.0f, 0.7071f, 0.0f,
+                    0.0f, 1.0f, 0.7071f, 0.5f, 0.0f, 0.7071f, 0.0f, 0.7071f
+                )
+            )
+        )
+        val audioProcessors: Array<AudioProcessor> = arrayOf(channelMixing, gainAudioProcessor)
         val baseAudioSink = DefaultAudioSink.Builder(context)
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -911,8 +911,8 @@ private class SubtitleOffsetRenderersFactory(
         )
         val audioProcessors: Array<AudioProcessor> = arrayOf(
             centerChannelGainAudioProcessor,
-            channelMixing,
             nightModeAudioProcessor,
+            channelMixing,
             gainAudioProcessor
         )
         val baseAudioSink = DefaultAudioSink.Builder(context)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -842,7 +842,7 @@ private class SubtitleOffsetRenderersFactory(
             arrayOf(gainAudioProcessor)
         }
         val baseAudioSink = DefaultAudioSink.Builder(context)
-            .setEnableFloatOutput(enableFloatOutput && !forceStereoDownmixProvider())
+            .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
             .setAudioProcessors(audioProcessors)
             .build()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -132,7 +132,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                 sessionNightModeOverride = null
                 sessionNightModeOverrideUrl = null
             }
-            cachedNightMode = sessionNightModeOverride ?: false
+            cachedNightMode = sessionNightModeOverride
+                ?: (playerSettings.persistAudioAmplification && playerSettings.nightMode)
             nightModeAudioProcessor.setEnabled(cachedNightMode)
             _uiState.update { it.copy(nightModeActive = cachedNightMode) }
             val preferredAudioLanguages = resolvePreferredAudioLanguages(
@@ -298,6 +299,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 nightModeAudioProcessor = nightModeAudioProcessor,
                 playbackSpeedProvider = { _uiState.value.playbackSpeed },
                 forceStereoDownmixProvider = { cachedForceStereoDownmix },
+                nightModeProvider = { cachedNightMode },
                 onPlaybackSpeedAwareAudioSinkCreated = { playbackSpeedAwareAudioSink = it }
             ).setExtensionRendererMode(playerSettings.decoderPriority)
                 .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || forceDv7ToHevc)
@@ -823,6 +825,7 @@ private class SubtitleOffsetRenderersFactory(
     private val nightModeAudioProcessor: NightModeAudioProcessor,
     private val playbackSpeedProvider: () -> Float,
     private val forceStereoDownmixProvider: () -> Boolean,
+    private val nightModeProvider: () -> Boolean,
     private val onPlaybackSpeedAwareAudioSinkCreated: (PlaybackSpeedAwareAudioSink) -> Unit
 ) : DefaultRenderersFactory(context) {
 
@@ -919,7 +922,8 @@ private class SubtitleOffsetRenderersFactory(
             .build()
         val playbackSpeedAwareAudioSink = PlaybackSpeedAwareAudioSink(
             sink = baseAudioSink,
-            forceStereoDownmixProvider = forceStereoDownmixProvider
+            forceStereoDownmixProvider = forceStereoDownmixProvider,
+            nightModeProvider = nightModeProvider
         )
         playbackSpeedAwareAudioSink.setInitialPlaybackSpeed(playbackSpeedProvider())
         onPlaybackSpeedAwareAudioSinkCreated(playbackSpeedAwareAudioSink)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1138,8 +1138,15 @@ internal fun PlayerRuntimeController.buildStreamInfoData(): StreamInfoData {
         videoFrameRate = state.detectedFrameRate.takeIf { it > 0f },
         videoBitrate = currentVideoBitrate,
         audioCodec = selectedAudio?.codec,
-        audioChannels = selectedAudio?.channelCount?.let {
-            CustomDefaultTrackNameProvider.getChannelLayoutName(it)
+        audioChannels = selectedAudio?.channelCount?.let { count ->
+            val showDownmix = cachedForceStereoDownmix &&
+                count > 2 &&
+                currentInternalPlayerEngine == com.nuvio.tv.data.local.InternalPlayerEngine.EXOPLAYER
+            if (showDownmix) {
+                context.getString(R.string.stream_info_channels_downmix_label)
+            } else {
+                CustomDefaultTrackNameProvider.getChannelLayoutName(count)
+            }
         },
         audioSampleRate = selectedAudio?.sampleRate,
         audioLanguage = selectedAudio?.language,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 
 internal const val AUDIO_AMPLIFICATION_MIN_DB = 0
 internal const val AUDIO_AMPLIFICATION_MAX_DB = 10
+internal const val AUDIO_AMPLIFICATION_CENTER_MAX_DB = AUDIO_AMPLIFICATION_MAX_DB * 2
 internal const val AUDIO_DELAY_MIN_MS = -3000
 internal const val AUDIO_DELAY_MAX_MS = 3000
 internal const val AUDIO_DELAY_STEP_MS = 25
@@ -35,7 +36,7 @@ internal fun PlayerRuntimeController.applyAudioDelay(
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
     if (cachedForceStereoDownmix) {
-        centerChannelGainAudioProcessor.setGainDb(clampedDb)
+        centerChannelGainAudioProcessor.setGainDb(clampedDb * 2)
         gainAudioProcessor.setGainDb(0)
     } else {
         centerChannelGainAudioProcessor.setGainDb(0)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -34,7 +34,13 @@ internal fun PlayerRuntimeController.applyAudioDelay(
 
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
-    gainAudioProcessor.setGainDb(clampedDb)
+    if (cachedForceStereoDownmix) {
+        centerChannelGainAudioProcessor.setGainDb(clampedDb)
+        gainAudioProcessor.setGainDb(0)
+    } else {
+        centerChannelGainAudioProcessor.setGainDb(0)
+        gainAudioProcessor.setGainDb(clampedDb)
+    }
     if (isUsingMpvEngine()) {
         mpvView?.applyAudioAmplificationDb(clampedDb)
     }
@@ -670,6 +676,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             sessionForceStereoDownmixOverride = event.enabled
             sessionForceStereoDownmixOverrideUrl = currentStreamUrl
             cachedForceStereoDownmix = event.enabled
+            applyAudioAmplification(_uiState.value.audioAmplificationDb)
             _uiState.update { it.copy(forceStereoDownmixActive = event.enabled) }
             playbackSpeedAwareAudioSink?.notifyAudioCapabilitiesChanged()
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -665,11 +665,13 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         is PlayerEvent.OnSetPersistAudioAmplification -> {
             val currentDb = _uiState.value.audioAmplificationDb
+            val currentNightMode = _uiState.value.nightModeActive
             _uiState.update { it.copy(persistAudioAmplification = event.enabled) }
             scope.launch {
                 playerSettingsDataStore.setPersistAudioAmplification(
                     enabled = event.enabled,
-                    dbToPersist = if (event.enabled) currentDb else null
+                    dbToPersist = if (event.enabled) currentDb else null,
+                    nightModeToPersist = if (event.enabled) currentNightMode else null
                 )
             }
         }
@@ -687,6 +689,12 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             cachedNightMode = event.enabled
             nightModeAudioProcessor.setEnabled(event.enabled)
             _uiState.update { it.copy(nightModeActive = event.enabled) }
+            playbackSpeedAwareAudioSink?.notifyAudioCapabilitiesChanged()
+            if (_uiState.value.persistAudioAmplification) {
+                scope.launch {
+                    playerSettingsDataStore.setNightMode(event.enabled)
+                }
+            }
         }
         is PlayerEvent.OnSelectSubtitleTrack -> {
             logSwitchTrace(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -681,6 +681,13 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             _uiState.update { it.copy(forceStereoDownmixActive = event.enabled) }
             playbackSpeedAwareAudioSink?.notifyAudioCapabilitiesChanged()
         }
+        is PlayerEvent.OnSetNightModeForSession -> {
+            sessionNightModeOverride = event.enabled
+            sessionNightModeOverrideUrl = currentStreamUrl
+            cachedNightMode = event.enabled
+            nightModeAudioProcessor.setEnabled(event.enabled)
+            _uiState.update { it.copy(nightModeActive = event.enabled) }
+        }
         is PlayerEvent.OnSelectSubtitleTrack -> {
             logSwitchTrace(
                 stage = "event-select-subtitle-internal",

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -35,12 +35,22 @@ internal fun PlayerRuntimeController.applyAudioDelay(
 
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
-    if (cachedForceStereoDownmix) {
-        centerChannelGainAudioProcessor.setGainDb(clampedDb * 2)
-        gainAudioProcessor.setGainDb(0)
-    } else {
-        centerChannelGainAudioProcessor.setGainDb(0)
-        gainAudioProcessor.setGainDb(clampedDb)
+    when {
+        cachedNightMode -> {
+            nightModeAudioProcessor.setDialogIsolationDb((clampedDb * 2).toFloat())
+            centerChannelGainAudioProcessor.setGainDb(0)
+            gainAudioProcessor.setGainDb(0)
+        }
+        cachedForceStereoDownmix -> {
+            nightModeAudioProcessor.setDialogIsolationDb(0f)
+            centerChannelGainAudioProcessor.setGainDb(clampedDb * 2)
+            gainAudioProcessor.setGainDb(0)
+        }
+        else -> {
+            nightModeAudioProcessor.setDialogIsolationDb(0f)
+            centerChannelGainAudioProcessor.setGainDb(0)
+            gainAudioProcessor.setGainDb(clampedDb)
+        }
     }
     if (isUsingMpvEngine()) {
         mpvView?.applyAudioAmplificationDb(clampedDb)
@@ -688,6 +698,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             sessionNightModeOverrideUrl = currentStreamUrl
             cachedNightMode = event.enabled
             nightModeAudioProcessor.setEnabled(event.enabled)
+            applyAudioAmplification(_uiState.value.audioAmplificationDb)
             _uiState.update { it.copy(nightModeActive = event.enabled) }
             playbackSpeedAwareAudioSink?.notifyAudioCapabilitiesChanged()
             if (_uiState.value.persistAudioAmplification) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -666,6 +666,13 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
                 )
             }
         }
+        is PlayerEvent.OnSetForceStereoDownmixForSession -> {
+            sessionForceStereoDownmixOverride = event.enabled
+            sessionForceStereoDownmixOverrideUrl = currentStreamUrl
+            cachedForceStereoDownmix = event.enabled
+            _uiState.update { it.copy(forceStereoDownmixActive = event.enabled) }
+            playbackSpeedAwareAudioSink?.notifyAudioCapabilitiesChanged()
+        }
         is PlayerEvent.OnSelectSubtitleTrack -> {
             logSwitchTrace(
                 stage = "event-select-subtitle-internal",

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1083,6 +1083,7 @@ fun PlayerScreen(
             isAmplificationAvailable = uiState.isAudioAmplificationAvailable,
             persistAmplification = uiState.persistAudioAmplification,
             forceStereoDownmixActive = uiState.forceStereoDownmixActive,
+            nightModeActive = uiState.nightModeActive,
             onTrackSelected = { viewModel.onEvent(PlayerEvent.OnSelectAudioTrack(it)) },
             onAudioDelayChange = { viewModel.onEvent(PlayerEvent.OnSetAudioDelayMs(it)) },
             onAmplificationChange = { viewModel.onEvent(PlayerEvent.OnSetAudioAmplificationDb(it)) },
@@ -1091,6 +1092,9 @@ fun PlayerScreen(
             },
             onForceStereoDownmixChange = {
                 viewModel.onEvent(PlayerEvent.OnSetForceStereoDownmixForSession(it))
+            },
+            onNightModeChange = {
+                viewModel.onEvent(PlayerEvent.OnSetNightModeForSession(it))
             },
             onDismiss = { viewModel.onEvent(PlayerEvent.OnDismissTransientOverlay) },
             modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1082,11 +1082,15 @@ fun PlayerScreen(
             audioAmplificationDb = uiState.audioAmplificationDb,
             isAmplificationAvailable = uiState.isAudioAmplificationAvailable,
             persistAmplification = uiState.persistAudioAmplification,
+            forceStereoDownmixActive = uiState.forceStereoDownmixActive,
             onTrackSelected = { viewModel.onEvent(PlayerEvent.OnSelectAudioTrack(it)) },
             onAudioDelayChange = { viewModel.onEvent(PlayerEvent.OnSetAudioDelayMs(it)) },
             onAmplificationChange = { viewModel.onEvent(PlayerEvent.OnSetAudioAmplificationDb(it)) },
             onPersistAmplificationChange = {
                 viewModel.onEvent(PlayerEvent.OnSetPersistAudioAmplification(it))
+            },
+            onForceStereoDownmixChange = {
+                viewModel.onEvent(PlayerEvent.OnSetForceStereoDownmixForSession(it))
             },
             onDismiss = { viewModel.onEvent(PlayerEvent.OnDismissTransientOverlay) },
             modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1082,16 +1082,12 @@ fun PlayerScreen(
             audioAmplificationDb = uiState.audioAmplificationDb,
             isAmplificationAvailable = uiState.isAudioAmplificationAvailable,
             persistAmplification = uiState.persistAudioAmplification,
-            forceStereoDownmixActive = uiState.forceStereoDownmixActive,
             nightModeActive = uiState.nightModeActive,
             onTrackSelected = { viewModel.onEvent(PlayerEvent.OnSelectAudioTrack(it)) },
             onAudioDelayChange = { viewModel.onEvent(PlayerEvent.OnSetAudioDelayMs(it)) },
             onAmplificationChange = { viewModel.onEvent(PlayerEvent.OnSetAudioAmplificationDb(it)) },
             onPersistAmplificationChange = {
                 viewModel.onEvent(PlayerEvent.OnSetPersistAudioAmplification(it))
-            },
-            onForceStereoDownmixChange = {
-                viewModel.onEvent(PlayerEvent.OnSetForceStereoDownmixForSession(it))
             },
             onNightModeChange = {
                 viewModel.onEvent(PlayerEvent.OnSetNightModeForSession(it))

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -50,6 +50,7 @@ data class PlayerUiState(
     val isAudioAmplificationAvailable: Boolean = true,
     val persistAudioAmplification: Boolean = false,
     val forceStereoDownmixActive: Boolean = false,
+    val nightModeActive: Boolean = false,
     val showAudioOverlay: Boolean = false,
     val showSubtitleOverlay: Boolean = false,
     val showSubtitleStylePanel: Boolean = false,
@@ -214,6 +215,7 @@ sealed class PlayerEvent {
     data class OnSetAudioAmplificationDb(val db: Int) : PlayerEvent()
     data class OnSetPersistAudioAmplification(val enabled: Boolean) : PlayerEvent()
     data class OnSetForceStereoDownmixForSession(val enabled: Boolean) : PlayerEvent()
+    data class OnSetNightModeForSession(val enabled: Boolean) : PlayerEvent()
     data class OnSelectSubtitleTrack(val index: Int) : PlayerEvent()
     data object OnDisableSubtitles : PlayerEvent()
     data class OnSelectAddonSubtitle(val subtitle: Subtitle) : PlayerEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -49,6 +49,7 @@ data class PlayerUiState(
     val audioAmplificationDb: Int = 0,
     val isAudioAmplificationAvailable: Boolean = true,
     val persistAudioAmplification: Boolean = false,
+    val forceStereoDownmixActive: Boolean = false,
     val showAudioOverlay: Boolean = false,
     val showSubtitleOverlay: Boolean = false,
     val showSubtitleStylePanel: Boolean = false,
@@ -212,6 +213,7 @@ sealed class PlayerEvent {
     data class OnSetAudioDelayMs(val delayMs: Int) : PlayerEvent()
     data class OnSetAudioAmplificationDb(val db: Int) : PlayerEvent()
     data class OnSetPersistAudioAmplification(val enabled: Boolean) : PlayerEvent()
+    data class OnSetForceStereoDownmixForSession(val enabled: Boolean) : PlayerEvent()
     data class OnSelectSubtitleTrack(val index: Int) : PlayerEvent()
     data object OnDisableSubtitles : PlayerEvent()
     data class OnSelectAddonSubtitle(val subtitle: Subtitle) : PlayerEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ToggleableChannelMixingAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ToggleableChannelMixingAudioProcessor.kt
@@ -1,0 +1,48 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.ChannelMixingAudioProcessor
+import androidx.media3.common.audio.ChannelMixingMatrix
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteBuffer
+
+@UnstableApi
+internal class ToggleableChannelMixingAudioProcessor(
+    private val enabledProvider: () -> Boolean
+) : AudioProcessor {
+
+    private val delegate = ChannelMixingAudioProcessor()
+
+    fun putChannelMixingMatrix(matrix: ChannelMixingMatrix) {
+        delegate.putChannelMixingMatrix(matrix)
+    }
+
+    override fun configure(
+        inputAudioFormat: AudioProcessor.AudioFormat
+    ): AudioProcessor.AudioFormat {
+        if (!enabledProvider()) return AudioProcessor.AudioFormat.NOT_SET
+        return delegate.configure(inputAudioFormat)
+    }
+
+    override fun isActive(): Boolean = enabledProvider() && delegate.isActive
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        delegate.queueInput(inputBuffer)
+    }
+
+    override fun queueEndOfStream() {
+        delegate.queueEndOfStream()
+    }
+
+    override fun getOutput(): ByteBuffer = delegate.output
+
+    override fun isEnded(): Boolean = delegate.isEnded
+
+    override fun flush() {
+        delegate.flush()
+    }
+
+    override fun reset() {
+        delegate.reset()
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Hearing
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Speed
@@ -71,6 +72,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onSetSkipSilence: (Boolean) -> Unit,
     onSetRememberAudioDelayPerDevice: (Boolean) -> Unit,
     onSetTunnelingEnabled: (Boolean) -> Unit,
+    onSetForceStereoDownmix: (Boolean) -> Unit,
     onSetMapDV7ToHevc: (Boolean) -> Unit,
     onItemFocused: () -> Unit = {},
     enabled: Boolean = true
@@ -237,6 +239,18 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
             subtitle = stringResource(R.string.audio_tunneled_sub),
             isChecked = playerSettings.tunnelingEnabled,
             onCheckedChange = onSetTunnelingEnabled,
+            onFocused = onItemFocused,
+            enabled = enabled
+        )
+    }
+
+    item(key = "audio_force_stereo_downmix") {
+        ToggleSettingsItem(
+            icon = Icons.Default.Hearing,
+            title = stringResource(R.string.audio_force_stereo_downmix),
+            subtitle = stringResource(R.string.audio_force_stereo_downmix_sub),
+            isChecked = playerSettings.forceStereoDownmix,
+            onCheckedChange = onSetForceStereoDownmix,
             onFocused = onItemFocused,
             enabled = enabled
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -271,6 +271,7 @@ fun PlaybackSettingsContent(
                     coroutineScope.launch { viewModel.setRememberAudioDelayPerDevice(enabled) }
                 },
                 onSetTunnelingEnabled = { enabled -> coroutineScope.launch { viewModel.setTunnelingEnabled(enabled) } },
+                onSetForceStereoDownmix = { enabled -> coroutineScope.launch { viewModel.setForceStereoDownmix(enabled) } },
                 onSetMapDV7ToHevc = { enabled -> coroutineScope.launch { viewModel.setMapDV7ToHevc(enabled) } },
                 onSetSubtitleSize = { newSize -> coroutineScope.launch { viewModel.setSubtitleSize(newSize) } },
                 onSetSubtitleVerticalOffset = { newOffset -> coroutineScope.launch { viewModel.setSubtitleVerticalOffset(newOffset) } },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -142,6 +142,7 @@ internal fun PlaybackSettingsSections(
     onSetSkipSilence: (Boolean) -> Unit,
     onSetRememberAudioDelayPerDevice: (Boolean) -> Unit,
     onSetTunnelingEnabled: (Boolean) -> Unit,
+    onSetForceStereoDownmix: (Boolean) -> Unit,
     onSetMapDV7ToHevc: (Boolean) -> Unit,
     onSetSubtitleSize: (Int) -> Unit,
     onSetSubtitleVerticalOffset: (Int) -> Unit,
@@ -461,6 +462,7 @@ internal fun PlaybackSettingsSections(
                 onSetSkipSilence = onSetSkipSilence,
                 onSetRememberAudioDelayPerDevice = onSetRememberAudioDelayPerDevice,
                 onSetTunnelingEnabled = onSetTunnelingEnabled,
+                onSetForceStereoDownmix = onSetForceStereoDownmix,
                 onSetMapDV7ToHevc = onSetMapDV7ToHevc,
                 onItemFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                 enabled = !generalUi.isExternalPlayer

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -92,6 +92,10 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setTunnelingEnabled(enabled)
     }
 
+    suspend fun setForceStereoDownmix(enabled: Boolean) {
+        playerSettingsDataStore.setForceStereoDownmix(enabled)
+    }
+
     suspend fun setSkipSilence(enabled: Boolean) {
         playerSettingsDataStore.setSkipSilence(enabled)
     }

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1062,6 +1062,8 @@
     <string name="audio_mix_value_db">%1$d dB</string>
     <string name="audio_mix_persist_on">Oturumlar arası sakla: Açık</string>
     <string name="audio_mix_persist_off">Oturumlar arası sakla: Kapalı</string>
+    <string name="audio_force_downmix_session_on">Stereo indirgeme: Açık</string>
+    <string name="audio_force_downmix_session_off">Stereo indirgeme: Kapalı</string>
     <string name="audio_mix_range">Aralık: %1$d dB - %2$d dB</string>
     <string name="audio_mix_range_saved">Aralık: %1$d dB - %2$d dB (kaydedildi)</string>
     <string name="audio_mix_unavailable">Bu cihazda amplifikasyon kullanılamıyor</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1064,6 +1064,8 @@
     <string name="audio_mix_persist_off">Oturumlar arası sakla: Kapalı</string>
     <string name="audio_force_downmix_session_on">Stereo indirgeme: Açık</string>
     <string name="audio_force_downmix_session_off">Stereo indirgeme: Kapalı</string>
+    <string name="audio_night_mode_session_on">Gece modu: Açık</string>
+    <string name="audio_night_mode_session_off">Gece modu: Kapalı</string>
     <string name="audio_mix_range">Aralık: %1$d dB - %2$d dB</string>
     <string name="audio_mix_range_saved">Aralık: %1$d dB - %2$d dB (kaydedildi)</string>
     <string name="audio_mix_unavailable">Bu cihazda amplifikasyon kullanılamıyor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="audio_mix_persist_off">Persist between sessions: OFF</string>
     <string name="audio_force_downmix_session_on">Stereo downmix: ON</string>
     <string name="audio_force_downmix_session_off">Stereo downmix: OFF</string>
+    <string name="audio_night_mode_session_on">Night mode: ON</string>
+    <string name="audio_night_mode_session_off">Night mode: OFF</string>
     <string name="audio_mix_range">Range: %1$d dB to %2$d dB</string>
     <string name="audio_mix_range_saved">Range: %1$d dB to %2$d dB (saved)</string>
     <string name="audio_mix_unavailable">Amplification is not available on this device</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -457,6 +457,9 @@
     <string name="audio_decoder_priority">Decoder Priority</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
+    <string name="audio_force_stereo_downmix">Force Stereo Downmix</string>
+    <string name="audio_force_stereo_downmix_sub">Limit playback to 2 channels. Boosts dialogue clarity on TVs without surround speakers, and avoids multichannel AudioTrack init failures</string>
+    <string name="stream_info_channels_downmix_label">Stereo (downmix)</string>
     <string name="audio_dv_sub">Map Dolby Vision Profile 7 to standard HEVC for devices without DV hardware support</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (MPV-only)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Select how libmpv should use hardware decoders.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1075,6 +1075,8 @@
     <string name="audio_mix_value_db">%1$d dB</string>
     <string name="audio_mix_persist_on">Persist between sessions: ON</string>
     <string name="audio_mix_persist_off">Persist between sessions: OFF</string>
+    <string name="audio_force_downmix_session_on">Stereo downmix: ON</string>
+    <string name="audio_force_downmix_session_off">Stereo downmix: OFF</string>
     <string name="audio_mix_range">Range: %1$d dB to %2$d dB</string>
     <string name="audio_mix_range_saved">Range: %1$d dB to %2$d dB (saved)</string>
     <string name="audio_mix_unavailable">Amplification is not available on this device</string>


### PR DESCRIPTION
## Summary

Extends the Force Stereo Downmix feature (#1664) with:

- 7.1/ 5.1 downmix matrices so surround content actually folds to stereo.

- Force PCM decode for encoded surround formats (E-AC3, AC3, TrueHD, DTS HD) when downmix is on, otherwise the bitstream passthrough bypasses the ChannelMixing processor and downmix silently does nothing.
- New per-stream toggle in the player's Audio overlay (under "Persist between sessions") so users can override the global setting for the current stream without leaving playback.
- When downmix is active, the existing "Amplification (PCM)" slider now boosts the center channel (dialogue) instead of applying broadband gain, so the user can raise speech over effects.

## PR type

- Approved larger change (link approval below)

## Why

On devices that pass surround bitstream to a stereo output (TV speakers, stereo soundbar, headphones) the 7.1/6.1 paths weren't producing any audible downmix, encoded surround was passing through untouched. On top of that, a common user need when folding 5.1/7.1 to stereo is dialogue intelligibility: effects and music get louder than speech after the fold-down. Reusing the existing amplification slider as a dialogue boost while downmix is active avoids adding a second control.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual, on real devices (Android TV ):

- 5.1 E-AC3 HLS stream, downmix OFF: bitstream passthrough to AVR, unchanged.
- 5.1 E-AC3 stream, downmix ON: PCM decode kicks in, ChannelMixingAudioProcessor folds to stereo, no silence.
- 7.1 E-AC3 stream, downmix ON: custom 8→2 matrix produces stereo with back + side channels preserved.
- Stereo content, downmix ON: identity matrix, no regressions.
- Per-stream toggle: enabling/disabling mid-playback flips behavior for the current URL only; next stream reverts to the global setting.
- Dialogue boost: with downmix ON and a 5.1 E-AC3 stream, dragging the amplification slider from 0→10 dB raises dialogue relative to effects; with downmix OFF the slider works as broadband gain (previous behavior preserved). Verified real-time response without reconfigure.
- `./gradlew :app:compileFullDebugKotlin` passes.

## Screenshots / Video (UI changes only)

New toggle card directly below "Persist between sessions" in the audio overlay. Same visual treatment as the existing persist toggle; D-pad routing wired up.

## Breaking changes

None. Global "Force Stereo Downmix" setting behavior is preserved; the new per-stream toggle is a pure override. When downmix is OFF, amplification still applies broadband gain exactly as before.

## Linked issues

Extends #1664.
