### PR TITLE
Revert player audio sink

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
@@ -22,10 +22,6 @@ internal class GainAudioProcessor : BaseAudioProcessor() {
         gainScale = gainToLinearScale(clampedDb)
     }
 
-    override fun isActive(): Boolean {
-        return super.isActive() && gainDb != 0
-    }
-
     override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
         return when (inputAudioFormat.encoding) {
             C.ENCODING_PCM_16BIT,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/GainAudioProcessor.kt
@@ -22,12 +22,8 @@ internal class GainAudioProcessor : BaseAudioProcessor() {
         gainScale = gainToLinearScale(clampedDb)
     }
 
-    fun isGainEnabled(): Boolean {
-        return gainDb != AUDIO_AMPLIFICATION_MIN_DB
-    }
-
     override fun isActive(): Boolean {
-        return super.isActive() && isGainEnabled()
+        return super.isActive() && gainDb != 0
     }
 
     override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
@@ -8,8 +8,7 @@ import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.ForwardingAudioSink
 
 internal class PlaybackSpeedAwareAudioSink(
-    sink: AudioSink,
-    private val forceAudioProcessingPcmProvider: () -> Boolean = { false }
+    sink: AudioSink
 ) : ForwardingAudioSink(sink) {
 
     @Volatile
@@ -67,14 +66,7 @@ internal class PlaybackSpeedAwareAudioSink(
         return shouldRejectDirectPlayback(format)
     }
 
-    fun notifyAudioProcessingRequirementChanged() {
-        listener?.onAudioCapabilitiesChanged()
-    }
-
     private fun shouldRejectDirectPlayback(format: Format): Boolean {
-        if (forceAudioProcessingPcmProvider() && requiresPcmForAudioProcessing(format)) {
-            return true
-        }
         return requiresPcmForSpeed(format) && (forcePcmForCurrentSession || playbackSpeed != 1f)
     }
 
@@ -89,11 +81,6 @@ internal class PlaybackSpeedAwareAudioSink(
 
     private fun normalizeSpeed(speed: Float): Float {
         return speed.takeIf { it > 0f } ?: 1f
-    }
-
-    private fun requiresPcmForAudioProcessing(format: Format): Boolean {
-        val mimeType = format.sampleMimeType ?: return false
-        return MimeTypes.isAudio(mimeType) && mimeType != MimeTypes.AUDIO_RAW
     }
 
     private fun requiresPcmForSpeed(format: Format): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -325,7 +325,6 @@ class PlayerRuntimeController(
     internal var audioOutputRouteCallback: AudioDeviceCallback? = null
 
     internal var lastBufferLogTimeMs: Long = 0L
-    internal var pendingSeekFlush: Boolean = false
     
     internal val gainAudioProcessor = GainAudioProcessor()
     internal var trackSelector: DefaultTrackSelector? = null
@@ -361,7 +360,6 @@ class PlayerRuntimeController(
     internal var hasRequestedScrobbleStartForCurrentItem: Boolean = false
     internal var scrobbleStartRequestGeneration: Long = 0L
     internal var playbackPreparationJob: Job? = null
-    internal var playerInitializationJob: Job? = null
     internal var hasSentCompletionScrobbleForCurrentItem: Boolean = false
     internal var requestedUseLibassByUser: Boolean = false
     internal var libassPipelineOverrideForCurrentStream: Boolean? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -116,8 +116,7 @@ internal fun PlayerRuntimeController.initializePlayer(
         return
     }
 
-    playerInitializationJob?.cancel()
-    playerInitializationJob = scope.launch {
+    scope.launch {
         try {
             if (allowEngineFailover) {
                 startupEngineFailoverTriggered = false
@@ -412,21 +411,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                 prepare()
 
                 addListener(object : Player.Listener {
-                    override fun onPositionDiscontinuity(
-                        oldPosition: Player.PositionInfo,
-                        newPosition: Player.PositionInfo,
-                        reason: Int
-                    ) {
-                        if (reason == Player.DISCONTINUITY_REASON_SEEK) {
-                            if (playbackState == Player.STATE_READY) {
-                                // In-buffer seek: player is already ready, flush immediately
-                            } else {
-                                // Out-of-buffer seek: wait for STATE_READY
-                                pendingSeekFlush = true
-                            }
-                        }
-                    }
-
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         val playerDuration = duration
                         if (playerDuration > lastKnownDuration) {
@@ -451,8 +435,9 @@ internal fun PlayerRuntimeController.initializePlayer(
                             }
                         }
                     
+                        
                         if (playbackState == Player.STATE_READY) {
-                            pendingSeekFlush = false
+
                             
                             // Don't auto-play on the initial STATE_READY — wait
                             // for onRenderedFirstFrame() to ensure A/V sync.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -927,10 +927,7 @@ private class SubtitleOffsetRenderersFactory(
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
             .setAudioProcessors(arrayOf(gainAudioProcessor))
             .build()
-        val playbackSpeedAwareAudioSink = PlaybackSpeedAwareAudioSink(
-            sink = baseAudioSink,
-            forceAudioProcessingPcmProvider = gainAudioProcessor::isGainEnabled
-        )
+        val playbackSpeedAwareAudioSink = PlaybackSpeedAwareAudioSink(baseAudioSink)
         playbackSpeedAwareAudioSink.setInitialPlaybackSpeed(playbackSpeedProvider())
         onPlaybackSpeedAwareAudioSinkCreated(playbackSpeedAwareAudioSink)
         return playbackSpeedAwareAudioSink

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -37,8 +37,6 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     subtitleAutoSyncLoadJob?.cancel()
     playbackPreparationJob?.cancel()
     playbackPreparationJob = null
-    playerInitializationJob?.cancel()
-    playerInitializationJob = null
     delayMpvResumeSeekUntilVideoTrack = false
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -52,17 +52,7 @@ internal fun PlayerRuntimeController.skipInterval(interval: SkipInterval): Boole
 
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
-    val wasActive = gainAudioProcessor.isActive()
     gainAudioProcessor.setGainDb(clampedDb)
-    val isActiveNow = gainAudioProcessor.isActive()
-
-    if (wasActive != isActiveNow && !isUsingMpvEngine()) {
-        // Force ExoPlayer to rebuild the audio pipeline so the processor is correctly added or removed
-        _exoPlayer?.let { player ->
-            player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().build()
-        }
-    }
-
     if (isUsingMpvEngine()) {
         mpvView?.applyAudioAmplificationDb(clampedDb)
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -52,12 +52,12 @@ internal fun PlayerRuntimeController.skipInterval(interval: SkipInterval): Boole
 
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
-    val wasActive = gainAudioProcessor.isGainEnabled()
+    val wasActive = gainAudioProcessor.isActive()
     gainAudioProcessor.setGainDb(clampedDb)
-    val isActiveNow = gainAudioProcessor.isGainEnabled()
+    val isActiveNow = gainAudioProcessor.isActive()
 
     if (wasActive != isActiveNow && !isUsingMpvEngine()) {
-        playbackSpeedAwareAudioSink?.notifyAudioProcessingRequirementChanged()
+        // Force ExoPlayer to rebuild the audio pipeline so the processor is correctly added or removed
         _exoPlayer?.let { player ->
             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().build()
         }


### PR DESCRIPTION
## Summary

This PR reverts the audio sink changes introduced in PR #1763 (`fix/player-audio-sink-dev`) which caused unexpected regressions in audio passthrough behavior, specifically breaking Dolby Atmos playback.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The audio sink changes from PR #1763 resulted in a severe regression where Dolby Atmos tracks were no longer passed through correctly to external sound systems. Instead, they were falling back to Multi-Channel PCM, or outputting no sound at all if "Device Decoders Only" was selected (#1891). Reverting these changes restores the original, stable ExoPlayer passthrough behavior and ensures Dolby Atmos functions correctly again.

## Issue or approval

Fixes #1891

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR focuses exclusively on reverting the commits from #1763 to restore audio passthrough. During conflict resolution in `PlayerRuntimeControllerInitialization.kt`, we carefully kept subsequent fixes (such as the hardware A/V flush logic and `disposeExoPlayerBeforeRebuild` enhancements) intact. No new behavior or unrelated formatting changes were included.

## Testing

Tested compiling successfully locally via `./gradlew compileFullDebugKotlin` and verified there are no missing references from the resolved merge conflicts.

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #1891 
