### PR TITLE
fix regression in legacy sidebar icon offset

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -942,7 +942,7 @@ private fun LegacySidebarScaffold(
                                         drawerItemFocusRequesters.getValue(item.route)
                                     )
                                         .width(itemWidth)
-                                        .then(if (!isExpanded) Modifier.offset(x = 12.dp) else Modifier)
+                                        .offset(x = 12.dp)
                                 )
                         }
                     }


### PR DESCRIPTION
## Summary

Fixed the legacy sidebar item positioning so sidebar icons keep a stable x-position while the sidebar expands and collapses.

## PR type

- Bug fix

## Why

A recent cleanup changed the sidebar item offset to apply only while collapsed. Because the item width animates during open/close, that caused icons to shift horizontally during the sidebar animation. Keeping the offset consistent prevents the icon anchor from moving, while preserving the focused item zoom effect.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.

## Testing

- Built apk off latest base and retested fix, no issues visually or in compiling
- Verified the code diff is limited to the sidebar item modifier in `MainActivity.kt`.

## Screenshots / Video (UI changes only)

As you see by the end of this PRs implementation: https://github.com/NuvioMedia/NuvioTV/pull/1779

## Breaking changes

None. Nothing is broken from my testing.

## Linked issues

Reimplements fix for: https://github.com/NuvioMedia/NuvioTV/issues/1728

Previous fixes: https://github.com/NuvioMedia/NuvioTV/pull/1779, https://github.com/NuvioMedia/NuvioTV/pull/1788
