### PR TITLE
i18n: localize color theme display names

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/ThemeSettingsScreen.kt
@@ -381,11 +381,22 @@ private fun ThemeSwatchChip(
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = theme.displayName,
+                text = theme.localizedName(),
                 style = MaterialTheme.typography.labelMedium,
                 color = if (isFocused || isSelected) NuvioColors.TextPrimary else NuvioColors.TextSecondary,
                 maxLines = 1
             )
         }
     }
+}
+
+@Composable
+private fun AppTheme.localizedName(): String = when (this) {
+    AppTheme.CRIMSON -> stringResource(R.string.theme_color_crimson)
+    AppTheme.OCEAN -> stringResource(R.string.theme_color_ocean)
+    AppTheme.VIOLET -> stringResource(R.string.theme_color_violet)
+    AppTheme.EMERALD -> stringResource(R.string.theme_color_emerald)
+    AppTheme.AMBER -> stringResource(R.string.theme_color_amber)
+    AppTheme.ROSE -> stringResource(R.string.theme_color_rose)
+    AppTheme.WHITE -> stringResource(R.string.theme_color_white)
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -303,6 +303,13 @@
     <string name="appearance_subtitle">Choisis ton thème de couleur, ta police et ta langue</string>
     <string name="appearance_color_theme">Thème de couleur</string>
     <string name="appearance_color_theme_subtitle">Choisis la couleur d’accent utilisée dans toute l’application</string>
+    <string name="theme_color_crimson">Cramoisi</string>
+    <string name="theme_color_ocean">Océan</string>
+    <string name="theme_color_violet">Violet</string>
+    <string name="theme_color_emerald">Émeraude</string>
+    <string name="theme_color_amber">Ambre</string>
+    <string name="theme_color_rose">Rose</string>
+    <string name="theme_color_white">Blanc</string>
     <string name="appearance_amoled_mode">Mode AMOLED</string>
     <string name="appearance_amoled_mode_subtitle">Utiliser un noir pur pour les arrière-plans de l’application</string>
     <string name="appearance_amoled_surfaces_mode">Surfaces noir pur</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,6 +305,13 @@
     <string name="appearance_subtitle">Choose your color theme, font and language</string>
     <string name="appearance_color_theme">Color Theme</string>
     <string name="appearance_color_theme_subtitle">Pick the accent color used across the app</string>
+    <string name="theme_color_crimson">Crimson</string>
+    <string name="theme_color_ocean">Ocean</string>
+    <string name="theme_color_violet">Violet</string>
+    <string name="theme_color_emerald">Emerald</string>
+    <string name="theme_color_amber">Amber</string>
+    <string name="theme_color_rose">Rose</string>
+    <string name="theme_color_white">White</string>
     <string name="appearance_amoled_mode">AMOLED Mode</string>
     <string name="appearance_amoled_mode_subtitle">Use pure black for app backgrounds</string>
     <string name="appearance_amoled_surfaces_mode">Pure Black Surfaces</string>


### PR DESCRIPTION
## Summary

Localize the 7 color theme names shown in **Settings → Appearance → Color Theme**:

- Adds 7 string resources in both `values/strings.xml` and `values-fr/strings.xml`:
  `theme_color_crimson` / `_ocean` / `_violet` / `_emerald` / `_amber` / `_rose` / `_white`.
- Replaces the direct `AppTheme.displayName` access in `ThemeSettingsScreen.kt` with a `@Composable` extension `AppTheme.localizedName()` that resolves the name via `stringResource`.

`AppTheme.displayName` (the enum field) is preserved for any non-Composable / fallback caller — currently no other usage in the codebase.

## Why

`AppTheme` (in `domain/model/AppTheme.kt`) defines the color theme picker entries with hardcoded English strings:

```kotlin
enum class AppTheme(val displayName: String) {
    CRIMSON("Crimson"),
    OCEAN("Ocean"),
    ...
    WHITE("White")
}
```

`ThemeSettingsScreen.kt:384` reads `theme.displayName` directly, so the theme labels in the picker stayed in English regardless of the active locale (FR users see "Crimson", "Ocean"… instead of "Cramoisi", "Océan"…).

## Testing

- Built the app (debug).
- Verified XML validity of both `values/strings.xml` and `values-fr/strings.xml`.
- Spot-checked the picker in FR locale: each color row now shows the translated name.
- Confirmed `AppTheme.displayName` has no other usage in the codebase (`grep -rn 'AppTheme.*displayName'`).

## Breaking changes

None. Pure resource addition + UI-only refactor (one line in `ThemeSettingsScreen.kt`).

## Linked issues

None.