### PR TITLE
feat(player): internal engine auto - use ExoPlayer if stream is HDR or DV

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -124,17 +124,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
-                val hasAnimeGenre = metaGenres.any { it.equals("anime", ignoreCase = true) }
-                val isAnimationFromJapan = (metaGenres.any { it.equals("animation", ignoreCase = true) } &&
-                        metaCountry?.contains("Japan", ignoreCase = true) == true)
-                val hasAnimeId = currentVideoId?.startsWith("kitsu:") == true ||
-                        currentVideoId?.startsWith("mal:") == true ||
-                        currentVideoId?.startsWith("anilist:") == true
-
-                // AIOMetadata usually matches hasAnimeGenre or hasAnimeId, Cinemeta usually matches isAnimationFromJapan
-                val isAnime = hasAnimeGenre || hasAnimeId || isAnimationFromJapan
-
-                effectiveInternalPlayerEngine = if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
+                effectiveInternalPlayerEngine = resolveAutoInternalPlayerEngine()
             }
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             if (overrideInternalPlayerEngine == null && playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO) {
@@ -553,6 +543,32 @@ internal fun PlayerRuntimeController.initializePlayer(
                 )
             }
         }
+    }
+}
+
+internal fun PlayerRuntimeController.resolveAutoInternalPlayerEngine(): InternalPlayerEngine {
+    val streamMetadataText = buildString {
+        currentFilename?.let { appendLine(it) }
+        streamName?.let { appendLine(it) }
+        currentStreamDescription?.let { appendLine(it) }
+        append(title)
+    }
+    val isHdrOrDv = Regex("""(?i)\b(hdr|hdr10\+?|dv|dolby\s*vision)\b""").containsMatchIn(streamMetadataText)
+
+    return if (isHdrOrDv) {
+        InternalPlayerEngine.EXOPLAYER
+    } else {
+        val hasAnimeGenre = metaGenres.any { it.equals("anime", ignoreCase = true) }
+        val isAnimationFromJapan = (metaGenres.any { it.equals("animation", ignoreCase = true) } &&
+                metaCountry?.contains("Japan", ignoreCase = true) == true)
+        val hasAnimeId = currentVideoId?.startsWith("kitsu:") == true ||
+                currentVideoId?.startsWith("mal:") == true ||
+                currentVideoId?.startsWith("anilist:") == true
+
+        // AIOMetadata usually matches hasAnimeGenre or hasAnimeId, Cinemeta usually matches isAnimationFromJapan
+        val isAnime = hasAnimeGenre || hasAnimeId || isAnimationFromJapan
+
+        if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
     }
 }
 


### PR DESCRIPTION
## Summary
When the internal player engine is set to **AUTO**, this change checks stream metadata (filename, stream name, description, title) for HDR / Dolby Vision tags **before** falling back to anime detection. This ensures HDR anime content uses ExoPlayer instead of mpv, avoiding stutter and improper tonemapping to SDR.

## PR type
- Small maintenance improvement

## Why
Currently, the AUTO engine selection detects anime properly but does not account for HDR/Dolby Vision content. When HDR anime is detected as anime, it falls back to mpv which causes improper tonemapping to SDR. With HDR/DV detection, ExoPlayer can be used for all HDR media.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing
Tested on Emulator and also on NVIDIA Shield.

I used the Demon Slayer Infinity Train movie, picking a stream with DV and HDR. It correctly used ExoPlayer.

## Screenshots / Video (UI changes only)
None

## Breaking changes
No breaking changes.

## Linked issues
Fixes #1546
