### PR TITLE
Update legal information link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ NuvioTV functions solely as a client-side interface for browsing metadata and pl
 
 NuvioTV is not affiliated with any third-party extensions or content providers. It does not host, store, or distribute any media content.
 
-For comprehensive legal information, including our full disclaimer, third-party extension policy, and DMCA/Copyright information, please visit our **[Legal & Disclaimer Page](https://tapframe.github.io/NuvioTV/#legal)**.
+For comprehensive legal information, including our full disclaimer, third-party extension policy, and DMCA/Copyright information, please visit our **[Legal & Disclaimer Page](https://nuvioapp.space/legal)**.
 
 ## Built With
 


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->
Changed the Legal & Disclaimer Page link from the README from https://tapframe.github.io/NuvioTV/#legal to https://nuvioapp.space/legal
## PR type

<!-- Pick one and delete the others -->

- Docs fix


## Why
The current link in the README points to a depreciated GitHub page, returning error code 404. The project has since moved to it's own domain, including the Legal & Disclaimer Page. This PR updates the link to point to the correct Legal & Disclaimer Page on the new website.
<!-- Why this change is needed. Link bug/issue/context. -->

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)
N/A

## Testing
Tested link change, it successfully points to the correct page.
<!-- What you tested and how (manual + automated). -->

## Screenshots / Video (UI changes only)
No UI change.
<!-- If UI changed, add before/after screenshots or a short clip. -->

## Breaking changes
None
<!-- Any breaking behavior/config/schema changes? If none, write: None -->

## Linked issues
N/A
<!-- Example: Fixes #123 -->
