### PR TITLE
skip full avatar catalog load on startup

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -312,15 +312,19 @@ class MainActivity : ComponentActivity() {
             }
 
             var avatarCatalog by remember { mutableStateOf(emptyList<com.nuvio.tv.data.remote.supabase.AvatarCatalogItem>()) }
+            val activeProfileAvatarId = activeProfile?.avatarId
+            val activeProfileAvatarUrl = activeProfile?.avatarUrl?.takeIf { it.isNotBlank() }
 
-            LaunchedEffect(Unit) {
-                avatarCatalog = runCatching { avatarRepository.getAvatarCatalog() }
-                    .getOrDefault(emptyList())
+            LaunchedEffect(activeProfileAvatarId, activeProfileAvatarUrl) {
+                if (activeProfileAvatarUrl == null && activeProfileAvatarId != null && avatarCatalog.isEmpty()) {
+                    avatarCatalog = runCatching { avatarRepository.getAvatarCatalog() }
+                        .getOrDefault(emptyList())
+                }
             }
 
-            val activeProfileAvatarImageUrl = remember(activeProfile, avatarCatalog) {
-                activeProfile?.avatarUrl?.takeIf { it.isNotBlank() }
-                    ?: activeProfile?.avatarId?.let { avatarRepository.getAvatarImageUrl(it, avatarCatalog) }
+            val activeProfileAvatarImageUrl = remember(activeProfileAvatarId, activeProfileAvatarUrl, avatarCatalog) {
+                activeProfileAvatarUrl
+                    ?: activeProfileAvatarId?.let { avatarRepository.getAvatarImageUrl(it, avatarCatalog) }
             }
 
             val mainUiPrefsFlow = remember(themeDataStore, layoutPreferenceDataStore, experienceModeDataStore) {


### PR DESCRIPTION
## Summary

Skips loading full avatar catalog on app open

- Normal app startup: skip avatar catalog unless the sidebar/profile chip needs an avatarId resolved.
- User opens avatar/profile selection: ProfileSelectionViewModel loads the avatar catalog then.
- If it was already loaded earlier: AvatarRepository has an in-memory cachedCatalog, so the profile screen can reuse it instead of fetching again.

## PR type

- Small maintenance improvement

## Why

Previously the app fetched the full avatar catalog on first composition every time. Now it only fetches that catalog if the active profile needs an avatarId lookup and does not already have a direct avatarUrl. That removes an avoidable startup network call for profiles that do not need it.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.

## Testing

Built out apk and tested, no issues on my end

## Screenshots / Video (UI changes only)

No visible UI changes to user

## Breaking changes

Nothing broken in my testing

## Linked issues

None, based on an idea to optimise initial loading times
