### PR TITLE
chore(i18n): complete French locale parity

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1883,4 +1883,41 @@
     <string name="tmdb_entity_error_load_named">Impossible de charger %1$s</string>
     <string name="tmdb_entity_error_load">Impossible de charger l’élément TMDB</string>
 
+
+    <!-- Locale parity (matches values/strings.xml additions on dev) -->
+    <string name="addon_manage_addons_only_from_phone_subtitle">Scanne un code QR pour installer ou supprimer des addons depuis ton téléphone</string>
+    <string name="addon_qr_addons_only_scan_instruction">Scanne avec ton téléphone pour installer ou supprimer des addons</string>
+    <string name="web_manage_addons_only_subtitle">Installer ou supprimer des addons</string>
+    <string name="auto_skip_intro">Intro / Générique de début</string>
+    <string name="auto_skip_intro_sub">Passer automatiquement les intros et les génériques d’anime.</string>
+    <string name="auto_skip_outro">Outro / Générique de fin</string>
+    <string name="auto_skip_outro_sub">Passer automatiquement les outros et les génériques de fin d’anime.</string>
+    <string name="auto_skip_recap">Résumé</string>
+    <string name="auto_skip_recap_sub">Passer automatiquement les segments de résumé.</string>
+    <string name="playback_auto_skip_segments">Saut automatique</string>
+    <string name="playback_auto_skip_segments_sub">Choisis les segments à passer automatiquement.</string>
+    <string name="collections_editor_tmdb_director_title_placeholder">Films de Christopher Nolan, réalisateurs favoris</string>
+    <string name="collections_editor_tmdb_help_director">Saisis un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de réalisation.</string>
+    <string name="collections_editor_tmdb_help_person">Saisis un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de casting.</string>
+    <string name="collections_editor_tmdb_mode_director">Réalisateur</string>
+    <string name="collections_editor_tmdb_mode_person">Personne</string>
+    <string name="collections_editor_tmdb_person_helper">Exemple : https://www.themoviedb.org/person/31-tom-hanks ou 31.</string>
+    <string name="collections_editor_tmdb_person_id">ID de personne</string>
+    <string name="collections_editor_tmdb_person_placeholder">31 pour Tom Hanks, ou URL de personne</string>
+    <string name="collections_editor_tmdb_person_title_placeholder">Films de Tom Hanks, acteurs favoris</string>
+    <string name="experience_mode_confirm_advanced_subtitle">Ce mode révèle l’ensemble des paramètres, y compris la configuration avancée et les contrôles de catalogue, de collection et de réglage fin.</string>
+    <string name="experience_mode_confirm_advanced_title">Passer en mode avancé&#160;?</string>
+    <string name="experience_mode_confirm_essential_subtitle">Les écrans de configuration avancée seront masqués, mais tes paramètres enregistrés restent inchangés. Tu peux revenir en arrière à tout moment.</string>
+    <string name="experience_mode_confirm_essential_title">Passer en mode essentiel&#160;?</string>
+    <string name="experience_mode_essential">Essentiel</string>
+    <string name="experience_mode_group_title">Mode d’expérience</string>
+    <string name="experience_mode_switch_to_advanced">Passer en mode avancé</string>
+    <string name="experience_mode_switch_to_advanced_header_subtitle">Passe en mode avancé pour accéder à l’ensemble des paramètres.</string>
+    <string name="experience_mode_switch_to_advanced_subtitle">Afficher la disposition complète, les plugins, les intégrations, les catalogues, les collections et les réglages fins.</string>
+    <string name="experience_mode_switch_to_essential">Passer en mode essentiel</string>
+    <string name="experience_mode_switch_to_essential_subtitle">Masquer les écrans de configuration avancée sans modifier les valeurs enregistrées.</string>
+    <string name="settings_experience">Expérience</string>
+    <string name="settings_experience_subtitle">Essentiel ou avancé</string>
+    <string name="profile_custom_avatar_web_panel_note">Les URL d’avatar personnalisé peuvent être configurées depuis le panneau web Nuvio.</string>
+    <string name="tv_channel_continue_watching">Continuer à regarder</string>
 </resources>


### PR DESCRIPTION
## Summary

Brings `values-fr/strings.xml` to 1:1 parity with `values/strings.xml` on `dev` by adding the 35 French translations for keys recently introduced in upstream:

- **Experience mode** (Essential / Advanced switching) — 12 keys
- **Auto-skip segments** (anime intros, outros, recaps + Continue Watching channel) — 8 keys
- **TMDB Person / Director picker modes** — 8 keys
- **Add-on management** (QR flow restricted to add-ons-only) — 3 keys
- **Profile** (custom avatar web panel note) — 1 key
- **Other** (settings_experience, tv_channel_continue_watching, etc.) — 3 keys

EN ↔ FR: 1746 keys on each side, 0 missing, 0 orphan, XML valid.

## Why

The French locale was 35 keys behind upstream `dev` after the recent merges (experience mode UX, auto-skip work, TMDB person/director picker, addons-only QR mode). Without these translations, the FR users see English fallbacks on these new screens. This PR brings the locale back to full parity, matching the pattern of the recent Greek (`#1725`) and PT-BR (`#1724`) parity PRs.

## Testing

- Verified XML validity of `values-fr/strings.xml` with `xml.etree.ElementTree`.
- Verified 1:1 key parity between EN and FR (no missing, no orphan).
- Spot-checked translations for: tutoiement, typographic apostrophes (`’`), non-breaking spaces before `: ; ? !`, ellipsis (`…`), preservation of technical terms (`addon`, `plugin`, `URL`, `TMDB`, `Tom Hanks`, etc.).

## Breaking changes

None. Pure resource additions.

## Linked issues

None.