### PR TITLE
Trakt sync performance improvements

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMapping.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMapping.kt
@@ -71,11 +71,10 @@ private fun remapEpisodeBetweenLists(
     // Cache normalized titles so each unique title is computed once, not once per
     // reverseRemap call. For large shows (One Piece: 1181 episodes × 100+ history
     // entries), this avoids ~236,000 redundant regex operations.
-    val titleCache = HashMap<String, String>()
-    val normalizedTitle = normalizeEpisodeTitle(requestedTitle ?: currentSourceEpisode.title, titleCache)
+    val normalizedTitle = normalizeEpisodeTitle(requestedTitle ?: currentSourceEpisode.title, normalizedTitleCache)
     if (isUsefulEpisodeTitle(normalizedTitle)) {
         val titleMatches = orderedTargetEpisodes.filter {
-            normalizeEpisodeTitle(it.title, titleCache) == normalizedTitle
+            normalizeEpisodeTitle(it.title, normalizedTitleCache) == normalizedTitle
         }
         if (titleMatches.size == 1) {
             return titleMatches.first()
@@ -90,8 +89,9 @@ private fun remapEpisodeBetweenLists(
 
 private val NON_ALPHANUMERIC = Regex("[^a-z0-9]+")
 private val COLLAPSED_SPACES = Regex("\\s+")
+private val normalizedTitleCache = java.util.concurrent.ConcurrentHashMap<String, String>()
 
-private fun normalizeEpisodeTitle(title: String?, cache: HashMap<String, String>): String {
+private fun normalizeEpisodeTitle(title: String?, cache: java.util.concurrent.ConcurrentHashMap<String, String>): String {
     if (title == null) return ""
     return cache.getOrPut(title) {
         title.lowercase()

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMapping.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMapping.kt
@@ -84,13 +84,16 @@ private fun remapEpisodeBetweenLists(
     return orderedTargetEpisodes[sourceIndex]
 }
 
+private val NON_ALPHANUMERIC = Regex("[^a-z0-9]+")
+private val COLLAPSED_SPACES = Regex("\\s+")
+
 private fun normalizeEpisodeTitle(title: String?): String {
     return title
         .orEmpty()
         .lowercase()
-        .replace(Regex("[^a-z0-9]+"), " ")
+        .replace(NON_ALPHANUMERIC, " ")
         .trim()
-        .replace(Regex("\\s+"), " ")
+        .replace(COLLAPSED_SPACES, " ")
 }
 
 private fun isUsefulEpisodeTitle(normalizedTitle: String): Boolean {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMapping.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMapping.kt
@@ -68,10 +68,14 @@ private fun remapEpisodeBetweenLists(
         }
         ?: return null
 
-    val normalizedTitle = normalizeEpisodeTitle(requestedTitle ?: currentSourceEpisode.title)
+    // Cache normalized titles so each unique title is computed once, not once per
+    // reverseRemap call. For large shows (One Piece: 1181 episodes × 100+ history
+    // entries), this avoids ~236,000 redundant regex operations.
+    val titleCache = HashMap<String, String>()
+    val normalizedTitle = normalizeEpisodeTitle(requestedTitle ?: currentSourceEpisode.title, titleCache)
     if (isUsefulEpisodeTitle(normalizedTitle)) {
         val titleMatches = orderedTargetEpisodes.filter {
-            normalizeEpisodeTitle(it.title) == normalizedTitle
+            normalizeEpisodeTitle(it.title, titleCache) == normalizedTitle
         }
         if (titleMatches.size == 1) {
             return titleMatches.first()
@@ -87,13 +91,14 @@ private fun remapEpisodeBetweenLists(
 private val NON_ALPHANUMERIC = Regex("[^a-z0-9]+")
 private val COLLAPSED_SPACES = Regex("\\s+")
 
-private fun normalizeEpisodeTitle(title: String?): String {
-    return title
-        .orEmpty()
-        .lowercase()
-        .replace(NON_ALPHANUMERIC, " ")
-        .trim()
-        .replace(COLLAPSED_SPACES, " ")
+private fun normalizeEpisodeTitle(title: String?, cache: HashMap<String, String>): String {
+    if (title == null) return ""
+    return cache.getOrPut(title) {
+        title.lowercase()
+            .replace(NON_ALPHANUMERIC, " ")
+            .trim()
+            .replace(COLLAPSED_SPACES, " ")
+    }
 }
 
 private fun isUsefulEpisodeTitle(normalizedTitle: String): Boolean {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -7,9 +7,16 @@ import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.repository.MetaRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -31,7 +38,8 @@ class TraktEpisodeMappingService @Inject constructor(
     private val reverseMappingCache = mutableMapOf<String, EpisodeMappingEntry>()
     // In-flight dedup: prevents multiple concurrent coroutines from fetching
     // the same show's addon episodes simultaneously.
-    private val addonEpisodesInFlight = mutableMapOf<String, kotlinx.coroutines.CompletableDeferred<List<EpisodeMappingEntry>>>()
+    private val addonEpisodesInFlight = mutableMapOf<String, CompletableDeferred<List<EpisodeMappingEntry>>>()
+    private val traktEpisodesInFlight = mutableMapOf<String, CompletableDeferred<List<EpisodeMappingEntry>>>()
 
     internal suspend fun prefetchEpisodeMapping(
         contentId: String?,
@@ -41,6 +49,28 @@ class TraktEpisodeMappingService @Inject constructor(
         episode: Int?
     ): EpisodeMappingEntry? {
         return resolveEpisodeMapping(contentId, contentType, videoId, season, episode)
+    }
+
+    /**
+     * Pre-fetches addon episode data for [contentIds] so that subsequent calls to
+     * [resolveAddonEpisodeMapping] hit the cache. Limits concurrency to [concurrency].
+     */
+    internal suspend fun prefetchAddonEpisodes(
+        contentIds: List<String>,
+        concurrency: Int = 8
+    ) {
+        val unique = contentIds.distinct()
+        if (unique.isEmpty()) return
+        val semaphore = Semaphore(concurrency)
+        coroutineScope {
+            unique.forEach { contentId ->
+                launch {
+                    semaphore.withPermit {
+                        getAddonEpisodes(contentId, "series")
+                    }
+                }
+            }
+        }
     }
 
     internal suspend fun resolveAddonEpisodeMapping(
@@ -221,6 +251,26 @@ class TraktEpisodeMappingService @Inject constructor(
             traktEpisodesCache[showLookupId]?.let { return it }
         }
 
+        val existingDeferred = cacheMutex.withLock { traktEpisodesInFlight[showLookupId] }
+        if (existingDeferred != null) {
+            return try { existingDeferred.await() } catch (_: Exception) { emptyList() }
+        }
+
+        val deferred = CompletableDeferred<List<EpisodeMappingEntry>>()
+        val weOwn = cacheMutex.withLock {
+            traktEpisodesCache[showLookupId]?.let { return it }
+            if (traktEpisodesInFlight.containsKey(showLookupId)) {
+ false
+            } else {
+                traktEpisodesInFlight[showLookupId] = deferred
+                true
+            }
+        }
+        if (!weOwn) {
+            val other = cacheMutex.withLock { traktEpisodesInFlight[showLookupId] }
+            return try { other?.await() ?: emptyList() } catch (_: Exception) { emptyList() }
+        }
+
         val t0 = System.currentTimeMillis()
         val seasonsResponse = traktAuthService.executeAuthorizedRequest { authHeader ->
             traktApi.getShowSeasons(
@@ -228,12 +278,16 @@ class TraktEpisodeMappingService @Inject constructor(
                 id = showLookupId,
                 extended = "episodes"
             )
-        } ?: return emptyList()
+        } ?: run {
+            cleanupTraktFlight(showLookupId)
+            return emptyList()
+        }
         if (!seasonsResponse.isSuccessful) {
             Log.w(
                 TAG,
                 "getTraktEpisodes: seasons request failed code=${seasonsResponse.code()} id=$showLookupId"
             )
+            cleanupTraktFlight(showLookupId)
             return emptyList()
         }
 
@@ -264,7 +318,13 @@ class TraktEpisodeMappingService @Inject constructor(
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "getTraktEpisodes $showLookupId -> ${traktEpisodes.size} episodes in ${System.currentTimeMillis() - t0}ms")
         }
+        deferred.complete(traktEpisodes)
+        cleanupTraktFlight(showLookupId)
         return traktEpisodes
+    }
+
+    private suspend fun cleanupTraktFlight(showLookupId: String) {
+        cacheMutex.withLock { traktEpisodesInFlight.remove(showLookupId) }
     }
 
     private fun cacheKey(

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -253,7 +253,7 @@ class TraktEpisodeMappingService @Inject constructor(
         val weOwn = cacheMutex.withLock {
             traktEpisodesCache[showLookupId]?.let { return it }
             if (traktEpisodesInFlight.containsKey(showLookupId)) {
- false
+                false
             } else {
                 traktEpisodesInFlight[showLookupId] = deferred
                 true

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -1,15 +1,12 @@
 package com.nuvio.tv.data.repository
 
 import android.util.Log
-import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.repository.MetaRepository
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -227,14 +224,10 @@ class TraktEpisodeMappingService @Inject constructor(
         }
 
         return try {
-            val t0 = System.currentTimeMillis()
             val meta = fetchSeriesMeta(contentId, contentType)
             val addonEpisodes = meta?.videos?.toEpisodeMappingEntries() ?: emptyList()
             if (addonEpisodes.isNotEmpty()) {
                 cacheMutex.withLock { addonEpisodesCache[cacheKey] = addonEpisodes }
-            }
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "getAddonEpisodes $cacheKey -> ${addonEpisodes.size} episodes in ${System.currentTimeMillis() - t0}ms")
             }
             deferred.complete(addonEpisodes)
             addonEpisodes
@@ -271,7 +264,6 @@ class TraktEpisodeMappingService @Inject constructor(
             return try { other?.await() ?: emptyList() } catch (_: Exception) { emptyList() }
         }
 
-        val t0 = System.currentTimeMillis()
         val seasonsResponse = traktAuthService.executeAuthorizedRequest { authHeader ->
             traktApi.getShowSeasons(
                 authorization = authHeader,
@@ -314,9 +306,6 @@ class TraktEpisodeMappingService @Inject constructor(
             cacheMutex.withLock {
                 traktEpisodesCache[showLookupId] = traktEpisodes
             }
-        }
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "getTraktEpisodes $showLookupId -> ${traktEpisodes.size} episodes in ${System.currentTimeMillis() - t0}ms")
         }
         deferred.complete(traktEpisodes)
         cleanupTraktFlight(showLookupId)

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktEpisodeMappingService.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.repository
 
 import android.util.Log
+import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.remote.api.TraktApi
 import com.nuvio.tv.domain.model.Meta
@@ -196,10 +197,14 @@ class TraktEpisodeMappingService @Inject constructor(
         }
 
         return try {
+            val t0 = System.currentTimeMillis()
             val meta = fetchSeriesMeta(contentId, contentType)
             val addonEpisodes = meta?.videos?.toEpisodeMappingEntries() ?: emptyList()
             if (addonEpisodes.isNotEmpty()) {
                 cacheMutex.withLock { addonEpisodesCache[cacheKey] = addonEpisodes }
+            }
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "getAddonEpisodes $cacheKey -> ${addonEpisodes.size} episodes in ${System.currentTimeMillis() - t0}ms")
             }
             deferred.complete(addonEpisodes)
             addonEpisodes
@@ -216,6 +221,7 @@ class TraktEpisodeMappingService @Inject constructor(
             traktEpisodesCache[showLookupId]?.let { return it }
         }
 
+        val t0 = System.currentTimeMillis()
         val seasonsResponse = traktAuthService.executeAuthorizedRequest { authHeader ->
             traktApi.getShowSeasons(
                 authorization = authHeader,
@@ -254,6 +260,9 @@ class TraktEpisodeMappingService @Inject constructor(
             cacheMutex.withLock {
                 traktEpisodesCache[showLookupId] = traktEpisodes
             }
+        }
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "getTraktEpisodes $showLookupId -> ${traktEpisodes.size} episodes in ${System.currentTimeMillis() - t0}ms")
         }
         return traktEpisodes
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -80,6 +80,8 @@ class TraktProgressService @Inject constructor(
 ) {
     companion object {
         private const val TAG = "TraktProgressSvc"
+        private val MAPPING_CONCURRENCY =
+            maxOf(2, minOf(Runtime.getRuntime().availableProcessors() * 2, 16))
     }
 
     private fun trace(message: String) {
@@ -211,7 +213,7 @@ class TraktProgressService @Inject constructor(
     @Volatile
     private var metadataWarmupScheduled: Boolean = false
     private val episodeProgressActivityVersion = AtomicLong(0L)
-    private val mappingSemaphore = Semaphore(8)
+    private val mappingSemaphore = Semaphore(MAPPING_CONCURRENCY)
 
     private val playbackCacheTtlMs = 30_000L
     private val userStatsCacheTtlMs = Long.MAX_VALUE

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1761,8 +1761,15 @@ class TraktProgressService @Inject constructor(
                 }
             }
 
-            // Map candidates in parallel to speed up videoId resolution.
+            // Pre-fetch addon episode data for all unique shows so the mapping
+            // phase hits warm caches instead of waiting on per-show network calls.
             if (candidateItems.isNotEmpty()) {
+                val uniqueShowIds = candidateItems
+                    .mapNotNull { normalizeContentId(it.show?.ids).takeIf { id -> id.isNotBlank() } }
+                    .distinct()
+                traktEpisodeMappingService.prefetchAddonEpisodes(uniqueShowIds, concurrency = MAPPING_CONCURRENCY)
+
+                // Map candidates in parallel to speed up videoId resolution.
                 val mapT0 = SystemClock.elapsedRealtime()
                 val mapped = coroutineScope {
                     candidateItems.map { item ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1630,13 +1630,11 @@ class TraktProgressService @Inject constructor(
     }
 
     private suspend fun fetchAllProgressSnapshot(force: Boolean = false): List<WatchProgress> {
-        val t0 = SystemClock.elapsedRealtime()
         val playbackStartAt = recentWatchWindowMs()?.let { windowMs ->
             toTraktUtcDateTime(System.currentTimeMillis() - windowMs)
         }
 
         val (recentCompletedEpisodes, inProgressMovies, inProgressEpisodes) = coroutineScope {
-            val t = SystemClock.elapsedRealtime()
             val historyDeferred = async { fetchRecentEpisodeHistorySnapshot() }
             val moviesDeferred = async {
                 val playback = getPlayback("movies", force = force, startAt = playbackStartAt)
@@ -1657,7 +1655,6 @@ class TraktProgressService @Inject constructor(
             val history = historyDeferred.await()
             val movies = moviesDeferred.await()
             val episodes = episodesDeferred.await()
-            trace("fetchAllProgress fetch took ${SystemClock.elapsedRealtime() - t}ms (history=${history.size} movies=${movies.size} episodes=${episodes.size})")
             Triple(history, movies, episodes)
         }
 
@@ -1704,7 +1701,6 @@ class TraktProgressService @Inject constructor(
         }
 
         val finalSnapshot = mergedByKey.values.sortedByDescending { it.lastWatched }
-        trace("fetchAllProgress done: ${finalSnapshot.size} items in ${SystemClock.elapsedRealtime() - t0}ms total")
         finalSnapshot.take(8).forEach { p ->
             val tag = if (p.source == WatchProgress.SOURCE_TRAKT_PLAYBACK) "PB" else "HI"
             val pct = p.progressPercentage.times(100).toInt()
@@ -1713,7 +1709,6 @@ class TraktProgressService @Inject constructor(
     }
 
     private suspend fun fetchRecentEpisodeHistorySnapshot(): List<WatchProgress> {
-        val t0 = SystemClock.elapsedRealtime()
         val cutoffMs = recentWatchWindowMs()?.let { windowMs ->
             System.currentTimeMillis() - windowMs
         }
@@ -1721,8 +1716,6 @@ class TraktProgressService @Inject constructor(
         var page = 1
         val pageLimit = 1000
         val maxPages = if (isAllHistoryWindow()) 20 else 5
-        var totalItemsFetched = 0
-        var totalMapped = 0
 
         while (page <= maxPages) {
             val response = traktAuthService.executeAuthorizedRequest { authHeader ->
@@ -1737,8 +1730,6 @@ class TraktProgressService @Inject constructor(
             if (!response.isSuccessful) break
             val items = response.body().orEmpty()
             if (items.isEmpty()) break
-            totalItemsFetched += items.size
-            trace("fetchRecentHistory page=$page fetched=${items.size} totalFetched=$totalItemsFetched")
 
             // Filter items first (cheap), then map in parallel (expensive).
             var shouldStop = false
@@ -1770,7 +1761,6 @@ class TraktProgressService @Inject constructor(
                 traktEpisodeMappingService.prefetchAddonEpisodes(uniqueShowIds, concurrency = MAPPING_CONCURRENCY)
 
                 // Map candidates in parallel to speed up videoId resolution.
-                val mapT0 = SystemClock.elapsedRealtime()
                 val mapped = coroutineScope {
                     candidateItems.map { item ->
                         async {
@@ -1780,12 +1770,9 @@ class TraktProgressService @Inject constructor(
                         }
                     }.awaitAll()
                 }
-                val mapMs = SystemClock.elapsedRealtime() - mapT0
-                val count = mapped.filterNotNull().forEach { progress ->
+                mapped.filterNotNull().forEach { progress ->
                     results.putIfAbsent(progress.contentId, progress)
-                }.let { candidateItems.size }
-                totalMapped += count
-                trace("fetchRecentHistory page=$page mapped=$count items in ${mapMs}ms")
+                }
             }
 
             val pageCount = response.headers()["X-Pagination-Page-Count"]?.toIntOrNull()
@@ -1793,9 +1780,6 @@ class TraktProgressService @Inject constructor(
             page += 1
         }
 
-        val totalMs = SystemClock.elapsedRealtime() - t0
-        val uniqueShows = results.values.map { it.contentId }.distinct().size
-        trace("fetchRecentHistory done: ${results.size} items across $uniqueShows unique shows, $totalItemsFetched fetched, ${page} pages in ${totalMs}ms")
         return results.values.toList()
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1630,11 +1630,13 @@ class TraktProgressService @Inject constructor(
     }
 
     private suspend fun fetchAllProgressSnapshot(force: Boolean = false): List<WatchProgress> {
+        val t0 = SystemClock.elapsedRealtime()
         val playbackStartAt = recentWatchWindowMs()?.let { windowMs ->
             toTraktUtcDateTime(System.currentTimeMillis() - windowMs)
         }
 
         val (recentCompletedEpisodes, inProgressMovies, inProgressEpisodes) = coroutineScope {
+            val t = SystemClock.elapsedRealtime()
             val historyDeferred = async { fetchRecentEpisodeHistorySnapshot() }
             val moviesDeferred = async {
                 val playback = getPlayback("movies", force = force, startAt = playbackStartAt)
@@ -1655,6 +1657,7 @@ class TraktProgressService @Inject constructor(
             val history = historyDeferred.await()
             val movies = moviesDeferred.await()
             val episodes = episodesDeferred.await()
+            trace("fetchAllProgress fetch took ${SystemClock.elapsedRealtime() - t}ms (history=${history.size} movies=${movies.size} episodes=${episodes.size})")
             Triple(history, movies, episodes)
         }
 
@@ -1701,6 +1704,7 @@ class TraktProgressService @Inject constructor(
         }
 
         val finalSnapshot = mergedByKey.values.sortedByDescending { it.lastWatched }
+        trace("fetchAllProgress done: ${finalSnapshot.size} items in ${SystemClock.elapsedRealtime() - t0}ms total")
         finalSnapshot.take(8).forEach { p ->
             val tag = if (p.source == WatchProgress.SOURCE_TRAKT_PLAYBACK) "PB" else "HI"
             val pct = p.progressPercentage.times(100).toInt()
@@ -1709,6 +1713,7 @@ class TraktProgressService @Inject constructor(
     }
 
     private suspend fun fetchRecentEpisodeHistorySnapshot(): List<WatchProgress> {
+        val t0 = SystemClock.elapsedRealtime()
         val cutoffMs = recentWatchWindowMs()?.let { windowMs ->
             System.currentTimeMillis() - windowMs
         }
@@ -1716,6 +1721,8 @@ class TraktProgressService @Inject constructor(
         var page = 1
         val pageLimit = 1000
         val maxPages = if (isAllHistoryWindow()) 20 else 5
+        var totalItemsFetched = 0
+        var totalMapped = 0
 
         while (page <= maxPages) {
             val response = traktAuthService.executeAuthorizedRequest { authHeader ->
@@ -1730,6 +1737,8 @@ class TraktProgressService @Inject constructor(
             if (!response.isSuccessful) break
             val items = response.body().orEmpty()
             if (items.isEmpty()) break
+            totalItemsFetched += items.size
+            trace("fetchRecentHistory page=$page fetched=${items.size} totalFetched=$totalItemsFetched")
 
             // Filter items first (cheap), then map in parallel (expensive).
             var shouldStop = false
@@ -1754,6 +1763,7 @@ class TraktProgressService @Inject constructor(
 
             // Map candidates in parallel to speed up videoId resolution.
             if (candidateItems.isNotEmpty()) {
+                val mapT0 = SystemClock.elapsedRealtime()
                 val mapped = coroutineScope {
                     candidateItems.map { item ->
                         async {
@@ -1763,9 +1773,12 @@ class TraktProgressService @Inject constructor(
                         }
                     }.awaitAll()
                 }
-                mapped.filterNotNull().forEach { progress ->
+                val mapMs = SystemClock.elapsedRealtime() - mapT0
+                val count = mapped.filterNotNull().forEach { progress ->
                     results.putIfAbsent(progress.contentId, progress)
-                }
+                }.let { candidateItems.size }
+                totalMapped += count
+                trace("fetchRecentHistory page=$page mapped=$count items in ${mapMs}ms")
             }
 
             val pageCount = response.headers()["X-Pagination-Page-Count"]?.toIntOrNull()
@@ -1773,6 +1786,9 @@ class TraktProgressService @Inject constructor(
             page += 1
         }
 
+        val totalMs = SystemClock.elapsedRealtime() - t0
+        val uniqueShows = results.values.map { it.contentId }.distinct().size
+        trace("fetchRecentHistory done: ${results.size} items across $uniqueShows unique shows, $totalItemsFetched fetched, ${page} pages in ${totalMs}ms")
         return results.values.toList()
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -211,6 +211,7 @@ class TraktProgressService @Inject constructor(
     @Volatile
     private var metadataWarmupScheduled: Boolean = false
     private val episodeProgressActivityVersion = AtomicLong(0L)
+    private val mappingSemaphore = Semaphore(8)
 
     private val playbackCacheTtlMs = 30_000L
     private val userStatsCacheTtlMs = Long.MAX_VALUE
@@ -1635,13 +1636,17 @@ class TraktProgressService @Inject constructor(
             val historyDeferred = async { fetchRecentEpisodeHistorySnapshot() }
             val moviesDeferred = async {
                 val playback = getPlayback("movies", force = force, startAt = playbackStartAt)
-                playback.map { item -> async { mapPlaybackMovie(item) } }
+                playback.map { item -> async {
+                    mappingSemaphore.withPermit { mapPlaybackMovie(item) }
+                } }
                     .awaitAll()
                     .filterNotNull()
             }
             val episodesDeferred = async {
                 val playback = getPlayback("episodes", force = force, startAt = playbackStartAt)
-                playback.map { item -> async { mapPlaybackEpisode(item, applyAddonRemap = true) } }
+                playback.map { item -> async {
+                    mappingSemaphore.withPermit { mapPlaybackEpisode(item, applyAddonRemap = true) }
+                } }
                     .awaitAll()
                     .filterNotNull()
             }
@@ -1749,7 +1754,11 @@ class TraktProgressService @Inject constructor(
             if (candidateItems.isNotEmpty()) {
                 val mapped = coroutineScope {
                     candidateItems.map { item ->
-                        async { mapEpisodeHistoryItem(item, applyAddonRemap = true) }
+                        async {
+                            mappingSemaphore.withPermit {
+                                mapEpisodeHistoryItem(item, applyAddonRemap = true)
+                            }
+                        }
                     }.awaitAll()
                 }
                 mapped.filterNotNull().forEach { progress ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1646,11 +1646,12 @@ class TraktProgressService @Inject constructor(
             }
             val episodesDeferred = async {
                 val playback = getPlayback("episodes", force = force, startAt = playbackStartAt)
-                playback.map { item -> async {
-                    mappingSemaphore.withPermit { mapPlaybackEpisode(item, applyAddonRemap = true) }
-                } }
-                    .awaitAll()
-                    .filterNotNull()
+                
+                playback.map { item ->
+                    async {
+                        mappingSemaphore.withPermit { mapPlaybackEpisode(item, applyAddonRemap = true) }
+                    }
+                }.awaitAll().filterNotNull()
             }
             val history = historyDeferred.await()
             val movies = moviesDeferred.await()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -294,10 +294,7 @@ class HomeViewModel @Inject constructor(
                     cwEnrichedInProgressOverlay.clear()
                     cwLastBadgeEpisodeKeys = emptySet()
                     _uiState.update {
-                        it.copy(
-                            continueWatchingItems = emptyList(),
-                            layoutPreferencesReady = false
-                        )
+                        it.copy(layoutPreferencesReady = false)
                     }
                     // Reset so the new profile's pipeline signals first completion correctly.
                     _initialCwResolved.value = false
@@ -458,7 +455,6 @@ class HomeViewModel @Inject constructor(
                         cwEnrichedInProgressOverlay.clear()
                         discoveredOlderNextUpItems.clear()
                         cwLastProcessedNextUpContentIds.clear()
-                        _uiState.update { it.copy(continueWatchingItems = emptyList()) }
                         // Clear disk cache for current profile.
                         viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
                             runCatching { cwEnrichmentCache.saveNextUpSnapshot(emptyList(), force = true) }
@@ -588,11 +584,7 @@ class HomeViewModel @Inject constructor(
                 nextUpItems = nextUpItems
             )
             if (items.isNotEmpty()) {
-                _uiState.update { state ->
-                    if (state.continueWatchingItems.isEmpty()) {
-                        state.copy(continueWatchingItems = items)
-                    } else state
-                }
+                _uiState.update { it.copy(continueWatchingItems = items) }
                 _initialCwResolved.value = true
             }
         }


### PR DESCRIPTION
## Summary

Three fixes in this PR:

1. **Freezes/crashes**: Commit 49bf0777 increased Trakt API page limits from 100 to 1000. `fetchRecentEpisodeHistorySnapshot` launched up to 1000 concurrent coroutines — the IO dispatcher was saturated and the app became unresponsive to the point of crashing.

2. **30-second sluggishness**: The cold-cache first page spent the time in `getAddonEpisodes` network calls and `reverseRemapEpisodeByTitleOrIndex` regex operations inside the mapping loop.

3. **CW flash on profile/source switch**: Switching profiles or progress sources (Trakt ↔ Nuvio Sync) caused the Continue Watching row to empty and refill, creating a visible flash. The profile-scoped disk cache already had the data — it just wasnt being restored before the live pipeline started.

## PR type

- Bug fix

## Investigation

Tested on a NVIDIA Shield with ~350 shows and ~1000 episode history entries. The semaphore was applied first to eliminate crashes, then each subsequent change targeted measurable timing bottlenecks:

### Stability (crashes eliminated by 2aeb3a40 + c59218d6)

| Before | After |
|---|---|
| App freezes and crashes during CW sync | Sync completes without crashing |
| 1000 concurrent coroutines saturating IO dispatcher | Capped at device-appropriate limit |

### Performance (cold-cache first page timing)

| Stage | Page time | Commit | Bottleneck fixed |
|---|---|---|---|
| After stability fix | 31,279ms | — | — |
| + Prefetch addon episodes | 20,345ms | c839161b | Network calls decoupled from mapping loop |
| + Static Regex objects | 14,908ms | 3efd4d65 | `Regex` compiled once instead of 236k times |
| + Title cache | **3,764ms** | 78915197 / 5de5b884 | Each title regex-normalized once, not 1181× per call |

The remaining ~3s is the addon episode prefetch across ~30 unique shows — network-bound with no further optimization possible without a bulk addon API.

### UX (CW flash eliminated by 6bce4ff5)

| Before | After |
|---|---|
| CW row empties and refills on profile/source switch | CW row transitions smoothly via disk cache |

## Why

### Stability

| Commit | Change | Files | Impact |
|---|---|---|---|
| 2aeb3a40 / c59218d6 | **Concurrency semaphore** | `TraktProgressService` | Caps coroutines at device-appropriate limit (8 on Shield). Eliminates freezes and crashes. |

### Performance

| Commit | Change | Files | Time saved |
|---|---|---|---|
| c839161b | **Prefetch addon episodes + inflight dedup** | `TraktProgressService` + `TraktEpisodeMappingService` | ~11s: moves network calls out of the mapping loop; prevents duplicate Trakt API calls |
| 3efd4d65 | **Static Regex objects** | `TraktEpisodeMapping` | ~5s: `Regex("[^a-z0-9]+")` now compiled once at class load |
| 78915197 / 5de5b884 | **File-level title cache** | `TraktEpisodeMapping` | ~11s: each of the 1181 One Piece episode titles is normalized once across all calls |

### UX

| Commit | Change | Files | Impact |
|---|---|---|---|
| 6bce4ff5 | **Eliminate CW flash** | `HomeViewModel` | Removes `emptyList()` clearing on profile/source switch; disk cache restoration now always overwrites current items |

### Semaphore sizing

Adapts to device at runtime:
```
maxOf(2, minOf(Runtime.getRuntime().availableProcessors() * 2, 16))
```

| Cores | Permits | Example devices |
|---|---|---|
| 1-2 | 4 | Chromecast HD, Fire TV Stick Lite |
| 4 | 8 | NVIDIA Shield, Chromecast 4K |
| 6 | 12 | Fire TV Cube (3rd gen) |
| 8+ | 16 (capped) | Homatics Box R 4K Plus |

## Impact

- **No more freezes or crashes** (semaphore caps resource usage)
- **8.3× faster** cold-cache page: 31,279ms → 3,764ms
- **No CW flash** on profile or progress source switch
- Concurrency scales with device capability

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing
1. Tested on NVIDIA Shield with Trakt signed in (350 shows, ~1000 episode history)
2. Cold-cache page refresh: 31,279ms → 3,764ms
3. UI no longer freezes or crashes during sync
4. Profile/source switching no longer flashes CW to empty
5. Warm-cache subsequent refreshes are instant

## Screenshots / Video (UI changes only)

N/A — no UI changes.

## Breaking changes

No breaking changes.

## Linked issues

No linked issues.
