### PR TITLE
fix(image): register SvgDecoder so SVG logos actually render

### DIFF
--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -10,6 +10,7 @@ import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import coil3.gif.GifDecoder
 import coil3.gif.AnimatedImageDecoder
+import coil3.svg.SvgDecoder
 import coil3.request.crossfade
 import coil3.request.allowHardware
 import coil3.request.allowRgb565
@@ -77,6 +78,7 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
                 } else {
                     add(GifDecoder.Factory())
                 }
+                add(SvgDecoder.Factory())
                 // Use a lean OkHttpClient for image fetching — no HTTP cache (Coil's own
                 // DiskCache handles caching), no cookie jar, no logging interceptors.
                 add(


### PR DESCRIPTION
## Summary

Registers `SvgDecoder.Factory()` on the singleton `ImageLoader` in `NuvioApplication.kt`. The `coil-svg:3.3.0` dependency was already declared in `build.gradle.kts` but the decoder was never wired up, so every SVG image silently fell through Coil's decoder chain and ended up unrendered.

Two-line change:

```kotlin
import coil3.svg.SvgDecoder
…
.components {
    if (Build.VERSION.SDK_INT >= 28) {
        add(AnimatedImageDecoder.Factory())
    } else {
        add(GifDecoder.Factory())
    }
    add(SvgDecoder.Factory())  // ← new
    add(coil3.network.okhttp.OkHttpNetworkFetcherFactory(…))
}
```

## Why

`coil-svg` is opt-in: declaring the dependency is necessary but not sufficient — the factory must also be registered on the `ImageLoader` for Coil to know it can handle `image/svg+xml` payloads. Without it, the response bytes flow into `BitmapFactory`, which returns `null` on SVG content, and Coil emits an `ImageDecoderException` that is silently swallowed by `AsyncImage` (no `error` painter set on most call sites).

This affects:
- **TMDB network / channel logos** — TMDB serves a mix of PNG and SVG depending on the asset; the SVG variants currently never display.
- **Any addon manifest** that uses an SVG `logo` field (the Stremio spec allows it; some custom addons take advantage of that).
- **Any custom artwork URL** the user pastes in the collection editor that happens to be SVG.

## Testing

- `./gradlew assembleFullDebug` — builds.
- `installFullDebug` on Android TV (Ugoos AM9 PRO) — confirmed an SVG logo URL that previously rendered as a blank box now displays correctly.
- Verified PNG / JPEG / WebP / GIF artwork is unchanged (Coil only invokes a decoder factory if the previous ones decline the source, so non-SVG content takes the same path as before).

## Breaking changes

None. Pure additive wiring.

## Linked issues

None.