### PR TITLE
Add collections delete confirmation and focus fixes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorFolderContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorFolderContent.kt
@@ -147,6 +147,7 @@ fun FolderEditorContent(
     }
 
     if (uiState.showEmojiPicker) {
+        BackHandler { viewModel.hideEmojiPicker() }
         EmojiPickerContent(
             selectedEmoji = folder.coverEmoji,
             onSelect = { emoji ->
@@ -172,6 +173,7 @@ fun FolderEditorContent(
         genrePickerCatalog != null &&
         genrePickerCatalog.genreOptions.isNotEmpty()
     ) {
+        BackHandler { viewModel.hideGenrePicker() }
         GenrePickerContent(
             title = genrePickerCatalog.catalogName,
             selectedGenre = genrePickerSource.genre,
@@ -185,6 +187,8 @@ fun FolderEditorContent(
         )
         return
     }
+
+    BackHandler { viewModel.cancelFolderEdit() }
 
     val titleFocusRequester = remember { FocusRequester() }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -34,7 +35,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -79,6 +83,7 @@ import com.nuvio.tv.domain.model.TmdbCollectionSort
 import com.nuvio.tv.domain.model.TmdbCollectionSource
 import com.nuvio.tv.domain.model.TmdbCollectionSourceType
 import com.nuvio.tv.ui.components.LoadingIndicator
+import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.R
 import androidx.compose.ui.res.stringResource
@@ -90,6 +95,33 @@ fun CollectionEditorScreen(
     onBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val listState = rememberLazyListState()
+    var lastFocusedFolderId by rememberSaveable { mutableStateOf<String?>(null) }
+    val folderFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+
+    var folderToDelete by remember { mutableStateOf<CollectionFolder?>(null) }
+    val deleteDialogFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(folderToDelete) {
+        if (folderToDelete != null) {
+            repeat(3) { withFrameNanos { } }
+            try {
+                deleteDialogFocusRequester.requestFocus()
+            } catch (_: Exception) {}
+        }
+    }
+
+    LaunchedEffect(uiState.showFolderEditor) {
+        if (!uiState.showFolderEditor && lastFocusedFolderId != null) {
+            val targetId = lastFocusedFolderId!!
+            repeat(3) { withFrameNanos { } }
+
+            try {
+                folderFocusRequesters[targetId]?.requestFocus()
+            } catch (_: Exception) {}
+        }
+    }
 
     if (uiState.isLoading) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -107,6 +139,7 @@ fun CollectionEditorScreen(
     }
 
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxSize()
             .padding(top = 48.dp),
@@ -398,13 +431,18 @@ fun CollectionEditorScreen(
             items = uiState.folders,
             key = { _, folder -> folder.id }
         ) { index, folder ->
+            val editFocusRequester = folderFocusRequesters.getOrPut(folder.id) { FocusRequester() }
             Box(modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp)) {
                 FolderListItem(
                     folder = folder,
                     isFirst = index == 0,
                     isLast = index == uiState.folders.size - 1,
-                    onEdit = { viewModel.editFolder(folder.id) },
-                    onDelete = { viewModel.removeFolder(folder.id) },
+                    editFocusRequester = editFocusRequester,
+                    onEdit = {
+                        lastFocusedFolderId = folder.id
+                        viewModel.editFolder(folder.id)
+                    },
+                    onDelete = { folderToDelete = folder },
                     onMoveUp = { viewModel.moveFolderUp(index) },
                     onMoveDown = { viewModel.moveFolderDown(index) }
                 )
@@ -412,11 +450,47 @@ fun CollectionEditorScreen(
         }
 
         item(key = "add_folder") {
+            val addFolderFocusRequester = folderFocusRequesters.getOrPut("add_folder") { FocusRequester() }
             Box(modifier = Modifier.padding(start = 8.dp, end = 8.dp, top = 4.dp)) {
-                NuvioButton(onClick = { viewModel.addFolder() }) {
+                NuvioButton(
+                    onClick = {
+                        lastFocusedFolderId = "add_folder"
+                        viewModel.addFolder()
+                    },
+                    modifier = Modifier.focusRequester(addFolderFocusRequester)
+                ) {
                     Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.cd_add))
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(stringResource(R.string.collections_editor_add_folder))
+                }
+            }
+        }
+    }
+
+    folderToDelete?.let { folder ->
+        NuvioDialog(
+            onDismiss = { folderToDelete = null },
+            title = stringResource(R.string.collections_editor_delete_folder_title),
+            subtitle = stringResource(R.string.collections_editor_delete_folder_subtitle, folder.title),
+            suppressFirstKeyUp = false
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)
+            ) {
+                NuvioButton(
+                    onClick = { folderToDelete = null },
+                    modifier = Modifier.focusRequester(deleteDialogFocusRequester)
+                ) {
+                    Text(stringResource(R.string.collections_cancel))
+                }
+                NuvioButton(
+                    onClick = {
+                        viewModel.removeFolder(folder.id)
+                        folderToDelete = null
+                    }
+                ) {
+                    Text(stringResource(R.string.cd_delete))
                 }
             }
         }
@@ -429,6 +503,7 @@ private fun FolderListItem(
     folder: CollectionFolder,
     isFirst: Boolean,
     isLast: Boolean,
+    editFocusRequester: FocusRequester? = null,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
     onMoveUp: () -> Unit,
@@ -475,7 +550,10 @@ private fun FolderListItem(
                 NuvioButton(onClick = onMoveDown) {
                     Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.cd_move_down), tint = if (!isLast) NuvioColors.TextSecondary else NuvioColors.TextTertiary)
                 }
-                NuvioButton(onClick = onEdit) {
+                NuvioButton(
+                    onClick = onEdit,
+                    modifier = if (editFocusRequester != null) Modifier.focusRequester(editFocusRequester) else Modifier
+                ) {
                     Icon(Icons.Default.Edit, stringResource(R.string.cd_edit), tint = NuvioColors.TextSecondary)
                 }
                 NuvioButton(onClick = onDelete) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionManagementScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionManagementScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
@@ -62,6 +63,7 @@ import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.ValidationResult
 import com.nuvio.tv.domain.model.Collection
 import com.nuvio.tv.ui.components.LoadingIndicator
+import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.R
 import androidx.compose.ui.res.stringResource
@@ -107,6 +109,21 @@ fun CollectionManagementScreen(
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+
+    var lastFocusedId by rememberSaveable { mutableStateOf<String?>(null) }
+    val itemFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+
+    var collectionToDelete by remember { mutableStateOf<Collection?>(null) }
+    val deleteDialogFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(collectionToDelete) {
+        if (collectionToDelete != null) {
+            repeat(3) { withFrameNanos { } }
+            try {
+                deleteDialogFocusRequester.requestFocus()
+            } catch (_: Exception) {}
+        }
+    }
 
     var exportMessage by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(exportMessage) {
@@ -168,7 +185,8 @@ fun CollectionManagementScreen(
             val newButtonFocusRequester = remember { FocusRequester() }
             LaunchedEffect(Unit) {
                 repeat(3) { withFrameNanos { } }
-                try { newButtonFocusRequester.requestFocus() } catch (_: Exception) {}
+                val targetRequester = lastFocusedId?.let { itemFocusRequesters[it] } ?: newButtonFocusRequester
+                try { targetRequester.requestFocus() } catch (_: Exception) {}
             }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 if (uiState.collections.isNotEmpty()) {
@@ -212,7 +230,10 @@ fun CollectionManagementScreen(
                     Text(stringResource(R.string.collections_import))
                 }
                 NuvioButton(
-                    onClick = { onNavigateToEditor(null) },
+                    onClick = {
+                        lastFocusedId = null
+                        onNavigateToEditor(null)
+                    },
                     modifier = Modifier.focusRequester(newButtonFocusRequester)
                 ) {
                     Text(stringResource(R.string.collections_new))
@@ -243,15 +264,49 @@ fun CollectionManagementScreen(
                     items = uiState.collections,
                     key = { _, item -> item.id }
                 ) { index, collection ->
+                    val editFocusRequester = itemFocusRequesters.getOrPut(collection.id) { FocusRequester() }
                     CollectionListItem(
                         collection = collection,
                         isFirst = index == 0,
                         isLast = index == uiState.collections.size - 1,
-                        onEdit = { onNavigateToEditor(collection.id) },
-                        onDelete = { viewModel.deleteCollection(collection.id) },
+                        editFocusRequester = editFocusRequester,
+                        onEdit = {
+                            lastFocusedId = collection.id
+                            onNavigateToEditor(collection.id)
+                        },
+                        onDelete = { collectionToDelete = collection },
                         onMoveUp = { viewModel.moveUp(index) },
                         onMoveDown = { viewModel.moveDown(index) }
                     )
+                }
+            }
+        }
+    }
+
+    collectionToDelete?.let { collection ->
+        NuvioDialog(
+            onDismiss = { collectionToDelete = null },
+            title = stringResource(R.string.collections_delete_confirm_title),
+            subtitle = stringResource(R.string.collections_delete_confirm_subtitle, collection.title),
+            suppressFirstKeyUp = false
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)
+            ) {
+                NuvioButton(
+                    onClick = { collectionToDelete = null },
+                    modifier = Modifier.focusRequester(deleteDialogFocusRequester)
+                ) {
+                    Text(stringResource(R.string.collections_cancel))
+                }
+                NuvioButton(
+                    onClick = {
+                        viewModel.deleteCollection(collection.id)
+                        collectionToDelete = null
+                    }
+                ) {
+                    Text(stringResource(R.string.collections_delete_confirm))
                 }
             }
         }
@@ -525,6 +580,7 @@ private fun CollectionListItem(
     collection: Collection,
     isFirst: Boolean,
     isLast: Boolean,
+    editFocusRequester: FocusRequester? = null,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
     onMoveUp: () -> Unit,
@@ -598,6 +654,7 @@ private fun CollectionListItem(
 
                 Button(
                     onClick = onEdit,
+                    modifier = if (editFocusRequester != null) Modifier.focusRequester(editFocusRequester) else Modifier,
                     colors = ButtonDefaults.colors(
                         containerColor = NuvioColors.BackgroundCard,
                         contentColor = NuvioColors.TextSecondary,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -57,14 +57,13 @@ internal fun StreamSourcesSidePanel(
     onStreamSelected: (Stream) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // Only request focus when loading finishes (not on addon filter changes)
-    LaunchedEffect(uiState.isLoadingSourceStreams) {
+    // Request focus when loading finishes OR when the list content updates
+    // (ensures higher-priority addons get focus if they load later)
+    LaunchedEffect(uiState.isLoadingSourceStreams, uiState.sourceFilteredStreams.size) {
         if (!uiState.isLoadingSourceStreams && uiState.sourceFilteredStreams.isNotEmpty()) {
             try {
                 streamsFocusRequester.requestFocus()
-            } catch (_: Exception) {
-                // Focus requester may not be ready yet
-            }
+            } catch (_: Exception) {}
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1784,6 +1784,9 @@
 
     <!-- Collection Management -->
     <string name="collections_header">Collections</string>
+    <string name="collections_delete_confirm_title">Delete Collection?</string>
+    <string name="collections_delete_confirm">Delete</string>
+    <string name="collections_delete_confirm_subtitle">This will permanently delete \"%1$s\". This cannot be undone.</string>
     <string name="collections_empty">No collections yet. Create one to organize your catalogs.</string>
     <string name="collections_new">New Collection</string>
     <string name="collections_import">Import</string>
@@ -2028,6 +2031,8 @@
     <string name="collection_editor_trakt_name_placeholder">Weekend Watch, Award Winners</string>
     <string name="collection_editor_folder_count_one">%1$d item</string>
     <string name="collection_editor_folder_count_other">%1$d items</string>
+    <string name="collections_editor_delete_folder_title">Delete Folder?</string>
+    <string name="collections_editor_delete_folder_subtitle">This will permanently delete \"%1$s\" and its contents.</string>
     <string name="collections_editor_tmdb_movie_title_placeholder">Marvel Movies, Netflix Originals, Pixar</string>
     <string name="collections_editor_tmdb_tv_title_placeholder">Best Action Movies, Korean Dramas, 2024 Animation</string>
     <string name="collections_editor_tmdb_person_title_placeholder">Tom Hanks Movies, Favorite Actors</string>


### PR DESCRIPTION
## Summary
- Added a confirmation prompt when deleting collections or folders in collections
- When exiting collection or folder, restores to the edit button initially pressed rather than to the top of the page
- In player source selection, request focus when loading finishes **OR** when the list content updates

## PR type

<!-- Pick one and delete the others -->
- Bug fix
- Small maintenance improvement

## Why
- Prevent accidental deletes
- General qol improvement when editing collections
- Ensures primary addon gets focus if it loaded later than other addons and prevents general loss of focus when subsequent addons finish loading

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [ ] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)
N/A

## Testing
For collections: ensure delete functions as intended with confirmation and focus is restored to the collections/folders edit button when backing out of edit page.
For source selection: moved addons to different priorities to ensure no loss of focus.

## Screenshots / Video (UI changes only)
<img width="1168" height="533" alt="image" src="https://github.com/user-attachments/assets/ba460f60-1d2f-4cb6-a8dc-b2a07b72200b" />
<img width="1220" height="647" alt="image" src="https://github.com/user-attachments/assets/ed81c0c0-7bff-410e-acf3-8d2ab99bf840" />


## Breaking changes
None.

## Linked issues
None.
