### PR TITLE
feat(player): prioritize HDR/DV detection in AUTO engine selection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -253,7 +253,8 @@ enum class PlayerPreference {
 
 enum class InternalPlayerEngine {
     EXOPLAYER,
-    MVP_PLAYER
+    MVP_PLAYER,
+    AUTO
 }
 
 /**

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -64,7 +64,7 @@ sealed class Screen(val route: String) {
             return "stream/$encodedVideoId/$encodedContentTypePath/$encodedTitle?poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&season=${season ?: ""}&episode=${episode ?: ""}&episodeName=$encodedEpisodeName&genres=$encodedGenres&year=$encodedYear&contentId=$encodedContentId&contentName=$encodedContentName&runtime=${runtime ?: ""}&manualSelection=$manualSelection&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&startFromBeginning=$startFromBeginning&contentLanguage=$encodedContentLanguage"
         }
     }
-    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}&startFromBeginning={startFromBeginning}&addonName={addonName}&addonLogo={addonLogo}&streamDescription={streamDescription}&infoHash={infoHash}&fileIdx={fileIdx}&sources={sources}&contentLanguage={contentLanguage}") {
+    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}&startFromBeginning={startFromBeginning}&addonName={addonName}&addonLogo={addonLogo}&streamDescription={streamDescription}&infoHash={infoHash}&fileIdx={fileIdx}&sources={sources}&contentLanguage={contentLanguage}&isAnime={isAnime}") {
         private fun encode(value: String): String =
             URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
@@ -98,7 +98,8 @@ sealed class Screen(val route: String) {
             infoHash: String? = null,
             fileIdx: Int? = null,
             sources: List<String>? = null,
-            contentLanguage: String? = null
+            contentLanguage: String? = null,
+            isAnime: Boolean = false
         ): String {
             val encodedUrl = encode(streamUrl)
             val encodedTitle = encode(title)
@@ -124,7 +125,7 @@ sealed class Screen(val route: String) {
             val encodedInfoHash = infoHash ?: ""
             val encodedSources = sources?.let { encode(org.json.JSONArray(it).toString()) } ?: ""
             val encodedContentLanguage = contentLanguage?.let { encode(it) } ?: ""
-            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}&startFromBeginning=$startFromBeginning&addonName=$encodedAddonName&addonLogo=$encodedAddonLogo&streamDescription=$encodedStreamDescription&infoHash=$encodedInfoHash&fileIdx=${fileIdx ?: ""}&sources=$encodedSources&contentLanguage=$encodedContentLanguage"
+            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}&startFromBeginning=$startFromBeginning&addonName=$encodedAddonName&addonLogo=$encodedAddonLogo&streamDescription=$encodedStreamDescription&infoHash=$encodedInfoHash&fileIdx=${fileIdx ?: ""}&sources=$encodedSources&contentLanguage=$encodedContentLanguage&isAnime=$isAnime"
         }
     }
     data object Search : Screen("search")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
@@ -31,7 +31,8 @@ internal data class PlayerNavigationArgs(
     val infoHash: String?,
     val fileIdx: Int?,
     val sourcesJson: String?,
-    val contentLanguage: String?
+    val contentLanguage: String?,
+    val isAnime: Boolean
 ) {
     val torrentTrackers: List<String>
         get() {
@@ -82,7 +83,8 @@ internal data class PlayerNavigationArgs(
                 infoHash = savedStateHandle.get<String>("infoHash")?.takeIf { it.isNotEmpty() },
                 fileIdx = savedStateHandle.get<String>("fileIdx")?.toIntOrNull(),
                 sourcesJson = decodedOrNull("sources"),
-                contentLanguage = decodedOrNull("contentLanguage")
+                contentLanguage = decodedOrNull("contentLanguage"),
+                isAnime = savedStateHandle.get<String>("isAnime")?.toBooleanStrictOrNull() == true
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerEngineFailover.kt
@@ -20,6 +20,7 @@ internal fun PlayerRuntimeController.maybeAutoSwitchInternalPlayerOnStartupError
     val targetEngine = when (currentInternalPlayerEngine) {
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
+        InternalPlayerEngine.AUTO -> InternalPlayerEngine.EXOPLAYER
     }
     beginSwitchTraceSession(reason = "startup-failover", targetEngine = targetEngine)
     logSwitchTrace(
@@ -67,6 +68,7 @@ internal fun PlayerRuntimeController.switchInternalPlayerEngineManually() {
     val targetEngine = when (currentInternalPlayerEngine) {
         InternalPlayerEngine.EXOPLAYER -> InternalPlayerEngine.MVP_PLAYER
         InternalPlayerEngine.MVP_PLAYER -> InternalPlayerEngine.EXOPLAYER
+        InternalPlayerEngine.AUTO -> InternalPlayerEngine.EXOPLAYER
     }
     beginSwitchTraceSession(reason = "manual-osd", targetEngine = targetEngine)
     val targetEngineLabel = targetEngineLabel(targetEngine)
@@ -135,6 +137,7 @@ private fun PlayerRuntimeController.targetEngineLabel(targetEngine: InternalPlay
     return when (targetEngine) {
         InternalPlayerEngine.EXOPLAYER -> context.getString(R.string.playback_engine_exoplayer)
         InternalPlayerEngine.MVP_PLAYER -> context.getString(R.string.playback_engine_mvplayer)
+        InternalPlayerEngine.AUTO -> context.getString(R.string.playback_player_auto)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -109,7 +109,17 @@ internal fun PlayerRuntimeController.initializePlayer(
             )
             mpvPreferredAudioLanguages = preferredAudioLanguages
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
-            val effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
+            var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
+            if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
+                // Determine if anime
+                val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
+                val isAnime = effectiveId.startsWith("kitsu:") ||
+                              effectiveId.startsWith("mal:") ||
+                              effectiveId.startsWith("anilist:") ||
+                              (currentStreamUrl.contains("/anime/"))
+
+                effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
+            }
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -110,16 +110,29 @@ internal fun PlayerRuntimeController.initializePlayer(
             mpvPreferredAudioLanguages = preferredAudioLanguages
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
+            Log.d("NuvioPlayer", "Initializing Player. Settings InternalPlayerEngine: ${playerSettings.internalPlayerEngine}")
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
                 // Determine if anime
                 val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
+                
+                // Logging extra data to help build a better heuristic!
+                Log.d("NuvioPlayer", "AUTO Engine Heuristic Data -> " +
+                    "contentId: '$contentId', videoId: '$currentVideoId', " +
+                    "contentType: '${navigationArgs.contentType}', " +
+                    "addonName: '${navigationArgs.addonName}', " +
+                    "streamName: '${navigationArgs.streamName}', " +
+                    "streamUrl: '$currentStreamUrl', " +
+                    "title: '${navigationArgs.title}'")
+
                 val isAnime = effectiveId.startsWith("kitsu:") ||
                               effectiveId.startsWith("mal:") ||
                               effectiveId.startsWith("anilist:") ||
                               (currentStreamUrl.contains("/anime/"))
-
+                
+                Log.d("NuvioPlayer", "AUTO Engine Selected. Effective ID: '$effectiveId'. isAnime: $isAnime")
                 effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
             }
+            Log.d("NuvioPlayer", "Final Effective InternalPlayerEngine: $effectiveInternalPlayerEngine")
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -112,22 +112,20 @@ internal fun PlayerRuntimeController.initializePlayer(
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             Log.d("NuvioPlayer", "Initializing Player. Settings InternalPlayerEngine: ${playerSettings.internalPlayerEngine}")
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
-                // Determine if anime
-                val effectiveId = (contentId ?: currentVideoId ?: "").lowercase()
-                
-                // Logging extra data to help build a better heuristic!
-                Log.d("NuvioPlayer", "AUTO Engine Heuristic Data -> " +
-                    "contentId: '$contentId', videoId: '$currentVideoId', " +
-                    "contentType: '${navigationArgs.contentType}', " +
-                    "addonName: '${navigationArgs.addonName}', " +
-                    "streamName: '${navigationArgs.streamName}', " +
-                    "streamUrl: '$currentStreamUrl', " +
-                    "title: '${navigationArgs.title}'")
+                val streamMetadataText = buildString {
+                    currentFilename?.let { appendLine(it) }
+                    streamName?.let { appendLine(it) }
+                    currentStreamDescription?.let { appendLine(it) }
+                    append(title)
+                }
+                val isHdr = Regex("""(?i)\b(hdr|hdr10\+?|dv|dolby\s*vision)\b""").containsMatchIn(streamMetadataText)
 
-                val isAnime = navigationArgs.isAnime
-                
-                Log.d("NuvioPlayer", "AUTO Engine Selected. Effective ID: '$effectiveId'. isAnime: $isAnime")
-                effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
+                effectiveInternalPlayerEngine = if (isHdr) {
+                    InternalPlayerEngine.EXOPLAYER
+                } else {
+                    val isAnime = navigationArgs.isAnime
+                    if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
+                }
             }
             Log.d("NuvioPlayer", "Final Effective InternalPlayerEngine: $effectiveInternalPlayerEngine")
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -124,10 +124,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     "streamUrl: '$currentStreamUrl', " +
                     "title: '${navigationArgs.title}'")
 
-                val isAnime = effectiveId.startsWith("kitsu:") ||
-                              effectiveId.startsWith("mal:") ||
-                              effectiveId.startsWith("anilist:") ||
-                              (currentStreamUrl.contains("/anime/"))
+                val isAnime = navigationArgs.isAnime
                 
                 Log.d("NuvioPlayer", "AUTO Engine Selected. Effective ID: '$effectiveId'. isAnime: $isAnime")
                 effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -194,6 +194,7 @@ internal fun PlaybackSettingsSections(
         internalEngineLabel = when (playerSettings.internalPlayerEngine) {
             InternalPlayerEngine.EXOPLAYER -> stringResource(R.string.playback_engine_exoplayer)
             InternalPlayerEngine.MVP_PLAYER -> stringResource(R.string.playback_engine_mvplayer)
+            InternalPlayerEngine.AUTO -> stringResource(R.string.playback_player_auto)
         }
     )
 
@@ -848,6 +849,11 @@ private fun InternalPlayerEngineDialog(
             InternalPlayerEngine.MVP_PLAYER,
             stringResource(R.string.playback_engine_mvplayer),
             stringResource(R.string.playback_engine_mvplayer_desc)
+        ),
+        Triple(
+            InternalPlayerEngine.AUTO,
+            stringResource(R.string.playback_player_auto),
+            stringResource(R.string.playback_player_auto_desc)
         )
     )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -254,7 +254,7 @@ class StreamScreenViewModel @Inject constructor(
                                 fileIdx = cached.fileIdx,
                                 sources = cached.sources,
                                 contentLanguage = contentLanguage,
-                                isAnime = isAnimeContent(streamUrl = cached.url, streamName = cached.streamName)
+                                isAnime = isAnimeContent()
                             )
                         )
                     }
@@ -724,7 +724,7 @@ class StreamScreenViewModel @Inject constructor(
             fileIdx = stream.fileIdx,
             sources = stream.sources,
             contentLanguage = contentLanguage,
-            isAnime = isAnimeContent(streamUrl = stream.getStreamUrl(), streamName = stream.name ?: stream.addonName)
+            isAnime = isAnimeContent()
         )
 
         val url = playbackInfo.url
@@ -753,7 +753,7 @@ class StreamScreenViewModel @Inject constructor(
     }
 
 
-        private fun isAnimeContent(streamUrl: String? = null, streamName: String? = null): Boolean {
+    private fun isAnimeContent(): Boolean {
         // 1. Anime-specific ID namespace
         val effectiveId = (contentId ?: videoId).lowercase()
         if (effectiveId.startsWith("kitsu:") ||
@@ -761,30 +761,10 @@ class StreamScreenViewModel @Inject constructor(
             effectiveId.startsWith("anilist:")) return true
 
         // 2. Explicit "Anime" or "Animation" genre tag
-        if (genres?.lowercase()?.contains("anime") == true ||
-            genres?.lowercase()?.contains("animation") == true ||
-            _uiState.value.genres?.lowercase()?.contains("anime") == true ||
-            _uiState.value.genres?.lowercase()?.contains("animation") == true) return true
-
-        // 3. Fallback to stream url/name heuristic for Anime release groups
-        val urlLower = streamUrl?.lowercase() ?: ""
-        val nameLower = streamName?.lowercase() ?: ""
-        
-        if (urlLower.contains("/anime/") || 
-            urlLower.contains("kitsune") || 
-            urlLower.contains("subsplease") || 
-            urlLower.contains("erai-raws") || 
-            urlLower.contains("judas") || 
-            urlLower.contains("ember") ||
-            urlLower.contains("[cr]") ||
-            nameLower.contains("kitsune") ||
-            nameLower.contains("subsplease") ||
-            nameLower.contains("erai-raws") ||
-            nameLower.contains("[cr]")) {
-            return true
-        }
-
-        return false
+        return genres?.lowercase()?.contains("anime") == true ||
+               genres?.lowercase()?.contains("animation") == true ||
+               _uiState.value.genres?.lowercase()?.contains("anime") == true ||
+               _uiState.value.genres?.lowercase()?.contains("animation") == true
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -254,7 +254,7 @@ class StreamScreenViewModel @Inject constructor(
                                 fileIdx = cached.fileIdx,
                                 sources = cached.sources,
                                 contentLanguage = contentLanguage,
-                                isAnime = isAnimeContent()
+                                isAnime = isAnimeContent(streamUrl = cached.url, streamName = cached.streamName)
                             )
                         )
                     }
@@ -724,7 +724,7 @@ class StreamScreenViewModel @Inject constructor(
             fileIdx = stream.fileIdx,
             sources = stream.sources,
             contentLanguage = contentLanguage,
-            isAnime = isAnimeContent()
+            isAnime = isAnimeContent(streamUrl = stream.getStreamUrl(), streamName = stream.name ?: stream.addonName)
         )
 
         val url = playbackInfo.url
@@ -753,7 +753,7 @@ class StreamScreenViewModel @Inject constructor(
     }
 
 
-    private fun isAnimeContent(): Boolean {
+        private fun isAnimeContent(streamUrl: String? = null, streamName: String? = null): Boolean {
         // 1. Anime-specific ID namespace
         val effectiveId = (contentId ?: videoId).lowercase()
         if (effectiveId.startsWith("kitsu:") ||
@@ -761,10 +761,30 @@ class StreamScreenViewModel @Inject constructor(
             effectiveId.startsWith("anilist:")) return true
 
         // 2. Explicit "Anime" or "Animation" genre tag
-        return genres?.lowercase()?.contains("anime") == true ||
-               genres?.lowercase()?.contains("animation") == true ||
-               _uiState.value.genres?.lowercase()?.contains("anime") == true ||
-               _uiState.value.genres?.lowercase()?.contains("animation") == true
+        if (genres?.lowercase()?.contains("anime") == true ||
+            genres?.lowercase()?.contains("animation") == true ||
+            _uiState.value.genres?.lowercase()?.contains("anime") == true ||
+            _uiState.value.genres?.lowercase()?.contains("animation") == true) return true
+
+        // 3. Fallback to stream url/name heuristic for Anime release groups
+        val urlLower = streamUrl?.lowercase() ?: ""
+        val nameLower = streamName?.lowercase() ?: ""
+        
+        if (urlLower.contains("/anime/") || 
+            urlLower.contains("kitsune") || 
+            urlLower.contains("subsplease") || 
+            urlLower.contains("erai-raws") || 
+            urlLower.contains("judas") || 
+            urlLower.contains("ember") ||
+            urlLower.contains("[cr]") ||
+            nameLower.contains("kitsune") ||
+            nameLower.contains("subsplease") ||
+            nameLower.contains("erai-raws") ||
+            nameLower.contains("[cr]")) {
+            return true
+        }
+
+        return false
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -253,7 +253,8 @@ class StreamScreenViewModel @Inject constructor(
                                 videoSize = cached.videoSize,
                                 fileIdx = cached.fileIdx,
                                 sources = cached.sources,
-                                contentLanguage = contentLanguage
+                                contentLanguage = contentLanguage,
+                                isAnime = isAnimeContent()
                             )
                         )
                     }
@@ -722,7 +723,8 @@ class StreamScreenViewModel @Inject constructor(
             streamDescription = stream.description,
             fileIdx = stream.fileIdx,
             sources = stream.sources,
-            contentLanguage = contentLanguage
+            contentLanguage = contentLanguage,
+            isAnime = isAnimeContent()
         )
 
         val url = playbackInfo.url
@@ -750,7 +752,22 @@ class StreamScreenViewModel @Inject constructor(
         sourceChipErrorDismissJob?.cancel()
     }
 
+
+    private fun isAnimeContent(): Boolean {
+        // 1. Anime-specific ID namespace
+        val effectiveId = (contentId ?: videoId).lowercase()
+        if (effectiveId.startsWith("kitsu:") ||
+            effectiveId.startsWith("mal:") ||
+            effectiveId.startsWith("anilist:")) return true
+
+        // 2. Explicit "Anime" or "Animation" genre tag
+        return genres?.lowercase()?.contains("anime") == true ||
+               genres?.lowercase()?.contains("animation") == true ||
+               _uiState.value.genres?.lowercase()?.contains("anime") == true ||
+               _uiState.value.genres?.lowercase()?.contains("animation") == true
+    }
 }
+
 
 data class StreamPlaybackInfo(
     val url: String?,
@@ -782,5 +799,6 @@ data class StreamPlaybackInfo(
     val streamDescription: String? = null,
     val fileIdx: Int? = null,
     val sources: List<String>? = null,
-    val contentLanguage: String? = null
+    val contentLanguage: String? = null,
+    val isAnime: Boolean = false
 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -754,6 +754,13 @@ class StreamScreenViewModel @Inject constructor(
 
 
     private fun isAnimeContent(): Boolean {
+        // Log all possible data to see if we have anime identifiers
+        val uiStateValue = _uiState.value
+        Log.d(TAG, "METADATA DUMP -> contentId: $contentId, videoId: $videoId, contentType: $contentType")
+        Log.d(TAG, "METADATA DUMP -> Top-level Genres: $genres, title: $title, year: $year, runtime: $runtime, contentName: $contentName")
+        Log.d(TAG, "METADATA DUMP -> UIState Genres: ${uiStateValue.genres}, Title: ${uiStateValue.title}, Year: ${uiStateValue.year}")
+        Log.d(TAG, "METADATA DUMP -> Season: ${uiStateValue.season}, Episode: ${uiStateValue.episode}")
+        
         // 1. Anime-specific ID namespace
         val effectiveId = (contentId ?: videoId).lowercase()
         if (effectiveId.startsWith("kitsu:") ||

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -1506,4 +1506,6 @@
     <string name="collections_tab_all">Todo</string>
     <string name="collections_tab_combined">Combinado</string>
  
+    <string name="playback_player_auto">Automático (Mejor para el contenido)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Películas y Series · MPV para Anime</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1119,4 +1119,6 @@
     <string name="update_ignore">Ignorovat</string>
     <string name="watchlist_added">Přidáno do watchlistu</string>
     <string name="watchlist_removed">Odstraněno z watchlistu</string>
+    <string name="playback_player_auto">Automaticky (Nejlepší pro obsah)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pro filmy a seriály · MPV pro anime</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1148,4 +1148,6 @@
     <string name="update_ignore">Ignorieren</string>
     <string name="watchlist_added">Zur Beobachtungsliste hinzugefügt</string>
     <string name="watchlist_removed">Aus Beobachtungsliste entfernt</string>
+    <string name="playback_player_auto">Automatisch (Am besten für Inhalt)</string>
+    <string name="playback_player_auto_desc">ExoPlayer für Filme &amp; Serien · MPV für Anime</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1182,4 +1182,6 @@
     <string name="update_ignore">Αγνόηση</string>
     <string name="watchlist_added">Προστέθηκε στη watchlist</string>
     <string name="watchlist_removed">Αφαιρέθηκε από τη watchlist</string>
+    <string name="playback_player_auto">Αυτόματο (Καλύτερο για το περιεχόμενο)</string>
+    <string name="playback_player_auto_desc">ExoPlayer για Ταινίες &amp; Σειρές · MPV για Anime</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1046,4 +1046,6 @@
     <string name="update_downloading_ellipsis">Descargando…</string>
     <string name="watchlist_added">Añadido a lista de deseos</string>
     <string name="watchlist_removed">Eliminado de lista de deseos</string>
+    <string name="playback_player_auto">Automático (Mejor para el contenido)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Películas y Series · MPV para Anime</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1509,4 +1509,6 @@
     <string name="collections_tab_all">Tout</string>
     <string name="collections_tab_combined">Combiné</string>
 
+    <string name="playback_player_auto">Auto (Meilleur pour le contenu)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pour les Films et Séries · MPV pour les Animes</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -998,4 +998,6 @@
     <string name="update_open_settings">सेटिंग्स खोलें</string>
     <string name="update_install">इंस्टॉल</string>
     <string name="update_ignore">नज़रअंदाज़ करें</string>
+    <string name="playback_player_auto">ऑटो (सामग्री के लिए सर्वश्रेष्ठ)</string>
+    <string name="playback_player_auto_desc">ExoPlayer मूवीज़ और टीवी शोज़ के लिए · MPV एनीमे के लिए</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1308,4 +1308,6 @@
     <string name="debug_generate_description">Debug-generato %1$s elemento #%2$d</string>
     <string name="debug_generate_result_failed">Fallito: %1$s</string>
 
+    <string name="playback_player_auto">Automatico (Il migliore per i contenuti)</string>
+    <string name="playback_player_auto_desc">ExoPlayer per Film e Serie TV · MPV per gli Anime</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1034,4 +1034,6 @@
     <string name="sub_mode_effects_gl">Effects OpenGL</string>
     <string name="sub_mode_effects_gl_sub">תמיכת אנימציה באמצעות אפקטי Media3. מהיר יותר מ-Canvas.</string>
     <string name="sub_advanced_section">רינדור כתוביות מתקדם</string>
+    <string name="playback_player_auto">אוטומטי (הטוב ביותר לתוכן)</string>
+    <string name="playback_player_auto_desc">ExoPlayer לסרטים ולתוכניות טלוויזיה · MPV לאנימה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1182,4 +1182,6 @@
     <string name="update_ignore">無視</string>
     <string name="watchlist_added">ウォッチリストに追加しました</string>
     <string name="watchlist_removed">ウォッチリストから削除しました</string>
+    <string name="playback_player_auto">自動（コンテンツに最適化）</string>
+    <string name="playback_player_auto_desc">映画やドラマにはExoPlayer・アニメにはMPV</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1011,4 +1011,6 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="update_ignore">Ignoruoti</string>
     <string name="watchlist_added">Pridėta į žiūrėjimo sąrašą</string>
     <string name="watchlist_removed">Pašalinta iš žiūrėjimo sąrašo</string>
+    <string name="playback_player_auto">Automatiškai (Geriausia turiniui)</string>
+    <string name="playback_player_auto_desc">ExoPlayer filmams ir serialams · MPV animėms</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -870,4 +870,6 @@
     <string name="update_open_settings">Open Instellingen</string>
     <string name="update_install">Installeer</string>
     <string name="update_ignore">Negeer</string>
+    <string name="playback_player_auto">Automatisch (Beste voor inhoud)</string>
+    <string name="playback_player_auto_desc">ExoPlayer voor films en series · MPV voor anime</string>
 </resources>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -1124,4 +1124,6 @@
     <string name="update_ignore">Ignorer</string>
     <string name="watchlist_added">Lagt til ønskelisten</string>
     <string name="watchlist_removed">Fjernet fra ønskelisten</string>
+    <string name="playback_player_auto">Automatisk (Best for innhold)</string>
+    <string name="playback_player_auto_desc">ExoPlayer for filmer og serier · MPV for anime</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1515,4 +1515,6 @@
     <string name="qr_login_signing_in">Logowanie…</string>
     <string name="qr_login_success">Zalogowano pomyślnie</string>
     <string name="qr_login_exchange_failed">Nie udało się dokończyć logowania QR</string>
+    <string name="playback_player_auto">Zalecane (Najlepsze dla treści)</string>
+    <string name="playback_player_auto_desc">ExoPlayer dla filmów i seriali · MPV dla anime</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1509,4 +1509,6 @@
     <string name="collections_tab_all">Tudo</string>
     <string name="collections_tab_combined">Combinado</string>
     
-  </resources>
+      <string name="playback_player_auto">Automático (Melhor para o conteúdo)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Filmes e Séries · MPV para Animes</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1058,4 +1058,6 @@
     <string name="update_ignore">Ignorar</string>
     <string name="watchlist_added">Adicionado à lista de interesses</string>
     <string name="watchlist_removed">Removido da lista de interesses</string>
+    <string name="playback_player_auto">Automático (Melhor para o conteúdo)</string>
+    <string name="playback_player_auto_desc">ExoPlayer para Filmes e Séries · MPV para Animes</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -842,4 +842,6 @@
     <string name="update_open_settings">Deschide Setările</string>
     <string name="update_install">Instalează</string>
     <string name="update_ignore">Ignoră</string>
-  </resources>
+      <string name="playback_player_auto">Automat (Cel mai bun pentru conținut)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pentru Filme și Seriale · MPV pentru Anime</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1488,4 +1488,6 @@
     <string name="collections_tab_all">Все</string>
     <string name="collections_tab_combined">Объединенные</string>
 
+    <string name="playback_player_auto">Авто (Лучшее для контента)</string>
+    <string name="playback_player_auto_desc">ExoPlayer для фильмов и сериалов · MPV для аниме</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -739,4 +739,6 @@
     <string name="update_open_settings">Otvoriť nastavenia</string>
     <string name="update_install">Inštalovať</string>
     <string name="update_ignore">Ignorovať</string>
+    <string name="playback_player_auto">Automaticky (Najlepšie pre obsah)</string>
+    <string name="playback_player_auto_desc">ExoPlayer pre filmy a seriály · MPV pre anime</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1418,4 +1418,6 @@
     <string name="collections_card_subtitle">Združite kataloge v mape na začetnem zaslonu</string>
     <string name="collections_tab_all">Vse</string>
     <string name="collections_tab_combined">Združeno</string>															  
-	</resources>
+	    <string name="playback_player_auto">Samodejno (Najboljše za vsebino)</string>
+    <string name="playback_player_auto_desc">ExoPlayer za filme in serije · MPV za anime</string>
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1203,4 +1203,6 @@
     <string name="update_checking">Söker efter uppdateringar…</string>
     <string name="update_download_complete">Nedladdning klar. Redo att installera.</string>
     <string name="update_up_to_date">Systemet är uppdaterat. Senaste ändringarna:</string>
+    <string name="playback_player_auto">Automatiskt (Bäst för innehåll)</string>
+    <string name="playback_player_auto_desc">ExoPlayer för filmer och serier · MPV för anime</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1384,4 +1384,6 @@
     <string name="debug_signin_success">Giriş başarılı</string>
     <string name="debug_generate_description">Hata ayıklama için %1$s öğesi oluşturuldu #%2$d</string>
     <string name="debug_generate_result_failed">Başarısız: %1$s</string>
+    <string name="playback_player_auto">Otomatik (İçerik için en iyisi)</string>
+    <string name="playback_player_auto_desc">Filmler ve Diziler için ExoPlayer · Anime için MPV</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -891,4 +891,6 @@
     <string name="update_open_settings">Mở cài đặt</string>
     <string name="update_install">Cài đặt</string>
     <string name="update_ignore">Bỏ qua</string>
+    <string name="playback_player_auto">Tự động (Tốt nhất cho nội dung)</string>
+    <string name="playback_player_auto_desc">ExoPlayer cho Phim &amp; TV Show · MPV cho Anime</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,6 +369,8 @@
     <string name="playback_resolution_matching_sub">Allow display mode changes to match video resolution.</string>
     <string name="playback_player_external_desc">Always open streams in an external app</string>
     <string name="playback_player_ask_desc">Choose the player each time</string>
+    <string name="playback_player_auto">Auto (Best for Content)</string>
+    <string name="playback_player_auto_desc">ExoPlayer for Movies &amp; TV Shows · MPV for Anime</string>
     <string name="playback_engine_exoplayer_desc">Best compatibility with current Nuvio features.</string>
     <string name="playback_engine_mvplayer_desc">Uses libmpv with Nuvio OSD controls. Experimental.</string>
 


### PR DESCRIPTION
## Summary
When the internal player engine is set to **AUTO**, this change checks stream metadata (filename, stream name, description, title) for HDR / Dolby Vision tags **before** falling back to anime detection. This ensures HDR anime content uses ExoPlayer instead of mpv, avoiding stutter and improper tonemapping to SDR.

## PR type
- Approved larger change (link approval below)

## Why
Fixes #1546. Currently, the AUTO engine selection detects anime properly but does not account for HDR/Dolby Vision content. When HDR anime is detected as anime, it falls back to mpv which causes massive stutter and improper tonemapping to SDR. By prioritizing HDR/DV detection, ExoPlayer is used for all HDR media.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Manual testing on emulator: verified that streams with "Dolby Vision" in the metadata correctly select ExoPlayer when engine is set to AUTO. Note: actual Dolby Vision playback requires a physical device with DV decoder support.

## Screenshots / Video (UI changes only)
None

## Breaking changes
None

## Linked issues
Fixes #1546
