### PR TITLE
Change CW channel source, fix profile sync crash, and fix expanded poster clipping

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -227,13 +227,13 @@ class ProfileSettingsSyncService @Inject constructor(
                         val entries = mutableMapOf<Preferences.Key<*>, Any>()
                         catalogKeysExcludedFromBlob.forEach { keyName ->
                             val strKey = stringPreferencesKey(keyName)
-                            mutablePrefs[strKey]?.let { entries[strKey] = it }
+                            runCatching { mutablePrefs[strKey] }.getOrNull()?.let { entries[strKey] = it }
                             val boolKey = booleanPreferencesKey(keyName)
-                            mutablePrefs[boolKey]?.let { entries[boolKey] = it }
+                            runCatching { mutablePrefs[boolKey] }.getOrNull()?.let { entries[boolKey] = it }
                         }
                         localOnlyLayoutKeys.forEach { keyName ->
                             val strKey = stringPreferencesKey(keyName)
-                            mutablePrefs[strKey]?.let { entries[strKey] = it }
+                            runCatching { mutablePrefs[strKey] }.getOrNull()?.let { entries[strKey] = it }
                         }
                         entries
                     } else {

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelSyncService.kt
@@ -2,34 +2,48 @@ package com.nuvio.tv.core.sync.androidtv
 
 import android.content.Context
 import android.util.Log
-import com.nuvio.tv.domain.repository.WatchProgressRepository
+import com.nuvio.tv.data.local.CachedInProgressItem
+import com.nuvio.tv.data.local.CachedNextUpItem
+import com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
+import com.nuvio.tv.domain.model.WatchProgress
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "TvChannelSync"
-private const val DEBOUNCE_MS = 300L
+private const val DEBOUNCE_MS = 2_000L
 private const val MAX_CHANNEL_ROWS = 20
 
 /**
  * Keeps the Android TV "Continue Watching" preview channel in sync with the app's
- * in-progress content. No-op on non-leanback (phone/tablet) devices.
+ * CW enrichment cache. Uses the same enriched data that the in-app Continue Watching
+ * section displays, respecting user settings (days cap, show unaired, etc.).
  *
- * The Flow-collector approach lets both the Trakt and Nuvio-sync progress backends
- * feed into a single reconcile call without requiring hooks in each write path.
+ * Items are sourced from [ContinueWatchingEnrichmentCache] which is populated by the
+ * HomeViewModel CW pipeline. This ensures the launcher channel shows the same items
+ * the user sees in the app UI.
+ *
+ * Before publishing new programs, all stale programs are removed first to avoid
+ * the launcher showing outdated tiles while new ones are being inserted.
  */
 @Singleton
 class AndroidTvChannelSyncService @Inject constructor(
     @ApplicationContext private val context: Context,
     private val manager: AndroidTvChannelManager,
-    private val watchProgressRepository: WatchProgressRepository,
+    private val cwEnrichmentCache: ContinueWatchingEnrichmentCache,
+    private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -40,18 +54,181 @@ class AndroidTvChannelSyncService @Inject constructor(
             return
         }
         TvChannelRefreshJobService.schedulePeriodic(context)
+
         scope.launch {
-            watchProgressRepository.continueWatching
-                // Skip the leading empty emitted by traktAllProgressFlow's onStart; any
-                // subsequent empty is a real removal and should reconcile (clear) the channel.
-                .dropWhile { it.isEmpty() }
+            // Clear stale programs from previous app sessions. The channel will be
+            // repopulated once the CW pipeline writes fresh data to the cache.
+            manager.clearAll()
+
+            // Observe cache snapshot updates and settings changes to trigger reconciliation.
+            // snapshotVersion bumps every time the CW pipeline writes new data to disk cache.
+            // We drop the initial value (0) to avoid reconciling with stale disk cache before
+            // the pipeline has had a chance to produce fresh data.
+            combine(
+                cwEnrichmentCache.snapshotVersion
+                    .dropWhile { it == 0 },
+                traktSettingsDataStore.continueWatchingDaysCap,
+                traktSettingsDataStore.dismissedNextUpKeys,
+                layoutPreferenceDataStore.useEpisodeThumbnailsInCw
+            ) { _, daysCap, dismissed, useEpisodeThumbnails ->
+                ChannelSettingsSnapshot(daysCap, dismissed, useEpisodeThumbnails)
+            }
                 .debounce(DEBOUNCE_MS)
-                // No distinctUntilChanged — reconcile on every emission so metadata-enriched
-                // artwork and new Trakt entries appear as soon as the Flow re-emits.
-                .collect { items ->
-                    Log.d(TAG, "Reconciling ${items.size} items: ${items.take(5).map { "${it.contentId} pct=${it.progressPercent} pos=${it.position} dur=${it.duration}" }}")
-                    manager.reconcile(items.take(MAX_CHANNEL_ROWS))
+                .collect { settings ->
+                    reconcileFromCache(settings)
                 }
         }
     }
+
+    /**
+     * Reads the CW enrichment cache and reconciles the launcher channel.
+     * Called both from the live observer and from [TvChannelRefreshJobService].
+     */
+    suspend fun reconcileFromCache(settings: ChannelSettingsSnapshot? = null) {
+        val resolvedSettings = settings ?: run {
+            val daysCap = traktSettingsDataStore.continueWatchingDaysCap.first()
+            val dismissed = traktSettingsDataStore.dismissedNextUpKeys.first()
+            val useEpisodeThumbnails = layoutPreferenceDataStore.useEpisodeThumbnailsInCw.first()
+            ChannelSettingsSnapshot(daysCap, dismissed, useEpisodeThumbnails)
+        }
+
+        val inProgressItems = runCatching { cwEnrichmentCache.getInProgressSnapshot() }
+            .getOrDefault(emptyList())
+        val nextUpItems = runCatching { cwEnrichmentCache.getNextUpSnapshot() }
+            .getOrDefault(emptyList())
+
+        val channelItems = buildChannelItems(inProgressItems, nextUpItems, resolvedSettings)
+
+        Log.d(
+            TAG,
+            "Reconciling from cache: ${channelItems.size} items " +
+                "(${inProgressItems.size} in-progress, ${nextUpItems.size} next-up raw)"
+        )
+        manager.reconcile(channelItems.take(MAX_CHANNEL_ROWS))
+    }
+
+    /**
+     * Merges in-progress and next-up cached items into a single list of [WatchProgress]
+     * suitable for the launcher channel, applying user settings:
+     * - Days cap filtering
+     * - Dismissed next-up filtering
+     * - Unreleased/unaired filtering (next-up items that haven't aired yet are excluded
+     *   to avoid showing content that can't be played)
+     * - Deduplication (in-progress takes priority over next-up for same contentId)
+     */
+    private fun buildChannelItems(
+        inProgress: List<CachedInProgressItem>,
+        nextUp: List<CachedNextUpItem>,
+        settings: ChannelSettingsSnapshot
+    ): List<WatchProgress> {
+        val cutoffMs = if (settings.daysCap == TraktSettingsDataStore.CONTINUE_WATCHING_DAYS_CAP_ALL) {
+            null
+        } else {
+            val windowMs = settings.daysCap.toLong() * 24L * 60L * 60L * 1000L
+            System.currentTimeMillis() - windowMs
+        }
+
+        // Filter in-progress items by days cap
+        val filteredInProgress = inProgress
+            .filter { cutoffMs == null || it.lastWatched >= cutoffMs }
+
+        // Filter next-up items: exclude unaired (launcher should only show playable content),
+        // respect days cap and dismissed keys
+        val filteredNextUp = nextUp
+            .filter { it.hasAired }  // Never show unaired in launcher — can't be played
+            .filter { cutoffMs == null || it.lastWatched >= cutoffMs }
+            .filter { nextUpDismissKey(it) !in settings.dismissedNextUp }
+
+        // Deduplicate: in-progress wins over next-up for same contentId
+        val inProgressContentIds = filteredInProgress.mapTo(mutableSetOf()) { it.contentId }
+        val deduplicatedNextUp = filteredNextUp.filter { it.contentId !in inProgressContentIds }
+
+        // Sort: in-progress by lastWatched, next-up by sortTimestamp (which is
+        // releaseTimestamp for release alerts, lastWatched for regular next-up).
+        // This mirrors the in-app CW order for aired content in both sort modes.
+        data class SortableItem(val watchProgress: WatchProgress, val sortKey: Long)
+
+        val inProgressSorted = filteredInProgress.map { item ->
+            SortableItem(item.toWatchProgress(settings.useEpisodeThumbnails), item.lastWatched)
+        }
+
+        val nextUpSorted = deduplicatedNextUp.map { item ->
+            SortableItem(item.toWatchProgress(settings.useEpisodeThumbnails), item.sortTimestamp)
+        }
+
+        return (inProgressSorted + nextUpSorted)
+            .sortedByDescending { it.sortKey }
+            .map { it.watchProgress }
+    }
+
+    private fun nextUpDismissKey(item: CachedNextUpItem): String {
+        return buildString {
+            append(item.contentId)
+            if (item.seedSeason != null) {
+                append("_s${item.seedSeason}")
+                if (item.seedEpisode != null) append("e${item.seedEpisode}")
+            }
+        }
+    }
+
+    data class ChannelSettingsSnapshot(
+        val daysCap: Int,
+        val dismissedNextUp: Set<String>,
+        val useEpisodeThumbnails: Boolean
+    )
+}
+
+/**
+ * Converts a [CachedInProgressItem] to [WatchProgress] for the launcher channel.
+ */
+private fun CachedInProgressItem.toWatchProgress(useEpisodeThumbnails: Boolean): WatchProgress {
+    val image = if (useEpisodeThumbnails) {
+        episodeThumbnail ?: backdrop
+    } else {
+        backdrop ?: episodeThumbnail
+    }
+    return WatchProgress(
+        contentId = contentId,
+        contentType = contentType,
+        name = name,
+        poster = poster,
+        backdrop = image,
+        logo = logo,
+        videoId = videoId,
+        season = season,
+        episode = episode,
+        episodeTitle = episodeTitle,
+        position = position,
+        duration = duration,
+        lastWatched = lastWatched,
+        progressPercent = progressPercent
+    )
+}
+
+/**
+ * Converts a [CachedNextUpItem] to [WatchProgress] for the launcher channel.
+ * Next-up items don't have playback position, so they appear as "0% watched"
+ * which launchers typically render without a progress bar.
+ */
+private fun CachedNextUpItem.toWatchProgress(useEpisodeThumbnails: Boolean): WatchProgress {
+    val image = if (useEpisodeThumbnails) {
+        thumbnail ?: backdrop
+    } else {
+        backdrop ?: thumbnail
+    }
+    return WatchProgress(
+        contentId = contentId,
+        contentType = contentType,
+        name = name,
+        poster = poster,
+        backdrop = image,
+        logo = logo,
+        videoId = videoId,
+        season = season,
+        episode = episode,
+        episodeTitle = episodeTitle,
+        position = 0,
+        duration = 0,
+        lastWatched = sortTimestamp
+    )
 }

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/TvChannelRefreshJobService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/TvChannelRefreshJobService.kt
@@ -7,7 +7,6 @@ import android.app.job.JobService
 import android.content.ComponentName
 import android.content.Context
 import android.util.Log
-import com.nuvio.tv.domain.repository.WatchProgressRepository
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -16,21 +15,20 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.dropWhile
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 
 private const val TAG = "TvChannelSync"
 private const val JOB_ID_PERIODIC = 10_010
 private const val JOB_ID_IMMEDIATE = 10_011
 private const val PERIODIC_INTERVAL_MS = 15 * 60_000L  // 15 minutes (JobScheduler OS minimum)
-private const val MAX_CHANNEL_ROWS = 20
 
 /**
  * Background job that keeps the Continue Watching preview channel in sync when the app
- * is not in the foreground. Scheduled as a periodic job so progress from other devices
- * (e.g. phone) appears without requiring the TV app to be opened.
+ * is not in the foreground. Reads from the CW enrichment cache on disk, which is
+ * populated by the HomeViewModel CW pipeline during normal app usage.
+ *
+ * This ensures the launcher channel stays up-to-date even when the app is backgrounded,
+ * using the same enriched data and settings-aware filtering as the in-app UI.
  *
  * Dependencies are obtained via Hilt EntryPoint since JobService is not a supported
  * Hilt injection target.
@@ -40,7 +38,7 @@ class TvChannelRefreshJobService : JobService() {
     @EntryPoint
     @InstallIn(SingletonComponent::class)
     interface TvChannelJobEntryPoint {
-        fun watchProgressRepository(): WatchProgressRepository
+        fun channelSyncService(): AndroidTvChannelSyncService
         fun channelManager(): AndroidTvChannelManager
     }
 
@@ -50,26 +48,22 @@ class TvChannelRefreshJobService : JobService() {
         val entryPoint = EntryPointAccessors.fromApplication(
             applicationContext, TvChannelJobEntryPoint::class.java
         )
-        val repo = entryPoint.watchProgressRepository()
+        val syncService = entryPoint.channelSyncService()
         val manager = entryPoint.channelManager()
+
+        if (!manager.isSupported()) {
+            jobFinished(params, false)
+            return false
+        }
 
         jobScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         jobScope!!.launch {
             try {
-                // Wait for continue watching to emit a non-empty list. Trakt has an 8s grace
-                // period before its flow produces data; give it 25s total.
-                val items = withTimeoutOrNull(25_000L) {
-                    repo.continueWatching
-                        .dropWhile { it.isEmpty() }
-                        .first()
-                } ?: emptyList()
-
-                if (items.isNotEmpty()) {
-                    Log.d(TAG, "Background job reconciling ${items.size} items")
-                    manager.reconcile(items.take(MAX_CHANNEL_ROWS))
-                } else {
-                    Log.d(TAG, "Background job: no items to reconcile (timeout or empty)")
-                }
+                // Read from CW enrichment cache and reconcile with current settings.
+                // The cache is on disk so it's available even when the app hasn't been
+                // in the foreground recently.
+                syncService.reconcileFromCache()
+                Log.d(TAG, "Background job: reconciled from CW cache")
             } catch (e: Exception) {
                 Log.w(TAG, "Background job reconcile failed", e)
             } finally {

--- a/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
@@ -87,6 +87,10 @@ class ContinueWatchingEnrichmentCache @Inject constructor(
     private val _cacheCleared = kotlinx.coroutines.flow.MutableStateFlow(0)
     val cacheCleared: kotlinx.coroutines.flow.StateFlow<Int> = _cacheCleared
 
+    /** Incremented on every successful snapshot write; channel sync observes this. */
+    private val _snapshotVersion = kotlinx.coroutines.flow.MutableStateFlow(0)
+    val snapshotVersion: kotlinx.coroutines.flow.StateFlow<Int> = _snapshotVersion
+
     // --- Next Up snapshot cache ---
 
     private fun nextUpFile(): File {
@@ -126,6 +130,7 @@ class ContinueWatchingEnrichmentCache @Inject constructor(
                 atomicWrite(file, gson.toJson(items))
                 lastNextUpWriteMs = System.currentTimeMillis()
                 lastNextUpHash = contentHash
+                _snapshotVersion.value++
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to write next-up cache: ${e.message}")
             }
@@ -171,6 +176,7 @@ class ContinueWatchingEnrichmentCache @Inject constructor(
                 atomicWrite(file, gson.toJson(items))
                 lastInProgressWriteMs = System.currentTimeMillis()
                 lastInProgressHash = contentHash
+                _snapshotVersion.value++
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to write in-progress cache: ${e.message}")
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.gestures.BringIntoViewSpec
 import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -729,6 +730,50 @@ internal fun ModernRowSection(
             }
         }
 
+        // When a poster in this row expands, ensure it scrolls fully into view.
+        var isExpansionScrollActive by remember { mutableStateOf(false) }
+        val expandedCardWidthPx = with(density) {
+            if (useLandscapePosters) {
+                landscapeCatalogCardWidth.roundToPx()
+            } else {
+                (portraitCatalogCardHeight * (16f / 9f)).roundToPx()
+            }
+        }
+        LaunchedEffect(expandedCatalogFocusKey.value, row.key, effectiveExpandEnabled, rowItemCount) {
+            if (!effectiveExpandEnabled) return@LaunchedEffect
+            val expandedKey = expandedCatalogFocusKey.value ?: return@LaunchedEffect
+            val lastIndex = row.items.list.lastIndex
+            if (lastIndex < 0) return@LaunchedEffect
+            // Find the index of the expanded item in this row
+            val expandedIndex = row.items.list.indexOfFirst { item ->
+                when (val p = item.payload) {
+                    is ModernPayload.Catalog -> p.focusKey == expandedKey
+                    is ModernPayload.CollectionFolder -> p.focusKey == expandedKey
+                    else -> false
+                }
+            }
+            if (expandedIndex < 0) return@LaunchedEffect
+            // Only act on the last two items in the row
+            if (expandedIndex < lastIndex - 1) return@LaunchedEffect
+            // Small delay so the item is still in visible layout info
+            delay(50)
+            // Calculate overshoot using the known final expanded width rather than
+            // the mid-animation layout size which underestimates the trailing edge.
+            val layoutInfo = rowListState.layoutInfo
+            val itemInfo = layoutInfo.visibleItemsInfo.firstOrNull { it.index == expandedIndex }
+                ?: return@LaunchedEffect
+            val viewportEnd = layoutInfo.viewportEndOffset
+            val itemEndExpanded = itemInfo.offset + expandedCardWidthPx
+            if (itemEndExpanded > viewportEnd) {
+                // Scroll just enough to reveal the trailing edge plus a small margin.
+                // Flag prevents isBackdropExpandedLambda from collapsing during this scroll.
+                val overshoot = itemEndExpanded - viewportEnd + with(density) { 15.dp.roundToPx() }
+                isExpansionScrollActive = true
+                rowListState.animateScrollBy(overshoot.toFloat())
+                isExpansionScrollActive = false
+            }
+        }
+
         CompositionLocalProvider(LocalBringIntoViewSpec provides horizontalBringIntoViewSpec) {
             val usesPlaceholderShimmer = row.isLoading &&
                 row.items.list.firstOrNull()?.imageUrl?.startsWith("placeholder://") == true
@@ -837,7 +882,8 @@ internal fun ModernRowSection(
                                 expandedFocusKey
                             ) {
                                 {
-                                    effectiveExpandEnabled && !isRowScrollingState.value &&
+                                    effectiveExpandEnabled &&
+                                        (!isRowScrollingState.value || isExpansionScrollActive) &&
                                         expandedCatalogFocusKey.value == expandedFocusKey
                                 }
                             }


### PR DESCRIPTION
## Summary

Refactor Android TV launcher Continue Watching channel to use the CW enrichment cache as its data source instead of the raw `WatchProgressRepository.continueWatching` flow. The channel now shows the same enriched items (in-progress + next-up) that the in-app CW section displays, respecting user settings (days cap, dismissed next-up, episode thumbnail preference).

Additionally fixes a critical bug where profile settings sync from Supabase would silently fail due to a `ClassCastException` in `importSettingsBlob`, preventing remote settings from being applied on app start.

Also fixes expanded poster cards at the end of horizontal rows being partially off-screen in the modern home view. When the last or second-to-last item in a row expands, the LazyRow now programmatically scrolls to reveal the full expanded width, using a flag to prevent the scroll from collapsing the expansion - #1867 

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The launcher channel previously only showed raw in-progress items without next-up episodes, without respecting user settings (days cap, dismissed items, thumbnail preference), and with stale data from the raw progress flow. This made the channel inconsistent with what the user sees in the app's Continue Watching section.

The profile settings sync bug caused `importSettingsBlob` to crash with `ClassCastException: String cannot be cast to Boolean` when preserving local-only DataStore keys. The code attempted to read catalog keys (e.g. `disabled_home_catalog_keys`) using both `stringPreferencesKey` and `booleanPreferencesKey` - if the key was stored as a String, the Boolean read threw. This meant remote settings changes (e.g. layout switch from MODERN to CLASSIC) were never applied despite being correctly fetched from Supabase.

The expanded poster fix addresses a UX issue where the last items in a modern home row would expand with their trailer but remain partially clipped by the viewport edge. The standard `BringIntoViewSpec` only fires at focus time (before expansion), so the expanded width was never accounted for in scroll calculations.

## Issue or approval
#1867 and also fixes a known inconsistency between in-app CW and launcher channel behavior, a silent sync failure reported by users whose settings wouldn't propagate across devices, and a visual clipping issue with expanded trailer posters at row edges.

## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
- `AndroidTvChannelManager.kt` is unchanged - reconcile logic (delete + re-insert) remains as-is on develop.
- No changes to the CW pipeline logic itself - only the channel sync reads from its cache.
- No changes to in-app CW UI behavior.
- Profile settings sync fix is a single-line defensive change in `ProfileSettingsSyncService.importSettingsBlob`.
- `ModernHomeRows.kt`: Added `LaunchedEffect` + `isExpansionScrollActive` flag to scroll expanded trailing-edge cards into view without collapsing the expansion state. Only triggers for the last two items in a row.

## Testing
- Tested on TCL Smart TV Pro with Projectivy launcher.
- Verified via `adb logcat -s TvChannelSync` that reconcile publishes correct items with correct position/duration values.
- Confirmed channel clears stale data on app start and repopulates after CW pipeline writes fresh cache.
- Confirmed `useEpisodeThumbnailsInCw` setting is respected (backdrop vs episode thumbnail).
- Confirmed days cap, dismissed next-up, and unaired filtering work correctly.
- Confirmed background job (`TvChannelRefreshJobService`) reads from disk cache without requiring foreground app.
- Verified profile settings sync: changed layout on device A (MODERN->CLASSIC), installed fresh build on device B, confirmed pull succeeds and applies remote settings (previously crashed with ClassCastException).
- Verified expanded poster trailer on last/second-to-last items in modern home rows scrolls fully into view.
- Confirmed expansion does not collapse/flicker during the compensating scroll.

## Screenshots / Video
Not a UI change (launcher channel content is data-driven; visual appearance depends on launcher).

## Breaking changes
Nothing should break

## Linked issues
#1867 
