### PR TITLE
Optimize stream add-on ordering for faster autoplay

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
@@ -12,9 +12,17 @@ object StreamAutoPlaySelector {
         installedOrder: List<String>
     ): List<AddonStreams> {
         if (streams.isEmpty()) return streams
+        if (installedOrder.isEmpty()) return streams
 
-        val (addonEntries, pluginEntries) = streams.partition { it.addonName in installedOrder }
-        val orderedAddons = addonEntries.sortedBy { installedOrder.indexOf(it.addonName) }
+        val addonRankByName = HashMap<String, Int>(installedOrder.size)
+        installedOrder.forEachIndexed { index, addonName ->
+            if (addonName !in addonRankByName) {
+                addonRankByName[addonName] = index
+            }
+        }
+
+        val (addonEntries, pluginEntries) = streams.partition { it.addonName in addonRankByName }
+        val orderedAddons = addonEntries.sortedBy { addonRankByName.getValue(it.addonName) }
         return orderedAddons + pluginEntries
     }
 

--- a/app/src/test/java/com/nuvio/tv/core/player/StreamAutoPlaySelectorTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/StreamAutoPlaySelectorTest.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.core.player
 import com.nuvio.tv.core.build.AppFeaturePolicy
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamAutoPlaySource
+import com.nuvio.tv.domain.model.AddonStreams
 import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.domain.model.StreamBehaviorHints
 import org.junit.Assert.assertEquals
@@ -10,6 +11,21 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class StreamAutoPlaySelectorTest {
+
+    @Test
+    fun `orderAddonStreams follows installed addon order and leaves plugins last`() {
+        val plugin = addonStreams("Plugin")
+        val addonB = addonStreams("AddonB")
+        val addonA = addonStreams("AddonA")
+        val unknown = addonStreams("UnknownPlugin")
+
+        val ordered = StreamAutoPlaySelector.orderAddonStreams(
+            streams = listOf(plugin, addonB, addonA, unknown),
+            installedOrder = listOf("AddonA", "AddonB")
+        )
+
+        assertEquals(listOf(addonA, addonB, plugin, unknown), ordered)
+    }
 
     @Test
     fun `bingeGroup-first selects matching stream before first stream mode`() {
@@ -204,5 +220,11 @@ class StreamAutoPlaySelectorTest {
         ),
         addonName = addonName,
         addonLogo = null
+    )
+
+    private fun addonStreams(addonName: String): AddonStreams = AddonStreams(
+        addonName = addonName,
+        addonLogo = null,
+        streams = emptyList()
     )
 }


### PR DESCRIPTION
## Summary

Optimised stream add-on ordering by replacing repeated installed add-on list scans with a precomputed add-on rank map.

## PR type

- Small maintenance improvement

## Why

Users trigger this path when opening the stream picker or starting playback for a title that returns streams from multiple add-ons/plugins.

Before this change, each stream ordering pass repeatedly scanned the installed add-on order list to check and calculate each add-on’s sort position. That preserved correct behaviour, but did extra CPU work on a hot stream loading path, especially when users had several installed add-ons/plugins and many stream groups were returned.

Now, NuvioTV builds a small lookup map once per ordering pass and ranks add-on stream groups with fast map lookups. User-facing ordering is unchanged: installed add-ons still appear first in installed order, while plugin/unknown stream groups remain after them in their existing incoming order.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.

## Testing

- Built apk and tested, no issues regarding what has been changed.
- Ran `git diff --check`.
- Manually reviewed the edited selector and focused unit test.

## Screenshots / Video (UI changes only)

N/A, nothing in UI has changed visually.

## Breaking changes

None. Tested and no issues.

## Linked issues

Nothing, just something I thought of.
