### PR TITLE
UI: fix sidebar icons shifting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -860,7 +860,9 @@ private fun LegacySidebarScaffold(
                                 },
                                 modifier = Modifier.focusRequester(
                                     drawerItemFocusRequesters.getValue(item.route)
-                                ).width(itemWidth)
+                                )
+                                    .width(itemWidth)
+                                    .then(if (!isExpanded) Modifier.offset(x = 12.dp) else Modifier)
                             )
                         }
                     }
@@ -983,7 +985,6 @@ private fun LegacySidebarButton(
                 Modifier
                     .size(22.dp)
                     .align(Alignment.Center)
-                    .offset(x = 12.dp)
             }
         )
         if (expanded) {

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -1166,9 +1166,7 @@ private fun ModernSidebarScaffold(
             }
         },
         label = "sidebarBloomScale"
-    ) { expanded ->
-        if (expanded) 1f else 0.9f
-    }
+    ) { 1f }
     val sidebarDeflateOffsetX by sidebarTransition.animateDp(
         transitionSpec = {
             if (targetState) {
@@ -1178,9 +1176,7 @@ private fun ModernSidebarScaffold(
             }
         },
         label = "sidebarDeflateOffsetX"
-    ) { expanded ->
-        if (expanded) 0.dp else (-10).dp
-    }
+    ) { 0.dp }
     val sidebarDeflateOffsetY by sidebarTransition.animateDp(
         transitionSpec = {
             if (targetState) {

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -789,7 +789,7 @@ private fun LegacySidebarScaffold(
                                 )
                                 Box(
                                     modifier = Modifier.fillMaxWidth(),
-                                    contentAlignment = Alignment.CenterStart
+                                    contentAlignment = Alignment.Center
                                 ) {
                                     Row(
                                         modifier = Modifier
@@ -839,7 +839,7 @@ private fun LegacySidebarScaffold(
                             .offset(y = 28.dp)
                             .fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(10.dp),
-                        horizontalAlignment = Alignment.Start
+                        horizontalAlignment = if (isExpanded) Alignment.CenterHorizontally else Alignment.Start
                     ) {
                         drawerItems.forEach { item ->
                             LegacySidebarButton(
@@ -983,6 +983,7 @@ private fun LegacySidebarButton(
                 Modifier
                     .size(22.dp)
                     .align(Alignment.Center)
+                    .offset(x = 12.dp)
             }
         )
         if (expanded) {

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -789,7 +789,7 @@ private fun LegacySidebarScaffold(
                                 )
                                 Box(
                                     modifier = Modifier.fillMaxWidth(),
-                                    contentAlignment = Alignment.Center
+                                    contentAlignment = Alignment.CenterStart
                                 ) {
                                     Row(
                                         modifier = Modifier
@@ -839,7 +839,7 @@ private fun LegacySidebarScaffold(
                             .offset(y = 28.dp)
                             .fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(10.dp),
-                        horizontalAlignment = if (isExpanded) Alignment.CenterHorizontally else Alignment.Start
+                        horizontalAlignment = Alignment.Start
                     ) {
                         drawerItems.forEach { item ->
                             LegacySidebarButton(
@@ -1166,7 +1166,9 @@ private fun ModernSidebarScaffold(
             }
         },
         label = "sidebarBloomScale"
-    ) { 1f }
+    ) { expanded ->
+        if (expanded) 1f else 0.9f
+    }
     val sidebarDeflateOffsetX by sidebarTransition.animateDp(
         transitionSpec = {
             if (targetState) {
@@ -1176,7 +1178,9 @@ private fun ModernSidebarScaffold(
             }
         },
         label = "sidebarDeflateOffsetX"
-    ) { 0.dp }
+    ) { expanded ->
+        if (expanded) 0.dp else (-10).dp
+    }
     val sidebarDeflateOffsetY by sidebarTransition.animateDp(
         transitionSpec = {
             if (targetState) {

--- a/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
@@ -136,7 +136,7 @@ internal fun ModernSidebarBlurPanel(
                 modifier = Modifier
                     .fillMaxWidth()
                     .offset(y = 12.dp),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.CenterStart
             ) {
                 SidebarProfileItem(
                     profileName = activeProfileName,
@@ -148,7 +148,7 @@ internal fun ModernSidebarBlurPanel(
                         if (focused) onDrawerItemFocused(drawerItems.size)
                     },
                     onClick = onSwitchProfile,
-                    modifier = Modifier.fillMaxWidth(0.92f)
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         } else {
@@ -179,8 +179,11 @@ internal fun ModernSidebarBlurPanel(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Column(
-                modifier = Modifier.offset(y = (-12).dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset(y = (-12).dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.Start
             ) {
                 drawerItems.forEachIndexed { index, item ->
                     SidebarNavigationItem(
@@ -198,7 +201,7 @@ internal fun ModernSidebarBlurPanel(
                         },
                         onClick = { onDrawerItemClick(item.route) },
                         modifier = Modifier
-                            .fillMaxWidth(0.92f)
+                            .fillMaxWidth()
                             .focusRequester(drawerItemFocusRequesters.getValue(item.route))
                     )
                 }
@@ -264,7 +267,7 @@ private fun SidebarNavigationItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 14.dp, vertical = 10.dp),
+                .padding(start = 2.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
         Box(
@@ -356,7 +359,7 @@ private fun SidebarProfileItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 14.dp, vertical = 10.dp),
+                .padding(start = 2.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
         Box(

--- a/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
@@ -136,7 +136,7 @@ internal fun ModernSidebarBlurPanel(
                 modifier = Modifier
                     .fillMaxWidth()
                     .offset(y = 12.dp),
-                contentAlignment = Alignment.CenterStart
+                contentAlignment = Alignment.Center
             ) {
                 SidebarProfileItem(
                     profileName = activeProfileName,
@@ -148,7 +148,7 @@ internal fun ModernSidebarBlurPanel(
                         if (focused) onDrawerItemFocused(drawerItems.size)
                     },
                     onClick = onSwitchProfile,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(0.92f)
                 )
             }
         } else {
@@ -179,11 +179,8 @@ internal fun ModernSidebarBlurPanel(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .offset(y = (-12).dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-                horizontalAlignment = Alignment.Start
+                modifier = Modifier.offset(y = (-12).dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
             ) {
                 drawerItems.forEachIndexed { index, item ->
                     SidebarNavigationItem(
@@ -201,7 +198,7 @@ internal fun ModernSidebarBlurPanel(
                         },
                         onClick = { onDrawerItemClick(item.route) },
                         modifier = Modifier
-                            .fillMaxWidth()
+                            .fillMaxWidth(0.92f)
                             .focusRequester(drawerItemFocusRequesters.getValue(item.route))
                     )
                 }
@@ -267,7 +264,7 @@ private fun SidebarNavigationItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 2.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+                .padding(horizontal = 14.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
         Box(
@@ -359,7 +356,7 @@ private fun SidebarProfileItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 2.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+                .padding(horizontal = 14.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
         Box(


### PR DESCRIPTION
## Summary

Fixed sidebar icons shifting inwards when opening legacy sidebar in modern view, and then back to the left when closing. To keep the icons from shifting during open/close, the minimized-state icon now gets a 12.dp right offset, matching the open sidebar icon position.

## PR type

- Small maintenance improvement

## Why

Noticeable in UI, and user raised a PR. Smoothens out the UI feel.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.

## Testing

Tested APK, tested affected code areas, no issues in use.

## Screenshots / Video (UI changes only)

<!-- If UI changed, add before/after screenshots or a short clip. -->
Before: 

https://github.com/user-attachments/assets/6250e862-b4f1-421b-a682-10d3af419445

After: 

https://github.com/user-attachments/assets/815be010-c0aa-4fb5-9a3f-e487650fab51

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None -->
None, tested and zero issues.

## Linked issues

Fixes: https://github.com/NuvioMedia/NuvioTV/issues/1728
