### PR TITLE
Fix scroll jank, gif, backdrop flash, ratings focus, and Trakt perf

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TraktApi.kt
@@ -123,14 +123,14 @@ interface TraktApi {
         @Path("section") section: String,
         @Query("type") type: String? = null,
         @Query("page") page: Int = 1,
-        @Query("limit") limit: Int = 100
+        @Query("limit") limit: Int = 1000
     ): Response<List<TraktHiddenItemDto>>
 
     @GET("sync/history/episodes")
     suspend fun getEpisodeHistory(
         @Header("Authorization") authorization: String,
         @Query("page") page: Int = 1,
-        @Query("limit") limit: Int = 100,
+        @Query("limit") limit: Int = 1000,
         @Query("start_at") startAt: String? = null,
         @Query("end_at") endAt: String? = null
     ): Response<List<TraktUserEpisodeHistoryItemDto>>
@@ -258,7 +258,7 @@ interface TraktApi {
         @Path("type") type: String,
         @Query("extended") extended: String = "full,images",
         @Query("page") page: Int = 1,
-        @Query("limit") limit: Int = 50,
+        @Query("limit") limit: Int = 1000,
         @Query("sort_by") sortBy: String? = null,
         @Query("sort_how") sortHow: String? = null
     ): Response<List<TraktListItemDto>>
@@ -318,7 +318,7 @@ interface TraktApi {
         @Path("type") type: String,
         @Query("extended") extended: String = "full,images",
         @Query("page") page: Int = 1,
-        @Query("limit") limit: Int = 100,
+        @Query("limit") limit: Int = 1000,
         @Query("sort_by") sortBy: String? = null,
         @Query("sort_how") sortHow: String? = null
     ): Response<List<TraktListItemDto>>
@@ -344,7 +344,7 @@ interface TraktApi {
         @Header("Authorization") authorization: String,
         @Path("type") type: String,
         @Query("page") page: Int = 1,
-        @Query("limit") limit: Int = 100
+        @Query("limit") limit: Int = 1000
     ): Response<List<TraktListItemDto>>
 
     @GET("users/{id}/watchlist/{type}/{sort}")
@@ -355,7 +355,7 @@ interface TraktApi {
         @Path("sort") sort: String = "rank",
         @Query("extended") extended: String = "full,images",
         @Query("page") page: Int = 1,
-        @Query("limit") limit: Int = 100
+        @Query("limit") limit: Int = 1000
     ): Response<List<TraktListItemDto>>
 
     @POST("sync/watchlist")

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -75,7 +75,8 @@ class TraktProgressService @Inject constructor(
     private val traktSettingsDataStore: TraktSettingsDataStore,
     private val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     private val traktEpisodeMappingService: TraktEpisodeMappingService,
-    private val profileManager: ProfileManager
+    private val profileManager: ProfileManager,
+    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
 ) {
     companion object {
         private const val TAG = "TraktProgressSvc"
@@ -1119,7 +1120,7 @@ class TraktProgressService @Inject constructor(
     private suspend fun fetchHiddenProgressShowIds(): Set<String> {
         val allIds = mutableSetOf<String>()
         var page = 1
-        val limit = 100
+        val limit = 1000
         while (true) {
             val response = traktAuthService.executeAuthorizedRequest { authHeader ->
                 traktApi.getHiddenItems(
@@ -1664,7 +1665,7 @@ class TraktProgressService @Inject constructor(
         }
         val results = linkedMapOf<String, WatchProgress>()
         var page = 1
-        val pageLimit = 100
+        val pageLimit = 1000
         val maxPages = if (isAllHistoryWindow()) 20 else 5
 
         while (page <= maxPages) {
@@ -1735,7 +1736,9 @@ class TraktProgressService @Inject constructor(
         if (contentId.isBlank()) return null
 
         val lastWatched = parseIsoToMillis(item.watchedAt)
-        val resolvedEpisode = if (applyAddonRemap) {
+        // Skip expensive addon remap for fully watched series — they won't appear in Continue Watching.
+        val isFullyWatched = contentId in watchedSeriesStateHolder.fullyWatchedSeriesIds.value
+        val resolvedEpisode = if (applyAddonRemap && !isFullyWatched) {
             resolveAddonEpisodeProgress(
                 contentId = contentId,
                 season = season,
@@ -1909,7 +1912,9 @@ class TraktProgressService @Inject constructor(
 
         val contentId = normalizeContentId(show.ids)
         if (contentId.isBlank()) return null
-        val resolvedEpisode = if (applyAddonRemap) {
+        // Skip expensive addon remap for fully watched series — they won't appear in Continue Watching.
+        val isFullyWatched = contentId in watchedSeriesStateHolder.fullyWatchedSeriesIds.value
+        val resolvedEpisode = if (applyAddonRemap && !isFullyWatched) {
             resolveAddonEpisodeProgress(
                 contentId = contentId,
                 season = season,

--- a/app/src/main/java/com/nuvio/tv/ui/components/CollectionFolderCardMedia.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CollectionFolderCardMedia.kt
@@ -6,14 +6,13 @@ fun collectionFolderCardImageUrl(
     folder: CollectionFolder,
     isFocused: Boolean
 ): String? {
-    if (!folder.focusGifEnabled) {
-        return firstNonBlank(folder.coverImageUrl)
-    }
-    return if (isFocused) {
+    // When focusGifEnabled is off, the GIF URL acts as a regular poster (priority over cover image).
+    val effectiveCover = if (!folder.focusGifEnabled) {
         firstNonBlank(folder.focusGifUrl, folder.coverImageUrl)
     } else {
-        firstNonBlank(folder.coverImageUrl, folder.focusGifUrl)
+        firstNonBlank(folder.coverImageUrl)
     }
+    return effectiveCover
 }
 
 private fun firstNonBlank(vararg candidates: String?): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/components/CollectionRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CollectionRowSection.kt
@@ -42,10 +42,13 @@ import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.BringIntoViewSpec
 import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -285,6 +288,27 @@ private fun FolderCard(
                         color = NuvioColors.TextSecondary
                     )
                 }
+            }
+
+            // GIF overlay: show on top of cover image or emoji, visible only once loaded
+            val focusGifUrl = if (isFocused && folder.focusGifEnabled) folder.focusGifUrl else null
+            if (!focusGifUrl.isNullOrBlank()) {
+                var gifLoaded by remember(focusGifUrl) { mutableStateOf(false) }
+                val gifAlpha by animateFloatAsState(
+                    targetValue = if (gifLoaded) 1f else 0f,
+                    animationSpec = tween(durationMillis = 200),
+                    label = "gifFadeIn"
+                )
+                AsyncImage(
+                    model = focusGifUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(shape)
+                        .graphicsLayer { alpha = gifAlpha },
+                    contentScale = ContentScale.FillBounds,
+                    onSuccess = { gifLoaded = true }
+                )
             }
 
             if (!folder.hideTitle) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -103,8 +103,10 @@ fun FolderDetailScreen(
 
     val enrichingItemId by viewModel.enrichingItemId.collectAsStateWithLifecycle()
     val enrichedPreviews by viewModel.enrichedPreviews.collectAsStateWithLifecycle()
+    val failedEnrichmentIds by viewModel.failedEnrichmentIds.collectAsStateWithLifecycle()
     val trailerPreviewUrls by viewModel.trailerPreviewUrls.collectAsStateWithLifecycle()
     val trailerPreviewAudioUrls by viewModel.trailerPreviewAudioUrls.collectAsStateWithLifecycle()
+    val scrollToTopTrigger by viewModel.scrollToTopTrigger.collectAsStateWithLifecycle()
 
     if (uiState.viewMode == FolderViewMode.FOLLOW_LAYOUT) {
         FollowLayoutContent(
@@ -112,6 +114,7 @@ fun FolderDetailScreen(
             focusState = followLayoutFocusState,
             enrichingItemId = enrichingItemId,
             enrichedPreviews = enrichedPreviews,
+            failedEnrichmentIds = failedEnrichmentIds,
             onNavigateToDetail = onNavigateToDetail,
             onLoadMoreCatalog = viewModel::loadMoreForCatalog,
             onSaveFocusState = { vi, vo, rk, ikm, m, ri, ii ->
@@ -119,9 +122,14 @@ fun FolderDetailScreen(
             },
             onSaveGridFocusState = viewModel::saveFollowLayoutGridFocusState,
             onItemFocus = viewModel::onItemFocused,
+            onPreloadAdjacentItem = viewModel::preloadAdjacentItem,
+            onCatalogItemLongPress = { item, addonBaseUrl ->
+                viewModel.posterOptions.show(item, addonBaseUrl)
+            },
             trailerPreviewUrls = trailerPreviewUrls,
             trailerPreviewAudioUrls = trailerPreviewAudioUrls,
-            onRequestTrailerPreview = viewModel::requestTrailerPreview
+            onRequestTrailerPreview = viewModel::requestTrailerPreview,
+            scrollToTopTrigger = scrollToTopTrigger
         )
     } else {
         Column(
@@ -667,14 +675,18 @@ private fun FollowLayoutContent(
     focusState: HomeScreenFocusState,
     enrichingItemId: String? = null,
     enrichedPreviews: Map<String, MetaPreview> = emptyMap(),
+    failedEnrichmentIds: Set<String> = emptySet(),
     onNavigateToDetail: (String, String, String) -> Unit,
     onLoadMoreCatalog: (String, String, String) -> Unit = { _, _, _ -> },
     onSaveFocusState: (Int, Int, String?, Map<String, String>, Map<String, Int>, Int, Int) -> Unit,
     onSaveGridFocusState: (Int, Int, String?) -> Unit,
     onItemFocus: (MetaPreview) -> Unit = {},
+    onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
+    onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     trailerPreviewUrls: Map<String, String> = emptyMap(),
     trailerPreviewAudioUrls: Map<String, String> = emptyMap(),
-    onRequestTrailerPreview: (String, String, String?, String) -> Unit = { _, _, _, _ -> }
+    onRequestTrailerPreview: (String, String, String?, String) -> Unit = { _, _, _, _ -> },
+    scrollToTopTrigger: Int = 0
 ) {
     val homeState = uiState.followLayoutHomeState
 
@@ -738,6 +750,7 @@ private fun FollowLayoutContent(
             focusState = focusState,
             enrichingItemId = enrichingItemId,
             enrichedPreviews = enrichedPreviews,
+            failedEnrichmentIds = failedEnrichmentIds,
             trailerPreviewUrls = trailerPreviewUrls,
             trailerPreviewAudioUrls = trailerPreviewAudioUrls,
             onNavigateToDetail = onNavigateToDetail,
@@ -746,9 +759,12 @@ private fun FollowLayoutContent(
             onLoadMoreCatalog = onLoadMoreCatalog,
             onRemoveContinueWatching = noOpRemoveCw,
             isCatalogItemWatched = isItemWatched,
+            onCatalogItemLongPress = onCatalogItemLongPress,
             onNavigateToFolderDetail = noOpFolderDetail,
             onItemFocus = onItemFocus,
-            onSaveFocusState = onSaveFocusState
+            onPreloadAdjacentItem = onPreloadAdjacentItem,
+            onSaveFocusState = onSaveFocusState,
+            scrollToTopTrigger = scrollToTopTrigger
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -140,6 +140,18 @@ class FolderDetailViewModel @Inject constructor(
     private var activeTrailerPreviewItemId: String? = null
     private var trailerPreviewRequestVersion: Long = 0L
 
+    /** Items for which enrichment was attempted but produced no enriched data. */
+    private val _failedEnrichmentIds = MutableStateFlow<Set<String>>(emptySet())
+    val failedEnrichmentIds: StateFlow<Set<String>> = _failedEnrichmentIds.asStateFlow()
+
+    private val _scrollToTopTrigger = MutableStateFlow(0)
+    val scrollToTopTrigger: StateFlow<Int> = _scrollToTopTrigger.asStateFlow()
+
+    private var adjacentItemPrefetchJob: Job? = null
+    private var pendingAdjacentPrefetchItemId: String? = null
+    private val prefetchedTmdbIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+    private val prefetchedExternalMetaIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
     private val _rowsFocusState = MutableStateFlow(com.nuvio.tv.ui.screens.home.HomeScreenFocusState())
     val rowsFocusState: StateFlow<com.nuvio.tv.ui.screens.home.HomeScreenFocusState> = _rowsFocusState.asStateFlow()
 
@@ -402,7 +414,8 @@ class FolderDetailViewModel @Inject constructor(
                 posterCardCornerRadiusDp = s.posterCardCornerRadiusDp,
                 hideUnreleasedContent = s.hideUnreleasedContent,
                 showFullReleaseDate = s.showFullReleaseDate,
-                movieWatchedStatus = s.movieWatchedStatus
+                movieWatchedStatus = s.movieWatchedStatus,
+                heroEnrichmentEnabled = true
             )
             s.copy(followLayoutHomeState = if (modernPresentation != null) {
                 homeState.copy(modernHomePresentation = modernPresentation)
@@ -908,7 +921,14 @@ class FolderDetailViewModel @Inject constructor(
                 }
             }
 
-            if (enrichment == null && !externalMetaEnabled) return@launch
+            if (enrichment == null && !externalMetaEnabled) {
+                // Mark as failed so the UI can show addon data immediately.
+                if (item.id !in _enrichedPreviews.value) {
+                    _failedEnrichmentIds.value = _failedEnrichmentIds.value + item.id
+                }
+                if (_enrichingItemId.value == item.id) _enrichingItemId.value = null
+                return@launch
+            }
             enrichedItemIds.add(item.id)
 
             // Apply TMDB enrichment if available.
@@ -965,6 +985,11 @@ class FolderDetailViewModel @Inject constructor(
                             imdbRating = meta.imdbRating ?: merged.imdbRating,
                             releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: merged.releaseInfo
                         )
+                    }
+                } else {
+                    // External meta also failed — mark as failed enrichment.
+                    if (item.id !in _enrichedPreviews.value) {
+                        _failedEnrichmentIds.value = _failedEnrichmentIds.value + item.id
                     }
                 }
             }
@@ -1048,6 +1073,129 @@ class FolderDetailViewModel @Inject constructor(
                 tab.copy(catalogRow = row.copy(items = items))
             }
             if (changed) state.copy(tabs = updatedTabs) else state
+        }
+    }
+
+    fun scrollToTop() {
+        _scrollToTopTrigger.value++
+    }
+
+    /**
+     * Preloads enrichment data for an adjacent item (next item in the row) so that
+     * when the user navigates to it, the hero/backdrop data is already available.
+     * Mirrors HomeViewModel.preloadAdjacentItem behavior.
+     */
+    fun preloadAdjacentItem(item: MetaPreview) {
+        if (item.id in enrichedItemIds) return
+        if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) return
+        if (pendingAdjacentPrefetchItemId == item.id) return
+
+        pendingAdjacentPrefetchItemId = item.id
+        adjacentItemPrefetchJob?.cancel()
+        adjacentItemPrefetchJob = viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            kotlinx.coroutines.delay(600)
+            if (pendingAdjacentPrefetchItemId != item.id) return@launch
+            if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) return@launch
+
+            val tmdbSettings = tmdbSettingsDataStore.settings.first()
+            val homeLayout = _uiState.value.homeLayout
+            val tmdbEnabled = tmdbSettings.enabled &&
+                (homeLayout != HomeLayout.MODERN || tmdbSettings.modernHomeEnabled)
+            val externalMetaEnabled = layoutPreferenceDataStore.preferExternalMetaAddonDetail.first()
+
+            if (!tmdbEnabled && !externalMetaEnabled) return@launch
+
+            try {
+                var tmdbEnriched = false
+                if (tmdbEnabled) {
+                    val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                    if (tmdbId != null) {
+                        val enrichment = runCatching {
+                            tmdbMetadataService.fetchEnrichment(
+                                tmdbId = tmdbId,
+                                contentType = item.type,
+                                language = tmdbSettings.language
+                            )
+                        }.getOrNull()
+                        if (enrichment != null) {
+                            prefetchedTmdbIds.add(item.id)
+                            prefetchedExternalMetaIds.add(item.id)
+                            enrichedItemIds.add(item.id)
+                            updateItemInTabs(item.id) { merged ->
+                                var result = merged
+                                if (tmdbSettings.useBasicInfo) {
+                                    val isModern = _uiState.value.homeLayout == HomeLayout.MODERN
+                                    result = result.copy(
+                                        name = if (isModern) enrichment.localizedTitle ?: result.name else result.name,
+                                        description = enrichment.description ?: result.description,
+                                        genres = if (enrichment.genres.isNotEmpty()) enrichment.genres else result.genres
+                                    )
+                                }
+                                if (tmdbSettings.useArtwork) {
+                                    result = result.copy(
+                                        background = enrichment.backdrop ?: result.background,
+                                        logo = enrichment.logo ?: result.logo
+                                    )
+                                }
+                                if (tmdbSettings.useReleaseDates) {
+                                    result = result.copy(
+                                        releaseInfo = enrichment.releaseInfo ?: result.releaseInfo
+                                    )
+                                }
+                                if (tmdbSettings.useDetails) {
+                                    result = result.copy(
+                                        runtime = enrichment.runtimeMinutes?.toString() ?: result.runtime,
+                                        ageRating = enrichment.ageRating ?: result.ageRating,
+                                        status = enrichment.status ?: result.status
+                                    )
+                                }
+                                result
+                            }
+                            val enrichedItem = _uiState.value.tabs
+                                .firstNotNullOfOrNull { tab ->
+                                    tab.catalogRow?.items?.firstOrNull { it.id == item.id }
+                                }
+                            if (enrichedItem != null) {
+                                _enrichedPreviews.update { it + (item.id to enrichedItem) }
+                            }
+                            rebuildFollowLayoutState()
+                            tmdbEnriched = true
+                        }
+                    }
+                }
+                if (!tmdbEnriched && externalMetaEnabled && item.id !in prefetchedExternalMetaIds) {
+                    prefetchedExternalMetaIds.add(item.id)
+                    val result = metaRepository.getMetaFromAllAddons(item.apiType, item.id)
+                        .first { it is com.nuvio.tv.core.network.NetworkResult.Success || it is com.nuvio.tv.core.network.NetworkResult.Error }
+                    if (result is com.nuvio.tv.core.network.NetworkResult.Success) {
+                        enrichedItemIds.add(item.id)
+                        val meta = result.data
+                        updateItemInTabs(item.id) { merged ->
+                            merged.copy(
+                                name = meta.name.takeIf { it.isNotBlank() } ?: merged.name,
+                                description = meta.description?.takeIf { it.isNotBlank() } ?: merged.description,
+                                background = meta.background?.takeIf { it.isNotBlank() } ?: merged.background,
+                                logo = meta.logo?.takeIf { it.isNotBlank() } ?: merged.logo,
+                                genres = meta.genres.takeIf { it.isNotEmpty() } ?: merged.genres,
+                                imdbRating = meta.imdbRating ?: merged.imdbRating,
+                                releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: merged.releaseInfo
+                            )
+                        }
+                        val enrichedItem = _uiState.value.tabs
+                            .firstNotNullOfOrNull { tab ->
+                                tab.catalogRow?.items?.firstOrNull { it.id == item.id }
+                            }
+                        if (enrichedItem != null) {
+                            _enrichedPreviews.update { it + (item.id to enrichedItem) }
+                        }
+                        rebuildFollowLayoutState()
+                    }
+                }
+            } finally {
+                if (pendingAdjacentPrefetchItemId == item.id) {
+                    pendingAdjacentPrefetchItemId = null
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
@@ -50,7 +50,8 @@ fun EpisodeRatingsSection(
     title: String = "Ratings",
     upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
-    firstItemFocusRequester: FocusRequester? = null
+    firstItemFocusRequester: FocusRequester? = null,
+    ratingsGridFocusRequester: FocusRequester? = null
 ) {
     val seasonNumbers = remember(episodes) {
         episodes
@@ -63,6 +64,8 @@ fun EpisodeRatingsSection(
     val seasonFocusRequesters = remember(seasonNumbers) {
         seasonNumbers.associateWith { FocusRequester() }
     }
+    val internalRatingsGridFocusRequester = remember { FocusRequester() }
+    val effectiveRatingsGridFocusRequester = ratingsGridFocusRequester ?: internalRatingsGridFocusRequester
     val defaultSeason = remember(seasonNumbers) {
         seasonNumbers.firstOrNull { it > 0 } ?: seasonNumbers.firstOrNull() ?: 0
     }
@@ -104,12 +107,14 @@ fun EpisodeRatingsSection(
     val upFocusModifier = if (upFocusRequester != null) {
         Modifier.focusProperties {
             up = upFocusRequester
-            if (downFocusRequester != null) {
-                down = downFocusRequester
-            }
         }
-    } else if (downFocusRequester != null) {
-        Modifier.focusProperties { down = downFocusRequester }
+    } else {
+        Modifier
+    }
+    val downFocusModifier = if (downFocusRequester != null) {
+        Modifier.focusProperties {
+            down = downFocusRequester
+        }
     } else {
         Modifier
     }
@@ -157,7 +162,9 @@ fun EpisodeRatingsSection(
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .focusRestorer(),
+                        .focusRestorer {
+                            seasonFocusRequesters[selectedSeason] ?: FocusRequester.Default
+                        },
                     contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
                     horizontalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
@@ -173,6 +180,7 @@ fun EpisodeRatingsSection(
                             onClick = { selectedSeason = season },
                             modifier = modifierWithRequester
                                 .then(upFocusModifier)
+                                .focusProperties { down = effectiveRatingsGridFocusRequester }
                                 .onFocusChanged { state ->
                                     if (state.isFocused && selectedSeason != season) {
                                         selectedSeason = season
@@ -215,6 +223,7 @@ fun EpisodeRatingsSection(
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .focusRequester(effectiveRatingsGridFocusRequester)
                         .focusRestorer(),
                     contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
                     horizontalArrangement = Arrangement.spacedBy(6.dp)
@@ -227,14 +236,9 @@ fun EpisodeRatingsSection(
                             modifier = if (selectedSeasonUpRequester != null) {
                                 Modifier.focusProperties {
                                     up = selectedSeasonUpRequester
-                                    if (downFocusRequester != null) {
-                                        down = downFocusRequester
-                                    }
-                                }
-                            } else if (downFocusRequester != null) {
-                                Modifier.focusProperties { down = downFocusRequester }
+                                }.then(downFocusModifier)
                             } else {
-                                Modifier
+                                Modifier.then(downFocusModifier)
                             },
                             shape = CardDefaults.shape(shape = RoundedCornerShape(14.dp)),
                             colors = CardDefaults.colors(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -888,6 +888,7 @@ private fun MetaDetailsContent(
     val collectionTabFocusRequester = remember { FocusRequester() }
     val ratingsTabFocusRequester = remember { FocusRequester() }
     val ratingsContentFocusRequester = remember { FocusRequester() }
+    val ratingsGridFocusRequester = remember { FocusRequester() }
     val castSectionFocusRequester = remember { FocusRequester() }
     val moreLikeSectionFocusRequester = remember { FocusRequester() }
     val trailerSectionFocusRequester = remember { FocusRequester() }
@@ -1257,7 +1258,7 @@ private fun MetaDetailsContent(
             PeopleSectionTab.MORE_LIKE_THIS -> moreLikeSectionFocusRequester
             PeopleSectionTab.TRAILER -> trailerSectionFocusRequester
             PeopleSectionTab.COLLECTION -> collectionSectionFocusRequester
-            PeopleSectionTab.RATINGS -> ratingsContentFocusRequester
+            PeopleSectionTab.RATINGS -> ratingsGridFocusRequester
         }
         isSeries -> seasonDownFocusRequester ?: heroPlayFocusRequester
         else -> heroPlayFocusRequester
@@ -1766,6 +1767,7 @@ private fun MetaDetailsContent(
                                     },
                                     downFocusRequester = if (shouldShowCommentsSection && canToggleEpisodeComments) commentsSelectedModeFocusRequester else null,
                                     firstItemFocusRequester = ratingsContentFocusRequester,
+                                    ratingsGridFocusRequester = ratingsGridFocusRequester,
                                     modifier = Modifier.heightIn(min = if (!hasItemsBelow) castSectionHeight else 0.dp)
                                 )
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.State
 import androidx.compose.foundation.lazy.grid.items
 import com.nuvio.tv.LocalContentFocusRequester
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
@@ -40,6 +42,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import com.nuvio.tv.ui.util.asStable
 import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.compose.ui.res.stringResource
@@ -728,6 +731,27 @@ private fun GridCollectionFolderCard(
                         color = NuvioColors.TextSecondary
                     )
                 }
+            }
+
+            // GIF overlay: show on top of cover image or emoji, visible only once loaded
+            val focusGifUrl = if (isFocused && folder.focusGifEnabled) folder.focusGifUrl else null
+            if (!focusGifUrl.isNullOrBlank()) {
+                var gifLoaded by remember(focusGifUrl) { mutableStateOf(false) }
+                val gifAlpha by animateFloatAsState(
+                    targetValue = if (gifLoaded) 1f else 0f,
+                    animationSpec = tween(durationMillis = 200),
+                    label = "gifFadeIn"
+                )
+                AsyncImage(
+                    model = focusGifUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(cardShape)
+                        .graphicsLayer { alpha = gifAlpha },
+                    contentScale = ContentScale.FillBounds,
+                    onSuccess = { gifLoaded = true }
+                )
             }
 
             if (!folder.hideTitle) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -771,7 +771,21 @@ fun ModernHomeContent(
                     }
                 }.collect { currentStable ->
                     if (stableHeroSceneStateRef.value != currentStable) {
-                        stableHeroSceneStateRef.value = currentStable
+                        // Don't update stable ref with a fallback backdrop (from heroItem)
+                        // when the active carousel item hasn't resolved yet for the new row.
+                        val currentItem = activeCarouselItemState.value
+                        if (currentItem == null && stableHeroSceneStateRef.value != null) {
+                            return@collect
+                        }
+                        val displayedBackdrop = HeroBackdropState.lastDisplayedUrl
+                        val corrected = if (!displayedBackdrop.isNullOrBlank() &&
+                            displayedBackdrop != currentStable.heroBackdrop
+                        ) {
+                            currentStable.copy(heroBackdrop = displayedBackdrop)
+                        } else {
+                            currentStable
+                        }
+                        stableHeroSceneStateRef.value = corrected
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -839,7 +839,9 @@ fun ModernHomeContent(
                         // is not at the target inset.
                         val currentLeadingEdge = offset
                         if (abs(currentLeadingEdge - topInsetPx) < 1f) return 0f
-                        return currentLeadingEdge - topInsetPx
+                        val distance = currentLeadingEdge - topInsetPx
+                        if (distance < 0f && currentLeadingEdge >= 0f) return 0f
+                        return distance
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -676,11 +676,13 @@ fun ModernHomeContent(
                 trailerPlaybackTarget,
                 heroTrailerUrlsState,
                 verticalRowListState,
-                isSidebarExpanded
+                isSidebarExpanded,
+                isRapidHorizontalNav
             ) {
                 derivedStateOf {
                     effectiveAutoplayEnabled &&
                         !isSidebarExpanded.value &&
+                        !isRapidHorizontalNav.value &&
                         !verticalRowListState.isScrollInProgress &&
                         trailerPlaybackTarget == FocusedPosterTrailerPlaybackTarget.HERO_MEDIA &&
                         !heroTrailerUrlsState.value.first.isNullOrBlank()
@@ -840,7 +842,10 @@ fun ModernHomeContent(
                         val currentLeadingEdge = offset
                         if (abs(currentLeadingEdge - topInsetPx) < 1f) return 0f
                         val distance = currentLeadingEdge - topInsetPx
-                        if (distance < 0f && currentLeadingEdge >= 0f) return 0f
+                        // When the list can't scroll backwards and the requested distance
+                        // is negative, clamp to 0 to avoid fighting the scroll bounds
+                        // (prevents first-row jank from impossible scroll-up attempts).
+                        if (distance < 0f && !verticalRowListState.canScrollBackward) return 0f
                         return distance
                     }
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -514,10 +514,14 @@ internal fun buildCollectionFolderItem(
     } else {
         folder.title
     }
-    val hasEmoji = !folder.coverEmoji.isNullOrBlank()
-    // When folder uses emoji as cover, don't use any image for the card poster —
-    // emoji always takes priority as the visual cover.
-    val imageUrl = if (hasEmoji) null else firstNonBlank(folder.coverImageUrl, collection.backdropImageUrl)
+    // Cover image takes priority over emoji. Emoji is only used as fallback
+    // when no cover image is available.
+    // When focusGifEnabled is off, the GIF URL acts as a regular poster (priority over cover image).
+    val imageUrl = if (!folder.focusGifEnabled) {
+        firstNonBlank(folder.focusGifUrl, folder.coverImageUrl, collection.backdropImageUrl)
+    } else {
+        firstNonBlank(folder.coverImageUrl, collection.backdropImageUrl)
+    }
     val heroBackdrop = firstNonBlank(folder.heroBackdropUrl, folder.coverImageUrl, collection.backdropImageUrl)
 
     return ModernCarouselItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -5,6 +5,8 @@ package com.nuvio.tv.ui.screens.home
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -47,6 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
@@ -979,8 +982,14 @@ private fun ModernCarouselCard(
     val imageUrl = when {
         payload == null -> baseImageUrl
         !payload.focusGifEnabled -> baseImageUrl
-        isFocused -> payload.focusGifUrl ?: baseImageUrl
-        else -> baseImageUrl ?: payload.focusGifUrl
+        else -> baseImageUrl
+    }
+    // GIF overlay: shown on top of the base image only when focused and loaded
+    val focusGifUrl = when {
+        payload == null -> null
+        !payload.focusGifEnabled -> null
+        isFocused -> payload.focusGifUrl
+        else -> null
     }
     val imageContentScale = when (item.payload) {
         is ModernPayload.CollectionFolder -> ContentScale.FillBounds
@@ -1211,6 +1220,32 @@ private fun ModernCarouselCard(
                         }
                     } else {
                         MonochromePosterPlaceholder()
+                    }
+
+                    // GIF overlay: renders on top of image or emoji, visible only once loaded
+                    if (!focusGifUrl.isNullOrBlank()) {
+                        val gifModel = remember(context, focusGifUrl, requestWidthPx, requestHeightPx) {
+                            ImageRequest.Builder(context)
+                                .data(focusGifUrl)
+                                .memoryCacheKey("${focusGifUrl}_${requestWidthPx}x${requestHeightPx}")
+                                .size(width = requestWidthPx, height = requestHeightPx)
+                                .build()
+                        }
+                        var gifLoaded by remember(focusGifUrl) { mutableStateOf(false) }
+                        val gifAlpha by animateFloatAsState(
+                            targetValue = if (gifLoaded) 1f else 0f,
+                            animationSpec = tween(durationMillis = 200),
+                            label = "gifFadeIn"
+                        )
+                        AsyncImage(
+                            model = gifModel,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .graphicsLayer { alpha = gifAlpha },
+                            contentScale = imageContentScale,
+                            onSuccess = { gifLoaded = true }
+                        )
                     }
 
                     if (shouldPlayTrailerInCard) {


### PR DESCRIPTION
## Summary

- Fix first-row horizontal scroll jank in Modern Home and Collection Folder views
- Fix GIF poster overlays: load correctly and fade in smoothly on focus
- Prevent hero trailer from playing during rapid horizontal D-pad navigation
- Fix focus navigation in Episode Ratings: DPAD down from season selector now goes to ratings grid (not Trakt Comments)
- Increase Trakt API page size (100->1000) and skip expensive addon episode remap for fully-watched series
- Stabilize hero backdrop during vertical scroll

## PR type

- Bug fix
- Small maintenance improvement

## Why

1. **First-row jank**: `BringIntoViewSpec` returned -40px scroll distance for the first row (which can't scroll up), causing repeated failed scroll attempts and frame drops on every horizontal focus change.
3. **GIF posters broken**: Collection folder GIF overlays weren't loading; added proper Coil GIF handling with fade-in on focus.
4. **Collection Folder missing features**: Follow Layout Modern mode lacked `failedEnrichmentIds`, `scrollToTopTrigger`, and adjacent item prefetch that Home already had.
5. **Trailer during scroll**: `shouldPlayCatalogHeroTrailerState` didn't check `isRapidHorizontalNav`, so cached trailer URLs would start playing immediately during D-pad hold.
6. **Ratings focus skip**: Season selector cards had `down = commentsModeFocusRequester`, bypassing the episode ratings grid below.
7. **Trakt performance**: 100-item pages caused many round-trips; addon remap for fully-watched series was wasted work.
8. **Backdrop flash**: `stableHeroSceneStateRef` stored raw addon backdrop URL; during scroll it showed this instead of the TMDB-enriched image that was actually displayed.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual testing on TCL TV
- Verified first-row horizontal scroll is smooth (no jank from BringIntoView)
- Verified GIF overlays load and fade in on collection folder cards
- Verified Collection Folder Modern layout handles enrichment failures correctly
- Verified trailers don't trigger during rapid horizontal D-pad hold
- Verified focus chain: season selector
- Verified Trakt sync completes faster with larger page size
- Verified hero backdrop always shows a correct image


## Screenshots / Video (UI changes only)

behavioral/performance fixes

## Breaking changes

Nothing should break

## Linked issues

Reported on Disocrd
