### PR TITLE
fix(folder): honor 'hide unreleased' toggle in CollectionFolder

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolver.kt
@@ -192,6 +192,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
                     logo = null,
                     description = it.overview?.takeIf { value -> value.isNotBlank() },
                     releaseInfo = it.releaseDate?.take(4),
+                    released = it.releaseDate?.takeIf { value -> value.isNotBlank() },
                     imdbRating = it.voteAverage?.toFloat(),
                     genres = emptyList()
                 )
@@ -345,6 +346,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
             logo = null,
             description = overview?.takeIf { it.isNotBlank() },
             releaseInfo = (releaseDate ?: firstAirDate)?.take(4),
+            released = (releaseDate ?: firstAirDate)?.takeIf { it.isNotBlank() },
             imdbRating = voteAverage?.toFloat(),
             genres = emptyList()
         )
@@ -372,6 +374,10 @@ class TmdbCollectionSourceResolver @Inject constructor(
                 TmdbCollectionMediaType.MOVIE -> releaseDate?.take(4)
                 TmdbCollectionMediaType.TV -> firstAirDate?.take(4)
             },
+            released = when (mediaType) {
+                TmdbCollectionMediaType.MOVIE -> releaseDate?.takeIf { it.isNotBlank() }
+                TmdbCollectionMediaType.TV -> firstAirDate?.takeIf { it.isNotBlank() }
+            },
             imdbRating = voteAverage?.toFloat(),
             genres = emptyList()
         )
@@ -398,6 +404,10 @@ class TmdbCollectionSourceResolver @Inject constructor(
                 TmdbCollectionMediaType.MOVIE -> releaseDate?.take(4)
                 TmdbCollectionMediaType.TV -> firstAirDate?.take(4)
             },
+            released = when (mediaType) {
+                TmdbCollectionMediaType.MOVIE -> releaseDate?.takeIf { it.isNotBlank() }
+                TmdbCollectionMediaType.TV -> firstAirDate?.takeIf { it.isNotBlank() }
+            },
             imdbRating = voteAverage?.toFloat(),
             genres = emptyList()
         )
@@ -423,6 +433,10 @@ class TmdbCollectionSourceResolver @Inject constructor(
             releaseInfo = when (mediaType) {
                 TmdbCollectionMediaType.MOVIE -> releaseDate?.take(4)
                 TmdbCollectionMediaType.TV -> firstAirDate?.take(4)
+            },
+            released = when (mediaType) {
+                TmdbCollectionMediaType.MOVIE -> releaseDate?.takeIf { it.isNotBlank() }
+                TmdbCollectionMediaType.TV -> firstAirDate?.takeIf { it.isNotBlank() }
             },
             imdbRating = voteAverage?.toFloat(),
             genres = emptyList()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.R
 import com.nuvio.tv.core.build.AppFeaturePolicy
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.tmdb.TmdbCollectionSourceResolver
+import com.nuvio.tv.core.util.isUnreleased
 import com.nuvio.tv.core.trakt.TraktPublicListSourceResolver
 import com.nuvio.tv.data.trailer.TrailerService
 import com.nuvio.tv.data.local.CollectionsDataStore
@@ -532,7 +533,7 @@ class FolderDetailViewModel @Inject constructor(
                             val tabs = state.tabs.toMutableList()
                             if (tabIndex < tabs.size) {
                                 tabs[tabIndex] = tabs[tabIndex].copy(
-                                    catalogRow = result.data,
+                                    catalogRow = result.data.filteredForRelease(state.hideUnreleasedContent),
                                     isLoading = false
                                 )
                             }
@@ -621,7 +622,13 @@ class FolderDetailViewModel @Inject constructor(
                             val currentTab = s.tabs.getOrNull(tabIndex)
                             val currentRow = currentTab?.catalogRow ?: return@update s
                             val existingIds = currentRow.items.map { "${it.apiType}:${it.id}" }.toHashSet()
-                            val newItems = result.data.items.filter { "${it.apiType}:${it.id}" !in existingIds }
+                            val incomingFiltered = if (s.hideUnreleasedContent) {
+                                val today = java.time.LocalDate.now()
+                                result.data.items.filterNot { it.isUnreleased(today) }
+                            } else {
+                                result.data.items
+                            }
+                            val newItems = incomingFiltered.filter { "${it.apiType}:${it.id}" !in existingIds }
                             val mergedItems = currentRow.items + newItems
                             val hasMore = if (newItems.isEmpty()) false else result.data.hasMore
 
@@ -766,16 +773,17 @@ class FolderDetailViewModel @Inject constructor(
                         _uiState.update { s ->
                             val tabs = s.tabs.toMutableList()
                             val currentRow = tabs.getOrNull(tabIndex)?.catalogRow
+                            val filteredData = result.data.filteredForRelease(s.hideUnreleasedContent)
                             val row = if (append && currentRow != null) {
                                 val existingIds = currentRow.items.map { "${it.apiType}:${it.id}" }.toHashSet()
-                                val newItems = result.data.items.filter { "${it.apiType}:${it.id}" !in existingIds }
-                                result.data.copy(
+                                val newItems = filteredData.items.filter { "${it.apiType}:${it.id}" !in existingIds }
+                                filteredData.copy(
                                     items = currentRow.items + newItems,
-                                    hasMore = result.data.hasMore && newItems.isNotEmpty(),
+                                    hasMore = filteredData.hasMore && newItems.isNotEmpty(),
                                     isLoading = false
                                 )
                             } else {
-                                result.data
+                                filteredData
                             }
                             if (tabIndex < tabs.size) tabs[tabIndex] = tabs[tabIndex].copy(catalogRow = row, isLoading = false)
                             s.copy(tabs = tabs)
@@ -823,16 +831,17 @@ class FolderDetailViewModel @Inject constructor(
                         _uiState.update { s ->
                             val tabs = s.tabs.toMutableList()
                             val currentRow = tabs.getOrNull(tabIndex)?.catalogRow
+                            val filteredData = result.data.filteredForRelease(s.hideUnreleasedContent)
                             val row = if (append && currentRow != null) {
                                 val existingIds = currentRow.items.map { "${it.apiType}:${it.id}" }.toHashSet()
-                                val newItems = result.data.items.filter { "${it.apiType}:${it.id}" !in existingIds }
-                                result.data.copy(
+                                val newItems = filteredData.items.filter { "${it.apiType}:${it.id}" !in existingIds }
+                                filteredData.copy(
                                     items = currentRow.items + newItems,
-                                    hasMore = result.data.hasMore && newItems.isNotEmpty(),
+                                    hasMore = filteredData.hasMore && newItems.isNotEmpty(),
                                     isLoading = false
                                 )
                             } else {
-                                result.data
+                                filteredData
                             }
                             if (tabIndex < tabs.size) tabs[tabIndex] = tabs[tabIndex].copy(catalogRow = row, isLoading = false)
                             s.copy(tabs = tabs)
@@ -1225,4 +1234,12 @@ class FolderDetailViewModel @Inject constructor(
         }
     }
 
+}
+
+/** Drops unreleased items from a freshly-loaded row when the user toggle is on. */
+private fun CatalogRow.filteredForRelease(hideUnreleased: Boolean): CatalogRow {
+    if (!hideUnreleased) return this
+    val today = java.time.LocalDate.now()
+    val filtered = items.filterNot { it.isUnreleased(today) }
+    return if (filtered.size == items.size) this else copy(items = filtered)
 }


### PR DESCRIPTION
## Summary

Items releasing later in the current year (e.g. *Avengers: Doomsday*, Dec 2026) were still shown in CollectionFolder rows when **Masquer le contenu non sorti** was on.

## PR type

- Bug fix

## Why

`TmdbCollectionSourceResolver` only populated `MetaPreview.releaseInfo` with the **year** (`releaseDate.take(4)`). `MetaPreview.isUnreleased` reads `released` first (ISO date) and only falls back to a year-vs-year comparison when no full date is available — which gave `2026 > 2026 = false`, so any in-year future title passed the filter. `FolderDetailViewModel` also didn't re-apply the toggle on freshly loaded / paginated rows, so even with a correct `isUnreleased` the result wasn't filtered.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual on Ugoos (debug APK) against the Marvel collection:
- Toggle ON → *Avengers: Doomsday* (Dec 2026) is hidden.
- Toggle OFF → *Avengers: Doomsday* is visible.
- Pagination still loads further pages without duplicates and respects the toggle.

## Screenshots / Video (UI changes only)

N/A — no UI surface changes, only filter behavior.

## Breaking changes

None.

## Linked issues

None.