### PR TITLE
perf: isolate buffering indicator recomposition scope and GPU layer

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/LoadingIndicator.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/LoadingIndicator.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.nuvio.tv.ui.theme.NuvioColors
 
@@ -18,7 +19,11 @@ fun LoadingIndicator(
         contentAlignment = Alignment.Center
     ) {
         CircularProgressIndicator(
-            modifier = Modifier.size(48.dp),
+            modifier = Modifier
+                .size(48.dp)
+                .graphicsLayer {
+                    clip = false
+                },
             color = NuvioColors.Primary
         )
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -667,52 +667,16 @@ fun PlayerScreen(
                 .zIndex(2.7f)
         )
 
-        // Buffering indicator
-        if (uiState.isBuffering && !uiState.showLoadingOverlay) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                if (uiState.isTorrentStream && uiState.torrentBufferingMessage != null) {
-                    // Torrent rebuffer: spinner + download stats + progress bar
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        LoadingIndicator()
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            text = uiState.torrentBufferingMessage ?: "",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = Color.White.copy(alpha = 0.8f)
-                        )
-                        if (uiState.torrentBufferingProgress > 0f) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Box(
-                                modifier = Modifier
-                                    .width(200.dp)
-                                    .height(3.dp)
-                                    .background(
-                                        color = Color.White.copy(alpha = 0.2f),
-                                        shape = RoundedCornerShape(2.dp)
-                                    )
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth(uiState.torrentBufferingProgress.coerceIn(0f, 1f))
-                                        .height(3.dp)
-                                        .background(
-                                            color = Color.White.copy(alpha = 0.85f),
-                                            shape = RoundedCornerShape(2.dp)
-                                        )
-                                )
-                            }
-                        }
-                    }
-                } else {
-                    LoadingIndicator()
-                }
-            }
-        }
+        // Buffering indicator — isolated in its own composable scope so that
+        // isBuffering state changes only recompose this small subtree instead
+        // of the entire PlayerScreen.
+        PlayerBufferingIndicator(
+            isBuffering = uiState.isBuffering,
+            showLoadingOverlay = uiState.showLoadingOverlay,
+            isTorrentStream = uiState.isTorrentStream,
+            torrentBufferingMessage = uiState.torrentBufferingMessage,
+            torrentBufferingProgress = uiState.torrentBufferingProgress
+        )
 
         // Error state
         if (uiState.error != null) {
@@ -2677,4 +2641,64 @@ private fun formatTime(millis: Long): String {
 
 private fun formatSubtitleDelay(delayMs: Int): String {
     return String.format(Locale.US, "%+.3fs", delayMs / 1000f)
+}
+
+/**
+ * Buffering indicator extracted into its own composable to isolate
+ * recomposition scope. When [isBuffering] toggles, only this subtree
+ * is recomposed — the rest of [PlayerScreen] is skipped by Compose.
+ */
+@Composable
+private fun PlayerBufferingIndicator(
+    isBuffering: Boolean,
+    showLoadingOverlay: Boolean,
+    isTorrentStream: Boolean,
+    torrentBufferingMessage: String?,
+    torrentBufferingProgress: Float
+) {
+    if (!isBuffering || showLoadingOverlay) return
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (isTorrentStream && torrentBufferingMessage != null) {
+            // Torrent rebuffer: spinner + download stats + progress bar
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                LoadingIndicator()
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = torrentBufferingMessage,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color.White.copy(alpha = 0.8f)
+                )
+                if (torrentBufferingProgress > 0f) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .width(200.dp)
+                            .height(3.dp)
+                            .background(
+                                color = Color.White.copy(alpha = 0.2f),
+                                shape = RoundedCornerShape(2.dp)
+                            )
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(torrentBufferingProgress.coerceIn(0f, 1f))
+                                .height(3.dp)
+                                .background(
+                                    color = Color.White.copy(alpha = 0.85f),
+                                    shape = RoundedCornerShape(2.dp)
+                                )
+                        )
+                    }
+                }
+            }
+        } else {
+            LoadingIndicator()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Isolate the mid-playback buffering indicator's Compose recomposition scope and GPU render layer to reduce unnecessary work during rebuffering on Android TV.

## PR type

- [x] Small maintenance only, with no UI or behavior change

## Why

On Android TV devices with limited GPU, the buffering spinner (`CircularProgressIndicator`) causes two performance issues during mid-playback rebuffering:

1. **Full PlayerScreen recomposition**: The inline `if (uiState.isBuffering)` block sits directly in the PlayerScreen body, so every `isBuffering` toggle triggers recomposition of the entire ~2700-line composable tree — including all overlays, controls, and side panels — even though only the small spinner needs updating.

2. **GPU overdraw from animation invalidation**: `CircularProgressIndicator` rotates every frame (16ms). Without layer isolation, each frame invalidates the parent Compose render node, forcing the GPU to redraw the full Compose overlay on top of the video surface.

## Issue or approval

No linked issue — internal performance maintenance with no UI or behavior change.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- The startup `LoadingOverlay` (backdrop + logo + fill animation) is not touched.
- `PlayerControlsOverlay` recomposition scope is not changed in this PR.
- No changes to ExoPlayer pipeline, decoder configuration, or playback logic.
- The buffering indicator looks and behaves identically — only the Compose tree structure and GPU layer strategy changed.

## Testing

- Installed `fullDebug` on Android TV via `adb connect` and `./gradlew installFullDebug`.
- Played several streams and triggered mid-playback rebuffering — spinner appears and disappears as expected.
- Confirmed spinner looks identical to before (same size, color, position).
- Verified startup loading overlay (backdrop + logo fill) is unaffected.


## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — performance maintenance only, no UI or behavior change.
