### PR TITLE
fix: remove duplicate Spanish continue watching string

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -778,7 +778,6 @@
     <string name="layout_section_detail">Página de Detalles</string>
     <string name="layout_section_detail_desc">Ajustes para las pantallas de detalles y episodios.</string>
     <string name="layout_section_continue_watching_desc">Configuraciones para la sección "Continuar viendo".</string>
-    <string name="layout_section_continue_watching_desc">Configuraciones para la sección Continuar viendo.</string>
     <string name="layout_use_episode_thumbnails_cw">Usar miniaturas de episodios en "Continuar viendo"</string>
     <string name="layout_use_episode_thumbnails_cw_sub">Usa miniaturas de episodios como imagen predeterminada. Cuando está desactivado, se usa el fondo.</string>
     <string name="layout_blur_unwatched">Desenfocar Episodios No Vistos</string>


### PR DESCRIPTION
## Summary

Fixed build failure error. Removed the duplicate `layout_section_continue_watching_desc` string from the Latin American Spanish resources, keeping the better-formatted translation with quoted “Continuar viendo”.

## PR type

- Bug fix

## Why

Android CI was failing in `:app:mergeFullReleaseResources` because `app/src/main/res/values-b+es+419/strings.xml` defined `layout_section_continue_watching_desc` twice.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the approved feature request issue below.

## Testing

Verified `layout_section_continue_watching_desc` appears only once in `app/src/main/res/values-b+es+419/strings.xml`.

Parsed `app/src/main/res/values-b+es+419/strings.xml` as XML successfully.

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

None, nothing broken, only fixed.

## Linked issues

Fixes CI failure in my own personal builds.
