### PR TITLE
fix(tmdb): skip cross-region artwork fallback once a region is resolved

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -1007,13 +1007,20 @@ class TmdbMetadataService(
     ): String? {
         if (images.isEmpty()) return null
         val languageCode = normalizedLanguage.substringBefore("-")
-        val regionCode = normalizedLanguage.substringAfter("-", "").uppercase(Locale.US).takeIf { it.length == 2 }
+        val explicitRegion = normalizedLanguage.substringAfter("-", "").uppercase(Locale.US).takeIf { it.length == 2 }
+        val regionCode = explicitRegion
+            ?: LANGUAGE_DEFAULT_REGION[languageCode]
             ?: DEFAULT_LANGUAGE_REGIONS[languageCode]
+        // Once we have any region (explicit like fr-FR, or inferred for a bare "fr" via
+        // the default-region map), skip the "same language, any other region" tier so a
+        // sibling locale (e.g. fr-CA) doesn't get picked ahead of the English original.
+        // With no resolvable region we keep the legacy lenient fallback.
+        val allowCrossRegionLanguageFallback = regionCode == null
         return images
             .sortedWith(
                 compareByDescending<TmdbImage> { it.iso6391 == languageCode && it.iso31661 == regionCode }
                     .thenByDescending { it.iso6391 == languageCode && it.iso31661 == null }
-                    .thenByDescending { it.iso6391 == languageCode }
+                    .thenByDescending { allowCrossRegionLanguageFallback && it.iso6391 == languageCode }
                     .thenByDescending { it.iso6391 == "en" }
                     .thenByDescending { it.iso6391 == null }
             )


### PR DESCRIPTION
## Summary

TMDB image selection used to fall back to *any* artwork sharing the same `iso_639_1` when no exact locale match was found, so a French-Canadian (`fr-CA`) logo or backdrop could be picked ahead of the English original for a user on French — even though they never asked for Canadian artwork. This PR makes `selectBestLocalizedImagePath` skip the cross-region tier once a region is resolved (explicit `fr-FR`, or inferred for a bare `fr` via the existing `LANGUAGE_DEFAULT_REGION` map), and falls through to English/null instead.

Comparator changes from:

```
fr+FR  >  fr+null  >  fr+ANY  >  en  >  null
```

to:

```
fr+FR  >  fr+null  >  en  >  null
```

The same code path is reused for backdrop selection on movie recommendations (line 565) and movie collection parts (line 647), so they all benefit.

## PR type

- Bug fix

## Why

We had reports of seemingly random Quebecois logos and backdrops appearing on the home rows for users running the app in French. Root cause: the previous comparator gave `fr-CA` priority over `en`/`null` when neither `fr-FR` nor `fr+null` artwork existed for a title — which is fairly common on TMDB.

The codebase already has a `LANGUAGE_DEFAULT_REGION` map (used by `preferredRegions()` for age ratings) that knows `fr → FR`, `de → DE`, `it → IT`, etc. Reusing it for image selection means a bare `fr` is treated like the user explicitly picked `fr-FR`, with no setting change required.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — small bug fix, single function touched (≈10 lines).

## Testing

- Built and ran on Android TV (Ugoos AM6B+) with TMDB language set to `French` (stored as bare `fr`). Browsed the home rows on the modern layout, watched several titles where I had previously seen `fr-CA` artwork — the English/null logo is now picked when no `fr-FR`/`fr+null` artwork exists, and `fr-FR` titles still get their proper localized logo.
- Verified at compile time that the three call sites of `selectBestLocalizedImagePath` (logo, recommendations backdrops, collections backdrops) all pick up the new behaviour.
- Greppped the repository for any other code path filtering TMDB images by `iso_639_1` — none exists, so no follow-up is needed elsewhere.
- No behaviour change for languages without a default-region entry (legacy lenient behaviour preserved), and no change for `en`, `en-US`, `en-GB`.

## Screenshots / Video (UI changes only)

N/A — no UI markup changes; same components, just a different image URL is selected.

## Breaking changes

None. Languages without a default-region entry keep the legacy lenient comparator. English fallbacks are unchanged.

## Linked issues

None — internal report.