### PR TITLE
i18n(fr): mass string extraction + new FR keys

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1883,4 +1883,41 @@
     <string name="tmdb_entity_error_load_named">Impossible de charger %1$s</string>
     <string name="tmdb_entity_error_load">Impossible de charger l’élément TMDB</string>
 
+
+    <!-- Locale parity (matches values/strings.xml additions on dev) -->
+    <string name="addon_manage_addons_only_from_phone_subtitle">Scanne un code QR pour installer ou supprimer des addons depuis ton téléphone</string>
+    <string name="addon_qr_addons_only_scan_instruction">Scanne avec ton téléphone pour installer ou supprimer des addons</string>
+    <string name="web_manage_addons_only_subtitle">Installer ou supprimer des addons</string>
+    <string name="auto_skip_intro">Intro / Générique de début</string>
+    <string name="auto_skip_intro_sub">Passer automatiquement les intros et les génériques d’anime.</string>
+    <string name="auto_skip_outro">Outro / Générique de fin</string>
+    <string name="auto_skip_outro_sub">Passer automatiquement les outros et les génériques de fin d’anime.</string>
+    <string name="auto_skip_recap">Résumé</string>
+    <string name="auto_skip_recap_sub">Passer automatiquement les segments de résumé.</string>
+    <string name="playback_auto_skip_segments">Saut automatique</string>
+    <string name="playback_auto_skip_segments_sub">Choisis les segments à passer automatiquement.</string>
+    <string name="collections_editor_tmdb_director_title_placeholder">Films de Christopher Nolan, réalisateurs favoris</string>
+    <string name="collections_editor_tmdb_help_director">Saisis un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de réalisation.</string>
+    <string name="collections_editor_tmdb_help_person">Saisis un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de casting.</string>
+    <string name="collections_editor_tmdb_mode_director">Réalisateur</string>
+    <string name="collections_editor_tmdb_mode_person">Personne</string>
+    <string name="collections_editor_tmdb_person_helper">Exemple : https://www.themoviedb.org/person/31-tom-hanks ou 31.</string>
+    <string name="collections_editor_tmdb_person_id">ID de personne</string>
+    <string name="collections_editor_tmdb_person_placeholder">31 pour Tom Hanks, ou URL de personne</string>
+    <string name="collections_editor_tmdb_person_title_placeholder">Films de Tom Hanks, acteurs favoris</string>
+    <string name="experience_mode_confirm_advanced_subtitle">Ce mode révèle l’ensemble des paramètres, y compris la configuration avancée et les contrôles de catalogue, de collection et de réglage fin.</string>
+    <string name="experience_mode_confirm_advanced_title">Passer en mode avancé&#160;?</string>
+    <string name="experience_mode_confirm_essential_subtitle">Les écrans de configuration avancée seront masqués, mais tes paramètres enregistrés restent inchangés. Tu peux revenir en arrière à tout moment.</string>
+    <string name="experience_mode_confirm_essential_title">Passer en mode essentiel&#160;?</string>
+    <string name="experience_mode_essential">Essentiel</string>
+    <string name="experience_mode_group_title">Mode d’expérience</string>
+    <string name="experience_mode_switch_to_advanced">Passer en mode avancé</string>
+    <string name="experience_mode_switch_to_advanced_header_subtitle">Passe en mode avancé pour accéder à l’ensemble des paramètres.</string>
+    <string name="experience_mode_switch_to_advanced_subtitle">Afficher la disposition complète, les plugins, les intégrations, les catalogues, les collections et les réglages fins.</string>
+    <string name="experience_mode_switch_to_essential">Passer en mode essentiel</string>
+    <string name="experience_mode_switch_to_essential_subtitle">Masquer les écrans de configuration avancée sans modifier les valeurs enregistrées.</string>
+    <string name="settings_experience">Expérience</string>
+    <string name="settings_experience_subtitle">Essentiel ou avancé</string>
+    <string name="profile_custom_avatar_web_panel_note">Les URL d’avatar personnalisé peuvent être configurées depuis le panneau web Nuvio.</string>
+    <string name="tv_channel_continue_watching">Continuer à regarder</string>
 </resources>


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1692. This pass:

- **70 additional UI strings extracted** from hardcoded literals into `R.string.*`:
  - `AddonManagerScreen` — refresh subtitles
  - `PluginScreen` — diagnostics expand/collapse
  - `CollectionEditorViewModel` — Trakt/TMDB error messages, Untitled Collection
  - `TraktViewModel` — status & error messages, "Connected as <user>"
  - `LibraryViewModel` — sync, list create/update/delete/reorder messages
  - `AccountViewModel` — full `userFriendlyError` mapping (26 messages: PIN, sync, auth, network, QR login)
  - `MetaDetailsViewModel` — library/lists/watched error messages
  - `SearchViewModel` / `SearchScreen`
  - `StreamScreenViewModel` — `Embedded Streams` group/fallback names
  - `ProfileManager` + `ProfileDataStore` — default profile name
- **25 new FR translations** for keys added in upstream `dev` after PR #1692 merge:
  - `experience_mode_*` (essential/advanced switching UX)
  - `auto_skip_intro/outro/recap` (anime opening/ending auto-skip)
  - `addon_manage_addons_only_*`, `web_manage_addons_only_subtitle`
  - `tv_channel_continue_watching`, `playback_auto_skip_segments`
- **Technical terms preserved as-is**: `addon`, `plugin`, `scraper`, `hero`, `stream`, `cache`, `buffer`, brand names (`Trakt`, `TMDB`, `Marvel Studios`, `Netflix`, `HBO`, `Disney+`, etc.).
- Includes user's manual work on multiple non-i18n files (TraktAuthService, AccountViewModel error pipeline, AddonWebPage server pages, NuvioTopBar, SidebarNavigation, etc.).

EN ↔ FR fully aligned: 1764 keys on each side, no missing/orphan, XML valid.

## Why

PR #1692 closed the first wave of FR i18n work (existing missing keys + a small set of hardcoded extractions). This second pass tackles the remaining hardcoded literals across ViewModels (errors, status messages, mappings) and brings the FR locale up to date with new EN keys merged into `dev` since #1692.

Goals:
- Make every user-visible message localizable so the FR (and any future locale) stays in sync without code changes.
- Keep the AccountViewModel error pipeline locale-aware: previously every error string was hardcoded English, now mapped through `R.string.account_error_*`.
- Maintain typography rules established in #1692 (typographic apostrophes, NBSP before `: ; ? !`, tutoiement, possessive agreement at French gender).

## Testing

- Built the app (debug) — all `R.string.*` references resolve, no missing-key compile errors.
- Verified XML validity of both `values/strings.xml` and `values-fr/strings.xml` via Python `xml.etree.ElementTree` parser.
- Verified 1:1 key parity between EN and FR (1764 keys, no missing, no orphan).
- Spot-checked impacted screens with locale set to FR: Addon manager (refresh action banner), Plugin manager (diagnostics toggle), Stream selector (`All` filter chip + Embedded Streams group), Player + subtitle timing, Folder detail, Collection editor (Catalog/TMDB/Trakt pickers, error messages, item count), Library (sync status, list ops), Account (sign-in errors).
- Verified no residual hardcoded literals matching `Text("...")`, `text = "<English>"`, `contentDescription = "<English>"`, `placeholder = "..."`, `Toast.makeText(... "...")` in extracted files.

## Breaking changes

None. All changes are additive (new string resources) or substitution-only (literals replaced by `stringResource(R.string.…)` / `context.getString(R.string.…)`). `CollectionEditorViewModel` gains a `@ApplicationContext Context` injection (Hilt) — no public API change.

## Linked issues

None.