### PR TITLE
Post Release Hotfixes - CW duplicates, GIFs & Trailer Fixes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -74,7 +74,8 @@ class TraktEpisodeMappingService @Inject constructor(
         val addonHasEpisode = addonEpisodes.any {
             it.season == requestedSeason && it.episode == requestedEpisode
         }
-        if (addonHasEpisode && hasSameSeasonStructure(addonEpisodes, traktEpisodes)) {
+        val sameStructure = hasSameSeasonStructure(addonEpisodes, traktEpisodes)
+        if (addonHasEpisode && sameStructure) {
             return null
         }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -462,16 +462,19 @@ class TraktProgressService @Inject constructor(
             watchedShowSeedsState,
             hiddenProgressShowIds
         ) { seeds, _ ->
-            // Replace IMDB-based seeds with TMDB when sibling mapping is available.
-            // This prevents addon meta resolution from returning anthology data.
+            // Replace IMDB-based seeds with TMDB ONLY for ambiguous IDs (anthology shows).
+            // Non-ambiguous shows keep their IMDB ID for correct deduplication.
             val currentSiblings = showIdSiblingsMap
             seeds
                 .filter { !isShowHiddenFromProgress(it.contentId) }
                 .map { seed ->
                     if (seed.contentId.startsWith("tt") && currentSiblings.isNotEmpty()) {
                         val siblings = currentSiblings[seed.contentId]
-                        val tmdbSibling = siblings?.firstOrNull { it.startsWith("tmdb:") }
-                        if (tmdbSibling != null) seed.copy(contentId = tmdbSibling) else seed
+                        val isAmbiguous = siblings != null && "__ambiguous__" in siblings
+                        if (isAmbiguous) {
+                            val tmdbSibling = siblings?.firstOrNull { it.startsWith("tmdb:") }
+                            if (tmdbSibling != null) seed.copy(contentId = tmdbSibling) else seed
+                        } else seed
                     } else seed
                 }
         }.onStart {
@@ -1276,11 +1279,12 @@ class TraktProgressService @Inject constructor(
                 .map { it.key }
                 .toSet()
 
-            // Fix seeds that use IMDB as contentId when a TMDB sibling is known.
-            // Addons resolve meta more accurately by TMDB — using IMDB can return
-            // anthology meta (combined seasons from different shows) causing wrong next-up.
+            // Fix seeds that use IMDB as contentId when a TMDB sibling is known
+            // BUT ONLY for ambiguous IDs (anthology shows where one IMDB ID maps to
+            // multiple Trakt entries). Non-ambiguous shows must keep their IMDB ID
+            // so that deduplication against local in-progress items works correctly.
             val fixedWatchedShowSeeds = watchedShowSeeds.map { seed ->
-                if (seed.contentId.startsWith("tt")) {
+                if (seed.contentId.startsWith("tt") && seed.contentId in ambiguousIds) {
                     val siblings = siblingsMap[seed.contentId]
                     val tmdbSibling = siblings?.firstOrNull { it.startsWith("tmdb:") }
                     if (tmdbSibling != null) {

--- a/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
@@ -243,6 +243,8 @@ class InAppYouTubeExtractor @Inject constructor() {
             source = withTimeout(EXTRACTOR_TIMEOUT_MS) {
                 extractPlaybackSourceInternal(youtubeUrl, forceRefreshConfig = false)
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (error: Exception) {
             Log.w(TAG, "Kotlin extractor failed for $youtubeUrl: ${error.message}")
         }
@@ -254,6 +256,8 @@ class InAppYouTubeExtractor @Inject constructor() {
                 source = withTimeout(EXTRACTOR_TIMEOUT_MS) {
                     extractPlaybackSourceInternal(youtubeUrl, forceRefreshConfig = true)
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (error: Exception) {
                 Log.w(TAG, "Kotlin extractor retry failed for $youtubeUrl: ${error.message}")
             }
@@ -289,6 +293,7 @@ class InAppYouTubeExtractor @Inject constructor() {
         var loginRequiredCount = 0
 
         for (client in CLIENTS) {
+            kotlinx.coroutines.yield()
             try {
                 val playerResponse = fetchPlayerResponse(
                     apiKey = config.apiKey,
@@ -304,6 +309,9 @@ class InAppYouTubeExtractor @Inject constructor() {
                 if (status == "LOGIN_REQUIRED") {
                     loginRequiredCount++
                     Log.w(TAG, "Client ${client.key}: LOGIN_REQUIRED (visitor may be stale)")
+                    continue
+                }
+                if (status != null && status != "OK") {
                     continue
                 }
 
@@ -389,6 +397,7 @@ class InAppYouTubeExtractor @Inject constructor() {
                     Log.w(TAG, "Client ${client.key} failed: ${error.message}")
                 }
             }
+
         }
 
         // If all clients returned LOGIN_REQUIRED, invalidate config for next attempt
@@ -432,32 +441,27 @@ class InAppYouTubeExtractor @Inject constructor() {
         val bestVideo = pickBestForClient(adaptiveVideo, PREFERRED_SEPARATE_CLIENT)
         val bestAudio = pickBestForClient(adaptiveAudio, PREFERRED_SEPARATE_CLIENT)
 
-        val bestCombinedIsManifest = bestManifest != null &&
-            (bestProgressive == null || bestManifest.height > bestProgressive.height)
+        // Try adaptive video + audio first (best quality, separate streams)
+        kotlinx.coroutines.yield()
+        val resolvedVideo = bestVideo?.url?.let { resolveReachableUrl(it) }
+        val resolvedAudio = if (resolvedVideo != null) bestAudio?.url?.let { resolveReachableUrl(it) } else null
 
-        val combinedUrl = if (bestCombinedIsManifest) {
-            bestManifest.manifestUrl
-        } else {
-            bestProgressive?.url
+        if (resolvedVideo != null) {
+            return TrailerPlaybackSource(videoUrl = resolvedVideo, audioUrl = resolvedAudio)
         }
 
-        val videoUrl = resolveReachableUrl(bestVideo?.url ?: combinedUrl ?: return null)
-        val audioUrl = bestAudio?.url?.let { resolveReachableUrl(it) }
-
-        if (BuildConfig.DEBUG) {
-            Log.d(
-                TAG,
-                "Kotlin selection video=${summarizeUrl(videoUrl)} " +
-                    "audioPresent=${!audioUrl.isNullOrBlank()} " +
-                    "progressiveCount=${progressive.size} " +
-                    "adaptiveVideoCount=${adaptiveVideo.size} adaptiveAudioCount=${adaptiveAudio.size}"
-            )
+        // Adaptive failed (403) — fall back to HLS manifest (1080p, always works for COPPA/kids content)
+        if (bestManifest != null) {
+            return TrailerPlaybackSource(videoUrl = bestManifest.manifestUrl, audioUrl = null)
         }
 
-        return TrailerPlaybackSource(
-            videoUrl = videoUrl,
-            audioUrl = audioUrl
-        )
+        // No HLS available — try progressive (combined video+audio, usually low quality)
+        val resolvedProgressive = bestProgressive?.url?.let { resolveReachableUrl(it) }
+        if (resolvedProgressive != null) {
+            return TrailerPlaybackSource(videoUrl = resolvedProgressive, audioUrl = null)
+        }
+
+        return null
     }
 
     private fun extractVideoId(input: String): String? {
@@ -524,15 +528,15 @@ class InAppYouTubeExtractor @Inject constructor() {
             if (!cookieHeader.isNullOrBlank()) put("cookie", cookieHeader)
         }
 
-        val payload = mapOf(
-            "videoId" to videoId,
-            "contentCheckOk" to true,
-            "racyCheckOk" to true,
-            "context" to mapOf("client" to client.context),
-            "playbackContext" to mapOf(
+        val payload = buildMap<String, Any> {
+            put("videoId", videoId)
+            put("contentCheckOk", true)
+            put("racyCheckOk", true)
+            put("context", mapOf("client" to client.context))
+            put("playbackContext", mapOf(
                 "contentPlaybackContext" to mapOf("html5Preference" to "HTML5_PREF_WANTS")
-            )
-        )
+            ))
+        }
 
         val response = performRequest(
             url = endpoint,
@@ -541,8 +545,7 @@ class InAppYouTubeExtractor @Inject constructor() {
             body = gson.toJson(payload)
         )
         if (!response.ok) {
-            val preview = response.body.take(200)
-            throw IllegalStateException("player API ${client.key} failed (${response.status}): $preview")
+            throw IllegalStateException("player API ${client.key} failed (${response.status})")
         }
 
         val parsed = gson.fromJson(response.body, Map::class.java)
@@ -704,7 +707,11 @@ class InAppYouTubeExtractor @Inject constructor() {
         return sortCandidates(items).firstOrNull()
     }
 
-    private suspend fun resolveReachableUrl(url: String): String {
+    /**
+     * Probes CDN nodes for the given googlevideo URL and returns the first reachable one.
+     * Returns null if no CDN node responds successfully (all return 403/timeout).
+     */
+    private suspend fun resolveReachableUrl(url: String): String? {
         if (!url.contains("googlevideo.com")) return url
         val uri = Uri.parse(url)
         val mnParam = uri.getQueryParameter("mn") ?: return url
@@ -725,18 +732,21 @@ class InAppYouTubeExtractor @Inject constructor() {
             candidates += url.replace(uri.host!!, altHost)
         }
 
-        if (candidates.size == 1) return candidates[0]
+        if (candidates.size == 1) {
+            // Single candidate — verify it's reachable
+            return if (isUrlReachable(candidates[0])) candidates[0] else null
+        }
+
         val result = CompletableDeferred<String>()
         val probeScope = CoroutineScope(Dispatchers.IO)
         candidates.forEach { candidate ->
             probeScope.launch {
                 val reachable = isUrlReachable(candidate)
-                Log.d(TAG, "CDN probe: ${Uri.parse(candidate).host} -> $reachable")
                 if (reachable) result.complete(candidate)
             }
         }
         return try {
-            withTimeoutOrNull(2_000L) { result.await() } ?: url
+            withTimeoutOrNull(2_000L) { result.await() }
         } finally {
             probeScope.cancel()
         }
@@ -760,7 +770,9 @@ class InAppYouTubeExtractor @Inject constructor() {
                 .header("Range", "bytes=0-0")
                 .headers(buildHeaders(DEFAULT_HEADERS))
                 .build()
-            probeClient.newCall(request).execute().use { val code = it.code; Log.d(TAG, "CDN probe code: ${Uri.parse(url).host} -> $code"); code == 200 }
+            probeClient.newCall(request).execute().use { response ->
+                response.code == 200 || response.code == 206
+            }
         }.getOrDefault(false)
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -86,7 +86,11 @@ class TrailerService(
                 return@withContext tmdbSource
             }
             Log.w(TAG, "TMDB path exhausted; no YouTube trailer key resolved for backend /trailer fallback")
-            cache[cacheKey] = NEGATIVE_CACHE
+            // Only cache negative result if tmdbId was available — if null, enrichment
+            // may not have completed yet and a retry with tmdbId could succeed.
+            if (tmdbId != null) {
+                cache[cacheKey] = NEGATIVE_CACHE
+            }
             null
         } catch (e: Exception) {
             Log.e(TAG, "Error fetching trailer for $title: ${e.message}", e)
@@ -238,6 +242,8 @@ class TrailerService(
             }
             Log.d(TAG, "Using backend fallback source for ${summarizeUrl(youtubeUrl)}")
             TrailerPlaybackSource(videoUrl = fallbackUrl)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error getting trailer from YouTube: ${e.message}", e)
             null

--- a/app/src/main/java/com/nuvio/tv/ui/components/CollectionFolderCardMedia.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CollectionFolderCardMedia.kt
@@ -6,13 +6,10 @@ fun collectionFolderCardImageUrl(
     folder: CollectionFolder,
     isFocused: Boolean
 ): String? {
-    // When focusGifEnabled is off, the GIF URL acts as a regular poster (priority over cover image).
-    val effectiveCover = if (!folder.focusGifEnabled) {
-        firstNonBlank(folder.focusGifUrl, folder.coverImageUrl)
-    } else {
-        firstNonBlank(folder.coverImageUrl)
-    }
-    return effectiveCover
+    // GIF URL is only used as an animated overlay on focus (when focusGifEnabled is true).
+    // When focusGifEnabled is off, fall back to cover image only — don't use the GIF
+    // as a static poster since it would still animate via Coil's GIF decoder.
+    return firstNonBlank(folder.coverImageUrl)
 }
 
 private fun firstNonBlank(vararg candidates: String?): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -166,18 +166,9 @@ fun ContentCard(
     }
 
     if (focusedPosterBackdropTrailerEnabled) {
-        LaunchedEffect(
-            item.id,
-            isFocused,
-            trailerPreviewUrl
-        ) {
-            if (!isFocused) return@LaunchedEffect
-            if (trailerPreviewUrl != null) return@LaunchedEffect
-            delay(TRAILER_PREVIEW_REQUEST_FOCUS_DEBOUNCE_MS)
-            if (!isFocused) return@LaunchedEffect
-            if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return@LaunchedEffect
-            onRequestTrailerPreview(item)
-        }
+        // Trailer extraction is triggered by ModernHomeContent/ClassicHomeContent
+        // based on actual user focus, not by individual cards becoming visible.
+        // ContentCard only observes trailerPreviewUrl to start playback.
     }
 
     // Only pay the animation cost on the card that is actually focused/expanding.

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -30,6 +30,7 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import com.nuvio.tv.data.trailer.YoutubeChunkedDataSourceFactory
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
@@ -86,8 +87,17 @@ fun TrailerPlayer(
                     /* bufferForPlaybackAfterRebufferMs = */ 10_000
                 )
                 .build()
+            val trackSelector = DefaultTrackSelector(context).apply {
+                setParameters(
+                    buildUponParameters()
+                        .setMaxVideoSizeSd()
+                        .clearVideoSizeConstraints()
+                        .setForceHighestSupportedBitrate(true)
+                )
+            }
             ExoPlayer.Builder(context)
                 .setLoadControl(loadControl)
+                .setTrackSelector(trackSelector)
                 .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS)
                 .build()
                 .apply {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -174,6 +174,7 @@ class HomeViewModel @Inject constructor(
     internal val trailerPreviewAudioUrlsState = mutableStateMapOf<String, String>()
     internal var activeTrailerPreviewItemId: String? = null
     internal var trailerPreviewRequestVersion: Long = 0L
+    internal var trailerPreviewJob: Job? = null
     internal var currentTmdbSettings: TmdbSettings = TmdbSettings()
     internal var currentMdbListSettings: MDBListSettings = MDBListSettings()
     internal var heroEnrichmentJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -512,6 +512,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             nextUpItems = cachedNextUpItems
                         )
                     )
+
                     _uiState.update { state ->
                         if (state.continueWatchingItems == initialItems) {
                             state
@@ -1510,16 +1511,16 @@ internal fun mergeContinueWatchingItems(
     inProgressItems: List<ContinueWatchingItem.InProgress>,
     nextUpItems: List<ContinueWatchingItem.NextUp>
 ): List<ContinueWatchingItem> {
-    val inProgressSeriesIds = inProgressItems
+    // Collect ALL in-progress content IDs (not just series) to ensure
+    // release alerts and next-up items never duplicate an in-progress entry.
+    val allInProgressIds = inProgressItems
         .asSequence()
-        .map { it.progress }
-        .filter { isSeriesTypeCW(it.contentType) }
-        .map { it.contentId }
+        .map { it.progress.contentId }
         .filter { it.isNotBlank() }
         .toSet()
 
     val filteredNextUpItems = nextUpItems.filter { item ->
-        item.info.contentId !in inProgressSeriesIds
+        item.info.contentId !in allInProgressIds
     }
 
     val combined = mutableListOf<Pair<Long, ContinueWatchingItem>>()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -45,7 +45,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
 private const val CW_MAX_RECENT_PROGRESS_ITEMS = 300
-private const val CW_MAX_NEXT_UP_LOOKUPS = 64
+private const val CW_MAX_NEXT_UP_LOOKUPS = 32
 private const val CW_MAX_NEXT_UP_CONCURRENCY = 4
 private const val CW_MAX_ENRICHMENT_CONCURRENCY = 4
 private const val CW_PROGRESS_DEBOUNCE_MS = 500L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -341,76 +341,82 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
 ) {
     if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled) return
     if (startupGracePeriodActive) return
-    if (activeTrailerPreviewItemId != itemId) {
-        activeTrailerPreviewItemId = itemId
-        trailerPreviewRequestVersion++
-    }
+
+    // Resolve fallbackYtId from catalog item if not provided
+    val resolvedFallbackYtId = fallbackYtId ?: findCatalogItemById(itemId)?.trailerYtIds?.firstOrNull()
+
+    // Always bump version — only the latest request (highest version) will proceed after debounce
+    activeTrailerPreviewItemId = itemId
+    trailerPreviewRequestVersion++
+    val requestVersion = trailerPreviewRequestVersion
 
     if (trailerPreviewNegativeCache.contains(itemId)) return
     if (trailerPreviewUrlsState.containsKey(itemId)) return
     if (!trailerPreviewLoadingIds.add(itemId)) return
 
-    val requestVersion = trailerPreviewRequestVersion
-
     viewModelScope.launch(Dispatchers.IO) {
-        val tmdbId = try {
-            tmdbService.ensureTmdbId(itemId, apiType)
-        } catch (_: Exception) {
-            null
-        }
+        try {
+            // Debounce: wait for focus to settle before hitting network
+            delay(180)
 
-        val trailerSource = trailerService.getTrailerPlaybackSource(
-            title = title,
-            year = extractYear(releaseInfo),
-            tmdbId = tmdbId,
-            type = apiType
-        )
+            // Only the LATEST request proceeds — all earlier ones are stale
+            if (trailerPreviewRequestVersion != requestVersion) {
+                return@launch
+            }
 
-        val isLatestFocusedItem =
-            activeTrailerPreviewItemId == itemId && trailerPreviewRequestVersion == requestVersion
-        if (!isLatestFocusedItem) {
-            trailerPreviewLoadingIds.remove(itemId)
-            return@launch
-        }
+            val tmdbId = try {
+                tmdbService.ensureTmdbId(itemId, apiType)
+            } catch (_: Exception) {
+                null
+            }
 
-        withContext(Dispatchers.Main) {
-            if (trailerSource?.videoUrl.isNullOrBlank()) {
-                val fallbackSource = fallbackYtId?.let { ytId ->
-                    trailerService.getTrailerPlaybackSourceFromYouTubeUrl(
-                        youtubeUrl = "https://www.youtube.com/watch?v=$ytId",
-                        title = title,
-                        year = extractYear(releaseInfo)
-                    )
-                }
-                if (fallbackSource?.videoUrl != null) {
-                    if (trailerPreviewUrlsState[itemId] != fallbackSource.videoUrl) {
-                        trailerPreviewUrlsState[itemId] = fallbackSource.videoUrl
+            val trailerSource = trailerService.getTrailerPlaybackSource(
+                title = title,
+                year = extractYear(releaseInfo),
+                tmdbId = tmdbId,
+                type = apiType
+            )
+
+            withContext(Dispatchers.Main) {
+                if (trailerSource?.videoUrl.isNullOrBlank()) {
+                    val fallbackSource = resolvedFallbackYtId?.let { ytId ->
+                        trailerService.getTrailerPlaybackSourceFromYouTubeUrl(
+                            youtubeUrl = "https://www.youtube.com/watch?v=$ytId",
+                            title = title,
+                            year = extractYear(releaseInfo)
+                        )
                     }
-                    val fallbackAudio = fallbackSource.audioUrl
-                    if (fallbackAudio.isNullOrBlank()) {
+                    if (fallbackSource?.videoUrl != null) {
+                        if (trailerPreviewUrlsState[itemId] != fallbackSource.videoUrl) {
+                            trailerPreviewUrlsState[itemId] = fallbackSource.videoUrl
+                        }
+                        val fallbackAudio = fallbackSource.audioUrl
+                        if (fallbackAudio.isNullOrBlank()) {
+                            trailerPreviewAudioUrlsState.remove(itemId)
+                        } else if (trailerPreviewAudioUrlsState[itemId] != fallbackAudio) {
+                            trailerPreviewAudioUrlsState[itemId] = fallbackAudio
+                        }
+                    } else {
+                        trailerPreviewNegativeCache.add(itemId)
+                        trailerPreviewUrlsState.remove(itemId)
                         trailerPreviewAudioUrlsState.remove(itemId)
-                    } else if (trailerPreviewAudioUrlsState[itemId] != fallbackAudio) {
-                        trailerPreviewAudioUrlsState[itemId] = fallbackAudio
                     }
                 } else {
-                    trailerPreviewNegativeCache.add(itemId)
-                    trailerPreviewUrlsState.remove(itemId)
-                    trailerPreviewAudioUrlsState.remove(itemId)
-                }
-            } else {
-                val videoUrl = trailerSource.videoUrl
-                if (trailerPreviewUrlsState[itemId] != videoUrl) {
-                    trailerPreviewUrlsState[itemId] = videoUrl
-                }
-                val audioUrl = trailerSource.audioUrl
-                if (audioUrl.isNullOrBlank()) {
-                    trailerPreviewAudioUrlsState.remove(itemId)
-                } else if (trailerPreviewAudioUrlsState[itemId] != audioUrl) {
-                    trailerPreviewAudioUrlsState[itemId] = audioUrl
+                    val videoUrl = trailerSource.videoUrl
+                    if (trailerPreviewUrlsState[itemId] != videoUrl) {
+                        trailerPreviewUrlsState[itemId] = videoUrl
+                    }
+                    val audioUrl = trailerSource.audioUrl
+                    if (audioUrl.isNullOrBlank()) {
+                        trailerPreviewAudioUrlsState.remove(itemId)
+                    } else if (trailerPreviewAudioUrlsState[itemId] != audioUrl) {
+                        trailerPreviewAudioUrlsState[itemId] = audioUrl
+                    }
                 }
             }
+        } finally {
+            trailerPreviewLoadingIds.remove(itemId)
         }
-        trailerPreviewLoadingIds.remove(itemId)
     }
 }
 
@@ -693,14 +699,13 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
     }
 
     // If external meta brought new trailerYtIds and the item has no trailer resolved yet, retry.
-    // Covers: (a) item was in negative cache, (b) pipeline finished without result but wasn't
-    // cached as negative (e.g. focus changed mid-flight), (c) pipeline still in-flight.
-    if (incomingTrailerYtIds.isNotEmpty() && !trailerPreviewUrlsState.containsKey(itemId)) {
+    // Only retry if this item is currently focused — avoid prefetching trailers for adjacent items.
+    if (incomingTrailerYtIds.isNotEmpty() && !trailerPreviewUrlsState.containsKey(itemId) && activeTrailerPreviewItemId == itemId) {
         trailerPreviewNegativeCache.remove(itemId)
         trailerPreviewLoadingIds.remove(itemId)
         // Bump version so any in-flight pipeline for this item treats itself as stale
         // and won't overwrite the retry result with a negative cache entry.
-        if (activeTrailerPreviewItemId == itemId) trailerPreviewRequestVersion++
+        trailerPreviewRequestVersion++
         val currentItem = findCatalogItemById(itemId) ?: return
         requestTrailerPreviewPipeline(currentItem)
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -516,12 +516,9 @@ internal fun buildCollectionFolderItem(
     }
     // Cover image takes priority over emoji. Emoji is only used as fallback
     // when no cover image is available.
-    // When focusGifEnabled is off, the GIF URL acts as a regular poster (priority over cover image).
-    val imageUrl = if (!folder.focusGifEnabled) {
-        firstNonBlank(folder.focusGifUrl, folder.coverImageUrl, collection.backdropImageUrl)
-    } else {
-        firstNonBlank(folder.coverImageUrl, collection.backdropImageUrl)
-    }
+    // GIF URL is only used as an animated overlay on focus (when focusGifEnabled is true).
+    // Don't use it as a static poster — it would still animate via Coil's GIF decoder.
+    val imageUrl = firstNonBlank(folder.coverImageUrl, collection.backdropImageUrl)
     val heroBackdrop = firstNonBlank(folder.heroBackdropUrl, folder.coverImageUrl, collection.backdropImageUrl)
 
     return ModernCarouselItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
@@ -247,9 +247,14 @@ internal fun buildModernHomePresentation(
                             )
                         )
                     }.asStable()
+                    val placeholderTitle = if (input.showCatalogTypeSuffix) {
+                        homeRow.displayTitle
+                    } else {
+                        homeRow.catalogName.replaceFirstChar { it.uppercase() }
+                    }
                     val placeholderRow = HeroCarouselRow(
                         key = homeRow.catalogKey,
-                        title = homeRow.displayTitle,
+                        title = placeholderTitle,
                         globalRowIndex = index,
                         catalogId = homeRow.catalogId,
                         addonId = homeRow.addonId,


### PR DESCRIPTION
## Summary
Fix CW duplicate entries and wrong episode numbering caused by unconditional IMDB->TMDB ID replacement in Trakt seeds. Also fix binge group next-episode timeout hanging indefinitely, shimmer rows ignoring catalog type suffix setting, collection GIFs playing continuously when "play on focus" is disabled, YouTube trailer extraction 403 errors for animated/family content, and excessive trailer prefetching during scrolling.

## PR type
- Bug fix

## Why
1. **CW duplicates + wrong episode numbers**: `TraktProgressService` was replacing ALL IMDB-based seed IDs with TMDB siblings unconditionally. This caused: (a) deduplication failures (InProgress had `tt...` while NextUp had `tmdb:...` for the same show), and (b) wrong episode numbering for anime (meta resolution with TMDB ID returned different season structure). Fix: only replace for ambiguous/anthology IDs.
2. **Shimmer row catalog type suffix**: Placeholder rows used pre-computed `displayTitle` ignoring the live `showCatalogTypeSuffix` setting.
3 **Collection GIFs always animating**: When `focusGifEnabled=false`, the GIF URL was used as a static poster — but Coil still animated it. Fix: never use GIF URL as poster; only as focus overlay.
4. **YouTube trailer 403 for animated/family content**: YouTube blocks direct adaptive stream URLs for "Made for Kids" (COPPA) content. Added HLS manifest fallback - when CDN probes return 403 for adaptive URLs, fall back to HLS master manifest from iOS client which always works. Added `DefaultTrackSelector` with `forceHighestSupportedBitrate` to ensure HLS playback starts at max quality.
5. **Trailer prefetch storm during scrolling**: Multiple ContentCard instances and the enrichment retry path were triggering YouTube extraction for non-focused items. Fix: removed ContentCard self-trigger, added version-based debounce (180ms) in pipeline so only the last-focused item proceeds, and gated enrichment retry on `activeTrailerPreviewItemId` check. Also: don't cache negative trailer results when `tmdbId` is null (enrichment pending), and properly propagate `CancellationException` through extractor/service layers.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing
- Verified CW no longer shows duplicate entries for shows with both IMDB and TMDB IDs
- Verified binge group auto-play falls back correctly after timeout
- Verified shimmer rows respect catalog type suffix toggle
- Verified collection GIFs don't animate when "play on focus" is off
- Verified animated/family movie trailers (e.g. glgmAwRDP8s) now play via HLS fallback with audio
- Verified trailer extraction only fires for the currently focused item (no prefetch storm)
- Verified trailers load correctly in all row positions (not just first item)

## Screenshots / Video (UI changes only)

behavioral fixes, no UI layout changes.

## Breaking changes

Nothing should break 

## Linked issues
Reported on Discord