### PR TITLE
Post Release Fixes 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
@@ -66,6 +66,7 @@ fun GridContentCard(
     modifier: Modifier = Modifier,
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
     showLabel: Boolean = true,
+    showLogo: Boolean = false,
     imageCrossfade: Boolean = true,
     isWatched: Boolean = false,
     focusRequester: FocusRequester? = null,
@@ -187,7 +188,7 @@ fun GridContentCard(
                     )
                 }
 
-                if (!item.logo.isNullOrBlank()) {
+                if (showLogo && !item.logo.isNullOrBlank()) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
@@ -238,7 +239,7 @@ fun GridContentCard(
             }
         }
 
-        if (showLabel && item.logo.isNullOrBlank()) {
+        if (showLabel && (!showLogo || item.logo.isNullOrBlank())) {
             Text(
                 text = item.name,
                 style = MaterialTheme.typography.titleMedium,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -134,7 +134,7 @@ fun GridHomeContent(
         }
     }
 
-    // Offset for section indices when continue watching is present
+    // Offset for section indices: pre-items + continue watching item (if present)
     val gridItems = uiState.gridItems
     val continueWatchingItems = uiState.continueWatchingItems
     val continueWatchingOffset = if (continueWatchingItems.isNotEmpty()) 1 else 0
@@ -230,6 +230,23 @@ fun GridHomeContent(
         }
     }
 
+    // Compute the split point: items before the first section divider/collection header
+    // are "pre-section" items (e.g. Hero). Continue Watching goes between them and the rest.
+    val firstSectionIndex = remember(gridItemsWithKeys) {
+        gridItemsWithKeys.indexOfFirst { (item, _) ->
+            item is GridItem.SectionDivider || item is GridItem.CollectionHeader
+        }
+    }
+    val preItems = remember(gridItemsWithKeys, firstSectionIndex) {
+        if (firstSectionIndex > 0) gridItemsWithKeys.subList(0, firstSectionIndex)
+        else if (firstSectionIndex == 0) emptyList()
+        else gridItemsWithKeys // no section divider found — all items are "pre"
+    }
+    val postItems = remember(gridItemsWithKeys, firstSectionIndex) {
+        if (firstSectionIndex >= 0) gridItemsWithKeys.subList(firstSectionIndex, gridItemsWithKeys.size)
+        else emptyList()
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         val contentFocusRequester = LocalContentFocusRequester.current
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
@@ -251,30 +268,128 @@ fun GridHomeContent(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            var continueWatchingInserted = false
             var firstGridFocusableAssigned = false
 
-            items(
-                items = gridItemsWithKeys,
-                key = { it.second },
-                span = { pair ->
-                    val spanCount = when (pair.first) {
-                        is GridItem.Hero, is GridItem.SectionDivider, is GridItem.CollectionHeader -> maxLineSpan
-                        else -> 1
+            // Emit pre-section items (Hero)
+            if (preItems.isNotEmpty()) {
+                items(
+                    items = preItems,
+                    key = { it.second },
+                    span = { pair ->
+                        val spanCount = when (pair.first) {
+                            is GridItem.Hero, is GridItem.SectionDivider, is GridItem.CollectionHeader -> maxLineSpan
+                            else -> 1
+                        }
+                        GridItemSpan(spanCount)
+                    },
+                    contentType = { pair ->
+                        when (pair.first) {
+                            is GridItem.Hero -> "hero"
+                            is GridItem.SectionDivider -> "divider"
+                            is GridItem.Content -> "content"
+                            is GridItem.SeeAll -> "see_all"
+                            is GridItem.CollectionHeader -> "collection_header"
+                            is GridItem.CollectionFolder -> "collection_folder"
+                        }
                     }
-                    GridItemSpan(spanCount)
-                },
-                contentType = { pair ->
-                    when (pair.first) {
-                        is GridItem.Hero -> "hero"
-                        is GridItem.SectionDivider -> "divider"
-                        is GridItem.Content -> "content"
-                        is GridItem.SeeAll -> "see_all"
-                        is GridItem.CollectionHeader -> "collection_header"
-                        is GridItem.CollectionFolder -> "collection_folder"
+                ) { (gridItem, itemKey) ->
+                    when (gridItem) {
+                        is GridItem.Hero -> {
+                            HeroCarousel(
+                                items = gridItem.items.asStable(),
+                                focusRequester = if (shouldRequestInitialFocus) heroFocusRequester else null,
+                                onItemClick = remember(onNavigateToDetail) {
+                                    { item ->
+                                        onNavigateToDetail(
+                                            item.id,
+                                            item.apiType,
+                                            ""
+                                        )
+                                    }
+                                },
+                                fullWidth = gridWidth,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                        else -> { /* pre-section should only contain Hero */ }
                     }
                 }
-            ) { (gridItem, itemKey) ->
+            }
+
+            // Emit Continue Watching as a dedicated item
+            if (continueWatchingItems.isNotEmpty()) {
+                item(
+                    key = "continue_watching",
+                    span = { GridItemSpan(maxLineSpan) },
+                    contentType = "continue_watching"
+                ) {
+                    GridContinueWatchingSection(
+                        modifier = Modifier.fillMaxWidth(),
+                        fullWidth = gridWidth,
+                        items = continueWatchingItems,
+                        focusedItemIndex = if (shouldRequestInitialFocus && !hasHero) 0 else -1,
+                        onItemClick = onContinueWatchingClick,
+                        onStartFromBeginning = onContinueWatchingStartFromBeginning,
+                        showManualPlayOption = showContinueWatchingManualPlayOption,
+                        onPlayManually = onContinueWatchingPlayManually,
+                        onDetailsClick = { item ->
+                            onNavigateToDetail(
+                                when (item) {
+                                    is ContinueWatchingItem.InProgress -> item.progress.contentId
+                                    is ContinueWatchingItem.NextUp -> item.info.contentId
+                                },
+                                when (item) {
+                                    is ContinueWatchingItem.InProgress -> item.progress.contentType
+                                    is ContinueWatchingItem.NextUp -> item.info.contentType
+                                },
+                                ""
+                            )
+                        },
+                        onRemoveItem = { item ->
+                            val contentId = when (item) {
+                                is ContinueWatchingItem.InProgress -> item.progress.contentId
+                                is ContinueWatchingItem.NextUp -> item.info.contentId
+                            }
+                            val season = when (item) {
+                                is ContinueWatchingItem.InProgress -> item.progress.season
+                                is ContinueWatchingItem.NextUp -> item.info.seedSeason
+                            }
+                            val episode = when (item) {
+                                is ContinueWatchingItem.InProgress -> item.progress.episode
+                                is ContinueWatchingItem.NextUp -> item.info.seedEpisode
+                            }
+                            val isNextUp = item is ContinueWatchingItem.NextUp
+                            onRemoveContinueWatching(contentId, season, episode, isNextUp)
+                        },
+                        blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
+                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
+                    )
+                }
+            }
+
+            // Emit post-section items (SectionDividers, Content, SeeAll, Collections)
+            if (postItems.isNotEmpty()) {
+                items(
+                    items = postItems,
+                    key = { it.second },
+                    span = { pair ->
+                        val spanCount = when (pair.first) {
+                            is GridItem.Hero, is GridItem.SectionDivider, is GridItem.CollectionHeader -> maxLineSpan
+                            else -> 1
+                        }
+                        GridItemSpan(spanCount)
+                    },
+                    contentType = { pair ->
+                        when (pair.first) {
+                            is GridItem.Hero -> "hero"
+                            is GridItem.SectionDivider -> "divider"
+                            is GridItem.Content -> "content"
+                            is GridItem.SeeAll -> "see_all"
+                            is GridItem.CollectionHeader -> "collection_header"
+                            is GridItem.CollectionFolder -> "collection_folder"
+                        }
+                    }
+                ) { (gridItem, itemKey) ->
                 when (gridItem) {
                     is GridItem.Hero -> {
                         HeroCarousel(
@@ -295,52 +410,6 @@ fun GridHomeContent(
                     }
 
                     is GridItem.SectionDivider -> {
-                        // Insert continue watching before the first section divider
-                        if (!continueWatchingInserted && continueWatchingItems.isNotEmpty()) {
-                            continueWatchingInserted = true
-                            GridContinueWatchingSection(
-                                modifier = Modifier.fillMaxWidth(),
-                                fullWidth = gridWidth,
-                                items = continueWatchingItems,
-                                focusedItemIndex = if (shouldRequestInitialFocus && !hasHero) 0 else -1,
-                                onItemClick = onContinueWatchingClick,
-                                onStartFromBeginning = onContinueWatchingStartFromBeginning,
-                                showManualPlayOption = showContinueWatchingManualPlayOption,
-                                onPlayManually = onContinueWatchingPlayManually,
-                                onDetailsClick = { item ->
-                                    onNavigateToDetail(
-                                        when (item) {
-                                            is ContinueWatchingItem.InProgress -> item.progress.contentId
-                                            is ContinueWatchingItem.NextUp -> item.info.contentId
-                                        },
-                                        when (item) {
-                                            is ContinueWatchingItem.InProgress -> item.progress.contentType
-                                            is ContinueWatchingItem.NextUp -> item.info.contentType
-                                        },
-                                        ""
-                                    )
-                                },
-                                onRemoveItem = { item ->
-                                    val contentId = when (item) {
-                                        is ContinueWatchingItem.InProgress -> item.progress.contentId
-                                        is ContinueWatchingItem.NextUp -> item.info.contentId
-                                    }
-                                    val season = when (item) {
-                                        is ContinueWatchingItem.InProgress -> item.progress.season
-                                        is ContinueWatchingItem.NextUp -> item.info.seedSeason
-                                    }
-                                    val episode = when (item) {
-                                        is ContinueWatchingItem.InProgress -> item.progress.episode
-                                        is ContinueWatchingItem.NextUp -> item.info.seedEpisode
-                                    }
-                                    val isNextUp = item is ContinueWatchingItem.NextUp
-                                    onRemoveContinueWatching(contentId, season, episode, isNextUp)
-                                },
-                                blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                                useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
-                            )
-                        }
-
                         val strTypeMovie = stringResource(R.string.type_movie)
                         val strTypeSeries = stringResource(R.string.type_series)
                         val typeLabel = when (gridItem.type.lowercase()) {
@@ -426,36 +495,6 @@ fun GridHomeContent(
                     }
 
                     is GridItem.CollectionHeader -> {
-                        if (!continueWatchingInserted && continueWatchingItems.isNotEmpty()) {
-                            continueWatchingInserted = true
-                            GridContinueWatchingSection(
-                                modifier = Modifier.fillMaxWidth(),
-                                fullWidth = gridWidth,
-                                items = continueWatchingItems,
-                                focusedItemIndex = if (shouldRequestInitialFocus && !hasHero) 0 else -1,
-                                onItemClick = { onContinueWatchingClick(it) },
-                                onStartFromBeginning = onContinueWatchingStartFromBeginning,
-                                showManualPlayOption = showContinueWatchingManualPlayOption,
-                                onPlayManually = onContinueWatchingPlayManually,
-                                onDetailsClick = { item ->
-                                    onNavigateToDetail(
-                                        when (item) { is ContinueWatchingItem.InProgress -> item.progress.contentId; is ContinueWatchingItem.NextUp -> item.info.contentId },
-                                        when (item) { is ContinueWatchingItem.InProgress -> item.progress.contentType; is ContinueWatchingItem.NextUp -> item.info.contentType },
-                                        ""
-                                    )
-                                },
-                                onRemoveItem = { item ->
-                                    onRemoveContinueWatching(
-                                        when (item) { is ContinueWatchingItem.InProgress -> item.progress.contentId; is ContinueWatchingItem.NextUp -> item.info.contentId },
-                                        when (item) { is ContinueWatchingItem.InProgress -> item.progress.season; is ContinueWatchingItem.NextUp -> item.info.seedSeason },
-                                        when (item) { is ContinueWatchingItem.InProgress -> item.progress.episode; is ContinueWatchingItem.NextUp -> item.info.seedEpisode },
-                                        item is ContinueWatchingItem.NextUp
-                                    )
-                                },
-                                blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                                useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
-                            )
-                        }
                         SectionDivider(catalogName = gridItem.title)
                     }
 
@@ -476,55 +515,6 @@ fun GridHomeContent(
                     }
                 }
             }
-
-            if (!continueWatchingInserted && continueWatchingItems.isNotEmpty()) {
-                item(
-                    key = "continue_watching_fallback",
-                    span = { GridItemSpan(maxLineSpan) },
-                    contentType = "continue_watching"
-                ) {
-                    GridContinueWatchingSection(
-                        modifier = Modifier.fillMaxWidth(),
-                        fullWidth = gridWidth,
-                        items = continueWatchingItems,
-                        focusedItemIndex = if (shouldRequestInitialFocus && !hasHero) 0 else -1,
-                        onItemClick = onContinueWatchingClick,
-                        onStartFromBeginning = onContinueWatchingStartFromBeginning,
-                        showManualPlayOption = showContinueWatchingManualPlayOption,
-                        onPlayManually = onContinueWatchingPlayManually,
-                        onDetailsClick = { item ->
-                            onNavigateToDetail(
-                                when (item) {
-                                    is ContinueWatchingItem.InProgress -> item.progress.contentId
-                                    is ContinueWatchingItem.NextUp -> item.info.contentId
-                                },
-                                when (item) {
-                                    is ContinueWatchingItem.InProgress -> item.progress.contentType
-                                    is ContinueWatchingItem.NextUp -> item.info.contentType
-                                },
-                                ""
-                            )
-                        },
-                        onRemoveItem = { item ->
-                            val contentId = when (item) {
-                                is ContinueWatchingItem.InProgress -> item.progress.contentId
-                                is ContinueWatchingItem.NextUp -> item.info.contentId
-                            }
-                            val season = when (item) {
-                                is ContinueWatchingItem.InProgress -> item.progress.season
-                                is ContinueWatchingItem.NextUp -> item.info.seedSeason
-                            }
-                            val episode = when (item) {
-                                is ContinueWatchingItem.InProgress -> item.progress.episode
-                                is ContinueWatchingItem.NextUp -> item.info.seedEpisode
-                            }
-                            val isNextUp = item is ContinueWatchingItem.NextUp
-                            onRemoveContinueWatching(contentId, season, episode, isNextUp)
-                        },
-                        blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
-                    )
-                }
             }
 
         } // end LazyVerticalGrid

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -657,6 +657,27 @@ class HomeViewModel @Inject constructor(
         loadCatalogPipeline(addon, catalog, generation)
     }
 
+    /**
+     * Load all pending lazy catalogs at once. Used when switching to GRID layout
+     * which needs all catalogs available upfront.
+     */
+    internal fun loadAllPendingLazyCatalogs() {
+        val pending = synchronized(catalogStateLock) {
+            val copy = pendingLazyCatalogs.toMap()
+            pendingLazyCatalogs.clear()
+            copy
+        }
+        if (pending.isEmpty()) return
+        val generation = catalogLoadGeneration
+        pending.forEach { (key, pair) ->
+            if (lazyLoadRequestedKeys.add(key)) {
+                val (addon, catalog) = pair
+                pendingCatalogLoads = (pendingCatalogLoads + 1)
+                loadCatalogPipeline(addon, catalog, generation)
+            }
+        }
+    }
+
     private suspend fun updateCatalogRows() = updateCatalogRowsPipeline()
 
     internal var posterStatusReconcileJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import com.nuvio.tv.domain.model.MetaPreview
 import kotlinx.coroutines.launch
@@ -270,8 +271,15 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
         }
 
         // Determine which home catalogs to load eagerly vs lazily.
-        val eagerHomeCatalogs = catalogsToLoad.take(eagerCatalogLoadCount)
-        val lazyHomeCatalogs = catalogsToLoad.drop(eagerCatalogLoadCount)
+        // Grid layout loads all catalogs eagerly since it doesn't support
+        // placeholder shimmer rows — all content must be available upfront.
+        // Wait for layout preferences if not yet ready, to avoid wrong eager/lazy split.
+        if (!_uiState.value.layoutPreferencesReady) {
+            _uiState.first { it.layoutPreferencesReady }
+        }
+        val isGridLayout = _uiState.value.homeLayout == HomeLayout.GRID
+        val eagerHomeCatalogs = if (isGridLayout) catalogsToLoad else catalogsToLoad.take(eagerCatalogLoadCount)
+        val lazyHomeCatalogs = if (isGridLayout) emptyList() else catalogsToLoad.drop(eagerCatalogLoadCount)
 
         // Build placeholder descriptors for lazy catalogs
         synchronized(catalogStateLock) {
@@ -734,7 +742,9 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                 when (homeRow) {
                     is HomeRow.Catalog -> {
                         val row = homeRow.row
-                        if (row.items.isNotEmpty()) {
+                        val isPlaceholderRow = row.isLoading &&
+                            row.items.firstOrNull()?.id?.startsWith("__placeholder_") == true
+                        if (row.items.isNotEmpty() && !isPlaceholderRow) {
                             add(GridItem.SectionDivider(
                                 catalogName = row.catalogName,
                                 catalogId = row.catalogId,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -220,6 +220,11 @@ internal fun HomeViewModel.observeLayoutPreferencesPipeline() {
                     )
                 }
                 if (shouldRefreshCatalogPresentation) {
+                    // When switching to GRID layout, load all pending lazy catalogs
+                    // since grid doesn't support placeholder shimmer rows.
+                    if (prefs.layout == HomeLayout.GRID) {
+                        loadAllPendingLazyCatalogs()
+                    }
                     // When hero catalog keys change, load any hero catalogs
                     // not yet in catalogsMap (e.g., after startup race or
                     // when user changes hero selection in settings).

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -270,7 +270,8 @@ fun ModernHomeContent(
         if (verticalRowListState.isScrollInProgress) return@LaunchedEffect
         val selection = focusedCatalogSelection.value ?: return@LaunchedEffect
         if (selection.payload !is ModernPayload.Catalog) return@LaunchedEffect
-        delay(uiState.focusedPosterBackdropExpandDelaySeconds.coerceAtLeast(0) * 1000L)
+        val expansionDelayMs = (uiState.focusedPosterBackdropExpandDelaySeconds.coerceAtLeast(0) * 1000L).coerceAtLeast(150L)
+        delay(expansionDelayMs)
         if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return@LaunchedEffect
         if (shouldActivateFocusedPosterFlow &&
             !verticalRowListState.isScrollInProgress &&

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -316,6 +316,7 @@ private fun ModernCatalogRowItem(
     val playTrailerInExpandedCard =
         effectiveAutoplayEnabled &&
             !isSidebarExpanded &&
+            isCardFocused &&
             trailerPlaybackTarget == FocusedPosterTrailerPlaybackTarget.EXPANDED_CARD &&
             effectiveBackdropExpanded
     val trailerUrl = expandedTrailerPreviewUrl()


### PR DESCRIPTION
## Summary

Fix multiple UI bugs in Grid and Library views:
- Remove clearlogo overlay from GridContentCard (logo display is only for extended/expanded posters in ContentCard)
- Fix Continue Watching section appearing multiple times and overlapping grid items during scroll
- Fix Grid view not loading all catalogs (lazy loading disabled for Grid, all catalogs load eagerly)
- Filter out placeholder shimmer rows from Grid view
- Fix potential trailer auto-play during fast horizontal D-pad scrolling in Modern view

## PR type

- Bug fix

## Why

Several regressions were reported:
1. Library items showing clearlogo overlay on poster cards (introduced in 3a13c681 by adding logo display to GridContentCard)
2. Continue Watching section appearing intermittently at different positions in Grid view due to a local var flag inside a lazy composition lambda that doesn't persist across recompositions
3. Grid view only showing a subset of catalogs because lazy catalog loading was enabled but Grid has no mechanism to trigger lazy loads (no placeholder shimmer rows)
4. Trailer preview could start playing during fast D-pad scrolling in Modern view due to missing focus check and insufficient expansion debounce

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual testing on Android TV with Grid layout: verified all catalogs load, no shimmer placeholders shown, Continue Watching appears once at correct position
- Manual testing Library screen: verified clearlogo no longer overlays poster cards, text labels shown correctly
- Manual testing Modern view: verified trailer does not trigger during fast horizontal scrolling
- Verified expanded poster cards in ContentCard still show logo overlay correctly (unaffected)

## Screenshots / Video (UI changes only)

 behavioral fixes, no visual design changes

## Breaking changes

Nothing should break

## Linked issues

Reported on Discord