### PR TITLE
Fix CEC remote long press handling

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -73,6 +73,7 @@ import coil3.request.crossfade
 import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.screens.home.LocalFastScrollActive
 import com.nuvio.tv.ui.theme.ThemeColors
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import kotlinx.coroutines.delay
 
 /**
@@ -126,6 +127,7 @@ fun ContentCard(
 
     var isFocused by remember { mutableStateOf(false) }
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
     var interactionNonce by remember { mutableIntStateOf(0) }
     var isBackdropExpanded by remember { mutableStateOf(false) }
     var trailerFirstFrameRendered by remember(trailerPreviewUrl) { mutableStateOf(false) }
@@ -324,17 +326,22 @@ fun ContentCard(
                                 onLongPress()
                                 return@onPreviewKeyEvent true
                             }
-                            val isLongPress = native.isLongPress || native.repeatCount > 0
-                            if (isLongPress && isSelectKey(native.keyCode)) {
-                                longPressTriggered = true
-                                onLongPress()
-                                return@onPreviewKeyEvent true
-                            }
                         }
+                    }
+                    if (onLongPress != null &&
+                        longPressKeyTracker.handle(native, ::isSelectKey) {
+                            longPressTriggered = true
+                            onLongPress()
+                        }
+                    ) {
+                        if (native.action == AndroidKeyEvent.ACTION_UP) {
+                            longPressTriggered = false
+                        }
+                        return@onPreviewKeyEvent true
                     }
                     if (native.action == AndroidKeyEvent.ACTION_UP &&
                         longPressTriggered &&
-                        isSelectKey(native.keyCode)
+                        (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
                     ) {
                         longPressTriggered = false
                         return@onPreviewKeyEvent true

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -76,6 +76,7 @@ import kotlin.math.roundToInt
 import java.util.concurrent.TimeUnit
 import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 
 private val CwCardShape = RoundedCornerShape(12.dp)
 private val CwClipShape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
@@ -282,6 +283,7 @@ fun ContinueWatchingCard(
     useEpisodeThumbnails: Boolean = true
 ) {
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
 
     val progress = remember(item) { (item as? ContinueWatchingItem.InProgress)?.progress }
     val nextUp = remember(item) { (item as? ContinueWatchingItem.NextUp)?.info }
@@ -438,14 +440,21 @@ fun ContinueWatchingCard(
                         onLongPress()
                         return@onPreviewKeyEvent true
                     }
-                    val isLongPress = native.isLongPress || native.repeatCount > 0
-                    if (isLongPress && isSelectKey(native.keyCode)) {
+                }
+                if (longPressKeyTracker.handle(native, ::isSelectKey) {
                         longPressTriggered = true
                         onLongPress()
-                        return@onPreviewKeyEvent true
                     }
+                ) {
+                    if (native.action == AndroidKeyEvent.ACTION_UP) {
+                        longPressTriggered = false
+                    }
+                    return@onPreviewKeyEvent true
                 }
-                if (native.action == AndroidKeyEvent.ACTION_UP && longPressTriggered && isSelectKey(native.keyCode)) {
+                if (native.action == AndroidKeyEvent.ACTION_UP &&
+                    longPressTriggered &&
+                    (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
+                ) {
                     longPressTriggered = false
                     return@onPreviewKeyEvent true
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
@@ -53,6 +53,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.theme.NuvioColors
 import androidx.compose.ui.platform.LocalContext
 import com.nuvio.tv.ui.util.recompositionHighlighter
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
@@ -81,6 +82,7 @@ fun GridContentCard(
     val requestHeightPx = remember(density, posterCardStyle.height) { with(density) { posterCardStyle.height.roundToPx() } }
     var isFocused by remember { mutableStateOf(false) }
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
 
 
     Column(
@@ -129,16 +131,21 @@ fun GridContentCard(
                             onLongPress()
                             return@onPreviewKeyEvent true
                         }
-                        val isLongPress = native.isLongPress || native.repeatCount > 0
-                        if (isLongPress && isSelectKey(native.keyCode)) {
+                    }
+                    if (onLongPress != null &&
+                        longPressKeyTracker.handle(native, ::isSelectKey) {
                             longPressTriggered = true
                             onLongPress()
-                            return@onPreviewKeyEvent true
                         }
+                    ) {
+                        if (native.action == AndroidKeyEvent.ACTION_UP) {
+                            longPressTriggered = false
+                        }
+                        return@onPreviewKeyEvent true
                     }
                     if (native.action == AndroidKeyEvent.ACTION_UP &&
                         longPressTriggered &&
-                        isSelectKey(native.keyCode)
+                        (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
                     ) {
                         longPressTriggered = false
                         return@onPreviewKeyEvent true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -90,6 +90,7 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 
 private const val EPISODE_CARD_CONTENT_TYPE = "episode_card"
 private const val EPISODE_SCROLL_REPEAT_THROTTLE_MS = 80L
@@ -162,6 +163,7 @@ fun SeasonTabs(
             val isSelected = season == selectedSeason
             var isFocused by remember { mutableStateOf(false) }
             var longPressTriggered by remember { mutableStateOf(false) }
+            val longPressKeyTracker = rememberLongPressKeyTracker()
 
             Card(
                 onClick = {
@@ -196,16 +198,20 @@ fun SeasonTabs(
                                 onSeasonLongPress(season)
                                 return@onPreviewKeyEvent true
                             }
-                            val isLongPress = native.isLongPress || native.repeatCount > 0
-                            if (isLongPress && isSelectKey(native.keyCode)) {
+                        }
+                        if (longPressKeyTracker.handle(native, ::isSelectKey) {
                                 longPressTriggered = true
                                 onSeasonLongPress(season)
-                                return@onPreviewKeyEvent true
                             }
+                        ) {
+                            if (native.action == AndroidKeyEvent.ACTION_UP) {
+                                longPressTriggered = false
+                            }
+                            return@onPreviewKeyEvent true
                         }
                         if (native.action == AndroidKeyEvent.ACTION_UP &&
                             longPressTriggered &&
-                            isSelectKey(native.keyCode)
+                            (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
                         ) {
                             longPressTriggered = false
                             return@onPreviewKeyEvent true
@@ -469,6 +475,7 @@ private fun EpisodeCard(
     }
     var isFocused by isFocusedState
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
     val shape = remember(cardMetrics.cornerRadius) { RoundedCornerShape(cardMetrics.cornerRadius) }
     val thumbnailWidthPx = remember(cardMetrics.cardWidth, density) {
         with(density) { cardMetrics.cardWidth.roundToPx() }
@@ -585,16 +592,20 @@ private fun EpisodeCard(
                         onLongPress()
                         return@onPreviewKeyEvent true
                     }
-                    val isLongPress = native.isLongPress || native.repeatCount > 0
-                    if (isLongPress && isSelectKey(native.keyCode)) {
+                }
+                if (longPressKeyTracker.handle(native, ::isSelectKey) {
                         longPressTriggered = true
                         onLongPress()
-                        return@onPreviewKeyEvent true
                     }
+                ) {
+                    if (native.action == AndroidKeyEvent.ACTION_UP) {
+                        longPressTriggered = false
+                    }
+                    return@onPreviewKeyEvent true
                 }
                 if (native.action == AndroidKeyEvent.ACTION_UP &&
                     longPressTriggered &&
-                    isSelectKey(native.keyCode)
+                    (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
                 ) {
                     longPressTriggered = false
                     return@onPreviewKeyEvent true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.painter.Painter
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import java.util.Locale
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -346,6 +347,7 @@ private fun PlayButton(
     onFocusRestored: () -> Unit = {}
 ) {
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
 
     LaunchedEffect(restoreFocusToken) {
         if (restoreFocusToken > 0 && focusRequester != null) {
@@ -381,23 +383,21 @@ private fun PlayButton(
                         onLongPress()
                         return@onPreviewKeyEvent true
                     }
-
-                    val isSelectKey = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
-                    if ((native.isLongPress || native.repeatCount > 0) && isSelectKey) {
+                }
+                if (onLongPress != null &&
+                    longPressKeyTracker.handle(native, ::isSelectKey) {
                         longPressTriggered = true
                         onLongPress()
-                        return@onPreviewKeyEvent true
                     }
+                ) {
+                    if (native.action == AndroidKeyEvent.ACTION_UP) {
+                        longPressTriggered = false
+                    }
+                    return@onPreviewKeyEvent true
                 }
 
                 if (native.action == AndroidKeyEvent.ACTION_UP && longPressTriggered) {
-                    val isSelectKey = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_MENU
-                    if (isSelectKey) {
+                    if (isSelectOrMenuKey(native.keyCode)) {
                         longPressTriggered = false
                         return@onPreviewKeyEvent true
                     }
@@ -496,6 +496,7 @@ private fun ActionIconButton(
     onFocused: () -> Unit = {}
 ) {
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
 
     IconButton(
         onClick = {
@@ -519,23 +520,21 @@ private fun ActionIconButton(
                         onLongPress()
                         return@onPreviewKeyEvent true
                     }
-
-                    val isSelectKey = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
-                    if ((native.isLongPress || native.repeatCount > 0) && isSelectKey) {
+                }
+                if (onLongPress != null &&
+                    longPressKeyTracker.handle(native, ::isSelectKey) {
                         longPressTriggered = true
                         onLongPress()
-                        return@onPreviewKeyEvent true
                     }
+                ) {
+                    if (native.action == AndroidKeyEvent.ACTION_UP) {
+                        longPressTriggered = false
+                    }
+                    return@onPreviewKeyEvent true
                 }
 
                 if (native.action == AndroidKeyEvent.ACTION_UP && longPressTriggered) {
-                    val isSelectKey = native.keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER ||
-                        native.keyCode == AndroidKeyEvent.KEYCODE_MENU
-                    if (isSelectKey) {
+                    if (isSelectOrMenuKey(native.keyCode)) {
                         longPressTriggered = false
                         return@onPreviewKeyEvent true
                     }
@@ -910,6 +909,16 @@ private fun MDBListRatingsRow(ratings: MDBListRatings) {
             }
         }
     }
+}
+
+private fun isSelectKey(keyCode: Int): Boolean {
+    return keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
+        keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
+        keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
+}
+
+private fun isSelectOrMenuKey(keyCode: Int): Boolean {
+    return isSelectKey(keyCode) || keyCode == AndroidKeyEvent.KEYCODE_MENU
 }
 
 private fun formatMDBListRating(provider: String, rating: Double): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -117,6 +117,7 @@ import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.util.StableMap
 import com.nuvio.tv.ui.util.StableRef
 import com.nuvio.tv.ui.util.asStable
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.debounce
 
@@ -1121,6 +1122,7 @@ private fun ModernCarouselCard(
             !effectiveLogoUrl.isNullOrBlank() &&
             !landscapeLogoLoadFailed
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
     val backgroundCardColor = NuvioColors.BackgroundCard
     val focusRingColor = NuvioColors.FocusRing
     val titleMedium = MaterialTheme.typography.titleMedium
@@ -1195,16 +1197,20 @@ private fun ModernCarouselCard(
                             onLongPress()
                             return@onPreviewKeyEvent true
                         }
-                        val isLongPress = native.isLongPress || native.repeatCount > 0
-                        if (isLongPress && isSelectKey(native.keyCode)) {
+                    }
+                    if (longPressKeyTracker.handle(native, ::isSelectKey) {
                             longPressTriggered = true
                             onLongPress()
-                            return@onPreviewKeyEvent true
                         }
+                    ) {
+                        if (native.action == AndroidKeyEvent.ACTION_UP) {
+                            longPressTriggered = false
+                        }
+                        return@onPreviewKeyEvent true
                     }
                     if (native.action == AndroidKeyEvent.ACTION_UP &&
                         longPressTriggered &&
-                        isSelectKey(native.keyCode)
+                        (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
                     ) {
                         longPressTriggered = false
                         return@onPreviewKeyEvent true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -96,6 +96,7 @@ import com.nuvio.tv.ui.components.AvatarPickerGrid
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.components.ProfileAvatarCircle
 import com.nuvio.tv.ui.theme.NuvioColors
+import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import kotlinx.coroutines.delay
 
 private object ProfileSelectionSpacing {
@@ -812,6 +813,7 @@ private fun ProfileCard(
 ) {
     var isFocused by remember { mutableStateOf(false) }
     var longPressTriggered by remember { mutableStateOf(false) }
+    val longPressKeyTracker = rememberLongPressKeyTracker()
     val interactionSource = remember { MutableInteractionSource() }
     val focusProgress by animateFloatAsState(
         targetValue = if (isFocused) 1f else 0f,
@@ -865,16 +867,20 @@ private fun ProfileCard(
                         onLongPress()
                         return@onPreviewKeyEvent true
                     }
-                    val isLongPress = native.isLongPress || native.repeatCount > 0
-                    if (isLongPress && isProfileSelectKey(native.keyCode)) {
+                }
+                if (longPressKeyTracker.handle(native, ::isProfileSelectKey) {
                         longPressTriggered = true
                         onLongPress()
-                        return@onPreviewKeyEvent true
                     }
+                ) {
+                    if (native.action == AndroidKeyEvent.ACTION_UP) {
+                        longPressTriggered = false
+                    }
+                    return@onPreviewKeyEvent true
                 }
                 if (native.action == AndroidKeyEvent.ACTION_UP &&
                     longPressTriggered &&
-                    isProfileSelectKey(native.keyCode)
+                    (isProfileSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU)
                 ) {
                     longPressTriggered = false
                     return@onPreviewKeyEvent true

--- a/app/src/main/java/com/nuvio/tv/ui/util/LongPressKeyTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/LongPressKeyTracker.kt
@@ -1,0 +1,74 @@
+package com.nuvio.tv.ui.util
+
+import android.view.KeyEvent
+import android.view.ViewConfiguration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+@Composable
+fun rememberLongPressKeyTracker(): LongPressKeyTracker = remember { LongPressKeyTracker() }
+
+class LongPressKeyTracker(
+    private val timeoutMillis: Long = ViewConfiguration.getLongPressTimeout().toLong()
+) {
+    private var pressedKeyCode: Int? = null
+    private var pressedAtMillis: Long = 0L
+    private var handledLongPress = false
+
+    fun handle(
+        event: KeyEvent,
+        isLongPressKey: (Int) -> Boolean,
+        onLongPress: () -> Unit
+    ): Boolean {
+        if (!isLongPressKey(event.keyCode)) return false
+
+        return when (event.action) {
+            KeyEvent.ACTION_DOWN -> handleDown(event, onLongPress)
+            KeyEvent.ACTION_UP -> handleUp(event, onLongPress)
+            else -> false
+        }
+    }
+
+    private fun handleDown(event: KeyEvent, onLongPress: () -> Unit): Boolean {
+        if (event.repeatCount == 0 || pressedKeyCode != event.keyCode) {
+            pressedKeyCode = event.keyCode
+            pressedAtMillis = event.eventTime
+            handledLongPress = false
+        }
+
+        if (event.isLongPress || event.repeatCount > 0 || heldDurationMillis(event) >= timeoutMillis) {
+            if (!handledLongPress) {
+                handledLongPress = true
+                onLongPress()
+            }
+            return true
+        }
+
+        return false
+    }
+
+    private fun handleUp(event: KeyEvent, onLongPress: () -> Unit): Boolean {
+        val wasHandled = handledLongPress && pressedKeyCode == event.keyCode
+        val isLongPress = !wasHandled && heldDurationMillis(event) >= timeoutMillis
+
+        reset()
+
+        if (isLongPress) {
+            onLongPress()
+            return true
+        }
+
+        return wasHandled
+    }
+
+    private fun heldDurationMillis(event: KeyEvent): Long {
+        val startedAt = if (pressedKeyCode == event.keyCode) pressedAtMillis else event.downTime
+        return event.eventTime - startedAt
+    }
+
+    private fun reset() {
+        pressedKeyCode = null
+        pressedAtMillis = 0L
+        handledLongPress = false
+    }
+}


### PR DESCRIPTION

## Summary

Fixes long-press handling for CEC remotes by tracking the elapsed time between select key down/up events, instead of relying only on repeated `ACTION_DOWN` events.

Native Android TV remotes still work through their existing repeat/`isLongPress` path, while CEC remotes can now trigger long press on release after the long-press timeout.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Users with CEC remotes currently cannot use long-press actions such as marking items as watched or starting playback from the beginning. This PR makes those actions available to CEC remote users, allowing them to use the app more fully.

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->

## Issue or approval
None
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
No UI changes or polish.
<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing
Tested personally on emulator to verify that normal remote presses keep working. Discord user verified that long presses now work on CEC remotes as well.

If anyone else would like to do additional testing:

Downloader codes:
arm64-v8a-debug.apk: 6922107
armeabi-v7a-debug.apk: 6941612

https://pub-44ff6559767b40c59db6db691dd0b7c2.r2.dev/app-full-arm64-v8a-debug.apk
https://pub-44ff6559767b40c59db6db691dd0b7c2.r2.dev/app-full-armeabi-v7a-debug.apk
https://pub-44ff6559767b40c59db6db691dd0b7c2.r2.dev/app-full-universal-debug.apk
<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->

## Screenshots / Video
Not a UI change
<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes
None
<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues
There is a [discord issue](https://discord.com/channels/1379902184207941732/1504236074157998314)
<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
