### PR TITLE
trailer ExoPlayer pool, Trakt revalidation, HLS cache TTL

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -217,6 +217,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var avatarRepository: AvatarRepository
 
+    @Inject
+    lateinit var trailerPlayerPool: com.nuvio.tv.core.player.TrailerPlayerPool
+
     private lateinit var jankStats: JankStats
 
     @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -368,7 +371,8 @@ class MainActivity : ComponentActivity() {
                 CompositionLocalProvider(
                     LocalBringIntoViewSpec provides bringIntoViewSpec,
                     LocalFastHorizontalNavigationEnabled provides mainUiPrefs.fastHorizontalNavigationEnabled,
-                    LocalRecompositionHighlighterEnabled provides mainUiPrefs.composeHighlighterEnabled
+                    LocalRecompositionHighlighterEnabled provides mainUiPrefs.composeHighlighterEnabled,
+                    com.nuvio.tv.core.player.LocalTrailerPlayerPool provides trailerPlayerPool
                 ) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/nuvio/tv/core/player/LocalTrailerPlayerPool.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/LocalTrailerPlayerPool.kt
@@ -1,0 +1,11 @@
+package com.nuvio.tv.core.player
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * CompositionLocal providing access to the shared [TrailerPlayerPool] singleton.
+ * This avoids threading the pool through every intermediate composable parameter list.
+ *
+ * Provided at the Activity/NavHost level via Hilt injection.
+ */
+val LocalTrailerPlayerPool = staticCompositionLocalOf<TrailerPlayerPool?> { null }

--- a/app/src/main/java/com/nuvio/tv/core/player/TrailerPlayerPool.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/TrailerPlayerPool.kt
@@ -1,0 +1,136 @@
+package com.nuvio.tv.core.player
+
+import android.content.Context
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Application-scoped singleton that holds a single ExoPlayer instance dedicated to
+ * trailer/preview playback on the home screen.
+ *
+ * Creating and tearing down ExoPlayer for every poster focus is extremely expensive
+ * (codec init, hardware decoder allocation). This pool keeps one instance alive and
+ * reuses it across focus changes. The player is stopped and cleared between uses but
+ * never released until the process dies or [release] is explicitly called.
+ *
+ * When the full-screen player needs hardware decoders, call [yield] to free
+ * codec resources without destroying the instance. Call [reclaim] when returning to
+ * the home screen to lazily rebuild if needed.
+ */
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@Singleton
+class TrailerPlayerPool @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val TAG = "TrailerPlayerPool"
+    }
+
+    private var _player: ExoPlayer? = null
+    private val yielded = AtomicBoolean(false)
+    private val released = AtomicBoolean(false)
+
+    /**
+     * Returns the shared trailer ExoPlayer, creating it lazily if needed.
+     * Returns null only if [release] was called (process shutdown).
+     */
+    fun acquire(): ExoPlayer? {
+        if (released.get()) return null
+        if (yielded.get()) {
+            // Reclaim was not called yet but someone wants the player — rebuild.
+            reclaim()
+        }
+        return _player ?: createPlayer().also { _player = it }
+    }
+
+    /**
+     * Stops playback and clears media but keeps the instance alive for reuse.
+     * Call this when the trailer is no longer visible (poster lost focus, screen change).
+     */
+    fun stop() {
+        _player?.let { player ->
+            runCatching {
+                player.playWhenReady = false
+                player.stop()
+                player.clearMediaItems()
+            }
+        }
+    }
+
+    /**
+     * Releases codec resources so the detail-screen player can claim hardware decoders.
+     * The ExoPlayer instance is released here; [reclaim] will create a fresh one.
+     */
+    fun yield() {
+        if (yielded.compareAndSet(false, true)) {
+            Log.d(TAG, "Yielding trailer player for detail playback")
+            _player?.let { player ->
+                runCatching { player.stop() }
+                runCatching { player.clearMediaItems() }
+                runCatching { player.release() }
+            }
+            _player = null
+        }
+    }
+
+    /**
+     * Re-creates the player after a [yield]. Safe to call multiple times.
+     */
+    fun reclaim() {
+        if (released.get()) return
+        if (yielded.compareAndSet(true, false)) {
+            Log.d(TAG, "Reclaiming trailer player")
+            // Player will be lazily created on next acquire()
+        }
+    }
+
+    /**
+     * Permanently releases the player. Called on process death / Application.onTerminate.
+     */
+    fun release() {
+        if (released.compareAndSet(false, true)) {
+            _player?.let { player ->
+                runCatching { player.stop() }
+                runCatching { player.clearMediaItems() }
+                runCatching { player.release() }
+            }
+            _player = null
+        }
+    }
+
+    private fun createPlayer(): ExoPlayer {
+        Log.d(TAG, "Creating shared trailer ExoPlayer instance")
+        val loadControl = DefaultLoadControl.Builder()
+            .setBufferDurationsMs(
+                /* minBufferMs = */ 30_000,
+                /* maxBufferMs = */ 120_000,
+                /* bufferForPlaybackMs = */ 5_000,
+                /* bufferForPlaybackAfterRebufferMs = */ 10_000
+            )
+            .build()
+        val trackSelector = DefaultTrackSelector(context).apply {
+            setParameters(
+                buildUponParameters()
+                    .setMaxVideoSizeSd()
+                    .clearVideoSizeConstraints()
+                    .setForceHighestSupportedBitrate(true)
+            )
+        }
+        return ExoPlayer.Builder(context)
+            .setLoadControl(loadControl)
+            .setTrackSelector(trackSelector)
+            .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS)
+            .build()
+            .apply {
+                repeatMode = Player.REPEAT_MODE_OFF
+            }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
@@ -64,7 +64,10 @@ class TraktSettingsDataStore @Inject constructor(
 
     val dismissedNextUpKeys: Flow<Set<String>> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { prefs ->
-            prefs[dismissedNextUpKeysKey] ?: emptySet()
+            val raw = prefs[dismissedNextUpKeysKey] ?: emptySet()
+            // Normalize: extract contentId from legacy "contentId|season|episode" keys
+            // so the check `contentId in dismissedSet` works for both old and new formats.
+            raw.mapTo(mutableSetOf()) { it.substringBefore("|") }
         }
     }
 
@@ -114,18 +117,23 @@ class TraktSettingsDataStore @Inject constructor(
 
     suspend fun addDismissedNextUpKey(key: String) {
         if (key.isBlank()) return
+        // Store just the contentId (no season/episode suffix) so dismiss
+        // survives anime episode remapping and seed changes.
+        val contentIdOnly = key.trim().substringBefore("|")
         store().edit { prefs ->
             val current = prefs[dismissedNextUpKeysKey] ?: emptySet()
-            prefs[dismissedNextUpKeysKey] = current + key
+            prefs[dismissedNextUpKeysKey] = current + contentIdOnly
         }
     }
 
     suspend fun removeDismissedNextUpKeysForContent(contentId: String) {
         if (contentId.isBlank()) return
-        val prefix = "${contentId.trim()}|"
+        val trimmed = contentId.trim()
+        val prefix = "$trimmed|"
         store().edit { prefs ->
             val current = prefs[dismissedNextUpKeysKey] ?: emptySet()
-            val filtered = current.filterNot { it.startsWith(prefix) }
+            // Remove both legacy format ("contentId|season|episode") and new format ("contentId")
+            val filtered = current.filterNot { it == trimmed || it.startsWith(prefix) }
             if (filtered.size != current.size) {
                 prefs[dismissedNextUpKeysKey] = filtered.toSet()
             }

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -212,7 +212,8 @@ class TrailerService(
                 if (!youtubeKey.isNullOrBlank()) {
                     youtubeSourceCache[youtubeKey] = CachedTrailerPlaybackSource(
                         playbackSource = localSource,
-                        cachedAt = Instant.now(clock)
+                        cachedAt = Instant.now(clock),
+                        expiresAt = extractUrlExpireInstant(localSource)
                     )
                 }
                 Log.d(
@@ -235,9 +236,11 @@ class TrailerService(
             if (!isValidUrl(fallbackUrl)) return@withContext null
 
             if (!youtubeKey.isNullOrBlank()) {
+                val fallbackSource = TrailerPlaybackSource(videoUrl = fallbackUrl)
                 youtubeSourceCache[youtubeKey] = CachedTrailerPlaybackSource(
-                    playbackSource = TrailerPlaybackSource(videoUrl = fallbackUrl),
-                    cachedAt = Instant.now(clock)
+                    playbackSource = fallbackSource,
+                    cachedAt = Instant.now(clock),
+                    expiresAt = extractUrlExpireInstant(fallbackSource)
                 )
             }
             Log.d(TAG, "Using backend fallback source for ${summarizeUrl(youtubeUrl)}")
@@ -347,19 +350,34 @@ class TrailerService(
 
     private fun getValidCachedYoutubeSource(youtubeKey: String): TrailerPlaybackSource? {
         val cached = youtubeSourceCache[youtubeKey] ?: return null
-        val age = Duration.between(cached.cachedAt, Instant.now(clock))
-        if (age <= YOUTUBE_SOURCE_CACHE_TTL) {
+        val now = Instant.now(clock)
+
+        // Use URL expire timestamp if available, otherwise fall back to TTL
+        val expired = cached.expiresAt?.let { now.isAfter(it) }
+            ?: (Duration.between(cached.cachedAt, now) > YOUTUBE_SOURCE_CACHE_TTL)
+
+        if (!expired) {
             return cached.playbackSource
         }
 
         youtubeSourceCache.remove(youtubeKey, cached)
-        Log.d(TAG, "YouTube cache expired for key=${obfuscateYoutubeKey(youtubeKey)} age=${age.toMinutes()}m")
         return null
     }
 
     fun clearCache() {
         cache.clear()
         youtubeSourceCache.clear()
+    }
+
+    /**
+     * Extracts the YouTube URL expiration timestamp from the `/expire/EPOCH/` path segment.
+     */
+    private fun extractUrlExpireInstant(source: TrailerPlaybackSource): Instant? {
+        val url = source.videoUrl
+        val expireRegex = Regex("/expire/(\\d+)/")
+        val match = expireRegex.find(url) ?: return null
+        val epoch = match.groupValues[1].toLongOrNull() ?: return null
+        return Instant.ofEpochSecond(epoch)
     }
 
     private fun extractYouTubeVideoId(input: String): String? {
@@ -407,7 +425,8 @@ class TrailerService(
 
     private data class CachedTrailerPlaybackSource(
         val playbackSource: TrailerPlaybackSource,
-        val cachedAt: Instant
+        val cachedAt: Instant,
+        val expiresAt: Instant? = null
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -26,17 +26,16 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
-import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import com.nuvio.tv.core.player.LocalTrailerPlayerPool
+import com.nuvio.tv.core.player.TrailerPlayerPool
 import com.nuvio.tv.data.trailer.YoutubeChunkedDataSourceFactory
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import android.view.LayoutInflater
 import com.nuvio.tv.R
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.delay
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
@@ -57,7 +56,8 @@ fun TrailerPlayer(
     overscanZoom: Float = 1f,
     modifier: Modifier = Modifier,
     enter: EnterTransition = fadeIn(animationSpec = tween(800)),
-    exit: ExitTransition = fadeOut(animationSpec = tween(500))
+    exit: ExitTransition = fadeOut(animationSpec = tween(500)),
+    trailerPlayerPool: TrailerPlayerPool? = null
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -77,45 +77,32 @@ fun TrailerPlayer(
         label = "trailerFirstFrameAlpha"
     )
 
-    val trailerPlayer = remember(trailerUrl, trailerAudioUrl) {
+    // Resolve pool: explicit parameter > CompositionLocal
+    val resolvedPool = trailerPlayerPool ?: LocalTrailerPlayerPool.current
+
+    // Use the shared pool instance instead of creating a new ExoPlayer per focus.
+    // The pool keeps one ExoPlayer alive across poster focus changes, eliminating
+    // the expensive create/teardown cycle that was the app-launch bottleneck.
+    val trailerPlayer = remember(trailerUrl, resolvedPool) {
         if (trailerUrl != null) {
-            val loadControl = DefaultLoadControl.Builder()
-                .setBufferDurationsMs(
-                    /* minBufferMs = */ 30_000,
-                    /* maxBufferMs = */ 120_000,
-                    /* bufferForPlaybackMs = */ 5_000,
-                    /* bufferForPlaybackAfterRebufferMs = */ 10_000
-                )
-                .build()
-            val trackSelector = DefaultTrackSelector(context).apply {
-                setParameters(
-                    buildUponParameters()
-                        .setMaxVideoSizeSd()
-                        .clearVideoSizeConstraints()
-                        .setForceHighestSupportedBitrate(true)
-                )
-            }
-            ExoPlayer.Builder(context)
-                .setLoadControl(loadControl)
-                .setTrackSelector(trackSelector)
-                .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS)
-                .build()
-                .apply {
-                    repeatMode = Player.REPEAT_MODE_OFF
-                    volume = if (muted) 0f else 1f
-                    videoScalingMode = if (cropToFill) {
-                        C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING
-                    } else {
-                        C.VIDEO_SCALING_MODE_SCALE_TO_FIT
-                    }
-                }
+            resolvedPool?.acquire()
         } else {
             null
         }
     }
-    val releaseCalled = remember(trailerPlayer) { AtomicBoolean(false) }
 
-    LaunchedEffect(isPlaying, trailerUrl, trailerAudioUrl, muted) {
+    // Configure player settings when acquired
+    LaunchedEffect(trailerPlayer, muted, cropToFill) {
+        val player = trailerPlayer ?: return@LaunchedEffect
+        player.volume = if (muted) 0f else 1f
+        player.videoScalingMode = if (cropToFill) {
+            C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING
+        } else {
+            C.VIDEO_SCALING_MODE_SCALE_TO_FIT
+        }
+    }
+
+    LaunchedEffect(isPlaying, trailerUrl, trailerAudioUrl, muted, trailerPlayer) {
         val player = trailerPlayer ?: return@LaunchedEffect
         player.volume = if (muted) 0f else 1f
         if (isPlaying && trailerUrl != null) {
@@ -216,13 +203,7 @@ fun TrailerPlayer(
                     player.stop()
                     player.clearMediaItems()
                 }
-                Lifecycle.Event.ON_DESTROY -> {
-                    if (releaseCalled.compareAndSet(false, true)) {
-                        runCatching { player.stop() }
-                        runCatching { player.clearMediaItems() }
-                        runCatching { player.release() }
-                    }
-                }
+                // Do NOT release on destroy — the pool owns the lifecycle.
                 else -> Unit
             }
         }
@@ -231,11 +212,8 @@ fun TrailerPlayer(
         onDispose {
             runCatching { activityLifecycleOwner.lifecycle.removeObserver(observer) }
             runCatching { player.removeListener(listener) }
-            if (releaseCalled.compareAndSet(false, true)) {
-                runCatching { player.stop() }
-                runCatching { player.clearMediaItems() }
-                runCatching { player.release() }
-            }
+            // Only stop — never release. The pool manages the ExoPlayer lifecycle.
+            resolvedPool?.stop()
         }
     }
 
@@ -263,6 +241,10 @@ fun TrailerPlayer(
                     }
                 },
                 update = { view ->
+                    // Re-attach player in case it was reclaimed after yield
+                    if (view.player !== trailerPlayer) {
+                        view.player = trailerPlayer
+                    }
                     view.resizeMode = if (cropToFill) {
                         AspectRatioFrameLayout.RESIZE_MODE_ZOOM
                     } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -434,9 +434,51 @@ class MetaDetailsViewModel @Inject constructor(
                         state.copy(episodeProgressMap = progressMap)
                     }
                 }
+                // Revalidate local watched items against Trakt truth
+                revalidateLocalWatchedEpisodesAgainstTrakt(progressMap)
                 // Recalculate next to watch when progress changes
                 reevaluateSeriesWatchedBadge()
                 calculateNextToWatch()
+            }
+        }
+    }
+
+    /**
+     * Removes local watched-episode entries that Trakt doesn't confirm,
+     * preventing stale state when a Trakt sync silently fails.
+     */
+    private fun revalidateLocalWatchedEpisodesAgainstTrakt(
+        traktProgressMap: Map<Pair<Int, Int>, WatchProgress>
+    ) {
+        if (itemType.equals("other", ignoreCase = true)) return
+        if (itemType.equals("movie", ignoreCase = true)) return
+        if (traktProgressMap.isEmpty()) return
+        val hasCompletedEntries = traktProgressMap.values.any { it.isCompleted() }
+        if (!hasCompletedEntries) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val isTraktActive = try {
+                watchProgressRepository.isTraktProgressActive()
+            } catch (_: Exception) { false }
+            if (!isTraktActive) return@launch
+
+            val contentId = _effectiveContentId.value
+            val localWatched = watchedItemsPreferences
+                .getWatchedEpisodesForContent(contentId)
+                .first()
+            if (localWatched.isEmpty()) return@launch
+
+            val staleEpisodes = localWatched.filter { (season, episode) ->
+                val traktEntry = traktProgressMap[season to episode]
+                traktEntry == null || !traktEntry.isCompleted()
+            }
+
+            if (staleEpisodes.isNotEmpty()) {
+                Log.d(TAG, "revalidateWatchedEpisodes: pruning ${staleEpisodes.size} stale entries for $contentId")
+                watchedItemsPreferences.unmarkAsWatchedBatch(
+                    contentId = contentId,
+                    episodes = staleEpisodes.toList()
+                )
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2771,13 +2771,7 @@ internal fun nextUpDismissKey(
     season: Int?,
     episode: Int?
 ): String {
-    return buildString {
-        append(contentId.trim())
-        append("|")
-        append(season ?: -1)
-        append("|")
-        append(episode ?: -1)
-    }
+    return contentId.trim()
 }
 
 internal fun HomeViewModel.removeContinueWatchingPipeline(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -53,8 +53,15 @@ class PlayerViewModel @Inject constructor(
     private val tmdbService: TmdbService,
     private val tmdbMetadataService: TmdbMetadataService,
     private val tmdbSettingsDataStore: TmdbSettingsDataStore,
+    private val trailerPlayerPool: com.nuvio.tv.core.player.TrailerPlayerPool,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    init {
+        // Release trailer player codec resources so the full-screen player can
+        // claim hardware decoders without contention (prevents black screen).
+        trailerPlayerPool.yield()
+    }
 
     private val controller = PlayerRuntimeController(
         context = context,
@@ -139,6 +146,8 @@ class PlayerViewModel @Inject constructor(
 
     override fun onCleared() {
         controller.onCleared()
+        // Allow the trailer player to be re-created when returning to home screen.
+        trailerPlayerPool.reclaim()
         super.onCleared()
     }
 }


### PR DESCRIPTION
## Summary

Four targeted fixes: singleton ExoPlayer pool for trailer playback, Trakt watched-state revalidation on series details, respect HLS URL expiration as cache TTL for trailer sources, and fix Next Up dismiss key to use contentId-only (immune to anime episode remapping).

## PR type

- Bug fix
- Performance improvement

## Why

1. **ExoPlayer churn** - Creating and destroying ExoPlayer for every poster focus caused massive jank on app launch and when changing focus on poster

2. **Trakt state divergence** - When mark-as-watched silently failed (e.g. anime episode remap mismatch), local state diverged from Trakt. Details screen showed episodes as watched while Continue Watching (reading from Trakt) showed the correct state, making CW appear broken.

3. **HLS trailer expiration** - YouTube HLS URLs contain an `/expire/EPOCH/` path segment. Previously we used a fixed TTL for the cache, which could serve expired URLs causing playback failures. Now we parse the actual expiration timestamp and use it as the cache TTL.

4. **Next Up dismiss key mismatch** - Dismiss key was `contentId|season|episode` using remapped (addon) numbering when stored, but checked against original Trakt numbering in the filter. For anime with episode remapping, dismissed shows would reappear. Now uses `contentId` only — immune to remapping and seed changes.

## Changes

### ExoPlayer Trailer Pool
- **New: `TrailerPlayerPool.kt`** - `@Singleton` that lazily creates one ExoPlayer for all trailer/preview playback with `acquire()`, `stop()`, `yield()`, `reclaim()` lifecycle.
- **New: `LocalTrailerPlayerPool.kt`** - `CompositionLocal` provider.
- **Modified: `TrailerPlayer.kt`** - Uses pool instead of creating/destroying per focus.
- **Modified: `PlayerViewModel.kt`** - `yield()` on init, `reclaim()` on cleared.
- **Modified: `MainActivity.kt`** - Provides pool via `CompositionLocalProvider`.

### Trakt Revalidation
- **Modified: `MetaDetailsViewModel.kt`** - Revalidates local watched-episode state against Trakt when opening series details. Prunes stale local entries that Trakt never confirmed. Only runs when Trakt is the active progress source.

### HLS Trailer TTL
- **Modified: `TrailerService.kt`** - Extracts `/expire/EPOCH/` from YouTube HLS URLs and uses it as cache expiration instead of fixed TTL. Falls back to duration-based TTL when no expire segment is present.

### Next Up Dismiss Key Fix
- **Modified: `HomeViewModelContinueWatching.kt`** - `nextUpDismissKey()` now returns just `contentId` instead of `contentId|season|episode`.
- **Modified: `TraktSettingsDataStore.kt`** - `addDismissedNextUpKey()` strips season/episode suffix, `dismissedNextUpKeys` Flow normalizes legacy keys from Supabase, `removeDismissedNextUpKeysForContent()` handles both old and new formats.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- **ExoPlayer pool**: Rapid poster navigation - single instance reused, no creation spam. Full player launch yields codecs (no black screen). Return reclaims correctly.
- **Trakt revalidation**: Marked anime episodes as watched, simulated Trakt rejection, confirmed details screen prunes stale entries on next open. Verified empty/partial Trakt snapshots don't trigger false pruning.
- **HLS TTL**: Verified URLs with `/expire/` segment use parsed timestamp. Verified fallback to duration-based TTL for URLs without expire segment. Confirmed expired cache entries are evicted and re-fetched.
- **Dismiss key**: Dismissed anime series with remapped episodes, confirmed it stays dismissed across CW rebuilds. Verified watching a new episode clears the dismiss. Verified legacy keys from Supabase sync are normalized correctly.

## Screenshots / Video (UI changes only)

No UI changes.

## Breaking changes

No breaking changes. Legacy dismiss keys synced from Supabase are transparently normalized to contentId-only format on read.

## Linked issues

Performance changes, bugfixes for issues I found by myself
