### PR TITLE
fix(continue-watching): correct inverted condition in cached next-up eviction

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -464,7 +464,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     if (!cached.hasAired && !showUnairedNextUp) return@mapNotNull null
                     // Drop if the series no longer has any watched-episode seeds
                     // (e.g. user unmarked all episodes as watched).
-                    if (!snapshot.hasLoadedRemoteProgress && cached.contentId !in activeSeedContentIds) return@mapNotNull null
+                    if (snapshot.hasLoadedRemoteProgress && cached.contentId !in activeSeedContentIds) return@mapNotNull null
                     val currentSeed = currentSeedByContentId[cached.contentId]
                     if (currentSeed != null && cached.seedSeason != null && cached.seedEpisode != null) {
                         val (curSeason, curEpisode) = currentSeed


### PR DESCRIPTION
## Summary

Fixes an inverted boolean condition introduced in PR #1675 that broke Continue Watching cache eviction for cached next-up items. The condition was meant to drop cached items only after remote progress has finished loading and the series no longer has any watched seeds, but the negation caused it to evaluate backwards.

## PR type

- Bug fix

## Why

After PR #1675, two bugs appeared:

1. **Ghost shows in CW:** When a user removed all Trakt history for a show, the show remained in the Continue Watching section indefinitely because the cached item was never evicted.

2. **"New episode" tag returning after profile switch:** When switching profiles, the inverted condition falsely dropped all cached next-up items during the initial loading window. This forced the pipeline to rebuild items from raw metadata before enrichment could correct `hasAired` and `airDateLabel`, causing already-watched episodes to temporarily display the "New episode" badge.

Both bugs trace back to the same single-character inversion (`!snapshot.hasLoadedRemoteProgress` instead of `snapshot.hasLoadedRemoteProgress`) on the cached next-up filter in `loadContinueWatchingPipeline()`.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

1. Compiled the project with `./gradlew :app:compileFullDebugKotlin` — build succeeded.
2. Verified the corrected condition now aligns with the other three `hasLoadedRemoteProgress` checks in the same pipeline (lines 328, 917, 961).

## Screenshots / Video (UI changes only)

N/A — no UI changes.

## Breaking changes

No breaking changes.

## Linked issues

No linked issues.