### PR TITLE
fix: hide Discover built-in header under modern floating-pill sidebar

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -926,6 +926,7 @@ fun NuvioNavHost(
 
         composable(Screen.Discover.route) {
             DiscoverScreen(
+                showBuiltInHeader = !hideBuiltInHeaders,
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
                     navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -35,6 +35,7 @@ import kotlin.math.roundToInt
 @Composable
 fun DiscoverScreen(
     viewModel: SearchViewModel = hiltViewModel(),
+    showBuiltInHeader: Boolean = true,
     onNavigateToDetail: (String, String, String) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -92,6 +93,7 @@ fun DiscoverScreen(
                 watchedMovieIds = watchedMovieIds,
                 watchedSeriesIds = watchedSeriesIds,
                 focusResults = false,
+                showBuiltInHeader = showBuiltInHeader,
                 firstItemFocusRequester = discoverFirstItemFocusRequester,
                 focusedItemIndex = discoverFocusedItemIndex,
                 shouldRestoreFocusedItem = restoreDiscoverFocus,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -76,6 +76,7 @@ internal fun DiscoverSection(
     watchedMovieIds: Set<String> = emptySet(),
     watchedSeriesIds: Set<String> = emptySet(),
     focusResults: Boolean,
+    showBuiltInHeader: Boolean = true,
     firstItemFocusRequester: FocusRequester,
     focusedItemIndex: Int,
     shouldRestoreFocusedItem: Boolean,
@@ -125,7 +126,7 @@ internal fun DiscoverSection(
         Text(
             text = stringResource(R.string.discover_title),
             style = MaterialTheme.typography.headlineMedium,
-            color = NuvioColors.TextPrimary
+            color = if (showBuiltInHeader) NuvioColors.TextPrimary else Color.Transparent
         )
 
         Row(


### PR DESCRIPTION
## Summary

Threads the existing `showBuiltInHeader` flag through `DiscoverScreen` and `DiscoverSection` so the per-screen "Discover" title is suppressed when the modern floating-pill sidebar is active. The Discover route was missed when #1794 added the `IN_SIDEBAR` placement. Paints the title text `Color.Transparent` when off, matching `LibraryScreen.kt:244` so the filter row's vertical position is unchanged.

## PR type

- [x] UI glitch/bug fix

## Why

When `DiscoverLocation` is set to `IN_SIDEBAR` and the modern sidebar is active, the per-screen "Discover" title renders alongside the sidebar pill's "Discover" label, producing two visible headers on the same screen. The same suppression was already in place for Library, Settings, and Addons; Discover was the only surface that fell through.

## Issue or approval

Fixes #1858. Follow-up to #1794.

## UI / behavior impact

- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- Only the Discover route's built-in header is touched. Library / Settings / Addons paths are unchanged.
- No changes to `DiscoverLocation` semantics, sidebar membership, routing, focus gating, or any of #1794's behavior.
- No changes to `SearchScreen.kt`, `SearchUiState`, or the in-Search Discover entry point. `showBuiltInHeader` defaults to `true` on both `DiscoverScreen` and `DiscoverSection`, so the `IN_SEARCH` placement and any future caller render identically to before.
- Two pre-existing `standard:statement-wrapping` ktlint findings (`NuvioNavHost.kt:1125`, `SearchDiscoverSection.kt:102`) are intentionally left alone per `.claude/rules/quality-checks.md` ("fix only findings on lines you actually modified").

## Testing

Manually verified on Android TV (Raspberry Pi 5, arm64-v8a, full-debug build):

- **Modern sidebar + uncollapsed + `IN_SIDEBAR`**, navigated to Discover via the sidebar entry. Built-in "Discover" title is gone, filter row sits at the same vertical position as in #1794's screenshots. No layout shift in the catalog/type/genre dropdown row or the poster grid below.
- **Modern sidebar + collapsed + `IN_SIDEBAR`**, `hideBuiltInHeadersForFloatingPill` falls back to `false` (`MainActivity.kt:495`); built-in "Discover" title reappears as expected.
- **Legacy sidebar + `IN_SIDEBAR`**, `LegacySidebarScaffold` passes `hideBuiltInHeaders = false` (`MainActivity.kt:657`); built-in title visible, unchanged from #1794 behavior.
- **`IN_SEARCH`**, opened Discover from the Search bar entry point. Built-in title visible (default `showBuiltInHeader = true`). No regression on the in-Search Discover path.
- **`OFF`**, no regression. Empty-state screen renders correctly, no sidebar entry, no Discover button in Search.
- **Sibling routes under modern sidebar + uncollapsed** (Library, Settings, Addons), built-in headers remain suppressed as #1794 left them. No collateral.

No JVM unit tests added. The change is a single-line UI-state forwarding through three call sites, no new logic to assert. Visible behavior is verified manually across the placement/sidebar-style matrix above.

## Screenshots / Video

| Bug | Fix |
|---|---|
| <img width="480" alt="discover-modern-sidebar-bug-overlap" src="https://github.com/user-attachments/assets/6602f6de-2ea2-41e3-b67e-d8797163c234" /> | <img width="480" alt="discover-modern-sidebar-expanded" src="https://github.com/user-attachments/assets/d3fd4007-c929-4b18-b5fb-ced8257190d7" /> |
| <img width="480" alt="discover-modern-sidebar-bug" src="https://github.com/user-attachments/assets/75c3f74e-f80d-441c-adec-910f7e8b4b4c" /> | <img width="480" alt="discover-modern-sidebar-fixed" src="https://github.com/user-attachments/assets/de98ad5a-1409-4457-83a4-58b38cf18309" /> |

## Breaking changes

None. `showBuiltInHeader` defaults to `true` on `DiscoverScreen` and `DiscoverSection`. Internal-only parameter thread; no DataStore, serialization, or sync changes.

## Linked issues

Fixes #1858. Follow-up to #1794.