### PR TITLE
Adds ability to mark previous seasons as watched

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -981,9 +981,11 @@ private fun EpisodeOptionsDialog(
 fun SeasonOptionsDialog(
     season: Int,
     isFullyWatched: Boolean,
+    hasPreviousSeasons: Boolean = false,
     onDismiss: () -> Unit,
     onMarkSeasonWatched: () -> Unit,
-    onMarkSeasonUnwatched: () -> Unit
+    onMarkSeasonUnwatched: () -> Unit,
+    onMarkPreviousSeasonsWatched: () -> Unit = {}
 ) {
     val primaryFocusRequester = remember { FocusRequester() }
 
@@ -1007,6 +1009,19 @@ fun SeasonOptionsDialog(
             )
         ) {
             Text(if (isFullyWatched) stringResource(R.string.episodes_mark_season_unwatched) else stringResource(R.string.episodes_mark_season_watched))
+        }
+
+        if (hasPreviousSeasons && season > 0) {
+            Button(
+                onClick = onMarkPreviousSeasonsWatched,
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    contentColor = NuvioColors.TextPrimary
+                ),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.episodes_mark_previous_seasons_watched))
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -557,6 +557,9 @@ fun MetaDetailsScreen(
                     onMarkPreviousEpisodesWatched = { video ->
                         viewModel.onEvent(MetaDetailsEvent.OnMarkPreviousEpisodesWatched(video))
                     },
+                    onMarkPreviousSeasonsWatched = { season ->
+                        viewModel.onEvent(MetaDetailsEvent.OnMarkPreviousSeasonsWatched(season))
+                    },
                     isSeasonFullyWatched = { season ->
                         viewModel.isSeasonFullyWatched(season)
                     },
@@ -799,6 +802,7 @@ private fun MetaDetailsContent(
     onMarkSeasonWatched: (Int) -> Unit,
     onMarkSeasonUnwatched: (Int) -> Unit,
     onMarkPreviousEpisodesWatched: (Video) -> Unit,
+    onMarkPreviousSeasonsWatched: (Int) -> Unit,
     isSeasonFullyWatched: (Int) -> Boolean,
     trailerUrl: String?,
     trailerAudioUrl: String?,
@@ -1915,9 +1919,13 @@ private fun MetaDetailsContent(
         }
 
         seasonOptionsDialogSeason?.let { season ->
+            val hasPreviousSeasons = remember(season, seasons) {
+                seasons.any { it != 0 && it < season }
+            }
             SeasonOptionsDialog(
                 season = season,
                 isFullyWatched = isSeasonFullyWatched(season),
+                hasPreviousSeasons = hasPreviousSeasons,
                 onDismiss = { seasonOptionsDialogSeason = null },
                 onMarkSeasonWatched = {
                     onMarkSeasonWatched(season)
@@ -1925,6 +1933,10 @@ private fun MetaDetailsContent(
                 },
                 onMarkSeasonUnwatched = {
                     onMarkSeasonUnwatched(season)
+                    seasonOptionsDialogSeason = null
+                },
+                onMarkPreviousSeasonsWatched = {
+                    onMarkPreviousSeasonsWatched(season)
                     seasonOptionsDialogSeason = null
                 }
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsUiState.kt
@@ -107,6 +107,7 @@ sealed class MetaDetailsEvent {
     data class OnMarkSeasonWatched(val season: Int) : MetaDetailsEvent()
     data class OnMarkSeasonUnwatched(val season: Int) : MetaDetailsEvent()
     data class OnMarkPreviousEpisodesWatched(val video: Video) : MetaDetailsEvent()
+    data class OnMarkPreviousSeasonsWatched(val season: Int) : MetaDetailsEvent()
     data object OnLibraryLongPress : MetaDetailsEvent()
     data class OnPickerMembershipToggled(val listKey: String) : MetaDetailsEvent()
     data object OnPickerSave : MetaDetailsEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -313,6 +313,7 @@ class MetaDetailsViewModel @Inject constructor(
             is MetaDetailsEvent.OnMarkSeasonWatched -> markSeasonWatched(event.season)
             is MetaDetailsEvent.OnMarkSeasonUnwatched -> markSeasonUnwatched(event.season)
             is MetaDetailsEvent.OnMarkPreviousEpisodesWatched -> markPreviousEpisodesWatched(event.video)
+            is MetaDetailsEvent.OnMarkPreviousSeasonsWatched -> markPreviousSeasonsWatched(event.season)
             MetaDetailsEvent.OnLibraryLongPress -> openListPicker()
             is MetaDetailsEvent.OnPickerMembershipToggled -> togglePickerMembership(event.listKey)
             MetaDetailsEvent.OnPickerSave -> savePickerMembership()
@@ -2137,6 +2138,46 @@ class MetaDetailsViewModel @Inject constructor(
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
             }
             showMessage(localizedContext.getString(R.string.detail_marked_previous_watched, unwatched.size))
+        }
+    }
+
+    private fun markPreviousSeasonsWatched(targetSeason: Int) {
+        val meta = _uiState.value.meta ?: return
+        suppressSeasonAutoSwitch = true
+        viewModelScope.launch {
+            val episodes = if (meta.apiType.equals("other", ignoreCase = true)) {
+                _uiState.value.episodesForSeason.filter { it.season != null && it.season < targetSeason && it.episode != null }
+            } else {
+                meta.videos.filter { it.season != null && it.season < targetSeason && it.episode != null }
+            }
+            val unwatched = episodes.filter { video ->
+                val s = video.season!!
+                val e = video.episode!!
+                val isWatched = _uiState.value.episodeProgressMap[s to e]?.isCompleted() == true
+                    || _uiState.value.watchedEpisodes.contains(s to e)
+                !isWatched
+            }
+            if (unwatched.isEmpty()) {
+                showMessage(localizedContext.getString(R.string.detail_all_previous_seasons_watched))
+                return@launch
+            }
+
+            val pendingKeys = unwatched.map { episodePendingKey(it) }.toSet()
+            _uiState.update {
+                it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKeys)
+            }
+
+            runCatching {
+                val progressList = unwatched.map { buildCompletedEpisodeProgress(meta, it) }
+                watchProgressRepository.markAsCompletedBatch(progressList)
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to batch mark previous seasons as watched: ${error.message}")
+            }
+
+            _uiState.update {
+                it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
+            }
+            showMessage(localizedContext.getString(R.string.detail_marked_episodes_watched, unwatched.size))
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="episodes_mark_season_watched">Mark season as watched</string>
     <string name="episodes_mark_season_unwatched">Mark season as unwatched</string>
     <string name="episodes_mark_previous_watched">Mark previous in this season as watched</string>
+    <string name="episodes_mark_previous_seasons_watched">Mark previous seasons as watched</string>
     <string name="episodes_play">Play</string>
     <string name="episodes_open_comments">Open episode comments</string>
     <string name="play_manually">Play manually</string>
@@ -203,6 +204,7 @@
     <string name="detail_all_episodes_watched">All episodes already watched</string>
     <string name="detail_no_watched_episodes">No watched episodes in this season</string>
     <string name="detail_all_previous_watched">All previous episodes already watched</string>
+    <string name="detail_all_previous_seasons_watched">All previous seasons already watched</string>
     <string name="detail_marked_episodes_watched">Episodes marked as watched: %1$d</string>
     <string name="detail_marked_episodes_unwatched">Episodes marked as unwatched: %1$d</string>
     <string name="detail_marked_previous_watched">Previous episodes marked as watched: %1$d</string>


### PR DESCRIPTION
## Summary
Adds the ability to mark previous seasons as watched.

## PR type
- Small maintenance improvement

## Why
Currently episodes allows you to mark previous as watched, but only applies to that season. This is convenient for shows with a larger number of season you've already watched and would like to mark as so.

## Policy check
- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)
None.

## Testing
Using the button on both watched and un-watched seasons to ensure it correctly marks season/episodes or recognizes if already marked.

## Screenshots / Video (UI changes only)
Adds button on hold press menu for seasons:
<img width="1298" height="717" alt="image" src="https://github.com/user-attachments/assets/93272909-a8ea-45b0-bc11-c1c4b3bdff2e" />

## Breaking changes
None.

## Linked issues
None.
