### PR TITLE
Add plugin provider repository grouping

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -230,6 +230,8 @@ class PluginManager @Inject constructor(
     
     // Flow of plugins enabled state
     val pluginsEnabled: Flow<Boolean> = dataStore.pluginsEnabled
+
+    val groupStreamsByRepository: Flow<Boolean> = dataStore.groupStreamsByRepository
     
     private val syncScope = kotlinx.coroutines.CoroutineScope(
         kotlinx.coroutines.SupervisorJob() + Dispatchers.IO
@@ -624,6 +626,10 @@ class PluginManager @Inject constructor(
     suspend fun setPluginsEnabled(enabled: Boolean) {
         dataStore.setPluginsEnabled(enabled)
     }
+
+    suspend fun setGroupStreamsByRepository(enabled: Boolean) {
+        dataStore.setGroupStreamsByRepository(enabled)
+    }
     
     /**
      * Execute all enabled scrapers for a given media
@@ -680,7 +686,7 @@ class PluginManager @Inject constructor(
         mediaType: String,
         season: Int? = null,
         episode: Int? = null
-    ): Flow<Pair<String, List<LocalScraperResult>>> = channelFlow {
+    ): Flow<Pair<ScraperInfo, List<LocalScraperResult>>> = channelFlow {
         val enabledList = enabledScrapers.first()
             .filter { it.supportsType(mediaType) }
         
@@ -705,7 +711,7 @@ class PluginManager @Inject constructor(
                 try {
                     val results = executeScraperWithSingleFlight(scraper, tmdbId, mediaType, season, episode)
                     if (results.isNotEmpty()) {
-                        send(scraper.name to results)
+                        send(scraper to results)
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "Scraper ${scraper.name} failed in streaming: ${e.message}")

--- a/app/src/main/java/com/nuvio/tv/data/local/PluginDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PluginDataStore.kt
@@ -52,6 +52,7 @@ class PluginDataStore @Inject constructor(
     private val repositoriesKey = stringPreferencesKey("repositories")
     private val scrapersKey = stringPreferencesKey("scrapers")
     private val pluginsEnabledKey = booleanPreferencesKey("plugins_enabled")
+    private val groupStreamsByRepositoryKey = booleanPreferencesKey("group_streams_by_repository")
     private val scraperSettingsKey = stringPreferencesKey("scraper_settings")
 
     private val repoListType = Types.newParameterizedType(List::class.java, PluginRepository::class.java)
@@ -171,6 +172,20 @@ class PluginDataStore @Inject constructor(
             if (active != null && !active.isPrimary && active.usesPrimaryPlugins) return
         store().edit { prefs ->
             prefs[pluginsEnabledKey] = enabled
+        }
+    }
+
+    val groupStreamsByRepository: Flow<Boolean> = effectiveProfileIdFlow.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map { prefs ->
+            prefs[groupStreamsByRepositoryKey] ?: false
+        }
+    }
+
+    suspend fun setGroupStreamsByRepository(enabled: Boolean) {
+            val active = profileManager.activeProfile
+            if (active != null && !active.isPrimary && active.usesPrimaryPlugins) return
+        store().edit { prefs ->
+            prefs[groupStreamsByRepositoryKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -11,7 +11,10 @@ import com.nuvio.tv.data.mapper.toDomain
 import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonStreams
+import com.nuvio.tv.domain.model.LocalScraperResult
+import com.nuvio.tv.domain.model.PluginRepository
 import com.nuvio.tv.domain.model.ProxyHeaders
+import com.nuvio.tv.domain.model.ScraperInfo
 import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.domain.model.StreamBehaviorHints
 import com.nuvio.tv.domain.repository.AddonRepository
@@ -171,7 +174,15 @@ class StreamRepositoryImpl @Inject constructor(
 
                 // Emit results as they arrive
                 for (result in resultChannel) {
-                    accumulatedResults.add(result)
+                    val existingIndex = accumulatedResults.indexOfFirst { it.addonName == result.addonName }
+                    if (existingIndex >= 0) {
+                        val existing = accumulatedResults[existingIndex]
+                        accumulatedResults[existingIndex] = existing.copy(
+                            streams = (existing.streams + result.streams).distinctBy { it.dedupKey() }
+                        )
+                    } else {
+                        accumulatedResults.add(result)
+                    }
                     emit(NetworkResult.Success(accumulatedResults.toList()))
                     Log.d(TAG, "Emitted ${accumulatedResults.size} addon(s), latest: ${result.addonName} with ${result.streams.size} streams")
                 }
@@ -225,61 +236,29 @@ class StreamRepositoryImpl @Inject constructor(
         Log.d(TAG, "Streaming plugins for TMDB: $tmdbId, type: $mediaType")
 
         try {
+            val groupByRepository = pluginManager.groupStreamsByRepository.first()
+            val repositoriesById = if (groupByRepository) {
+                pluginManager.repositories.first().associateBy { it.id }
+            } else {
+                emptyMap()
+            }
+
             // Collect streaming results from each scraper
             pluginManager.executeScrapersStreaming(
                 tmdbId = tmdbId,
                 mediaType = mediaType,
                 season = season,
                 episode = episode
-            ).collect { (scraperName, results) ->
+            ).collect { (scraper, results) ->
                 if (results.isNotEmpty()) {
+                    val addonName = scraper.pluginAddonName(groupByRepository, repositoriesById)
                     val addonStreams = AddonStreams(
-                        addonName = scraperName,
+                        addonName = addonName,
                         addonLogo = null,
-                        streams = results.map { result ->
-                            val baseTitle = result.title.takeIf { it.isNotBlank() }
-                            val baseName = result.name?.takeIf { it.isNotBlank() }
-                            val quality = result.quality?.takeIf { it.isNotBlank() }
-
-                            // Only show quality in the name field as "Name - resolution"
-                            val qualityLabel = quality ?: context.getString(com.nuvio.tv.R.string.stream_quality_unknown)
-                            val displayName = buildString {
-                                append(baseName ?: baseTitle ?: scraperName)
-                                if (!toString().contains(qualityLabel)) {
-                                    append(" - ").append(qualityLabel)
-                                }
-                            }.takeIf { it.isNotBlank() }
-
-                            // Title stays clean — no quality appended
-                            val displayTitle = (baseTitle ?: baseName ?: scraperName)
-                                .takeIf { it.isNotBlank() }
-
-                            Stream(
-                                name = displayName,
-                                title = displayTitle,
-                                url = result.url,
-                                addonName = scraperName,
-                                addonLogo = null,
-                                description = buildDescription(result),
-                                behaviorHints = result.headers?.let { headers ->
-                                    StreamBehaviorHints(
-                                        notWebReady = null,
-                                        bingeGroup = null,
-                                        countryWhitelist = null,
-                                        proxyHeaders = ProxyHeaders(request = headers, response = null)
-                                    )
-                                },
-                                infoHash = result.infoHash,
-                                fileIdx = null,
-                                ytId = null,
-                                externalUrl = null,
-                                quality = quality,
-                                qualityValue = parseQualityValue(quality)
-                            )
-                        }
+                        streams = results.map { result -> result.toPluginStream(scraper, addonName) }
                     )
                     resultChannel.send(addonStreams)
-                    Log.d(TAG, "Streamed ${results.size} results from $scraperName")
+                    Log.d(TAG, "Streamed ${results.size} results from ${scraper.name}")
                 }
             }
         } catch (e: Exception) {
@@ -289,6 +268,54 @@ class StreamRepositoryImpl @Inject constructor(
             onComplete()
         }
     }
+
+    private fun ScraperInfo.pluginAddonName(
+        groupByRepository: Boolean,
+        repositoriesById: Map<String, PluginRepository>
+    ): String {
+        if (!groupByRepository) return name
+        return repositoriesById[repositoryId]?.name?.takeIf { it.isNotBlank() } ?: name
+    }
+
+    private fun LocalScraperResult.toPluginStream(scraper: ScraperInfo, addonName: String): Stream {
+        val baseTitle = title.takeIf { it.isNotBlank() }
+        val baseName = name?.takeIf { it.isNotBlank() }
+        val quality = quality?.takeIf { it.isNotBlank() }
+        val qualityLabel = quality ?: context.getString(com.nuvio.tv.R.string.stream_quality_unknown)
+        val displayName = buildString {
+            append(baseName ?: baseTitle ?: scraper.name)
+            if (!toString().contains(qualityLabel)) {
+                append(" - ").append(qualityLabel)
+            }
+        }.takeIf { it.isNotBlank() }
+        val displayTitle = (baseTitle ?: baseName ?: scraper.name).takeIf { it.isNotBlank() }
+
+        return Stream(
+            name = displayName,
+            title = displayTitle,
+            url = url,
+            addonName = addonName,
+            addonLogo = null,
+            description = buildDescription(this),
+            behaviorHints = headers?.let { headers ->
+                StreamBehaviorHints(
+                    notWebReady = null,
+                    bingeGroup = null,
+                    countryWhitelist = null,
+                    proxyHeaders = ProxyHeaders(request = headers, response = null)
+                )
+            },
+            infoHash = infoHash,
+            fileIdx = null,
+            ytId = null,
+            externalUrl = null,
+            quality = quality,
+            qualityValue = parseQualityValue(quality)
+        )
+    }
+
+    private fun Stream.dedupKey(): String =
+        infoHash?.lowercase() ?: url ?: externalUrl ?: ytId ?: "${addonName}:${name}:${title}"
 
     /**
      * Build a description string from scraper result

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -128,11 +128,19 @@ internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
                     val allStreams = addonStreams.flatMap { it.streams }
                     val availableAddons = addonStreams.map { it.addonName }
                     _uiState.update {
+                        val selectedAddon = it.sourceSelectedAddonFilter?.takeIf { selected ->
+                            selected in availableAddons
+                        }
+                        val filteredStreams = if (selectedAddon == null) {
+                            allStreams
+                        } else {
+                            allStreams.filter { stream -> stream.addonName == selectedAddon }
+                        }
                         it.copy(
                             isLoadingSourceStreams = false,
                             sourceAllStreams = allStreams,
-                            sourceSelectedAddonFilter = null,
-                            sourceFilteredStreams = allStreams,
+                            sourceSelectedAddonFilter = selectedAddon,
+                            sourceFilteredStreams = filteredStreams,
                             sourceAvailableAddons = availableAddons,
                             sourceChips = mergeSourceChipStatuses(
                                 existing = it.sourceChips,
@@ -198,10 +206,25 @@ private suspend fun PlayerRuntimeController.updateSourceChipsForFetchStart(
 
     val pluginNames = try {
         if (pluginManager.pluginsEnabled.first()) {
-            pluginManager.enabledScrapers.first()
-                .filter { it.supportsType(type) }
-                .map { it.name }
-                .distinct()
+            val mediaType = when (type.lowercase()) {
+                "series", "tv", "show" -> "tv"
+                else -> type.lowercase()
+            }
+            val groupByRepository = pluginManager.groupStreamsByRepository.first()
+            val scrapers = pluginManager.enabledScrapers.first()
+                .filter { it.supportsType(mediaType) }
+            if (groupByRepository) {
+                val repositoriesById = pluginManager.repositories.first().associateBy { it.id }
+                scrapers
+                    .map { scraper ->
+                        repositoriesById[scraper.repositoryId]?.name?.takeIf { it.isNotBlank() } ?: scraper.name
+                    }
+                    .distinct()
+            } else {
+                scrapers
+                    .map { it.name }
+                    .distinct()
+            }
         } else {
             emptyList()
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginScreen.kt
@@ -151,16 +151,6 @@ fun PluginScreenContent(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier.fillMaxSize()
         ) {
-            if (showHeader) {
-                item {
-                    PluginHeader(
-                        pluginsEnabled = uiState.pluginsEnabled,
-                        isReadOnly = viewModel.isReadOnly,
-                        onPluginsEnabledChange = { viewModel.onEvent(PluginUiEvent.SetPluginsEnabled(it)) }
-                    )
-                }
-            }
-
             if (viewModel.isReadOnly) {
                 item {
                     androidx.compose.material3.Card(
@@ -199,6 +189,24 @@ fun PluginScreenContent(
                 item {
                     ManageFromPhoneCard(onClick = { viewModel.onEvent(PluginUiEvent.StartQrMode) })
                 }
+            }
+
+            item {
+                PluginsEnabledCard(
+                    pluginsEnabled = uiState.pluginsEnabled,
+                    isReadOnly = viewModel.isReadOnly,
+                    onPluginsEnabledChange = { viewModel.onEvent(PluginUiEvent.SetPluginsEnabled(it)) }
+                )
+            }
+
+            item {
+                PluginStreamGroupingCard(
+                    groupStreamsByRepository = uiState.groupStreamsByRepository,
+                    isReadOnly = viewModel.isReadOnly,
+                    onGroupStreamsByRepositoryChange = {
+                        viewModel.onEvent(PluginUiEvent.SetGroupStreamsByRepository(it))
+                    }
+                )
             }
 
             // Repositories section
@@ -307,70 +315,123 @@ fun PluginScreenContent(
 }
 
 @Composable
-private fun PluginHeader(
+private fun PluginStreamGroupingCard(
+    groupStreamsByRepository: Boolean,
+    isReadOnly: Boolean,
+    onGroupStreamsByRepositoryChange: (Boolean) -> Unit
+) {
+    Surface(
+        onClick = {
+            if (!isReadOnly) {
+                onGroupStreamsByRepositoryChange(!groupStreamsByRepository)
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            focusedContainerColor = NuvioColors.FocusBackground
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(12.dp)
+            )
+        ),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.plugin_group_by_repository_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = NuvioColors.TextPrimary
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.plugin_group_by_repository_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary
+                )
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Switch(
+                checked = groupStreamsByRepository,
+                onCheckedChange = null,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = NuvioColors.Secondary,
+                    checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f)
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun PluginsEnabledCard(
     pluginsEnabled: Boolean,
     isReadOnly: Boolean,
     onPluginsEnabledChange: (Boolean) -> Unit
 ) {
-    Row(
+    Surface(
+        onClick = {
+            if (!isReadOnly) {
+                onPluginsEnabledChange(!pluginsEnabled)
+            }
+        },
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            focusedContainerColor = NuvioColors.FocusBackground
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(12.dp)
+            )
+        ),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f)
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = stringResource(R.string.plugin_title),
-                style = MaterialTheme.typography.headlineMedium,
-                color = NuvioColors.Secondary
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = stringResource(R.string.plugin_subtitle),
-                style = MaterialTheme.typography.bodyMedium,
-                color = NuvioColors.TextSecondary
-            )
-        }
-
-        Surface(
-            onClick = {
-                if (!isReadOnly) {
-                    onPluginsEnabledChange(!pluginsEnabled)
-                }
-            },
-            colors = ClickableSurfaceDefaults.colors(
-                containerColor = NuvioColors.BackgroundCard,
-                focusedContainerColor = NuvioColors.FocusBackground
-            ),
-            border = ClickableSurfaceDefaults.border(
-                focusedBorder = Border(
-                    border = BorderStroke(2.dp, NuvioColors.FocusRing),
-                    shape = RoundedCornerShape(12.dp)
-                )
-            ),
-            shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
-            scale = ClickableSurfaceDefaults.scale(focusedScale = 1.02f)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = if (pluginsEnabled) stringResource(R.string.plugin_enabled) else stringResource(R.string.plugin_disabled),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (pluginsEnabled) NuvioColors.Secondary else NuvioColors.TextSecondary
+                    text = stringResource(R.string.plugin_enable_plugins_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = NuvioColors.TextPrimary
                 )
-                Switch(
-                    checked = pluginsEnabled,
-                    onCheckedChange = null,
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = NuvioColors.Secondary,
-                        checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f)
-                    )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.plugin_enable_plugins_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioColors.TextSecondary
                 )
             }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Switch(
+                checked = pluginsEnabled,
+                onCheckedChange = null,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = NuvioColors.Secondary,
+                    checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f)
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginUiState.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.domain.model.ScraperInfo
 
 data class PluginUiState(
     val pluginsEnabled: Boolean = true,
+    val groupStreamsByRepository: Boolean = false,
     val repositories: List<PluginRepository> = emptyList(),
     val scrapers: List<ScraperInfo> = emptyList(),
     val isLoading: Boolean = false,
@@ -49,6 +50,7 @@ sealed interface PluginUiEvent {
     data class ToggleAllScrapersForRepo(val repoId: String, val enabled: Boolean) : PluginUiEvent
     data class TestScraper(val scraperId: String) : PluginUiEvent
     data class SetPluginsEnabled(val enabled: Boolean) : PluginUiEvent
+    data class SetGroupStreamsByRepository(val enabled: Boolean) : PluginUiEvent
     object ClearTestResults : PluginUiEvent
     object ClearError : PluginUiEvent
     object ClearSuccess : PluginUiEvent

--- a/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/plugin/PluginViewModel.kt
@@ -56,20 +56,27 @@ class PluginViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 pluginManager.pluginsEnabled,
+                pluginManager.groupStreamsByRepository,
                 pluginManager.repositories,
                 pluginManager.scrapers
-            ) { enabled, repos, scrapers ->
-                Triple(enabled, repos, scrapers)
-            }.collect { (enabled, repos, scrapers) ->
+            ) { enabled, groupStreamsByRepository, repos, scrapers ->
+                PluginUiState(
+                    pluginsEnabled = enabled,
+                    groupStreamsByRepository = groupStreamsByRepository,
+                    repositories = repos,
+                    scrapers = scrapers
+                )
+            }.collect { nextState ->
                 val visibleScrapers = if (isReadOnly) {
-                    scrapers.filter { it.enabled }
+                    nextState.scrapers.filter { it.enabled }
                 } else {
-                    scrapers
+                    nextState.scrapers
                 }
                 _uiState.update {
                     it.copy(
-                        pluginsEnabled = enabled,
-                        repositories = repos,
+                        pluginsEnabled = nextState.pluginsEnabled,
+                        groupStreamsByRepository = nextState.groupStreamsByRepository,
+                        repositories = nextState.repositories,
                         scrapers = visibleScrapers
                     )
                 }
@@ -86,6 +93,7 @@ class PluginViewModel @Inject constructor(
             is PluginUiEvent.ToggleAllScrapersForRepo -> toggleAllScrapersForRepo(event.repoId, event.enabled)
             is PluginUiEvent.TestScraper -> testScraper(event.scraperId)
             is PluginUiEvent.SetPluginsEnabled -> setPluginsEnabled(event.enabled)
+            is PluginUiEvent.SetGroupStreamsByRepository -> setGroupStreamsByRepository(event.enabled)
             PluginUiEvent.ClearTestResults -> _uiState.update { it.copy(testResults = null, testDiagnostics = null, testScraperId = null) }
             PluginUiEvent.ClearError -> _uiState.update { it.copy(errorMessage = null) }
             PluginUiEvent.ClearSuccess -> _uiState.update { it.copy(successMessage = null) }
@@ -215,6 +223,13 @@ class PluginViewModel @Inject constructor(
         if (isReadOnly) return
         viewModelScope.launch {
             pluginManager.setPluginsEnabled(enabled)
+        }
+    }
+
+    private fun setGroupStreamsByRepository(enabled: Boolean) {
+        if (isReadOnly) return
+        viewModelScope.launch {
+            pluginManager.setGroupStreamsByRepository(enabled)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -492,10 +492,21 @@ class StreamScreenViewModel @Inject constructor(
 
         val pluginNames = try {
             if (pluginManager.pluginsEnabled.first()) {
-                pluginManager.enabledScrapers.first()
+                val groupByRepository = pluginManager.groupStreamsByRepository.first()
+                val scrapers = pluginManager.enabledScrapers.first()
                     .filter { it.supportsType(contentType) }
-                    .map { it.name }
-                    .distinct()
+                if (groupByRepository) {
+                    val repositoriesById = pluginManager.repositories.first().associateBy { it.id }
+                    scrapers
+                        .map { scraper ->
+                            repositoriesById[scraper.repositoryId]?.name?.takeIf { it.isNotBlank() } ?: scraper.name
+                        }
+                        .distinct()
+                } else {
+                    scrapers
+                        .map { it.name }
+                        .distinct()
+                }
             } else {
                 emptyList()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1496,6 +1496,10 @@
     <string name="plugin_providers_section">Providers (%1$d)</string>
     <string name="plugin_title">Plugins</string>
     <string name="plugin_subtitle">Manage local scrapers and providers</string>
+    <string name="plugin_enable_plugins_title">Enable plugin providers globally</string>
+    <string name="plugin_enable_plugins_subtitle">Use plugin providers during stream discovery</string>
+    <string name="plugin_group_by_repository_title">Group plugin providers by repository</string>
+    <string name="plugin_group_by_repository_subtitle">In Streams, show one provider per repository instead of one per source</string>
     <string name="plugin_add_repository">Add repository</string>
     <string name="plugin_add_btn">Add</string>
     <string name="plugin_manage_from_phone_title">Manage from phone</string>

--- a/app/src/playstore/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/playstore/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -14,6 +14,7 @@ class PluginManager {
     val repositories: Flow<List<PluginRepository>> = flowOf(emptyList())
     val scrapers: Flow<List<ScraperInfo>> = flowOf(emptyList())
     val pluginsEnabled: Flow<Boolean> = flowOf(false)
+    val groupStreamsByRepository: Flow<Boolean> = flowOf(false)
     val enabledScrapers: Flow<List<ScraperInfo>> = flowOf(emptyList())
 
     var isSyncingFromRemote: Boolean = false
@@ -45,6 +46,8 @@ class PluginManager {
 
     suspend fun setPluginsEnabled(enabled: Boolean) = Unit
 
+    suspend fun setGroupStreamsByRepository(enabled: Boolean) = Unit
+
     suspend fun executeScrapers(
         tmdbId: String,
         mediaType: String,
@@ -57,7 +60,7 @@ class PluginManager {
         mediaType: String,
         season: Int? = null,
         episode: Int? = null
-    ): Flow<Pair<String, List<LocalScraperResult>>> = emptyFlow()
+    ): Flow<Pair<ScraperInfo, List<LocalScraperResult>>> = emptyFlow()
 
     suspend fun executeScraper(
         scraper: ScraperInfo,


### PR DESCRIPTION
## Summary

- Port mobile plugin provider repository grouping to TV.
- Add TV plugin settings for global provider enablement and grouping plugin providers by repository.
- Keep stream/source chips and player sidebar results consistent with the grouping setting.

## PR type

- Approved larger change

## Why

TV plugin sources were always shown per provider, while mobile supports grouping plugin providers by repository. This makes the TV stream source list noisy when a repository contains many providers and differs from the mobile behavior.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

Approved in #1814

## Testing

- `./gradlew :app:compileFullDebugKotlin`
- `./gradlew installFullDebug`

## Screenshots / Video (UI changes only)

<img width="1920" height="1080" alt="plugins_settings" src="https://github.com/user-attachments/assets/d2e9cf4a-f536-4ddc-8271-0f7db0f32355" />

<img width="1920" height="1080" alt="stream_sources_sidebar" src="https://github.com/user-attachments/assets/e7c451aa-ba75-4b89-85e8-357e8a476945" />

## Breaking changes

- None

## Linked issues

Fixes #1814
