### PR TITLE
ConcurrentModificationException crash on collection navigation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -336,7 +336,9 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     synchronized(discoveredOlderNextUpItems) {
                         discoveredOlderNextUpItems.removeAll { it.info.contentId !in activeSeedContentIds }
                     }
-                    cwEnrichedNextUpOverlay.keys.removeAll { it !in activeSeedContentIds }
+                    synchronized(cwEnrichedNextUpOverlay) {
+                        cwEnrichedNextUpOverlay.keys.removeAll { it !in activeSeedContentIds }
+                    }
                 }
 
                 debug.logStart(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -181,10 +181,10 @@ class ModernCarouselRowBuildCache {
     var continueWatchingUpcomingLabel: String = ""
     var continueWatchingUseLandscapePosters: Boolean = false
     var continueWatchingRow: HeroCarouselRow? = null
-    internal val catalogRows = mutableMapOf<String, ModernCatalogRowBuildCacheEntry>()
-    internal val collectionRows = mutableMapOf<String, ModernCollectionRowBuildCacheEntry>()
+    internal val catalogRows = java.util.concurrent.ConcurrentHashMap<String, ModernCatalogRowBuildCacheEntry>()
+    internal val collectionRows = java.util.concurrent.ConcurrentHashMap<String, ModernCollectionRowBuildCacheEntry>()
     // per-item cache: rowKey -> (itemId -> cached carousel item + source MetaPreview)
-    internal val catalogItemCache = mutableMapOf<String, MutableMap<String, CachedCarouselItem>>()
+    internal val catalogItemCache = java.util.concurrent.ConcurrentHashMap<String, MutableMap<String, CachedCarouselItem>>()
 }
 
 internal data class CachedCarouselItem(

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2223,5 +2223,4 @@
 
     <string name="profile_pin_saved_for_profile">PIN zapisany dla %1$s.</string>
     <string name="profile_pin_lock_removed_for_profile">Blokada PIN usunięta dla %1$s.</string>
-    <string name="profile_pin_save_error">Nie udało się zapisać PIN. Spróbuj ponownie.</string>
 </resources>


### PR DESCRIPTION
## Summary

Fix ConcurrentModificationException crash triggered when navigating in/out of collections. Two race conditions on shared mutable maps accessed from `Dispatchers.Default`:

1. `cwEnrichedNextUpOverlay.keys.removeAll` iterating without holding the synchronizedMap lock.
2. `ModernCarouselRowBuildCache` using plain `LinkedHashMap` for `catalogRows`, `collectionRows`, and `catalogItemCache` while `buildModernHomePresentation` runs on background threads.

Also removes a duplicate `profile_pin_save_error` string in `values-pl/strings.xml` that broke resource merging.

## PR type

- Bug fix

## Why

App crashes with `java.util.ConcurrentModificationException` at `AbstractCollection.retainAll` on `DefaultDispatcher-worker` when entering a collection and navigating back. The `retainAll`/`removeAll` calls iterate over map key sets while other coroutines concurrently mutate the same maps.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Verified build compiles successfully (`compileFullDebugKotlin` passes).
- Manual: enter collection screen, navigate back rapidly — no crash.
- Confirmed via `adb logcat` that `ConcurrentModificationException` no longer appears.

## Screenshots / Video (UI changes only)

no UI changes.

## Breaking changes

Nothing

## Linked issues

Reported on Discrod
