### PR TITLE
Expose stream filename as media_content_id (fixes #1804)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
@@ -62,12 +62,16 @@ internal fun PlayerRuntimeController.buildMediaSessionMetadata(): MediaMetadata 
 internal fun PlayerRuntimeController.updateMediaSessionMetadata() {
     val session = currentMediaSession ?: return
     val metadata = buildMediaSessionMetadata()
+    val mediaId = currentFilename?.takeIf { it.isNotBlank() }
     try {
         // Media3 MediaSession reads metadata from the player's current MediaItem.
         // Setting mediaMetadata on the player propagates to the session automatically.
         _exoPlayer?.let { player ->
             val current = player.currentMediaItem ?: return@let
             val updated = current.buildUpon()
+                .apply {
+                    mediaId?.let(::setMediaId)
+                }
                 .setMediaMetadata(metadata)
                 .build()
             player.replaceMediaItem(player.currentMediaItemIndex, updated)
@@ -75,7 +79,7 @@ internal fun PlayerRuntimeController.updateMediaSessionMetadata() {
         Log.d(
             PlayerRuntimeController.TAG,
             "MediaSession metadata updated: title=${metadata.title}, " +
-                "artist=${metadata.artist}, artworkUri=${metadata.artworkUri}"
+                "artist=${metadata.artist}, mediaId=$mediaId, artworkUri=${metadata.artworkUri}"
         )
     } catch (e: Exception) {
         Log.w(PlayerRuntimeController.TAG, "Failed to update MediaSession metadata", e)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -84,6 +84,7 @@ internal class PlayerMediaSourceFactory {
 
         val mediaItemBuilder = MediaItem.Builder().setUri(url)
         resolvedMimeType?.let(mediaItemBuilder::setMimeType)
+        filename?.takeIf { it.isNotBlank() }?.let(mediaItemBuilder::setMediaId)
         mediaMetadata?.let(mediaItemBuilder::setMediaMetadata)
 
         if (subtitleConfigurations.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Expose the current stream's filename as the `MediaItem.mediaId` on the active Media3 session so external media controllers (HomeAssistant, Google Home, Wear OS, etc.) can read the full release name via `media_content_id`.

## PR type

- Bug fix

## Why

Issue #1804 reports that HomeAssistant's `media_content_id` is empty for Nuvio playback, which blocks automations like ezbeq EQ selection that need to parse the release name (TrueHD/Atmos/DTS/DV/etc.) out of the filename.

Nuvio already tracks `currentFilename` (from `behaviorHints.filename`, navigation args, or URL fallback) but never wrote it to `MediaItem.mediaId`, so Android's `MediaSession` exposed an empty `media_content_id` to the system.

## Testing

- Built `:app:compileFullDebugKotlin` — success, only pre-existing warnings.
- Installed `installFullDebug` on Nvidia Shield via adb and started playback.
- Verified via HomeAssistant media_player entity that `media_content_id` is now populated with the stream filename (e.g. `Aladdin.1992.UHD.BluRay.2160p.TrueHD.Atmos.7.1.DV.HEVC.HYBRID.REMUX-FraMeSToR`) for addons that provide `behaviorHints.filename`, and with the URL-derived filename otherwise.
- Confirmed existing title/artist/artwork metadata and session updates (TMDB enrichment, episode switches) still work.

## Screenshots / Video (UI changes only)

No UI changes.

## Breaking changes

No breaking changes. `MediaItem.mediaId` was previously unset; consumers that relied on it being empty are not expected.

## Linked issues

Fixes #1804
