### PR TITLE
fix: eliminate ExoPlayer resume race condition causing buffering hang

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -380,9 +380,11 @@ class PlayerRuntimeController(
         }
 
     init {
-        if (!navigationArgs.startFromBeginning) {
-            loadSavedProgressFor(currentSeason, currentEpisode)
-        }
+        // NOTE: Saved watch progress is loaded inside preparePlaybackBeforeStart()
+        // via loadSavedProgressSuspend() — NOT here.  Loading it in the init block
+        // was a fire-and-forget coroutine that raced against initializePlayer(),
+        // causing the resume seek to be silently lost when ExoPlayer's STATE_READY
+        // fired before the DB read completed.
         fetchParentalGuide(contentId, contentType, currentSeason, currentEpisode)
         observeSubtitleSettings()
         fetchMetaDetails(contentId, contentType)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -401,6 +401,38 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
     }
 }
 
+/**
+ * Suspend variant of [loadSavedProgressFor] that completes the DB read inline
+ * instead of launching a fire-and-forget coroutine.
+ *
+ * This MUST be called **before** [initializePlayer] inside [preparePlaybackBeforeStart]
+ * so that [pendingResumeProgress] is guaranteed to be set by the time ExoPlayer's
+ * `STATE_READY` callback fires.  The fire-and-forget version races against the
+ * player lifecycle and can lose the resume position entirely.
+ */
+internal suspend fun PlayerRuntimeController.loadSavedProgressSuspend(season: Int?, episode: Int?) {
+    if (contentId == null) return
+
+    pendingResumeProgress = null
+    val progress = if (season != null && episode != null) {
+        watchProgressRepository.getEpisodeProgress(contentId, season, episode).firstOrNull()
+    } else {
+        watchProgressRepository.getProgress(contentId).firstOrNull()
+    }
+
+    progress?.let { saved ->
+        if (saved.isInProgress()) {
+            pendingResumeProgress = saved
+            Log.d(
+                PlayerRuntimeController.TAG,
+                "loadSavedProgressSuspend: set pendingResumeProgress " +
+                    "position=${saved.position} duration=${saved.duration} " +
+                    "percent=${saved.progressPercent} S${season}E${episode}"
+            )
+        }
+    }
+}
+
 internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int?, episode: Int?) {
     if (!skipIntroEnabled) return
     if (id.isNullOrBlank()) return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -64,10 +64,15 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
                     "subtitle=${persistedTrackPreference?.subtitle?.javaClass?.simpleName ?: "none"}"
             )
         }
-        initializePlayer(url, headers)
+        // Load saved watch progress BEFORE player init.
+        // This eliminates the race condition where ExoPlayer's STATE_READY
+        // callback fired before the DB read completed, causing the resume
+        // seek to be silently skipped — the player would start from 0:00
+        // or hang in buffering after a late seek.
         if (loadSavedProgress) {
-            loadSavedProgressFor(currentSeason, currentEpisode)
+            loadSavedProgressSuspend(currentSeason, currentEpisode)
         }
+        initializePlayer(url, headers)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
@@ -60,7 +60,7 @@ internal fun PlayerRuntimeController.startInitialPlaybackIfNeeded() {
     preparePlaybackBeforeStart(
         url = currentStreamUrl,
         headers = currentHeaders,
-        loadSavedProgress = false
+        loadSavedProgress = !navigationArgs.startFromBeginning
     )
 }
 


### PR DESCRIPTION
## Summary

Eliminate race condition between `loadSavedProgressFor` and `initializePlayer` that caused ExoPlayer to either hang in infinite buffering or silently skip the resume seek when resuming content from a saved position.

## PR type

- Bug fix

## Why

When resuming content (especially noticeable on CW streams), playback intermittently:
- Gets **stuck in infinite buffering** when trying to resume from saved position
- Starts from **0:00** instead of the saved position
- Works fine when explicitly starting from the beginning

Root cause: `loadSavedProgressFor` was called **after** `initializePlayer` in `preparePlaybackBeforeStart()`, launching a fire-and-forget coroutine that raced against ExoPlayer's `STATE_READY` callback. When the DB read completed after `STATE_READY` had already fired, `pendingResumeProgress` was still `null` and the resume seek was silently skipped. A late-arriving seek then caused a rebuffer cycle that could hang indefinitely.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified resume from saved position (mid-movie, mid-episode) — seek applied correctly on first `STATE_READY`
- Verified "start from beginning" flag still works (no unintended resume)
- Verified episode switching with resume
- Verified source switching with resume


## Screenshots / Video (UI changes only)

N/A — no UI changes, this is a backend race condition fix in the player initialization pipeline.

## Breaking changes

- None

## Linked issues

Reported on Discord — intermittent buffering hang when resuming from saved position
