### PR TITLE
Fix Classic View extended posters trailers

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -249,11 +249,27 @@ fun ClassicHomeContent(
         .apply { value = trailerPreviewAudioUrls }
     var focusedArtwork by remember { mutableStateOf<ClassicFocusArtwork?>(null) }
     val latestOnItemFocus by rememberUpdatedState(onItemFocus)
+    val latestOnRequestTrailerPreview by rememberUpdatedState(onRequestTrailerPreview)
 
-    val handleMetaFocus: (MetaPreview) -> Unit = remember(uiState.classicFocusGradientEnabled, uiState.focusedPosterBackdropExpandEnabled) {
+    // Track focused catalog item for trailer preview requests (mirrors ModernHomeContent behavior).
+    var focusedCatalogItem by remember { mutableStateOf<MetaPreview?>(null) }
+    if (uiState.focusedPosterBackdropTrailerEnabled) {
+        LaunchedEffect(focusedCatalogItem) {
+            val item = focusedCatalogItem ?: return@LaunchedEffect
+            if (trailerPreviewUrls.containsKey(item.id)) return@LaunchedEffect
+            delay(150)
+            if (focusedCatalogItem?.id != item.id) return@LaunchedEffect
+            latestOnRequestTrailerPreview(item)
+        }
+    }
+
+    val handleMetaFocus: (MetaPreview) -> Unit = remember(uiState.classicFocusGradientEnabled, uiState.focusedPosterBackdropExpandEnabled, uiState.focusedPosterBackdropTrailerEnabled) {
         { item ->
             if (uiState.classicFocusGradientEnabled) {
                 focusedArtwork = item.toClassicFocusArtwork(uiState.focusedPosterBackdropExpandEnabled)
+            }
+            if (uiState.focusedPosterBackdropTrailerEnabled) {
+                focusedCatalogItem = item
             }
             latestOnItemFocus(item)
         }


### PR DESCRIPTION
## Summary

Fix trailer autoplay not working in Classic Home view. After the trailer player pool reuse optimization (19914c80), the trailer URL request trigger was moved out of `ContentCard` into the parent content views, but only `ModernHomeContent` received the new trigger - `ClassicHomeContent` was missed.

## PR type

- [x] Behavior bug/regression fix

## Why

In commit `19914c80` ("Trailer fixes - fallback to hls"), the per-card `LaunchedEffect` that called `onRequestTrailerPreview` on focus was removed from `ContentCard` to prevent every visible card in Modern view from independently triggering trailer extraction. The intent was to centralize the trigger in the parent content composable. `ModernHomeContent` received a replacement `LaunchedEffect` that fires `onRequestTrailerPreview` after a 150ms focus debounce, but `ClassicHomeContent` did not. As a result, in Classic view no one ever requests the trailer URL, `trailerPreviewUrl` is always `null`, and the `shouldPlayTrailerPreview` condition in `ContentCard` is never satisfied — trailers never play in expanded posters.

## Issue or approval

Regression introduced in 19914c80, reported on Discord 

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `ClassicHomeContent.kt` is changed.
- `ContentCard.kt` is intentionally left unchanged — the centralized trigger pattern (parent requests, card observes) is preserved.
- Modern view is unaffected; its existing trigger in `ModernHomeContent` continues to work as before.

## Testing

- Enabled "Autoplay trailer in expanded poster" in Layout Settings.
- Switched to Classic Home layout.
- Focused a catalog item, waited for backdrop expansion.
- Confirmed trailer loads and plays in the expanded card after ~150ms focus debounce.
- Switched to Modern Home layout, confirmed trailers still work (no double-trigger regression).
- Tested rapid D-pad scrolling in Classic view - confirmed debounce prevents unnecessary trailer requests.

## Screenshots / Video (UI changes only)

Not a UI change - restores existing behavior that regressed.

## Breaking changes

Nothing should break

## Linked issues

reported on Discord 
