### PR TITLE
fix(subtitles): prefer normal embedded subtitles over forced/CC

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -420,6 +420,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             val forced = (mpv.getPropertyBoolean("track-list/$i/forced") == true) || listOfNotNull(title, language).any {
                 it.contains("forced", ignoreCase = true)
             }
+            val cc = listOfNotNull(title, language).any {
+                it.contains("cc", ignoreCase = true) ||
+                    it.contains("closed caption", ignoreCase = true) ||
+                    it.contains("sdh", ignoreCase = true)
+            }
             val selected = when (type) {
                 "audio" -> (selectedAudioTrackId != null && selectedAudioTrackId == id) || selectedByFlag
                 "sub" -> (selectedSubtitleTrackId != null && selectedSubtitleTrackId == id) || selectedByFlag
@@ -437,6 +442,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
                         channelCount = channelCount,
                         isSelected = selected,
                         isForced = false,
+                        isCC = false,
                         isExternal = external
                     )
                 }
@@ -451,6 +457,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
                         channelCount = null,
                         isSelected = selected,
                         isForced = forced,
+                        isCC = cc,
                         isExternal = external
                     )
                 }
@@ -612,5 +619,6 @@ data class MpvTrack(
     val channelCount: Int?,
     val isSelected: Boolean,
     val isForced: Boolean,
+    val isCC: Boolean,
     val isExternal: Boolean
 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -47,6 +47,9 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         startProgressUpdates()
         startWatchProgressSaving()
         updateMpvAvailableTracks()
+        if (_uiState.value.subtitleTracks.isNotEmpty() && _uiState.value.selectedAddonSubtitle != null) {
+            autoSubtitleSelected = false
+        }
         tryAutoSelectPreferredSubtitleFromAvailableTracks()
         scheduleHideControls()
         emitScrobbleStart()
@@ -131,6 +134,9 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         startProgressUpdates()
         startWatchProgressSaving()
         updateMpvAvailableTracks()
+        if (_uiState.value.subtitleTracks.isNotEmpty() && _uiState.value.selectedAddonSubtitle != null) {
+            autoSubtitleSelected = false
+        }
         tryAutoSelectPreferredSubtitleFromAvailableTracks()
         scheduleHideControls()
         emitScrobbleStart()
@@ -276,6 +282,7 @@ internal fun PlayerRuntimeController.updateMpvAvailableTracks() {
                 trackId = track.id.toString(),
                 codec = track.codec,
                 isForced = track.isForced,
+                isCC = track.isCC,
                 isSelected = track.isSelected
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -110,6 +110,11 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                     val isSongsAndSigns = trackTexts.any {
                         it.contains("songs", ignoreCase = true) && it.contains("sign", ignoreCase = true)
                     }
+                    val isCC = trackTexts.any {
+                        it.contains("cc", ignoreCase = true) ||
+                            it.contains("closed caption", ignoreCase = true) ||
+                            it.contains("sdh", ignoreCase = true)
+                    }
 
                     subtitleTracks.add(
                         TrackInfo(
@@ -119,6 +124,7 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                             trackId = format.id,
                             codec = CustomDefaultTrackNameProvider.formatNameFromMime(format.sampleMimeType),
                             isForced = hasForcedFlag || nameHintForced || isSongsAndSigns,
+                            isCC = isCC,
                             isSelected = isSelected
                         )
                     )
@@ -1065,7 +1071,7 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
             )
             if (tieBroken >= 0) return tieBroken
         }
-        return candidateIndexes.first()
+        return pickBestNonForcedPreferNonCC(candidateIndexes, subtitleTracks)
     }
     return -1
 }
@@ -1073,6 +1079,18 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
 private fun findBestForcedSubtitleTrackIndex(subtitleTracks: List<TrackInfo>): Int {
     // isForced is set from both the ExoPlayer SELECTION_FLAG_FORCED and name/label/id containing "forced"
     return subtitleTracks.indexOfFirst { it.isForced }
+}
+
+private fun pickBestNonForcedPreferNonCC(
+    candidateIndexes: List<Int>,
+    subtitleTracks: List<TrackInfo>
+): Int {
+    // Prefer non-forced, non-CC (normal subtitles)
+    candidateIndexes.firstOrNull { !subtitleTracks[it].isForced && !subtitleTracks[it].isCC }?.let { return it }
+    // Then non-forced, CC
+    candidateIndexes.firstOrNull { !subtitleTracks[it].isForced && subtitleTracks[it].isCC }?.let { return it }
+    // Fallback to first available
+    return candidateIndexes.first()
 }
 
 internal fun PlayerRuntimeController.findBrazilianPortugueseInGenericPtTracks(
@@ -1084,12 +1102,19 @@ internal fun PlayerRuntimeController.findBrazilianPortugueseInGenericPtTracks(
     }
     if (genericPtIndexes.isEmpty()) return -1
 
-    val brazilianNonForced = genericPtIndexes.filter { index ->
-        !subtitleTracks[index].isForced &&
+    val brazilianNonForcedNonCC = genericPtIndexes.filter { index ->
+        !subtitleTracks[index].isForced && !subtitleTracks[index].isCC &&
             subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
             !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
     }
-    if (brazilianNonForced.isNotEmpty()) return brazilianNonForced.first()
+    if (brazilianNonForcedNonCC.isNotEmpty()) return brazilianNonForcedNonCC.first()
+
+    val brazilianNonForcedCC = genericPtIndexes.filter { index ->
+        !subtitleTracks[index].isForced && subtitleTracks[index].isCC &&
+            subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
+            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
+    }
+    if (brazilianNonForcedCC.isNotEmpty()) return brazilianNonForcedCC.first()
 
     return genericPtIndexes.firstOrNull { index ->
         subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
@@ -1115,12 +1140,12 @@ internal fun PlayerRuntimeController.breakPortugueseSubtitleTie(
     return if (normalizedTarget == "pt-br") {
         candidateIndexes.firstOrNull { hasBrazilianTags(it) && !hasEuropeanTags(it) }
             ?: candidateIndexes.firstOrNull { hasBrazilianTags(it) }
-            ?: candidateIndexes.first()
+            ?: pickBestNonForcedPreferNonCC(candidateIndexes, subtitleTracks)
     } else {
         candidateIndexes.firstOrNull { hasEuropeanTags(it) && !hasBrazilianTags(it) }
             ?: candidateIndexes.firstOrNull { hasEuropeanTags(it) }
             ?: candidateIndexes.firstOrNull { !hasBrazilianTags(it) }
-            ?: candidateIndexes.first()
+            ?: pickBestNonForcedPreferNonCC(candidateIndexes, subtitleTracks)
     }
 }
 
@@ -1133,12 +1158,19 @@ internal fun PlayerRuntimeController.findLatinoSpanishInGenericEsTracks(
     }
     if (genericEsIndexes.isEmpty()) return -1
 
-    val latinoNonForced = genericEsIndexes.filter { index ->
-        !subtitleTracks[index].isForced &&
+    val latinoNonForcedNonCC = genericEsIndexes.filter { index ->
+        !subtitleTracks[index].isForced && !subtitleTracks[index].isCC &&
             subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
             !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
     }
-    if (latinoNonForced.isNotEmpty()) return latinoNonForced.first()
+    if (latinoNonForcedNonCC.isNotEmpty()) return latinoNonForcedNonCC.first()
+
+    val latinoNonForcedCC = genericEsIndexes.filter { index ->
+        !subtitleTracks[index].isForced && subtitleTracks[index].isCC &&
+            subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
+            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
+    }
+    if (latinoNonForcedCC.isNotEmpty()) return latinoNonForcedCC.first()
 
     return genericEsIndexes.firstOrNull { index ->
         subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
@@ -1164,12 +1196,12 @@ internal fun PlayerRuntimeController.breakSpanishSubtitleTie(
     return if (normalizedTarget == "es-419") {
         candidateIndexes.firstOrNull { hasLatinoTags(it) && !hasCastilianTags(it) }
             ?: candidateIndexes.firstOrNull { hasLatinoTags(it) }
-            ?: candidateIndexes.first()
+            ?: pickBestNonForcedPreferNonCC(candidateIndexes, subtitleTracks)
     } else {
         candidateIndexes.firstOrNull { hasCastilianTags(it) && !hasLatinoTags(it) }
             ?: candidateIndexes.firstOrNull { hasCastilianTags(it) }
             ?: candidateIndexes.firstOrNull { !hasLatinoTags(it) }
-            ?: candidateIndexes.first()
+            ?: pickBestNonForcedPreferNonCC(candidateIndexes, subtitleTracks)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -178,6 +178,7 @@ data class TrackInfo(
     val codec: String? = null,
     val channelCount: Int? = null,
     val isForced: Boolean = false,
+    val isCC: Boolean = false,
     val isSelected: Boolean = false,
     val sampleRate: Int? = null
 )


### PR DESCRIPTION
## Summary

When a release has multiple embedded subtitle tracks per language (e.g. forced, CC, normal), the auto-selection now prefers the normal one. Previously it picked whichever track came first in the file, which was often forced.

## PR type

- Small maintenance improvement

## Why

Some anime releases ship with 3 embedded subtitle tracks per language: forced (songs & signs), CC (closed captions), and normal (dialogue). The auto-selection was picking the first matching track, which was often the forced one. Users had to manually switch to the normal subtitle every time.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.

## Testing

Tested with anime releases containing 3 embedded subs per language across 7+ languages. Verified:
- Normal track is selected over forced and CC on fresh play
- CC is preferred over forced when no normal track exists
- PT/ES regional variant tie-breaking still works correctly
- MPV engine switch (auto internal engine) re-evaluates auto-selection when embedded tracks are discovered after an addon fallback

## Screenshots / Video (UI changes only)
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/aa591fb8-828b-4a0a-8f74-7c4fd8884a61" />

## Breaking changes

No breaking changes

## Linked issues

No linked issue.
