### PR TITLE
feat(detail): show watched badge on season tabs

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -15,9 +15,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.zIndex
 import androidx.compose.foundation.lazy.LazyListPrefetchStrategy
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -103,7 +105,8 @@ fun SeasonTabs(
     onSeasonLongPress: (Int) -> Unit = {},
     selectedTabFocusRequester: FocusRequester,
     upFocusRequester: FocusRequester? = null,
-    downFocusRequester: FocusRequester? = null
+    downFocusRequester: FocusRequester? = null,
+    isSeasonWatched: (Int) -> Boolean = { false }
 ) {
     // Move season 0 (specials) to the end
     val sortedSeasons = remember(seasons) {
@@ -162,7 +165,9 @@ fun SeasonTabs(
             val isSelected = season == selectedSeason
             var isFocused by remember { mutableStateOf(false) }
             var longPressTriggered by remember { mutableStateOf(false) }
+            val watched = isSeasonWatched(season)
 
+            Box(contentAlignment = Alignment.TopEnd) {
             Card(
                 onClick = {
                     if (longPressTriggered) {
@@ -230,6 +235,29 @@ fun SeasonTabs(
                     },
                     modifier = Modifier.padding(vertical = 10.dp, horizontal = 20.dp)
                 )
+            }
+            if (watched) {
+                val badgeBackground = if (isFocused) NuvioColors.OnSecondary else NuvioColors.Secondary
+                val badgeTint = if (isFocused) NuvioColors.Secondary else {
+                    if (NuvioColors.Secondary == ThemeColors.White.secondary) Color.Black else Color.White
+                }
+                Box(
+                    modifier = Modifier
+                        .zIndex(1f)
+                        .offset(x = 6.dp, y = (-6).dp)
+                        .size(20.dp)
+                        .clip(CircleShape)
+                        .background(badgeBackground),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = stringResource(R.string.episodes_cd_watched),
+                        tint = badgeTint,
+                        modifier = Modifier.size(14.dp)
+                    )
+                }
+            }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1573,7 +1573,8 @@ private fun MetaDetailsContent(
                             onSeasonLongPress = { seasonOptionsDialogSeason = it },
                             selectedTabFocusRequester = selectedSeasonFocusRequester,
                             upFocusRequester = heroPlayFocusRequester,
-                            downFocusRequester = seasonDownFocusRequester
+                            downFocusRequester = seasonDownFocusRequester,
+                            isSeasonWatched = isSeasonFullyWatched
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

Adds a small circular check badge to a season tab in the series detail screen when the entire season is fully watched.

- Badge sits in the **top-right** of the tab, slightly offset (`x = 6.dp, y = -6.dp`) so it overlaps the empty space around the chip rather than the tab text.
- **Colors adapt to focus state**:
  - Unfocused: filled with `NuvioColors.Secondary` (matches the existing watched-episode badge on episode cards) + light check.
  - Focused: light fill (`NuvioColors.OnSecondary`) + check tinted with `Secondary` — stays readable on top of the orange focus background.
- `Modifier.zIndex(1f)` keeps the badge above the focused tab surface.
- Wires the existing `isSeasonFullyWatched: (Int) -> Boolean` callback (already exposed by `MetaDetailsScreen`) into a new optional `isSeasonWatched` parameter on `SeasonTabs`. Default is `{ false }` so other call sites (skeletons, previews) keep working unchanged.

> _Screenshot to be attached in a comment below — drag-drop a 1400×120 PNG showing 3 unfocused tabs with the orange badge, the focused "Saison 4" tab with the inverted badge, and 2 unwatched tabs without a badge._

## Why

Currently, a user browsing a series with several finished seasons has no quick visual cue of which seasons are already fully watched — they have to open each tab to see the per-episode watched badges. This adds a single glance indicator on the tab itself, consistent with the existing per-episode watched badge style.

## Testing

- Built `installFullDebug` locally and verified on an Ugoos AM9 PRO (Android TV).
- Verified rendering for a series with mixed seasons: fully watched seasons show the badge, partially watched / unwatched seasons don't.
- Verified focus interaction on the tab strip: badge stays on top of the focused (orange) tab and switches to the inverted color set for readability.
- No XML/string resource changes — `R.string.episodes_cd_watched` is reused for the `contentDescription` (already localized in all locales).

## Breaking changes

None. `SeasonTabs.isSeasonWatched` has a default `{ false }` so existing call sites compile unchanged.

## Linked issues

None.



<img width="1400" height="120" alt="season-tabs-final" src="https://github.com/user-attachments/assets/2b8225b9-ce21-4036-a227-e4b278db6beb" />
