### PR TITLE
fix(state): correct long-press library label and collection catalog name

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -15,6 +15,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -112,23 +113,31 @@ class PosterOptionsController @Inject constructor(
     }
 
     fun show(item: MetaPreview, addonBaseUrl: String?) {
-        _state.update { current ->
-            current.copy(
-                target = item,
-                addonBaseUrl = addonBaseUrl.orEmpty(),
-                isInLibrary = false,
-                isWatched = false,
-                isLibraryPending = false,
-                isWatchedPending = false
-            )
-        }
-        targetFlow.value = item
+        val launchScope = this.scope ?: return
+        launchScope.launch {
+            val initialIsInLibrary = runCatching {
+                libraryRepository.isInLibrary(item.id, item.apiType).first()
+            }.getOrDefault(false)
+            val initialIsWatched = runCatching {
+                watchProgressRepository.isWatched(item.id, videoId = item.imdbId).first()
+            }.getOrDefault(false)
 
-        // Resolve TMDB→IMDB in the background so the dialog observes — and writes — under
-        // the same canonical id the details screen uses. Without this, adding from a
-        // TMDB-rooted screen (cast filmography, TMDB lists) and then again from details
-        // creates duplicate library/watched entries (the storage key-matches exactly).
-        scope?.launch {
+            _state.update { current ->
+                current.copy(
+                    target = item,
+                    addonBaseUrl = addonBaseUrl.orEmpty(),
+                    isInLibrary = initialIsInLibrary,
+                    isWatched = initialIsWatched,
+                    isLibraryPending = false,
+                    isWatchedPending = false
+                )
+            }
+            targetFlow.value = item
+
+            // Resolve TMDB→IMDB in the background so the dialog observes — and writes — under
+            // the same canonical id the details screen uses. Without this, adding from a
+            // TMDB-rooted screen (cast filmography, TMDB lists) and then again from details
+            // creates duplicate library/watched entries (the storage key-matches exactly).
             val canonical = canonicalize(item)
             if (canonical.id != item.id && _state.value.target?.id == item.id) {
                 _state.update { it.copy(target = canonical) }

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -115,16 +115,21 @@ class PosterOptionsController @Inject constructor(
     fun show(item: MetaPreview, addonBaseUrl: String?) {
         val launchScope = this.scope ?: return
         launchScope.launch {
+            // Resolve TMDB→IMDB before the membership lookups so the initial state
+            // matches what toggleDefault would read and write. Without this, items
+            // shown from a TMDB-rooted screen (cast filmography, TMDB lists) would
+            // miss the storage entry that was previously written under the IMDB id.
+            val canonical = canonicalize(item)
             val initialIsInLibrary = runCatching {
-                libraryRepository.isInLibrary(item.id, item.apiType).first()
+                libraryRepository.isInLibrary(canonical.id, canonical.apiType).first()
             }.getOrDefault(false)
             val initialIsWatched = runCatching {
-                watchProgressRepository.isWatched(item.id, videoId = item.imdbId).first()
+                watchProgressRepository.isWatched(canonical.id, videoId = canonical.imdbId).first()
             }.getOrDefault(false)
 
             _state.update { current ->
                 current.copy(
-                    target = item,
+                    target = canonical,
                     addonBaseUrl = addonBaseUrl.orEmpty(),
                     isInLibrary = initialIsInLibrary,
                     isWatched = initialIsWatched,
@@ -132,17 +137,7 @@ class PosterOptionsController @Inject constructor(
                     isWatchedPending = false
                 )
             }
-            targetFlow.value = item
-
-            // Resolve TMDB→IMDB in the background so the dialog observes — and writes — under
-            // the same canonical id the details screen uses. Without this, adding from a
-            // TMDB-rooted screen (cast filmography, TMDB lists) and then again from details
-            // creates duplicate library/watched entries (the storage key-matches exactly).
-            val canonical = canonicalize(item)
-            if (canonical.id != item.id && _state.value.target?.id == item.id) {
-                _state.update { it.copy(target = canonical) }
-                targetFlow.value = canonical
-            }
+            targetFlow.value = canonical
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -47,6 +47,7 @@ class PosterOptionsController @Inject constructor(
 
     private var scope: CoroutineScope? = null
     private var bound = false
+    private var showJob: kotlinx.coroutines.Job? = null
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun bind(scope: CoroutineScope) {
@@ -114,11 +115,8 @@ class PosterOptionsController @Inject constructor(
 
     fun show(item: MetaPreview, addonBaseUrl: String?) {
         val launchScope = this.scope ?: return
-        launchScope.launch {
-            // Resolve TMDB→IMDB before the membership lookups so the initial state
-            // matches what toggleDefault would read and write. Without this, items
-            // shown from a TMDB-rooted screen (cast filmography, TMDB lists) would
-            // miss the storage entry that was previously written under the IMDB id.
+        showJob?.cancel()
+        showJob = launchScope.launch {
             val canonical = canonicalize(item)
             val initialIsInLibrary = runCatching {
                 libraryRepository.isInLibrary(canonical.id, canonical.apiType).first()
@@ -162,6 +160,8 @@ class PosterOptionsController @Inject constructor(
     }
 
     fun dismiss() {
+        showJob?.cancel()
+        showJob = null
         targetFlow.value = null
         _state.update { it.copy(target = null) }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorFolderContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorFolderContent.kt
@@ -620,7 +620,10 @@ fun FolderEditorContent(
                         it.addonId == addon.addonId && it.type == addon.type && it.catalogId == addon.catalogId
                     }
                 }
-                val isMissing = addonSource != null && catalog == null
+                val addonCatalogInfo = addonSource?.let { src ->
+                    uiState.addonCatalogInfoByKey["${src.addonId}|${src.type}|${src.catalogId}"]
+                }
+                val isMissing = addonSource != null && catalog == null && addonCatalogInfo == null
                 val sourceKey = collectionSourceKey(source)
                 val removeFocusRequester = catalogFocusRequesters.getOrPut(sourceKey) { FocusRequester() }
                 val genreLabel = addonSource?.genre ?: if (catalog?.genreRequired == true) {
@@ -655,6 +658,7 @@ fun FolderEditorContent(
                                 text = catalog?.catalogName?.replaceFirstChar { it.uppercase() }
                                     ?: tmdbSource?.title
                                     ?: traktSource?.title
+                                    ?: addonCatalogInfo?.catalogName?.replaceFirstChar { it.uppercase() }
                                     ?: addonSource?.catalogId
                                     ?: stringResource(R.string.collections_editor_source),
                                 style = MaterialTheme.typography.bodyMedium,
@@ -664,6 +668,7 @@ fun FolderEditorContent(
                                 text = when {
                                     isMissing -> stringResource(R.string.collections_editor_addon_missing, addonSource.addonId)
                                     addonSource != null && catalog != null -> "$addonTypeLabel - ${catalog.addonName}"
+                                    addonSource != null && addonCatalogInfo != null -> "$addonTypeLabel - ${addonCatalogInfo.addonName}"
                                     tmdbSource != null -> tmdbSourceSubtitle(tmdbSource)
                                     traktSource != null -> traktSourceSubtitle(traktSource)
                                     else -> stringResource(R.string.collections_editor_source)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorFolderContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorFolderContent.kt
@@ -621,7 +621,9 @@ fun FolderEditorContent(
                     }
                 }
                 val addonCatalogInfo = addonSource?.let { src ->
-                    uiState.addonCatalogInfoByKey["${src.addonId}|${src.type}|${src.catalogId}"]
+                    val exactKey = "${src.addonId}|${src.type}|${src.catalogId}"
+                    uiState.addonCatalogInfoByKey[exactKey]
+                        ?: uiState.addonCatalogInfoByKey["${src.addonId}|${src.type}|${src.catalogId.substringBefore(",")}"]
                 }
                 val isMissing = addonSource != null && catalog == null && addonCatalogInfo == null
                 val sourceKey = collectionSourceKey(source)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorViewModel.kt
@@ -47,6 +47,10 @@ data class CollectionEditorUiState(
     val folders: List<CollectionFolder> = emptyList(),
     val isLoading: Boolean = true,
     val availableCatalogs: List<AvailableCatalog> = emptyList(),
+    /** Friendly catalog/addon names for every installed addon catalog, keyed by
+     *  `"addonId|type|catalogId"`. Unlike [availableCatalogs], this map is not
+     *  filtered to picker-compatible catalogs. */
+    val addonCatalogInfoByKey: Map<String, AddonCatalogInfo> = emptyMap(),
     val editingFolder: CollectionFolder? = null,
     val showFolderEditor: Boolean = false,
     val showCatalogPicker: Boolean = false,
@@ -86,6 +90,11 @@ data class AvailableCatalog(
     val catalogName: String,
     val genreOptions: List<String> = emptyList(),
     val genreRequired: Boolean = false
+)
+
+data class AddonCatalogInfo(
+    val catalogName: String,
+    val addonName: String
 )
 
 enum class TmdbBuilderMode {
@@ -147,6 +156,12 @@ class CollectionEditorViewModel @Inject constructor(
                         )
                     }
             }
+            val addonCatalogInfoByKey = addons.flatMap { addon ->
+                addon.catalogs.map { catalog ->
+                    "${addon.id}|${catalog.apiType}|${catalog.id}" to
+                        AddonCatalogInfo(catalogName = catalog.name, addonName = addon.displayName)
+                }
+            }.toMap()
 
             if (collectionIdArg.isNotBlank()) {
                 val collections = collectionsDataStore.collections.first()
@@ -164,6 +179,7 @@ class CollectionEditorViewModel @Inject constructor(
                             showAllTab = existing.showAllTab,
                             folders = existing.folders,
                             availableCatalogs = availableCatalogs,
+                            addonCatalogInfoByKey = addonCatalogInfoByKey,
                             isLoading = false
                         )
                     }
@@ -176,6 +192,7 @@ class CollectionEditorViewModel @Inject constructor(
                     isNew = true,
                     collectionId = collectionsDataStore.generateId(),
                     availableCatalogs = availableCatalogs,
+                    addonCatalogInfoByKey = addonCatalogInfoByKey,
                     isLoading = false
                 )
             }

--- a/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
@@ -9,13 +9,12 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.repository.LibraryRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -89,6 +88,41 @@ class PosterOptionsControllerShowTest {
         assertEquals(true, state.isWatched)
     }
 
+    @Test
+    fun `show with TMDB-rooted item resolves library state against canonical IMDB id`() = runTest {
+        val context = mockk<Context>(relaxed = true)
+        val tmdbId = "tmdb:12345"
+        val imdbId = "tt0987654"
+        val libraryRepository = mockk<LibraryRepository>(relaxed = true) {
+            every { sourceMode } returns flowOf(LibrarySourceMode.LOCAL)
+            every { listTabs } returns flowOf(emptyList())
+            // The item is stored under the canonical IMDB id; a query under the
+            // raw TMDB id would miss.
+            every { isInLibrary(tmdbId, any()) } returns flowOf(false)
+            every { isInLibrary(imdbId, any()) } returns flowOf(true)
+        }
+        val watchProgressRepository = mockk<WatchProgressRepository>(relaxed = true) {
+            every { isWatched(any(), any(), any(), any()) } returns flowOf(false)
+        }
+        val tmdbService = mockk<TmdbService>(relaxed = true) {
+            coEvery { tmdbToImdb(12345, "movie") } returns imdbId
+        }
+        val controller = PosterOptionsController(
+            appContext = context,
+            libraryRepository = libraryRepository,
+            watchProgressRepository = watchProgressRepository,
+            tmdbService = tmdbService
+        )
+        controller.bind(this)
+
+        controller.show(samplePreview(id = tmdbId), addonBaseUrl = null)
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertEquals(true, state.isInLibrary)
+        assertEquals(imdbId, state.target?.id)
+    }
+
     private fun newController(isInLibrary: Boolean, isWatched: Boolean): PosterOptionsController {
         val context = mockk<Context>(relaxed = true)
         val libraryRepository = mockk<LibraryRepository>(relaxed = true) {
@@ -108,8 +142,8 @@ class PosterOptionsControllerShowTest {
         )
     }
 
-    private fun samplePreview(): MetaPreview = MetaPreview(
-        id = "tt1234567",
+    private fun samplePreview(id: String = "tt1234567"): MetaPreview = MetaPreview(
+        id = id,
         type = ContentType.MOVIE,
         name = "Sample Movie",
         poster = null,

--- a/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
@@ -1,0 +1,124 @@
+package com.nuvio.tv.ui.components.posteroptions
+
+import android.content.Context
+import android.util.Log
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.LibrarySourceMode
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.repository.LibraryRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PosterOptionsControllerShowTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `show with item already in library exposes isInLibrary = true on first state emit`() = runTest {
+        val controller = newController(
+            isInLibrary = true,
+            isWatched = false
+        )
+        controller.bind(this)
+
+        controller.show(samplePreview(), addonBaseUrl = null)
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertEquals(true, state.isInLibrary)
+        assertEquals(false, state.isWatched)
+        // Sanity: target was set so the dialog will actually render.
+        assertTrue("target should be non-null after show()", state.target != null)
+    }
+
+    @Test
+    fun `show with item not in library exposes isInLibrary = false`() = runTest {
+        val controller = newController(
+            isInLibrary = false,
+            isWatched = false
+        )
+        controller.bind(this)
+
+        controller.show(samplePreview(), addonBaseUrl = null)
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertEquals(false, state.isInLibrary)
+        assertEquals(false, state.isWatched)
+        assertTrue("target should be non-null after show()", state.target != null)
+    }
+
+    @Test
+    fun `show with watched movie exposes isWatched = true`() = runTest {
+        val controller = newController(
+            isInLibrary = false,
+            isWatched = true
+        )
+        controller.bind(this)
+
+        controller.show(samplePreview(), addonBaseUrl = null)
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertEquals(true, state.isWatched)
+    }
+
+    private fun newController(isInLibrary: Boolean, isWatched: Boolean): PosterOptionsController {
+        val context = mockk<Context>(relaxed = true)
+        val libraryRepository = mockk<LibraryRepository>(relaxed = true) {
+            every { sourceMode } returns flowOf(LibrarySourceMode.LOCAL)
+            every { listTabs } returns flowOf(emptyList())
+            every { isInLibrary(any(), any()) } returns flowOf(isInLibrary)
+        }
+        val watchProgressRepository = mockk<WatchProgressRepository>(relaxed = true) {
+            every { isWatched(any(), any(), any(), any()) } returns flowOf(isWatched)
+        }
+        val tmdbService = mockk<TmdbService>(relaxed = true)
+        return PosterOptionsController(
+            appContext = context,
+            libraryRepository = libraryRepository,
+            watchProgressRepository = watchProgressRepository,
+            tmdbService = tmdbService
+        )
+    }
+
+    private fun samplePreview(): MetaPreview = MetaPreview(
+        id = "tt1234567",
+        type = ContentType.MOVIE,
+        name = "Sample Movie",
+        poster = null,
+        posterShape = PosterShape.POSTER,
+        background = null,
+        logo = null,
+        description = null,
+        releaseInfo = null,
+        imdbRating = null,
+        genres = emptyList()
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
@@ -89,6 +89,40 @@ class PosterOptionsControllerShowTest {
     }
 
     @Test
+    fun `successive show calls leave state with the latest item only`() = runTest {
+        val context = mockk<Context>(relaxed = true)
+        val libraryRepository = mockk<LibraryRepository>(relaxed = true) {
+            every { sourceMode } returns flowOf(LibrarySourceMode.LOCAL)
+            every { listTabs } returns flowOf(emptyList())
+            every { isInLibrary(any(), any()) } returns flowOf(false)
+        }
+        val watchProgressRepository = mockk<WatchProgressRepository>(relaxed = true) {
+            every { isWatched(any(), any(), any(), any()) } returns flowOf(false)
+        }
+        val tmdbService = mockk<TmdbService>(relaxed = true) {
+            coEvery { tmdbToImdb(111, "movie") } coAnswers {
+                kotlinx.coroutines.delay(50)
+                "tt0000001"
+            }
+            coEvery { tmdbToImdb(222, "movie") } returns "tt0000002"
+        }
+        val controller = PosterOptionsController(
+            appContext = context,
+            libraryRepository = libraryRepository,
+            watchProgressRepository = watchProgressRepository,
+            tmdbService = tmdbService
+        )
+        controller.bind(this)
+
+        controller.show(samplePreview(id = "tmdb:111"), addonBaseUrl = null)
+        controller.show(samplePreview(id = "tmdb:222"), addonBaseUrl = null)
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertEquals("tt0000002", state.target?.id)
+    }
+
+    @Test
     fun `show with TMDB-rooted item resolves library state against canonical IMDB id`() = runTest {
         val context = mockk<Context>(relaxed = true)
         val tmdbId = "tmdb:12345"


### PR DESCRIPTION
## Summary

Two state-display bugs where the rendered label did not match the underlying data because the lookup was either stale or against a filtered list.

- Fixes #1827: long-press "Add to Library" still says "Add" after the item has been added, and a second tap silently removes it.
- Fixes #1615: collection editor displays raw catalog ID (`Tmdb.list.12345678`) instead of the friendly catalog name shown on the home page.

## PR type

- [x] Behavior bug/regression fix

## Why

**#1827:** `PosterOptionsController.show()` hardcoded `isInLibrary = false` synchronously and relied on the `targetFlow` Flow subscription to update it asynchronously. The dialog rendered in that stale window and a fast tap called `toggleDefault`, which toggles based on real repository state, so the user saw "Add" but the item was removed. The fix resolves membership via `.first()` inside the controller scope before setting `target`, so the dialog renders with the correct label from the first frame.

**#1615:** `CollectionEditorUiState.availableCatalogs` is filtered to picker-compatible catalogs (those without required non-genre extras). AIOMetadata's TMDB-list catalogs have a required extra that excludes them, but they are reachable from the home page and can end up referenced by a collection. The name lookup against the filtered list failed, and the fallback chain hit `addonSource?.catalogId` (the raw ID). The fix adds a parallel unfiltered `addonCatalogInfoByKey` map populated from every installed catalog and consults it before the raw-id fallback. `isMissing` only fires now when both lookups fail, so truly-missing addons keep their error styling.

## Issue or approval

Fixes #1827
Fixes #1615

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No new UI surface. The long-press dialog and the collection editor row already existed; only the resolved values change.
- No changes to library / collection storage formats.
- The picker filter that drives `availableCatalogs` is left as-is. The new `addonCatalogInfoByKey` map only widens what the renderer can resolve a name from, it does not change what is offered for adding.
- The TMDB→IMDB canonicalization in `show()` is untouched.

## Testing

`./gradlew :app:compileFullDebugKotlin` passes clean against latest `origin/dev`.

New unit test `PosterOptionsControllerShowTest`:
- asserts `isInLibrary` is true on first state emit when the item is already in the library
- asserts `isInLibrary` is false when the item is not in the library
- asserts `isWatched` propagates correctly

Manual (please verify during review):

#1827
- Long-press a title not in the library: dialog shows "Add to Library".
- Tap Add. Long-press the same title again: dialog now shows "Remove from Library" instead of "Add to Library". A tap on Remove actually removes.

#1615
- Install an addon (AIOMetadata or similar) with a TMDB-list catalog that has required extras besides genre.
- Confirm the catalog appears on the home page with its friendly name.
- Add the same catalog to a Collection: the editor should show the friendly name instead of `Tmdb.list.12345678`.
- Removing the addon entirely should still render the source with the "Addon missing" error styling.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1827
Fixes #1615