### PR TITLE
fix(home): drop stray brace in applyContinueWatchingEnrichmentOverlay

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2465,7 +2465,6 @@ private suspend fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
         }
         if (sortChanged) sortContinueWatchingItems(mapped, continueWatchingSortMode) else mapped
     }
-    }
 }
 
 private fun HomeViewModel.publishBadgeUpdate(


### PR DESCRIPTION
## Summary

Removes a stray closing brace in `applyContinueWatchingEnrichmentOverlay` that was left over from `0e629295 feat(settings): add Continue Watching sort mode setting`. `dev` does not currently compile.

## PR type

- Bug fix

## Why

Building `dev` clean fails with:

```
e: HomeViewModelContinueWatching.kt:2469:1 Syntax error: Expecting a top level declaration.
```

The function had a duplicated `}` after the `withContext { ... }` block. One-character delete, no behavior change.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- `./gradlew :app:compileFullDebugKotlin` passes on `dev` with the patch applied (fails without it).

## Screenshots / Video (UI changes only)

N/A - no UI change.

## Breaking changes

None.

## Linked issues

N/A.
