### PR TITLE
fix: remaining time badge shows full duration instead of proportional remaining time

### DIFF
--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
@@ -63,7 +63,10 @@ data class WatchProgress(
      * Returns the remaining time in milliseconds
      */
     val remainingTime: Long
-        get() = (duration - position).coerceAtLeast(0)
+        get() {
+            if (duration <= 0) return 0L
+            return (duration * (1f - progressPercentage)).toLong().coerceAtLeast(0)
+        }
 
     fun resolveResumePosition(actualDuration: Long): Long {
         if (actualDuration <= 0) return position.coerceAtLeast(0L)


### PR DESCRIPTION
## Summary

Fix: the remaining time badge in Continue Watching shows the full episode/movie duration instead of proportional remaining time when Trakt provides progress data with `position=0`.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When Trakt returns an in-progress item, it provides `progressPercent` (e.g., 50%) but leaves `position=0` and `duration=0`. After metadata hydration fills `duration` from runtime, `remainingTime` was computing `duration - position`, yielding the full duration since position remained 0.

Example: a 1-hour episode at 50% progress showed "1 hour left" instead of "30 minutes left".

The `progressPercentage` property already correctly handles Trakt explicit percentage, and `resolveResumePosition` already follows the same pattern. This change makes `remainingTime` consistent with the rest of the model.

## Issue or approval

Fixes #1901

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the `remainingTime` computed property in `WatchProgress.kt` is changed. No UI changes, no other behavior changes. `progressPercentage` and `resolveResumePosition` remain unchanged as they already handle this correctly.

## Testing

Manual testing with various progress states (0%, 25%, 50%, 75%, 90%) to verify the remaining time badge reflects proportional remaining time correctly.

## Screenshots / Video

Check the time left tag.

### Before
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/54b6a3c9-f3ba-4cf9-bbdd-a2ff298010ad" />

### After
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/ef3b4360-e11b-4442-988e-84adecac645c" />


## Breaking changes

No breaking changes.

## Linked issues

Fixes #1901