### PR TITLE
feat(settings): add Continue Watching sort mode setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -15,6 +15,7 @@ import com.nuvio.tv.core.sync.homeCatalogKey
 import com.nuvio.tv.core.sync.homeCollectionKey
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.Collection
+import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import kotlinx.coroutines.flow.Flow
@@ -75,6 +76,7 @@ class LayoutPreferenceDataStore @Inject constructor(
     private val showUnairedNextUpKey = booleanPreferencesKey("show_unaired_next_up")
     private val nextUpFromFurthestEpisodeKey = booleanPreferencesKey("next_up_from_furthest_episode")
     private val blurContinueWatchingNextUpKey = booleanPreferencesKey("blur_continue_watching_next_up")
+    private val continueWatchingSortModeKey = stringPreferencesKey("continue_watching_sort_mode")
     private val detailPageTrailerButtonEnabledKey = booleanPreferencesKey("detail_page_trailer_button_enabled")
     private val preferExternalMetaAddonDetailKey = booleanPreferencesKey("prefer_external_meta_addon_detail")
     private val modernHeroFullScreenBackdropKey = booleanPreferencesKey("modern_hero_full_screen_backdrop")
@@ -254,6 +256,12 @@ class LayoutPreferenceDataStore @Inject constructor(
 
     val blurContinueWatchingNextUp: Flow<Boolean> = profileFlow { prefs ->
         prefs[blurContinueWatchingNextUpKey] ?: false
+    }
+
+    val continueWatchingSortMode: Flow<ContinueWatchingSortMode> = profileFlow { prefs ->
+        val stored = prefs[continueWatchingSortModeKey] ?: ContinueWatchingSortMode.DEFAULT.name
+        runCatching { ContinueWatchingSortMode.valueOf(stored) }
+            .getOrDefault(ContinueWatchingSortMode.DEFAULT)
     }
 
     val detailPageTrailerButtonEnabled: Flow<Boolean> = profileFlow { prefs ->
@@ -534,6 +542,12 @@ class LayoutPreferenceDataStore @Inject constructor(
     suspend fun setBlurContinueWatchingNextUp(enabled: Boolean) {
         store().edit { prefs ->
             prefs[blurContinueWatchingNextUpKey] = enabled
+        }
+    }
+
+    suspend fun setContinueWatchingSortMode(mode: ContinueWatchingSortMode) {
+        store().edit { prefs ->
+            prefs[continueWatchingSortModeKey] = mode.name
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/domain/model/ContinueWatchingSortMode.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/ContinueWatchingSortMode.kt
@@ -1,0 +1,6 @@
+package com.nuvio.tv.domain.model
+
+enum class ContinueWatchingSortMode {
+    DEFAULT,
+    STREAMING_STYLE
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -24,6 +24,7 @@ import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
 import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.Collection
+import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaPreview
@@ -223,6 +224,8 @@ class HomeViewModel @Inject constructor(
     internal var posterStatusObservationEnabled: Boolean = false
     @Volatile
     internal var externalMetaPrefetchEnabled: Boolean = false
+    @Volatile
+    internal var continueWatchingSortMode: ContinueWatchingSortMode = ContinueWatchingSortMode.DEFAULT
     internal val startupStartedAtMs: Long = SystemClock.elapsedRealtime()
     @Volatile
     internal var startupGracePeriodActive: Boolean = true
@@ -257,6 +260,7 @@ class HomeViewModel @Inject constructor(
             observeLayoutPreferences()
             observeModernHomePresentation()
             observeExternalMetaPrefetchPreference()
+            observeContinueWatchingSortMode()
             loadHomeCatalogOrderPreference()
             loadFollowAddonsOrder()
             loadDisabledHomeCatalogPreference()
@@ -358,6 +362,18 @@ class HomeViewModel @Inject constructor(
     private fun observeModernHomePresentation() = observeModernHomePresentationPipeline()
 
     private fun observeExternalMetaPrefetchPreference() = observeExternalMetaPrefetchPreferencePipeline()
+
+    private fun observeContinueWatchingSortMode() {
+        viewModelScope.launch {
+            layoutPreferenceDataStore.continueWatchingSortMode
+                .distinctUntilChanged()
+                .collect { mode ->
+                    continueWatchingSortMode = mode
+                    // Clear caches so the new sort is applied immediately on next pipeline run
+                    clearAllCwInMemoryCaches()
+                }
+        }
+    }
 
     private fun observeBlurUnwatchedEpisodes() {
         viewModelScope.launch {
@@ -581,7 +597,8 @@ class HomeViewModel @Inject constructor(
             }
             val items = mergeContinueWatchingItems(
                 inProgressItems = inProgressItems,
-                nextUpItems = nextUpItems
+                nextUpItems = nextUpItems,
+                mode = continueWatchingSortMode
             )
             if (items.isNotEmpty()) {
                 _uiState.update { it.copy(continueWatchingItems = items) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchedItemsPreferences
+import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Video
@@ -63,6 +64,7 @@ private data class ContinueWatchingSettingsSnapshot(
     val dismissedNextUp: Set<String>,
     val showUnairedNextUp: Boolean,
     val nextUpFromFurthestEpisode: Boolean,
+    val continueWatchingSortMode: ContinueWatchingSortMode,
     val watchedItemsVersion: Int,  // triggers re-evaluation when watched items change
     val hasLoadedRemoteProgress: Boolean
 )
@@ -264,9 +266,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 traktSettingsDataStore.continueWatchingDaysCap,
                 traktSettingsDataStore.dismissedNextUpKeys,
                 layoutPreferenceDataStore.showUnairedNextUp,
-                layoutPreferenceDataStore.nextUpFromFurthestEpisode
-            ) { daysCap, dismissedNextUp, showUnairedNextUp, nextUpFromFurthest ->
-                arrayOf(daysCap, dismissedNextUp, showUnairedNextUp, nextUpFromFurthest)
+                layoutPreferenceDataStore.nextUpFromFurthestEpisode,
+                layoutPreferenceDataStore.continueWatchingSortMode
+            ) { daysCap, dismissedNextUp, showUnairedNextUp, nextUpFromFurthest, sortMode ->
+                arrayOf(daysCap, dismissedNextUp, showUnairedNextUp, nextUpFromFurthest, sortMode)
             },
             watchedItemsPreferences.allItems.map { it.size },
             cwPipelineRefreshTrigger
@@ -277,6 +280,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
             val dismissedNextUp = settingsSnapshot[1] as Set<String>
             val showUnairedNextUp = settingsSnapshot[2] as Boolean
             val nextUpFromFurthestEpisode = settingsSnapshot[3] as Boolean
+            val continueWatchingSortMode = settingsSnapshot[4] as ContinueWatchingSortMode
             ContinueWatchingSettingsSnapshot(
                 items = items,
                 nextUpSeeds = nextUpSeeds,
@@ -284,6 +288,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 dismissedNextUp = dismissedNextUp,
                 showUnairedNextUp = showUnairedNextUp,
                 nextUpFromFurthestEpisode = nextUpFromFurthestEpisode,
+                continueWatchingSortMode = continueWatchingSortMode,
                 watchedItemsVersion = watchedItemsSize,
                 hasLoadedRemoteProgress = hasLoadedRemoteProgress
             )
@@ -299,6 +304,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val dismissedNextUp = snapshot.dismissedNextUp
                 val showUnairedNextUp = snapshot.showUnairedNextUp
                 val nextUpFromFurthestEpisode = snapshot.nextUpFromFurthestEpisode
+                val continueWatchingSortMode = snapshot.continueWatchingSortMode
                 val cutoffMs = if (!useTraktProgress || daysCap == TraktSettingsDataStore.CONTINUE_WATCHING_DAYS_CAP_ALL) {
                     null
                 } else {
@@ -509,7 +515,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     val initialItems = applyContinueWatchingEnrichmentOverlay(
                         mergeContinueWatchingItems(
                             inProgressItems = inProgressOnly,
-                            nextUpItems = cachedNextUpItems
+                            nextUpItems = cachedNextUpItems,
+                            mode = continueWatchingSortMode
                         )
                     )
 
@@ -589,7 +596,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 val partialItems = applyContinueWatchingEnrichmentOverlay(
                                     mergeContinueWatchingItems(
                                         inProgressItems = inProgressOnly,
-                                        nextUpItems = cachedPartialNextUp + retainedCached
+                                        nextUpItems = cachedPartialNextUp + retainedCached,
+                                        mode = continueWatchingSortMode
                                     )
                                 )
                                 _uiState.update { state ->
@@ -815,13 +823,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                                             nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
                                                     }
                                                     if (newItems.isEmpty()) return@update state
-                                                    val merged = (state.continueWatchingItems + newItems)
-                                                        .sortedByDescending { item ->
-                                                            when (item) {
-                                                                is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                                                                is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
-                                                            }
-                                                        }
+                                                    val merged = sortContinueWatchingItems(
+                                                        state.continueWatchingItems + newItems,
+                                                        continueWatchingSortMode
+                                                    )
                                                     state.copy(continueWatchingItems = merged)
                                                 }
                                             }
@@ -878,13 +883,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                                 nextUpDismissKey(it.info.contentId, it.info.seedSeason, it.info.seedEpisode) !in dismissedNextUp
                                         }
                                         if (newItems.isEmpty()) return@update state
-                                        val merged = (state.continueWatchingItems + newItems)
-                                            .sortedByDescending { item ->
-                                                when (item) {
-                                                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                                                    is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
-                                                }
-                                            }
+                                        val merged = sortContinueWatchingItems(
+                                            state.continueWatchingItems + newItems,
+                                            continueWatchingSortMode
+                                        )
                                         state.copy(continueWatchingItems = merged)
                                     }
                                     // Persist updated CW snapshot
@@ -1009,7 +1011,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                     contentLanguage = cached.contentLanguage ?: nextUp.info.contentLanguage
                                 ))
                             } else nextUp
-                        }
+                        },
+                        mode = continueWatchingSortMode
                     )
                 )
 
@@ -1467,12 +1470,7 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
         enrichedTs != originalTs
     }
     val sortedEnrichedItems = if (sortChanged) {
-        enrichedItems.sortedByDescending { item ->
-            when (item) {
-                is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
-            }
-        }
+        sortContinueWatchingItems(enrichedItems, continueWatchingSortMode)
     } else {
         enrichedItems
     }
@@ -1507,9 +1505,63 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
     true
 }
 
+internal fun sortContinueWatchingItems(
+    items: List<ContinueWatchingItem>,
+    mode: ContinueWatchingSortMode
+): List<ContinueWatchingItem> {
+    return when (mode) {
+        ContinueWatchingSortMode.DEFAULT -> items.sortedByDescending { item ->
+            when (item) {
+                is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
+            }
+        }
+
+        ContinueWatchingSortMode.STREAMING_STYLE -> {
+            val (released, unreleased) = items.partition { item ->
+                when (item) {
+                    is ContinueWatchingItem.InProgress -> true // in-progress is always released
+                    is ContinueWatchingItem.NextUp -> item.info.hasAired
+                }
+            }
+
+            val sortedReleased = released.sortedByDescending { item ->
+                when (item) {
+                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                    is ContinueWatchingItem.NextUp -> item.info.lastWatched
+                }
+            }
+
+            val sortedUnreleased = unreleased.sortedWith { a, b ->
+                val dateA = parseEpisodeReleaseDate(
+                    when (a) {
+                        is ContinueWatchingItem.InProgress -> null
+                        is ContinueWatchingItem.NextUp -> a.info.released
+                    }
+                )
+                val dateB = parseEpisodeReleaseDate(
+                    when (b) {
+                        is ContinueWatchingItem.InProgress -> null
+                        is ContinueWatchingItem.NextUp -> b.info.released
+                    }
+                )
+                when {
+                    dateA == null && dateB == null -> 0
+                    dateA == null -> 1 // unknown dates go to the end
+                    dateB == null -> -1
+                    else -> dateA.compareTo(dateB) // ascending: soonest first
+                }
+            }
+
+            sortedReleased + sortedUnreleased
+        }
+    }
+}
+
 internal fun mergeContinueWatchingItems(
     inProgressItems: List<ContinueWatchingItem.InProgress>,
-    nextUpItems: List<ContinueWatchingItem.NextUp>
+    nextUpItems: List<ContinueWatchingItem.NextUp>,
+    mode: ContinueWatchingSortMode = ContinueWatchingSortMode.DEFAULT
 ): List<ContinueWatchingItem> {
     // Collect ALL in-progress content IDs (not just series) to ensure
     // release alerts and next-up items never duplicate an in-progress entry.
@@ -1523,23 +1575,18 @@ internal fun mergeContinueWatchingItems(
         item.info.contentId !in allInProgressIds
     }
 
-    val combined = mutableListOf<Pair<Long, ContinueWatchingItem>>()
-    inProgressItems.forEach { combined.add(it.progress.lastWatched to it) }
-    filteredNextUpItems.forEach { combined.add(it.info.sortTimestamp to it) }
+    val combined = inProgressItems + filteredNextUpItems
 
     val seen = mutableSetOf<String>()
-    val result = combined
-        .sortedByDescending { it.first }
-        .map { it.second }
-        .filter { item ->
-            val contentId = when (item) {
-                is ContinueWatchingItem.InProgress -> item.progress.contentId
-                is ContinueWatchingItem.NextUp -> item.info.contentId
-            }
-            contentId.isBlank() || seen.add(contentId)
+    val deduplicated = combined.filter { item ->
+        val contentId = when (item) {
+            is ContinueWatchingItem.InProgress -> item.progress.contentId
+            is ContinueWatchingItem.NextUp -> item.info.contentId
         }
+        contentId.isBlank() || seen.add(contentId)
+    }
 
-    return result
+    return sortContinueWatchingItems(deduplicated, mode)
 }
 
 private suspend fun HomeViewModel.buildNextUpItem(
@@ -1891,6 +1938,8 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
 
     val nextSeason = nextVideo.season ?: return null
     val nextEpisode = nextVideo.episode ?: return null
+    val rawReleased = nextVideo.released?.trim()?.takeIf { it.isNotBlank() }
+    val computedHasAired = hasEpisodeAired(rawReleased, fallback = true)
     val resolution = NextUpResolution(
         season = nextSeason,
         episode = nextEpisode,
@@ -1901,10 +1950,10 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
                 nextEpisode
             ),
         episodeTitle = nextVideo.title?.takeIf { it.isNotBlank() },
-        released = nextVideo.released?.trim()?.takeIf { it.isNotBlank() },
-        hasAired = hasEpisodeAired(nextVideo.released, fallback = true),
-        airDateLabel = nextVideo.released?.let(::parseEpisodeReleaseDate)?.let { releaseDate ->
-            if (hasEpisodeAired(nextVideo.released, fallback = true)) null
+        released = rawReleased,
+        hasAired = computedHasAired,
+        airDateLabel = rawReleased?.let(::parseEpisodeReleaseDate)?.let { releaseDate ->
+            if (computedHasAired) null
             else formatEpisodeAirDateLabel(releaseDate)
         },
         lastWatched = progress.lastWatched
@@ -2414,17 +2463,8 @@ private suspend fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
                 }
             }
         }
-        // Re-sort if any sortTimestamp was updated by the overlay to maintain correct order.
-        if (sortChanged) {
-            mapped.sortedByDescending { item ->
-                when (item) {
-                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                    is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
-                }
-            }
-        } else {
-            mapped
-        }
+        if (sortChanged) sortContinueWatchingItems(mapped, continueWatchingSortMode) else mapped
+    }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -55,11 +57,13 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.ui.components.ClassicLayoutPreview
 import com.nuvio.tv.ui.components.GridLayoutPreview
 import com.nuvio.tv.ui.components.ModernLayoutPreview
+import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioColors
 
 @Composable
@@ -100,6 +104,7 @@ fun LayoutSettingsContent(
     var continueWatchingExpanded by rememberSaveable { mutableStateOf(false) }
     var focusedPosterExpanded by rememberSaveable { mutableStateOf(false) }
     var posterCardStyleExpanded by rememberSaveable { mutableStateOf(false) }
+    var showCwSortModeDialog by rememberSaveable { mutableStateOf(false) }
 
     val defaultHomeLayoutHeaderFocus = remember { FocusRequester() }
     val homeContentHeaderFocus = remember { FocusRequester() }
@@ -541,6 +546,17 @@ fun LayoutSettingsContent(
                         },
                         onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
                     )
+
+                    SettingsActionRow(
+                        title = stringResource(R.string.layout_cw_sort_mode),
+                        subtitle = stringResource(R.string.layout_cw_sort_mode_sub),
+                        value = when (uiState.continueWatchingSortMode) {
+                            ContinueWatchingSortMode.DEFAULT -> stringResource(R.string.layout_cw_sort_default)
+                            ContinueWatchingSortMode.STREAMING_STYLE -> stringResource(R.string.layout_cw_sort_streaming)
+                        },
+                        onClick = { showCwSortModeDialog = true },
+                        onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
+                    )
                 }
             }
 
@@ -686,6 +702,112 @@ fun LayoutSettingsContent(
         }
         SettingsVerticalScrollIndicators(state = layoutListState)
         }
+        }
+
+        if (showCwSortModeDialog) {
+            ContinueWatchingSortModeDialog(
+                currentMode = uiState.continueWatchingSortMode,
+                onModeSelected = { mode ->
+                    viewModel.onEvent(LayoutSettingsEvent.SetContinueWatchingSortMode(mode))
+                    showCwSortModeDialog = false
+                },
+                onDismiss = { showCwSortModeDialog = false }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContinueWatchingSortModeDialog(
+    currentMode: ContinueWatchingSortMode,
+    onModeSelected: (ContinueWatchingSortMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    val options = listOf(
+        Triple(
+            ContinueWatchingSortMode.DEFAULT,
+            stringResource(R.string.layout_cw_sort_default),
+            stringResource(R.string.layout_cw_sort_default_desc)
+        ),
+        Triple(
+            ContinueWatchingSortMode.STREAMING_STYLE,
+            stringResource(R.string.layout_cw_sort_streaming),
+            stringResource(R.string.layout_cw_sort_streaming_desc)
+        )
+    )
+
+    NuvioDialog(
+        onDismiss = onDismiss,
+        title = stringResource(R.string.layout_cw_sort_mode),
+        width = 420.dp,
+        suppressFirstKeyUp = false
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 320.dp)
+        ) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(vertical = 4.dp)
+            ) {
+                items(
+                    count = options.size,
+                    key = { index -> options[index].first.name }
+                ) { index ->
+                    val (mode, title, description) = options[index]
+                    val isSelected = mode == currentMode
+
+                    Card(
+                        onClick = { onModeSelected(mode) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(if (index == 0) Modifier.focusRequester(focusRequester) else Modifier),
+                        colors = CardDefaults.colors(
+                            containerColor = if (isSelected) NuvioColors.FocusBackground else NuvioColors.BackgroundCard,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        shape = CardDefaults.shape(shape = RoundedCornerShape(10.dp)),
+                        scale = CardDefaults.scale(focusedScale = 1f)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = title,
+                                    color = if (isSelected) NuvioColors.Primary else NuvioColors.TextPrimary,
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = description,
+                                    color = NuvioColors.TextSecondary,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                            if (isSelected) {
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = stringResource(R.string.cd_selected),
+                                    tint = NuvioColors.Primary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
+import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.domain.repository.AddonRepository
@@ -50,7 +51,8 @@ data class LayoutSettingsUiState(
     val hideUnreleasedContent: Boolean = false,
     val showFullReleaseDate: Boolean = true,
     val nextUpFromFurthestEpisode: Boolean = true,
-    val showUnairedNextUp: Boolean = true
+    val showUnairedNextUp: Boolean = true,
+    val continueWatchingSortMode: ContinueWatchingSortMode = ContinueWatchingSortMode.DEFAULT
 )
 
 data class CatalogInfo(
@@ -91,6 +93,7 @@ sealed class LayoutSettingsEvent {
     data class SetShowFullReleaseDate(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetNextUpFromFurthestEpisode(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetShowUnairedNextUp(val enabled: Boolean) : LayoutSettingsEvent()
+    data class SetContinueWatchingSortMode(val mode: ContinueWatchingSortMode) : LayoutSettingsEvent()
     data object ResetPosterCardStyle : LayoutSettingsEvent()
 }
 
@@ -270,6 +273,13 @@ class LayoutSettingsViewModel @Inject constructor(
                 updateUiStateIfChanged { it.copy(showUnairedNextUp = enabled) }
             }
         }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.continueWatchingSortMode
+                .distinctUntilChanged()
+                .collect { mode ->
+                    updateUiStateIfChanged { it.copy(continueWatchingSortMode = mode) }
+                }
+        }
         loadAvailableCatalogs()
     }
 
@@ -305,6 +315,7 @@ class LayoutSettingsViewModel @Inject constructor(
             is LayoutSettingsEvent.SetShowFullReleaseDate -> setShowFullReleaseDate(event.enabled)
             is LayoutSettingsEvent.SetNextUpFromFurthestEpisode -> setNextUpFromFurthestEpisode(event.enabled)
             is LayoutSettingsEvent.SetShowUnairedNextUp -> setShowUnairedNextUp(event.enabled)
+            is LayoutSettingsEvent.SetContinueWatchingSortMode -> setContinueWatchingSortMode(event.mode)
             LayoutSettingsEvent.ResetPosterCardStyle -> resetPosterCardStyle()
         }
     }
@@ -516,6 +527,13 @@ class LayoutSettingsViewModel @Inject constructor(
         if (_uiState.value.showUnairedNextUp == enabled) return
         viewModelScope.launch {
             layoutPreferenceDataStore.setShowUnairedNextUp(enabled)
+        }
+    }
+
+    private fun setContinueWatchingSortMode(mode: ContinueWatchingSortMode) {
+        if (_uiState.value.continueWatchingSortMode == mode) return
+        viewModelScope.launch {
+            layoutPreferenceDataStore.setContinueWatchingSortMode(mode)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -703,6 +703,12 @@
     <string name="layout_next_up_furthest_episode_sub">Show next episode based on the furthest watched episode. Disable for rewatches to use the most recently watched episode instead.</string>
     <string name="layout_show_unaired_next_up">Show Unaired Next Up Episodes</string>
     <string name="layout_show_unaired_next_up_sub">Include upcoming episodes in Continue Watching before they air.</string>
+    <string name="layout_cw_sort_mode">Sort Order</string>
+    <string name="layout_cw_sort_mode_sub">How Continue Watching items are arranged</string>
+    <string name="layout_cw_sort_default">Default</string>
+    <string name="layout_cw_sort_default_desc">Sort all items by recency</string>
+    <string name="layout_cw_sort_streaming">Streaming Style</string>
+    <string name="layout_cw_sort_streaming_desc">Released items first, upcoming at the end</string>
     <string name="layout_trailer_button">Show Trailer Button</string>
     <string name="layout_trailer_button_sub">Show trailer button on detail page (only when trailer is available).</string>
     <string name="layout_prefer_external_meta">Prefer meta from external addon</string>


### PR DESCRIPTION
## Summary

This PR adds a new **Continue Watching sort mode** setting under Layout Settings, giving users control over how the CW row is ordered.

## PR type

- Small maintenance improvement

## Why

The existing Continue Watching sort (last watched descending with release alerts on top) works well for tracking progress, but many streaming apps (Netflix, HBO Max) use a different pattern: released content bubbles up by recency, while unreleased upcoming episodes are pushed to the end. This PR lets users choose between the two behaviors.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified build: `./gradlew :app:compileFullDebugKotlin` passes
- Manually verified both sort modes update the CW row correctly
- Verified cache invalidation triggers on sort mode change

## Screenshots / Video (UI changes only)

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/9113e295-9c5e-4a79-a772-6a86a9ab8148" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/fa5d0a19-c6ea-41c1-94b8-29028d9d1a7d" />


## Breaking changes

None. Default sort mode preserves existing behavior.

## Linked issues

No linked issues.
