### PR TITLE
fix: exclude special episodes (season 0) from episode filtering

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -2200,9 +2200,9 @@ class MetaDetailsViewModel @Inject constructor(
         suppressSeasonAutoSwitch = true
         viewModelScope.launch {
             val episodes = if (meta.apiType.equals("other", ignoreCase = true)) {
-                _uiState.value.episodesForSeason.filter { it.season != null && it.season < targetSeason && it.episode != null }
+                _uiState.value.episodesForSeason.filter { it.season != null && it.season < targetSeason && it.season > 0 && it.episode != null }
             } else {
-                meta.videos.filter { it.season != null && it.season < targetSeason && it.episode != null }
+                meta.videos.filter { it.season != null && it.season < targetSeason && it.season > 0 && it.episode != null }
             }
             val unwatched = episodes.filter { video ->
                 val s = video.season!!


### PR DESCRIPTION
## Summary
Excluded special episodes (season 0) from being marked as watched with "Mark previous seasons as watched".

## PR type
- [X] Small maintenance only, with no UI or behavior change

## Why
When a user selects "Mark previous seasons as watched" for a specific season (e.g., season 3), they expect to mark the chronological main story episodes leading up to that point. This ensures specials remain unwatched until the user explicitly interacts with them.

## Issue or approval
#1866 - @skoruppa acknowledged

## UI / behavior impact
- [X] No UI change

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [X] I have read and understood `CONTRIBUTING.md`.
- [X] This PR is small, focused, and limited to one problem.
- [X] This PR is not cosmetic-only.
- [X] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [X] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [X] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [X] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [X] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
The only change made was to the filtering of episodes for bulk marking as watched. No visual changes were made nor any other functions.

## Testing
On both Studio virtual device and my TV box, tested marking previous seasons as watched, along with individual season marking, episode marking, and specials individual/bulk marking. Everything thing seems to be working as intended.

## Screenshots / Video
Not a UI change

## Breaking changes
None.

## Linked issues
#1866 
