### PR TITLE
feat(network): send Accept-Language header to addons

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -19,6 +19,7 @@ import com.nuvio.tv.data.remote.api.SeriesGraphApi
 import com.nuvio.tv.data.remote.api.SponsorsApi
 import com.nuvio.tv.data.remote.api.TmdbApi
 import com.nuvio.tv.data.remote.api.UniqueContributionsApi
+import com.nuvio.tv.LocaleCache
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -54,6 +55,28 @@ private fun normalizedBaseUrl(rawUrl: String, fallback: String): String {
     return if (trimmed.endsWith('/')) trimmed else "$trimmed/"
 }
 
+/**
+ * Builds the value sent in the `Accept-Language` request header so addons can
+ * serve localized payloads (catalog names, descriptions, etc.). Falls back to
+ * the system locale when the user has not overridden the app language. The
+ * primary tag is given the highest q-weight; English is appended at q=0.7 as
+ * a sensible fallback for addons that don't support the requested locale.
+ */
+private fun buildAcceptLanguageHeader(): String {
+    val explicit = LocaleCache.localeTag
+        .takeIf { it.isNotBlank() && it != LocaleCache.UNSET }
+    val primaryTag = (explicit ?: java.util.Locale.getDefault().toLanguageTag())
+        .takeIf { it.isNotBlank() && it != "und" }
+        ?: "en"
+    return if (primaryTag.equals("en", ignoreCase = true) ||
+        primaryTag.startsWith("en-", ignoreCase = true)
+    ) {
+        primaryTag
+    } else {
+        "$primaryTag,en;q=0.7"
+    }
+}
+
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
@@ -86,6 +109,7 @@ object NetworkModule {
                 val version = BuildConfig.VERSION_NAME.ifBlank { "dev" }
                 val request = chain.request().newBuilder()
                     .header("User-Agent", "Nuvio/$version")
+                    .header("Accept-Language", buildAcceptLanguageHeader())
                     .build()
                 chain.proceed(request)
             }


### PR DESCRIPTION
## Summary

Sends an `Accept-Language` HTTP request header on every call made through the shared `OkHttpClient`, so Stremio-compatible addons can serve localized payloads (catalog names, descriptions, …) when they support it.

- Header value priority:
  1. The user-overridden app language tag (`LocaleCache.localeTag`) when set.
  2. Otherwise `Locale.getDefault().toLanguageTag()`.
  3. `en` as a final fallback if both are blank/`und`.
- When the primary tag isn't English, appends `,en;q=0.7` so addons that don't have the requested language gracefully serve English instead of returning empty payloads.

Touched file: `app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt` (one new helper + one header on the existing shared interceptor — 24 added lines).

## Why

Currently the FR locale shows English catalog row names (e.g. `TMDB Popular - Séries`, `TMDB Trending - Films`) because Nuvio asks every addon for its manifest/catalog/meta/stream/subtitle endpoints **without telling it which language to use**. Addons like AIO Metadata that already maintain localized catalog titles have no way of knowing what the user wants.

Sending `Accept-Language` is the standard HTTP way to negotiate this — it's a one-line addition for the addon side (read the header, return the localized field), zero change for addons that don't care (they just ignore it).

This affects every place in the app that displays a catalog name pulled from an addon manifest:

- Home rows (`GridHomeContent.kt`, classic/modern home titles)
- "See all" header (`CatalogSeeAllScreen.kt`)
- Search → Discover catalog selector (`SearchDiscoverSection.kt`)
- Addons → "Reorder home catalogs" (`CatalogOrderScreen.kt`)
- Collection editor catalog picker

## Testing

- Built `assembleFullDebug` locally on the FR locale.
- Verified via `adb logcat` that addon requests now carry `Accept-Language: fr-FR,en;q=0.7` while previously they had no language header.
- Verified that Trakt requests still work (Trakt ignores Accept-Language; uses its own header set in `provideTraktOkHttpClient` — confirmed unchanged).
- Verified that TMDB requests still work (TMDB uses the `?language=` query param via `TmdbService`, ignores the header).
- Switched app language to EN: header becomes `en` only (no `,en;q=0.7` suffix).
- Force-stopped + relaunched the app: addons that ignore the header (legacy Stremio addons) keep returning identical payloads — no breakage.

## Breaking changes

None. Adding a request header is fully backward-compatible — addons that don't read it ignore it.

## Linked issues

None.