### PR TITLE
i18n: localize last-link cache duration values

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -503,17 +503,24 @@ private fun NextEpisodeThresholdModeDialog(
     }
 }
 
+@Composable
 private fun formatReuseCacheDuration(hours: Int): String {
     return when {
-        hours < 24 -> "$hours hour${if (hours == 1) "" else "s"}"
+        hours < 24 -> stringResource(
+            if (hours == 1) R.string.cache_duration_hour_one else R.string.cache_duration_hour_other,
+            hours
+        )
         hours % 24 == 0 -> {
             val days = hours / 24
-            "$days day${if (days == 1) "" else "s"}"
+            stringResource(
+                if (days == 1) R.string.cache_duration_day_one else R.string.cache_duration_day_other,
+                days
+            )
         }
         else -> {
             val days = hours / 24
             val remainingHours = hours % 24
-            "${days}d ${remainingHours}h"
+            stringResource(R.string.cache_duration_days_hours, days, remainingHours)
         }
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -569,6 +569,11 @@
     <string name="autoplay_reuse_last_link">Réutiliser le dernier lien</string>
     <string name="autoplay_reuse_last_link_sub">Lire automatiquement ton dernier flux fonctionnel pour ce même film/épisode tant que le cache est valide</string>
     <string name="autoplay_last_link_cache">Durée du cache du dernier lien</string>
+    <string name="cache_duration_hour_one">%1$d heure</string>
+    <string name="cache_duration_hour_other">%1$d heures</string>
+    <string name="cache_duration_day_one">%1$d jour</string>
+    <string name="cache_duration_day_other">%1$d jours</string>
+    <string name="cache_duration_days_hours">%1$dj %2$dh</string>
     <string name="autoplay_mode_manual">Manuel (choisir le flux)</string>
     <string name="autoplay_mode_first">Lecture automatique de la première source</string>
     <string name="autoplay_mode_regex">Lecture automatique par correspondance regex</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -592,6 +592,11 @@
     <string name="autoplay_reuse_last_link">Reuse Last Link</string>
     <string name="autoplay_reuse_last_link_sub">Auto-play your last working stream for this same movie/episode when cache is still valid</string>
     <string name="autoplay_last_link_cache">Last Link Cache Duration</string>
+    <string name="cache_duration_hour_one">%1$d hour</string>
+    <string name="cache_duration_hour_other">%1$d hours</string>
+    <string name="cache_duration_day_one">%1$d day</string>
+    <string name="cache_duration_day_other">%1$d days</string>
+    <string name="cache_duration_days_hours">%1$dd %2$dh</string>
     <string name="autoplay_mode_manual">Manual (choose stream)</string>
     <string name="autoplay_mode_first">Auto-play first source</string>
     <string name="autoplay_mode_regex">Auto-play regex match</string>


### PR DESCRIPTION
## Summary

Localize the duration values shown in **Settings → Playback → Last Link Cache Duration** (subtitle row + picker dialog).

- Adds 5 string resources in `values/strings.xml` and `values-fr/strings.xml`:
  `cache_duration_hour_one` / `_hour_other` / `_day_one` / `_day_other` / `_days_hours`.
- Converts `formatReuseCacheDuration(hours: Int): String` in `PlaybackAutoPlaySettings.kt` into a `@Composable` and replaces hardcoded strings (`"$hours hour"`, `"$days day"`, `"${days}d ${remainingHours}h"`) with `stringResource` calls.

## Why

`formatReuseCacheDuration` produced hardcoded English values regardless of the active locale. FR users with the cache row visible saw "1 hour", "2 days", "3d 12h" instead of "1 heure", "2 jours", "3j 12h".

## Testing

- Built locally (debug).
- Verified XML validity of both `values/strings.xml` and `values-fr/strings.xml`.
- Spot-checked the picker dialog in FR locale: each preset (1, 6, 12, 24, 48, 72, 168 hours) renders translated.
- Verified subtitle row on the Auto-play settings screen reflects the localized format.

## Breaking changes

None. `formatReuseCacheDuration` was `private` and only used inside `PlaybackAutoPlaySettings.kt`.

## Linked issues

None.