### PR TITLE
fix(i18n): close malformed </string> tag in pt-rBR Continue Watching

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -380,7 +380,7 @@
     <string name="advanced_memory_only_vertical_scroll_subtitle">Não carrega imagens ao rolar as fileiras</string>
     <string name="advanced_compose_highlighter">Destacador de interface</string>
     <string name="advanced_compose_highlighter_subtitle">Destaca elementos recarregados na tela</string>
-    <string name="advanced_clear_cw_cache">Limpar cache de "Continuar Assistindo<"/string>
+    <string name="advanced_clear_cw_cache">Limpar cache de "Continuar Assistindo"</string>
     <string name="advanced_clear_cw_cache_subtitle">Apaga dados do "Continuar Assistindo"</string>
     <string name="advanced_clear_cw_cache_done">Cache limpo com sucesso</string>
     <string name="advanced_remember_last_profile">Lembrar último perfil</string>


### PR DESCRIPTION
## Summary

`values-pt-rBR/strings.xml:383` had `<"/string>` instead of `"</string>` on the `advanced_clear_cw_cache` entry. Closing the tag correctly.

## PR type

- Bug fix

## Why

The malformed tag breaks the resource merge step - `./gradlew :app:assembleDebug` fails on `mergeFullDebugResources` with "The content of elements must consist of well-formed character data or markup." Build is broken on `dev` until this lands.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A - one-character fix.

## Testing

`./gradlew :app:compileFullDebugKotlin` fails before, passes after. No behavior change.

## Screenshots / Video (UI changes only)

N/A - no UI change.

## Breaking changes

None.

## Linked issues

N/A.
