### PR TITLE
feat(catalog): allow renaming home catalog rows

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/server/AddonConfigChangeSanitizer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonConfigChangeSanitizer.kt
@@ -31,6 +31,15 @@ internal fun sanitizePendingAddonChange(
                 .filter { it.isDisabled }
                 .map { it.disableKey }
         },
+        proposedCustomCatalogTitles = if (mode.allowCatalogManagement) {
+            proposedChange.proposedCustomCatalogTitles
+        } else {
+            currentState.catalogs
+                .mapNotNull { catalog ->
+                    catalog.customTitle?.takeIf { it.isNotBlank() }?.let { catalog.key to it }
+                }
+                .toMap()
+        },
         proposedCollectionsJson = if (mode.allowCollectionManagement) {
             proposedChange.proposedCollectionsJson
         } else {

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServer.kt
@@ -169,6 +169,7 @@ class AddonConfigServer(
             val urls = parseStringList(parsed["urls"])
             val catalogOrderKeys = parseStringList(parsed["catalogOrderKeys"])
             val disabledCatalogKeys = parseStringList(parsed["disabledCatalogKeys"])
+            val customCatalogTitles = parseStringMap(parsed["customCatalogTitles"])
             val collectionsRaw = parsed["collections"]
             val collectionsJson = if (collectionsRaw != null) gson.toJson(collectionsRaw) else null
             val disabledCollectionKeys = parseStringList(parsed["disabledCollectionKeys"])
@@ -179,6 +180,7 @@ class AddonConfigServer(
                     proposedUrls = urls,
                     proposedCatalogOrderKeys = catalogOrderKeys,
                     proposedDisabledCatalogKeys = disabledCatalogKeys,
+                    proposedCustomCatalogTitles = customCatalogTitles,
                     proposedCollectionsJson = collectionsJson,
                     proposedDisabledCollectionKeys = disabledCollectionKeys,
                     proposedFollowAddonsOrder = followAddonsOrder
@@ -216,6 +218,17 @@ class AddonConfigServer(
             .filter { it.isNotEmpty() }
             .distinct()
             .toList()
+    }
+
+    private fun parseStringMap(rawValue: Any?): Map<String, String> {
+        val map = rawValue as? Map<*, *> ?: return emptyMap()
+        return map.asSequence()
+            .mapNotNull { entry ->
+                val key = (entry.key as? String)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val value = (entry.value as? String)?.trim()?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                key to value
+            }
+            .toMap()
     }
 
     companion object {

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServerModels.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServerModels.kt
@@ -36,7 +36,8 @@ data class CatalogInfo(
     val catalogName: String,
     val addonName: String,
     val type: String,
-    val isDisabled: Boolean
+    val isDisabled: Boolean,
+    val customTitle: String? = null
 )
 
 data class CollectionInfo(
@@ -160,6 +161,7 @@ data class PendingAddonChange(
     val proposedUrls: List<String>,
     val proposedCatalogOrderKeys: List<String> = emptyList(),
     val proposedDisabledCatalogKeys: List<String> = emptyList(),
+    val proposedCustomCatalogTitles: Map<String, String> = emptyMap(),
     val proposedCollectionsJson: String? = null,
     val proposedDisabledCollectionKeys: List<String> = emptyList(),
     val proposedFollowAddonsOrder: Boolean? = null,

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
@@ -609,6 +609,21 @@ ${tabButtons}
   }
   .collection-title-input:focus { border-bottom-color: rgba(255, 255, 255, 0.5); outline: none; }
   .collection-title-input::placeholder { color: rgba(255,255,255,0.2); }
+  .catalog-title-input {
+    width: 100%;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0;
+    padding: 0.15rem 0;
+    color: #fff;
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .catalog-title-input:focus { border-bottom-color: rgba(255, 255, 255, 0.4); outline: none; }
+  .catalog-title-input::placeholder { color: rgba(255,255,255,0.25); font-weight: 400; }
   .col-actions {
     display: flex;
     align-items: center;
@@ -1732,10 +1747,18 @@ function renderCatalogs() {
         '</button>' +
       '</div>' +
       '<div class="catalog-info">' +
-        '<div class="catalog-name">' + escapeHtml(formatCatalogTitle(catalog.catalogName, catalog.type)) +
-          (isCollection ? '<span class="badge-collection">${context.getString(R.string.web_badge_collection).replace("'", "\\'")}</span>' : '') +
-          (catalog.isDisabled ? '<span class="badge-disabled">${context.getString(R.string.web_badge_disabled).replace("'", "\\'")}</span>' : '') +
-        '</div>' +
+        (isCollection
+          ? '<div class="catalog-name">' + escapeHtml(formatCatalogTitle(catalog.catalogName, catalog.type)) +
+              '<span class="badge-collection">${context.getString(R.string.web_badge_collection).replace("'", "\\'")}</span>' +
+              (catalog.isDisabled ? '<span class="badge-disabled">${context.getString(R.string.web_badge_disabled).replace("'", "\\'")}</span>' : '') +
+            '</div>'
+          : '<div class="catalog-name">' +
+              '<input class="catalog-title-input" type="text" value="' + escapeAttr(catalog.customTitle || '') +
+                '" placeholder="' + escapeAttr(formatCatalogTitle(catalog.catalogName, catalog.type)) +
+                '" oninput="updateCatalogTitle(' + i + ',this.value);updateSaveButtonState()">' +
+              (catalog.isDisabled ? '<span class="badge-disabled">${context.getString(R.string.web_badge_disabled).replace("'", "\\'")}</span>' : '') +
+            '</div>'
+        ) +
         '<div class="catalog-meta">' + escapeHtml(catalog.addonName) + '</div>' +
       '</div>' +
       '<div class="addon-actions">' +
@@ -1946,6 +1969,12 @@ async function saveChanges() {
   var disabledCatalogKeys = catalogs
     .filter(function(c) { return c.isDisabled; })
     .map(function(c) { return c.disableKey; });
+  var customCatalogTitles = {};
+  catalogs.forEach(function(c) {
+    if (c.isCollection) return;
+    var title = (c.customTitle || '').trim();
+    if (title) customCatalogTitles[c.key] = title;
+  });
   try {
     var res = await fetchWithTimeout('/api/addons', {
       method: 'POST',
@@ -1954,6 +1983,7 @@ async function saveChanges() {
         urls: urls,
         catalogOrderKeys: catalogOrderKeys,
         disabledCatalogKeys: disabledCatalogKeys,
+        customCatalogTitles: customCatalogTitles,
         collections: collections,
         disabledCollectionKeys: disabledCollectionKeys,
         followAddonsOrder: followAddonsOrder
@@ -2175,6 +2205,11 @@ function moveCollection(ci, dir) {
 
 function updateCollectionTitle(ci, val) {
   collections[ci].title = val;
+}
+
+function updateCatalogTitle(i, val) {
+  if (!catalogs[i]) return;
+  catalogs[i].customTitle = val;
 }
 
 function addFolder(ci) {

--- a/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
@@ -1752,12 +1752,16 @@ function renderCatalogs() {
               '<span class="badge-collection">${context.getString(R.string.web_badge_collection).replace("'", "\\'")}</span>' +
               (catalog.isDisabled ? '<span class="badge-disabled">${context.getString(R.string.web_badge_disabled).replace("'", "\\'")}</span>' : '') +
             '</div>'
-          : '<div class="catalog-name">' +
-              '<input class="catalog-title-input" type="text" value="' + escapeAttr(catalog.customTitle || '') +
-                '" placeholder="' + escapeAttr(formatCatalogTitle(catalog.catalogName, catalog.type)) +
-                '" oninput="updateCatalogTitle(' + i + ',this.value);updateSaveButtonState()">' +
-              (catalog.isDisabled ? '<span class="badge-disabled">${context.getString(R.string.web_badge_disabled).replace("'", "\\'")}</span>' : '') +
-            '</div>'
+          : (function() {
+              var originalTitle = formatCatalogTitle(catalog.catalogName, catalog.type);
+              var displayTitle = (catalog.customTitle && catalog.customTitle.length > 0) ? catalog.customTitle : originalTitle;
+              return '<div class="catalog-name">' +
+                '<input class="catalog-title-input" type="text" value="' + escapeAttr(displayTitle) +
+                  '" data-original-title="' + escapeAttr(originalTitle) +
+                  '" oninput="updateCatalogTitle(' + i + ',this.value);updateSaveButtonState()">' +
+                (catalog.isDisabled ? '<span class="badge-disabled">${context.getString(R.string.web_badge_disabled).replace("'", "\\'")}</span>' : '') +
+              '</div>';
+            })()
         ) +
         '<div class="catalog-meta">' + escapeHtml(catalog.addonName) + '</div>' +
       '</div>' +
@@ -1973,7 +1977,13 @@ async function saveChanges() {
   catalogs.forEach(function(c) {
     if (c.isCollection) return;
     var title = (c.customTitle || '').trim();
-    if (title) customCatalogTitles[c.key] = title;
+    var original = formatCatalogTitle(c.catalogName, c.type);
+    // Only persist as a custom override when the value is non-empty and
+    // differs from the manifest title — otherwise the user has reverted
+    // to the original and we should clear any existing override.
+    if (title && title !== original) {
+      customCatalogTitles[c.key] = title;
+    }
   });
   try {
     var res = await fetchWithTimeout('/api/addons', {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerUiState.kt
@@ -24,6 +24,7 @@ data class PendingChangeInfo(
     val proposedUrls: List<String>,
     val proposedCatalogOrderKeys: List<String> = emptyList(),
     val proposedDisabledCatalogKeys: List<String> = emptyList(),
+    val proposedCustomCatalogTitles: Map<String, String> = emptyMap(),
     val addedUrls: List<String>,
     val removedUrls: List<String>,
     val catalogsReordered: Boolean = false,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
@@ -96,6 +96,7 @@ class AddonManagerViewModel @Inject constructor(
     private var logoBytes: ByteArray? = null
     private var homeCatalogOrderKeys: List<String> = emptyList()
     private var disabledHomeCatalogKeys: Set<String> = emptySet()
+    private var customCatalogTitles: Map<String, String> = emptyMap()
     private var followAddonsOrderEnabled: Boolean = false
     private var currentCollections: List<Collection> = emptyList()
 
@@ -267,7 +268,8 @@ class AddonManagerViewModel @Inject constructor(
                         catalogName = catalog.catalogName,
                         addonName = catalog.addonName,
                         type = catalog.typeLabel,
-                        isDisabled = catalog.isDisabled
+                        isDisabled = catalog.isDisabled,
+                        customTitle = customCatalogTitles[catalog.key]?.takeIf { it.isNotBlank() }
                     )
                 }
                 val collectionInfos = currentCollections.map { col ->
@@ -554,6 +556,7 @@ class AddonManagerViewModel @Inject constructor(
                     proposedUrls = change.proposedUrls,
                     proposedCatalogOrderKeys = resolvedProposedCatalogOrderKeys,
                     proposedDisabledCatalogKeys = resolvedProposedDisabledCatalogKeys,
+                    proposedCustomCatalogTitles = change.proposedCustomCatalogTitles,
                     addedUrls = added,
                     removedUrls = removed,
                     catalogsReordered = catalogsReordered,
@@ -671,6 +674,12 @@ class AddonManagerViewModel @Inject constructor(
 
         layoutPreferenceDataStore.setHomeCatalogOrderKeys(validCatalogOrder)
         layoutPreferenceDataStore.setDisabledHomeCatalogKeys(validDisabledCatalogs)
+        // Apply custom catalog titles (renamed rows) — keep only entries whose key still exists.
+        val sanitizedCustomTitles = pending.proposedCustomCatalogTitles
+            .asSequence()
+            .filter { (key, value) -> key in allValidOrderKeys && value.isNotBlank() }
+            .associate { (key, value) -> key to value.trim() }
+        layoutPreferenceDataStore.setCustomCatalogTitles(sanitizedCustomTitles)
         homeCatalogSettingsSyncService.triggerPush()
     }
 
@@ -683,6 +692,11 @@ class AddonManagerViewModel @Inject constructor(
         viewModelScope.launch {
             layoutPreferenceDataStore.disabledHomeCatalogKeys.collect { keys ->
                 disabledHomeCatalogKeys = keys.toSet()
+            }
+        }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.customCatalogTitles.collect { titles ->
+                customCatalogTitles = titles
             }
         }
         viewModelScope.launch {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderScreen.kt
@@ -17,17 +17,30 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -57,6 +70,7 @@ fun CatalogOrderScreen(
     val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    var renameTarget by remember { mutableStateOf<CatalogOrderItem?>(null) }
 
     BackHandler { onBackPress() }
 
@@ -157,10 +171,140 @@ fun CatalogOrderScreen(
                                     )
                                 }
                             },
-                            onToggleEnabled = { viewModel.toggleCatalogEnabled(item.disableKey) }
+                            onToggleEnabled = { viewModel.toggleCatalogEnabled(item.disableKey) },
+                            onRename = { renameTarget = item }
                         )
                     }
                 }
+            }
+        }
+
+        renameTarget?.let { target ->
+            CatalogRenameDialog(
+                target = target,
+                onConfirm = { newTitle ->
+                    viewModel.setCustomTitle(target.key, newTitle)
+                    renameTarget = null
+                },
+                onClear = {
+                    viewModel.setCustomTitle(target.key, null)
+                    renameTarget = null
+                },
+                onDismiss = { renameTarget = null }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CatalogRenameDialog(
+    target: CatalogOrderItem,
+    onConfirm: (String) -> Unit,
+    onClear: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var draft by remember(target.key) {
+        mutableStateOf(target.catalogName.takeIf { it.isNotBlank() } ?: "")
+    }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(target.key) { focusRequester.requestFocus() }
+
+    com.nuvio.tv.ui.components.NuvioDialog(
+        onDismiss = onDismiss,
+        title = stringResource(R.string.catalog_order_rename),
+        subtitle = stringResource(R.string.catalog_order_rename_subtitle, target.originalCatalogName)
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = NuvioColors.BackgroundCard),
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            BasicTextField(
+                value = draft,
+                onValueChange = { draft = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 14.dp)
+                    .focusRequester(focusRequester),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(onDone = { onConfirm(draft) }),
+                textStyle = MaterialTheme.typography.bodyLarge.copy(color = NuvioColors.TextPrimary),
+                cursorBrush = SolidColor(NuvioColors.Primary),
+                decorationBox = { innerTextField ->
+                    if (draft.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.catalog_order_rename_placeholder),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = NuvioColors.TextSecondary
+                        )
+                    }
+                    innerTextField()
+                }
+            )
+        }
+        Spacer(modifier = Modifier.height(20.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End)
+        ) {
+            Button(
+                onClick = onClear,
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    contentColor = NuvioColors.TextSecondary,
+                    focusedContainerColor = NuvioColors.FocusBackground,
+                    focusedContentColor = NuvioColors.Error
+                ),
+                border = ButtonDefaults.border(
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                ),
+                shape = ButtonDefaults.shape(RoundedCornerShape(10.dp))
+            ) {
+                Text(text = stringResource(R.string.action_clear))
+            }
+            Button(
+                onClick = onDismiss,
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioColors.BackgroundCard,
+                    contentColor = NuvioColors.TextSecondary,
+                    focusedContainerColor = NuvioColors.FocusBackground,
+                    focusedContentColor = NuvioColors.Primary
+                ),
+                border = ButtonDefaults.border(
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                ),
+                shape = ButtonDefaults.shape(RoundedCornerShape(10.dp))
+            ) {
+                Text(text = stringResource(R.string.action_cancel))
+            }
+            Button(
+                onClick = { onConfirm(draft) },
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioColors.Primary,
+                    contentColor = NuvioColors.OnPrimary,
+                    focusedContainerColor = NuvioColors.FocusBackground,
+                    focusedContentColor = NuvioColors.Primary
+                ),
+                border = ButtonDefaults.border(
+                    focusedBorder = Border(
+                        border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                ),
+                shape = ButtonDefaults.shape(RoundedCornerShape(10.dp))
+            ) {
+                Text(text = stringResource(R.string.web_btn_save))
             }
         }
     }
@@ -171,7 +315,8 @@ private fun CatalogOrderCard(
     item: CatalogOrderItem,
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
-    onToggleEnabled: () -> Unit
+    onToggleEnabled: () -> Unit,
+    onRename: () -> Unit = {}
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -254,6 +399,28 @@ private fun CatalogOrderCard(
                     Icon(
                         imageVector = Icons.Default.ArrowDownward,
                         contentDescription = stringResource(R.string.cd_move_down)
+                    )
+                }
+
+                Button(
+                    onClick = onRename,
+                    colors = ButtonDefaults.colors(
+                        containerColor = NuvioColors.BackgroundCard,
+                        contentColor = NuvioColors.TextSecondary,
+                        focusedContainerColor = NuvioColors.FocusBackground,
+                        focusedContentColor = NuvioColors.Primary
+                    ),
+                    border = ButtonDefaults.border(
+                        focusedBorder = Border(
+                            border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                    ),
+                    shape = ButtonDefaults.shape(RoundedCornerShape(12.dp))
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = stringResource(R.string.catalog_order_rename)
                     )
                 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/CatalogOrderViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -56,6 +57,20 @@ class CatalogOrderViewModel @Inject constructor(
     fun toggleFollowAddonsOrder(enabled: Boolean) {
         viewModelScope.launch {
             layoutPreferenceDataStore.setFollowAddonsOrder(enabled)
+        }
+    }
+
+    fun setCustomTitle(key: String, title: String?) {
+        viewModelScope.launch {
+            val current = layoutPreferenceDataStore.customCatalogTitles.first()
+            val trimmed = title?.trim().orEmpty()
+            val updated = if (trimmed.isEmpty()) {
+                current - key
+            } else {
+                current + (key to trimmed)
+            }
+            if (updated == current) return@launch
+            layoutPreferenceDataStore.setCustomCatalogTitles(updated)
         }
     }
 
@@ -314,6 +329,7 @@ class CatalogOrderViewModel @Inject constructor(
                 key = entry.key,
                 disableKey = entry.disableKey,
                 catalogName = displayName,
+                originalCatalogName = entry.catalogName,
                 addonName = entry.addonName,
                 typeLabel = entry.typeLabel,
                 isDisabled = entry.disableKey in disabledKeys ||
@@ -451,6 +467,7 @@ data class CatalogOrderItem(
     val key: String,
     val disableKey: String,
     val catalogName: String,
+    val originalCatalogName: String,
     val addonName: String,
     val typeLabel: String,
     val isDisabled: Boolean,

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1007,6 +1007,9 @@
     <string name="catalog_order_disabled_on_home">Désactivé sur l’accueil</string>
     <string name="catalog_order_enable">Activer</string>
     <string name="catalog_order_disable">Désactiver</string>
+    <string name="catalog_order_rename">Renommer</string>
+    <string name="catalog_order_rename_subtitle">Titre personnalisé pour «&#160;%1$s&#160;»</string>
+    <string name="catalog_order_rename_placeholder">Titre personnalisé (laisser vide pour réinitialiser)</string>
 
 
     <!-- StreamScreen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1033,6 +1033,9 @@
     <string name="catalog_order_disabled_on_home">Disabled on Home</string>
     <string name="catalog_order_enable">Enable</string>
     <string name="catalog_order_disable">Disable</string>
+    <string name="catalog_order_rename">Rename</string>
+    <string name="catalog_order_rename_subtitle">Custom title for “%1$s”</string>
+    <string name="catalog_order_rename_placeholder">Custom title (leave empty to reset)</string>
 
 
     <!-- StreamScreen -->


### PR DESCRIPTION
## Summary

Lets the user override the displayed name of any home catalog row, in two places:

1. **Web config UI** ("Home Layout" tab): each addon catalog row gets an inline editable title input (mirrors the collection-row title input pattern that already exists). Catalogs that are collections keep their read-only label since collections already have their own dedicated title editor.
2. **Native screen "Reorder Home Catalogs"**: adds a small Edit button next to Move ↑ / ↓ / Enable–Disable. Opens a `NuvioDialog` with a `BasicTextField`, preseeded with the current title.

The override is stored in `LayoutPreferenceDataStore.customCatalogTitles` (the key & DataStore plumbing already existed in the codebase but was unreachable from the UI). Every screen that consumes `CatalogOrderItem.catalogName` / `CatalogRow.catalogName` automatically picks up the override (Home rows, Discover, See-all header, Catalog picker in the collection editor, …).

## Why

- Catalog names come from the addon's `manifest.json` and are not localized. Users running addons that don't honor `Accept-Language` (most Stremio-compatible addons today, including AIO Metadata) end up with row names like "TMDB Popular - Séries,série,series,serie" no matter what the app locale is.
- This PR lets the user fix any row name themselves, locally, without modifying the addon. Clearing the field reverts to the manifest title.
- The behaviour intentionally mimics the existing collection-row rename UX for consistency.

## Plumbing additions

- `CatalogInfo.customTitle`, `PendingAddonChange.proposedCustomCatalogTitles` (server models)
- `AddonConfigChangeSanitizer` keeps the new map per `AddonWebConfigMode` (FULL / ADDONS_ONLY / COLLECTIONS_ONLY)
- `AddonConfigServer.handleAddonUpdate` parses `customCatalogTitles` from the JSON body
- `AddonManagerViewModel` observes `customCatalogTitles`, injects them when building `CatalogInfo` for the web payload, and applies them via `setCustomCatalogTitles` on commit
- `CatalogOrderItem.originalCatalogName` (the manifest name, exposed so the dialog can show it in the subtitle / placeholder)
- `CatalogOrderViewModel.setCustomTitle(key, title?)` — `null` or blank removes the override

## Strings

3 new keys in `values/strings.xml` + `values-fr/strings.xml` (FR uses proper NBSP before `: ; ? !`):
- `catalog_order_rename` — "Rename" / "Renommer"
- `catalog_order_rename_subtitle` — `Custom title for "%1$s"` / `Titre personnalisé pour « %1$s »`
- `catalog_order_rename_placeholder` — "Custom title (leave empty to reset)" / "Titre personnalisé (laisser vide pour réinitialiser)"

## Testing

- `./gradlew assembleFullDebug` succeeds.
- `installFullDebug` on Android TV (Ugoos AM9 PRO):
  - Native: Settings → Reorder Home Catalogs → tap Edit on a row → dialog opens prefilled, Save/Clear/Cancel all behave correctly.
  - Web: open the QR-pairing URL on a phone, edit a row name, hit Save, confirm on TV → row name updates everywhere it appears.
- Verified that an empty / whitespace input deletes the override (row falls back to the manifest name).
- Verified that the override survives an addon refresh (`Refresh Addons`) and an app restart.

## Breaking changes

None. All new fields default to empty / null. Existing addons behave identically when no custom title is set.

## Linked issues

None.