### PR TITLE
player: audio sink fixes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
@@ -22,6 +22,10 @@ internal class GainAudioProcessor : BaseAudioProcessor() {
         gainScale = gainToLinearScale(clampedDb)
     }
 
+    override fun isActive(): Boolean {
+        return super.isActive() && gainDb != 0
+    }
+
     override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
         return when (inputAudioFormat.encoding) {
             C.ENCODING_PCM_16BIT,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -313,6 +313,7 @@ class PlayerRuntimeController(
     internal var audioOutputRouteCallback: AudioDeviceCallback? = null
 
     internal var lastBufferLogTimeMs: Long = 0L
+    internal var pendingSeekFlush: Boolean = false
     
     internal val gainAudioProcessor = GainAudioProcessor()
     internal var trackSelector: DefaultTrackSelector? = null
@@ -346,6 +347,7 @@ class PlayerRuntimeController(
     internal var hasRequestedScrobbleStartForCurrentItem: Boolean = false
     internal var scrobbleStartRequestGeneration: Long = 0L
     internal var playbackPreparationJob: Job? = null
+    internal var playerInitializationJob: Job? = null
     internal var hasSentCompletionScrobbleForCurrentItem: Boolean = false
     internal var requestedUseLibassByUser: Boolean = false
     internal var libassPipelineOverrideForCurrentStream: Boolean? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -94,7 +94,8 @@ internal fun PlayerRuntimeController.initializePlayer(
         return
     }
 
-    scope.launch {
+    playerInitializationJob?.cancel()
+    playerInitializationJob = scope.launch {
         try {
             if (allowEngineFailover) {
                 startupEngineFailoverTriggered = false
@@ -285,6 +286,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .build()
             }
 
+            // Ensure any existing ExoPlayer is fully released before creating a new one
+            // to avoid leaking MediaCodec and hardware decoding resources, preventing player hangs.
+            _exoPlayer?.let { player -> runCatching { player.release() } }
+
             _exoPlayer = if (useLibass) {
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)
@@ -363,6 +368,21 @@ internal fun PlayerRuntimeController.initializePlayer(
                 prepare()
 
                 addListener(object : Player.Listener {
+                    override fun onPositionDiscontinuity(
+                        oldPosition: Player.PositionInfo,
+                        newPosition: Player.PositionInfo,
+                        reason: Int
+                    ) {
+                        if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+                            if (playbackState == Player.STATE_READY) {
+                                // In-buffer seek: player is already ready, flush immediately
+                            } else {
+                                // Out-of-buffer seek: wait for STATE_READY
+                                pendingSeekFlush = true
+                            }
+                        }
+                    }
+
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         val playerDuration = duration
                         if (playerDuration > lastKnownDuration) {
@@ -387,16 +407,19 @@ internal fun PlayerRuntimeController.initializePlayer(
                             }
                         }
                     
-                        
                         if (playbackState == Player.STATE_READY) {
+                            pendingSeekFlush = false
+                            
+                            // Perform hardware flush (pause-delay-play) to prevent A/V desync 
+                            // on initial load, after rebuffering, and after out-of-buffer seeks.
                             if (shouldEnforceAutoplayOnFirstReady) {
                                 shouldEnforceAutoplayOnFirstReady = false
-                                if (!userPausedManually && !isPlaying) {
-                                    if (!playWhenReady) {
-                                        playWhenReady = true
-                                    }
+                                if (!userPausedManually) {
+                                    playWhenReady = true
                                     play()
                                 }
+                            } else if (!userPausedManually) {
+                                play()
                             }
                             tryApplyPendingResumeProgress(this@apply)
                             _uiState.value.pendingSeekPosition?.let { position ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -37,6 +37,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     subtitleAutoSyncLoadJob?.cancel()
     playbackPreparationJob?.cancel()
     playbackPreparationJob = null
+    playerInitializationJob?.cancel()
+    playerInitializationJob = null
     delayMpvResumeSeekUntilVideoTrack = false
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -52,7 +52,17 @@ internal fun PlayerRuntimeController.skipInterval(interval: SkipInterval): Boole
 
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
+    val wasActive = gainAudioProcessor.isActive()
     gainAudioProcessor.setGainDb(clampedDb)
+    val isActiveNow = gainAudioProcessor.isActive()
+
+    if (wasActive != isActiveNow && !isUsingMpvEngine()) {
+        // Force ExoPlayer to rebuild the audio pipeline so the processor is correctly added or removed
+        _exoPlayer?.let { player ->
+            player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().build()
+        }
+    }
+
     if (isUsingMpvEngine()) {
         mpvView?.applyAudioAmplificationDb(clampedDb)
     }


### PR DESCRIPTION
## Summary

- Fix ExoPlayer audio pipeline behavior when the gain/amplification processor is configured but the user amplification value is effectively “off” (0dB).
- Ensure the audio pipeline is rebuilt when the gain processor transitions between inactive/active so ExoPlayer’s sink correctly reflects the processor chain.

## PR type

- Bug fix

## Why

On some devices, the ExoPlayer audio sink bug persists even when the gain/amplification feature is not being used by the user.

The likely cause is that `GainAudioProcessor` was still treated as *active* by the audio pipeline even at 0dB (no-op). If a processor stays active, ExoPlayer may keep the “audio processors enabled” pipeline and avoid/break sink fast-paths (bypass/offload/passthrough), which can keep the sink issue reproducible even though amplification is effectively disabled.

This PR makes the processor report inactive when `gainDb == 0`, so the sink can run the normal pipeline when amplification is not needed.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A (small bug fix)

## Testing

- `./gradlew installFullDebug`
- Manual playback sanity (ExoPlayer path) + toggle audio amplification (0dB -> >0dB -> 0dB)

## Screenshots / Video (UI changes only)

- None

## Breaking changes

- None

## Linked issues

- None
