### PR TITLE
feat: add Discover Location setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -1,38 +1,30 @@
 package com.nuvio.tv
 
-import android.os.Bundle
 import android.content.Context
 import android.content.res.Configuration
-import androidx.core.os.ConfigurationCompat
+import android.os.Bundle
 import android.util.Log
-import androidx.compose.ui.platform.LocalView
-import androidx.metrics.performance.JankStats
-import androidx.metrics.performance.PerformanceMetricsState
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
-import androidx.lifecycle.lifecycleScope
-import java.util.Locale
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateDp
-import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -50,16 +42,20 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
@@ -67,9 +63,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
@@ -85,7 +81,9 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -93,14 +91,18 @@ import com.nuvio.tv.core.runtime.PluginRuntimeHooks
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.os.ConfigurationCompat
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.lifecycleScope
+import androidx.metrics.performance.JankStats
+import androidx.metrics.performance.PerformanceMetricsState
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.tv.material3.DrawerValue
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.DrawerValue
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.ModalNavigationDrawer
@@ -108,27 +110,31 @@ import androidx.tv.material3.Surface
 import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import androidx.tv.material3.rememberDrawerState
-import com.nuvio.tv.core.profile.ProfileManager
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
+import com.nuvio.tv.R
 import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.sync.ProfileSettingsSyncService
+import com.nuvio.tv.core.sync.ProfileSyncService
+import com.nuvio.tv.core.sync.StartupSyncService
 import com.nuvio.tv.data.local.AppOnboardingDataStore
 import com.nuvio.tv.data.local.ExperienceModeDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.ThemeDataStore
+import com.nuvio.tv.data.remote.supabase.AvatarRepository
 import com.nuvio.tv.data.repository.TraktProgressService
 import com.nuvio.tv.domain.model.AppFont
 import com.nuvio.tv.domain.model.AppTheme
 import com.nuvio.tv.domain.model.AuthState
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.ExperienceMode
 import com.nuvio.tv.domain.repository.AddonRepository
-import com.nuvio.tv.core.sync.ProfileSettingsSyncService
-import com.nuvio.tv.core.sync.ProfileSyncService
-import com.nuvio.tv.core.sync.StartupSyncService
-import com.nuvio.tv.data.remote.supabase.AvatarRepository
-import com.nuvio.tv.ui.navigation.NuvioNavHost
-import com.nuvio.tv.ui.navigation.Screen
 import com.nuvio.tv.ui.components.NuvioScrollDefaults
 import com.nuvio.tv.ui.components.ProfileAvatarCircle
+import com.nuvio.tv.ui.navigation.NuvioNavHost
+import com.nuvio.tv.ui.navigation.Screen
 import com.nuvio.tv.ui.screens.account.AuthQrSignInScreen
 import com.nuvio.tv.ui.screens.addon.EssentialAddonSetupScreen
 import com.nuvio.tv.ui.screens.profile.ProfileSelectionScreen
@@ -136,20 +142,18 @@ import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.ui.theme.NuvioTheme
 import com.nuvio.tv.ui.util.LocalFastHorizontalNavigationEnabled
 import com.nuvio.tv.ui.util.LocalRecompositionHighlighterEnabled
+import com.nuvio.tv.ui.util.rememberDrawerItemFocusRequesters
 import com.nuvio.tv.updater.UpdateViewModel
 import com.nuvio.tv.updater.ui.UpdatePromptDialog
 import dagger.hilt.android.AndroidEntryPoint
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.haze
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import coil3.compose.rememberAsyncImagePainter
-import coil3.request.ImageRequest
-import androidx.compose.ui.res.stringResource
-import com.nuvio.tv.R
 
 val LocalSidebarExpanded = compositionLocalOf { false }
 val LocalContentFocusRequester = compositionLocalOf { FocusRequester.Default }
@@ -173,6 +177,7 @@ private data class MainUiPrefs(
     val sidebarCollapsed: Boolean = false,
     val modernSidebarEnabled: Boolean = false,
     val modernSidebarBlurPref: Boolean = false,
+    val discoverLocation: DiscoverLocation? = null,
     val smoothBringIntoViewEnabled: Boolean = true,
     val fastHorizontalNavigationEnabled: Boolean = false,
     val composeHighlighterEnabled: Boolean = false
@@ -343,6 +348,8 @@ class MainActivity : ComponentActivity() {
                     prefs.copy(amoledSurfacesMode = amoledSurfacesMode)
                 }.combine(layoutPreferenceDataStore.modernSidebarBlurEnabled) { prefs, modernSidebarBlurPref ->
                     prefs.copy(modernSidebarBlurPref = modernSidebarBlurPref)
+                }.combine(layoutPreferenceDataStore.discoverLocation) { prefs, discoverLocation ->
+                    prefs.copy(discoverLocation = discoverLocation)
                 }.combine(layoutPreferenceDataStore.smoothBringIntoViewEnabled) { prefs, smoothBringIntoViewEnabled ->
                     prefs.copy(smoothBringIntoViewEnabled = smoothBringIntoViewEnabled)
                 }.combine(layoutPreferenceDataStore.fastHorizontalNavigationEnabled) { prefs, fastHorizontalNavigationEnabled ->
@@ -355,6 +362,7 @@ class MainActivity : ComponentActivity() {
             val installedAddons by remember(addonRepository) {
                 addonRepository.getInstalledAddons()
             }.collectAsState(initial = null)
+            val discoverLocation = mainUiPrefs.discoverLocation
 
             NuvioTheme(
                 appTheme = mainUiPrefs.theme,
@@ -519,55 +527,92 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
-                    val rootRoutes = remember {
-                        setOf(
-                            Screen.Home.route,
-                            Screen.Search.route,
-                            Screen.Library.route,
-                            Screen.Settings.route,
-                            Screen.AddonManager.route
-                        )
+                    LaunchedEffect(discoverLocation, currentRoute) {
+                        if (discoverLocation == null) return@LaunchedEffect
+                        val onDiscoverRoute = currentRoute == Screen.Discover.route ||
+                            currentRoute?.startsWith("${Screen.Discover.route}/") == true
+                        if (discoverLocation == DiscoverLocation.OFF && onDiscoverRoute) {
+                            navController.navigate(Screen.Home.route) {
+                                popUpTo(navController.graph.startDestinationId) { saveState = false }
+                                launchSingleTop = true
+                            }
+                        }
+                    }
+
+                    val rootRoutes = remember(discoverLocation) {
+                        buildSet {
+                            add(Screen.Home.route)
+                            add(Screen.Search.route)
+                            add(Screen.Library.route)
+                            add(Screen.Settings.route)
+                            add(Screen.AddonManager.route)
+                            if (discoverLocation == DiscoverLocation.IN_SIDEBAR) {
+                                add(Screen.Discover.route)
+                            }
+                        }
                     }
 
                     val strNavHome = stringResource(R.string.nav_home)
+                    val strNavDiscover = stringResource(R.string.nav_discover)
                     val strNavSearch = stringResource(R.string.nav_search)
                     val strNavLibrary = stringResource(R.string.nav_library)
                     val strNavAddons = stringResource(R.string.nav_addons)
                     val strNavSettings = stringResource(R.string.nav_settings)
                     val drawerItems = remember(
                         strNavHome,
+                        strNavDiscover,
                         strNavSearch,
                         strNavLibrary,
                         strNavAddons,
-                        strNavSettings
+                        strNavSettings,
+                        discoverLocation
                     ) {
-                        listOf(
-                            DrawerItem(
-                                route = Screen.Home.route,
-                                label = strNavHome,
-                                icon = Icons.Default.Home
-                            ),
-                            DrawerItem(
-                                route = Screen.Search.route,
-                                label = strNavSearch,
-                                iconRes = R.raw.sidebar_search
-                            ),
-                            DrawerItem(
-                                route = Screen.Library.route,
-                                label = strNavLibrary,
-                                iconRes = R.raw.sidebar_library
-                            ),
-                            DrawerItem(
-                                route = Screen.AddonManager.route,
-                                label = strNavAddons,
-                                iconRes = R.raw.sidebar_plugin
-                            ),
-                            DrawerItem(
-                                route = Screen.Settings.route,
-                                label = strNavSettings,
-                                iconRes = R.raw.sidebar_settings
+                        buildList {
+                            add(
+                                DrawerItem(
+                                    route = Screen.Home.route,
+                                    label = strNavHome,
+                                    icon = Icons.Default.Home
+                                )
                             )
-                        )
+                            if (discoverLocation == DiscoverLocation.IN_SIDEBAR) {
+                                add(
+                                    DrawerItem(
+                                        route = Screen.Discover.route,
+                                        label = strNavDiscover,
+                                        icon = Icons.Default.Explore
+                                    )
+                                )
+                            }
+                            add(
+                                DrawerItem(
+                                    route = Screen.Search.route,
+                                    label = strNavSearch,
+                                    iconRes = R.raw.sidebar_search
+                                )
+                            )
+                            add(
+                                DrawerItem(
+                                    route = Screen.Library.route,
+                                    label = strNavLibrary,
+                                    iconRes = R.raw.sidebar_library
+                                )
+                            )
+                            add(
+                                DrawerItem(
+                                    route = Screen.AddonManager.route,
+                                    label = strNavAddons,
+                                    iconRes = R.raw.sidebar_plugin
+                                )
+                            )
+                            add(
+                                DrawerItem(
+                                    route = Screen.Settings.route,
+                                    label = strNavSettings,
+                                    iconRes = R.raw.sidebar_settings
+                                )
+                            )
+                        }
                     }
                     val selectedDrawerRoute = drawerItems.firstOrNull { item ->
                         currentRoute == item.route || currentRoute?.startsWith("${item.route}/") == true
@@ -672,6 +717,27 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@Composable
+private fun SidebarFocusRecoveryEffect(
+    drawerItems: List<DrawerItem>,
+    selectedDrawerRoute: String?,
+    drawerItemFocusRequesters: Map<String, FocusRequester>,
+    sidebarOwnsFocus: Boolean
+) {
+    LaunchedEffect(drawerItems, sidebarOwnsFocus, selectedDrawerRoute) {
+        if (!sidebarOwnsFocus) {
+            return@LaunchedEffect
+        }
+        if (selectedDrawerRoute != null && drawerItems.any { it.route == selectedDrawerRoute }) {
+            return@LaunchedEffect
+        }
+        val fallbackRoute = drawerItems.firstOrNull()?.route ?: return@LaunchedEffect
+        val requester = drawerItemFocusRequesters[fallbackRoute] ?: return@LaunchedEffect
+        repeat(2) { withFrameNanos { } }
+        runCatching { requester.requestFocus() }
+    }
+}
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun LegacySidebarScaffold(
@@ -692,9 +758,7 @@ private fun LegacySidebarScaffold(
     onExitApp: () -> Unit
 ) {
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-    val drawerItemFocusRequesters = remember(drawerItems) {
-        drawerItems.associate { item -> item.route to FocusRequester() }
-    }
+    val drawerItemFocusRequesters = rememberDrawerItemFocusRequesters(drawerItems)
     val showSidebar = currentRoute in rootRoutes
 
     LaunchedEffect(currentRoute) {
@@ -733,7 +797,7 @@ private fun LegacySidebarScaffold(
         if (!showSidebar || !pendingSidebarFocusRequest || drawerState.currentValue != DrawerValue.Open) {
             return@LaunchedEffect
         }
-        val targetRoute = selectedDrawerRoute ?: run {
+        val targetRoute = selectedDrawerRoute ?: drawerItems.firstOrNull()?.route ?: run {
             pendingSidebarFocusRequest = false
             return@LaunchedEffect
         }
@@ -745,6 +809,13 @@ private fun LegacySidebarScaffold(
         runCatching { requester.requestFocus() }
         pendingSidebarFocusRequest = false
     }
+
+    SidebarFocusRecoveryEffect(
+        drawerItems = drawerItems,
+        selectedDrawerRoute = selectedDrawerRoute,
+        drawerItemFocusRequesters = drawerItemFocusRequesters,
+        sidebarOwnsFocus = showSidebar && drawerState.currentValue == DrawerValue.Open
+    )
 
     ModalNavigationDrawer(
         drawerState = drawerState,
@@ -846,28 +917,30 @@ private fun LegacySidebarScaffold(
                         horizontalAlignment = if (isExpanded) Alignment.CenterHorizontally else Alignment.Start
                     ) {
                         drawerItems.forEach { item ->
-                            LegacySidebarButton(
-                                label = item.label,
-                                iconRes = item.iconRes,
-                                icon = item.icon,
-                                selected = selectedDrawerRoute == item.route,
-                                expanded = isExpanded,
-                                onClick = {
-                                    onNavigate(item.route)
-                                    navigateToDrawerRoute(
-                                        navController = navController,
-                                        currentRoute = currentRoute,
-                                        targetRoute = item.route
+                            key(item.route) {
+                                LegacySidebarButton(
+                                    label = item.label,
+                                    iconRes = item.iconRes,
+                                    icon = item.icon,
+                                    selected = selectedDrawerRoute == item.route,
+                                    expanded = isExpanded,
+                                    onClick = {
+                                        onNavigate(item.route)
+                                        navigateToDrawerRoute(
+                                            navController = navController,
+                                            currentRoute = currentRoute,
+                                            targetRoute = item.route
+                                        )
+                                        drawerState.setValue(DrawerValue.Closed)
+                                        pendingContentFocusTransfer = true
+                                    },
+                                    modifier = Modifier.focusRequester(
+                                        drawerItemFocusRequesters.getValue(item.route)
                                     )
-                                    drawerState.setValue(DrawerValue.Closed)
-                                    pendingContentFocusTransfer = true
-                                },
-                                modifier = Modifier.focusRequester(
-                                    drawerItemFocusRequesters.getValue(item.route)
+                                        .width(itemWidth)
+                                        .then(if (!isExpanded) Modifier.offset(x = 12.dp) else Modifier)
                                 )
-                                    .width(itemWidth)
-                                    .then(if (!isExpanded) Modifier.offset(x = 12.dp) else Modifier)
-                            )
+                            }
                         }
                     }
                 }
@@ -1033,9 +1106,7 @@ private fun ModernSidebarScaffold(
     val focusManager = LocalFocusManager.current
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val contentFocusRequester = remember { FocusRequester() }
-    val drawerItemFocusRequesters = remember(drawerItems) {
-        drawerItems.associate { item -> item.route to FocusRequester() }
-    }
+    val drawerItemFocusRequesters = rememberDrawerItemFocusRequesters(drawerItems)
 
     var isSidebarExpanded by remember { mutableStateOf(false) }
     var sidebarCollapsePending by remember { mutableStateOf(false) }
@@ -1213,7 +1284,7 @@ private fun ModernSidebarScaffold(
         if (!showSidebar || !pendingSidebarFocusRequest || !isSidebarExpanded) {
             return@LaunchedEffect
         }
-        val targetRoute = selectedDrawerRoute ?: run {
+        val targetRoute = selectedDrawerRoute ?: drawerItems.firstOrNull()?.route ?: run {
             pendingSidebarFocusRequest = false
             return@LaunchedEffect
         }
@@ -1225,6 +1296,13 @@ private fun ModernSidebarScaffold(
         runCatching { requester.requestFocus() }
         pendingSidebarFocusRequest = false
     }
+
+    SidebarFocusRecoveryEffect(
+        drawerItems = drawerItems,
+        selectedDrawerRoute = selectedDrawerRoute,
+        drawerItemFocusRequesters = drawerItemFocusRequesters,
+        sidebarOwnsFocus = showSidebar && isSidebarExpanded
+    )
 
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
@@ -1573,6 +1651,7 @@ private fun rememberRawSvgPainter(rawIconRes: Int): Painter {
 
 object LocaleCache {
     const val UNSET = "__UNSET__"
+
     @Volatile
     var localeTag: String = UNSET
 }

--- a/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ModernSidebarBlurPanel.kt
@@ -21,14 +21,15 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
@@ -45,13 +46,13 @@ import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.Icon
 import androidx.tv.material3.Text
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeChild
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
 import com.nuvio.tv.ui.components.AutoResizeText
 import com.nuvio.tv.ui.components.ProfileAvatarCircle
 import com.nuvio.tv.ui.theme.NuvioColors
-import coil3.compose.rememberAsyncImagePainter
-import coil3.request.ImageRequest
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeChild
 
 private val SidebarLeadingVisualSize = 34.dp
 private val SidebarContentGap = 14.dp
@@ -183,28 +184,29 @@ internal fun ModernSidebarBlurPanel(
                 verticalArrangement = Arrangement.spacedBy(6.dp)
             ) {
                 drawerItems.forEachIndexed { index, item ->
-                    SidebarNavigationItem(
-                        label = item.label,
-                        iconRes = item.iconRes,
-                        icon = item.icon,
-                        selected = selectedDrawerRoute == item.route,
-                        focusEnabled = keepSidebarFocusDuringCollapse,
-                        labelAlpha = sidebarLabelAlpha,
-                        iconScale = sidebarIconScale,
-                        onFocusChanged = {
-                            if (it) {
-                                onDrawerItemFocused(index)
-                            }
-                        },
-                        onClick = { onDrawerItemClick(item.route) },
-                        modifier = Modifier
-                            .fillMaxWidth(0.92f)
-                            .focusRequester(drawerItemFocusRequesters.getValue(item.route))
-                    )
+                    key(item.route) {
+                        SidebarNavigationItem(
+                            label = item.label,
+                            iconRes = item.iconRes,
+                            icon = item.icon,
+                            selected = selectedDrawerRoute == item.route,
+                            focusEnabled = keepSidebarFocusDuringCollapse,
+                            labelAlpha = sidebarLabelAlpha,
+                            iconScale = sidebarIconScale,
+                            onFocusChanged = {
+                                if (it) {
+                                    onDrawerItemFocused(index)
+                                }
+                            },
+                            onClick = { onDrawerItemClick(item.route) },
+                            modifier = Modifier
+                                .fillMaxWidth(0.92f)
+                                .focusRequester(drawerItemFocusRequesters.getValue(item.route))
+                        )
+                    }
                 }
             }
         }
-
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -16,6 +16,7 @@ import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.ExperienceModeDataStore
 import com.nuvio.tv.data.local.ProfileDataStoreFactory
 import com.nuvio.tv.data.remote.supabase.SupabaseProfileSettingsBlob
+import com.nuvio.tv.domain.model.DiscoverLocation
 import io.github.jan.supabase.postgrest.Postgrest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -66,8 +67,10 @@ class ProfileSettingsSyncService @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val syncMutex = Mutex()
+
     @Volatile
     private var applyingRemoteBlob: Boolean = false
+
     @Volatile
     private var skipNextPushSignature: String? = null
     private var foregroundPullJob: Job? = null
@@ -90,6 +93,10 @@ class ProfileSettingsSyncService @Inject constructor(
         "home_catalog_order_keys",
         "disabled_home_catalog_keys",
         "custom_catalog_titles"
+    )
+
+    private val localOnlyLayoutKeys = setOf(
+        "last_non_off_discover_location"
     )
 
     init {
@@ -194,6 +201,8 @@ class ProfileSettingsSyncService @Inject constructor(
                 val serialized = buildJsonObject {
                     prefs.asMap().forEach { (key, rawValue) ->
                         if (feature == "layout_settings" && key.name in catalogKeysExcludedFromBlob) return@forEach
+                        if (feature == "layout_settings" && key.name in localOnlyLayoutKeys) return@forEach
+                        if (feature == "layout_settings" && key.name == "search_discover_enabled") return@forEach
                         val encoded = encodePreferenceValue(rawValue) ?: return@forEach
                         put(key.name, encoded)
                     }
@@ -222,14 +231,54 @@ class ProfileSettingsSyncService @Inject constructor(
                             val boolKey = booleanPreferencesKey(keyName)
                             mutablePrefs[boolKey]?.let { entries[boolKey] = it }
                         }
+                        localOnlyLayoutKeys.forEach { keyName ->
+                            val strKey = stringPreferencesKey(keyName)
+                            mutablePrefs[strKey]?.let { entries[strKey] = it }
+                        }
                         entries
                     } else {
                         emptyMap()
                     }
+                    val priorDiscoverLocation = if (feature == "layout_settings") {
+                        mutablePrefs[stringPreferencesKey("discover_location")]
+                    } else null
+                    val priorLastNonOff = if (feature == "layout_settings") {
+                        mutablePrefs[stringPreferencesKey("last_non_off_discover_location")]?.let {
+                            runCatching { DiscoverLocation.valueOf(it) }.getOrNull()
+                        }?.takeIf { it != DiscoverLocation.OFF }
+                    } else null
 
                     mutablePrefs.clear()
+                    val hasWellFormedNewDiscoverKey = feature == "layout_settings" &&
+                        extractDiscoverLocationString(featureJson) != null
                     featureJson.forEach { (keyName, encodedValue) ->
                         if (feature == "layout_settings" && keyName in catalogKeysExcludedFromBlob) return@forEach
+                        if (feature == "layout_settings" && keyName in localOnlyLayoutKeys) return@forEach
+                        if (feature == "layout_settings" && keyName == "search_discover_enabled") {
+                            if (!hasWellFormedNewDiscoverKey) {
+                                val legacy = (encodedValue as? JsonObject)
+                                    ?.get("value")?.jsonPrimitive?.contentOrNull
+                                    ?.toBooleanStrictOrNull()
+                                if (legacy != null) {
+                                    val translated = DiscoverLocation.fromLegacySearchDiscoverEnabled(legacy)
+                                    val priorLocation = priorDiscoverLocation?.let {
+                                        runCatching { DiscoverLocation.valueOf(it) }.getOrNull()
+                                    }
+                                    val priorIsValidNonOff = priorLocation != null && priorLocation != DiscoverLocation.OFF
+                                    when {
+                                        translated == DiscoverLocation.OFF ->
+                                            mutablePrefs[stringPreferencesKey("discover_location")] = translated.name
+                                        priorIsValidNonOff -> {}
+                                        priorLastNonOff != null ->
+                                            mutablePrefs[stringPreferencesKey("discover_location")] = priorLastNonOff.name
+                                        else ->
+                                            mutablePrefs[stringPreferencesKey("discover_location")] = translated.name
+                                    }
+                                }
+                            }
+                            return@forEach
+                        }
+                        if (feature == "layout_settings" && keyName == "discover_location" && !hasWellFormedNewDiscoverKey) return@forEach
                         applyEncodedPreference(mutablePrefs, keyName, encodedValue)
                     }
 
@@ -242,6 +291,21 @@ class ProfileSettingsSyncService @Inject constructor(
                             is Long -> mutablePrefs[key as Preferences.Key<Long>] = value
                             is Float -> mutablePrefs[key as Preferences.Key<Float>] = value
                             is Double -> mutablePrefs[key as Preferences.Key<Double>] = value
+                        }
+                    }
+                    if (feature == "layout_settings" && priorDiscoverLocation != null) {
+                        val discoverKey = stringPreferencesKey("discover_location")
+                        if (mutablePrefs[discoverKey] == null) {
+                            mutablePrefs[discoverKey] = priorDiscoverLocation
+                        }
+                    }
+                    if (feature == "layout_settings") {
+                        val finalDiscover = mutablePrefs[stringPreferencesKey("discover_location")]?.let {
+                            runCatching { DiscoverLocation.valueOf(it) }.getOrNull()
+                        }
+                        if (finalDiscover != null && finalDiscover != DiscoverLocation.OFF) {
+                            mutablePrefs[stringPreferencesKey("last_non_off_discover_location")] =
+                                finalDiscover.name
                         }
                     }
                 }
@@ -295,10 +359,58 @@ class ProfileSettingsSyncService @Inject constructor(
         return signatures.joinToString(separator = "||")
     }
 
+    private fun extractDiscoverLocationString(featureJson: JsonObject): String? {
+        val encoded = featureJson["discover_location"] as? JsonObject ?: return null
+        val type = encoded["type"]?.jsonPrimitive?.contentOrNull
+        if (type != "string") return null
+        return encoded["value"]?.jsonPrimitive?.contentOrNull
+    }
+
+    private fun normalizeLayoutSettingsForSignature(featureJson: JsonObject): JsonObject {
+        val hasLegacy = "search_discover_enabled" in featureJson
+        val hasNewKey = "discover_location" in featureJson
+        val hasLocalOnly = featureJson.keys.any { it in localOnlyLayoutKeys }
+        if (!hasLegacy && !hasNewKey && !hasLocalOnly) return featureJson
+        val newDiscoverString = extractDiscoverLocationString(featureJson)
+        if (!hasLegacy && newDiscoverString != null && !hasLocalOnly) return featureJson
+        return buildJsonObject {
+            featureJson.forEach { (keyName, encodedValue) ->
+                when {
+                    keyName == "search_discover_enabled" -> return@forEach
+                    keyName == "discover_location" && newDiscoverString == null -> return@forEach
+                    keyName in localOnlyLayoutKeys -> return@forEach
+                    else -> put(keyName, encodedValue)
+                }
+            }
+            if (newDiscoverString == null && hasLegacy) {
+                val legacy = (featureJson["search_discover_enabled"] as? JsonObject)
+                    ?.get("value")?.jsonPrimitive?.contentOrNull
+                    ?.toBooleanStrictOrNull()
+                if (legacy != null) {
+                    put(
+                        "discover_location",
+                        buildJsonObject {
+                            put("type", "string")
+                            put(
+                                "value",
+                                DiscoverLocation.fromLegacySearchDiscoverEnabled(legacy).name
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+
     private fun buildSettingsSignature(featuresJson: JsonObject): String {
         return syncedFeatures.joinToString(separator = "||") { feature ->
             val featureJson = featuresJson[feature]?.jsonObject ?: JsonObject(emptyMap())
-            "$feature={${buildFeatureSignature(featureJson)}}"
+            val normalized = if (feature == "layout_settings") {
+                normalizeLayoutSettingsForSignature(featureJson)
+            } else {
+                featureJson
+            }
+            "$feature={${buildFeatureSignature(normalized)}}"
         }
     }
 
@@ -307,6 +419,7 @@ class ProfileSettingsSyncService @Inject constructor(
             .entries
             .mapNotNull { (key, rawValue) ->
                 if (feature == "layout_settings" && key.name in catalogKeysExcludedFromBlob) return@mapNotNull null
+                if (feature == "layout_settings" && key.name in localOnlyLayoutKeys) return@mapNotNull null
                 encodePreferenceValue(rawValue)?.let { encoded ->
                     key.name to encoded.toString()
                 }

--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -16,6 +16,7 @@ import com.nuvio.tv.core.sync.homeCollectionKey
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.Collection
 import com.nuvio.tv.domain.model.ContinueWatchingSortMode
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import kotlinx.coroutines.flow.Flow
@@ -57,7 +58,6 @@ class LayoutPreferenceDataStore @Inject constructor(
     private val modernSidebarBlurEnabledKey = booleanPreferencesKey("modern_sidebar_blur_enabled")
     private val modernLandscapePostersEnabledKey = booleanPreferencesKey("modern_landscape_posters_enabled")
     private val heroSectionEnabledKey = booleanPreferencesKey("hero_section_enabled")
-    private val searchDiscoverEnabledKey = booleanPreferencesKey("search_discover_enabled")
     private val posterLabelsEnabledKey = booleanPreferencesKey("poster_labels_enabled")
     private val catalogAddonNameEnabledKey = booleanPreferencesKey("catalog_addon_name_enabled")
     private val catalogTypeSuffixEnabledKey = booleanPreferencesKey("catalog_type_suffix_enabled")
@@ -180,8 +180,20 @@ class LayoutPreferenceDataStore @Inject constructor(
         prefs[heroSectionEnabledKey] ?: true
     }
 
-    val searchDiscoverEnabled: Flow<Boolean> = profileFlow { prefs ->
-        prefs[searchDiscoverEnabledKey] ?: true
+    val discoverLocation: Flow<DiscoverLocation> = profileFlow { prefs ->
+        val stored = prefs[discoverLocationKey] ?: DiscoverLocation.IN_SEARCH.name
+        runCatching { DiscoverLocation.valueOf(stored) }
+            .getOrDefault(DiscoverLocation.IN_SEARCH)
+    }
+
+    val lastNonOffDiscoverLocation: Flow<DiscoverLocation> = profileFlow { prefs ->
+        val stored = prefs[lastNonOffDiscoverLocationKey]
+            ?.takeIf { it != DiscoverLocation.OFF.name }
+        val fallback = prefs[discoverLocationKey]
+            ?.takeIf { it != DiscoverLocation.OFF.name }
+        val source = stored ?: fallback ?: DiscoverLocation.IN_SEARCH.name
+        runCatching { DiscoverLocation.valueOf(source) }
+            .getOrDefault(DiscoverLocation.IN_SEARCH)
     }
 
     val posterLabelsEnabled: Flow<Boolean> = profileFlow { prefs ->
@@ -427,9 +439,13 @@ class LayoutPreferenceDataStore @Inject constructor(
         }
     }
 
-    suspend fun setSearchDiscoverEnabled(enabled: Boolean) {
+    suspend fun setDiscoverLocation(location: DiscoverLocation) {
         store().edit { prefs ->
-            prefs[searchDiscoverEnabledKey] = enabled
+            prefs[discoverLocationKey] = location.name
+            if (location != DiscoverLocation.OFF) {
+                prefs[lastNonOffDiscoverLocationKey] = location.name
+            }
+            prefs.remove(legacySearchDiscoverEnabledKey)
         }
     }
 
@@ -673,3 +689,7 @@ class LayoutPreferenceDataStore @Inject constructor(
         )
     }
 }
+
+internal val legacySearchDiscoverEnabledKey = booleanPreferencesKey("search_discover_enabled")
+internal val discoverLocationKey = stringPreferencesKey("discover_location")
+internal val lastNonOffDiscoverLocationKey = stringPreferencesKey("last_non_off_discover_location")

--- a/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStoreFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStoreFactory.kt
@@ -2,12 +2,14 @@ package com.nuvio.tv.data.local
 
 import android.content.Context
 import android.util.Log
+import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.nuvio.tv.domain.model.DiscoverLocation
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +25,31 @@ private class ScopedDataStore(
     val job: Job
 )
 
+internal val discoverLocationMigration = object : DataMigration<Preferences> {
+    override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+        legacySearchDiscoverEnabledKey in currentData
+
+    override suspend fun migrate(currentData: Preferences): Preferences {
+        val mutable = currentData.toMutablePreferences()
+        val legacy = mutable[legacySearchDiscoverEnabledKey]
+        if (legacy != null && mutable[discoverLocationKey] == null) {
+            val rememberedLocation = mutable[lastNonOffDiscoverLocationKey]?.let {
+                runCatching { DiscoverLocation.valueOf(it) }.getOrNull()
+            }?.takeIf { it != DiscoverLocation.OFF }
+            val resolved = if (legacy && rememberedLocation != null) {
+                rememberedLocation
+            } else {
+                DiscoverLocation.fromLegacySearchDiscoverEnabled(legacy)
+            }
+            mutable[discoverLocationKey] = resolved.name
+        }
+        mutable.remove(legacySearchDiscoverEnabledKey)
+        return mutable.toPreferences()
+    }
+
+    override suspend fun cleanUp() = Unit
+}
+
 @Singleton
 class ProfileDataStoreFactory @Inject constructor(
     @ApplicationContext private val context: Context
@@ -35,7 +62,7 @@ class ProfileDataStoreFactory @Inject constructor(
     val corruptedFileNames: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     fun get(profileId: Int, featureName: String): DataStore<Preferences> {
-        val fileName = if (profileId == 1) featureName else "${featureName}_p${profileId}"
+        val fileName = if (profileId == 1) featureName else "${featureName}_p$profileId"
         synchronized(lock) {
             cache[fileName]?.let { return it.store }
             return createAndCache(fileName).store
@@ -45,7 +72,7 @@ class ProfileDataStoreFactory @Inject constructor(
     suspend fun clearProfile(profileId: Int) {
         if (profileId == 1) return
         deletedProfileIds.add(profileId)
-        val suffix = "_p${profileId}"
+        val suffix = "_p$profileId"
         val keysToRemove = synchronized(lock) {
             cache.keys.filter { it.endsWith(suffix) }
         }
@@ -69,6 +96,11 @@ class ProfileDataStoreFactory @Inject constructor(
     private fun createAndCache(fileName: String): ScopedDataStore {
         val job = SupervisorJob()
         val scope = CoroutineScope(Dispatchers.IO + job)
+        val migrations = if (fileName == "layout_settings" || fileName.startsWith("layout_settings_p")) {
+            listOf(discoverLocationMigration)
+        } else {
+            emptyList()
+        }
         val store = PreferenceDataStoreFactory.create(
             corruptionHandler = androidx.datastore.core.handlers.ReplaceFileCorruptionHandler { ex ->
                 Log.e("ProfileDataStoreFactory", "DataStore corrupted ($fileName): ${ex.message} — resetting to empty preferences")
@@ -76,6 +108,7 @@ class ProfileDataStoreFactory @Inject constructor(
                 emptyPreferences()
             },
             scope = scope,
+            migrations = migrations,
             produceFile = { context.preferencesDataStoreFile(fileName) }
         )
         val scoped = ScopedDataStore(store, scope, job)

--- a/app/src/main/java/com/nuvio/tv/domain/model/DiscoverLocation.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/DiscoverLocation.kt
@@ -1,0 +1,12 @@
+package com.nuvio.tv.domain.model
+
+enum class DiscoverLocation {
+    OFF,
+    IN_SEARCH,
+    IN_SIDEBAR;
+
+    companion object {
+        fun fromLegacySearchDiscoverEnabled(enabled: Boolean): DiscoverLocation =
+            if (enabled) IN_SEARCH else OFF
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +25,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.ui.components.EmptyScreenState
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
@@ -55,6 +57,12 @@ fun DiscoverScreen(
         )
     }
 
+    LaunchedEffect(uiState.discoverLocation) {
+        if (uiState.discoverLocation != DiscoverLocation.OFF) {
+            viewModel.ensureDiscoverLoaded()
+        }
+    }
+
     val latestPendingDiscoverRestore by rememberUpdatedState(pendingDiscoverRestoreOnResume)
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -71,7 +79,7 @@ fun DiscoverScreen(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        if (!uiState.discoverEnabled) {
+        if (uiState.discoverLocation == DiscoverLocation.OFF) {
             EmptyScreenState(
                 title = stringResource(R.string.discover_disabled_title),
                 subtitle = stringResource(R.string.discover_disabled_subtitle),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -578,7 +578,8 @@ fun SearchScreen(
                                     },
                                     onSectionFocusChanged = { focused ->
                                         isRecentSearchSectionFocused = focused
-                                    }
+                                    },
+                                    modifier = Modifier.padding(horizontal = 52.dp)
                                 )
                             } else {
                                 EmptyScreenState(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -91,6 +91,7 @@ import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
 import com.nuvio.tv.ui.theme.NuvioColors
+import com.nuvio.tv.domain.model.DiscoverLocation
 import android.view.inputmethod.CompletionInfo
 import android.view.inputmethod.InputMethodManager
 import androidx.compose.ui.platform.LocalView
@@ -303,8 +304,11 @@ fun SearchScreen(
         searchRowFocusedItemIndex.keys.retainAll(visibleRowKeys)
     }
 
-    val isDiscoverMode = remember(uiState.discoverEnabled, trimmedSubmittedQuery) {
-        uiState.discoverEnabled && trimmedSubmittedQuery.isEmpty()
+    val isDiscoverMode = remember(uiState.discoverLocation, trimmedSubmittedQuery) {
+        uiState.discoverLocation == DiscoverLocation.IN_SEARCH && trimmedSubmittedQuery.isEmpty()
+    }
+    LaunchedEffect(isDiscoverMode) {
+        if (isDiscoverMode) viewModel.ensureDiscoverLoaded()
     }
     val hasPendingUnsubmittedQuery = remember(isDiscoverMode, trimmedQuery, trimmedSubmittedQuery) {
         !isDiscoverMode && trimmedQuery.length >= 2 && trimmedQuery != trimmedSubmittedQuery
@@ -483,6 +487,7 @@ fun SearchScreen(
                     onVoiceSearch = launchVoiceSearch,
                     onMoveToResults = { focusResults = true },
                     onOpenDiscover = onOpenDiscover,
+                    showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
                     keyboardController = keyboardController
                 )
 
@@ -543,6 +548,7 @@ fun SearchScreen(
                             focusResults = true
                         },
                         onOpenDiscover = onOpenDiscover,
+                        showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
                         keyboardController = keyboardController
                     )
                 }
@@ -577,10 +583,10 @@ fun SearchScreen(
                             } else {
                                 EmptyScreenState(
                                     title = stringResource(R.string.search_start_title),
-                                    subtitle = if (uiState.discoverEnabled) {
-                                        stringResource(R.string.search_start_subtitle)
-                                    } else {
+                                    subtitle = if (uiState.discoverLocation == DiscoverLocation.OFF) {
                                         stringResource(R.string.search_start_subtitle_no_discover)
+                                    } else {
+                                        stringResource(R.string.search_start_subtitle)
                                     },
                                     icon = Icons.Default.Search
                                 )
@@ -775,6 +781,7 @@ private fun SearchInputField(
     onVoiceSearch: () -> Unit,
     onMoveToResults: () -> Unit,
     onOpenDiscover: () -> Unit,
+    showDiscoverButton: Boolean,
     keyboardController: androidx.compose.ui.platform.SoftwareKeyboardController?
 ) {
     var isDiscoverButtonFocused by remember { mutableStateOf(false) }
@@ -786,29 +793,31 @@ private fun SearchInputField(
             .padding(horizontal = 48.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconButton(
-            onClick = onOpenDiscover,
-            modifier = Modifier
-                .onFocusChanged { isDiscoverButtonFocused = it.isFocused }
-                .size(56.dp)
-                .border(
-                    width = if (isDiscoverButtonFocused) 2.dp else 1.dp,
-                    color = if (isDiscoverButtonFocused) NuvioColors.FocusRing else NuvioColors.Border,
-                    shape = RoundedCornerShape(12.dp)
+        if (showDiscoverButton) {
+            IconButton(
+                onClick = onOpenDiscover,
+                modifier = Modifier
+                    .onFocusChanged { isDiscoverButtonFocused = it.isFocused }
+                    .size(56.dp)
+                    .border(
+                        width = if (isDiscoverButtonFocused) 2.dp else 1.dp,
+                        color = if (isDiscoverButtonFocused) NuvioColors.FocusRing else NuvioColors.Border,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .background(
+                        color = NuvioColors.BackgroundCard,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Explore,
+                    contentDescription = stringResource(R.string.cd_open_discover),
+                    tint = NuvioColors.TextPrimary
                 )
-                .background(
-                    color = NuvioColors.BackgroundCard,
-                    shape = RoundedCornerShape(12.dp)
-                )
-        ) {
-            Icon(
-                imageVector = Icons.Default.Explore,
-                contentDescription = stringResource(R.string.cd_open_discover),
-                tint = NuvioColors.TextPrimary
-            )
-        }
+            }
 
-        Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(12.dp))
+        }
 
         if (showVoiceSearch) {
             val themeAccent = NuvioColors.Secondary

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.search
 import androidx.compose.runtime.Immutable
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.MetaPreview
 
 @Immutable
@@ -13,7 +14,7 @@ data class SearchUiState(
     val error: String? = null,
     val catalogRows: List<CatalogRow> = emptyList(),
     val installedAddons: List<Addon> = emptyList(),
-    val discoverEnabled: Boolean = true,
+    val discoverLocation: DiscoverLocation = DiscoverLocation.IN_SEARCH,
     val discoverInitialized: Boolean = false,
     val discoverLoading: Boolean = false,
     val discoverLoadingMore: Boolean = false,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -10,6 +10,7 @@ import com.nuvio.tv.data.local.SearchHistoryDataStore
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
 import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.skipStep
 import com.nuvio.tv.domain.model.supportsExtra
 import com.nuvio.tv.core.util.filterReleasedItems
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
@@ -80,18 +82,25 @@ class SearchViewModel @Inject constructor(
                 .collect { ids -> _watchedMovieIds.value = ids }
         }
         viewModelScope.launch {
-            layoutPreferenceDataStore.searchDiscoverEnabled.collectLatest { enabled ->
-                _uiState.update { it.copy(discoverEnabled = enabled) }
-                if (enabled) {
-                    loadDiscoverCatalogs()
-                } else {
+            layoutPreferenceDataStore.discoverLocation.distinctUntilChanged().collectLatest { location ->
+                _uiState.update { it.copy(discoverLocation = location) }
+                if (location == DiscoverLocation.OFF) {
                     discoverJob?.cancel()
+                    discoverJob = null
+                    revealBatchAfterNextDiscoverFetch = false
                     _uiState.update {
                         it.copy(
+                            discoverInitialized = false,
                             discoverLoading = false,
                             discoverLoadingMore = false,
+                            discoverCatalogs = emptyList(),
+                            selectedDiscoverType = "movie",
+                            selectedDiscoverCatalogKey = null,
+                            selectedDiscoverGenre = null,
                             discoverResults = emptyList(),
-                            pendingDiscoverResults = emptyList()
+                            pendingDiscoverResults = emptyList(),
+                            discoverHasMore = true,
+                            discoverPage = 1
                         )
                     }
                 }
@@ -144,6 +153,13 @@ class SearchViewModel @Inject constructor(
         val heightDp: Int,
         val cornerRadiusDp: Int
     )
+
+    fun ensureDiscoverLoaded() {
+        val state = _uiState.value
+        if (state.discoverLocation == DiscoverLocation.OFF) return
+        if (state.discoverInitialized || state.discoverLoading) return
+        viewModelScope.launch { loadDiscoverCatalogs() }
+    }
 
     fun onEvent(event: SearchEvent) {
         when (event) {
@@ -302,11 +318,7 @@ class SearchViewModel @Inject constructor(
                     catalogRows = emptyList()
                 )
             }
-            if (_uiState.value.discoverEnabled && !_uiState.value.discoverInitialized) {
-                viewModelScope.launch {
-                    loadDiscoverCatalogs()
-                }
-            }
+            ensureDiscoverLoaded()
             return
         }
 
@@ -554,7 +566,7 @@ class SearchViewModel @Inject constructor(
     }
 
     private suspend fun loadDiscoverCatalogs() {
-        if (!_uiState.value.discoverEnabled) return
+        if (_uiState.value.discoverLocation == DiscoverLocation.OFF) return
         _uiState.update { it.copy(discoverLoading = true) }
         val addons = try {
             addonRepository.getInstalledAddons().first()
@@ -739,6 +751,7 @@ class SearchViewModel @Inject constructor(
                 extraArgs = extraArgs,
                 supportsSkip = selectedCatalog.supportsSkip
             ).collect { result ->
+                if (_uiState.value.discoverLocation == DiscoverLocation.OFF) return@collect
                 when (result) {
                     is NetworkResult.Success -> {
                         val incoming = result.data.items
@@ -823,6 +836,6 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun catalogKey(addonId: String, type: String, catalogId: String): String {
-        return "${addonId}_${type}_${catalogId}"
+        return "${addonId}_${type}_$catalogId"
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -910,7 +910,8 @@ private fun DiscoverLocationRow(
     onFocused: () -> Unit
 ) {
     val sectionEnabled = selectedLocation != DiscoverLocation.OFF
-    val pinnedToSidebar = selectedLocation == DiscoverLocation.IN_SIDEBAR
+    var dialogOpen by remember { mutableStateOf(false) }
+
     CompactToggleRow(
         title = stringResource(R.string.layout_show_discover),
         subtitle = stringResource(R.string.layout_show_discover_sub),
@@ -927,21 +928,129 @@ private fun DiscoverLocationRow(
         onFocused = onFocused
     )
     if (sectionEnabled) {
-        CompactToggleRow(
-            title = stringResource(R.string.layout_discover_pin_to_sidebar),
-            subtitle = stringResource(R.string.layout_discover_pin_to_sidebar_sub),
-            checked = pinnedToSidebar,
-            onToggle = {
-                onLocationSelected(
-                    when (selectedLocation) {
-                        DiscoverLocation.IN_SIDEBAR -> DiscoverLocation.IN_SEARCH
-                        DiscoverLocation.IN_SEARCH -> DiscoverLocation.IN_SIDEBAR
-                        DiscoverLocation.OFF -> error("unreachable: OFF excluded by sectionEnabled")
-                    }
-                )
-            },
+        val currentLabel = when (selectedLocation) {
+            DiscoverLocation.IN_SIDEBAR -> stringResource(R.string.layout_discover_location_in_sidebar)
+            DiscoverLocation.IN_SEARCH -> stringResource(R.string.layout_discover_location_in_search)
+            DiscoverLocation.OFF -> ""
+        }
+        SettingsActionRow(
+            title = stringResource(R.string.layout_discover_location_action),
+            subtitle = currentLabel,
+            onClick = { dialogOpen = true },
             onFocused = onFocused
         )
+    }
+
+    if (dialogOpen) {
+        DiscoverLocationDialog(
+            selectedLocation = selectedLocation,
+            onLocationSelected = { location ->
+                onLocationSelected(location)
+                dialogOpen = false
+            },
+            onDismiss = { dialogOpen = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun DiscoverLocationDialog(
+    selectedLocation: DiscoverLocation,
+    onLocationSelected: (DiscoverLocation) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    val options = listOf(
+        Triple(
+            DiscoverLocation.IN_SEARCH,
+            stringResource(R.string.layout_discover_location_in_search),
+            stringResource(R.string.layout_discover_location_in_search_desc)
+        ),
+        Triple(
+            DiscoverLocation.IN_SIDEBAR,
+            stringResource(R.string.layout_discover_location_in_sidebar),
+            stringResource(R.string.layout_discover_location_in_sidebar_desc)
+        )
+    )
+
+    val effectiveSelected = if (selectedLocation == DiscoverLocation.OFF) {
+        DiscoverLocation.IN_SEARCH
+    } else {
+        selectedLocation
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    NuvioDialog(
+        onDismiss = onDismiss,
+        title = stringResource(R.string.layout_discover_location_dialog_title),
+        width = 460.dp,
+        suppressFirstKeyUp = false
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 320.dp)
+        ) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(vertical = 4.dp)
+            ) {
+                items(
+                    count = options.size,
+                    key = { index -> options[index].first.name }
+                ) { index ->
+                    val (location, title, description) = options[index]
+                    val isSelected = location == effectiveSelected
+
+                    Card(
+                        onClick = { onLocationSelected(location) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(if (index == 0) Modifier.focusRequester(focusRequester) else Modifier),
+                        colors = CardDefaults.colors(
+                            containerColor = if (isSelected) NuvioColors.FocusBackground else NuvioColors.BackgroundCard,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        shape = CardDefaults.shape(shape = RoundedCornerShape(10.dp)),
+                        scale = CardDefaults.scale(focusedScale = 1f)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = title,
+                                    color = if (isSelected) NuvioColors.Primary else NuvioColors.TextPrimary,
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = description,
+                                    color = NuvioColors.TextSecondary,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                            if (isSelected) {
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = stringResource(R.string.cd_selected),
+                                    tint = NuvioColors.Primary,
+                                    modifier = Modifier.height(20.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.core.build.AppFeaturePolicy
 import com.nuvio.tv.domain.model.ContinueWatchingSortMode
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.ui.components.ClassicLayoutPreview
@@ -350,6 +351,14 @@ fun LayoutSettingsContent(
                             onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
                         )
                     }
+                    DiscoverLocationRow(
+                        selectedLocation = uiState.discoverLocation,
+                        rememberedLocation = uiState.lastNonOffDiscoverLocation,
+                        onLocationSelected = { location ->
+                            viewModel.onEvent(LayoutSettingsEvent.SetDiscoverLocation(location))
+                        },
+                        onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
+                    )
                     if (uiState.selectedLayout != HomeLayout.MODERN) {
                         CompactToggleRow(
                             title = stringResource(R.string.layout_show_hero),
@@ -363,17 +372,6 @@ fun LayoutSettingsContent(
                             onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
                         )
                     }
-                    CompactToggleRow(
-                        title = stringResource(R.string.layout_show_discover),
-                        subtitle = stringResource(R.string.layout_show_discover_sub),
-                        checked = uiState.searchDiscoverEnabled,
-                        onToggle = {
-                            viewModel.onEvent(
-                                LayoutSettingsEvent.SetSearchDiscoverEnabled(!uiState.searchDiscoverEnabled)
-                            )
-                        },
-                        onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
-                    )
                     if (uiState.selectedLayout != HomeLayout.MODERN) {
                         CompactToggleRow(
                             title = stringResource(R.string.layout_poster_labels),
@@ -901,6 +899,49 @@ private fun ModernTrailerPlaybackTargetRow(
                 onFocused = onFocused
             )
         }
+    }
+}
+
+@Composable
+private fun DiscoverLocationRow(
+    selectedLocation: DiscoverLocation,
+    rememberedLocation: DiscoverLocation,
+    onLocationSelected: (DiscoverLocation) -> Unit,
+    onFocused: () -> Unit
+) {
+    val sectionEnabled = selectedLocation != DiscoverLocation.OFF
+    val pinnedToSidebar = selectedLocation == DiscoverLocation.IN_SIDEBAR
+    CompactToggleRow(
+        title = stringResource(R.string.layout_show_discover),
+        subtitle = stringResource(R.string.layout_show_discover_sub),
+        checked = sectionEnabled,
+        onToggle = {
+            onLocationSelected(
+                when (selectedLocation) {
+                    DiscoverLocation.OFF -> rememberedLocation
+                    DiscoverLocation.IN_SEARCH,
+                    DiscoverLocation.IN_SIDEBAR -> DiscoverLocation.OFF
+                }
+            )
+        },
+        onFocused = onFocused
+    )
+    if (sectionEnabled) {
+        CompactToggleRow(
+            title = stringResource(R.string.layout_discover_pin_to_sidebar),
+            subtitle = stringResource(R.string.layout_discover_pin_to_sidebar_sub),
+            checked = pinnedToSidebar,
+            onToggle = {
+                onLocationSelected(
+                    when (selectedLocation) {
+                        DiscoverLocation.IN_SIDEBAR -> DiscoverLocation.IN_SEARCH
+                        DiscoverLocation.IN_SEARCH -> DiscoverLocation.IN_SIDEBAR
+                        DiscoverLocation.OFF -> error("unreachable: OFF excluded by sectionEnabled")
+                    }
+                )
+            },
+            onFocused = onFocused
+        )
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.domain.model.ContinueWatchingSortMode
+import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.domain.repository.AddonRepository
@@ -29,7 +30,8 @@ data class LayoutSettingsUiState(
     val modernLandscapePostersEnabled: Boolean = false,
     val modernHeroFullScreenBackdropEnabled: Boolean = false,
     val heroSectionEnabled: Boolean = true,
-    val searchDiscoverEnabled: Boolean = true,
+    val discoverLocation: DiscoverLocation = DiscoverLocation.IN_SEARCH,
+    val lastNonOffDiscoverLocation: DiscoverLocation = DiscoverLocation.IN_SEARCH,
     val posterLabelsEnabled: Boolean = true,
     val catalogAddonNameEnabled: Boolean = true,
     val catalogTypeSuffixEnabled: Boolean = true,
@@ -70,7 +72,7 @@ sealed class LayoutSettingsEvent {
     data class SetModernLandscapePostersEnabled(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetModernHeroFullScreenBackdropEnabled(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetHeroSectionEnabled(val enabled: Boolean) : LayoutSettingsEvent()
-    data class SetSearchDiscoverEnabled(val enabled: Boolean) : LayoutSettingsEvent()
+    data class SetDiscoverLocation(val location: DiscoverLocation) : LayoutSettingsEvent()
     data class SetPosterLabelsEnabled(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetCatalogAddonNameEnabled(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetCatalogTypeSuffixEnabled(val enabled: Boolean) : LayoutSettingsEvent()
@@ -164,8 +166,13 @@ class LayoutSettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            layoutPreferenceDataStore.searchDiscoverEnabled.distinctUntilChanged().collectLatest { enabled ->
-                updateUiStateIfChanged { it.copy(searchDiscoverEnabled = enabled) }
+            layoutPreferenceDataStore.discoverLocation.distinctUntilChanged().collectLatest { location ->
+                updateUiStateIfChanged { it.copy(discoverLocation = location) }
+            }
+        }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.lastNonOffDiscoverLocation.distinctUntilChanged().collectLatest { location ->
+                updateUiStateIfChanged { it.copy(lastNonOffDiscoverLocation = location) }
             }
         }
         viewModelScope.launch {
@@ -293,7 +300,7 @@ class LayoutSettingsViewModel @Inject constructor(
             is LayoutSettingsEvent.SetModernLandscapePostersEnabled -> setModernLandscapePostersEnabled(event.enabled)
             is LayoutSettingsEvent.SetModernHeroFullScreenBackdropEnabled -> setModernHeroFullScreenBackdropEnabled(event.enabled)
             is LayoutSettingsEvent.SetHeroSectionEnabled -> setHeroSectionEnabled(event.enabled)
-            is LayoutSettingsEvent.SetSearchDiscoverEnabled -> setSearchDiscoverEnabled(event.enabled)
+            is LayoutSettingsEvent.SetDiscoverLocation -> setDiscoverLocation(event.location)
             is LayoutSettingsEvent.SetPosterLabelsEnabled -> setPosterLabelsEnabled(event.enabled)
             is LayoutSettingsEvent.SetCatalogAddonNameEnabled -> setCatalogAddonNameEnabled(event.enabled)
             is LayoutSettingsEvent.SetCatalogTypeSuffixEnabled -> setCatalogTypeSuffixEnabled(event.enabled)
@@ -381,10 +388,10 @@ class LayoutSettingsViewModel @Inject constructor(
         }
     }
 
-    private fun setSearchDiscoverEnabled(enabled: Boolean) {
-        if (_uiState.value.searchDiscoverEnabled == enabled) return
+    private fun setDiscoverLocation(location: DiscoverLocation) {
+        if (_uiState.value.discoverLocation == location) return
         viewModelScope.launch {
-            layoutPreferenceDataStore.setSearchDiscoverEnabled(enabled)
+            layoutPreferenceDataStore.setDiscoverLocation(location)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/util/DrawerFocusRequesters.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/DrawerFocusRequesters.kt
@@ -1,0 +1,31 @@
+package com.nuvio.tv.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.focus.FocusRequester
+import com.nuvio.tv.DrawerItem
+
+internal fun <T> syncRouteMap(
+    existing: MutableMap<String, T>,
+    routes: List<String>,
+    create: () -> T
+) {
+    val validRoutes = routes.toSet()
+    existing.keys.retainAll(validRoutes)
+    routes.forEach { route ->
+        existing.getOrPut(route, create)
+    }
+}
+
+@Composable
+internal fun rememberDrawerItemFocusRequesters(
+    drawerItems: List<DrawerItem>
+): Map<String, FocusRequester> {
+    val focusRequesters = remember { linkedMapOf<String, FocusRequester>() }
+    syncRouteMap(
+        existing = focusRequesters,
+        routes = drawerItems.map(DrawerItem::route),
+        create = ::FocusRequester
+    )
+    return focusRequesters
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -702,10 +702,14 @@
     <string name="layout_classic_focus_gradient_sub">Blend artwork colors into the right side of Classic home.</string>
     <string name="layout_show_hero">Show Hero Section</string>
     <string name="layout_show_hero_sub">Display hero carousel at top of home.</string>
-    <string name="layout_show_discover">Show Discover</string>
+    <string name="layout_show_discover">Show/Hide Discover</string>
     <string name="layout_show_discover_sub">Adds a Discover section for browsing.</string>
-    <string name="layout_discover_pin_to_sidebar">Pin Discover to Sidebar</string>
-    <string name="layout_discover_pin_to_sidebar_sub">Moves Discover to the Sidebar instead of Search.</string>
+    <string name="layout_discover_location_action">Discover Location</string>
+    <string name="layout_discover_location_dialog_title">Discover Location</string>
+    <string name="layout_discover_location_in_search">Show in Search</string>
+    <string name="layout_discover_location_in_search_desc">Discover appears inside the Search tab.</string>
+    <string name="layout_discover_location_in_sidebar">Show in Side Panel</string>
+    <string name="layout_discover_location_in_sidebar_desc">Discover gets its own item in the side panel.</string>
     <string name="layout_poster_labels">Show Poster Labels</string>
     <string name="layout_poster_labels_sub">Show titles under posters in rows, grid, and see-all.</string>
     <string name="layout_addon_name">Show Addon Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -702,8 +702,10 @@
     <string name="layout_classic_focus_gradient_sub">Blend artwork colors into the right side of Classic home.</string>
     <string name="layout_show_hero">Show Hero Section</string>
     <string name="layout_show_hero_sub">Display hero carousel at top of home.</string>
-    <string name="layout_show_discover">Show Discover in Search</string>
-    <string name="layout_show_discover_sub">Show browse section when search is empty.</string>
+    <string name="layout_show_discover">Show Discover</string>
+    <string name="layout_show_discover_sub">Adds a Discover section for browsing.</string>
+    <string name="layout_discover_pin_to_sidebar">Pin Discover to Sidebar</string>
+    <string name="layout_discover_pin_to_sidebar_sub">Moves Discover to the Sidebar instead of Search.</string>
     <string name="layout_poster_labels">Show Poster Labels</string>
     <string name="layout_poster_labels_sub">Show titles under posters in rows, grid, and see-all.</string>
     <string name="layout_addon_name">Show Addon Name</string>
@@ -1575,7 +1577,7 @@
     <string name="search_no_results_title">No Results</string>
     <string name="search_no_results_subtitle">Try searching with different keywords</string>
     <string name="discover_disabled_title">Discover is disabled</string>
-    <string name="discover_disabled_subtitle">Enable Search Discover in settings</string>
+    <string name="discover_disabled_subtitle">Enable Discover in Layout settings</string>
 
     <!-- Library -->
     <string name="library_list_create_dialog_title">Create List</string>

--- a/app/src/test/java/com/nuvio/tv/data/local/DiscoverLocationMigrationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/DiscoverLocationMigrationTest.kt
@@ -1,0 +1,92 @@
+package com.nuvio.tv.data.local
+
+import androidx.datastore.preferences.core.emptyPreferences
+import com.nuvio.tv.domain.model.DiscoverLocation
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiscoverLocationMigrationTest {
+
+    private val legacyKey = legacySearchDiscoverEnabledKey
+    private val newKey = discoverLocationKey
+    private val lastNonOffKey = lastNonOffDiscoverLocationKey
+
+    @Test
+    fun `shouldMigrate is true when legacy key present`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = true
+        }.toPreferences()
+        assertTrue(discoverLocationMigration.shouldMigrate(prefs))
+    }
+
+    @Test
+    fun `shouldMigrate is false when legacy key absent`() = runBlocking {
+        assertFalse(discoverLocationMigration.shouldMigrate(emptyPreferences()))
+    }
+
+    @Test
+    fun `migrate with legacy true and no remembered yields IN_SEARCH`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = true
+        }.toPreferences()
+        val migrated = discoverLocationMigration.migrate(prefs)
+        assertEquals(DiscoverLocation.IN_SEARCH.name, migrated[newKey])
+        assertNull(migrated[legacyKey])
+    }
+
+    @Test
+    fun `migrate with legacy false yields OFF`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = false
+        }.toPreferences()
+        val migrated = discoverLocationMigration.migrate(prefs)
+        assertEquals(DiscoverLocation.OFF.name, migrated[newKey])
+        assertNull(migrated[legacyKey])
+    }
+
+    @Test
+    fun `migrate with legacy true and remembered IN_SIDEBAR restores IN_SIDEBAR`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = true
+            this[lastNonOffKey] = DiscoverLocation.IN_SIDEBAR.name
+        }.toPreferences()
+        val migrated = discoverLocationMigration.migrate(prefs)
+        assertEquals(DiscoverLocation.IN_SIDEBAR.name, migrated[newKey])
+    }
+
+    @Test
+    fun `migrate ignores OFF as remembered fallback`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = true
+            this[lastNonOffKey] = DiscoverLocation.OFF.name
+        }.toPreferences()
+        val migrated = discoverLocationMigration.migrate(prefs)
+        assertEquals(DiscoverLocation.IN_SEARCH.name, migrated[newKey])
+    }
+
+    @Test
+    fun `migrate does not overwrite existing new key`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = false
+            this[newKey] = DiscoverLocation.IN_SIDEBAR.name
+        }.toPreferences()
+        val migrated = discoverLocationMigration.migrate(prefs)
+        assertEquals(DiscoverLocation.IN_SIDEBAR.name, migrated[newKey])
+        assertNull(migrated[legacyKey])
+    }
+
+    @Test
+    fun `migrate is idempotent across runs`() = runBlocking {
+        val prefs = emptyPreferences().toMutablePreferences().apply {
+            this[legacyKey] = true
+        }.toPreferences()
+        val first = discoverLocationMigration.migrate(prefs)
+        assertFalse(discoverLocationMigration.shouldMigrate(first))
+        val second = discoverLocationMigration.migrate(first)
+        assertEquals(first[newKey], second[newKey])
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/util/DrawerFocusRequesterStateTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/util/DrawerFocusRequesterStateTest.kt
@@ -1,0 +1,102 @@
+package com.nuvio.tv.ui.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class DrawerFocusRequesterStateTest {
+
+    @Test
+    fun `syncRouteMap preserves existing identities when discover route is inserted`() {
+        val home = Any()
+        val search = Any()
+        val library = Any()
+        val addons = Any()
+        val settings = Any()
+        val requesters = linkedMapOf(
+            "home" to home,
+            "search" to search,
+            "library" to library,
+            "addons" to addons,
+            "settings" to settings
+        )
+
+        syncRouteMap(
+            existing = requesters,
+            routes = listOf("home", "discover", "search", "library", "addons", "settings"),
+            create = { Any() }
+        )
+
+        assertSame(home, requesters.getValue("home"))
+        assertSame(search, requesters.getValue("search"))
+        assertSame(library, requesters.getValue("library"))
+        assertSame(addons, requesters.getValue("addons"))
+        assertSame(settings, requesters.getValue("settings"))
+        assertNotNull(requesters["discover"])
+    }
+
+    @Test
+    fun `syncRouteMap drops stale routes when a route is removed`() {
+        val home = Any()
+        val discover = Any()
+        val search = Any()
+        val library = Any()
+        val addons = Any()
+        val settings = Any()
+        val requesters = linkedMapOf(
+            "home" to home,
+            "discover" to discover,
+            "search" to search,
+            "library" to library,
+            "addons" to addons,
+            "settings" to settings
+        )
+
+        syncRouteMap(
+            existing = requesters,
+            routes = listOf("home", "search", "library", "addons", "settings"),
+            create = { Any() }
+        )
+
+        assertFalse(requesters.containsKey("discover"))
+        assertSame(home, requesters.getValue("home"))
+        assertSame(search, requesters.getValue("search"))
+        assertSame(library, requesters.getValue("library"))
+        assertSame(addons, requesters.getValue("addons"))
+        assertSame(settings, requesters.getValue("settings"))
+    }
+
+    @Test
+    fun `syncRouteMap is a no-op when routes match existing entries`() {
+        val home = Any()
+        val discover = Any()
+        val search = Any()
+        val library = Any()
+        val addons = Any()
+        val settings = Any()
+        val requesters = linkedMapOf(
+            "home" to home,
+            "discover" to discover,
+            "search" to search,
+            "library" to library,
+            "addons" to addons,
+            "settings" to settings
+        )
+
+        syncRouteMap(
+            existing = requesters,
+            routes = listOf("home", "discover", "search", "library", "addons", "settings"),
+            create = { Any() }
+        )
+
+        assertEquals(6, requesters.size)
+        assertSame(home, requesters.getValue("home"))
+        assertSame(discover, requesters.getValue("discover"))
+        assertSame(search, requesters.getValue("search"))
+        assertSame(library, requesters.getValue("library"))
+        assertSame(addons, requesters.getValue("addons"))
+        assertSame(settings, requesters.getValue("settings"))
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the legacy `search_discover_enabled` boolean with a three-state `DiscoverLocation` preference (`OFF` / `IN_SEARCH` / `IN_SIDEBAR`). Layout Settings now exposes a `Show/Hide Discover` toggle and, when on, a `Discover Location` row that opens a dialog letting the user pick between `Show in Search` (default) or `Show in Side Panel`. Includes a DataStore migration, profile-sync compatibility for the legacy field, sidebar membership / routing / focus gating, mid-session redirect when the setting flips OFF on Discover, and the Search-screen off-state padding fix from the original issue.

## PR type

- Approved larger change (link approval below)

## Why
The old `search_discover_enabled` boolean only controlled whether Discover rendered inside Search. That left no fast path for users who treat Discover as a primary surface, and the off-state was visibly broken (Discover button stayed interactable; Recent Searches stretched edge to edge). Full problem statement, behavior, and migration details are in the approved feature request: NuvioMedia/NuvioTV#1470.

@tapframe approved the design subject to a wording and behavioral tweak: rename the toggle to `Show/Hide Discover`, and replace the inline `Pin Discover to Sidebar` toggle with a dialog asking whether to show Discover in Search (default) or in the Side Panel. This PR ships that revision.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)
Approved in NuvioMedia/NuvioTV#1470, see the comment from @tapframe on May 9, 2026 approving the design with the wording and dialog change.

## Testing
Every check from the original feature-request comment was re-run against the rebased branch, plus the new dialog flow:

- **Discover locations (Off / In Search / In Side Panel)**, each placement renders correctly. Off: no Discover button in Search, no sidebar entry, Recent Searches displays correctly. In Search: Discover button on the search bar, opens Discover. In Side Panel: Explore icon in the sidebar, Search loses the Discover button. Toggled between every pair and watched the UI update live.
- **Show/Hide Discover toggle**, turning the toggle off hides Discover everywhere; turning it back on restores the last non-off location and the dialog reflects that selection.
- **Discover Location dialog**, opens from the new action row, shows the current selection as subtitle, two options with descriptions, focus lands on the first option, dismisses on selection. Selecting a different location updates the sidebar / search surface immediately.
- **Sidebar variants**, cycled through standard expanded, collapsed (icon-only), and modern (floating pill / blur) sidebars. Discover entry renders with correct styling in each variant. Flipped Discover off in each style, nothing breaks visually.
- **Off -> On restores previous selection**, set Discover to Side Panel, toggled Off, toggled back On, dialog and routing return to Side Panel. Same flow with In Search. Force-stopped between toggles, placement still restored on relaunch.
- **Search off-state bugs from #1470**, Discover button is fully gone (not just disabled), Recent Searches no longer stretches edge to edge in either layout path (the follow-up that added padding to the second `RecentSearchesSection` invocation is included).
- **Back button**, Discover-in-Search: Home -> Search -> Discover -> Back lands on Search. Discover-in-Side-Panel: Home -> Discover (via sidebar) -> Back behaves like a root route.
- **Mid-session redirect**, confirmed the `LaunchedEffect` in `MainActivity` fires when `discoverLocation` flips to `OFF` while sitting on Discover. To actually trigger the redirect without the in-app profile switcher rebuilding the `NavHostController` (which lands on Home for the wrong reason), I swapped `activeProfileId` in place via `profileManager.setActiveProfile(otherId)`. Switching from a profile with Discover-in-Side-Panel to one with Discover-off while on Discover transitioned from Discover to Home as expected. Reverted the change after testing.
- **Persistence**, for each of Off / In Search / In Side Panel: set the state, ran `adb shell am force-stop com.nuviodebug.com`, relaunched, confirmed state survives in Layout Settings, the sidebar, and the Search screen. Also confirmed `lastNonOff` persists across kills (set Side Panel -> Off, force-stop, relaunch, toggle on -> came back to Side Panel).
- **Upgrade migration on device** (real install-old-then-install-new, not just JVM tests):
  1. `adb uninstall com.nuviodebug.com` to wipe data.
  2. Built and installed pre-feature `dev` APK.
  3. Layout Settings -> set the old `Show Discover in Search` toggle to ON. Force-stopped.
  4. Built and installed this branch on top (no uninstall, `installFullDebug` preserves DataStore files).
  5. Opened Layout Settings: new `Show/Hide Discover` toggle ON, location dialog reflects `Show in Search`. Matches spec (`true` -> `IN_SEARCH`, never `IN_SIDEBAR`).
  6. Repeated with legacy boolean OFF: new `Show/Hide Discover` came up OFF after upgrade. Matches `false` -> `OFF`.
  - Migration helper (`fromLegacySearchDiscoverEnabled` + registered `DataMigration<Preferences>`) also covered by JVM unit tests in `DiscoverLocationMigrationTest`.

### Not tested
- **Cloud-sync paths**, every sync entry point (foreground pull, startup pull, local-changes observer) checks `authManager.isAuthenticated` before hitting the Postgrest RPC. Debug has no signed-in account, so the cloud round-trip code never runs. The legacy field translation between app versions is therefore untested against a real sync.

## Screenshots / Video (UI changes only)
Demo video and screenshots of all three states (Off / In Search / In Side Panel) and the Layout Settings flow are on the feature request: NuvioMedia/NuvioTV#1470. The new dialog (replacing the inline `Pin Discover to Sidebar` toggle) is the only UI change since the issue's screenshots.

**Screenshots of Tap's requested changes:**
<table>
<tr>
<td align="center"><b>Show/Hide Discover</b><br/>Discover location row hidden when off</td>
<td align="center"><b>Discover Location</b><br/>Dialog for choosing placement</td>
</tr>
<tr>
<td><img width="480" alt="Show/Hide Discover toggle with location row hidden when off" src="https://github.com/user-attachments/assets/998504ff-a4f8-482c-921e-555fc0edf607" /></td>
<td><img width="480" alt="Discover Location dialog for choosing placement" src="https://github.com/user-attachments/assets/3ca4ef88-1385-4649-9920-08727bbd46c1" /></td> 
</tr>
</table>

## Breaking changes
None. The legacy `search_discover_enabled` boolean migrates 1:1 to `DiscoverLocation` automatically on first read and on cloud-profile import (`true` -> `IN_SEARCH`, `false` -> `OFF`). Existing users are never auto-promoted to `IN_SIDEBAR`. Profile sync remains backward compatible across app versions.

## Linked issues
Closes NuvioMedia/NuvioTV#1470.