### PR TITLE
fix: defer playback start until first video frame to prevent audio-video desync

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -399,10 +399,15 @@ internal fun PlayerRuntimeController.initializePlayer(
                     )
                 )
                 if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }
+                val isTunneledPlayback = playerSettings.tunnelingEnabled
                 // Always start paused — playback begins in onRenderedFirstFrame()
                 // so audio and video start in perfect sync. Without this, the
                 // audio renderer races ahead by 1-2s while the video decoder
                 // is still decoding the first I-frame.
+                //
+                // Exception: tunneled playback bypasses the normal video
+                // rendering pipeline so onRenderedFirstFrame() never fires.
+                // In that case we fall back to starting on STATE_READY.
                 playWhenReady = false
                 prepare()
 
@@ -453,9 +458,29 @@ internal fun PlayerRuntimeController.initializePlayer(
                             // for onRenderedFirstFrame() to ensure A/V sync.
                             // After the first frame is visible, rebuffer events
                             // can resume playback normally.
+                            //
+                            // Exception: tunneled playback never fires
+                            // onRenderedFirstFrame(), so we must start here.
                             if (shouldEnforceAutoplayOnFirstReady) {
                                 shouldEnforceAutoplayOnFirstReady = false
-                                // Playback will start in onRenderedFirstFrame().
+                                if (isTunneledPlayback) {
+                                    // Tunneled mode — onRenderedFirstFrame() won't
+                                    // fire; treat STATE_READY as the sync point.
+                                    hasRenderedFirstFrame = true
+                                    if (!startPaused && !userPausedManually) {
+                                        playWhenReady = true
+                                        play()
+                                    }
+                                    _uiState.update {
+                                        it.copy(
+                                            showLoadingOverlay = false,
+                                            loadingMessage = null,
+                                            loadingProgress = if (it.loadingProgress != null) 1f else null,
+                                            showPlayerEngineSwitchInfo = false
+                                        )
+                                    }
+                                }
+                                // Non-tunneled: playback will start in onRenderedFirstFrame().
                             } else if (!userPausedManually && hasRenderedFirstFrame) {
                                 play()
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -399,7 +399,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                     )
                 )
                 if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }
-                playWhenReady = !startPaused
+                // Always start paused — playback begins in onRenderedFirstFrame()
+                // so audio and video start in perfect sync. Without this, the
+                // audio renderer races ahead by 1-2s while the video decoder
+                // is still decoding the first I-frame.
+                playWhenReady = false
                 prepare()
 
                 addListener(object : Player.Listener {
@@ -445,15 +449,14 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (playbackState == Player.STATE_READY) {
                             pendingSeekFlush = false
                             
-                            // Perform hardware flush (pause-delay-play) to prevent A/V desync 
-                            // on initial load, after rebuffering, and after out-of-buffer seeks.
+                            // Don't auto-play on the initial STATE_READY — wait
+                            // for onRenderedFirstFrame() to ensure A/V sync.
+                            // After the first frame is visible, rebuffer events
+                            // can resume playback normally.
                             if (shouldEnforceAutoplayOnFirstReady) {
                                 shouldEnforceAutoplayOnFirstReady = false
-                                if (!userPausedManually) {
-                                    playWhenReady = true
-                                    play()
-                                }
-                            } else if (!userPausedManually) {
+                                // Playback will start in onRenderedFirstFrame().
+                            } else if (!userPausedManually && hasRenderedFirstFrame) {
                                 play()
                             }
                             tryApplyPendingResumeProgress(this@apply)
@@ -507,6 +510,12 @@ internal fun PlayerRuntimeController.initializePlayer(
 
                     override fun onRenderedFirstFrame() {
                         hasRenderedFirstFrame = true
+                        // Start playback now that the first video frame is
+                        // visible — audio and video begin in perfect sync.
+                        if (!startPaused && !userPausedManually) {
+                            playWhenReady = true
+                            play()
+                        }
                         resetErrorRetryState()
                         // Restore speed after PCM fallback — audio sink is already
                         // configured in PCM mode and won't revert to passthrough.


### PR DESCRIPTION
## Summary

Defer ExoPlayer playback start until the first video frame is rendered to eliminate audio-before-video desync on startup. The player now starts with `playWhenReady = false` and switches to `playWhenReady = true` + `play()` inside `onRenderedFirstFrame()`, ensuring audio and video begin at the exact same moment.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When starting playback, ExoPlayer's audio renderer becomes ready and begins outputting audio significantly faster than the video decoder can decode and render the first I-frame. This causes two distinct issues depending on device hardware:

- **Slow devices (TCL Google TV, Fire Stick):** Audio starts 1–2 seconds before the first video frame appears, resulting in audio playing over a black/loading screen. Especially noticeable on 4K streams.
- **Fast devices (Nvidia Shield Pro, high-end devices):** The audio pipeline initializes and flushes aggressively before the video surface is ready, causing an audible audio pop/burst at the start of playback.

The issue is most prominent on 4K and 4K HDR/DV streams where the first I-frame is significantly larger (1–3 MB), increasing video decoder startup latency while the audio decoder is ready almost instantly. Both symptoms originate from the same root cause: `playWhenReady = true` is set before `prepare()`, allowing the audio renderer to race ahead of the video decoder.

## Issue or approval

Fixes #1840

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `PlayerRuntimeControllerInitialization.kt` is modified.
- No changes to LoadControl, buffer sizes, networking, track selection, or any other player subsystem.
- No changes to MPV player engine path — this fix only affects the ExoPlayer pipeline.
- Rebuffer resume behavior after the first frame is preserved via the `hasRenderedFirstFrame` guard in `STATE_READY`.

## Testing


- **TCL Google TV (Android 12):** Verified audio no longer races ahead of video. Both start in sync after the loading overlay dismisses.
- **Resume playback:** Verified that seeking to a saved resume position still works correctly — `tryApplyPendingResumeProgress` runs in `STATE_READY` before `onRenderedFirstFrame`, so the first visible frame is at the resume position.
- **Start paused:** Verified `startPaused = true` still works — player shows first frame but does not auto-play.
- **Rebuffering:** Verified that mid-playback rebuffer events still auto-resume via the `hasRenderedFirstFrame` guard in the `STATE_READY` handler.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1840
