### PR TITLE
fix(i18n): localize remaining error messages in repositories, player runtime, and TorrServer

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/TorrentModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/TorrentModule.kt
@@ -37,7 +37,8 @@ object TorrentModule {
     @Provides
     @Singleton
     fun provideTorrentService(
+        @dagger.hilt.android.qualifiers.ApplicationContext appContext: android.content.Context,
         binary: TorrServerBinary,
         api: TorrServerApi
-    ): TorrentService = TorrentService(binary, api)
+    ): TorrentService = TorrentService(appContext, binary, api)
 }

--- a/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerBinary.kt
+++ b/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerBinary.kt
@@ -66,7 +66,7 @@ class TorrServerBinary @Inject constructor(
         killOrphanedProcess()
 
         if (!isBinaryAvailable) {
-            throw TorrentException("TorrServer binary not found at ${binaryFile.absolutePath}")
+            throw TorrentException(context.getString(com.nuvio.tv.R.string.torrent_error_binary_missing, binaryFile.absolutePath))
         }
 
         if (!binaryFile.canExecute()) {
@@ -108,13 +108,13 @@ class TorrServerBinary @Inject constructor(
             if (!isProcessAlive(process)) {
                 val exitCode = process?.exitValue() ?: -1
                 process = null
-                throw TorrentException("TorrServer process died on startup (exit code $exitCode)")
+                throw TorrentException(context.getString(com.nuvio.tv.R.string.torrent_error_process_died, exitCode))
             }
             delay(HEALTH_CHECK_INTERVAL_MS)
         }
 
         stop()
-        throw TorrentException("TorrServer failed to start within ${STARTUP_TIMEOUT_MS / 1000}s")
+        throw TorrentException(context.getString(com.nuvio.tv.R.string.torrent_error_start_timeout, (STARTUP_TIMEOUT_MS / 1000).toInt()))
     }
 
     private fun killOrphanedProcess() {

--- a/app/src/main/java/com/nuvio/tv/core/torrent/TorrentService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/torrent/TorrentService.kt
@@ -21,6 +21,7 @@ private val VIDEO_EXTENSIONS = setOf("mkv", "mp4", "avi", "webm", "ts", "m4v", "
 
 @Singleton
 class TorrentService @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val binary: TorrServerBinary,
     private val api: TorrServerApi
 ) {
@@ -62,7 +63,7 @@ class TorrentService @Inject constructor(
 
         // Add torrent
         val hash = api.addTorrent(magnetLink)
-            ?: throw TorrentException("Failed to add torrent")
+            ?: throw TorrentException(appContext.getString(com.nuvio.tv.R.string.torrent_error_add_failed))
         currentHash = hash
 
         // Resolve file index

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -380,7 +380,7 @@ class MetaRepositoryImpl @Inject constructor(
         return MetaAttemptFailure(
             addonName = addon.displayName,
             kind = MetaFailureKind.MISSING,
-            detail = "returned no metadata for this id"
+            detail = context.getString(com.nuvio.tv.R.string.meta_error_detail_no_metadata_for_id)
         )
     }
 
@@ -390,15 +390,15 @@ class MetaRepositoryImpl @Inject constructor(
         }
         val normalizedReason = when {
             error.message.contains("Unable to resolve host", ignoreCase = true) ->
-                "could not reach the addon server"
+                context.getString(com.nuvio.tv.R.string.meta_error_detail_addon_unreachable)
             error.message.contains("Failed to connect", ignoreCase = true) ->
-                "connection to the addon failed"
+                context.getString(com.nuvio.tv.R.string.meta_error_detail_addon_connection_failed)
             error.message.contains("timeout", ignoreCase = true) ->
-                "the addon request timed out"
+                context.getString(com.nuvio.tv.R.string.meta_error_detail_addon_timeout)
             error.message.contains("CLEARTEXT communication", ignoreCase = true) ->
-                "the addon uses an insecure HTTP connection blocked by Android"
+                context.getString(com.nuvio.tv.R.string.meta_error_detail_addon_cleartext_blocked)
             error.message.isBlank() ->
-                "the addon request failed"
+                context.getString(com.nuvio.tv.R.string.meta_error_detail_addon_request_failed)
             else -> error.message.replaceFirstChar { char ->
                 if (char.isLowerCase()) char.titlecase() else char.toString()
             }

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -131,7 +131,7 @@ class StreamRepositoryImpl @Inject constructor(
                             attemptedFailures += StreamAttemptFailure(
                                 addonName = addon.displayName,
                                 kind = StreamFailureKind.REQUEST_FAILED,
-                                detail = e.message ?: "the addon request failed"
+                                detail = e.message ?: context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_request_failed)
                             )
                         } finally {
                             completedJobs++
@@ -194,7 +194,7 @@ class StreamRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Log.e(TAG, "Failed to fetch streams: ${e.message}", e)
-            emit(NetworkResult.Error(e.message ?: "Failed to fetch streams"))
+            emit(NetworkResult.Error(e.message ?: context.getString(com.nuvio.tv.R.string.stream_error_fetch_failed)))
         }
     }
 
@@ -425,7 +425,7 @@ class StreamRepositoryImpl @Inject constructor(
         return StreamAttemptFailure(
             addonName = addon.displayName,
             kind = StreamFailureKind.MISSING,
-            detail = "returned no streams for this id"
+            detail = context.getString(com.nuvio.tv.R.string.stream_error_detail_no_streams_for_id)
         )
     }
 
@@ -435,15 +435,15 @@ class StreamRepositoryImpl @Inject constructor(
         }
         val normalizedReason = when {
             error.message.contains("Unable to resolve host", ignoreCase = true) ->
-                "could not reach the addon server"
+                context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_unreachable)
             error.message.contains("Failed to connect", ignoreCase = true) ->
-                "connection to the addon failed"
+                context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_connection_failed)
             error.message.contains("timeout", ignoreCase = true) ->
-                "the addon request timed out"
+                context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_timeout)
             error.message.contains("CLEARTEXT communication", ignoreCase = true) ->
-                "the addon uses an insecure HTTP connection blocked by Android"
+                context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_cleartext_blocked)
             error.message.isBlank() ->
-                "the addon request failed"
+                context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_request_failed)
             else -> error.message.replaceFirstChar { char ->
                 if (char.isLowerCase()) char.titlecase() else char.toString()
             }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -893,7 +893,7 @@ class TraktLibraryService @Inject constructor(
         while (true) {
             val response = fetch(currentPage)
             if (!response.isSuccessful) {
-                throw IllegalStateException("Trakt paginated fetch failed (${response.code()})")
+                throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_library_error_paginated_fetch_failed, response.code()))
             }
             allItems.addAll(response.body().orEmpty())
             val pageCount = response.headers()["X-Pagination-Page-Count"]?.toIntOrNull() ?: 1

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
@@ -128,7 +128,7 @@ fun HomeViewModel.openPosterListPicker(item: MetaPreview, addonBaseUrl: String?)
                 state.copy(
                     showPosterListPicker = true,
                     posterListPickerPending = false,
-                    posterListPickerError = error.message ?: "Failed to load lists"
+                    posterListPickerError = error.message ?: appContext.getString(com.nuvio.tv.R.string.home_poster_lists_error_load_failed)
                 )
             }
         }
@@ -182,7 +182,7 @@ fun HomeViewModel.savePosterListPickerMembership() {
             _uiState.update { state ->
                 state.copy(
                     posterListPickerPending = false,
-                    posterListPickerError = error.message ?: "Failed to update lists"
+                    posterListPickerError = error.message ?: appContext.getString(com.nuvio.tv.R.string.home_poster_lists_error_update_failed)
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -369,9 +369,9 @@ private fun PlayerRuntimeController.openExternalStreamInBrowser(
     if (externalUrl.isNullOrBlank()) {
         _uiState.update {
             if (fromEpisodePanel) {
-                it.copy(episodeStreamsError = "Invalid external URL")
+                it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_external_url))
             } else {
-                it.copy(sourceStreamsError = "Invalid external URL")
+                it.copy(sourceStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_external_url))
             }
         }
         return true
@@ -403,9 +403,9 @@ private fun PlayerRuntimeController.openExternalStreamInBrowser(
     }.onFailure { error ->
         _uiState.update {
             if (fromEpisodePanel) {
-                it.copy(episodeStreamsError = error.message ?: "Unable to open external link")
+                it.copy(episodeStreamsError = error.message ?: context.getString(com.nuvio.tv.R.string.player_stream_error_open_external_link_failed))
             } else {
-                it.copy(sourceStreamsError = error.message ?: "Unable to open external link")
+                it.copy(sourceStreamsError = error.message ?: context.getString(com.nuvio.tv.R.string.player_stream_error_open_external_link_failed))
             }
         }
     }
@@ -461,7 +461,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
 
     val url = stream.getStreamUrl()
     if (url.isNullOrBlank()) {
-        _uiState.update { it.copy(sourceStreamsError = "Invalid stream URL") }
+        _uiState.update { it.copy(sourceStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
         return
     }
 
@@ -622,7 +622,7 @@ internal fun PlayerRuntimeController.buildEpisodeRequestKey(type: String, video:
 internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRefresh: Boolean) {
     val type = contentType
     if (type.isNullOrBlank()) {
-        _uiState.update { it.copy(episodeStreamsError = "Missing content type") }
+        _uiState.update { it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_missing_content_type)) }
         return
     }
 
@@ -757,7 +757,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
 
     val url = stream.getStreamUrl()
     if (url.isNullOrBlank()) {
-        _uiState.update { it.copy(episodeStreamsError = "Invalid stream URL") }
+        _uiState.update { it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
         return
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTorrent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTorrent.kt
@@ -28,7 +28,7 @@ internal suspend fun PlayerRuntimeController.startTorrentStream(
     _uiState.update {
         it.copy(
             showLoadingOverlay = true,
-            loadingMessage = "Starting P2P engine...",
+            loadingMessage = context.getString(com.nuvio.tv.R.string.player_torrent_starting_engine),
             loadingProgress = null,
             isTorrentStream = true
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -310,7 +310,7 @@ fun ProfileSelectionScreen(
                                         is SetProfilePinResult.Success -> {
                                             pinOverlayState = null
                                             pinOverlayError = null
-                                            pinActionMessage = "PIN saved for ${activePinOverlay.profile.name}."
+                                            pinActionMessage = context.getString(R.string.profile_pin_saved_for_profile, activePinOverlay.profile.name)
                                         }
                                         is SetProfilePinResult.CurrentPinRequired -> {
                                             pinOverlayState = ProfilePinOverlayState.VerifyCurrentForChange(
@@ -378,7 +378,7 @@ fun ProfileSelectionScreen(
                                     if (success) {
                                         pinOverlayError = null
                                         pinOverlayState = null
-                                        pinActionMessage = "PIN lock removed for ${activePinOverlay.profile.name}."
+                                        pinActionMessage = context.getString(R.string.profile_pin_lock_removed_for_profile, activePinOverlay.profile.name)
                                     } else {
                                         pinOverlayError = context.getString(R.string.profile_pin_incorrect)
                                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -130,7 +130,7 @@ private fun ConnectionStatusBadge(type: ConnectionType) {
     }
 }
 
-private suspend fun fetchFastComUrls(): List<String> = withContext(Dispatchers.IO) {
+private suspend fun fetchFastComUrls(context: android.content.Context): List<String> = withContext(Dispatchers.IO) {
     // 1. Load fast.com page to find the app JS bundle URL
     val html = (URL("https://fast.com").openConnection() as HttpURLConnection).run {
         connectTimeout = 10_000
@@ -139,7 +139,7 @@ private suspend fun fetchFastComUrls(): List<String> = withContext(Dispatchers.I
         inputStream.bufferedReader().use { it.readText() }.also { disconnect() }
     }
     val scriptPath = Regex("""<script src="(/app[^"]+\.js)"""").find(html)?.groupValues?.get(1)
-        ?: throw Exception("fast.com: script path not found")
+        ?: throw Exception(context.getString(com.nuvio.tv.R.string.network_fast_error_script_path_missing))
 
     // 2. Extract the API token from the JS bundle
     val js = (URL("https://fast.com$scriptPath").openConnection() as HttpURLConnection).run {
@@ -149,7 +149,7 @@ private suspend fun fetchFastComUrls(): List<String> = withContext(Dispatchers.I
         inputStream.bufferedReader().use { it.readText() }.also { disconnect() }
     }
     val token = Regex("""token:"([^"]+)"""").find(js)?.groupValues?.get(1)
-        ?: throw Exception("fast.com: token not found in bundle")
+        ?: throw Exception(context.getString(com.nuvio.tv.R.string.network_fast_error_token_missing))
 
     // 3. Fetch CDN URLs from the speed-test API
     val apiJson = (URL("https://api.fast.com/netflix/speedtest/v2?https=true&token=$token&urlCount=15")
@@ -210,7 +210,7 @@ fun AdvancedSettingsContent(
                 // ── Download: parallel streams from fast.com for 10 s ────────
                 testState = NetworkTestState.TestingDownload
                 val (totalBytes, elapsed) = withContext(Dispatchers.IO) {
-                    val urls = fetchFastComUrls()
+                    val urls = fetchFastComUrls(context)
                     val deadline = System.currentTimeMillis() + 10_000L
                     val startTime = System.currentTimeMillis()
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2171,4 +2171,54 @@
     <!-- Badges de rôle des contributeurs -->
     <string name="contributor_role_translator">Traducteur</string>
     <string name="contributor_role_maintainer">Mainteneur</string>
+
+    <!-- Erreurs réseau / safe API -->
+    <string name="network_error_empty_response_body">Réponse vide</string>
+    <string name="network_error_unknown">Une erreur inconnue est survenue</string>
+
+    <!-- Paramètres réseau&#160;: erreurs fast.com -->
+    <string name="network_fast_error_script_path_missing">fast.com&#160;: chemin du script introuvable</string>
+    <string name="network_fast_error_token_missing">fast.com&#160;: jeton introuvable dans le bundle</string>
+
+    <!-- Service torrent / erreurs binaire TorrServer -->
+    <string name="torrent_error_add_failed">Échec de l’ajout du torrent</string>
+    <string name="torrent_error_binary_missing">Binaire TorrServer introuvable à %1$s</string>
+    <string name="torrent_error_process_died">Le processus TorrServer s’est arrêté au démarrage (code de sortie %1$d)</string>
+    <string name="torrent_error_start_timeout">TorrServer n’a pas démarré dans les %1$ds</string>
+
+    <!-- Lecteur&#160;: erreurs flux / lien externe -->
+    <string name="player_torrent_starting_engine">Démarrage du moteur P2P…</string>
+    <string name="player_torrent_rebuffer_status">%1$s en mémoire tampon</string>
+    <string name="player_stream_error_invalid_external_url">URL externe invalide</string>
+    <string name="player_stream_error_open_external_link_failed">Impossible d’ouvrir le lien externe</string>
+    <string name="player_stream_error_invalid_url">URL de flux invalide</string>
+    <string name="player_stream_error_missing_content_type">Type de contenu manquant</string>
+
+    <!-- Repository méta&#160;: fragments d’erreur addon -->
+    <string name="meta_error_detail_no_metadata_for_id">n’a renvoyé aucune métadonnée pour cet identifiant</string>
+    <string name="meta_error_detail_addon_unreachable">impossible de joindre le serveur de l’addon</string>
+    <string name="meta_error_detail_addon_connection_failed">la connexion à l’addon a échoué</string>
+    <string name="meta_error_detail_addon_timeout">la requête vers l’addon a expiré</string>
+    <string name="meta_error_detail_addon_cleartext_blocked">l’addon utilise une connexion HTTP non sécurisée bloquée par Android</string>
+    <string name="meta_error_detail_addon_request_failed">la requête vers l’addon a échoué</string>
+
+    <!-- Repository flux&#160;: fragments d’erreur addon + récupération -->
+    <string name="stream_error_detail_no_streams_for_id">n’a renvoyé aucun flux pour cet identifiant</string>
+    <string name="stream_error_detail_addon_unreachable">impossible de joindre le serveur de l’addon</string>
+    <string name="stream_error_detail_addon_connection_failed">la connexion à l’addon a échoué</string>
+    <string name="stream_error_detail_addon_timeout">la requête vers l’addon a expiré</string>
+    <string name="stream_error_detail_addon_cleartext_blocked">l’addon utilise une connexion HTTP non sécurisée bloquée par Android</string>
+    <string name="stream_error_detail_addon_request_failed">la requête vers l’addon a échoué</string>
+    <string name="stream_error_fetch_failed">Échec de la récupération des flux</string>
+
+    <!-- Trakt&#160;: récupération paginée + commentaires -->
+    <string name="trakt_library_error_paginated_fetch_failed">Échec de la requête paginée Trakt (%1$d)</string>
+
+    <!-- Accueil&#160;: erreurs sélecteur de listes (appui long sur poster) -->
+    <string name="home_poster_lists_error_load_failed">Échec du chargement des listes</string>
+    <string name="home_poster_lists_error_update_failed">Échec de la mise à jour des listes</string>
+
+    <!-- Sélection de profil&#160;: messages overlay PIN -->
+    <string name="profile_pin_saved_for_profile">PIN enregistré pour %1$s.</string>
+    <string name="profile_pin_lock_removed_for_profile">Verrouillage PIN supprimé pour %1$s.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2214,4 +2214,54 @@
     <string name="contributor_role_translator">Translator</string>
     <string name="contributor_role_maintainer">Maintainer</string>
 
+    <!-- Network / safe API errors -->
+    <string name="network_error_empty_response_body">Empty response body</string>
+    <string name="network_error_unknown">Unknown error occurred</string>
+
+    <!-- Network settings: fast.com errors -->
+    <string name="network_fast_error_script_path_missing">fast.com: script path not found</string>
+    <string name="network_fast_error_token_missing">fast.com: token not found in bundle</string>
+
+    <!-- Torrent service / TorrServer binary errors -->
+    <string name="torrent_error_add_failed">Failed to add torrent</string>
+    <string name="torrent_error_binary_missing">TorrServer binary not found at %1$s</string>
+    <string name="torrent_error_process_died">TorrServer process died on startup (exit code %1$d)</string>
+    <string name="torrent_error_start_timeout">TorrServer failed to start within %1$ds</string>
+
+    <!-- Player runtime: stream / external link errors -->
+    <string name="player_torrent_starting_engine">Starting P2P engine…</string>
+    <string name="player_torrent_rebuffer_status">%1$s buffered</string>
+    <string name="player_stream_error_invalid_external_url">Invalid external URL</string>
+    <string name="player_stream_error_open_external_link_failed">Unable to open external link</string>
+    <string name="player_stream_error_invalid_url">Invalid stream URL</string>
+    <string name="player_stream_error_missing_content_type">Missing content type</string>
+
+    <!-- Meta repository: addon detail error fragments -->
+    <string name="meta_error_detail_no_metadata_for_id">returned no metadata for this id</string>
+    <string name="meta_error_detail_addon_unreachable">could not reach the addon server</string>
+    <string name="meta_error_detail_addon_connection_failed">connection to the addon failed</string>
+    <string name="meta_error_detail_addon_timeout">the addon request timed out</string>
+    <string name="meta_error_detail_addon_cleartext_blocked">the addon uses an insecure HTTP connection blocked by Android</string>
+    <string name="meta_error_detail_addon_request_failed">the addon request failed</string>
+
+    <!-- Stream repository: addon detail error fragments + fetch -->
+    <string name="stream_error_detail_no_streams_for_id">returned no streams for this id</string>
+    <string name="stream_error_detail_addon_unreachable">could not reach the addon server</string>
+    <string name="stream_error_detail_addon_connection_failed">connection to the addon failed</string>
+    <string name="stream_error_detail_addon_timeout">the addon request timed out</string>
+    <string name="stream_error_detail_addon_cleartext_blocked">the addon uses an insecure HTTP connection blocked by Android</string>
+    <string name="stream_error_detail_addon_request_failed">the addon request failed</string>
+    <string name="stream_error_fetch_failed">Failed to fetch streams</string>
+
+    <!-- Trakt: paginated fetch + comments -->
+    <string name="trakt_library_error_paginated_fetch_failed">Trakt paginated fetch failed (%1$d)</string>
+
+    <!-- Home: poster long-press list picker errors -->
+    <string name="home_poster_lists_error_load_failed">Failed to load lists</string>
+    <string name="home_poster_lists_error_update_failed">Failed to update lists</string>
+
+    <!-- Profile selection: PIN overlay messages -->
+    <string name="profile_pin_saved_for_profile">PIN saved for %1$s.</string>
+    <string name="profile_pin_lock_removed_for_profile">PIN lock removed for %1$s.</string>
+
 </resources>


### PR DESCRIPTION
## Summary

Round 3 of the i18n cleanup, after #1783 / #1786 / #1787. Catches the strings the previous audits missed in the data + player layers:

- Addon failure detail fragments in `MetaRepositoryImpl` and `StreamRepositoryImpl` consumed by `buildAggregateFailureMessage` and surfaced through the meta detail / stream error UI (no-metadata-for-id, addon unreachable, connection failed, timeout, cleartext blocked, request failed) — 12 fragments + 1 top-level \"Failed to fetch streams\" fallback.
- `TraktLibraryService.fetchAllPages` paginated fetch error.
- `PlayerRuntimeControllerStreams` external-URL / open-link / invalid-stream-URL / missing-content-type messages.
- `PlayerRuntimeControllerTorrent` \"Starting P2P engine…\" loading overlay.
- `TorrentService` and `TorrServerBinary` startup / add-torrent errors. `TorrentService` now takes an `@ApplicationContext`; `TorrentModule.provideTorrentService` is updated.
- `HomeViewModelLibraryActions` poster long-press list-picker errors.
- `ProfileSelectionScreen` PIN saved / PIN lock removed transient overlay messages with profile-name interpolation.
- `NetworkSettingsScreen.fetchFastComUrls` script-path-missing / token-missing exception messages (function now takes `Context`).

29 new EN + FR string resources, with French translations following the existing typographic conventions (typographic apostrophe, `&#160;` NBSP before `:` / `?` / `!`, tutoiement).

## PR type

- Bug fix

## Why

Codex re-audited the codebase after the round-2 PRs were merged into a temporary worktree. The remaining hits were predominantly in the data layer (addon failure normalization, Trakt paginated fetch) and player runtime (external link / stream-URL / torrent overlay), all of which surface to the user through `UiState.error` / `NetworkResult.Error` / loading overlays.

## Deliberately skipped (out of scope or sentinel)

- `core/network/SafeApiCall.kt` (\"Empty response body\" / \"Unknown error occurred\") — a free top-level function with no `Context`; every ViewModel that consumes its `NetworkResult.Error` already wraps the message with its own `R.string.*` fallback, so the user-facing text is already localized at the call site.
- `TmdbMetadataService` entity-header \"Unknown\" fallbacks — a singleton service without `Context`, and the fallback is rare enough that threading a `Context` through would be high-friction for low return.
- Compose \"Trakt\" / \"TMDB\" / \"MDBList\" / \"Anime-Skip\" marketing labels in `SettingsScreen` / `TraktScreen` and animation labels (`TmdbEntityBrowse`, `CastDetailStateCrossfade`) — brand names / non-display strings.
- `PlayerRuntimeControllerPlaybackEvents` torrent rebuffer status formatter — the matching string keys (`player_torrent_peer_info`, `player_torrent_buffered_status`) are introduced by #1786 and don't exist on `dev` yet; will be addressed once #1786 lands.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — i18n bug fix, broad-but-shallow.

## Testing

- Built and ran on Android TV (Ugoos AM6B+).
- Triggered each error path:
  - `MetaRepositoryImpl` / `StreamRepositoryImpl` failure fragments by pointing at an unreachable addon, a 404, and a cleartext HTTP addon.
  - `TraktLibraryService` paginated fetch by interrupting the network during a personal-list refresh.
  - Player runtime: forced an invalid external URL on a stream entry, blanked an external_url, and queued an invalid m3u8.
  - TorrServer binary missing path by deleting the binary, plus a forced startup-timeout.
  - Profile PIN flows for both \"saved\" and \"lock removed\" toasts.
  - fast.com speed-test by mocking a 404 response.
- Each toast / error overlay reads in French.

## Screenshots / Video (UI changes only)

N/A — text content only.

## Breaking changes

- `TorrentService` constructor gains a leading `@ApplicationContext appContext`. `TorrentModule.provideTorrentService` updated; no other manual instantiation of `TorrentService` exists in the codebase (it's always injected by Hilt).
- `NetworkSettingsScreen.fetchFastComUrls` now takes a `Context` parameter; the only caller (one composable) is updated.

## Linked issues

Follows up #1786 / #1787.