### PR TITLE
fix: extend OkHttp read timeout to 60s for slow addon stream responses

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -107,7 +107,7 @@ object NetworkModule {
             .hostnameVerifier { _, _ -> true }
             .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
             .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
             .addInterceptor { chain ->
                 val version = BuildConfig.VERSION_NAME.ifBlank { "dev" }
                 val request = chain.request().newBuilder()


### PR DESCRIPTION
## Summary

Fixes #1850: the shared OkHttp client used a 30s read timeout, so addon stream-fetch requests configured for longer (e.g. the reporter's 50s) were aborted before the addon could respond, regardless of the in-app "stream selection timeout" setting (that setting is the autoplay-pick timeout, not an HTTP timeout). Bumped read timeout to 60s.

## PR type

- [x] Critical bug fix

## Why

`NetworkModule.provideOkHttpClient` set `readTimeout(30, TimeUnit.SECONDS)` for all network calls. The user-facing "stream selection timeout" preference only governs how long autoplay waits before picking a stream from whatever has arrived; it does not propagate to the HTTP timeout. So addons that take longer than 30s to resolve streams (slow debrid resolves, big scrapers) were silently cut off at 30s and the user saw "no sources" even though the addon was still working.

60s matches common defaults and covers the reporter's 50s addon. A proper per-call timeout would be a bigger refactor.

## Issue or approval

Fixes #1850

## Reproduction steps

1. Install or configure an addon known to take >30s to resolve streams (slow debrid or scraper).
2. Open a movie or episode and tap Play.
3. Observe that the stream list fails with "no sources" after exactly 30s, even though the addon's own configured timeout (e.g. 50s) has not been reached.

Cause: `NetworkModule.provideOkHttpClient.readTimeout` is hardcoded to 30s; the user-facing "stream selection timeout" setting only controls autoplay-pick timing, not the HTTP timeout.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- One-line change to the global OkHttp read timeout. Affects all network calls equally (TMDB, Trakt, addons, manifests). 60s is a pragmatic split between the 30s default and the "Unlimited" intent of the user preference.
- This PR originally also contained a poster-priority flip for #1855, which has been reverted following review feedback. The poster path was not the actual cause of the reporter's symptom; that issue is being investigated separately.

## Testing

`./gradlew :app:compileFullDebugKotlin` passes clean.

Manual:
- Configure an addon known to take >30s to resolve streams. Hit play. Streams arrive instead of failing with a generic "no sources" error after exactly 30s.
- Normal-latency addons unaffected.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1850