### PR TITLE
Fix focus restoration, binge group timeout, and missing PL translations

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -172,7 +172,7 @@ class SubtitleRepositoryImpl @Inject constructor(
                     subtitles
                 }
                 is NetworkResult.Error -> {
-                    Log.e(TAG, "Failed to fetch subtitles from ${addon.name}: ${result.message}")
+                    Log.e(TAG, "Failed to fetch subtitles from ${addon.name}: code=${result.code} message=${result.message}")
                     emptyList()
                 }
                 NetworkResult.Loading -> emptyList()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailScreen.kt
@@ -23,19 +23,27 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
@@ -45,6 +53,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.tv.material3.Border
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
@@ -62,6 +73,7 @@ import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.PosterCardStyle
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.rememberShimmerBrush
+import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
 import com.nuvio.tv.ui.theme.NuvioColors
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -148,6 +160,23 @@ private fun CastDetailContent(
 
     val firstPosterFocusRequester = remember { FocusRequester() }
 
+    // Focus restoration state for filmography row
+    var pendingRestoreItemId by rememberSaveable { mutableStateOf<String?>(null) }
+    var restoreFocusToken by rememberSaveable { mutableIntStateOf(0) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner, pendingRestoreItemId) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME && pendingRestoreItemId != null) {
+                restoreFocusToken += 1
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         // Left accent gradient overlay
         val accentGradient = remember(accentColor, backgroundColor) {
@@ -185,7 +214,11 @@ private fun CastDetailContent(
                         credits = allCredits,
                         posterCardStyle = filmographyPosterStyle,
                         firstItemFocusRequester = firstPosterFocusRequester,
+                        restoreItemId = pendingRestoreItemId,
+                        restoreFocusToken = restoreFocusToken,
+                        onRestoreFocusHandled = { pendingRestoreItemId = null },
                         onItemClick = { item ->
+                            pendingRestoreItemId = item.id
                             onNavigateToDetail(item.id, item.apiType, null)
                         },
                         onItemLongPress = { item ->
@@ -381,18 +414,42 @@ private fun SectionHeader(title: String, count: Int) {
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun FilmographyRow(
     credits: List<MetaPreview>,
     posterCardStyle: PosterCardStyle,
     firstItemFocusRequester: FocusRequester,
+    restoreItemId: String? = null,
+    restoreFocusToken: Int = 0,
+    onRestoreFocusHandled: () -> Unit = {},
     onItemClick: (MetaPreview) -> Unit,
     onItemLongPress: (MetaPreview) -> Unit = {}
 ) {
     val hasRequestedInitialFocus = remember(credits) { mutableStateOf(false) }
+    val restoreFocusRequester = remember { FocusRequester() }
+    var restorePending by remember { mutableStateOf(false) }
+    val lazyListState = rememberLazyListState()
+
+    LaunchedEffect(restoreFocusToken) {
+        if (restoreFocusToken <= 0 || restoreItemId == null) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        val targetIndex = credits.indexOfFirst { it.id == restoreItemId }
+        if (targetIndex < 0) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        restorePending = true
+        restoreFocusRequester.requestFocusAfterFrames()
+    }
 
     LazyRow(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRestorer { if (restorePending) restoreFocusRequester else firstItemFocusRequester },
+        state = lazyListState,
         contentPadding = PaddingValues(horizontal = 48.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -400,11 +457,19 @@ private fun FilmographyRow(
             items = credits,
             key = { _, item -> item.id + item.name }
         ) { index, item ->
+            val isRestoreTarget = item.id == restoreItemId
+            val isFirstItem = index == 0
+            val itemFocusRequester = when {
+                isRestoreTarget -> restoreFocusRequester
+                isFirstItem -> firstItemFocusRequester
+                else -> null
+            }
+
             GridContentCard(
                 item = item,
                 onClick = { onItemClick(item) },
                 onLongPress = { onItemLongPress(item) },
-                modifier = if (index == 0) {
+                modifier = if (isFirstItem) {
                     Modifier.onGloballyPositioned {
                         if (!hasRequestedInitialFocus.value) {
                             hasRequestedInitialFocus.value = true
@@ -416,7 +481,13 @@ private fun FilmographyRow(
                 },
                 posterCardStyle = posterCardStyle,
                 showLabel = true,
-                focusRequester = if (index == 0) firstItemFocusRequester else null
+                focusRequester = itemFocusRequester,
+                onFocused = {
+                    if (isRestoreTarget && restoreFocusToken > 0) {
+                        onRestoreFocusHandled()
+                        restorePending = false
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CastSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CastSection.kt
@@ -92,11 +92,24 @@ fun CastSection(
         itemFocusRequesters.keys.retainAll(validKeys)
     }
 
-    LaunchedEffect(restoreFocusToken, restorePersonId, leadingCast, cast) {
-        if (restoreFocusToken <= 0 || restorePersonId == null) return@LaunchedEffect
-        val existsInLeading = leadingCast.any { it.tmdbId == restorePersonId }
-        val existsInCast = cast.any { it.tmdbId == restorePersonId }
-        if (!existsInLeading && !existsInCast) return@LaunchedEffect
+    // Track whether a restore is pending so focusRestorer can use the correct fallback
+    var restorePending by remember { mutableStateOf(false) }
+
+    // Only react to restoreFocusToken changes (triggered on ON_RESUME).
+    // restorePersonId/cast lists are read inside but not used as keys to avoid
+    // triggering scroll at the moment of click (before navigation happens).
+    LaunchedEffect(restoreFocusToken) {
+        if (restoreFocusToken <= 0 || restorePersonId == null) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        val leadingIndex = leadingCast.indexOfFirst { it.tmdbId == restorePersonId }
+        val castIndex = cast.indexOfFirst { it.tmdbId == restorePersonId }
+        if (leadingIndex < 0 && castIndex < 0) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        restorePending = true
         restoreFocusRequester.requestFocusAfterFrames()
     }
 
@@ -134,7 +147,7 @@ fun CastSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(if (sectionFocusRequester != null) Modifier.focusRequester(sectionFocusRequester) else Modifier)
-                .focusRestorer { firstItemFocusRequester },
+                .focusRestorer { if (restorePending) restoreFocusRequester else firstItemFocusRequester },
             state = lazyListState,
             contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.Start
@@ -171,6 +184,7 @@ fun CastSection(
                             onFocused = {
                                 onCastMemberFocused(member)
                                 if (isRestoreTarget && restoreFocusToken > 0) {
+                                    restorePending = false
                                     onRestoreFocusHandled()
                                 }
                             },
@@ -223,6 +237,7 @@ fun CastSection(
                         onFocused = {
                             onCastMemberFocused(member)
                             if (isRestoreTarget && restoreFocusToken > 0) {
+                                restorePending = false
                                 onRestoreFocusHandled()
                             }
                         },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1274,6 +1274,19 @@ private fun MetaDetailsContent(
         }
     }
 
+    // Switch to the correct people tab when restoring focus after navigation
+    LaunchedEffect(restoreFocusToken, pendingRestoreType) {
+        if (restoreFocusToken <= 0 || pendingRestoreType == null) return@LaunchedEffect
+        val targetTab = when (pendingRestoreType) {
+            RestoreTarget.MORE_LIKE_THIS -> PeopleSectionTab.MORE_LIKE_THIS
+            RestoreTarget.CAST_MEMBER -> PeopleSectionTab.CAST
+            else -> null
+        }
+        if (targetTab != null && targetTab in visiblePeopleTabsList && activePeopleTab != targetTab) {
+            activePeopleTab = targetTab
+        }
+    }
+
     // Backdrop alpha for crossfade
     val backgroundColor = NuvioColors.Background
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MoreLikeThisSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MoreLikeThisSection.kt
@@ -11,7 +11,10 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -52,9 +55,18 @@ fun MoreLikeThisSection(
         itemFocusRequesters.keys.retainAll(validIds)
     }
 
-    LaunchedEffect(restoreFocusToken, restoreItemId, items) {
-        if (restoreFocusToken <= 0 || restoreItemId.isNullOrBlank()) return@LaunchedEffect
-        if (items.none { it.id == restoreItemId }) return@LaunchedEffect
+    var restorePending by remember { mutableStateOf(false) }
+
+    LaunchedEffect(restoreFocusToken) {
+        if (restoreFocusToken <= 0 || restoreItemId.isNullOrBlank()) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        if (items.none { it.id == restoreItemId }) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        restorePending = true
         restoreFocusRequester.requestFocusAfterFrames()
     }
 
@@ -77,7 +89,7 @@ fun MoreLikeThisSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(if (sectionFocusRequester != null) Modifier.focusRequester(sectionFocusRequester) else Modifier)
-                .focusRestorer { firstItemFocusRequester },
+                .focusRestorer { if (restorePending) restoreFocusRequester else firstItemFocusRequester },
             contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -107,6 +119,7 @@ fun MoreLikeThisSection(
                         onFocused = {
                             onItemFocused(item)
                             if (isRestoreTarget && restoreFocusToken > 0) {
+                                restorePending = false
                                 onRestoreFocusHandled()
                             }
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -270,6 +270,7 @@ class PlayerRuntimeController(
     internal var skipIntervals: List<SkipInterval> = emptyList()
     internal var skipIntroEnabled: Boolean = true
     internal var autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet()
+    internal var playerSettingsInitialized: Boolean = false
     internal var skipIntroFetchedKey: String? = null
     internal var lastAutoSkippedIntervalKey: String? = null
     internal var lastActiveSkipType: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -364,7 +364,6 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
     // Without this, autoSkipSegmentTypes is empty on first iterations, causing the
     // skip button to appear instead of auto-skipping.
     if (!playerSettingsInitialized) return
-    }
 
     val positionSec = positionMs / 1000.0
     val active = skipIntervals.find { interval ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -360,6 +360,12 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
         return
     }
 
+    // Don't evaluate skip intervals until player settings are loaded from DataStore.
+    // Without this, autoSkipSegmentTypes is empty on first iterations, causing the
+    // skip button to appear instead of auto-skipping.
+    if (!playerSettingsInitialized) return
+    }
+
     val positionSec = positionMs / 1000.0
     val active = skipIntervals.find { interval ->
         positionSec >= interval.startTime && positionSec < (interval.endTime - 0.5)
@@ -456,7 +462,6 @@ internal fun PlayerRuntimeController.fetchParentalGuide(id: String?, type: Strin
                 )
             }
 
-            
             if (_uiState.value.isPlaying) {
                 tryShowParentalGuide()
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -351,6 +351,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             val wasEnabled = skipIntroEnabled
             skipIntroEnabled = settings.skipIntroEnabled
             autoSkipSegmentTypes = settings.autoSkipSegmentTypes
+            playerSettingsInitialized = true
             if (!skipIntroEnabled) {
                 if (skipIntervals.isNotEmpty() || _uiState.value.activeSkipInterval != null) {
                     skipIntervals = emptyList()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -18,6 +18,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** Hard ceiling for next-episode stream search to prevent hanging forever. */
+private const val NEXT_EPISODE_HARD_TIMEOUT_MS = 120_000L
 
 internal fun PlayerRuntimeController.showEpisodesPanel() {
     _uiState.update {
@@ -1091,12 +1095,35 @@ internal fun PlayerRuntimeController.playNextEpisode() {
                     }
                 }
                 if (selectedStream != null) {
+                    // Found a match within timeout - use it.
                     innerJob.cancel()
+                } else if (lastSuccessData != null) {
+                    // Streams arrived but no match (e.g. binge group not found).
+                    // Respect the original timeout - don't wait further.
+                    innerJob.cancel()
+                    autoSelectTriggered = true
                 } else {
-                    innerJob.join()
+                    // No addon responded yet - wait for the first result with
+                    // a hard ceiling so we never hang indefinitely.
+                    val completed = withTimeoutOrNull(timeoutMs) { innerJob.join() }
+                    if (completed == null) {
+                        innerJob.cancel()
+                        // One last attempt with whatever data arrived
+                        if (!autoSelectTriggered && lastSuccessData != null) {
+                            selectedStream = trySelectStream(lastSuccessData!!)
+                        }
+                    }
                 }
             } else {
-                innerJob.join()
+                // "Unlimited" mode - still apply a hard ceiling to prevent
+                // hanging forever if a scraper/addon never responds.
+                val completed = withTimeoutOrNull(NEXT_EPISODE_HARD_TIMEOUT_MS) { innerJob.join() }
+                if (completed == null) {
+                    innerJob.cancel()
+                    if (!autoSelectTriggered && lastSuccessData != null) {
+                        selectedStream = trySelectStream(lastSuccessData!!)
+                    }
+                }
             }
 
             val streamToPlay = selectedStream

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -296,6 +296,11 @@
     <string name="autoplay_reuse_last_link">Ponownie użyj ostatniego linku</string>
     <string name="autoplay_reuse_last_link_sub">Auto-odtwarzaj ostatni działający strumień dla tego samego filmu/odcinka gdy cache jest aktualny</string>
     <string name="autoplay_last_link_cache">Czas ważności cache linku</string>
+    <string name="cache_duration_hour_one">%1$d godzina</string>
+    <string name="cache_duration_hour_other">%1$d godzin</string>
+    <string name="cache_duration_day_one">%1$d dzień</string>
+    <string name="cache_duration_day_other">%1$d dni</string>
+    <string name="cache_duration_days_hours">%1$dd %2$dh</string>
     <string name="autoplay_mode_manual">Ręczny (wybierz strumień)</string>
     <string name="autoplay_mode_first">Auto-odtwarzaj pierwsze źródło</string>
     <string name="autoplay_mode_regex">Auto-odtwarzaj dopasowanie regex</string>
@@ -1598,6 +1603,13 @@
     <string name="appearance_amoled_mode_subtitle">Użyj czystej czerni jako tła aplikacji</string>
     <string name="appearance_amoled_surfaces_mode">Czysto czarne powierzchnie</string>
     <string name="appearance_amoled_surfaces_mode_subtitle">Karty, panele i kontenery również będą czysto czarne</string>
+    <string name="theme_color_crimson">Karmazyn</string>
+    <string name="theme_color_ocean">Ocean</string>
+    <string name="theme_color_violet">Fiolet</string>
+    <string name="theme_color_emerald">Szmaragd</string>
+    <string name="theme_color_amber">Bursztyn</string>
+    <string name="theme_color_rose">Róż</string>
+    <string name="theme_color_white">Biel</string>
     <string name="collections_editor_add_source">Dodaj źródło</string>
     <string name="collections_editor_add_tmdb_source">Dodaj źródło TMDB</string>
     <string name="collections_editor_edit_tmdb_source">Edytuj źródło TMDB</string>


### PR DESCRIPTION
## Summary

- Fix focus restoration in Cast, More Like This, and Filmography rows - focus no longer jumps to the first item when navigating back
- Hard timeout for binge group matching during next-episode stream resolution
- Possible fix for opening auto skip race condition
- Add missing Polish translations (cache duration formats + theme color names)

## PR type

- Bug fix
- Translation update

## Why

Focus restoration in detail screen horizontal rows (Cast, More Like This, Filmography) was unreliable. The `focusRestorer` fallback always pointed to the first item, causing a race condition where the system would grab focus before the `LaunchedEffect` could redirect it. Additionally, the "More Like This" section wasn't switching the active tab on resume, so the restore target didn't exist in the composition tree.

The binge group timeout prevents indefinite hangs when addon stream resolution stalls during next-episode autoplay.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Manual testing on Android TV: navigated to detail screen, scrolled cast row, clicked various cast members (near beginning and far right), verified focus returns to the correct member on back press.
- Tested filmography row in cast detail screen - clicked items at various positions, confirmed focus restores correctly.
- Tested "More Like This" row - verified tab switches and focus restores to the clicked item.
- Verified no unwanted scroll jump occurs at the moment of clicking (before navigation).
- Confirmed binge group timeout fires correctly when stream resolution stalls.

## Screenshots / Video (UI changes only)

behavioral fix, no visual changes.

## Breaking changes

Nothing should break

## Linked issues

Reported on Discord
