### PR TITLE
fix: sync native watch next with CW pipeline

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
@@ -1,0 +1,217 @@
+package com.nuvio.tv.core.recommendations
+
+import android.content.Context
+import android.net.Uri
+import androidx.tvprovider.media.tv.TvContractCompat
+import androidx.tvprovider.media.tv.WatchNextProgram
+import com.nuvio.tv.domain.model.WatchProgress
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ProgramBuilder @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    fun watchNextId(progress: WatchProgress): String =
+        if (progress.season != null && progress.episode != null)
+            "wn_${progress.contentId}_s${progress.season}e${progress.episode}"
+        else
+            "wn_${progress.contentId}"
+
+    fun buildWatchNextProgram(progress: WatchProgress): WatchNextProgram {
+        val isMovie = progress.contentType == "movie"
+        val programType = if (isMovie) {
+            TvContractCompat.WatchNextPrograms.TYPE_MOVIE
+        } else {
+            TvContractCompat.WatchNextPrograms.TYPE_TV_EPISODE
+        }
+
+        val builder = WatchNextProgram.Builder()
+            .setType(programType)
+            .setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
+            .setTitle(progress.name)
+            .setLastEngagementTimeUtcMillis(progress.lastWatched)
+            .setInternalProviderId(watchNextId(progress))
+            .setIntentUri(buildPlayUri(progress))
+
+        builder.setPosterArtAspectRatio(TvContractCompat.PreviewPrograms.ASPECT_RATIO_16_9)
+
+        val horizontalArt = progress.backdrop ?: progress.poster
+        horizontalArt?.let {
+            val uriWithCacheBuster = Uri.parse(it).buildUpon()
+                .appendQueryParameter("v", "horizontal_fix")
+                .build()
+            builder.setPosterArtUri(uriWithCacheBuster)
+        }
+
+        if (progress.duration > 0) {
+            builder.setLastPlaybackPositionMillis(progress.position.toInt())
+            builder.setDurationMillis(progress.duration.toInt())
+        }
+
+        if (!isMovie) {
+            progress.season?.let { builder.setSeasonNumber(it) }
+            progress.episode?.let { builder.setEpisodeNumber(it) }
+            progress.episodeTitle?.let { builder.setEpisodeTitle(it) }
+        }
+
+        return builder.build()
+    }
+
+    fun upsertWatchNextProgram(program: WatchNextProgram, internalId: String) {
+        try {
+            val existingId = findWatchNextByInternalId(internalId)
+            if (existingId != null) {
+                val uri = TvContractCompat.buildWatchNextProgramUri(existingId)
+                context.contentResolver.update(uri, program.toContentValues(), null, null)
+            } else {
+                context.contentResolver.insert(
+                    TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                    program.toContentValues()
+                )
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    fun removeWatchNextProgram(internalId: String) {
+        try {
+            val existingId = findWatchNextByInternalId(internalId) ?: return
+            val uri = TvContractCompat.buildWatchNextProgramUri(existingId)
+            context.contentResolver.delete(uri, null, null)
+        } catch (_: Exception) {
+        }
+    }
+
+    fun removeWatchNextByContentId(contentId: String) {
+        try {
+            val cursor = context.contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                arrayOf(
+                    TvContractCompat.WatchNextPrograms._ID,
+                    TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID
+                ),
+                null, null, null
+            )
+            cursor?.use {
+                while (it.moveToNext()) {
+                    val idIdx = it.getColumnIndex(
+                        TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID
+                    )
+                    if (idIdx >= 0) {
+                        val providerId = it.getString(idIdx)
+                        if (providerId != null && providerId.startsWith("wn_${contentId}")) {
+                            val pkIdx = it.getColumnIndex(TvContractCompat.WatchNextPrograms._ID)
+                            if (pkIdx >= 0) {
+                                val uri = TvContractCompat.buildWatchNextProgramUri(it.getLong(pkIdx))
+                                context.contentResolver.delete(uri, null, null)
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    fun clearAllWatchNextPrograms() {
+        var cursor: android.database.Cursor? = null
+        try {
+            cursor = context.contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                arrayOf(
+                    TvContractCompat.WatchNextPrograms._ID,
+                    TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID
+                ),
+                null, null, null
+            )
+            cursor?.let {
+                while (it.moveToNext()) {
+                    val idIdx = it.getColumnIndex(
+                        TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID
+                    )
+                    if (idIdx >= 0) {
+                        val providerId = it.getString(idIdx)
+                        if (providerId?.startsWith("wn_") == true) {
+                            val pkIdx = it.getColumnIndex(TvContractCompat.WatchNextPrograms._ID)
+                            if (pkIdx >= 0) {
+                                val uri = TvContractCompat.buildWatchNextProgramUri(it.getLong(pkIdx))
+                                context.contentResolver.delete(uri, null, null)
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (_: Exception) {
+        } finally {
+            cursor?.close()
+        }
+    }
+
+    private fun findWatchNextByInternalId(internalId: String): Long? {
+        return try {
+            val cursor = context.contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                arrayOf(
+                    TvContractCompat.WatchNextPrograms._ID,
+                    TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID
+                ),
+                null,
+                null,
+                null
+            )
+            var foundId: Long? = null
+            cursor?.use {
+                while (it.moveToNext()) {
+                    val providerIdIdx = it.getColumnIndex(
+                        TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID
+                    )
+                    if (providerIdIdx >= 0) {
+                        val currentProviderId = it.getString(providerIdIdx)
+                        if (currentProviderId == internalId) {
+                            val idIdx = it.getColumnIndex(TvContractCompat.WatchNextPrograms._ID)
+                            if (idIdx >= 0) {
+                                foundId = it.getLong(idIdx)
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+            foundId
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun buildPlayUri(progress: WatchProgress): Uri =
+        Uri.Builder()
+            .scheme(RecommendationConstants.DEEP_LINK_SCHEME)
+            .authority(RecommendationConstants.DEEP_LINK_HOST)
+            .appendPath(RecommendationConstants.DEEP_LINK_PATH_PLAY)
+            .appendPath(progress.contentId)
+            .appendQueryParameter(RecommendationConstants.PARAM_CONTENT_TYPE, progress.contentType)
+            .appendQueryParameter(RecommendationConstants.PARAM_VIDEO_ID, progress.videoId)
+            .appendQueryParameter(RecommendationConstants.PARAM_NAME, progress.name)
+            .apply {
+                progress.season?.let {
+                    appendQueryParameter(RecommendationConstants.PARAM_SEASON, it.toString())
+                }
+                progress.episode?.let {
+                    appendQueryParameter(RecommendationConstants.PARAM_EPISODE, it.toString())
+                }
+                appendQueryParameter(
+                    RecommendationConstants.PARAM_RESUME_POSITION,
+                    progress.position.toString()
+                )
+                progress.poster?.let {
+                    appendQueryParameter(RecommendationConstants.PARAM_POSTER, it)
+                }
+                progress.backdrop?.let {
+                    appendQueryParameter(RecommendationConstants.PARAM_BACKDROP, it)
+                }
+            }
+            .build()
+}

--- a/app/src/main/java/com/nuvio/tv/core/recommendations/RecommendationConstants.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/RecommendationConstants.kt
@@ -1,0 +1,17 @@
+package com.nuvio.tv.core.recommendations
+
+internal object RecommendationConstants {
+    const val DEEP_LINK_SCHEME = "nuvio"
+    const val DEEP_LINK_HOST = "tv"
+    const val DEEP_LINK_PATH_PLAY = "play"
+    const val DEEP_LINK_PATH_DETAIL = "detail"
+
+    const val PARAM_CONTENT_TYPE = "contentType"
+    const val PARAM_VIDEO_ID = "videoId"
+    const val PARAM_NAME = "name"
+    const val PARAM_SEASON = "season"
+    const val PARAM_EPISODE = "episode"
+    const val PARAM_RESUME_POSITION = "resumePosition"
+    const val PARAM_POSTER = "poster"
+    const val PARAM_BACKDROP = "backdrop"
+}

--- a/app/src/main/java/com/nuvio/tv/core/recommendations/TvRecommendationManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/TvRecommendationManager.kt
@@ -1,0 +1,62 @@
+package com.nuvio.tv.core.recommendations
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import com.nuvio.tv.ui.screens.home.ContinueWatchingItem
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TvRecommendationManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val programBuilder: ProgramBuilder
+) {
+
+    private val mutex = Mutex()
+
+    private companion object {
+        const val TAG = "TvRecommendation"
+    }
+
+    suspend fun updateWatchNextFromCwItems(items: List<ContinueWatchingItem>) {
+        if (!isTvDevice()) return
+        mutex.withLock {
+            withContext(Dispatchers.IO) {
+                try {
+                    val inProgress = items
+                        .filterIsInstance<ContinueWatchingItem.InProgress>()
+
+                    programBuilder.clearAllWatchNextPrograms()
+                    inProgress.forEach { item ->
+                        val program = programBuilder.buildWatchNextProgram(item.progress)
+                        programBuilder.upsertWatchNextProgram(
+                            program,
+                            programBuilder.watchNextId(item.progress)
+                        )
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "updateWatchNextFromCwItems failed", e)
+                }
+            }
+        }
+    }
+
+    suspend fun onProgressRemoved(contentId: String) {
+        if (!isTvDevice()) return
+        withContext(Dispatchers.IO) {
+            try {
+                programBuilder.removeWatchNextByContentId(contentId)
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    private fun isTvDevice(): Boolean =
+        context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+}

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
@@ -49,14 +49,25 @@ class AndroidTvChannelManager @Inject constructor(
                 prefs.clearChannelId()
             }
 
-            // Reuse an orphaned channel row from a previous install / data-clear.
-            // The TV provider auto-scopes channel queries to the calling app's package,
-            // and rejects any explicit selection clause with SecurityException.
             val orphan = context.contentResolver.query(
                 TvContractCompat.Channels.CONTENT_URI,
-                arrayOf(TvContractCompat.Channels._ID),
+                arrayOf(
+                    TvContractCompat.Channels._ID,
+                    TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID
+                ),
                 null, null, null
-            )?.use { c -> if (c.moveToFirst()) c.getLong(0) else null }
+            )?.use { c ->
+                val idIdx = c.getColumnIndex(TvContractCompat.Channels._ID)
+                val providerIdx = c.getColumnIndex(TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID)
+                if (idIdx < 0 || providerIdx < 0) return@use null
+                while (c.moveToNext()) {
+                    val providerId = c.getString(providerIdx)
+                    if (providerId != null && providerId.startsWith(context.packageName)) {
+                        return@use c.getLong(idIdx)
+                    }
+                }
+                null
+            }
             if (orphan != null) {
                 Log.d(TAG, "Reusing orphaned channel $orphan")
                 prefs.setChannelId(orphan)

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelSyncService.kt
@@ -7,7 +7,9 @@ import com.nuvio.tv.data.local.CachedNextUpItem
 import com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
+import com.nuvio.tv.core.recommendations.TvRecommendationManager
 import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.ui.screens.home.ContinueWatchingItem
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,7 +25,6 @@ import javax.inject.Singleton
 
 private const val TAG = "TvChannelSync"
 private const val DEBOUNCE_MS = 2_000L
-private const val MAX_CHANNEL_ROWS = 20
 
 /**
  * Keeps the Android TV "Continue Watching" preview channel in sync with the app's
@@ -44,6 +45,7 @@ class AndroidTvChannelSyncService @Inject constructor(
     private val cwEnrichmentCache: ContinueWatchingEnrichmentCache,
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
     private val traktSettingsDataStore: TraktSettingsDataStore,
+    private val tvRecommendationManager: TvRecommendationManager
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -56,10 +58,6 @@ class AndroidTvChannelSyncService @Inject constructor(
         TvChannelRefreshJobService.schedulePeriodic(context)
 
         scope.launch {
-            // Clear stale programs from previous app sessions. The channel will be
-            // repopulated once the CW pipeline writes fresh data to the cache.
-            manager.clearAll()
-
             // Observe cache snapshot updates and settings changes to trigger reconciliation.
             // snapshotVersion bumps every time the CW pipeline writes new data to disk cache.
             // We drop the initial value (0) to avoid reconciling with stale disk cache before
@@ -104,7 +102,23 @@ class AndroidTvChannelSyncService @Inject constructor(
             "Reconciling from cache: ${channelItems.size} items " +
                 "(${inProgressItems.size} in-progress, ${nextUpItems.size} next-up raw)"
         )
-        manager.reconcile(channelItems.take(MAX_CHANNEL_ROWS))
+        manager.reconcile(channelItems)
+
+        val cutoffMs = if (resolvedSettings.daysCap == TraktSettingsDataStore.CONTINUE_WATCHING_DAYS_CAP_ALL) {
+            null
+        } else {
+            val windowMs = resolvedSettings.daysCap.toLong() * 24L * 60L * 60L * 1000L
+            System.currentTimeMillis() - windowMs
+        }
+        val watchNextInProgress = inProgressItems
+            .filter { cutoffMs == null || it.lastWatched >= cutoffMs }
+
+        runCatching {
+            val cwItems = watchNextInProgress.map {
+                ContinueWatchingItem.InProgress(it.toWatchProgress(resolvedSettings.useEpisodeThumbnails))
+            }
+            tvRecommendationManager.updateWatchNextFromCwItems(cwItems)
+        }
     }
 
     /**

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.LocaleCache
 import com.nuvio.tv.core.player.StreamAutoPlayPolicy
+import com.nuvio.tv.core.recommendations.TvRecommendationManager
 import com.nuvio.tv.core.tmdb.TmdbMetadataService
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.AuthSessionNoticeDataStore
@@ -77,7 +78,8 @@ class HomeViewModel @Inject constructor(
     internal val watchedItemsPreferences: WatchedItemsPreferences,
     internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     internal val cwEnrichmentCache: ContinueWatchingEnrichmentCache,
-    private val profileManager: com.nuvio.tv.core.profile.ProfileManager
+    private val profileManager: com.nuvio.tv.core.profile.ProfileManager,
+    internal val tvRecommendationManager: TvRecommendationManager
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
@@ -274,6 +276,15 @@ class HomeViewModel @Inject constructor(
             observeProgressSourceChanges()
             observeCollections()
             observeInstalledAddons()
+
+            viewModelScope.launch {
+                _uiState
+                    .map { it.continueWatchingItems }
+                    .distinctUntilChanged()
+                    .collect { items ->
+                        runCatching { tvRecommendationManager.updateWatchNextFromCwItems(items) }
+                    }
+            }
 
             // Clear CW state when profile changes so items don't leak between profiles.
             var previousProfileId = profileManager.activeProfileId.value


### PR DESCRIPTION
## Summary

Keep Android TV launcher recommendations aligned with the Home Continue Watching list by adding native Watch Next synchronization, stable episodic Watch Next IDs, safer channel reuse, and CW-length-based item publishing.

## PR type

- [x] Small maintenance only, with no UI or behavior change

## Why

The Android TV launcher sync path had several maintenance gaps that could make launcher recommendations drift from the app's Continue Watching state:

- Native Watch Next entries were not populated from the latest Home CW stream.
- Episodic Watch Next entries needed stable season/episode-aware provider IDs.
- Fixed item limits could make launcher rows shorter than the current CW list.
- Legacy channel startup behavior could clear launcher content too early, and orphan channel reuse was broader than necessary.

## Issue or approval

No linked issue — focused Android TV launcher recommendation maintenance with no UI changes.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No visual redesign or UI polish changes.
- No player playback pipeline changes (decoder/stream stack untouched).
- No new dependency, migration, or architecture rewrite outside TV recommendations sync path.
- Existing preview-channel code path is retained; this PR only tightens launcher recommendation synchronization and identifier handling.

## Testing

- `./gradlew :app:compileFullDebugKotlin` (pass)
- Verified branch clean commit and successful Kotlin compilation after Watch Next/CW changes.
- Manually tested on Android TV: Home Continue Watching updates are reflected in the native Watch Next row.
- Confirmed episodic entries keep distinct launcher IDs and do not overwrite each other.


## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — focused Android TV launcher recommendation maintenance with no UI changes.
