### PR TITLE
migrate parental guide to imdbapi.dev

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -244,7 +244,7 @@ object NetworkModule {
     @Named("parentalGuide")
     fun provideParentalGuideRetrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit =
         Retrofit.Builder()
-            .baseUrl(BuildConfig.PARENTAL_GUIDE_API_URL.ifEmpty { "https://localhost/" })
+            .baseUrl("https://api.imdbapi.dev/")
             .client(okHttpClient)
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/ParentalGuideApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/ParentalGuideApi.kt
@@ -8,35 +8,32 @@ import retrofit2.http.Path
 
 interface ParentalGuideApi {
 
-    @GET("movie/{imdbId}")
-    suspend fun getMovieGuide(
+    @GET("titles/{imdbId}/parentsGuide")
+    suspend fun getParentsGuide(
         @Path("imdbId") imdbId: String
-    ): Response<ParentalGuideResponse>
-
-    @GET("tv/{imdbId}/{season}/{episode}")
-    suspend fun getTVGuide(
-        @Path("imdbId") imdbId: String,
-        @Path("season") season: Int,
-        @Path("episode") episode: Int
-    ): Response<ParentalGuideResponse>
+    ): Response<ImdbApiParentsGuideResponse>
 }
 
 @JsonClass(generateAdapter = true)
-data class ParentalGuideResponse(
-    @Json(name = "imdbId") val imdbId: String? = null,
-    @Json(name = "parentalGuide") val parentalGuide: ParentalGuideData? = null,
-    @Json(name = "hasData") val hasData: Boolean = false,
-    @Json(name = "seriesId") val seriesId: String? = null,
-    @Json(name = "season") val season: Int? = null,
-    @Json(name = "episode") val episode: Int? = null,
-    @Json(name = "cached") val cached: Boolean? = null
+data class ImdbApiParentsGuideResponse(
+    @Json(name = "parentsGuide") val parentsGuide: List<ImdbApiParentsGuideCategory>? = null
 )
 
 @JsonClass(generateAdapter = true)
-data class ParentalGuideData(
-    @Json(name = "nudity") val nudity: String? = null,
-    @Json(name = "violence") val violence: String? = null,
-    @Json(name = "profanity") val profanity: String? = null,
-    @Json(name = "alcohol") val alcohol: String? = null,
-    @Json(name = "frightening") val frightening: String? = null
+data class ImdbApiParentsGuideCategory(
+    @Json(name = "category") val category: String,
+    @Json(name = "severityBreakdowns") val severityBreakdowns: List<ImdbApiSeverityBreakdown>? = null,
+    @Json(name = "reviews") val reviews: List<ImdbApiParentsGuideReview>? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class ImdbApiSeverityBreakdown(
+    @Json(name = "severityLevel") val severityLevel: String,
+    @Json(name = "voteCount") val voteCount: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class ImdbApiParentsGuideReview(
+    @Json(name = "text") val text: String? = null,
+    @Json(name = "isSpoiler") val isSpoiler: Boolean? = null
 )

--- a/app/src/main/java/com/nuvio/tv/data/repository/ParentalGuideRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/ParentalGuideRepository.kt
@@ -1,58 +1,85 @@
 package com.nuvio.tv.data.repository
 
 import android.util.Log
-import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.data.remote.api.ImdbApiParentsGuideCategory
 import com.nuvio.tv.data.remote.api.ParentalGuideApi
-import com.nuvio.tv.data.remote.api.ParentalGuideResponse
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+
+/**
+ * Resolved parental guide data with a single severity per category,
+ * determined by the highest-voted severity level from the API.
+ */
+data class ParentalGuideResult(
+    val nudity: String? = null,
+    val violence: String? = null,
+    val profanity: String? = null,
+    val alcohol: String? = null,
+    val frightening: String? = null
+)
 
 @Singleton
 class ParentalGuideRepository @Inject constructor(
     private val api: ParentalGuideApi
 ) {
-    private val cache = ConcurrentHashMap<String, ParentalGuideResponse>()
-    private val isConfigured = BuildConfig.PARENTAL_GUIDE_API_URL.isNotEmpty()
+    private val cache = ConcurrentHashMap<String, ParentalGuideResult>()
 
-    suspend fun getMovieGuide(imdbId: String): ParentalGuideResponse? {
-        if (!isConfigured) return null
+    suspend fun getParentalGuide(imdbId: String): ParentalGuideResult? {
         if (!imdbId.startsWith("tt")) return null
 
-        val cacheKey = "movie:$imdbId"
-        cache[cacheKey]?.let { return it }
+        cache[imdbId]?.let { return it }
 
         return try {
-            val response = api.getMovieGuide(imdbId)
-            if (response.isSuccessful && response.body()?.hasData == true) {
-                response.body()!!.also { cache[cacheKey] = it }
+            val response = api.getParentsGuide(imdbId)
+            if (response.isSuccessful && !response.body()?.parentsGuide.isNullOrEmpty()) {
+                val categories = response.body()!!.parentsGuide!!
+                val result = mapToResult(categories)
+                cache[imdbId] = result
+                result
             } else {
                 null
             }
         } catch (e: Exception) {
-            Log.e("ParentalGuide", "Failed to fetch movie guide", e)
+            Log.e("ParentalGuide", "Failed to fetch parental guide for $imdbId", e)
             null
         }
     }
 
-    suspend fun getTVGuide(imdbId: String, season: Int, episode: Int): ParentalGuideResponse? {
-        if (!isConfigured) return null
-        if (!imdbId.startsWith("tt")) return null
-        if (season < 0 || episode < 0) return null
+    private fun mapToResult(categories: List<ImdbApiParentsGuideCategory>): ParentalGuideResult {
+        val categoryMap = categories.associateBy { it.category.uppercase() }
 
-        val cacheKey = "tv:$imdbId:$season:$episode"
-        cache[cacheKey]?.let { return it }
+        return ParentalGuideResult(
+            nudity = resolveSeverity(categoryMap["SEXUAL_CONTENT"]),
+            violence = resolveSeverity(categoryMap["VIOLENCE"]),
+            profanity = resolveSeverity(categoryMap["PROFANITY"]),
+            alcohol = resolveSeverity(categoryMap["ALCOHOL_DRUGS"]),
+            frightening = resolveSeverity(categoryMap["FRIGHTENING_INTENSE_SCENES"])
+        )
+    }
 
-        return try {
-            val response = api.getTVGuide(imdbId, season, episode)
-            if (response.isSuccessful && response.body()?.hasData == true) {
-                response.body()!!.also { cache[cacheKey] = it }
-            } else {
-                null
-            }
-        } catch (e: Exception) {
-            Log.e("ParentalGuide", "Failed to fetch TV guide", e)
-            null
-        }
+    /**
+     * Determines the dominant severity level for a category by picking
+     * the level with the highest vote count (excluding "none").
+     * Returns null if no meaningful votes exist.
+     */
+    private fun resolveSeverity(category: ImdbApiParentsGuideCategory?): String? {
+        if (category == null) return null
+
+        val breakdowns = category.severityBreakdowns ?: return null
+
+        // Find the severity with the most votes, excluding "none"
+        val dominant = breakdowns
+            .filter { it.severityLevel.lowercase() != "none" }
+            .maxByOrNull { it.voteCount }
+
+        // If "none" has more votes than any other severity, treat as no concern
+        val noneVotes = breakdowns
+            .firstOrNull { it.severityLevel.lowercase() == "none" }
+            ?.voteCount ?: 0
+
+        if (dominant == null || dominant.voteCount <= noneVotes) return null
+
+        return dominant.severityLevel.lowercase()
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -409,58 +409,50 @@ internal fun PlayerRuntimeController.fetchParentalGuide(id: String?, type: Strin
     val imdbId = id.split(":").firstOrNull()?.takeIf { it.startsWith("tt") } ?: return
 
     scope.launch {
-        val response = if (type in listOf("series", "tv") && season != null && episode != null) {
-            parentalGuideRepository.getTVGuide(imdbId, season, episode)
-        } else {
-            parentalGuideRepository.getMovieGuide(imdbId)
+        val guide = parentalGuideRepository.getParentalGuide(imdbId) ?: return@launch
+
+        val labels = mapOf(
+            "nudity" to context.getString(R.string.parental_nudity),
+            "violence" to context.getString(R.string.parental_violence),
+            "profanity" to context.getString(R.string.parental_profanity),
+            "alcohol" to context.getString(R.string.parental_alcohol),
+            "frightening" to context.getString(R.string.parental_frightening)
+        )
+        val severityOrder = mapOf(
+            "severe" to 0, "moderate" to 1, "mild" to 2
+        )
+
+        val entries = listOfNotNull(
+            guide.nudity?.let { "nudity" to it },
+            guide.violence?.let { "violence" to it },
+            guide.profanity?.let { "profanity" to it },
+            guide.alcohol?.let { "alcohol" to it },
+            guide.frightening?.let { "frightening" to it }
+        )
+
+        val warnings = entries
+            .sortedBy { severityOrder[it.second.lowercase()] ?: 3 }
+            .map {
+                val localizedSeverity = when (it.second.lowercase()) {
+                    "severe" -> context.getString(R.string.parental_severity_severe)
+                    "moderate" -> context.getString(R.string.parental_severity_moderate)
+                    "mild" -> context.getString(R.string.parental_severity_mild)
+                    else -> it.second
+                }
+                ParentalWarning(label = labels[it.first] ?: it.first, severity = localizedSeverity)
+            }
+            .take(5)
+
+        _uiState.update {
+            it.copy(
+                parentalWarnings = warnings,
+                showParentalGuide = false,
+                parentalGuideHasShown = false
+            )
         }
 
-        if (response?.parentalGuide != null) {
-            val guide = response.parentalGuide
-            val labels = mapOf(
-                "nudity" to context.getString(R.string.parental_nudity),
-                "violence" to context.getString(R.string.parental_violence),
-                "profanity" to context.getString(R.string.parental_profanity),
-                "alcohol" to context.getString(R.string.parental_alcohol),
-                "frightening" to context.getString(R.string.parental_frightening)
-            )
-            val severityOrder = mapOf(
-                "severe" to 0, "moderate" to 1, "mild" to 2
-            )
-
-            val entries = listOfNotNull(
-                guide.nudity?.let { "nudity" to it },
-                guide.violence?.let { "violence" to it },
-                guide.profanity?.let { "profanity" to it },
-                guide.alcohol?.let { "alcohol" to it },
-                guide.frightening?.let { "frightening" to it }
-            )
-
-            val warnings = entries
-                .filter { it.second.lowercase() != "none" }
-                .sortedBy { severityOrder[it.second.lowercase()] ?: 3 }
-                .map {
-                    val localizedSeverity = when (it.second.lowercase()) {
-                        "severe" -> context.getString(R.string.parental_severity_severe)
-                        "moderate" -> context.getString(R.string.parental_severity_moderate)
-                        "mild" -> context.getString(R.string.parental_severity_mild)
-                        else -> it.second
-                    }
-                    ParentalWarning(label = labels[it.first] ?: it.first, severity = localizedSeverity)
-                }
-                .take(5)
-
-            _uiState.update {
-                it.copy(
-                    parentalWarnings = warnings,
-                    showParentalGuide = false,
-                    parentalGuideHasShown = false
-                )
-            }
-
-            if (_uiState.value.isPlaying) {
-                tryShowParentalGuide()
-            }
+        if (_uiState.value.isPlaying) {
+            tryShowParentalGuide()
         }
     }
 }


### PR DESCRIPTION
## Summary

Migrate parental guide feature from our custom (now defunct) API to imdbapi.dev (`https://api.imdbapi.dev/titles/{imdbId}/parentsGuide`). The new API has a different response structure (vote-based severity breakdowns instead of flat severity strings), so the repository layer now resolves the dominant severity per category from vote counts. The UI overlay remains unchanged.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The previous parental guide API server we relied on stopped working, breaking the parental guidance overlay in the player. This migrates to a publicly available alternative (imdbapi.dev) so the feature is functional again. Maybe a temporary solution but restores functionality now.

## Issue or approval

Approved by @tapframe

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- The `PARENTAL_GUIDE_API_URL` build config field is left in `build.gradle.kts` (dead code) to avoid breaking anyone's `local.properties`. It is no longer read by Kotlin code.
- No per-episode parental guide - the new API provides guide data at the title level only (same as IMDb itself). This was already the effective behavior for most content.
- The UI overlay (`ParentalGuideOverlay.kt`) is completely untouched.

## Testing

- Verified API response manually via `curl https://api.imdbapi.dev/titles/tt1190634/parentsGuide`
- Tested playback of movie content - overlay appears with correct severity labels
- Tested playback of series content - overlay appears using series-level IMDB ID
- Confirmed categories with "none" as dominant vote do not appear in overlay
- Confirmed severity ordering (severe -> moderate -> mild) is preserved
- Tested with invalid/missing IMDB IDs - no crash, overlay simply doesn't show

## Screenshots / Video

Not a UI change - the overlay appearance is identical to before.

## Breaking changes

None. The `PARENTAL_GUIDE_API_URL` property in `local.properties` is no longer used, but its presence won't cause errors.

## Linked issues

No linked issue - previous API server went offline, approved replacement by @tapframe. Issues reported on Discord
