### PR TITLE
fix(i18n): localize remaining hardcoded user-facing strings across the app

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonConfigServer.kt
@@ -186,7 +186,7 @@ class AddonConfigServer(
                 currentState = currentPageStateProvider()
             )
         } catch (e: Exception) {
-            val error = mapOf("error" to "Invalid request body")
+            val error = mapOf("error" to context.getString(com.nuvio.tv.R.string.web_error_invalid_request_body))
             return newFixedLengthResponse(
                 Response.Status.BAD_REQUEST,
                 "application/json; charset=utf-8",

--- a/app/src/main/java/com/nuvio/tv/core/server/RepositoryConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/RepositoryConfigServer.kt
@@ -94,7 +94,7 @@ class RepositoryConfigServer(
             @Suppress("UNCHECKED_CAST")
             (parsed["urls"] as? List<String>) ?: emptyList()
         } catch (e: Exception) {
-            val error = mapOf("error" to "Invalid request body")
+            val error = mapOf("error" to context.getString(com.nuvio.tv.R.string.web_error_invalid_request_body))
             return newFixedLengthResponse(
                 Response.Status.BAD_REQUEST,
                 "application/json",

--- a/app/src/main/java/com/nuvio/tv/data/local/CollectionsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/CollectionsDataStore.kt
@@ -124,52 +124,52 @@ class CollectionsDataStore @Inject constructor(
     }
 
     fun validateCollectionsJson(json: String): ValidationResult {
-        if (json.isBlank()) return ValidationResult(false, "Empty input")
+        if (json.isBlank()) return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_empty_input))
         return try {
             val type = object : TypeToken<List<Map<String, Any?>>>() {}.type
             val parsed = gson.fromJson<List<Map<String, Any?>>>(json, type)
-                ?: return ValidationResult(false, "Invalid format: expected an array")
-            if (parsed.isEmpty()) return ValidationResult(false, "Empty array: no collections found")
+                ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_expected_array))
+            if (parsed.isEmpty()) return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_empty_array))
 
             var folderCount = 0
             val validShapes = setOf("POSTER", "LANDSCAPE", "SQUARE", "poster", "wide", "square")
 
             for ((i, item) in parsed.withIndex()) {
                 val id = item["id"] as? String
-                if (id.isNullOrBlank()) return ValidationResult(false, "Collection ${i + 1}: missing or invalid \"id\"")
+                if (id.isNullOrBlank()) return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_missing_id, i + 1))
                 val title = item["title"] as? String
-                    ?: return ValidationResult(false, "Collection \"$id\": missing or invalid \"title\"")
+                    ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_missing_title, id))
                 val folders = item["folders"] as? List<*>
-                    ?: return ValidationResult(false, "Collection \"$title\": \"folders\" must be an array")
+                    ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_folders_array, title))
 
                 for ((j, f) in folders.withIndex()) {
                     val folder = f as? Map<*, *>
-                        ?: return ValidationResult(false, "Collection \"$title\", folder ${j + 1}: invalid format")
+                        ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_folder_invalid, title, j + 1))
                     val folderId = folder["id"] as? String
-                    if (folderId.isNullOrBlank()) return ValidationResult(false, "Collection \"$title\", folder ${j + 1}: missing \"id\"")
+                    if (folderId.isNullOrBlank()) return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_folder_missing_id, title, j + 1))
                     val folderTitle = folder["title"] as? String
-                        ?: return ValidationResult(false, "Collection \"$title\", folder \"$folderId\": missing \"title\"")
+                        ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_folder_missing_title, title, folderId))
                     val sources = (folder["sources"] as? List<*>) ?: (folder["catalogSources"] as? List<*>)
-                        ?: return ValidationResult(false, "Collection \"$title\", folder \"$folderTitle\": \"sources\" must be an array")
+                        ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_sources_array, title, folderTitle))
                     val shape = folder["tileShape"] as? String
                     if (shape != null && shape !in validShapes) {
-                        return ValidationResult(false, "Collection \"$title\", folder \"$folderTitle\": invalid tileShape \"$shape\"")
+                        return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_invalid_tile_shape, title, folderTitle, shape))
                     }
                     for ((k, s) in sources.withIndex()) {
                         val source = s as? Map<*, *>
-                            ?: return ValidationResult(false, "Collection \"$title\", folder \"$folderTitle\", source ${k + 1}: invalid format")
+                            ?: return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_source_invalid, title, folderTitle, k + 1))
                         val provider = (source["provider"] as? String)?.lowercase()
                         val isAddonSource = provider == null || provider == "addon"
                         val isTmdbSource = provider == "tmdb"
                         val isTraktSource = provider == "trakt"
                         if (isAddonSource && (source["addonId"] !is String || source["type"] !is String || source["catalogId"] !is String)) {
-                            return ValidationResult(false, "Collection \"$title\", folder \"$folderTitle\", source ${k + 1}: missing required fields")
+                            return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_source_required_fields, title, folderTitle, k + 1))
                         }
                         if (isTmdbSource && source["tmdbSourceType"] !is String) {
-                            return ValidationResult(false, "Collection \"$title\", folder \"$folderTitle\", source ${k + 1}: missing TMDB source type")
+                            return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_missing_tmdb_type, title, folderTitle, k + 1))
                         }
                         if (isTraktSource && (source["traktListId"] as? Number)?.toLong() == null) {
-                            return ValidationResult(false, "Collection \"$title\", folder \"$folderTitle\", source ${k + 1}: missing Trakt list ID")
+                            return ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_missing_trakt_list_id, title, folderTitle, k + 1))
                         }
                     }
                     folderCount++
@@ -177,7 +177,7 @@ class CollectionsDataStore @Inject constructor(
             }
             ValidationResult(true, collectionCount = parsed.size, folderCount = folderCount)
         } catch (e: Exception) {
-            ValidationResult(false, "JSON parse error: ${e.message}")
+            ValidationResult(false, appContext.getString(com.nuvio.tv.R.string.collections_import_error_json_parse, e.message.orEmpty()))
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/GitHubContributorsRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/GitHubContributorsRepository.kt
@@ -20,18 +20,19 @@ data class GitHubContributor(
 
 @Singleton
 class GitHubContributorsRepository @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val contributionsApi: UniqueContributionsApi,
     @param:Named("uniqueContributionsBaseUrl") private val contributionsBaseUrl: String
 ) {
 
     suspend fun getContributors(): Result<List<GitHubContributor>> = runCatching {
         if (contributionsBaseUrl.isBlank()) {
-            error("Contributors API is not configured.")
+            error(appContext.getString(com.nuvio.tv.R.string.contributors_error_api_not_configured))
         }
 
         val response = contributionsApi.getUniqueContributions()
         if (!response.isSuccessful) {
-            error("Contributors API error: ${response.code()}")
+            error(appContext.getString(com.nuvio.tv.R.string.contributors_error_api_http, response.code()))
         }
 
         response.body()

--- a/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
@@ -40,6 +40,7 @@ import javax.inject.Singleton
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class LibraryRepositoryImpl @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val libraryPreferences: LibraryPreferences,
     private val traktAuthDataStore: TraktAuthDataStore,
     private val traktSettingsDataStore: TraktSettingsDataStore,
@@ -258,7 +259,7 @@ class LibraryRepositoryImpl @Inject constructor(
 
     private suspend fun requireTraktAuth() {
         if (!traktAuthDataStore.isEffectivelyAuthenticated.first()) {
-            throw IllegalStateException("Trakt authentication required")
+            throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_error_auth_required))
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/SponsorsRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SponsorsRepository.kt
@@ -15,13 +15,14 @@ data class DevelopmentSponsor(
 
 @Singleton
 class SponsorsRepository @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val sponsorsApi: SponsorsApi
 ) {
 
     suspend fun getSponsors(): Result<List<DevelopmentSponsor>> = runCatching {
         val response = sponsorsApi.getSponsors()
         if (!response.isSuccessful) {
-            error("Sponsors API error: ${response.code()}")
+            error(appContext.getString(com.nuvio.tv.R.string.sponsors_error_api_http, response.code()))
         }
 
         response.body()

--- a/app/src/main/java/com/nuvio/tv/data/repository/SupportersRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SupportersRepository.kt
@@ -15,13 +15,14 @@ data class SupporterDonation(
 
 @Singleton
 class SupportersRepository @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val donationsApi: DonationsApi
 ) {
 
     suspend fun getSupporters(limit: Int = 200): Result<List<SupporterDonation>> = runCatching {
         val response = donationsApi.getDonations(limit = limit)
         if (!response.isSuccessful) {
-            error("Donations API error: ${response.code()}")
+            error(appContext.getString(com.nuvio.tv.R.string.supporters_error_api_http, response.code()))
         }
 
         response.body()

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -196,10 +196,10 @@ class TraktLibraryService @Inject constructor(
                     privacy = privacy.apiValue
                 )
             )
-        } ?: throw IllegalStateException("Trakt request failed")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
         if (!response.isSuccessful) {
-            throw IllegalStateException(errorMessageForCode(response.code(), "Failed to create list"))
+            throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_create_list_failed)))
         }
 
         val createdTab = response.body()?.let(::mapListTab)
@@ -248,10 +248,10 @@ class TraktLibraryService @Inject constructor(
                         privacy = privacy.apiValue
                     )
                 )
-            } ?: throw IllegalStateException("Trakt request failed")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
             if (!response.isSuccessful) {
-                throw IllegalStateException(errorMessageForCode(response.code(), "Failed to update list"))
+                throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_update_list_failed)))
             }
         }
     }
@@ -274,10 +274,10 @@ class TraktLibraryService @Inject constructor(
                     id = ME_PATH,
                     listId = listId
                 )
-            } ?: throw IllegalStateException("Trakt request failed")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
             if (!response.isSuccessful && response.code() != 204) {
-                throw IllegalStateException(errorMessageForCode(response.code(), "Failed to delete list"))
+                throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_delete_list_failed)))
             }
         }
     }
@@ -309,10 +309,10 @@ class TraktLibraryService @Inject constructor(
                     id = ME_PATH,
                     body = TraktReorderListsRequestDto(rank = rank)
                 )
-            } ?: throw IllegalStateException("Trakt request failed")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
             if (!response.isSuccessful) {
-                throw IllegalStateException(errorMessageForCode(response.code(), "Failed to reorder lists"))
+                throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_reorder_lists_failed)))
             }
         }
     }
@@ -525,7 +525,7 @@ class TraktLibraryService @Inject constructor(
                     sort = "rank",
                     page = page
                 )
-            } ?: throw IllegalStateException("Failed to fetch watchlist movies")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_fetch_watchlist_movies))
         }
 
         val shows = fetchAllPages<TraktListItemDto> { page ->
@@ -537,7 +537,7 @@ class TraktLibraryService @Inject constructor(
                     sort = "rank",
                     page = page
                 )
-            } ?: throw IllegalStateException("Failed to fetch watchlist shows")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_fetch_watchlist_shows))
         }
 
         return (movies + shows)
@@ -559,10 +559,10 @@ class TraktLibraryService @Inject constructor(
                 authorization = authHeader,
                 id = ME_PATH
             )
-        } ?: throw IllegalStateException("Failed to fetch personal lists")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_fetch_personal_lists))
 
         if (!response.isSuccessful) {
-            throw IllegalStateException("Failed to fetch personal lists (${response.code()})")
+            throw IllegalStateException("${appContext.getString(com.nuvio.tv.R.string.trakt_library_error_fetch_personal_lists)} (${response.code()})")
         }
 
         val personal = response.body().orEmpty()
@@ -638,7 +638,7 @@ class TraktLibraryService @Inject constructor(
 
         return LibraryListTab(
             key = PERSONAL_KEY_PREFIX + listIdPath,
-            title = dto.name?.takeIf { it.isNotBlank() } ?: "List",
+            title = dto.name?.takeIf { it.isNotBlank() } ?: appContext.getString(com.nuvio.tv.R.string.library_list_fallback_title),
             type = LibraryListTab.Type.PERSONAL,
             traktListId = traktId,
             slug = slug,
@@ -736,10 +736,10 @@ class TraktLibraryService @Inject constructor(
                 authorization = authHeader,
                 body = body
             )
-        } ?: throw IllegalStateException("Trakt request failed")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
         if (!response.isSuccessful || !isSuccessfulAddResponse(response.body())) {
-            throw IllegalStateException(errorMessageForCode(response.code(), "Failed to add to watchlist"))
+            throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_add_watchlist_failed)))
         }
     }
 
@@ -750,10 +750,10 @@ class TraktLibraryService @Inject constructor(
                 authorization = authHeader,
                 body = body
             )
-        } ?: throw IllegalStateException("Trakt request failed")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
         if (!response.isSuccessful) {
-            throw IllegalStateException(errorMessageForCode(response.code(), "Failed to remove from watchlist"))
+            throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_remove_watchlist_failed)))
         }
     }
 
@@ -766,10 +766,10 @@ class TraktLibraryService @Inject constructor(
                 listId = listId,
                 body = body
             )
-        } ?: throw IllegalStateException("Trakt request failed")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
         if (!response.isSuccessful || !isSuccessfulAddResponse(response.body())) {
-            throw IllegalStateException(errorMessageForCode(response.code(), "Failed to add to list"))
+            throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_add_to_list_failed)))
         }
     }
 
@@ -782,17 +782,17 @@ class TraktLibraryService @Inject constructor(
                 listId = listId,
                 body = body
             )
-        } ?: throw IllegalStateException("Trakt request failed")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_request_failed))
 
         if (!response.isSuccessful) {
-            throw IllegalStateException(errorMessageForCode(response.code(), "Failed to remove from list"))
+            throw IllegalStateException(errorMessageForCode(response.code(), appContext.getString(com.nuvio.tv.R.string.trakt_library_error_remove_from_list_failed)))
         }
     }
 
     private fun buildMutationBody(item: LibraryEntryInput): TraktListItemsMutationRequestDto {
         val ids = resolveIds(item)
         if (!ids.hasAnyId()) {
-            throw IllegalStateException("Missing compatible IDs for Trakt list operation")
+            throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_missing_compatible_ids))
         }
 
         val normalizedType = normalizeItemType(item.itemType)
@@ -838,9 +838,9 @@ class TraktLibraryService @Inject constructor(
 
     private fun errorMessageForCode(code: Int, defaultMessage: String): String {
         return when (code) {
-            401, 403 -> "Trakt authentication expired"
-            404 -> "Trakt list not found"
-            420 -> "Trakt list limit reached. Upgrade required."
+            401, 403 -> appContext.getString(com.nuvio.tv.R.string.trakt_library_error_auth_expired)
+            404 -> appContext.getString(com.nuvio.tv.R.string.trakt_library_error_list_not_found)
+            420 -> appContext.getString(com.nuvio.tv.R.string.trakt_library_error_list_limit_reached)
             else -> "$defaultMessage ($code)"
         }
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -68,6 +68,7 @@ import javax.inject.Singleton
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class TraktProgressService @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService,
     private val metaRepository: MetaRepository,
@@ -597,7 +598,7 @@ class TraktProgressService @Inject constructor(
             "contentType=${progress.contentType} title=$title year=$year")
 
         val body = buildHistoryAddRequest(progress, title, year)
-            ?: throw IllegalStateException("Insufficient Trakt IDs to mark watched")
+            ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_error_insufficient_ids_mark_watched))
 
         val isSeriesEpisode = isSeriesEpisodeProgress(progress)
         val watchedShowSeedsSnapshot = if (isSeriesEpisode) {
@@ -616,7 +617,7 @@ class TraktProgressService @Inject constructor(
         val response = try {
             traktAuthService.executeAuthorizedWriteRequest { authHeader ->
                 traktApi.addHistory(authHeader, body)
-            } ?: throw IllegalStateException("Trakt request failed")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_error_request_failed))
         } catch (error: Throwable) {
             if (watchedShowSeedsSnapshot != null) {
                 restoreWatchedShowSeeds(watchedShowSeedsSnapshot)
@@ -668,7 +669,7 @@ class TraktProgressService @Inject constructor(
             if (watchedShowSeedsSnapshot != null) {
                 restoreWatchedShowSeeds(watchedShowSeedsSnapshot)
             }
-            throw IllegalStateException("Failed to mark watched on Trakt ($effectiveResponseCode)")
+            throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_error_mark_watched_failed, effectiveResponseCode))
         }
         if (!hasSuccessfulHistoryAdd(responseBody)) {
             trace("markAsWatched: Trakt accepted request with no new history rows (code=$effectiveResponseCode)")

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
  * wires [show] to each card's `onLongPress`.
  */
 class PosterOptionsController @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val libraryRepository: LibraryRepository,
     private val watchProgressRepository: WatchProgressRepository,
     private val tmdbService: TmdbService
@@ -228,7 +229,7 @@ class PosterOptionsController @Inject constructor(
                 _state.update { current ->
                     current.copy(
                         listPickerPending = false,
-                        listPickerError = error.message ?: "Failed to load lists"
+                        listPickerError = error.message ?: appContext.getString(com.nuvio.tv.R.string.poster_options_error_load_lists_failed)
                     )
                 }
             }
@@ -278,7 +279,7 @@ class PosterOptionsController @Inject constructor(
                 _state.update {
                     it.copy(
                         listPickerPending = false,
-                        listPickerError = error.message ?: "Failed to update lists"
+                        listPickerError = error.message ?: appContext.getString(com.nuvio.tv.R.string.poster_options_error_update_lists_failed)
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -170,7 +170,7 @@ fun CatalogSeeAllScreen(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = catalogRow?.catalogName ?: "Catalog",
+                text = catalogRow?.catalogName ?: stringResource(R.string.catalog_see_all_title_fallback),
                 style = MaterialTheme.typography.headlineLarge,
                 color = NuvioColors.TextPrimary
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
@@ -440,7 +440,7 @@ class AddonManagerViewModel @Inject constructor(
                         .map {
                             TmdbSourceSearchResultInfo(
                                 id = it.id,
-                                title = it.name ?: "TMDB Company ${it.id}",
+                                title = it.name ?: context.getString(com.nuvio.tv.R.string.web_tmdb_company_fallback, it.id),
                                 subtitle = it.originCountry?.takeIf { value -> value.isNotBlank() }
                             )
                         }
@@ -448,7 +448,7 @@ class AddonManagerViewModel @Inject constructor(
                         .map {
                             TmdbSourceSearchResultInfo(
                                 id = it.id,
-                                title = it.name ?: "TMDB Collection ${it.id}",
+                                title = it.name ?: context.getString(com.nuvio.tv.R.string.web_tmdb_collection_fallback, it.id),
                                 subtitle = it.overview?.takeIf { value -> value.isNotBlank() }
                             )
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/EssentialAddonSetupScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/EssentialAddonSetupScreen.kt
@@ -69,13 +69,13 @@ fun EssentialAddonSetupScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "Set up add-ons",
+                text = stringResource(R.string.essential_addon_setup_title),
                 style = MaterialTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Bold),
                 color = NuvioColors.TextPrimary
             )
             Spacer(modifier = Modifier.height(10.dp))
             Text(
-                text = "Install one add-on to start streaming. You can add more later from Addons.",
+                text = stringResource(R.string.essential_addon_setup_subtitle),
                 style = MaterialTheme.typography.bodyLarge,
                 color = NuvioColors.TextSecondary
             )
@@ -204,7 +204,7 @@ fun EssentialAddonSetupScreen(
                             shape = ButtonDefaults.shape(RoundedCornerShape(50))
                         ) {
                             Icon(imageVector = Icons.Default.QrCode2, contentDescription = null)
-                            Text(text = "Show QR")
+                            Text(text = stringResource(R.string.essential_addon_show_qr))
                         }
                     }
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorGenreEmojiPickers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorGenreEmojiPickers.kt
@@ -212,6 +212,23 @@ fun GenrePickerOptionCard(
     }
 }
 
+@androidx.annotation.StringRes
+private fun emojiCategoryLabel(key: String): Int = when (key) {
+    "Streaming" -> R.string.collections_editor_emoji_category_streaming
+    "Genres" -> R.string.collections_editor_emoji_category_genres
+    "Sports" -> R.string.collections_editor_emoji_category_sports
+    "Music" -> R.string.collections_editor_emoji_category_music
+    "Nature" -> R.string.collections_editor_emoji_category_nature
+    "Animals" -> R.string.collections_editor_emoji_category_animals
+    "Food" -> R.string.collections_editor_emoji_category_food
+    "Travel" -> R.string.collections_editor_emoji_category_travel
+    "People" -> R.string.collections_editor_emoji_category_people
+    "Objects" -> R.string.collections_editor_emoji_category_objects
+    "Flags" -> R.string.collections_editor_emoji_category_flags
+    "Symbols" -> R.string.collections_editor_emoji_category_symbols
+    else -> R.string.collections_editor_emoji_category_symbols
+}
+
 private val emojiCategories = linkedMapOf(
     "Streaming" to listOf("🎬", "🎭", "🎥", "📺", "🍿", "🎞️", "📽️", "🎦", "📡", "📻"),
     "Genres" to listOf("💀", "👻", "🔪", "💣", "🚀", "🛸", "🧙", "🦸", "🧟", "🤖", "💘", "😂", "😱", "🤯", "🥺", "😈"),
@@ -289,7 +306,7 @@ fun EmojiPickerContent(
             emojiCategories.forEach { (category, emojis) ->
                 item(key = "category_$category") {
                     Text(
-                        text = category,
+                        text = stringResource(emojiCategoryLabel(category)),
                         style = MaterialTheme.typography.titleSmall,
                         color = NuvioColors.TextSecondary
                     )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorScreen.kt
@@ -454,8 +454,15 @@ private fun FolderListItem(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
+                val shapeLabel = stringResource(
+                    when (folder.tileShape) {
+                        com.nuvio.tv.domain.model.PosterShape.POSTER -> R.string.collections_editor_shape_poster
+                        com.nuvio.tv.domain.model.PosterShape.LANDSCAPE -> R.string.collections_editor_shape_wide
+                        com.nuvio.tv.domain.model.PosterShape.SQUARE -> R.string.collections_editor_shape_square
+                    }
+                )
                 Text(
-                    text = "${folder.tileShape.name.lowercase().replaceFirstChar { it.uppercase() }} - ${stringResource(R.string.collections_editor_source_count, folder.sources.size)}",
+                    text = "$shapeLabel - ${stringResource(R.string.collections_editor_source_count, folder.sources.size)}",
                     style = MaterialTheme.typography.bodySmall,
                     color = NuvioColors.TextTertiary
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorTmdbPicker.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorTmdbPicker.kt
@@ -362,9 +362,9 @@ private fun TmdbBasicSourceForm(
             onValueChange = onInputChange,
             placeholder = when (uiState.tmdbBuilderMode) {
                 TmdbBuilderMode.LIST -> "https://www.themoviedb.org/list/8504994 or 8504994"
-                TmdbBuilderMode.NETWORK -> "213 for Netflix, 49 for HBO, 2739 for Disney+"
-                TmdbBuilderMode.COLLECTION -> "10 for Star Wars Collection"
-                TmdbBuilderMode.PRODUCTION -> "Marvel Studios, 420, or company URL"
+                TmdbBuilderMode.NETWORK -> stringResource(R.string.collections_editor_tmdb_network_placeholder_example)
+                TmdbBuilderMode.COLLECTION -> stringResource(R.string.collections_editor_tmdb_collection_placeholder_example)
+                TmdbBuilderMode.PRODUCTION -> stringResource(R.string.collections_editor_tmdb_company_placeholder_example)
                 TmdbBuilderMode.PERSON,
                 TmdbBuilderMode.DIRECTOR -> stringResource(R.string.collections_editor_tmdb_person_placeholder)
                 else -> stringResource(R.string.collections_editor_tmdb_id_or_url)
@@ -721,23 +721,24 @@ private fun TmdbQuickChips(
     }
 }
 
+@Composable
 private fun tmdbGenreQuickChips(mediaType: TmdbCollectionMediaType): List<Pair<String, String>> {
     return when (mediaType) {
         TmdbCollectionMediaType.MOVIE -> listOf(
-            "Action" to "28",
-            "Adventure" to "12",
-            "Animation" to "16",
-            "Comedy" to "35",
-            "Horror" to "27",
-            "Sci-Fi" to "878"
+            stringResource(R.string.collections_editor_tmdb_genre_action) to "28",
+            stringResource(R.string.collections_editor_tmdb_genre_adventure) to "12",
+            stringResource(R.string.collections_editor_tmdb_genre_animation) to "16",
+            stringResource(R.string.collections_editor_tmdb_genre_comedy) to "35",
+            stringResource(R.string.collections_editor_tmdb_genre_horror) to "27",
+            stringResource(R.string.collections_editor_tmdb_genre_scifi) to "878"
         )
         TmdbCollectionMediaType.TV -> listOf(
-            "Drama" to "18",
-            "Comedy" to "35",
-            "Animation" to "16",
-            "Crime" to "80",
-            "Sci-Fi" to "10765",
-            "Reality" to "10764"
+            stringResource(R.string.collections_editor_tmdb_genre_drama) to "18",
+            stringResource(R.string.collections_editor_tmdb_genre_comedy) to "35",
+            stringResource(R.string.collections_editor_tmdb_genre_animation) to "16",
+            stringResource(R.string.collections_editor_tmdb_genre_crime) to "80",
+            stringResource(R.string.collections_editor_tmdb_genre_scifi) to "10765",
+            stringResource(R.string.collections_editor_tmdb_genre_reality) to "10764"
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorViewModel.kt
@@ -551,7 +551,7 @@ class CollectionEditorViewModel @Inject constructor(
                 it.copy(
                     traktSearchResults = mapped,
                     traktSearchError = results.exceptionOrNull()?.message
-                        ?: if (mapped.isEmpty()) "No Trakt lists found" else null
+                        ?: if (mapped.isEmpty()) string(R.string.collection_editor_no_trakt_lists_found) else null
                 )
             }
         }
@@ -1062,7 +1062,7 @@ class CollectionEditorViewModel @Inject constructor(
         val rawFolder = _uiState.value.editingFolder ?: return
         if (rawFolder.sources.isEmpty()) return
         val cleanedFolder = rawFolder.copy(
-            title = rawFolder.title.ifBlank { "Untitled" },
+            title = rawFolder.title.ifBlank { string(R.string.collection_editor_untitled_folder) },
             coverImageUrl = rawFolder.coverImageUrl?.ifBlank { null },
             heroBackdropUrl = rawFolder.heroBackdropUrl?.ifBlank { null },
             heroVideoUrl = rawFolder.heroVideoUrl?.ifBlank { null },
@@ -1109,7 +1109,7 @@ class CollectionEditorViewModel @Inject constructor(
         viewModelScope.launch {
             val collection = Collection(
                 id = state.collectionId,
-                title = state.title.ifBlank { "Untitled Collection" },
+                title = state.title.ifBlank { string(R.string.collection_editor_untitled_collection) },
                 backdropImageUrl = state.backdropImageUrl.ifBlank { null },
                 pinToTop = state.pinToTop,
                 focusGlowEnabled = state.focusGlowEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1842,7 +1842,7 @@ class MetaDetailsViewModel @Inject constructor(
                 showMessage(message)
             }.onFailure { error ->
                 showMessage(
-                    message = error.message ?: "Failed to update library",
+                    message = error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_update_library_failed),
                     isError = true
                 )
             }
@@ -1867,11 +1867,11 @@ class MetaDetailsViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         pickerPending = false,
-                        pickerError = error.message ?: "Failed to load lists",
+                        pickerError = error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_load_lists_failed),
                         showListPicker = false
                     )
                 }
-                showMessage(error.message ?: "Failed to load lists", isError = true)
+                showMessage(error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_load_lists_failed), isError = true)
             }
         }
     }
@@ -1914,10 +1914,10 @@ class MetaDetailsViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         pickerPending = false,
-                        pickerError = error.message ?: "Failed to update lists"
+                        pickerError = error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_update_lists_failed)
                     )
                 }
-                showMessage(error.message ?: "Failed to update lists", isError = true)
+                showMessage(error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_update_lists_failed), isError = true)
             }
         }
     }
@@ -1949,7 +1949,7 @@ class MetaDetailsViewModel @Inject constructor(
                 }
             }.onFailure { error ->
                 showMessage(
-                    message = error.message ?: "Failed to update watched status",
+                    message = error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_update_watched_failed),
                     isError = true
                 )
             }
@@ -1981,7 +1981,7 @@ class MetaDetailsViewModel @Inject constructor(
                 }
             }.onFailure { error ->
                 showMessage(
-                    message = error.message ?: "Failed to update episode watched status",
+                    message = error.message ?: context.getString(com.nuvio.tv.R.string.detail_error_update_episode_watched_failed),
                     isError = true
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -182,12 +182,12 @@ class LibraryViewModel @Inject constructor(
     fun onRefresh() {
         if (_uiState.value.isSyncing) return
         viewModelScope.launch {
-            setTransientMessage("Syncing Trakt library...")
+            setTransientMessage(context.getString(R.string.library_syncing))
             runCatching {
                 libraryRepository.refreshNow()
-                setTransientMessage("Library synced")
+                setTransientMessage(context.getString(R.string.library_synced))
             }.onFailure { error ->
-                setError(error.message ?: "Failed to refresh library")
+                setError(error.message ?: context.getString(R.string.library_error_refresh_failed))
             }
         }
     }
@@ -288,25 +288,25 @@ class LibraryViewModel @Inject constructor(
                             description = editor.description.trim().ifBlank { null },
                             privacy = editor.privacy
                         )
-                        setTransientMessage("List created")
+                        setTransientMessage(context.getString(R.string.library_list_created))
                     }
                     LibraryListEditorState.Mode.EDIT -> {
                         val listId = editor.listId
-                            ?: throw IllegalStateException("Invalid list")
+                            ?: throw IllegalStateException(context.getString(R.string.library_error_invalid_list))
                         libraryRepository.updatePersonalList(
                             listId = listId,
                             name = name,
                             description = editor.description.trim().ifBlank { null },
                             privacy = editor.privacy
                         )
-                        setTransientMessage("List updated")
+                        setTransientMessage(context.getString(R.string.library_list_updated))
                     }
                 }
             }.onSuccess {
                 _uiState.update { it.copy(listEditorState = null, pendingOperation = false) }
             }.onFailure { error ->
                 _uiState.update { it.copy(pendingOperation = false) }
-                setError(error.message ?: "Failed to save list")
+                setError(error.message ?: context.getString(R.string.library_error_save_list_failed))
             }
         }
     }
@@ -320,12 +320,12 @@ class LibraryViewModel @Inject constructor(
             _uiState.update { it.copy(pendingOperation = true, errorMessage = null) }
             runCatching {
                 libraryRepository.deletePersonalList(listId)
-                setTransientMessage("List deleted")
+                setTransientMessage(context.getString(R.string.library_list_deleted))
             }.onSuccess {
                 _uiState.update { it.copy(pendingOperation = false) }
             }.onFailure { error ->
                 _uiState.update { it.copy(pendingOperation = false) }
-                setError(error.message ?: "Failed to delete list")
+                setError(error.message ?: context.getString(R.string.library_error_delete_list_failed))
             }
         }
     }
@@ -485,12 +485,12 @@ class LibraryViewModel @Inject constructor(
             _uiState.update { it.copy(pendingOperation = true, errorMessage = null) }
             runCatching {
                 libraryRepository.reorderPersonalLists(orderedIds)
-                setTransientMessage("List order updated")
+                setTransientMessage(context.getString(R.string.library_list_order_updated))
             }.onSuccess {
                 _uiState.update { it.copy(pendingOperation = false) }
             }.onFailure { error ->
                 _uiState.update { it.copy(pendingOperation = false) }
-                setError(error.message ?: "Failed to reorder lists")
+                setError(error.message ?: context.getString(R.string.library_error_reorder_lists_failed))
             }
         }
     }
@@ -530,7 +530,7 @@ class LibraryViewModel @Inject constructor(
                     if (ch.isLowerCase()) ch.titlecase(Locale.ROOT) else ch.toString()
                 }
             }
-            .ifBlank { "Unknown" }
+            .ifBlank { context.getString(R.string.type_unknown) }
     }
 
     private val yearRegex = Regex("""\b(19|20)\d{2}\b""")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -431,7 +431,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
                     audioTracks += MpvTrack(
                         id = id,
                         type = type,
-                        name = title ?: language ?: "Audio $id",
+                        name = title ?: language ?: context.getString(com.nuvio.tv.R.string.player_track_audio_fallback, id),
                         language = language,
                         codec = codec,
                         channelCount = channelCount,
@@ -445,7 +445,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
                     subtitleTracks += MpvTrack(
                         id = id,
                         type = type,
-                        name = title ?: language ?: "Subtitle $id",
+                        name = title ?: language ?: context.getString(com.nuvio.tv.R.string.player_track_subtitle_fallback, id),
                         language = language,
                         codec = codec,
                         channelCount = null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -111,17 +111,17 @@ internal fun PlaybackException.findInvalidResponseCodeException(): HttpDataSourc
     return null
 }
 
-internal fun PlaybackException.toDisplayMessage(): String {
+internal fun PlaybackException.toDisplayMessage(context: android.content.Context): String {
     val responseException = findInvalidResponseCodeException()
     if (responseException != null) {
         val code = responseException.responseCode
         val statusText = responseException.responseMessage?.takeIf { it.isNotBlank() }
         val providerHint = when (code) {
-            403 -> "\n\nThe stream source is blocked or restricted. Try a different source."
-            404 -> "\n\nThe stream link has expired or been removed. Try a different source."
-            410 -> "\n\nThe stream link has expired. Try a different source."
-            429 -> "\n\nToo many requests to the stream source. Wait a moment and try again."
-            500, 502, 503 -> "\n\nThe stream server is currently unavailable. Try a different source."
+            403 -> context.getString(com.nuvio.tv.R.string.player_error_stream_blocked)
+            404 -> context.getString(com.nuvio.tv.R.string.player_error_stream_removed)
+            410 -> context.getString(com.nuvio.tv.R.string.player_error_stream_expired)
+            429 -> context.getString(com.nuvio.tv.R.string.player_error_stream_rate_limited)
+            500, 502, 503 -> context.getString(com.nuvio.tv.R.string.player_error_stream_unavailable)
             else -> ""
         }
         return buildString {
@@ -135,9 +135,7 @@ internal fun PlaybackException.toDisplayMessage(): String {
     // Check for unrecognized format (provider returned non-video content)
     val isUnrecognizedFormat = findCauseOfType<androidx.media3.exoplayer.source.UnrecognizedInputFormatException>() != null
     if (isUnrecognizedFormat) {
-        return "Source error: The stream source returned invalid or unplayable content. " +
-            "The link may have expired or the server returned an error page instead of video.\n\n" +
-            "Try a different source. [$errorCodeName]"
+        return context.getString(com.nuvio.tv.R.string.player_error_source_invalid_content, errorCodeName)
     }
 
     // Check for codec/renderer errors
@@ -145,8 +143,9 @@ internal fun PlaybackException.toDisplayMessage(): String {
         errorCode == PlaybackException.ERROR_CODE_DECODER_INIT_FAILED
     if (isRendererError) {
         val meaningfulMessage = findMostRelevantCauseMessage()
-        return "${meaningfulMessage ?: "Decoder error"}\n\n" +
-            "This stream uses a format your device may not support. Try a different source. [$errorCodeName]"
+        val decoderHeader = meaningfulMessage ?: context.getString(com.nuvio.tv.R.string.player_error_decoder)
+        val unsupported = context.getString(com.nuvio.tv.R.string.player_error_unsupported_format, errorCodeName)
+        return "$decoderHeader\n\n$unsupported"
     }
 
     val meaningfulMessage = findMostRelevantCauseMessage()
@@ -166,9 +165,12 @@ private inline fun <reified T : Throwable> Throwable.findCauseOfType(): T? {
     return null
 }
 
-internal fun Throwable.toDisplayMessage(fallback: String = "Playback error"): String {
+internal fun Throwable.toDisplayMessage(context: android.content.Context, fallback: String? = null): String {
     val meaningfulMessage = findMostRelevantCauseMessage()
-    return meaningfulMessage ?: message?.takeIf { it.isNotBlank() } ?: fallback
+    return meaningfulMessage
+        ?: message?.takeIf { it.isNotBlank() }
+        ?: fallback
+        ?: context.getString(com.nuvio.tv.R.string.player_error_playback_fallback)
 }
 
 private fun Throwable.findMostRelevantCauseMessage(): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -472,7 +472,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (isReleasingPlayer && error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) {
                             return
                         }
-                        val detailedError = error.toDisplayMessage()
+                        val detailedError = error.toDisplayMessage(context)
 
                         // If the codec crashed while the app is in the background (e.g. another
                         // app reclaimed the hardware decoder), don't run the retry chain — each
@@ -530,7 +530,7 @@ internal fun PlayerRuntimeController.initializePlayer(
         } catch (e: Exception) {
             if (
                 maybeAutoSwitchInternalPlayerOnStartupError(
-                    detailedError = e.message ?: "Failed to initialize player",
+                    detailedError = e.message ?: context.getString(com.nuvio.tv.R.string.player_error_initialize_failed),
                     allowEngineFailover = allowEngineFailover
                 )
             ) {
@@ -538,7 +538,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             }
             _uiState.update {
                 it.copy(
-                    error = e.toDisplayMessage("Failed to initialize player"),
+                    error = e.toDisplayMessage(context, context.getString(com.nuvio.tv.R.string.player_error_initialize_failed)),
                     showLoadingOverlay = false
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -51,7 +51,7 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         scheduleHideControls()
         emitScrobbleStart()
     }.onFailure {
-        val detailedError = it.message ?: "Failed to initialize libmpv surface"
+        val detailedError = it.message ?: context.getString(com.nuvio.tv.R.string.player_error_mpv_surface_failed)
         if (
             maybeAutoSwitchInternalPlayerOnStartupError(
                 detailedError = detailedError,
@@ -136,7 +136,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         emitScrobbleStart()
     }.onFailure { error ->
         Log.e(PlayerRuntimeController.TAG, "libmpv initialize failed: ${error.message}", error)
-        val detailedError = error.message ?: "Failed to initialize libmpv playback"
+        val detailedError = error.message ?: context.getString(com.nuvio.tv.R.string.player_error_mpv_playback_failed)
         if (
             maybeAutoSwitchInternalPlayerOnStartupError(
                 detailedError = detailedError,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -498,7 +498,7 @@ internal fun PlayerRuntimeController.retryCurrentStreamFromStartAfter416() {
         }.onFailure { e ->
             _uiState.update {
                 it.copy(
-                    error = e.toDisplayMessage(),
+                    error = e.toDisplayMessage(context),
                     showLoadingOverlay = false,
                     showPauseOverlay = false
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
@@ -159,7 +159,7 @@ private fun PlayerRuntimeController.maybeLoadSubtitleAutoSyncCues(force: Boolean
                     subtitleAutoSyncLoading = false,
                     subtitleAutoSyncCues = parsedCues,
                     subtitleAutoSyncError = if (parsedCues.isEmpty()) {
-                        "No subtitle lines were found in this file."
+                        context.getString(com.nuvio.tv.R.string.subtitle_timing_file_no_lines)
                     } else {
                         null
                     },
@@ -176,7 +176,7 @@ private fun PlayerRuntimeController.maybeLoadSubtitleAutoSyncCues(force: Boolean
                 it.copy(
                     subtitleAutoSyncLoading = false,
                     subtitleAutoSyncCues = emptyList(),
-                    subtitleAutoSyncError = e.message ?: "Failed to load subtitle lines.",
+                    subtitleAutoSyncError = e.message ?: context.getString(com.nuvio.tv.R.string.subtitle_timing_load_lines_failed),
                     subtitleAutoSyncLoadedTrackKey = selectedTrackKey
                 )
             }
@@ -201,11 +201,11 @@ private suspend fun PlayerRuntimeController.downloadSubtitleBody(url: String): S
 
         subtitleAutoSyncHttpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
-                error("Subtitle download failed (HTTP ${response.code})")
+                error(context.getString(com.nuvio.tv.R.string.subtitle_download_failed_http, response.code))
             }
             val body = response.body?.string()
             if (body.isNullOrBlank()) {
-                error("Subtitle download returned empty content.")
+                error(context.getString(com.nuvio.tv.R.string.subtitle_download_empty_content))
             }
             body
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTorrent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTorrent.kt
@@ -71,7 +71,7 @@ internal fun PlayerRuntimeController.observeTorrentState() {
                         _uiState.update {
                             it.copy(
                                 showLoadingOverlay = true,
-                                loadingMessage = "Connecting to peers...",
+                                loadingMessage = context.getString(com.nuvio.tv.R.string.player_torrent_connecting_peers),
                                 loadingProgress = null,
                                 torrentBufferingMessage = null
                             )
@@ -81,7 +81,7 @@ internal fun PlayerRuntimeController.observeTorrentState() {
 
                 is TorrentState.Streaming -> {
                     val speed = formatSpeed(torrentState.downloadSpeed)
-                    val peerInfo = "${torrentState.seeds} seeds \u00B7 ${torrentState.peers} peers"
+                    val peerInfo = context.getString(com.nuvio.tv.R.string.player_torrent_peer_info, torrentState.seeds, torrentState.peers)
                     val mbLoaded = formatMB(torrentState.preloadedBytes)
                     val statsHidden = _uiState.value.hideTorrentStats
 
@@ -90,7 +90,7 @@ internal fun PlayerRuntimeController.observeTorrentState() {
                         // TorrServer preloads ~5MB before streaming starts
                         val preloadTarget = 5_242_880L // 5MB
                         val progress = (torrentState.preloadedBytes.toFloat() / preloadTarget).coerceIn(0f, 1f)
-                        val message = if (statsHidden) null else "$mbLoaded buffered \u00B7 $peerInfo \u00B7 $speed"
+                        val message = if (statsHidden) null else context.getString(com.nuvio.tv.R.string.player_torrent_buffered_status, mbLoaded, peerInfo, speed)
                         _uiState.update {
                             it.copy(
                                 showLoadingOverlay = true,
@@ -108,7 +108,7 @@ internal fun PlayerRuntimeController.observeTorrentState() {
                     } else {
                         // During playback: update stats, rebuffer message is
                         // handled by the progress loop in PlaybackEvents
-                        val message = if (statsHidden) null else "$peerInfo \u00B7 $speed"
+                        val message = if (statsHidden) null else context.getString(com.nuvio.tv.R.string.player_torrent_status, peerInfo, speed)
                         _uiState.update {
                             it.copy(
                                 loadingProgress = null,
@@ -128,7 +128,7 @@ internal fun PlayerRuntimeController.observeTorrentState() {
                     Log.e(TAG, "Torrent error: ${torrentState.message}")
                     _uiState.update {
                         it.copy(
-                            error = "Torrent error: ${torrentState.message}",
+                            error = context.getString(com.nuvio.tv.R.string.player_error_torrent, torrentState.message),
                             showLoadingOverlay = false,
                             torrentBufferingMessage = null
                         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -78,7 +78,7 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                     val langDisplay = format.language?.takeIf { it != "und" }?.let {
                         com.nuvio.tv.ui.util.languageCodeToName(it)
                     }
-                    val baseName = format.label ?: langDisplay ?: "Audio ${audioTracks.size + 1}"
+                    val baseName = format.label ?: langDisplay ?: context.getString(com.nuvio.tv.R.string.player_track_audio_fallback, audioTracks.size + 1)
                     val suffix = listOfNotNull(codecName, channelLayout).joinToString(" ")
                     val displayName = if (suffix.isNotEmpty()) "$baseName ($suffix)" else baseName
 
@@ -114,7 +114,7 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                     subtitleTracks.add(
                         TrackInfo(
                             index = subtitleTracks.size,
-                            name = format.label ?: format.language ?: "Subtitle ${subtitleTracks.size + 1}",
+                            name = format.label ?: format.language ?: context.getString(com.nuvio.tv.R.string.player_track_subtitle_fallback, subtitleTracks.size + 1),
                             language = format.language,
                             trackId = format.id,
                             codec = CustomDefaultTrackNameProvider.formatNameFromMime(format.sampleMimeType),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/TorrentOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/TorrentOverlay.kt
@@ -13,10 +13,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
+import com.nuvio.tv.R
 
 @Composable
 fun TorrentOverlay(
@@ -65,7 +67,7 @@ fun TorrentOverlay(
                 )
             }
             Text(
-                text = "$peers peers · $seeds seeds · ${(totalProgress * 100).toInt()}%",
+                text = stringResource(R.string.player_torrent_stats, peers, seeds, (totalProgress * 100).toInt()),
                 color = Color.White.copy(alpha = 0.6f),
                 fontSize = 10.sp
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -607,7 +607,7 @@ fun SearchScreen(
                     uiState.error != null && uiState.catalogRows.isEmpty() -> {
                         item {
                             ErrorState(
-                                message = uiState.error ?: "Search failed",
+                                message = uiState.error ?: stringResource(R.string.search_error_failed),
                                 onRetry = { viewModel.onEvent(SearchEvent.Retry) }
                             )
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -316,7 +316,7 @@ class SearchViewModel @Inject constructor(
             val addons = try {
                 addonRepository.getInstalledAddons().first()
             } catch (e: Exception) {
-                _uiState.update { it.copy(isSearching = false, error = e.message ?: "Failed to load addons") }
+                _uiState.update { it.copy(isSearching = false, error = e.message ?: context.getString(com.nuvio.tv.R.string.search_error_load_addons_failed)) }
                 return@launch
             }
 
@@ -437,7 +437,7 @@ class SearchViewModel @Inject constructor(
                     pendingCatalogResponses = (pendingCatalogResponses - 1).coerceAtLeast(0)
                     // Ignore per-catalog errors unless we have nothing to show.
                     if (catalogsMap.isEmpty()) {
-                        _uiState.update { it.copy(error = result.message ?: "Search failed") }
+                        _uiState.update { it.copy(error = result.message ?: context.getString(com.nuvio.tv.R.string.search_error_failed)) }
                     }
                     scheduleCatalogRowsUpdate()
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -931,21 +931,38 @@ private fun StreamRegexDialog(
     var isInputFocused by remember { mutableStateOf(false) }
     val inputFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
-    val presets = remember {
+    val presetAny1080p = stringResource(R.string.autoplay_regex_preset_any_1080p_plus)
+    val preset4kRemux = stringResource(R.string.autoplay_regex_preset_4k_remux)
+    val preset1080pStandard = stringResource(R.string.autoplay_regex_preset_1080p_standard)
+    val preset720pSmaller = stringResource(R.string.autoplay_regex_preset_720p_smaller)
+    val presetWebSources = stringResource(R.string.autoplay_regex_preset_web_sources)
+    val presetBlurayQuality = stringResource(R.string.autoplay_regex_preset_bluray_quality)
+    val presetHevcX265 = stringResource(R.string.autoplay_regex_preset_hevc_x265)
+    val presetAvcX264 = stringResource(R.string.autoplay_regex_preset_avc_x264)
+    val presetHdrDv = stringResource(R.string.autoplay_regex_preset_hdr_dolby_vision)
+    val presetDolbyAtmosDts = stringResource(R.string.autoplay_regex_preset_dolby_atmos_dts)
+    val presetEnglish = stringResource(R.string.autoplay_regex_preset_english)
+    val presetNoCamTs = stringResource(R.string.autoplay_regex_preset_no_cam_ts)
+    val presetNoRemuxHdr = stringResource(R.string.autoplay_regex_preset_no_remux_hdr)
+    val presets = remember(
+        presetAny1080p, preset4kRemux, preset1080pStandard, preset720pSmaller,
+        presetWebSources, presetBlurayQuality, presetHevcX265, presetAvcX264,
+        presetHdrDv, presetDolbyAtmosDts, presetEnglish, presetNoCamTs, presetNoRemuxHdr
+    ) {
         listOf(
-            "Any 1080p+" to "(2160p|4k|1080p)",
-            "4K / Remux" to "(2160p|4k|remux)",
-            "1080p Standard" to "(1080p|full\\s*hd)",
-            "720p / Smaller" to "(720p|webrip|web-dl)",
-            "WEB Sources" to "(web[-\\s]?dl|webrip)",
-            "BluRay Quality" to "(bluray|b[dr]rip|remux)",
-            "HEVC / x265" to "(hevc|x265|h\\.265)",
-            "AVC / x264" to "(x264|h\\.264|avc)",
-            "HDR / Dolby Vision" to "(hdr|hdr10\\+?|dv|dolby\\s*vision)",
-            "Dolby Atmos / DTS" to "(atmos|truehd|dts[-\\s]?hd|dtsx?)",
-            "English" to "(\\beng\\b|english)",
-            "No CAM/TS" to "^(?!.*\\b(cam|hdcam|ts|telesync)\\b).*$",
-            "No REMUX/HDR" to "(?is)^(?!.*\\b(hdr|hdr10|dv|dolby|vision|hevc|remux|2160p)\\b).+$"
+            presetAny1080p to "(2160p|4k|1080p)",
+            preset4kRemux to "(2160p|4k|remux)",
+            preset1080pStandard to "(1080p|full\\s*hd)",
+            preset720pSmaller to "(720p|webrip|web-dl)",
+            presetWebSources to "(web[-\\s]?dl|webrip)",
+            presetBlurayQuality to "(bluray|b[dr]rip|remux)",
+            presetHevcX265 to "(hevc|x265|h\\.265)",
+            presetAvcX264 to "(x264|h\\.264|avc)",
+            presetHdrDv to "(hdr|hdr10\\+?|dv|dolby\\s*vision)",
+            presetDolbyAtmosDts to "(atmos|truehd|dts[-\\s]?hd|dtsx?)",
+            presetEnglish to "(\\beng\\b|english)",
+            presetNoCamTs to "^(?!.*\\b(cam|hdcam|ts|telesync)\\b).*$",
+            presetNoRemuxHdr to "(?is)^(?!.*\\b(hdr|hdr10|dv|dolby|vision|hevc|remux|2160p)\\b).+$"
         )
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -1015,7 +1015,7 @@ private fun PlayerPreferenceDialog(
     }
 
     val options = listOf(
-        Triple(PlayerPreference.INTERNAL, stringResource(R.string.playback_player_internal), "Use NuvioTV's built-in player"),
+        Triple(PlayerPreference.INTERNAL, stringResource(R.string.playback_player_internal), stringResource(R.string.playback_player_internal_desc)),
         Triple(PlayerPreference.EXTERNAL, stringResource(R.string.playback_player_external), stringResource(R.string.playback_player_external_desc)),
         Triple(PlayerPreference.ASK_EVERY_TIME, stringResource(R.string.playback_player_ask), stringResource(R.string.playback_player_ask_desc))
     )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSubtitleSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSubtitleSettings.kt
@@ -102,7 +102,7 @@ internal fun LazyListScope.subtitleSettingsItems(
         } else {
             AVAILABLE_SUBTITLE_LANGUAGES.find {
                 it.code == playerSettings.subtitleStyle.preferredLanguage
-            }?.displayName ?: "English"
+            }?.displayName ?: stringResource(R.string.language_english)
         }
 
         NavigationSettingsItem(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SupportersContributorsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SupportersContributorsViewModel.kt
@@ -43,6 +43,7 @@ data class SupportersContributorsUiState(
 
 @HiltViewModel
 class SupportersContributorsViewModel @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val supportersRepository: SupportersRepository,
     private val sponsorsRepository: SponsorsRepository,
     private val contributorsRepository: GitHubContributorsRepository
@@ -148,7 +149,7 @@ class SupportersContributorsViewModel @Inject constructor(
                             isSupportersLoading = false,
                             hasLoadedSupporters = false,
                             supporters = emptyList(),
-                            supportersErrorMessage = error.message ?: "Unable to load supporters."
+                            supportersErrorMessage = error.message ?: appContext.getString(com.nuvio.tv.R.string.supporters_error_load)
                         )
                     }
                 }
@@ -185,7 +186,7 @@ class SupportersContributorsViewModel @Inject constructor(
                             isContributorsLoading = false,
                             hasLoadedContributors = false,
                             contributors = emptyList(),
-                            contributorsErrorMessage = error.message ?: "Unable to load contributors."
+                            contributorsErrorMessage = error.message ?: appContext.getString(com.nuvio.tv.R.string.contributors_error_load)
                         )
                     }
                 }
@@ -222,7 +223,7 @@ class SupportersContributorsViewModel @Inject constructor(
                             isSponsorsLoading = false,
                             hasLoadedSponsors = false,
                             sponsors = emptyList(),
-                            sponsorsErrorMessage = error.message ?: "Unable to load sponsors."
+                            sponsorsErrorMessage = error.message ?: appContext.getString(com.nuvio.tv.R.string.sponsors_error_load)
                         )
                     }
                 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -961,6 +961,14 @@
     <string name="profile_pin_overlay_back_hint">Appuie sur « Retour » pour annuler</string>
 
 
+    <!-- Assistant d’installation des addons (mode essentiel) -->
+    <string name="essential_addon_setup_title">Installer un addon</string>
+    <string name="essential_addon_setup_subtitle">Installe un addon pour commencer à diffuser. Tu pourras en ajouter d’autres plus tard depuis Addons.</string>
+    <string name="essential_addon_show_qr">Afficher le QR</string>
+    <!-- Repli éditeur de collection -->
+    <string name="collection_editor_no_trakt_lists_found">Aucune liste Trakt trouvée</string>
+    <string name="collection_editor_untitled_folder">Sans titre</string>
+    <string name="collection_editor_untitled_collection">Collection sans titre</string>
     <!-- AddonManagerScreen -->
     <string name="addon_title">Addons</string>
     <string name="addon_readonly_notice">Utilise les addons du profil principal et ne peut pas être modifié</string>
@@ -1922,4 +1930,174 @@
     <string name="settings_experience_subtitle">Essentiel ou avancé</string>
     <string name="profile_custom_avatar_web_panel_note">Les URL d’avatar personnalisé peuvent être configurées depuis le panneau web Nuvio.</string>
     <string name="tv_channel_continue_watching">Continuer à regarder</string>
+
+    <!-- Repli titre catalogue voir tout -->
+    <string name="catalog_see_all_title_fallback">Catalogue</string>
+
+    <!-- Éditeur de collection : catégories d’emoji -->
+    <string name="collections_editor_emoji_category_streaming">Streaming</string>
+    <string name="collections_editor_emoji_category_genres">Genres</string>
+    <string name="collections_editor_emoji_category_sports">Sports</string>
+    <string name="collections_editor_emoji_category_music">Musique</string>
+    <string name="collections_editor_emoji_category_nature">Nature</string>
+    <string name="collections_editor_emoji_category_animals">Animaux</string>
+    <string name="collections_editor_emoji_category_food">Cuisine</string>
+    <string name="collections_editor_emoji_category_travel">Voyage</string>
+    <string name="collections_editor_emoji_category_people">Personnes</string>
+    <string name="collections_editor_emoji_category_objects">Objets</string>
+    <string name="collections_editor_emoji_category_flags">Drapeaux</string>
+    <string name="collections_editor_emoji_category_symbols">Symboles</string>
+    <!-- Éditeur de collection : exemples de placeholder + genres TMDB -->
+    <string name="collections_editor_tmdb_network_placeholder_example">213 pour Netflix, 49 pour HBO, 2739 pour Disney+</string>
+    <string name="collections_editor_tmdb_collection_placeholder_example">10 pour la collection Star Wars</string>
+    <string name="collections_editor_tmdb_company_placeholder_example">Marvel Studios, 420, ou URL d’une société</string>
+    <string name="collections_editor_tmdb_genre_action">Action</string>
+    <string name="collections_editor_tmdb_genre_adventure">Aventure</string>
+    <string name="collections_editor_tmdb_genre_animation">Animation</string>
+    <string name="collections_editor_tmdb_genre_comedy">Comédie</string>
+    <string name="collections_editor_tmdb_genre_horror">Horreur</string>
+    <string name="collections_editor_tmdb_genre_scifi">Science-fiction</string>
+    <string name="collections_editor_tmdb_genre_drama">Drame</string>
+    <string name="collections_editor_tmdb_genre_crime">Policier</string>
+    <string name="collections_editor_tmdb_genre_reality">Téléréalité</string>
+    <!-- Préréglages regex de lecture automatique -->
+    <string name="autoplay_regex_preset_any_1080p_plus">1080p ou supérieur</string>
+    <string name="autoplay_regex_preset_4k_remux">4K / Remux</string>
+    <string name="autoplay_regex_preset_1080p_standard">1080p standard</string>
+    <string name="autoplay_regex_preset_720p_smaller">720p ou inférieur</string>
+    <string name="autoplay_regex_preset_web_sources">Sources WEB</string>
+    <string name="autoplay_regex_preset_bluray_quality">Qualité BluRay</string>
+    <string name="autoplay_regex_preset_hevc_x265">HEVC / x265</string>
+    <string name="autoplay_regex_preset_avc_x264">AVC / x264</string>
+    <string name="autoplay_regex_preset_hdr_dolby_vision">HDR / Dolby Vision</string>
+    <string name="autoplay_regex_preset_dolby_atmos_dts">Dolby Atmos / DTS</string>
+    <string name="autoplay_regex_preset_english">Anglais</string>
+    <string name="autoplay_regex_preset_no_cam_ts">Sans CAM/TS</string>
+    <string name="autoplay_regex_preset_no_remux_hdr">Sans REMUX/HDR</string>
+
+    <!-- Sections paramètres lecture -->
+    <string name="playback_player_internal_desc">Utiliser le lecteur intégré de NuvioTV</string>
+
+    <!-- Lecteur : torrent + pistes -->
+    <string name="player_torrent_peer_info">%1$d sources · %2$d pairs</string>
+    <string name="player_torrent_buffered_status">%1$s en mémoire tampon · %2$s · %3$s</string>
+    <string name="player_torrent_status">%1$s · %2$s</string>
+    <string name="player_torrent_stats">%1$d pairs · %2$d sources · %3$d&#160;%%</string>
+    <string name="player_torrent_connecting_peers">Connexion aux pairs…</string>
+    <string name="player_track_audio_fallback">Audio %1$d</string>
+    <string name="player_track_subtitle_fallback">Sous-titres %1$d</string>
+
+    <!-- Lecteur : récupération d’erreur -->
+    <string name="player_error_stream_blocked">\n\nLa source du flux est bloquée ou restreinte. Essaie une autre source.</string>
+    <string name="player_error_stream_removed">\n\nLe lien du flux a expiré ou a été supprimé. Essaie une autre source.</string>
+    <string name="player_error_stream_expired">\n\nLe lien du flux a expiré. Essaie une autre source.</string>
+    <string name="player_error_stream_rate_limited">\n\nTrop de requêtes vers la source du flux. Patiente un instant et réessaie.</string>
+    <string name="player_error_stream_unavailable">\n\nLe serveur du flux est actuellement indisponible. Essaie une autre source.</string>
+    <string name="player_error_source_invalid_content">Erreur de source&#160;: la source du flux a renvoyé du contenu invalide ou non lisible. Le lien a peut-être expiré ou le serveur a renvoyé une page d’erreur au lieu de la vidéo.\n\nEssaie une autre source. [%1$s]</string>
+    <string name="player_error_decoder">Erreur de décodeur</string>
+    <string name="player_error_unsupported_format">Ce flux utilise un format que ton appareil ne prend peut-être pas en charge. Essaie une autre source. [%1$s]</string>
+    <string name="player_error_initialize_failed">Échec de l’initialisation du lecteur</string>
+    <string name="player_error_mpv_surface_failed">Échec de l’initialisation de la surface libmpv</string>
+    <string name="player_error_mpv_playback_failed">Échec de l’initialisation de la lecture libmpv</string>
+    <string name="player_error_torrent">Erreur de torrent&#160;: %1$s</string>
+    <string name="player_error_playback_fallback">Erreur de lecture</string>
+    <!-- Sous-titres : récupération horloge -->
+    <string name="subtitle_timing_file_no_lines">Aucune ligne de sous-titre trouvée dans ce fichier.</string>
+    <string name="subtitle_timing_load_lines_failed">Échec du chargement des lignes de sous-titres.</string>
+    <string name="subtitle_download_failed_http">Échec du téléchargement des sous-titres (HTTP %1$d)</string>
+    <string name="subtitle_download_empty_content">Le téléchargement des sous-titres a retourné un contenu vide.</string>
+
+    <!-- Erreurs d’import de collection -->
+    <string name="collections_import_error_empty_input">Entrée vide</string>
+    <string name="collections_import_error_expected_array">Format invalide&#160;: tableau attendu</string>
+    <string name="collections_import_error_empty_array">Tableau vide&#160;: aucune collection trouvée</string>
+    <string name="collections_import_error_missing_id">Collection %1$d&#160;: \"id\" manquant ou invalide</string>
+    <string name="collections_import_error_missing_title">Collection \"%1$s\"&#160;: \"title\" manquant ou invalide</string>
+    <string name="collections_import_error_folders_array">Collection \"%1$s\"&#160;: \"folders\" doit être un tableau</string>
+    <string name="collections_import_error_folder_invalid">Collection \"%1$s\", dossier %2$d&#160;: format invalide</string>
+    <string name="collections_import_error_folder_missing_id">Collection \"%1$s\", dossier %2$d&#160;: \"id\" manquant</string>
+    <string name="collections_import_error_folder_missing_title">Collection \"%1$s\", dossier \"%2$s\"&#160;: \"title\" manquant</string>
+    <string name="collections_import_error_sources_array">Collection \"%1$s\", dossier \"%2$s\"&#160;: \"sources\" doit être un tableau</string>
+    <string name="collections_import_error_invalid_tile_shape">Collection \"%1$s\", dossier \"%2$s\"&#160;: tileShape \"%3$s\" invalide</string>
+    <string name="collections_import_error_source_invalid">Collection \"%1$s\", dossier \"%2$s\", source %3$d&#160;: format invalide</string>
+    <string name="collections_import_error_source_required_fields">Collection \"%1$s\", dossier \"%2$s\", source %3$d&#160;: champs requis manquants</string>
+    <string name="collections_import_error_missing_tmdb_type">Collection \"%1$s\", dossier \"%2$s\", source %3$d&#160;: type de source TMDB manquant</string>
+    <string name="collections_import_error_missing_trakt_list_id">Collection \"%1$s\", dossier \"%2$s\", source %3$d&#160;: ID de liste Trakt manquant</string>
+    <string name="collections_import_error_json_parse">Erreur d’analyse JSON&#160;: %1$s</string>
+
+    <!-- Messages bibliothèque -->
+    <string name="library_synced">Bibliothèque synchronisée</string>
+    <string name="library_error_refresh_failed">Échec de l’actualisation de la bibliothèque</string>
+    <string name="library_list_created">Liste créée</string>
+    <string name="library_error_invalid_list">Liste invalide</string>
+    <string name="library_list_updated">Liste mise à jour</string>
+    <string name="library_error_save_list_failed">Échec de l’enregistrement de la liste</string>
+    <string name="library_list_deleted">Liste supprimée</string>
+    <string name="library_error_delete_list_failed">Échec de la suppression de la liste</string>
+    <string name="library_list_order_updated">Ordre des listes mis à jour</string>
+    <string name="library_error_reorder_lists_failed">Échec du réordonnancement des listes</string>
+    <string name="library_list_fallback_title">Liste</string>
+    <!-- Étiquettes de confidentialité bibliothèque (mappage depuis la valeur API) -->
+    <string name="library_privacy_private">Privée</string>
+    <string name="library_privacy_link">Lien</string>
+    <string name="library_privacy_friends">Amis</string>
+    <string name="library_privacy_public">Publique</string>
+
+    <!-- Erreurs Trakt -->
+    <string name="trakt_error_auth_required">Authentification Trakt requise</string>
+    <string name="trakt_library_error_request_failed">Échec de la requête Trakt</string>
+    <string name="trakt_library_error_create_list_failed">Échec de la création de la liste</string>
+    <string name="trakt_library_error_update_list_failed">Échec de la mise à jour de la liste</string>
+    <string name="trakt_library_error_delete_list_failed">Échec de la suppression de la liste</string>
+    <string name="trakt_library_error_reorder_lists_failed">Échec du réordonnancement des listes</string>
+    <string name="trakt_library_error_fetch_watchlist_movies">Échec de la récupération des films de la watchlist</string>
+    <string name="trakt_library_error_fetch_watchlist_shows">Échec de la récupération des séries de la watchlist</string>
+    <string name="trakt_library_error_fetch_personal_lists">Échec de la récupération des listes personnelles</string>
+    <string name="trakt_library_error_add_watchlist_failed">Échec de l’ajout à la watchlist</string>
+    <string name="trakt_library_error_remove_watchlist_failed">Échec du retrait de la watchlist</string>
+    <string name="trakt_library_error_add_to_list_failed">Échec de l’ajout à la liste</string>
+    <string name="trakt_library_error_remove_from_list_failed">Échec du retrait de la liste</string>
+    <string name="trakt_library_error_missing_compatible_ids">Identifiants compatibles manquants pour l’opération de liste Trakt</string>
+    <string name="trakt_library_error_auth_expired">Authentification Trakt expirée</string>
+    <string name="trakt_library_error_list_not_found">Liste Trakt introuvable</string>
+    <string name="trakt_library_error_list_limit_reached">Limite de listes Trakt atteinte. Mise à niveau requise.</string>
+    <string name="trakt_error_insufficient_ids_mark_watched">Identifiants Trakt insuffisants pour marquer comme vu</string>
+    <string name="trakt_error_request_failed">Échec de la requête Trakt</string>
+    <string name="trakt_error_mark_watched_failed">Échec du marquage comme vu sur Trakt (%1$d)</string>
+
+    <!-- Erreurs détails / poster options -->
+    <string name="detail_error_update_library_failed">Échec de la mise à jour de la bibliothèque</string>
+    <string name="detail_error_load_lists_failed">Échec du chargement des listes</string>
+    <string name="detail_error_update_lists_failed">Échec de la mise à jour des listes</string>
+    <string name="detail_error_update_watched_failed">Échec de la mise à jour du statut vu</string>
+    <string name="detail_error_update_episode_watched_failed">Échec de la mise à jour du statut vu de l’épisode</string>
+    <string name="poster_options_error_load_lists_failed">Échec du chargement des listes</string>
+    <string name="poster_options_error_update_lists_failed">Échec de la mise à jour des listes</string>
+
+    <!-- Erreurs de recherche -->
+    <string name="search_error_load_addons_failed">Échec du chargement des addons</string>
+    <string name="search_error_failed">Échec de la recherche</string>
+
+    <!-- Replis flux / TMDB / addons -->
+    <string name="stream_unknown">Flux inconnu</string>
+    <string name="stream_embedded_group">Flux intégrés</string>
+    <string name="stream_embedded_fallback_name">Flux intégré</string>
+    <string name="stream_quality_unknown">Inconnu</string>
+    <string name="stream_addon_unknown">Inconnu</string>
+    <string name="tmdb_unknown_entity">Inconnu</string>
+    <string name="web_tmdb_company_fallback">Société TMDB %1$d</string>
+    <string name="web_tmdb_collection_fallback">Collection TMDB %1$d</string>
+    <string name="web_error_invalid_request_body">Corps de requête invalide</string>
+
+    <!-- Repli langue préférée des sous-titres -->
+    <string name="language_english">Anglais</string>
+
+    <!-- Erreurs supporters / contributeurs / sponsors -->
+    <string name="supporters_error_load">Impossible de charger les supporters.</string>
+    <string name="contributors_error_load">Impossible de charger les contributeurs.</string>
+    <string name="sponsors_error_load">Impossible de charger les sponsors.</string>
+    <string name="contributors_error_api_not_configured">L’API contributeurs n’est pas configurée.</string>
+    <string name="contributors_error_api_http">Erreur API contributeurs&#160;: %1$d</string>
+    <string name="supporters_error_api_http">Erreur API dons&#160;: %1$d</string>
+    <string name="sponsors_error_api_http">Erreur API sponsors&#160;: %1$d</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -985,6 +985,14 @@
     <string name="profile_pin_overlay_back_hint">Press back to cancel</string>
 
 
+    <!-- Essential addon setup wizard -->
+    <string name="essential_addon_setup_title">Set up add-ons</string>
+    <string name="essential_addon_setup_subtitle">Install one add-on to start streaming. You can add more later from Addons.</string>
+    <string name="essential_addon_show_qr">Show QR</string>
+    <!-- Collection editor fallbacks -->
+    <string name="collection_editor_no_trakt_lists_found">No Trakt lists found</string>
+    <string name="collection_editor_untitled_folder">Untitled</string>
+    <string name="collection_editor_untitled_collection">Untitled Collection</string>
     <!-- AddonManagerScreen -->
     <string name="addon_title">Addons</string>
     <string name="addon_readonly_notice">Using primary profile\'s addons and can\'t be changed</string>
@@ -1919,5 +1927,175 @@
     <string name="cast_error_load_details_for">Could not load details for %1$s</string>
     <string name="tmdb_entity_error_load_named">Could not load %1$s</string>
     <string name="tmdb_entity_error_load">Could not load TMDB entity</string>
+
+    <!-- Catalog see-all fallback -->
+    <string name="catalog_see_all_title_fallback">Catalog</string>
+
+    <!-- Collection editor: emoji categories -->
+    <string name="collections_editor_emoji_category_streaming">Streaming</string>
+    <string name="collections_editor_emoji_category_genres">Genres</string>
+    <string name="collections_editor_emoji_category_sports">Sports</string>
+    <string name="collections_editor_emoji_category_music">Music</string>
+    <string name="collections_editor_emoji_category_nature">Nature</string>
+    <string name="collections_editor_emoji_category_animals">Animals</string>
+    <string name="collections_editor_emoji_category_food">Food</string>
+    <string name="collections_editor_emoji_category_travel">Travel</string>
+    <string name="collections_editor_emoji_category_people">People</string>
+    <string name="collections_editor_emoji_category_objects">Objects</string>
+    <string name="collections_editor_emoji_category_flags">Flags</string>
+    <string name="collections_editor_emoji_category_symbols">Symbols</string>
+    <!-- Collection editor: TMDB picker placeholders + genres -->
+    <string name="collections_editor_tmdb_network_placeholder_example">213 for Netflix, 49 for HBO, 2739 for Disney+</string>
+    <string name="collections_editor_tmdb_collection_placeholder_example">10 for Star Wars Collection</string>
+    <string name="collections_editor_tmdb_company_placeholder_example">Marvel Studios, 420, or company URL</string>
+    <string name="collections_editor_tmdb_genre_action">Action</string>
+    <string name="collections_editor_tmdb_genre_adventure">Adventure</string>
+    <string name="collections_editor_tmdb_genre_animation">Animation</string>
+    <string name="collections_editor_tmdb_genre_comedy">Comedy</string>
+    <string name="collections_editor_tmdb_genre_horror">Horror</string>
+    <string name="collections_editor_tmdb_genre_scifi">Sci-Fi</string>
+    <string name="collections_editor_tmdb_genre_drama">Drama</string>
+    <string name="collections_editor_tmdb_genre_crime">Crime</string>
+    <string name="collections_editor_tmdb_genre_reality">Reality</string>
+    <!-- Auto-play regex presets -->
+    <string name="autoplay_regex_preset_any_1080p_plus">Any 1080p+</string>
+    <string name="autoplay_regex_preset_4k_remux">4K / Remux</string>
+    <string name="autoplay_regex_preset_1080p_standard">1080p Standard</string>
+    <string name="autoplay_regex_preset_720p_smaller">720p / Smaller</string>
+    <string name="autoplay_regex_preset_web_sources">WEB Sources</string>
+    <string name="autoplay_regex_preset_bluray_quality">BluRay Quality</string>
+    <string name="autoplay_regex_preset_hevc_x265">HEVC / x265</string>
+    <string name="autoplay_regex_preset_avc_x264">AVC / x264</string>
+    <string name="autoplay_regex_preset_hdr_dolby_vision">HDR / Dolby Vision</string>
+    <string name="autoplay_regex_preset_dolby_atmos_dts">Dolby Atmos / DTS</string>
+    <string name="autoplay_regex_preset_english">English</string>
+    <string name="autoplay_regex_preset_no_cam_ts">No CAM/TS</string>
+    <string name="autoplay_regex_preset_no_remux_hdr">No REMUX/HDR</string>
+
+    <!-- Playback settings sections -->
+    <string name="playback_player_internal_desc">Use NuvioTV\'s built-in player</string>
+
+    <!-- Player runtime: torrent overlay + tracks -->
+    <string name="player_torrent_peer_info">%1$d seeds · %2$d peers</string>
+    <string name="player_torrent_buffered_status">%1$s buffered · %2$s · %3$s</string>
+    <string name="player_torrent_status">%1$s · %2$s</string>
+    <string name="player_torrent_stats">%1$d peers · %2$d seeds · %3$d%%</string>
+    <string name="player_torrent_connecting_peers">Connecting to peers…</string>
+    <string name="player_track_audio_fallback">Audio %1$d</string>
+    <string name="player_track_subtitle_fallback">Subtitle %1$d</string>
+
+    <!-- Player runtime: error recovery -->
+    <string name="player_error_stream_blocked">\n\nThe stream source is blocked or restricted. Try a different source.</string>
+    <string name="player_error_stream_removed">\n\nThe stream link has expired or been removed. Try a different source.</string>
+    <string name="player_error_stream_expired">\n\nThe stream link has expired. Try a different source.</string>
+    <string name="player_error_stream_rate_limited">\n\nToo many requests to the stream source. Wait a moment and try again.</string>
+    <string name="player_error_stream_unavailable">\n\nThe stream server is currently unavailable. Try a different source.</string>
+    <string name="player_error_source_invalid_content">Source error: The stream source returned invalid or unplayable content. The link may have expired or the server returned an error page instead of video.\n\nTry a different source. [%1$s]</string>
+    <string name="player_error_decoder">Decoder error</string>
+    <string name="player_error_unsupported_format">This stream uses a format your device may not support. Try a different source. [%1$s]</string>
+    <string name="player_error_initialize_failed">Failed to initialize player</string>
+    <string name="player_error_mpv_surface_failed">Failed to initialize libmpv surface</string>
+    <string name="player_error_mpv_playback_failed">Failed to initialize libmpv playback</string>
+    <string name="player_error_torrent">Torrent error: %1$s</string>
+    <string name="player_error_playback_fallback">Playback error</string>
+    <!-- Subtitle timing recovery -->
+    <string name="subtitle_timing_file_no_lines">No subtitle lines were found in this file.</string>
+    <string name="subtitle_timing_load_lines_failed">Failed to load subtitle lines.</string>
+    <string name="subtitle_download_failed_http">Subtitle download failed (HTTP %1$d)</string>
+    <string name="subtitle_download_empty_content">Subtitle download returned empty content.</string>
+
+    <!-- Collection import errors -->
+    <string name="collections_import_error_empty_input">Empty input</string>
+    <string name="collections_import_error_expected_array">Invalid format: expected an array</string>
+    <string name="collections_import_error_empty_array">Empty array: no collections found</string>
+    <string name="collections_import_error_missing_id">Collection %1$d: missing or invalid \"id\"</string>
+    <string name="collections_import_error_missing_title">Collection \"%1$s\": missing or invalid \"title\"</string>
+    <string name="collections_import_error_folders_array">Collection \"%1$s\": \"folders\" must be an array</string>
+    <string name="collections_import_error_folder_invalid">Collection \"%1$s\", folder %2$d: invalid format</string>
+    <string name="collections_import_error_folder_missing_id">Collection \"%1$s\", folder %2$d: missing \"id\"</string>
+    <string name="collections_import_error_folder_missing_title">Collection \"%1$s\", folder \"%2$s\": missing \"title\"</string>
+    <string name="collections_import_error_sources_array">Collection \"%1$s\", folder \"%2$s\": \"sources\" must be an array</string>
+    <string name="collections_import_error_invalid_tile_shape">Collection \"%1$s\", folder \"%2$s\": invalid tileShape \"%3$s\"</string>
+    <string name="collections_import_error_source_invalid">Collection \"%1$s\", folder \"%2$s\", source %3$d: invalid format</string>
+    <string name="collections_import_error_source_required_fields">Collection \"%1$s\", folder \"%2$s\", source %3$d: missing required fields</string>
+    <string name="collections_import_error_missing_tmdb_type">Collection \"%1$s\", folder \"%2$s\", source %3$d: missing TMDB source type</string>
+    <string name="collections_import_error_missing_trakt_list_id">Collection \"%1$s\", folder \"%2$s\", source %3$d: missing Trakt list ID</string>
+    <string name="collections_import_error_json_parse">JSON parse error: %1$s</string>
+
+    <!-- Library messages -->
+    <string name="library_synced">Library synced</string>
+    <string name="library_error_refresh_failed">Failed to refresh library</string>
+    <string name="library_list_created">List created</string>
+    <string name="library_error_invalid_list">Invalid list</string>
+    <string name="library_list_updated">List updated</string>
+    <string name="library_error_save_list_failed">Failed to save list</string>
+    <string name="library_list_deleted">List deleted</string>
+    <string name="library_error_delete_list_failed">Failed to delete list</string>
+    <string name="library_list_order_updated">List order updated</string>
+    <string name="library_error_reorder_lists_failed">Failed to reorder lists</string>
+    <string name="library_list_fallback_title">List</string>
+    <!-- Library privacy display labels (mapped from API value, not used as a key) -->
+    <string name="library_privacy_private">Private</string>
+    <string name="library_privacy_link">Link</string>
+    <string name="library_privacy_friends">Friends</string>
+    <string name="library_privacy_public">Public</string>
+
+    <!-- Trakt errors -->
+    <string name="trakt_error_auth_required">Trakt authentication required</string>
+    <string name="trakt_library_error_request_failed">Trakt request failed</string>
+    <string name="trakt_library_error_create_list_failed">Failed to create list</string>
+    <string name="trakt_library_error_update_list_failed">Failed to update list</string>
+    <string name="trakt_library_error_delete_list_failed">Failed to delete list</string>
+    <string name="trakt_library_error_reorder_lists_failed">Failed to reorder lists</string>
+    <string name="trakt_library_error_fetch_watchlist_movies">Failed to fetch watchlist movies</string>
+    <string name="trakt_library_error_fetch_watchlist_shows">Failed to fetch watchlist shows</string>
+    <string name="trakt_library_error_fetch_personal_lists">Failed to fetch personal lists</string>
+    <string name="trakt_library_error_add_watchlist_failed">Failed to add to watchlist</string>
+    <string name="trakt_library_error_remove_watchlist_failed">Failed to remove from watchlist</string>
+    <string name="trakt_library_error_add_to_list_failed">Failed to add to list</string>
+    <string name="trakt_library_error_remove_from_list_failed">Failed to remove from list</string>
+    <string name="trakt_library_error_missing_compatible_ids">Missing compatible IDs for Trakt list operation</string>
+    <string name="trakt_library_error_auth_expired">Trakt authentication expired</string>
+    <string name="trakt_library_error_list_not_found">Trakt list not found</string>
+    <string name="trakt_library_error_list_limit_reached">Trakt list limit reached. Upgrade required.</string>
+    <string name="trakt_error_insufficient_ids_mark_watched">Insufficient Trakt IDs to mark watched</string>
+    <string name="trakt_error_request_failed">Trakt request failed</string>
+    <string name="trakt_error_mark_watched_failed">Failed to mark watched on Trakt (%1$d)</string>
+
+    <!-- Detail / poster options errors -->
+    <string name="detail_error_update_library_failed">Failed to update library</string>
+    <string name="detail_error_load_lists_failed">Failed to load lists</string>
+    <string name="detail_error_update_lists_failed">Failed to update lists</string>
+    <string name="detail_error_update_watched_failed">Failed to update watched status</string>
+    <string name="detail_error_update_episode_watched_failed">Failed to update episode watched status</string>
+    <string name="poster_options_error_load_lists_failed">Failed to load lists</string>
+    <string name="poster_options_error_update_lists_failed">Failed to update lists</string>
+
+    <!-- Search errors -->
+    <string name="search_error_load_addons_failed">Failed to load addons</string>
+    <string name="search_error_failed">Search failed</string>
+
+    <!-- Stream / TMDB / addons fallbacks -->
+    <string name="stream_unknown">Unknown Stream</string>
+    <string name="stream_embedded_group">Embedded Streams</string>
+    <string name="stream_embedded_fallback_name">Embed Stream</string>
+    <string name="stream_quality_unknown">Unknown</string>
+    <string name="stream_addon_unknown">Unknown</string>
+    <string name="tmdb_unknown_entity">Unknown</string>
+    <string name="web_tmdb_company_fallback">TMDB Company %1$d</string>
+    <string name="web_tmdb_collection_fallback">TMDB Collection %1$d</string>
+    <string name="web_error_invalid_request_body">Invalid request body</string>
+
+    <!-- Subtitle preferred language fallback -->
+    <string name="language_english">English</string>
+
+    <!-- Supporters / contributors / sponsors errors -->
+    <string name="supporters_error_load">Unable to load supporters.</string>
+    <string name="contributors_error_load">Unable to load contributors.</string>
+    <string name="sponsors_error_load">Unable to load sponsors.</string>
+    <string name="contributors_error_api_not_configured">Contributors API is not configured.</string>
+    <string name="contributors_error_api_http">Contributors API error: %1$d</string>
+    <string name="supporters_error_api_http">Donations API error: %1$d</string>
+    <string name="sponsors_error_api_http">Sponsors API error: %1$d</string>
 
 </resources>


### PR DESCRIPTION
## Summary

Second round of i18n cleanup after #1783. Adds ~150 new EN + FR string resources and replaces hardcoded English literals with `stringResource` / `context.getString` lookups across every surface that bled through to French builds: onboarding wizard, settings screens, ViewModels (errors / status messages), the player runtime (error recovery, subtitle timing, torrent overlay, track fallbacks), data import / Trakt library, sync errors, Supabase / Trakt / GitHub repositories, and the embedded web-config server.

Where a viewmodel or repository didn't already have one, the appropriate `@ApplicationContext private val appContext: Context` is injected via Hilt. The two `Throwable.toDisplayMessage(...)` extensions in `PlayerRuntimeControllerErrorRecovery` now take a `Context` so the runtime errors land in the right locale; their existing call sites in `Initialization` / `Observers` were updated accordingly.

Some strings that *look* English-only were intentionally left alone because they are sentinel/identifier values used in equality / set-membership / API payloads — translating them would silently break filtering / matching logic. Those are listed under \"Deliberately skipped\" below.

## PR type

- Bug fix

## Why

A walk-through of the app on a French-locale device surfaced a long tail of buttons, dialogs, error toasts and inline status strings still in English. Codex was used to generate a triaged hardcoded-strings audit; this PR works through the actionable items in that report (excluding the ones already handled by #1783).

## What

Onboarding / Settings (Compose):
- `EssentialAddonSetupScreen`: \"Set up add-ons\", subtitle, \"Show QR\".
- `CatalogSeeAllScreen`: \"Catalog\" fallback title.
- `CollectionEditorScreen`: tile-shape suffix uses the existing `collections_editor_shape_*` keys via a `PosterShape` `when`.
- `CollectionEditorGenreEmojiPickers`: 12 emoji-category headers via a `String -> @StringRes` mapping at render time (the `linkedMapOf` keys stay as internal identifiers).
- `CollectionEditorTmdbPicker`: 3 example placeholders and 9 TMDB-genre quick chips (function turned `@Composable` to call `stringResource`).
- `PlaybackAutoPlaySettings`: the 13 regex preset labels read via `stringResource` and folded into a single keyed `remember`.
- `PlaybackSettingsSections`: \"Use NuvioTV's built-in player\".
- `PlaybackSubtitleSettings`: \"English\" fallback for subtitle language.

ViewModels / state errors:
- `CollectionEditorViewModel` (\"No Trakt lists found\" / \"Untitled\" / \"Untitled Collection\")
- `LibraryViewModel` (refresh / list create / update / delete / reorder messages + \"Unknown\")
- `MetaDetailsViewModel` (5 library / lists / watched errors)
- `PosterOptionsController` (2 list-picker errors)
- `SearchViewModel` + `SearchScreen` (\"Failed to load addons\", \"Search failed\")
- `AddonManagerViewModel` (\"TMDB Company \$id\" / \"TMDB Collection \$id\" fallbacks)
- `SupportersContributorsViewModel` (3 \"Unable to load …\" messages)

Player runtime:
- `PlayerRuntimeControllerErrorRecovery`: 5 HTTP-code provider hints + unrecognized-format / decoder messages routed through `Context`. Both `toDisplayMessage` extensions now take a `Context`; existing call sites in `Initialization` / `Observers` updated.
- `PlayerRuntimeControllerMpv`: surface + playback init failures.
- `PlayerRuntimeControllerInitialization`: bare \"Failed to initialize player\" fallback.
- `PlayerRuntimeControllerSubtitleTiming`: 4 subtitle download / load errors.
- `PlayerRuntimeControllerTorrent`: \"Connecting to peers…\", the 3 buffered/status formats, \"Torrent error: …\".
- `PlayerRuntimeControllerTracks` + `NuvioMpvSurfaceView`: \"Audio N\" / \"Subtitle N\" fallback names.
- `TorrentOverlay`: \"%d peers · %d seeds · %d%%\" overlay line.

Data + repositories (Context injected where needed):
- `CollectionsDataStore.validateCollectionsJson`: all 16 import-error messages.
- `TraktLibraryService`: 17 messages (request failed, list CRUD, watchlist + personal-list fetch, watchlist add/remove, list add/remove, missing compatible IDs, `errorMessageForCode` mapping for 401/403/404/420).
- `TraktProgressService`: 3 mark-watched messages.
- `LibraryRepositoryImpl`: \"Trakt authentication required\".
- `GitHubContributorsRepository` / `SupportersRepository` / `SponsorsRepository`: API not-configured + HTTP error formats.

Web config server:
- `AddonConfigServer` / `RepositoryConfigServer`: \"Invalid request body\" served as JSON to the embedded web UI now reads from resources.

### Deliberately skipped (sentinel values, not display strings)

- `\"Director\"` / `\"Writer\"` in `MetaMapper` + `TmdbMetadataService` — matched by `character.equals(..., ignoreCase = true)` inside `CastSection`, which is the layer that maps the role key to a localized `R.string.cast_role_director` / `cast_role_writer`. Translating them would stop the role detection.
- `\"Embedded Streams\"` / `\"Embed Stream\"` / `\"Unknown Stream\"` in `StreamScreenViewModel`, `Stream.kt`, `MetaMapper` — used as `addonName` identity for stream filter chips and `selectedAddonFilter` equality.
- `\"POSTER\"` / `\"LANDSCAPE\"` / `\"SQUARE\"` / `\"poster\"` / `\"wide\"` / `\"square\"` in `CollectionsDataStore.validShapes` — strict set membership for tileShape parsing.
- `\"private\"` / `\"link\"` / `\"friends\"` / `\"public\"` in `LibraryScreen` — `apiValue` passed verbatim to the Trakt API; localized display labels added under `library_privacy_*` so a future display layer can consume them.
- `\"Unknown\"` inside `TmdbMetadataService` entity headers — fallback in a non-Hilt singleton service that doesn't carry a `Context`; would require coupling the service to Android `Context` for a rare empty-name TMDB response.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — translation / i18n bug fix. The diff is large because it is broad-but-shallow (one literal replaced per spot), and every change is mechanical.

## Testing

- Built and ran on Android TV (Ugoos AM6B+). Walked through:
  - Experience-mode wizard (new flows from #1783) — already French.
  - **This PR added**: Essential addon setup wizard, the Catalog see-all screen, the collection editor (folder list with tile-shape labels, emoji picker, TMDB picker placeholders + genre chips), the playback auto-play preset list, the playback player-preference dialog, the subtitle-language settings.
  - Library tab error / status messages by triggering refresh / list create / delete / reorder; deliberately failed a few requests.
  - Player error overlays — forced HTTP 403 / 404 / 410 / 429 / 503 against a stream proxy, MPV init errors, decoder fallback, subtitle download failure (bad URL).
  - Web config server — submitted an invalid JSON body, observed the localized error.
- Verified by greppage that no other previously-listed surface still has the matching literal hardcoded.
- French strings follow the existing `values-fr/strings.xml` typographic conventions: typographic apostrophe `’`, `&#160;` (NBSP) before `:` / `?` / `!`, tutoiement.

## Screenshots / Video (UI changes only)

N/A — text content only, no markup or layout change.

## Breaking changes

- Public API surface change: `PlaybackException.toDisplayMessage()` and `Throwable.toDisplayMessage(fallback)` now require a `Context` parameter. Both functions are `internal` and only called from the player runtime files in the same module; all call sites are updated in this PR.

## Linked issues

None — internal report.