### PR TITLE
fix(detail): make section tab focus visible on MetaDetails screen

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -2194,18 +2194,44 @@ private fun PeopleSectionTabButton(
                 shape = RoundedCornerShape(16.dp)
             )
         ),
-        scale = CardDefaults.scale(focusedScale = 1.03f)
+        scale = CardDefaults.scale(focusedScale = 1.06f)
     ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.titleLarge,
-            color = when {
-                isFocused -> NuvioColors.TextPrimary
-                selected -> NuvioColors.TextPrimary.copy(alpha = 0.92f)
-                else -> NuvioColors.TextPrimary.copy(alpha = 0.55f)
-            },
-            modifier = Modifier.padding(horizontal = 2.dp, vertical = 2.dp)
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(horizontal = 10.dp, vertical = 4.dp)
+                .then(
+                    if (isFocused) {
+                        Modifier
+                            .background(NuvioColors.FocusBackground, RoundedCornerShape(12.dp))
+                            .border(2.dp, NuvioColors.FocusRing, RoundedCornerShape(12.dp))
+                            .padding(horizontal = 10.dp, vertical = 4.dp)
+                    } else {
+                        Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    }
+                )
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleLarge,
+                color = when {
+                    isFocused -> NuvioColors.TextPrimary
+                    selected -> NuvioColors.TextPrimary.copy(alpha = 0.92f)
+                    else -> NuvioColors.TextPrimary.copy(alpha = 0.55f)
+                }
+            )
+            // Discrete underline marks the currently selected tab when it
+            // isn't focused, so the user can tell which section is active.
+            if (selected && !isFocused) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Box(
+                    modifier = Modifier
+                        .height(2.dp)
+                        .width(24.dp)
+                        .background(NuvioColors.TextPrimary.copy(alpha = 0.45f), RoundedCornerShape(2.dp))
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

On the meta detail screen, the Distribution / Similar / Trailer section tabs were almost invisible when focused — `PeopleSectionTabButton` only nudged the text alpha and applied a 1.03 scale. Without a focus ring, on TV navigation it's hard to tell which tab is focused when the user comes down from the action row above.

This PR makes the focus indicator match the rest of the app: when focused, the tab draws the shared `NuvioColors.FocusRing` border + `NuvioColors.FocusBackground` fill (same chrome as `ExperienceModeSelectionScreen`, `LayoutSelectionScreen`, `EpisodeRatingsSection`, `ExperienceModeCard`, etc.). A discrete 24×2 dp underline keeps the currently *active* tab visible when focus moves elsewhere. Scale bumped from 1.03 to 1.06 for a slightly stronger affordance.

## PR type

- Bug fix

## Why

Reported by a French TV user: \"on the detail page, when I go down to Créateur et distribution / Similaires / Bande-annonces, nothing visually shows that I'm on it.\" Cause is `PeopleSectionTabButton` deliberately drawing a transparent border / container, so the only visual feedback was a 7% alpha bump on the text + 1.03 scale — easy to miss on a 4K TV.

## What

`MetaDetailsScreen.PeopleSectionTabButton`:

- Wraps the label in a `Column` that conditionally applies `border(NuvioColors.FocusRing, RoundedCornerShape(12.dp))` + `background(NuvioColors.FocusBackground, RoundedCornerShape(12.dp))` when `isFocused`. Padding adjusted so the focused pill keeps the same baseline height as the unfocused state.
- Adds a 24×2 dp underline (`NuvioColors.TextPrimary @ 0.45 alpha`) under the active tab when it isn't focused, so the user can still tell which section is active after focus leaves the bar.
- Focused scale: 1.03 → 1.06.

No new resources, no behaviour change to focus traversal, `up` / `down` requesters unchanged.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.

  *Edge case — the change is visual but it fixes a focus-affordance regression on TV navigation, not a pure restyle.*
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

N/A — small UX bug fix, one file touched, ~37 lines added / 11 removed.

## Testing

- Built and ran on Android TV (Ugoos AM6B+).
- Opened the detail page of a movie (Star Wars: A New Hope) and a TV show. Navigated DPAD-down from the action row into the tabs — the focused tab now shows the orange/gold focus ring + dim background, identical to the rest of the app's focus chrome.
- Moved focus from the tabs into the cast row / similar row / trailer row and back; the selected tab keeps the discrete underline so the user knows which section the cards below belong to.
- Verified scale animation still feels right at 1.06 (no clipping under the parent `focusRestorer`).
- No regression on the existing `up` / `down` focus traversal or the focus-restorer to the active tab.

## Screenshots

Focused tab \"Créateur et distribution\" with the new ring + background (drag-drop attached in the PR thread):

![](https://github.com/user-attachments/assets/tabs-focus.png)

## Breaking changes

None.

## Linked issues

None — internal report.

<img width="2500" height="182" alt="Copie d&#39;écran_20260511_193808" src="https://github.com/user-attachments/assets/ffc6ff0b-7dad-4bf4-8a0a-20d202a543ed" />

