### PR TITLE
fix player WebDAV auth, autoplay double search, back navigation after completion

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -707,7 +707,7 @@ fun NuvioNavHost(
             )
         ) { backStackEntry ->
             PlayerScreen(
-                onBackPress = { currentVideoId, currentSeason, currentEpisode, autoPlayEnabled ->
+                onBackPress = { currentVideoId, currentSeason, currentEpisode, autoPlayEnabled, playbackCompleted ->
                     val args = backStackEntry.arguments
                     val initialSeason = args?.getString("season")?.toIntOrNull()
                     val initialEpisode = args?.getString("episode")?.toIntOrNull()
@@ -781,33 +781,58 @@ fun NuvioNavHost(
                             }
                         }
                         else -> {
-                            // normal back — try returning to Stream of this episode
-                            val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
-                            if (!returnedToStream) {
-                                if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
-                                    val detailOnStack = navController.previousBackStackEntry
-                                        ?.destination?.route?.startsWith("detail/") == true
-                                    if (detailOnStack) {
-                                        navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusSeason", focusSeason)
-                                        navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusEpisode", focusEpisode)
-                                        navController.popBackStack()
-                                    } else {
-                                        navController.navigate(
-                                            Screen.Detail.createRoute(
-                                                itemId = contentId,
-                                                itemType = contentType,
-                                                addonBaseUrl = null,
-                                                returnFocusSeason = focusSeason,
-                                                returnFocusEpisode = focusEpisode,
-                                                returnToHomeOnBack = returnToHomeOnBack
-                                            )
-                                        ) {
-                                            popUpTo(Screen.Player.route) { inclusive = true }
-                                            launchSingleTop = true
-                                        }
-                                    }
-                                } else {
+                            // normal back — skip Stream screen if episode/movie was completed
+                            val skipStreamScreen = playbackCompleted && contentId.isNotBlank()
+                            if (skipStreamScreen) {
+                                val detailOnStack = navController.previousBackStackEntry
+                                    ?.destination?.route?.startsWith("detail/") == true
+                                if (detailOnStack) {
+                                    navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusSeason", focusSeason)
+                                    navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusEpisode", focusEpisode)
                                     navController.popBackStack()
+                                } else {
+                                    navController.navigate(
+                                        Screen.Detail.createRoute(
+                                            itemId = contentId,
+                                            itemType = contentType,
+                                            addonBaseUrl = null,
+                                            returnFocusSeason = focusSeason,
+                                            returnFocusEpisode = focusEpisode,
+                                            returnToHomeOnBack = returnToHomeOnBack
+                                        )
+                                    ) {
+                                        popUpTo(Screen.Player.route) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                }
+                            } else {
+                                val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
+                                if (!returnedToStream) {
+                                    if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
+                                        val detailOnStack = navController.previousBackStackEntry
+                                            ?.destination?.route?.startsWith("detail/") == true
+                                        if (detailOnStack) {
+                                            navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusSeason", focusSeason)
+                                            navController.previousBackStackEntry?.savedStateHandle?.set("returnFocusEpisode", focusEpisode)
+                                            navController.popBackStack()
+                                        } else {
+                                            navController.navigate(
+                                                Screen.Detail.createRoute(
+                                                    itemId = contentId,
+                                                    itemType = contentType,
+                                                    addonBaseUrl = null,
+                                                    returnFocusSeason = focusSeason,
+                                                    returnFocusEpisode = focusEpisode,
+                                                    returnToHomeOnBack = returnToHomeOnBack
+                                                )
+                                            ) {
+                                                popUpTo(Screen.Player.route) { inclusive = true }
+                                                launchSingleTop = true
+                                            }
+                                        }
+                                    } else {
+                                        navController.popBackStack()
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackNetworking.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackNetworking.kt
@@ -50,7 +50,33 @@ internal object PlayerPlaybackNetworking {
 
     @OptIn(UnstableApi::class)
     fun createHttpDataSourceFactory(defaultHeaders: Map<String, String> = emptyMap()): DataSource.Factory {
-        return OkHttpDataSource.Factory(playbackHttpClient).apply {
+        val client = if (defaultHeaders.any { it.key.equals("Authorization", ignoreCase = true) }) {
+            // OkHttp strips the Authorization header on cross-host redirects.
+            // WebDAV servers behind reverse proxies commonly redirect to a
+            // different host/port, causing auth to be lost. A network
+            // interceptor ensures the header is always present on every
+            // outgoing request — same behavior as mpv/curl.
+            val authValue = defaultHeaders.entries
+                .first { it.key.equals("Authorization", ignoreCase = true) }
+                .value
+            playbackHttpClient.newBuilder()
+                .addNetworkInterceptor { chain ->
+                    val request = chain.request()
+                    if (request.header("Authorization") == null) {
+                        chain.proceed(
+                            request.newBuilder()
+                                .header("Authorization", authValue)
+                                .build()
+                        )
+                    } else {
+                        chain.proceed(request)
+                    }
+                }
+                .build()
+        } else {
+            playbackHttpClient
+        }
+        return OkHttpDataSource.Factory(client).apply {
             setDefaultRequestProperties(defaultHeaders)
             setUserAgent(PlayerMediaSourceFactory.DEFAULT_USER_AGENT)
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -866,6 +866,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
             skipIntervalDismissed = false,
             postPlayMode = null,
             postPlayDismissedForCurrentEpisode = false,
+            playbackEnded = false,
         )
     }
     showStreamSourceIndicator(stream)
@@ -951,6 +952,7 @@ private fun PlayerRuntimeController.switchToEpisodeStreamCommon(
             skipIntervalDismissed = false,
             postPlayMode = null,
             postPlayDismissedForCurrentEpisode = false,
+            playbackEnded = false,
         )
     }
     showStreamSourceIndicator(stream)
@@ -1187,6 +1189,7 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                     it.copy(
                         postPlayMode = null,
                         postPlayDismissedForCurrentEpisode = true,
+                        playbackEnded = false,
                     )
                 }
                 switchToEpisodeStream(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -111,6 +111,7 @@ import com.nuvio.tv.data.local.LibassRenderType
 import com.nuvio.tv.data.local.SubtitleStyleSettings
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.domain.model.Subtitle
+import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.theme.NuvioColors
 import android.text.format.DateFormat
@@ -129,8 +130,8 @@ import kotlin.math.abs
 @Composable
 fun PlayerScreen(
     viewModel: PlayerViewModel = hiltViewModel(),
-    onBackPress: (currentVideoId: String?, currentSeason: Int?, currentEpisode: Int?, autoPlayEnabled: Boolean) -> Unit,
-    onPlaybackErrorBack: () -> Unit = { onBackPress(null, null, null, false) },
+    onBackPress: (currentVideoId: String?, currentSeason: Int?, currentEpisode: Int?, autoPlayEnabled: Boolean, playbackCompleted: Boolean) -> Unit,
+    onPlaybackErrorBack: () -> Unit = { onBackPress(null, null, null, false, false) },
     onPlaybackEnded: ((nextVideoId: String?, nextSeason: Int?, nextEpisode: Int?, exitReason: PlayerExitReason?) -> Unit)? = null
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -150,7 +151,10 @@ fun PlayerScreen(
     var subtitleTimingConsumeNextConfirmKeyUp by remember { mutableStateOf(false) }
     val exitPlayer: () -> Unit = {
         viewModel.stopAndRelease()
-        onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL)
+        val timeline = viewModel.playbackTimeline.value
+        val completed = timeline.duration > 0L &&
+            (timeline.currentPosition.toFloat() / timeline.duration.toFloat()) >= WatchProgress.COMPLETED_THRESHOLD
+        onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL, completed)
     }
     val exitPlayerFromError: () -> Unit = {
         viewModel.stopAndRelease()
@@ -222,7 +226,8 @@ fun PlayerScreen(
                         uiState.currentVideoId,
                         uiState.currentSeason,
                         uiState.currentEpisode,
-                        uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL
+                        uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL,
+                        true
                     )
                 }
                 viewModel.consumePendingExitReason()
@@ -238,7 +243,8 @@ fun PlayerScreen(
                         uiState.currentVideoId,
                         uiState.currentSeason,
                         uiState.currentEpisode,
-                        uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL
+                        uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL,
+                        true
                     )
                 }
             }
@@ -846,7 +852,10 @@ fun PlayerScreen(
                     val title = uiState.title
                     val headers = viewModel.getCurrentHeaders()
                     viewModel.stopAndRelease()
-                    onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL)
+                    val timeline = viewModel.playbackTimeline.value
+                    val completed = timeline.duration > 0L &&
+                        (timeline.currentPosition.toFloat() / timeline.duration.toFloat()) >= WatchProgress.COMPLETED_THRESHOLD
+                    onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL, completed)
                     ExternalPlayerLauncher.launch(
                         context = context,
                         url = url,


### PR DESCRIPTION
## Summary

Three player fixes:
1. **WebDAV auth on redirect** - ExoPlayer's OkHttpDataSource strips the `Authorization` header on cross-host redirects. WebDAV servers behind reverse proxies commonly redirect to a different host/port, causing auth to be lost. Added a network interceptor that re-attaches the Authorization header on every outgoing request (same behavior as mpv/curl).
2. **Autoplay double source search** - Reset `playbackEnded` when transitioning to next episode, preventing the `LaunchedEffect` in PlayerScreen from triggering navigation to StreamScreen (which caused a redundant second source search when both autoplay and auto-stream selection were enabled).
3. **Back navigation after completion** - When playback progress >= 90% and user presses back, navigate to Details instead of StreamScreen (applies to both series and movies). Uses `WatchProgress.COMPLETED_THRESHOLD`.

## PR type

- [x] Behavior bug/regression fix

## Why

1. WebDAV streams with Authorization headers failed after redirect because ExoPlayer's OkHttpDataSource strips auth headers on cross-host redirects. Users with WebDAV servers behind reverse proxies couldn't play content.
2. When both "autoplay next episode" and "auto-stream selection" were enabled, the next episode button would find sources, do the countdown, then the player would exit to StreamScreen and search for sources again. Root cause: `playbackEnded` remained `true` after countdown finished and `postPlayMode` was set to `null`, causing `shouldDispatchNatural` to fire and navigate away.
3. After finishing an episode (>= 90%), pressing back returned to StreamScreen showing sources for the already-watched content - pointless UX. Users expect to land on the Details page.

## Issue or approval
#1754 and other user-reported bugs confirmed via debug builds and code analysis.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- WebDAV interceptor only activates when Authorization header is present in stream headers
- Autoplay fix only resets `playbackEnded` during episode transition - does not affect watch progress saving or scrobble
- Back navigation change only affects the manual back press path when progress >= 90%
- Does not change autoplay stream selection logic (regex, first stream, binge group)

## Testing

- WebDAV fix tested by user with WebDAV setup via dedicated debug build - confirmed playback works after redirect 
- Autoplay fix: verified episode ends, finds source, countdown, switches without double search
- Back navigation: verified back at < 90% goes to StreamScreen (unchanged), back at >= 90% goes to Details
- Natural playback end with no next episode goes to Details (unchanged)
- Tested on emulator (API 33, Android TV)

## Screenshots / Video

Not a UI change.

## Breaking changes

Nothing should break

## Linked issues
#1754
and other user-reported behavior bugs confirmed via debug builds and code analysis.
