### PR TITLE
fix(i18n): localize Trakt related/comments/list-items error fallbacks

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktCommentsService.kt
@@ -138,7 +138,7 @@ class TraktCommentsService @Inject constructor(
                     limit = COMMENTS_LIMIT
                 )
             }
-        } ?: throw IllegalStateException("Trakt comments request failed")
+        } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_comments_error_request_failed))
 
         val comments = when {
             response.code() == 404 -> emptyList()

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -626,7 +626,7 @@ class TraktLibraryService @Inject constructor(
                     sortBy = sortBy?.takeIf { it.isNotBlank() },
                     sortHow = sortHow?.takeIf { it.isNotBlank() }
                 )
-            } ?: throw IllegalStateException("Failed to fetch list items")
+            } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_fetch_list_items))
         }
         return items.mapNotNull { mapListItem(listKey = listKey, item = it) }
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktRelatedService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktRelatedService.kt
@@ -32,6 +32,7 @@ internal data class ResolvedRelatedTarget(
 
 @Singleton
 class TraktRelatedService @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService
 ) {
@@ -73,7 +74,7 @@ class TraktRelatedService @Inject constructor(
                         id = target.pathId,
                         limit = RELATED_LIMIT
                     )
-                } ?: throw IllegalStateException("Trakt related request failed")
+                } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_related_error_request_failed))
 
                 when {
                     response.code() == 404 -> emptyList()
@@ -95,7 +96,7 @@ class TraktRelatedService @Inject constructor(
                         id = target.pathId,
                         limit = RELATED_LIMIT
                     )
-                } ?: throw IllegalStateException("Trakt related request failed")
+                } ?: throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_related_error_request_failed))
 
                 when {
                     response.code() == 404 -> emptyList()

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2221,4 +2221,9 @@
     <!-- Sélection de profil&#160;: messages overlay PIN -->
     <string name="profile_pin_saved_for_profile">PIN enregistré pour %1$s.</string>
     <string name="profile_pin_lock_removed_for_profile">Verrouillage PIN supprimé pour %1$s.</string>
+
+    <!-- Trakt&#160;: replis erreur Related / commentaires / éléments de liste -->
+    <string name="trakt_related_error_request_failed">Échec du chargement des contenus similaires Trakt</string>
+    <string name="trakt_comments_error_request_failed">Échec de la requête de commentaires Trakt</string>
+    <string name="trakt_library_error_fetch_list_items">Échec de la récupération des éléments de la liste</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2264,4 +2264,9 @@
     <string name="profile_pin_saved_for_profile">PIN saved for %1$s.</string>
     <string name="profile_pin_lock_removed_for_profile">PIN lock removed for %1$s.</string>
 
+    <!-- Trakt: Related / comments / list items error fallbacks -->
+    <string name="trakt_related_error_request_failed">Trakt related request failed</string>
+    <string name="trakt_comments_error_request_failed">Trakt comments request failed</string>
+    <string name="trakt_library_error_fetch_list_items">Failed to fetch list items</string>
+
 </resources>


### PR DESCRIPTION
## Summary

Catches three remaining hardcoded English fallbacks that the previous i18n pass (#1786) missed:

- `TraktRelatedService` — \"Trakt related request failed\" (×2)
- `TraktCommentsService` — \"Trakt comments request failed\"
- `TraktLibraryService:629` — \"Failed to fetch list items\" (was shadowed by the larger `errorMessageForCode` block in #1786)

Each service now takes an `@ApplicationContext appContext` and the error is resolved through three new resources with French translations.

## PR type

- Bug fix

## Why

Follow-up to #1786. A grep over `throw IllegalStateException(\"...\")` after that PR was merged into the local working copy surfaced these three sites; they sit in service classes that #1786 didn't visit.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — small i18n bug fix, three files touched.

## Testing

- Built and installed on Android TV (Ugoos AM6B+). Forced each error path:
  - `TraktRelatedService` by setting an invalid Trakt token while opening the \"Related\" rail on a movie detail.
  - `TraktCommentsService` similarly while opening the comments tab.
  - `TraktLibraryService` list-items fetch by interrupting the network on a personal list.
- Each toast / error overlay now reads in French.
- French translation reads naturally — no \"Trakt Related\" calque (uses \"contenus similaires Trakt\" instead).

## Screenshots / Video (UI changes only)

N/A — text content only.

## Breaking changes

None. Each service ctor gains a leading `@ApplicationContext` parameter; Hilt injects it for every call site.

## Linked issues

Follows up #1786.