### PR TITLE
fix(home): apply TMDB-enriched logo on landscape cards when the addon ships none

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -946,8 +946,17 @@ private fun ModernCarouselCard(
     if (frozenLogoUrl.value.isNullOrBlank() && !item.heroPreview.logo.isNullOrBlank()) {
         frozenLogoUrl.value = item.heroPreview.logo
     }
-    if (!useLandscapeOverlayTreatment && !enrichedLogoUrl.isNullOrBlank() && frozenLogoUrl.value != enrichedLogoUrl) {
-        frozenLogoUrl.value = enrichedLogoUrl
+    if (!enrichedLogoUrl.isNullOrBlank() && frozenLogoUrl.value != enrichedLogoUrl) {
+        // Outside landscape we always pick up the enriched URL so manual artwork
+        // updates land instantly. Inside landscape we still adopt the enriched
+        // URL when there was no logo to begin with — otherwise the card would
+        // permanently fall back to the title text whenever the addon manifest
+        // ships items without a logo (e.g. AIO Metadata for some shows) even
+        // though TMDB has one. Once we have any non-blank value we keep it
+        // frozen to avoid mid-scroll flicker on enrichment refresh.
+        if (!useLandscapeOverlayTreatment || frozenLogoUrl.value.isNullOrBlank()) {
+            frozenLogoUrl.value = enrichedLogoUrl
+        }
     }
     val effectiveLogoUrl = frozenLogoUrl.value
     // Freeze the backdrop URL for landscape cards - prevents image reload when enrichment updates backdrop.


### PR DESCRIPTION
## Summary

Fixes a case in **Modern Home / Affiches paysage** where a row card silently falls back to its **title text** even though TMDB has a perfectly good logo for the show.

The freeze logic in `ModernCarouselCard` (`ModernHomeRows.kt:949`) was gated by `!useLandscapeOverlayTreatment`, so the TMDB-enriched logo URL was simply **never applied** to landscape cards. The original intent of that gate is to keep the card's logo from flickering mid-scroll once it's already showing — but it also blocks the enrichment from filling in the logo for items where the addon manifest didn't ship one in the first place.

## Why

Reproducer:
1. Use Modern Home with **Affiches paysage** ON.
2. Have at least one row that contains an item whose addon manifest entry has no `logo` field (very common with AIO Metadata for recent / not-yet-cached shows).
3. The card displays the title text instead of a logo, even though TMDB has a `/logo/*.png` for that show that is correctly fetched and applied to the **hero** at the top of Home.

## Fix

Swap the freeze condition so we still adopt the enriched URL **when `frozenLogoUrl.value` is blank** (i.e. there was nothing to freeze yet), but keep the existing protection against replacing an already-loaded logo:

```kotlin
if (!enrichedLogoUrl.isNullOrBlank() && frozenLogoUrl.value != enrichedLogoUrl) {
    if (!useLandscapeOverlayTreatment || frozenLogoUrl.value.isNullOrBlank()) {
        frozenLogoUrl.value = enrichedLogoUrl
    }
}
```

- Outside landscape: behaviour unchanged (the enriched URL is always applied — same as before).
- In landscape, with an addon-supplied logo: behaviour unchanged (we keep the addon URL frozen, no flicker).
- In landscape, without an addon-supplied logo: **new** — the enriched URL is adopted, so the card now shows the TMDB logo instead of the title text.

## Testing

- Built `installFullDebug` on Android TV (Ugoos AM9 PRO).
- Verified on a row containing both items with addon-supplied logos and items without — in modern landscape mode:
  - Items that already had a logo from the addon: unchanged, no flicker on enrichment refresh.
  - Items without an addon logo: now display the TMDB logo (matched the hero).
- Switched back to portrait modern: behaviour unchanged.

## Breaking changes

None.

## Linked issues

None.