### PR TITLE
Enhance ExoPlayer audio fallback and teardown lifecycle

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -335,6 +335,7 @@ class PlayerRuntimeController(
     internal var isReleasingPlayer: Boolean = false
     internal var cachedDecoderPriority: Int = 1
     internal var hasTriedAudioPcmFallback: Boolean = false
+    internal var pendingAudioPcmFallbackRebuild: Boolean = false
     internal var hasTriedDv7HevcFallback: Boolean = false
     internal var forceDv7ToHevc: Boolean = false
     internal var startupRetryCount: Int = 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -2,7 +2,6 @@ package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
 import androidx.media3.common.PlaybackException
-import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
 import com.nuvio.tv.R
@@ -267,6 +266,7 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
 internal fun PlayerRuntimeController.resetErrorRetryState() {
     startupRetryCount = 0
     errorRetryCount = 0
+    pendingAudioPcmFallbackRebuild = false
     errorRetryJob?.cancel()
     errorRetryJob = null
 }
@@ -294,32 +294,23 @@ internal fun PlayerRuntimeController.tryAudioTrackPcmFallback(
     if (_uiState.value.tunnelingEnabled) return false
 
     hasTriedAudioPcmFallback = true
+    pendingAudioPcmFallbackRebuild = true
 
     val player = _exoPlayer ?: return false
     val savedPosition = player.currentPosition.takeIf { it > 0L } ?: 0L
+    val paused = userPausedManually
 
-    Log.d(
-        PlayerRuntimeController.TAG,
-        "Audio track init failed (5001) — forcing PCM via speed trick, position=${savedPosition}ms"
-    )
-
-    // Show loading overlay with fallback info instead of error screen.
+    Log.d(PlayerRuntimeController.TAG, "Audio track init failed (5001) — rebuilding player with PCM forcing, position=${savedPosition}ms")
     showRecoveryOverlay()
 
-    // An imperceptible speed offset disables audio passthrough and forces
-    // software PCM decoding through the GainAudioProcessor pipeline.
-    val currentSpeed = _uiState.value.playbackSpeed
-    val pcmSpeed = if (currentSpeed == 1f) 1.00001f else currentSpeed
-    player.playbackParameters = PlaybackParameters(pcmSpeed)
-    player.trackSelectionParameters = player.trackSelectionParameters
-        .buildUpon()
-        .build()
-
-    if (savedPosition > 0L) {
-        player.seekTo(savedPosition)
+    errorRetryJob?.cancel()
+    errorRetryJob = scope.launch {
+        releasePlayer(flushPlaybackState = false)
+        if (savedPosition > 0L) {
+            _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
+        }
+        initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
     }
-    player.prepare()
-    player.playWhenReady = !userPausedManually
 
     return true
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -94,9 +94,9 @@ private fun PlayerRuntimeController.disposeExoPlayerBeforeRebuild() {
     _exoPlayer?.let { player ->
         runCatching { player.playWhenReady = false }
         runCatching { player.pause() }
-        runCatching { player.clearVideoSurface() }
-        runCatching { player.clearMediaItems() }
         runCatching { player.stop() }
+        runCatching { player.clearMediaItems() }
+        runCatching { player.clearVideoSurface() }
         runCatching { player.release() }
     }
     _exoPlayer = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -51,6 +51,9 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 private const val STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS = 20_000L
 private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
+private const val AUDIO_DELAY_REFRESH_DEBOUNCE_MS = 120L
+private const val PLAYER_RELEASE_TIMEOUT_MS = 3000L
+private const val PLAYER_REBUILD_SETTLE_DELAY_MS = 120L
 
 internal data class StartupSubtitlePreparation(
     val fetchedSubtitles: List<Subtitle>,
@@ -81,6 +84,25 @@ private suspend fun PlayerRuntimeController.resolveCurrentStreamMimeType(
     )
 }
 
+private fun PlayerRuntimeController.disposeExoPlayerBeforeRebuild() {
+    notifyAudioSessionUpdate(false)
+    try {
+        currentMediaSession?.release()
+        currentMediaSession = null
+    } catch (_: Exception) {
+    }
+    _exoPlayer?.let { player ->
+        runCatching { player.playWhenReady = false }
+        runCatching { player.pause() }
+        runCatching { player.clearVideoSurface() }
+        runCatching { player.clearMediaItems() }
+        runCatching { player.stop() }
+        runCatching { player.release() }
+    }
+    _exoPlayer = null
+    playbackSpeedAwareAudioSink = null
+}
+
 @androidx.annotation.OptIn(UnstableApi::class)
 internal fun PlayerRuntimeController.initializePlayer(
     url: String,
@@ -105,8 +127,13 @@ internal fun PlayerRuntimeController.initializePlayer(
                 userPausedManually = true
                 shouldEnforceAutoplayOnFirstReady = false
             }
-            hasTriedAudioPcmFallback = false
+            val applyPcmFallbackOnStartup = pendingAudioPcmFallbackRebuild
+            val applyDv7FallbackOnStartup = forceDv7ToHevc
+            if (!applyPcmFallbackOnStartup) {
+                hasTriedAudioPcmFallback = false
+            }
             hasTriedDv7HevcFallback = false
+            forceDv7ToHevc = false
             mpvDelayStartAfterAfrSwitch = false
             val playerSettings = playerSettingsDataStore.playerSettings.first()
             rememberAudioDelayPerDeviceEnabled = playerSettings.rememberAudioDelayPerDevice
@@ -267,7 +294,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 playbackSpeedProvider = { _uiState.value.playbackSpeed },
                 onPlaybackSpeedAwareAudioSinkCreated = { playbackSpeedAwareAudioSink = it }
             ).setExtensionRendererMode(playerSettings.decoderPriority)
-                .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || forceDv7ToHevc)
+                .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || applyDv7FallbackOnStartup)
 
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             val buildDefaultPlayer = {
@@ -281,14 +308,13 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
-                    .setReleaseTimeoutMs(3000)
+                    .setReleaseTimeoutMs(PLAYER_RELEASE_TIMEOUT_MS)
                     .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
                     .build()
             }
 
-            // Ensure any existing ExoPlayer is fully released before creating a new one
-            // to avoid leaking MediaCodec and hardware decoding resources, preventing player hangs.
-            _exoPlayer?.let { player -> runCatching { player.release() } }
+            disposeExoPlayerBeforeRebuild()
+            delay(PLAYER_REBUILD_SETTLE_DELAY_MS)
 
             _exoPlayer = if (useLibass) {
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
@@ -296,7 +322,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setLoadControl(loadControl)
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
-                    .setReleaseTimeoutMs(3000)
+                    .setReleaseTimeoutMs(PLAYER_RELEASE_TIMEOUT_MS)
                     .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
                     .buildWithAssSupportCompat(
                         context = context,
@@ -319,7 +345,16 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
                     .build()
                 setAudioAttributes(audioAttributes, true)
-                setPlaybackSpeed(_uiState.value.playbackSpeed)
+                val startupSpeed = if ((applyPcmFallbackOnStartup || hasTriedAudioPcmFallback) && _uiState.value.playbackSpeed == 1f) {
+                    1.00001f
+                } else {
+                    _uiState.value.playbackSpeed
+                }
+                setPlaybackSpeed(startupSpeed)
+                if (applyPcmFallbackOnStartup) {
+                    pendingAudioPcmFallbackRebuild = false
+                    hasTriedAudioPcmFallback = true
+                }
 
                 
                 if (playerSettings.skipSilence) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -49,6 +49,7 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
         runCatching { player.playWhenReady = false }
         runCatching { player.pause() }
         runCatching { player.clearVideoSurface() }
+        runCatching { player.clearMediaItems() }
         runCatching { player.stop() }
         runCatching { player.release() }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -48,9 +48,9 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     _exoPlayer?.let { player ->
         runCatching { player.playWhenReady = false }
         runCatching { player.pause() }
-        runCatching { player.clearVideoSurface() }
-        runCatching { player.clearMediaItems() }
         runCatching { player.stop() }
+        runCatching { player.clearMediaItems() }
+        runCatching { player.clearVideoSurface() }
         runCatching { player.release() }
     }
     _exoPlayer = null


### PR DESCRIPTION
## Summary

This PR hardens ExoPlayer audio error recovery and teardown paths to avoid persistent audio-state corruption across sessions.

Key changes:
- Use full player rebuild for `ERROR_CODE_AUDIO_TRACK_INIT_FAILED (5001)` instead of in-place fallback on the same player.
- Add and consume one-shot pending flags for rebuild-time fallbacks (`pendingAudioPcmFallbackRebuild`, DV7 apply-on-startup snapshot).
- Ensure fallback flags do not leak into future streams (`pendingAudioPcmFallbackRebuild` reset in retry-state reset, `forceDv7ToHevc` reset per initialization while preserving current rebuild intent).
- Keep teardown symmetric and stricter by aligning release path cleanup with rebuild cleanup (explicit `clearMediaItems()` before stop/release).
- Reorder teardown sequence to `playWhenReady=false → pause → stop → clearMediaItems → clearVideoSurface → release` so renderers drain and release codec references before the surface is detached.
- Keep startup speed forcing (`1.00001f`) one-shot and restore speed back to `1f` after first frame while PCM session latch remains active for the current player session.

## PR type

- Bug fix

## Why

After repeated playbacks on some Android TV devices, audio could enter a bad state that sometimes required device reboot to recover. Main risk areas were:
- Reusing a possibly-corrupted player instance in 5001 fallback path.
- Fallback state leaking across streams.
- Teardown/rebuild asymmetry causing incomplete cleanup.
- Lingering audio focus ownership when release fails mid-way, blocking subsequent `AudioTrack` init.
- Surface detached before renderers drained, leaving codec references attached to a dead surface.

This PR aims to make recovery closer to a clean restart while keeping behavior scoped to the current playback session.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual / build verification:
- `./gradlew :app:compileFullDebugKotlin` passed.
- `./gradlew installFullDebug` passed.

Behavioral checks performed in code-path review:
- 5001 fallback now schedules release + initialize flow (position preserved via `pendingSeekPosition`).
- First-frame callback restores speed to `1f` after one-shot startup forcing.
- Fallback intent flags are reset to avoid unintended carry-over to next streams.

## Screenshots / Video (UI changes only)

No UI changes.

## Breaking changes

No breaking API/config/schema changes. Runtime behavior change is limited to internal playback recovery strategy.

## Linked issues

N/A (internal stability bugfix, no public issue linked)
