### PR TITLE
Fix forced subtitle selection after audio and saved-track changes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -690,8 +690,16 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
                 stage = "event-select-audio",
                 message = "index=${event.index}"
             )
+            val shouldReevaluateForcedSubtitles = shouldReevaluateForcedSubtitlesAfterAudioSelection()
+            if (shouldReevaluateForcedSubtitles) {
+                autoSubtitleSelected = false
+            }
             rememberAudioSelection(event.index)
             selectAudioTrack(event.index)
+            if (shouldReevaluateForcedSubtitles && isUsingMpvEngine()) {
+                updateMpvAvailableTracks()
+                tryAutoSelectPreferredSubtitleFromAvailableTracks()
+            }
             _uiState.update {
                 it.copy(
                     showAudioOverlay = false,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -786,7 +786,17 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         }
     }
 
-    when (val subtitleSelection = pending.subtitle) {
+    if (!usingSwitchPending && shouldSkipPersistedSubtitleForForcedAutoSelection(updatedPending.subtitle, audioTracks)) {
+        logSwitchTrace(
+            stage = "restore-subtitle-skip-forced-auto",
+            message = "reason=forced-auto-target subtitle=${describeRememberedSubtitleForSwitchTrace(updatedPending.subtitle)}"
+        )
+        autoSubtitleSelected = false
+        subtitleAddonRestoredByPersistedPreference = false
+        updatedPending = updatedPending.copy(subtitle = null)
+    }
+
+    when (val subtitleSelection = updatedPending.subtitle) {
         null -> Unit
         PlayerRuntimeController.RememberedSubtitleSelection.Disabled -> {
             val alreadyDisabled = subtitleTracks.none { it.isSelected }
@@ -986,10 +996,47 @@ internal fun PlayerRuntimeController.subtitleLanguageTargets(): List<String> {
     return listOfNotNull(preferred, secondary)
 }
 
+private fun PlayerRuntimeController.forcedSubtitleLanguageTargets(): List<String> {
+    val style = _uiState.value.subtitleStyle
+    val preferred = style.preferredLanguage
+        .takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+        ?.lowercase()
+    val secondary = style.secondaryPreferredLanguage
+        ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+        ?.lowercase()
+    return preferred?.let { listOf(it) } ?: listOfNotNull(secondary)
+}
+
+private fun PlayerRuntimeController.forcedSubtitleTargetForAudio(
+    selectedAudioTrack: TrackInfo?
+): String? {
+    if (selectedAudioTrack == null) return null
+    val forcedTargets = forcedSubtitleLanguageTargets()
+    return forcedTargets.firstOrNull { target -> audioTrackMatchesLanguage(selectedAudioTrack, target) }
+        ?: if (forcedTargets.isEmpty() && selectedAudioMatchesResolvedPreferredAudio(selectedAudioTrack)) {
+            selectedAudioLanguageTarget(selectedAudioTrack)
+        } else {
+            null
+        }
+}
+
+private fun PlayerRuntimeController.shouldSkipPersistedSubtitleForForcedAutoSelection(
+    subtitleSelection: PlayerRuntimeController.RememberedSubtitleSelection?,
+    audioTracks: List<TrackInfo>
+): Boolean {
+    if (subtitleSelection == null || subtitleSelection == PlayerRuntimeController.RememberedSubtitleSelection.Disabled) {
+        return false
+    }
+    if (!_uiState.value.subtitleStyle.useForcedSubtitles) return false
+    val selectedAudioTrack = audioTracks.firstOrNull { it.isSelected }
+        ?: selectedAudioTrackForSubtitleMatching(_uiState.value)
+    return forcedSubtitleTargetForAudio(selectedAudioTrack) != null
+}
+
 internal fun PlayerRuntimeController.shouldReevaluateForcedSubtitlesAfterAudioSelection(): Boolean {
     val style = _uiState.value.subtitleStyle
     if (!style.useForcedSubtitles) return false
-    if (rememberedTrackPreference?.subtitle != null || persistedTrackPreference?.subtitle != null) return false
+    if (rememberedTrackPreference?.subtitle != null) return false
     if (subtitleDisabledByPersistedPreference || subtitleAddonRestoredByPersistedPreference) return false
     return true
 }
@@ -1470,15 +1517,10 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
     val selectedAudioTrack = selectedAudioTrackForSubtitleMatching(state)
     val primaryTarget = preferredTargets.firstOrNull()
     val useForcedSubtitles = state.subtitleStyle.useForcedSubtitles
-    val forcedTarget = when {
-        !useForcedSubtitles -> null
-        primaryTarget != null && selectedAudioTrack != null && audioTrackMatchesLanguage(selectedAudioTrack, primaryTarget) ->
-            primaryTarget
-        primaryTarget == null &&
-            selectedAudioTrack != null &&
-            selectedAudioMatchesResolvedPreferredAudio(selectedAudioTrack) ->
-            selectedAudioLanguageTarget(selectedAudioTrack)
-        else -> null
+    val forcedTarget = if (useForcedSubtitles) {
+        forcedSubtitleTargetForAudio(selectedAudioTrack)
+    } else {
+        null
     }
     val forcedOnly = forcedTarget != null
     val targets = when {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -986,6 +986,14 @@ internal fun PlayerRuntimeController.subtitleLanguageTargets(): List<String> {
     return listOfNotNull(preferred, secondary)
 }
 
+internal fun PlayerRuntimeController.shouldReevaluateForcedSubtitlesAfterAudioSelection(): Boolean {
+    val style = _uiState.value.subtitleStyle
+    if (!style.useForcedSubtitles) return false
+    if (rememberedTrackPreference?.subtitle != null || persistedTrackPreference?.subtitle != null) return false
+    if (subtitleDisabledByPersistedPreference || subtitleAddonRestoredByPersistedPreference) return false
+    return true
+}
+
 internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
     subtitleTracks: List<TrackInfo>,
     targets: List<String>,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -748,6 +748,7 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
     var updatedPending = pending
     var updatedSubtitleIndex: Int? = null
     var updatedAddonSubtitle: com.nuvio.tv.domain.model.Subtitle? = null
+    var skippedSubtitleForForcedAutoSelection: PlayerRuntimeController.RememberedSubtitleSelection? = null
 
     pending.audio?.let { audioSelection ->
         if (audioTracks.isEmpty()) {
@@ -793,6 +794,7 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         )
         autoSubtitleSelected = false
         subtitleAddonRestoredByPersistedPreference = false
+        skippedSubtitleForForcedAutoSelection = updatedPending.subtitle
         updatedPending = updatedPending.copy(subtitle = null)
     }
 
@@ -965,7 +967,16 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
             selectedAddonSubtitle = updatedAddonSubtitle ?: if (updatedSubtitleIndex != null) null else state.selectedAddonSubtitle
         )
     }
-    val normalizedPending = updatedPending.takeUnless { it.audio == null && it.subtitle == null }
+    val pendingForPersistence = if (
+        !usingSwitchPending &&
+        skippedSubtitleForForcedAutoSelection != null &&
+        updatedPending.subtitle == null
+    ) {
+        updatedPending.copy(subtitle = skippedSubtitleForForcedAutoSelection)
+    } else {
+        updatedPending
+    }
+    val normalizedPending = pendingForPersistence.takeUnless { it.audio == null && it.subtitle == null }
     if (usingSwitchPending) {
         logSwitchTrace(
             stage = "restore-exit-switch",


### PR DESCRIPTION
## Summary

Fix forced subtitle auto-selection so it re-evaluates correctly when audio changes during playback, honors `Preferred Language = None` with a secondary forced subtitle language, and prevents stale saved subtitle choices from blocking forced subtitle selection.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Forced subtitles could still fail to activate in a few cases:
- After switching audio during playback, auto subtitle selection had already completed and did not re-check forced subtitles.
- With `Preferred Language = None`, `Secondary Preferred Language = English`, and forced subtitles enabled, English was not consistently used as the forced-subtitle target.
- Persisted subtitle choices, such as prior main/SDH/signs selections, could restore before forced auto-selection and prevent the forced track from being chosen, especially across episodes or mpv playback.
- The forced-subtitle pass now bypasses those stale persisted subtitle choices without erasing them, so the user's saved subtitle choice remains available if forced selection does not find a match.

## Issue or approval

https://github.com/NuvioMedia/NuvioTV/issues/1869

Additional comment provided over Discord from original reporter, which has been addressed.

"If the primary audio is, for example, English, and the primary subtitle is pt-br (full subtitle), and you change the audio to pt-br during playback, the change will not be forced; the full subtitle will remain."

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only forced subtitle auto-selection behavior was changed. No subtitle scoring tables, UI, provider fetching, playback engine selection, subtitle rendering behavior, or broader subtitle persistence model was changed.

## Testing

APK built and tested with user who reported issues, alongside myself.

Static verification of the changed code paths:
- Confirmed forced subtitle auto-selection is re-armed after audio changes.
- Confirmed `Preferred Language = None` plus secondary English can now target English forced subtitles without selecting full English subtitles when no forced target applies.
- Confirmed persisted non-disabled subtitle selections are bypassed for the current forced auto-selection pass when the selected audio has a matching forced target.
- Confirmed bypassed persisted subtitle selections are preserved rather than erased, so they remain available if forced selection does not find a match.
- Confirmed engine-switch pending subtitle restoration is not skipped by this persisted-preference guard.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/1869
