### PR TITLE
fix(sidebar): auto-collapse the home pill / drawer after a few seconds idle

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -154,6 +154,8 @@ import com.nuvio.tv.R
 val LocalSidebarExpanded = compositionLocalOf { false }
 val LocalContentFocusRequester = compositionLocalOf { FocusRequester.Default }
 
+private const val SIDEBAR_AUTO_COLLAPSE_DELAY_MS = 4_000L
+
 data class DrawerItem(
     val route: String,
     val label: String,
@@ -706,6 +708,21 @@ private fun LegacySidebarScaffold(
     val contentFocusRequester = remember { FocusRequester() }
     var pendingContentFocusTransfer by remember { mutableStateOf(false) }
     var pendingSidebarFocusRequest by remember { mutableStateOf(false) }
+    // Bumped on every key event the drawer sees so the auto-collapse timer
+    // resets while the user navigates between drawer items.
+    var legacyDrawerInteractionVersion by remember { mutableStateOf(0) }
+
+    // Auto-close the legacy drawer after a short period of inactivity, mirroring
+    // the modern sidebar behaviour. The timer resets every time the user
+    // navigates inside the drawer (legacyDrawerInteractionVersion change).
+    LaunchedEffect(drawerState.currentValue, legacyDrawerInteractionVersion, showSidebar) {
+        if (!showSidebar || drawerState.currentValue != DrawerValue.Open) {
+            return@LaunchedEffect
+        }
+        delay(SIDEBAR_AUTO_COLLAPSE_DELAY_MS)
+        pendingContentFocusTransfer = false
+        drawerState.setValue(DrawerValue.Closed)
+    }
 
     BackHandler(enabled = currentRoute in rootRoutes && drawerState.currentValue == DrawerValue.Closed) {
         pendingSidebarFocusRequest = true
@@ -755,6 +772,9 @@ private fun LegacySidebarScaffold(
                         .padding(12.dp)
                         .selectableGroup()
                         .onPreviewKeyEvent { keyEvent ->
+                            if (keyEvent.type == KeyEventType.KeyDown) {
+                                legacyDrawerInteractionVersion++
+                            }
                             val closeKey = if (isRtl) Key.DirectionLeft else Key.DirectionRight
                             if (keyEvent.key == closeKey && keyEvent.type == KeyEventType.KeyDown) {
                                 drawerState.setValue(DrawerValue.Closed)
@@ -1080,6 +1100,32 @@ private fun ModernSidebarScaffold(
         delay(95L)
         isSidebarExpanded = false
         sidebarCollapsePending = false
+    }
+
+    // Auto-collapse the expanded sidebar after a short period of inactivity.
+    // The timer resets every time focus moves between drawer items, so the
+    // sidebar only folds back up once the user stops navigating it. We keep
+    // pendingContentFocusTransfer = false so the focus stays parked on the
+    // (now collapsed) sidebar pill instead of jumping back into the content.
+    LaunchedEffect(isSidebarExpanded, focusedDrawerIndex, sidebarCollapsePending, showSidebar) {
+        if (!showSidebar || !isSidebarExpanded || sidebarCollapsePending) {
+            return@LaunchedEffect
+        }
+        delay(SIDEBAR_AUTO_COLLAPSE_DELAY_MS)
+        pendingContentFocusTransfer = false
+        sidebarCollapsePending = true
+    }
+
+    // Auto-collapse the floating pill back to icon-only when the user reveals
+    // its label (DPAD UP from content) and then leaves it idle. The DPAD DOWN
+    // path already collapses it instantly, this just covers the case where the
+    // user releases UP and walks away.
+    LaunchedEffect(isFloatingPillIconOnly, keepFloatingPillExpanded, showSidebar, isSidebarExpanded) {
+        if (!showSidebar || isFloatingPillIconOnly || keepFloatingPillExpanded || isSidebarExpanded) {
+            return@LaunchedEffect
+        }
+        delay(SIDEBAR_AUTO_COLLAPSE_DELAY_MS)
+        isFloatingPillIconOnly = true
     }
 
     val sidebarVisible = showSidebar && (isSidebarExpanded || !sidebarCollapsed)


### PR DESCRIPTION
## Summary

The DPAD UP path that reveals the home pill's label (modern sidebar) and the equivalent path that opens the legacy `ModalNavigationDrawer` both stayed expanded indefinitely until the user pressed DOWN or otherwise dismissed them — walking away from the device left the sidebar half-deployed.

This PR adds a shared 4 second auto-collapse timer in `MainActivity` so the pill / drawer folds back on its own once the user stops interacting with it. The DPAD DOWN / navigation paths are unchanged.

## PR type

- Bug fix

## Why

Several testers reported that bumping the focus up onto the home pill (or opening the legacy drawer) just to peek at the route name then walking away left the chrome stuck open until the next key press. Mirroring the auto-hide behaviour the rest of the TV UI already has makes the chrome feel transient, like the rest of the focus indicators.

## What

`MainActivity.kt` now defines `private const val SIDEBAR_AUTO_COLLAPSE_DELAY_MS = 4_000L` and adds two `LaunchedEffect`s:

- **Modern sidebar (`ModernSidebarScaffold`)**:
  - One keyed on `isFloatingPillIconOnly` + `keepFloatingPillExpanded` folds the pill back to icon-only once it has been idle. Skipped while `keepFloatingPillExpanded` is true (Settings screen, where the label is intentionally pinned).
  - A second one handles the full-sidebar-expanded case (BACK key / pill click) and resets on `focusedDrawerIndex` changes so the timer only fires once the user stops navigating items. Both paths set `pendingContentFocusTransfer = false`, leaving focus parked on the (now collapsed) pill instead of jumping back into the content.
- **Legacy sidebar (`LegacySidebarScaffold`)**:
  - A new `legacyDrawerInteractionVersion` is bumped from the existing `onPreviewKeyEvent` on every `KeyDown`. The auto-collapse `LaunchedEffect` is keyed on `drawerState.currentValue` + that counter, so the timer resets while the user navigates inside the drawer and only fires after a real idle period. When it fires it just calls `drawerState.setValue(DrawerValue.Closed)`.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — small UX bug fix, one file changed (`MainActivity.kt`).

## Testing

- Built and ran on Android TV (Ugoos AM6B+).
- Modern sidebar: pressed DPAD UP from the home rows, watched the \"Accueil\" label appear, idled, and confirmed the pill collapses back to icon-only after ~4s. Pressing DPAD DOWN before the timeout still collapses immediately. Navigating between drawer items resets the timer (added temporary `Log.e` calls to verify, removed before commit). On the Settings screen the label stays pinned (`keepFloatingPillExpanded`) and the timer never fires.
- Legacy sidebar (`Settings → Modern sidebar OFF`): opened the drawer with BACK / DPAD LEFT, idled, drawer closes after ~4s. Navigating between items keeps it open.
- Verified the focus stays where the user left it (no surprise jump into the content) when the auto-collapse fires.

## Screenshots / Video (UI changes only)

N/A — pure timing change, same components.

## Breaking changes

None. The DPAD-driven open / close paths are unchanged.

## Linked issues

None — internal report.