### PR TITLE
fix(i18n): drop duplicate layout_section_continue_watching_desc in es-419

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -778,7 +778,6 @@
     <string name="layout_section_detail">Página de Detalles</string>
     <string name="layout_section_detail_desc">Ajustes para las pantallas de detalles y episodios.</string>
     <string name="layout_section_continue_watching_desc">Configuraciones para la sección "Continuar viendo".</string>
-    <string name="layout_section_continue_watching_desc">Configuraciones para la sección Continuar viendo.</string>
     <string name="layout_use_episode_thumbnails_cw">Usar miniaturas de episodios en "Continuar viendo"</string>
     <string name="layout_use_episode_thumbnails_cw_sub">Usa miniaturas de episodios como imagen predeterminada. Cuando está desactivado, se usa el fondo.</string>
     <string name="layout_blur_unwatched">Desenfocar Episodios No Vistos</string>


### PR DESCRIPTION
## Summary

Removes a duplicate `<string name="layout_section_continue_watching_desc">` entry in `values-b+es+419/strings.xml`. Two consecutive lines defined the same key, which is a hard error in AAPT2 resource merging.

## PR type

- Bug fix

## Why

`./gradlew :app:mergeFullDebugResources` fails on `dev` with:

> Error: Found item String/layout_section_continue_watching_desc more than one time

`:app:assembleFullDebug` and anything else that depends on resource merging fail the same way. The duplicate came in with the recent Latin American Spanish localization update. Both values translate the same English source string; the quoted form is kept to match the surrounding entries.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Testing

`./gradlew :app:assembleFullDebug` fails on `dev`, succeeds with this patch applied.

## Screenshots / Video (UI changes only)

None. String resource only.

## Breaking changes

None.

## Linked issues

None.