### PR TITLE
fix(collection): use localized TMDB trailers on folder hero

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -990,9 +990,42 @@ class FolderDetailViewModel @Inject constructor(
                             status = finalEnrichment.status ?: result.status
                         )
                     }
+                    // Propagate TMDB-fetched localized trailer YT ids onto the item
+                    // so the trailer pipeline can use them as a fallback when the
+                    // direct TMDB videos lookup misses the user locale (e.g. Trakt
+                    // list items that didn't carry trailers from their addon).
+                    val enrichedYtIds = finalEnrichment.trailers.mapNotNull { it.ytId }.distinct()
+                    if (enrichedYtIds.isNotEmpty() && result.trailerYtIds.isEmpty()) {
+                        result = result.copy(trailerYtIds = enrichedYtIds)
+                    }
                 }
                 result
             }
+            }
+
+            // If the trailer pipeline already ran for this item without a hit and
+            // enrichment just brought localized YT ids, retry now using them as
+            // fallback. Mirrors the behaviour in HomeViewModelPresentationPipeline.
+            if (enrichment != null) {
+                val ytFallback = enrichment.trailers.mapNotNull { it.ytId }.firstOrNull()
+                if (ytFallback != null && !_trailerPreviewUrls.value.containsKey(item.id)) {
+                    trailerPreviewNegativeCache.remove(item.id)
+                    trailerPreviewLoadingIds.remove(item.id)
+                    if (activeTrailerPreviewItemId == item.id) trailerPreviewRequestVersion++
+                    val refreshedItem = _uiState.value.tabs
+                        .firstNotNullOfOrNull { tab ->
+                            tab.catalogRow?.items?.firstOrNull { it.id == item.id }
+                        }
+                    if (refreshedItem != null) {
+                        requestTrailerPreview(
+                            itemId = refreshedItem.id,
+                            title = refreshedItem.name,
+                            releaseInfo = refreshedItem.releaseInfo,
+                            apiType = refreshedItem.apiType,
+                            fallbackYtId = ytFallback
+                        )
+                    }
+                }
             }
 
             // External meta addon fallback when TMDB didn't enrich.
@@ -1034,7 +1067,13 @@ class FolderDetailViewModel @Inject constructor(
         }
     }
 
-    fun requestTrailerPreview(itemId: String, title: String, releaseInfo: String?, apiType: String) {
+    fun requestTrailerPreview(
+        itemId: String,
+        title: String,
+        releaseInfo: String?,
+        apiType: String,
+        fallbackYtId: String? = null
+    ) {
         if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled) return
         if (activeTrailerPreviewItemId != itemId) {
             activeTrailerPreviewItemId = itemId
@@ -1061,13 +1100,27 @@ class FolderDetailViewModel @Inject constructor(
                 return@launch
             }
 
-            if (trailerSource?.videoUrl.isNullOrBlank()) {
+            // Prefer the localized YT id provided by the caller (typically TMDB
+            // enrichment trailers in the user locale) when the direct TMDB videos
+            // lookup didn't find anything for this language and we'd otherwise
+            // fall through to TMDB's en-US fallback.
+            val resolvedSource = if (trailerSource?.videoUrl.isNullOrBlank() && !fallbackYtId.isNullOrBlank()) {
+                trailerService.getTrailerPlaybackSourceFromYouTubeUrl(
+                    youtubeUrl = "https://www.youtube.com/watch?v=$fallbackYtId",
+                    title = title,
+                    year = extractYear(releaseInfo)
+                )
+            } else {
+                trailerSource
+            }
+
+            if (resolvedSource?.videoUrl.isNullOrBlank()) {
                 trailerPreviewNegativeCache.add(itemId)
                 _trailerPreviewUrls.update { it - itemId }
                 _trailerPreviewAudioUrls.update { it - itemId }
             } else {
-                _trailerPreviewUrls.update { it + (itemId to trailerSource.videoUrl) }
-                val audioUrl = trailerSource.audioUrl
+                _trailerPreviewUrls.update { it + (itemId to resolvedSource.videoUrl) }
+                val audioUrl = resolvedSource.audioUrl
                 if (audioUrl.isNullOrBlank()) {
                     _trailerPreviewAudioUrls.update { it - itemId }
                 } else {


### PR DESCRIPTION
## Summary

CollectionFolder hero trailers played the English (en-US) version while the home hero played the localized one for the same item. Aligns the folder trailer pipeline with the home pipeline so users on a non-English locale get the localized trailer when TMDB has one.

Two changes in `FolderDetailViewModel`:

1. **Propagate enrichment trailers onto the item**: when `tmdbMetadataService.fetchEnrichment` returns localized trailers, copy their YouTube ids into `MetaPreview.trailerYtIds` (only when the item didn't already carry trailers from its addon). This is what `MetaMapper`/`CatalogMapper` already do for addon-provided items on the home screen.
2. **Retry the trailer pipeline once enrichment lands**, mirroring the same retry that `HomeViewModelPresentationPipeline` does at line 705. The retry passes the now-known YouTube id as a fallback.
3. **Wire a `fallbackYtId` parameter through `requestTrailerPreview`** so that when the direct TMDB videos lookup misses the user locale (and would otherwise fall through to TMDB's en-US fallback), we resolve playback from the localized YouTube id we already have.

## PR type

- Bug fix

## Why

`HomeViewModelPresentationPipeline.requestTrailerPreviewPipeline` accepts `fallbackYtId = item.trailerYtIds.firstOrNull()`. For addon-driven items on the home screen, `trailerYtIds` is already populated by `CatalogMapper.collectTrailerYtIds(...)` from the addon meta, so even when TMDB's `/videos` endpoint has no localized trailer, playback resolves from the addon's localized YouTube id.

CollectionFolder rows backed by a Trakt list (or any non-Stremio source) start from items that don't carry trailer metadata: `TraktPublicListSourceResolver.toPreview()` doesn't fill `trailerYtIds` because it doesn't have it. The only way for those items to obtain localized trailers is via `tmdbMetadataService.fetchEnrichment`, which already fetches them in the user locale via `fetchTmdbTrailers(preferredLanguage = normalizedLanguage)` — but `FolderDetailViewModel` was not propagating that data to the items, and `requestTrailerPreview` had no fallback path. Result: TMDB's en-US fallback won every time.

This PR closes the gap by reusing the same enrichment data the rest of the screen already consumes.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — small bug fix, one file changed (`FolderDetailViewModel.kt`).

## Testing

- Built and ran on Android TV (Ugoos AM6B+) with TMDB language set to French. Opened a CollectionFolder backed by a Trakt list, focused several films and let the hero trailer auto-play. Trailers now match the home screen experience: French dub when TMDB has one, English when it doesn't.
- Verified the early-exit paths still hold: items already in the trailer URL state, in the negative cache, or currently loading are still skipped.

## Screenshots / Video (UI changes only)

N/A — playback URL change only.

## Breaking changes

None. The new `fallbackYtId` parameter on `requestTrailerPreview` defaults to `null` and the existing call site (4-arg) continues to compile unchanged.

## Linked issues

None — internal report.