### PR TITLE
fix(trailers): honor "Disable Trailers in TMDB Enrichment" toggle (#1647)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -63,14 +63,18 @@ class TrailerService(
         tmdbId: String? = null,
         type: String? = null
     ): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
-        // Respect the user's "Disable Trailers in TMDB Enrichment" toggle. The
-        // TMDB path below is the only trailer source surfaced through this
-        // function, so when the toggle is off, return no trailer at all rather
-        // than silently falling through to TMDB's /videos endpoint. See #1647.
-        if (!tmdbSettingsDataStore.settings.first().useTrailers) {
+        // Read the TMDB settings once and reuse for both the "Disable Trailers"
+        // gate and the trailer language lookup below. The gate respects the
+        // user's "Disable Trailers in TMDB Enrichment" toggle: the TMDB path
+        // below is the only trailer source surfaced through this function,
+        // so when the toggle is off we return no trailer at all rather than
+        // silently falling through to TMDB's /videos endpoint. See #1647.
+        val tmdbSettings = runCatching { tmdbSettingsDataStore.settings.first() }.getOrNull()
+        if (tmdbSettings?.useTrailers != true) {
             Log.d(TAG, "Trailers disabled in TMDB enrichment settings; skipping lookup")
             return@withContext null
         }
+        val tmdbLanguage = normalizeTmdbTrailerLanguage(tmdbSettings.language)
 
         val cacheKey = "$title|$year|$tmdbId|$type"
 
@@ -89,7 +93,8 @@ class TrailerService(
                 tmdbId = tmdbId,
                 type = type,
                 title = title,
-                year = year
+                year = year,
+                languageOverride = tmdbLanguage
             )
             if (tmdbSource != null) {
                 cache[cacheKey] = tmdbSource
@@ -129,13 +134,17 @@ class TrailerService(
         tmdbId: String?,
         type: String?
     ): String? = withContext(Dispatchers.IO) {
-        // Same gate as getTrailerPlaybackSource — see #1647.
-        if (!tmdbSettingsDataStore.settings.first().useTrailers) {
+        // Parse the id first so an invalid/null tmdbId short-circuits without
+        // touching the settings DataStore at all.
+        val numericTmdbId = tmdbId?.toIntOrNull() ?: return@withContext null
+        // Read settings once and use for both the "Disable Trailers" gate and
+        // the trailer language. See #1647 for the gate rationale.
+        val tmdbSettings = runCatching { tmdbSettingsDataStore.settings.first() }.getOrNull()
+        if (tmdbSettings?.useTrailers != true) {
             return@withContext null
         }
-        val numericTmdbId = tmdbId?.toIntOrNull() ?: return@withContext null
         val mediaType = normalizeTmdbMediaType(type)
-        val tmdbLanguage = getPreferredTmdbTrailerLanguage()
+        val tmdbLanguage = normalizeTmdbTrailerLanguage(tmdbSettings.language)
         val tmdbResults = when (mediaType) {
             "movie" -> fetchTmdbMovieVideos(numericTmdbId, tmdbLanguage)
             "tv" -> fetchTmdbTvVideos(numericTmdbId, tmdbLanguage)
@@ -156,11 +165,12 @@ class TrailerService(
         tmdbId: String?,
         type: String?,
         title: String? = null,
-        year: String? = null
+        year: String? = null,
+        languageOverride: String? = null
     ): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
         val numericTmdbId = tmdbId?.toIntOrNull() ?: return@withContext null
         val mediaType = normalizeTmdbMediaType(type)
-        val tmdbLanguage = getPreferredTmdbTrailerLanguage()
+        val tmdbLanguage = languageOverride ?: getPreferredTmdbTrailerLanguage()
         Log.d(
             TAG,
             "TMDB trailer lookup start: tmdbId=$numericTmdbId type=${mediaType ?: "unknown"} language=$tmdbLanguage"

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -63,6 +63,15 @@ class TrailerService(
         tmdbId: String? = null,
         type: String? = null
     ): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
+        // Respect the user's "Disable Trailers in TMDB Enrichment" toggle. The
+        // TMDB path below is the only trailer source surfaced through this
+        // function, so when the toggle is off, return no trailer at all rather
+        // than silently falling through to TMDB's /videos endpoint. See #1647.
+        if (!tmdbSettingsDataStore.settings.first().useTrailers) {
+            Log.d(TAG, "Trailers disabled in TMDB enrichment settings; skipping lookup")
+            return@withContext null
+        }
+
         val cacheKey = "$title|$year|$tmdbId|$type"
 
         cache[cacheKey]?.let { cached ->
@@ -74,7 +83,8 @@ class TrailerService(
         try {
             Log.d(TAG, "Searching trailer: title=$title, year=$year, tmdbId=$tmdbId, type=$type")
 
-            // 1) TMDB-first path (independent of TMDB enrichment settings).
+            // TMDB-first path. Gated on `useTrailers` above so the
+            // user's toggle in TMDB enrichment settings is honored.
             val tmdbSource = getTrailerPlaybackSourceFromTmdbId(
                 tmdbId = tmdbId,
                 type = type,
@@ -119,6 +129,10 @@ class TrailerService(
         tmdbId: String?,
         type: String?
     ): String? = withContext(Dispatchers.IO) {
+        // Same gate as getTrailerPlaybackSource — see #1647.
+        if (!tmdbSettingsDataStore.settings.first().useTrailers) {
+            return@withContext null
+        }
         val numericTmdbId = tmdbId?.toIntOrNull() ?: return@withContext null
         val mediaType = normalizeTmdbMediaType(type)
         val tmdbLanguage = getPreferredTmdbTrailerLanguage()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -705,7 +705,12 @@ class MetaDetailsViewModel @Inject constructor(
             awards = null,
             language = enrichment.language,
             links = emptyList(),
-            trailers = enrichment.trailers
+            // Honor the "Disable Trailers in TMDB Enrichment" toggle even on
+            // this synthetic fallback meta (issue #1647). The main enrichment
+            // merge at the bottom of applyMetaWithEnrichment already gates on
+            // settings.useTrailers; without the same gate here, the fallback
+            // path would smuggle TMDB trailers in unconditionally.
+            trailers = if (settings.useTrailers) enrichment.trailers else emptyList()
         )
         applyMetaWithEnrichment(meta)
         return true

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceUseTrailersGateTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceUseTrailersGateTest.kt
@@ -1,0 +1,112 @@
+package com.nuvio.tv.data.trailer
+
+import android.util.Log
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TrailerApi
+import com.nuvio.tv.domain.model.TmdbSettings
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression coverage for issue #1647: the "Disable Trailers in TMDB Enrichment"
+ * toggle in TMDB settings must short-circuit trailer lookups, not just skip
+ * merging TMDB trailers into the metadata model.
+ *
+ * Before the fix, both [TrailerService.getTrailerPlaybackSource] and
+ * [TrailerService.getExternalTrailerUrl] reached out to TMDB unconditionally
+ * (the source even acknowledged it with a comment "independent of TMDB
+ * enrichment settings"), so disabling the toggle had no observable effect.
+ */
+class TrailerServiceUseTrailersGateTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any<Throwable>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `getTrailerPlaybackSource returns null and does not call TMDB when useTrailers is false`() = runTest {
+        val service = newServiceWithUseTrailers(enabled = false)
+        val (trailerApi, tmdbApi, extractor) = service.collaborators
+
+        val result = service.target.getTrailerPlaybackSource(
+            title = "Some Movie",
+            year = "2024",
+            tmdbId = "12345",
+            type = "movie"
+        )
+
+        assertNull("Trailer lookup must return null when useTrailers is disabled", result)
+        // No TMDB calls of any kind should fire when the user has opted out.
+        coVerify(exactly = 0) { tmdbApi.getMovieVideos(any(), any(), any()) }
+        coVerify(exactly = 0) { tmdbApi.getTvVideos(any(), any(), any()) }
+        coVerify(exactly = 0) { extractor.extractPlaybackSource(any()) }
+        coVerify(exactly = 0) { trailerApi.getTrailer(any(), any(), any()) }
+    }
+
+    @Test
+    fun `getExternalTrailerUrl returns null when useTrailers is false`() = runTest {
+        val service = newServiceWithUseTrailers(enabled = false)
+        val (_, tmdbApi, _) = service.collaborators
+
+        val result = service.target.getExternalTrailerUrl(tmdbId = "12345", type = "movie")
+
+        assertNull("External trailer URL must be null when useTrailers is disabled", result)
+        coVerify(exactly = 0) { tmdbApi.getMovieVideos(any(), any(), any()) }
+        coVerify(exactly = 0) { tmdbApi.getTvVideos(any(), any(), any()) }
+    }
+
+    private data class HarnessedService(
+        val target: TrailerService,
+        val collaborators: Collaborators
+    )
+
+    private data class Collaborators(
+        val trailerApi: TrailerApi,
+        val tmdbApi: TmdbApi,
+        val extractor: InAppYouTubeExtractor
+    )
+
+    private fun newServiceWithUseTrailers(enabled: Boolean): HarnessedService {
+        val trailerApi = mockk<TrailerApi>(relaxed = true)
+        val tmdbApi = mockk<TmdbApi>(relaxed = true)
+        val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
+        val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
+            every { settings } returns flowOf(TmdbSettings(language = "en", useTrailers = enabled))
+        }
+        val tmdbService = mockk<TmdbService> {
+            every { apiKey() } returns "tmdb-key"
+        }
+        val service = TrailerService(
+            trailerApi = trailerApi,
+            tmdbApi = tmdbApi,
+            inAppYouTubeExtractor = extractor,
+            tmdbSettingsDataStore = tmdbSettingsDataStore,
+            tmdbService = tmdbService
+        )
+        return HarnessedService(
+            target = service,
+            collaborators = Collaborators(trailerApi, tmdbApi, extractor)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1647. The "Disable Trailers in TMDB Enrichment" toggle in TMDB settings did nothing for the TMDB-sourced trailer that plays on the detail page.

## PR type

- Bug fix

## Why

`TrailerService.getTrailerPlaybackSource` was reaching out to TMDB unconditionally (the source even acknowledged it with a comment "independent of TMDB enrichment settings"), so disabling the toggle had no observable effect. `getExternalTrailerUrl` had the same gap, as did the synthetic-meta fallback in `MetaDetailsViewModel.tryApplyTmdbFallbackMeta` that smuggled `enrichment.trailers` into the model bypassing the `useTrailers` gate that the main enrichment merge already honored.

All three paths now short-circuit when `tmdbSettings.useTrailers` is false. Addon-supplied trailers (`meta.trailerYtIds`) keep playing through `getTrailerPlaybackSourceFromYouTubeUrl`, which is intentionally not gated since that toggle is scoped to TMDB enrichment.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Testing

`./gradlew :app:compileFullDebugKotlin` passes clean.

New unit test `TrailerServiceUseTrailersGateTest`:
- asserts `getTrailerPlaybackSource` returns null when `useTrailers` is false and verifies no TMDB or YouTube extractor calls fire
- asserts `getExternalTrailerUrl` returns null when `useTrailers` is false and verifies no TMDB calls fire

Manual:
- Enable TMDB enrichment, toggle "Trailers" off, open a detail page where TMDB is the only trailer source: no trailer should play.
- Same toggle state, but the addon ships a trailer in `meta.trailerYtIds`: that addon trailer should still play (the toggle is scoped to TMDB enrichment, not all trailers).
- Toggle "Trailers" back on: TMDB trailer lookup resumes as before.

## Screenshots / Video (UI changes only)

No UI changes.

## Breaking changes

None.

## Linked issues

Fixes #1647