### PR TITLE
fix: accept Trakt history entries as CW next-up seeds

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -405,7 +405,8 @@ class WatchProgressRepositoryImpl @Inject constructor(
                             .map { items ->
                                 val nowMs = System.currentTimeMillis()
                                 items.filter { progress ->
-                                    isOptimisticNextUpSeedCandidate(progress, nowMs)
+                                    isOptimisticNextUpSeedCandidate(progress, nowMs) ||
+                                        progress.source == WatchProgress.SOURCE_TRAKT_HISTORY
                                 }
                             }
                             .onStart { emit(emptyList()) }


### PR DESCRIPTION
## Summary

Trakt `/sync/history/episodes` entries (source=`trakt_history`) were silently dropped by the continue-watching seed filter, which only accepted `trakt_playback` entries via `isOptimisticNextUpSeedCandidate`. Episodes marked as watched via scrobble appear in `/sync/history/episodes` but not `/sync/watched/shows`, causing the CW pipeline to use a stale seed and show an already-watched episode as "New Episode".

Now history entries also pass the seed filter so they can advance the CW seed.

## PR type

- [x] Reproducible bug fix

## Why

When a user watches an episode that gets scrobbled but not added to Trakt history (`sync/history`), the `/sync/watched/shows` endpoint used for canonical seeds does not include it. The episode IS present in `/sync/history/episodes` which already flows through `observeAllProgress()` → `remoteProgress`. But `isOptimisticNextUpSeedCandidate` drops it because the source is `trakt_history` rather than `trakt_playback`.

## Issue or approval

Fixes #1886

## UI / behavior impact

- [ ] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the seed candidate filter in `observeNextUpSeeds()` is changed. No other seed sources, CW pipeline logic, or Trakt sync behavior is modified.

## Testing

- Verified that after the fix, the CW pipeline advances the seed past the scrobbled episode and no longer shows a false "New Episode" tag.
- Compiled with `./gradlew :app:compileFullDebugKotlin` — no errors.

## Screenshots / Video

### Before
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/21dc7560-07d2-459d-ae4f-7810ccc4ba3e" />

### After
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/7f8cab2f-781e-46be-9f6e-30e5d10068cd" />

## Breaking changes

None.

## Linked issues

Fixes #1886