### PR TITLE
fix(collection): prefetch enrichment for the first items of a folder tab

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -37,6 +37,8 @@ import com.nuvio.tv.domain.repository.CatalogRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -540,6 +542,7 @@ class FolderDetailViewModel @Inject constructor(
                         }
                         rebuildAllTab()
                         rebuildFollowLayoutState()
+                        prefetchTabInitialItems(tabIndex)
                     }
                     is NetworkResult.Error -> {
                         _uiState.update { state ->
@@ -782,6 +785,7 @@ class FolderDetailViewModel @Inject constructor(
                         }
                         rebuildAllTab()
                         rebuildFollowLayoutState()
+                        if (!append) prefetchTabInitialItems(tabIndex)
                     }
                     is NetworkResult.Error -> {
                         _uiState.update { s ->
@@ -839,6 +843,7 @@ class FolderDetailViewModel @Inject constructor(
                         }
                         rebuildAllTab()
                         rebuildFollowLayoutState()
+                        if (!append) prefetchTabInitialItems(tabIndex)
                     }
                     is NetworkResult.Error -> {
                         _uiState.update { s ->
@@ -1104,6 +1109,113 @@ class FolderDetailViewModel @Inject constructor(
 
     fun scrollToTop() {
         _scrollToTopTrigger.value++
+    }
+
+    /**
+     * Pre-enriches the first [count] items of a freshly-loaded tab so the cards
+     * in the visible viewport get their TMDB logo / backdrop without waiting
+     * for the user to focus each one. Items beyond the viewport keep being
+     * enriched lazily through [preloadAdjacentItem] / [onItemFocused].
+     *
+     * Trakt-list and TMDB-collection items don't carry logos in their addon
+     * payload (unlike Stremio addons such as cinemeta), so without this the
+     * cards stay logo-less until the user scrolls onto them.
+     */
+    private fun prefetchTabInitialItems(tabIndex: Int, count: Int = 16) {
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            val tmdbSettings = tmdbSettingsDataStore.settings.first()
+            val homeLayout = _uiState.value.homeLayout
+            val tmdbEnabled = tmdbSettings.enabled &&
+                (homeLayout != HomeLayout.MODERN || tmdbSettings.modernHomeEnabled)
+            if (!tmdbEnabled) return@launch
+            val mdbSettings = mdbListSettingsDataStore.settings.first()
+            val mdbEnabled = mdbSettings.enabled && mdbSettings.apiKey.isNotBlank()
+            val items = _uiState.value.tabs.getOrNull(tabIndex)?.catalogRow?.items.orEmpty()
+            if (items.isEmpty()) return@launch
+
+            coroutineScope {
+                items.take(count).forEach { item ->
+                    if (item.id in enrichedItemIds || item.id in prefetchedTmdbIds) return@forEach
+                    launch {
+                        val (enrichment, mdbImdbRating) = coroutineScope {
+                            val tmdbDeferred = async {
+                                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                                    ?: return@async null
+                                runCatching {
+                                    tmdbMetadataService.fetchEnrichment(
+                                        tmdbId = tmdbId,
+                                        contentType = item.type,
+                                        language = tmdbSettings.language
+                                    )
+                                }.getOrNull()
+                            }
+                            val mdbDeferred = if (mdbEnabled) {
+                                async {
+                                    runCatching {
+                                        mdbListRepository.getImdbRatingForItem(item.id, item.apiType)
+                                    }.getOrNull()
+                                }
+                            } else {
+                                null
+                            }
+                            tmdbDeferred.await() to mdbDeferred?.await()
+                        }
+                        if (enrichment == null && mdbImdbRating == null) return@launch
+                        if (enrichment != null) {
+                            prefetchedTmdbIds.add(item.id)
+                            enrichedItemIds.add(item.id)
+                        }
+                        updateItemInTabs(item.id) { merged ->
+                            var result = merged
+                            if (mdbImdbRating != null) {
+                                result = result.copy(imdbRating = mdbImdbRating.toFloat())
+                            }
+                            if (enrichment != null) {
+                                if (tmdbSettings.useBasicInfo) {
+                                    val isModern = _uiState.value.homeLayout == HomeLayout.MODERN
+                                    result = result.copy(
+                                        name = if (isModern) enrichment.localizedTitle ?: result.name else result.name,
+                                        description = enrichment.description ?: result.description,
+                                        genres = if (enrichment.genres.isNotEmpty()) enrichment.genres else result.genres
+                                    )
+                                }
+                                if (tmdbSettings.useArtwork) {
+                                    result = result.copy(
+                                        background = enrichment.backdrop ?: result.background,
+                                        logo = enrichment.logo ?: result.logo
+                                    )
+                                }
+                                if (tmdbSettings.useReleaseDates) {
+                                    result = result.copy(
+                                        releaseInfo = enrichment.releaseInfo ?: result.releaseInfo
+                                    )
+                                }
+                                if (tmdbSettings.useDetails) {
+                                    result = result.copy(
+                                        runtime = enrichment.runtimeMinutes?.toString() ?: result.runtime,
+                                        ageRating = enrichment.ageRating ?: result.ageRating,
+                                        status = enrichment.status ?: result.status
+                                    )
+                                }
+                            }
+                            result
+                        }
+                        // Mirror the post-enrichment work onItemFocused does so the hero
+                        // info panel (title / overview / rating) and the modern poster
+                        // expansion pick up the freshly merged item.
+                        val enrichedItem = _uiState.value.tabs
+                            .firstNotNullOfOrNull { tab ->
+                                tab.catalogRow?.items?.firstOrNull { it.id == item.id }
+                            }
+                        if (enrichedItem != null) {
+                            _enrichedPreviews.update { it + (item.id to enrichedItem) }
+                        }
+                    }
+                }
+            }
+            rebuildAllTab()
+            rebuildFollowLayoutState()
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

CollectionFolder cards backed by a Trakt list or a TMDB collection had no logo / localized backdrop until the user actually focused each card, since neither source ships logos in its raw payload (unlike Stremio addons such as cinemeta that the home screen typically consumes). The hero info panel (title / overview / rating) was also only populated on focus, so the screen looked half-empty on first paint.

When a folder tab finishes loading (Trakt list, TMDB collection or addon catalog), this PR pre-enriches the first 16 items in parallel using the existing `TmdbMetadataService.fetchEnrichment`, mirroring what the home screen gets for free thanks to addon-provided metadata. Each slot also runs an MDBList `getImdbRatingForItem` call in parallel (gated by the existing MDBList settings) and the merged preview is pushed into `_enrichedPreviews`, so the modern hero info panel lights up without waiting for the user to focus the card.

## PR type

- Bug fix

## Why

On the home screen, `MetaPreview.logo` is filled by `CatalogMapper` from the addon meta payload, so cards have their logo as soon as the row is mapped. On a CollectionFolder backed by a Trakt list (`TraktPublicListSourceResolver.toPreview`) or a TMDB collection (`TmdbCollectionSourceResolver.resolveCollection`), the source doesn't expose a logo, so the cards stay logo-less until something enriches them.

The existing enrichment hooks in `FolderDetailViewModel` were both reactive: `onItemFocused` runs after a 350 ms debounce when the user focuses an item, and `preloadAdjacentItem` only fires once the user has already focused something else. Neither covers the initial viewport. Result: opening a folder showed bare posters with no logo until you scrolled, and the hero info panel was empty until you focused something.

The new `prefetchTabInitialItems(tabIndex, count = 16)` runs immediately after each tab's success path and reuses the same merge logic as `onItemFocused` (gated by the same `useArtwork` / `useBasicInfo` / `useReleaseDates` / `useDetails` settings). It additionally:

- Runs the TMDB enrichment and the MDBList IMDb rating fetch concurrently per item (`coroutineScope { async ... async ... }`), mirroring `enrichHeroItemsPipeline` on the home screen.
- Merges the MDBList rating into `MetaPreview.imdbRating` so cards and the hero info panel show the IMDb score immediately on first paint.
- Pushes the merged preview into `_enrichedPreviews` so the modern hero info panel (title / overview / rating) is filled in for the focused item, matching what `onItemFocused` already does.
- Defaults to 16 so collections like Star Wars (11 films) are fully covered without the user having to scroll horizontally.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — small bug fix, one file changed (`FolderDetailViewModel.kt`).

## Testing

- Built and ran on Android TV (Ugoos AM6B+). Opened a CollectionFolder backed by a Trakt list of films (DreamWorks franchises) and a TMDB collection (Star Wars Skywalker Saga, 11 films): the visible cards now show their TMDB-localized logo as soon as the screen lands instead of staying bare until focus, and the hero info panel above shows title / overview / IMDb rating without waiting for focus.
- Re-verified that focused-item behaviour, `preloadAdjacentItem`, and the existing trailer / enrichment retries still work. `prefetchTabInitialItems` adds the same item ids to `prefetchedTmdbIds` / `enrichedItemIds`, so subsequent `onItemFocused` calls correctly skip re-enriching them and the cache hits the in-memory `enrichmentCache` instantly when the user revisits the folder (verified with `Log.e` traces, removed before commit).
- The prefetch only runs on the initial page (`!append`), so paging through `loadMoreItems` doesn't kick off an extra round of TMDB calls for items that won't be in the viewport.

## Screenshots / Video (UI changes only)

N/A — same components, just metadata arrives sooner.

## Breaking changes

None. Pure additive change inside `FolderDetailViewModel`.

## Linked issues

None — internal report.