### PR TITLE
fix: playback stuttering

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -137,8 +137,8 @@ data class SubtitleStyleSettings(
  * Data class representing buffer settings
  */
 data class BufferSettings(
-    val minBufferMs: Int = 50_000,
-    val maxBufferMs: Int = 70_000,
+    val minBufferMs: Int = PlayerSettingsDataStore.DEFAULT_MIN_BUFFER_MS,
+    val maxBufferMs: Int = PlayerSettingsDataStore.DEFAULT_MAX_BUFFER_MS,
     val bufferForPlaybackMs: Int = 2_500,
     val bufferForPlaybackAfterRebufferMs: Int = 5_000,
     val targetBufferSizeMb: Int = 0, // 0 = ExoPlayer default
@@ -308,6 +308,8 @@ class PlayerSettingsDataStore @Inject constructor(
         private const val FEATURE = "player_settings"
         private const val AUDIO_AMPLIFICATION_DB_MIN = 0
         private const val AUDIO_AMPLIFICATION_DB_MAX = 10
+        const val DEFAULT_MIN_BUFFER_MS = 50_000
+        const val DEFAULT_MAX_BUFFER_MS = 50_000
     }
 
     private fun store(profileId: Int = profileManager.activeProfileId.value) =
@@ -405,8 +407,8 @@ class PlayerSettingsDataStore @Inject constructor(
                         (currentMin == 15_000 && currentMax == 25_000)
 
                     if (legacyDefaultsDetected) {
-                        prefs[minBufferMsKey] = 50_000
-                        prefs[maxBufferMsKey] = 70_000
+                        prefs[minBufferMsKey] = DEFAULT_MIN_BUFFER_MS
+                        prefs[maxBufferMsKey] = DEFAULT_MAX_BUFFER_MS
                     }
 
                     prefs[migrationLoadControlDefaultsAlignedDoneKey] = true
@@ -594,8 +596,8 @@ class PlayerSettingsDataStore @Inject constructor(
                     outlineWidth = prefs[subtitleOutlineWidthKey] ?: 2
                 ),
                 bufferSettings = BufferSettings(
-                    minBufferMs = prefs[minBufferMsKey] ?: 50_000,
-                    maxBufferMs = prefs[maxBufferMsKey] ?: 70_000,
+                    minBufferMs = prefs[minBufferMsKey] ?: DEFAULT_MIN_BUFFER_MS,
+                    maxBufferMs = prefs[maxBufferMsKey] ?: DEFAULT_MAX_BUFFER_MS,
                     bufferForPlaybackMs = prefs[bufferForPlaybackMsKey] ?: 2_500,
                     bufferForPlaybackAfterRebufferMs = prefs[bufferForPlaybackAfterRebufferMsKey] ?: 5_000,
                     targetBufferSizeMb = prefs[targetBufferSizeMbKey] ?: 0,
@@ -1100,7 +1102,7 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             val newMin = ms.coerceIn(5_000, 120_000)
             prefs[minBufferMsKey] = newMin
-            val currentMax = prefs[maxBufferMsKey] ?: 70_000
+            val currentMax = prefs[maxBufferMsKey] ?: DEFAULT_MAX_BUFFER_MS
             if (currentMax < newMin) {
                 prefs[maxBufferMsKey] = newMin
             }
@@ -1109,7 +1111,7 @@ class PlayerSettingsDataStore @Inject constructor(
 
     suspend fun setBufferMaxBufferMs(ms: Int) {
         store().edit { prefs ->
-            val currentMin = prefs[minBufferMsKey] ?: 50_000
+            val currentMin = prefs[minBufferMsKey] ?: DEFAULT_MIN_BUFFER_MS
             prefs[maxBufferMsKey] = ms.coerceIn(currentMin, 120_000)
         }
     }

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -138,7 +138,7 @@ data class SubtitleStyleSettings(
  */
 data class BufferSettings(
     val minBufferMs: Int = 50_000,
-    val maxBufferMs: Int = 50_000,
+    val maxBufferMs: Int = 70_000,
     val bufferForPlaybackMs: Int = 2_500,
     val bufferForPlaybackAfterRebufferMs: Int = 5_000,
     val targetBufferSizeMb: Int = 0, // 0 = ExoPlayer default
@@ -406,7 +406,7 @@ class PlayerSettingsDataStore @Inject constructor(
 
                     if (legacyDefaultsDetected) {
                         prefs[minBufferMsKey] = 50_000
-                        prefs[maxBufferMsKey] = 50_000
+                        prefs[maxBufferMsKey] = 70_000
                     }
 
                     prefs[migrationLoadControlDefaultsAlignedDoneKey] = true
@@ -595,7 +595,7 @@ class PlayerSettingsDataStore @Inject constructor(
                 ),
                 bufferSettings = BufferSettings(
                     minBufferMs = prefs[minBufferMsKey] ?: 50_000,
-                    maxBufferMs = prefs[maxBufferMsKey] ?: 50_000,
+                    maxBufferMs = prefs[maxBufferMsKey] ?: 70_000,
                     bufferForPlaybackMs = prefs[bufferForPlaybackMsKey] ?: 2_500,
                     bufferForPlaybackAfterRebufferMs = prefs[bufferForPlaybackAfterRebufferMsKey] ?: 5_000,
                     targetBufferSizeMb = prefs[targetBufferSizeMbKey] ?: 0,
@@ -1100,7 +1100,7 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             val newMin = ms.coerceIn(5_000, 120_000)
             prefs[minBufferMsKey] = newMin
-            val currentMax = prefs[maxBufferMsKey] ?: 50_000
+            val currentMax = prefs[maxBufferMsKey] ?: 70_000
             if (currentMax < newMin) {
                 prefs[maxBufferMsKey] = newMin
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -35,6 +35,7 @@ import androidx.media3.extractor.ts.TsExtractor
 import androidx.media3.session.MediaSession
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioLanguageOption
+import com.nuvio.tv.data.local.BufferSettings
 import com.nuvio.tv.data.local.SUBTITLE_LANGUAGE_FORCED
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
@@ -54,6 +55,8 @@ private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
 private const val AUDIO_DELAY_REFRESH_DEBOUNCE_MS = 120L
 private const val PLAYER_RELEASE_TIMEOUT_MS = 3000L
 private const val PLAYER_REBUILD_SETTLE_DELAY_MS = 120L
+private const val BYTES_PER_MEGABYTE = 1024 * 1024
+private const val MAX_TARGET_BUFFER_SIZE_MB = Int.MAX_VALUE / BYTES_PER_MEGABYTE
 
 internal data class StartupSubtitlePreparation(
     val fetchedSubtitles: List<Subtitle>,
@@ -226,17 +229,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     libassRenderType = playerSettings.libassRenderType
                 )
             }
-            val loadControl = run {
-                DefaultLoadControl.Builder()
-                    .setTargetBufferBytes(100 * 1024 * 1024)
-                    .setBufferDurationsMs(
-                        DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-                        70_000,
-                        DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-                        5_000
-                    )
-                    .build()
-            }
+            val loadControl = buildPlaybackLoadControl(playerSettings.bufferSettings)
 
             
             trackSelector = DefaultTrackSelector(context).apply {
@@ -628,6 +621,34 @@ internal fun PlayerRuntimeController.resolveAutoInternalPlayerEngine(): Internal
 
         if (isAnime) InternalPlayerEngine.MVP_PLAYER else InternalPlayerEngine.EXOPLAYER
     }
+}
+
+@androidx.annotation.OptIn(UnstableApi::class)
+private fun buildPlaybackLoadControl(bufferSettings: BufferSettings): DefaultLoadControl {
+    val minBufferMs = bufferSettings.minBufferMs
+    val maxBufferMs = bufferSettings.maxBufferMs.coerceAtLeast(minBufferMs)
+
+    return DefaultLoadControl.Builder()
+        .setBufferDurationsMs(
+            minBufferMs,
+            maxBufferMs,
+            bufferSettings.bufferForPlaybackMs,
+            bufferSettings.bufferForPlaybackAfterRebufferMs
+        )
+        .setBackBuffer(
+            bufferSettings.backBufferDurationMs,
+            bufferSettings.retainBackBufferFromKeyframe
+        )
+        .setPrioritizeTimeOverSizeThresholds(true)
+        .apply {
+            if (bufferSettings.targetBufferSizeMb > 0) {
+                setTargetBufferBytes(
+                    bufferSettings.targetBufferSizeMb
+                        .coerceAtMost(MAX_TARGET_BUFFER_SIZE_MB) * BYTES_PER_MEGABYTE
+                )
+            }
+        }
+        .build()
 }
 
 internal fun resolvePreferredAudioLanguages(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -55,8 +55,7 @@ private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
 private const val AUDIO_DELAY_REFRESH_DEBOUNCE_MS = 120L
 private const val PLAYER_RELEASE_TIMEOUT_MS = 3000L
 private const val PLAYER_REBUILD_SETTLE_DELAY_MS = 120L
-private const val BYTES_PER_MEGABYTE = 1024 * 1024
-private const val MAX_TARGET_BUFFER_SIZE_MB = Int.MAX_VALUE / BYTES_PER_MEGABYTE
+private const val BYTES_PER_MEGABYTE = 1024L * 1024L
 
 internal data class StartupSubtitlePreparation(
     val fetchedSubtitles: List<Subtitle>,
@@ -625,27 +624,28 @@ internal fun PlayerRuntimeController.resolveAutoInternalPlayerEngine(): Internal
 
 @androidx.annotation.OptIn(UnstableApi::class)
 private fun buildPlaybackLoadControl(bufferSettings: BufferSettings): DefaultLoadControl {
-    val minBufferMs = bufferSettings.minBufferMs
+    val minBufferMs = bufferSettings.minBufferMs.coerceAtLeast(0)
     val maxBufferMs = bufferSettings.maxBufferMs.coerceAtLeast(minBufferMs)
+    val bufferForPlaybackMs = bufferSettings.bufferForPlaybackMs.coerceIn(0, minBufferMs)
+    val bufferForPlaybackAfterRebufferMs =
+        bufferSettings.bufferForPlaybackAfterRebufferMs.coerceIn(0, minBufferMs)
 
     return DefaultLoadControl.Builder()
         .setBufferDurationsMs(
             minBufferMs,
             maxBufferMs,
-            bufferSettings.bufferForPlaybackMs,
-            bufferSettings.bufferForPlaybackAfterRebufferMs
+            bufferForPlaybackMs,
+            bufferForPlaybackAfterRebufferMs
         )
         .setBackBuffer(
-            bufferSettings.backBufferDurationMs,
+            bufferSettings.backBufferDurationMs.coerceAtLeast(0),
             bufferSettings.retainBackBufferFromKeyframe
         )
         .setPrioritizeTimeOverSizeThresholds(true)
         .apply {
             if (bufferSettings.targetBufferSizeMb > 0) {
-                setTargetBufferBytes(
-                    bufferSettings.targetBufferSizeMb
-                        .coerceAtMost(MAX_TARGET_BUFFER_SIZE_MB) * BYTES_PER_MEGABYTE
-                )
+                val targetBufferBytes = bufferSettings.targetBufferSizeMb.toLong() * BYTES_PER_MEGABYTE
+                setTargetBufferBytes(targetBufferBytes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt())
             }
         }
         .build()


### PR DESCRIPTION
## Summary

Fix ExoPlayer playback buffering for high-bitrate debrid streams by using the app's persisted buffer settings instead of a hardcoded byte-capped load control, while validating those settings before building the player.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Issue #1844 reports frequent buffering/stuttering during internal-player playback, especially around the middle/later parts of 4K Torbox debrid videos and sometimes after pausing.

The ExoPlayer path was forcing a 100 MB target buffer and fixed buffer durations. For large 4K files, the byte target could stop loading before enough playback time was buffered, making playback vulnerable to repeated rebuffers during normal network variation.

This change keeps the existing buffer defaults, removes the hardcoded playback byte cap, prioritizes buffered playback time, and clamps persisted buffer values so invalid settings cannot crash player initialization.

## Issue or approval

Fixes #1844.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only ExoPlayer load-control setup and buffer-setting default reuse were changed. No provider logic, playback UI, subtitle/audio selection, MPV playback, stream selection, or remote navigation behavior was changed.

The default max buffer duration remains unchanged to avoid increasing memory pressure on slower or lower-memory TV hardware.

## Testing

- Ran `git diff --check`.
- Verified the bundled forked ExoPlayer AAR includes the `DefaultLoadControl.Builder` APIs used by the change.
- Reviewed the touched playback initialization path to confirm ExoPlayer now uses persisted buffer settings, validates thresholds before player creation, and no longer forces the 100 MB playback byte cap by default.
- Manual device playback validation confirmed no buffering issues on same source that was causing the issue in current latest beta.

## Screenshots / Video

Not applicable

## Breaking changes

None.

## Linked issues

Fixes #1844.
