### PR TITLE
subtitle fixes: regressions in pt-pt/pt-br considerations, technical ID display and respecting forced setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -431,7 +431,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
                     audioTracks += MpvTrack(
                         id = id,
                         type = type,
-                        name = title ?: language ?: context.getString(com.nuvio.tv.R.string.player_track_audio_fallback, id),
+                        name = readableMpvTrackName(
+                            title = title,
+                            language = language,
+                            fallback = context.getString(com.nuvio.tv.R.string.player_track_audio_fallback, id)
+                        ),
                         language = language,
                         codec = codec,
                         channelCount = channelCount,
@@ -445,7 +449,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
                     subtitleTracks += MpvTrack(
                         id = id,
                         type = type,
-                        name = title ?: language ?: context.getString(com.nuvio.tv.R.string.player_track_subtitle_fallback, id),
+                        name = readableMpvTrackName(
+                            title = title,
+                            language = language,
+                            fallback = context.getString(com.nuvio.tv.R.string.player_track_subtitle_fallback, id)
+                        ),
                         language = language,
                         codec = codec,
                         channelCount = null,
@@ -461,6 +469,16 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             audioTracks = audioTracks,
             subtitleTracks = subtitleTracks
         )
+    }
+
+    private fun readableMpvTrackName(title: String?, language: String?, fallback: String): String {
+        title
+            ?.takeUnless { PlayerSubtitleUtils.isTechnicalTrackLabel(it) }
+            ?.let { return it }
+        return language
+            ?.takeIf { it.isNotBlank() && !it.equals("und", ignoreCase = true) }
+            ?.let { com.nuvio.tv.ui.util.languageCodeToName(it) }
+            ?: fallback
     }
 
     fun releasePlayer() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -786,21 +786,7 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         }
     }
 
-    val shouldPreferForcedSubtitleAutoSelection = pending.subtitle != null &&
-        forcedSubtitleAutoSelectionTargetForCurrentAudio() != null
-    val subtitleToRestore = if (shouldPreferForcedSubtitleAutoSelection) {
-        logSwitchTrace(
-            stage = "restore-subtitle-skip",
-            message = "reason=forced-subtitle-auto-selection"
-        )
-        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: subtitle skipped so forced subtitle auto-selection can run")
-        updatedPending = updatedPending.copy(subtitle = null)
-        null
-    } else {
-        pending.subtitle
-    }
-
-    when (val subtitleSelection = subtitleToRestore) {
+    when (val subtitleSelection = pending.subtitle) {
         null -> Unit
         PlayerRuntimeController.RememberedSubtitleSelection.Disabled -> {
             val alreadyDisabled = subtitleTracks.none { it.isSelected }
@@ -990,19 +976,6 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
         )
         persistedTrackPreference = normalizedPending
-    }
-}
-
-private fun PlayerRuntimeController.forcedSubtitleAutoSelectionTargetForCurrentAudio(): String? {
-    val state = _uiState.value
-    if (!state.subtitleStyle.useForcedSubtitles) return null
-    val selectedAudioTrack = selectedAudioTrackForSubtitleMatching(state) ?: return null
-    val primaryTarget = subtitleLanguageTargets().firstOrNull()
-    return when {
-        primaryTarget != null && audioTrackMatchesLanguage(selectedAudioTrack, primaryTarget) -> primaryTarget
-        primaryTarget == null && selectedAudioMatchesResolvedPreferredAudio(selectedAudioTrack) ->
-            selectedAudioLanguageTarget(selectedAudioTrack)
-        else -> null
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1125,13 +1125,19 @@ internal fun findBestForcedSubtitleTrackIndex(
                 targetScore >= PlayerSubtitleUtils.LANGUAGE_MATCH_GENERIC_FALLBACK &&
                 audioScore >= PlayerSubtitleUtils.LANGUAGE_MATCH_GENERIC_FALLBACK
             ) {
-                ForcedSubtitleCandidate(index, targetScore, audioScore)
+                ForcedSubtitleCandidate(
+                    index = index,
+                    targetScore = targetScore,
+                    variantScore = portugueseVariantPreferenceScore(track, normalizedTarget ?: PlayerSubtitleUtils.normalizeLanguageCode(target)),
+                    audioScore = audioScore
+                )
             } else {
                 null
             }
         }
         .maxWithOrNull(
             compareBy<ForcedSubtitleCandidate> { it.targetScore }
+                .thenBy { it.variantScore }
                 .thenBy { it.audioScore }
                 .thenBy { -it.index }
         )
@@ -1139,9 +1145,43 @@ internal fun findBestForcedSubtitleTrackIndex(
         ?: -1
 }
 
+private fun portugueseVariantPreferenceScore(track: TrackInfo, normalizedTarget: String): Int {
+    if (normalizedTarget != "pt" && normalizedTarget != "pt-pt" && normalizedTarget != "pt-br") return 0
+
+    val hasBrazilianTags = PlayerSubtitleUtils.containsAnyLanguageTag(
+        name = track.name,
+        language = track.language,
+        trackId = track.trackId,
+        tags = PlayerSubtitleUtils.BRAZILIAN_TAGS
+    )
+    val hasEuropeanTags = PlayerSubtitleUtils.containsAnyLanguageTag(
+        name = track.name,
+        language = track.language,
+        trackId = track.trackId,
+        tags = PlayerSubtitleUtils.EUROPEAN_PT_TAGS
+    )
+
+    return if (normalizedTarget == "pt-br") {
+        when {
+            hasBrazilianTags && !hasEuropeanTags -> 3
+            hasBrazilianTags -> 2
+            !hasEuropeanTags -> 1
+            else -> 0
+        }
+    } else {
+        when {
+            hasEuropeanTags && !hasBrazilianTags -> 3
+            hasEuropeanTags -> 2
+            !hasBrazilianTags -> 1
+            else -> 0
+        }
+    }
+}
+
 private data class ForcedSubtitleCandidate(
     val index: Int,
     val targetScore: Int,
+    val variantScore: Int,
     val audioScore: Int
 )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -831,21 +831,37 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                         "sourceEngine=$switchSourceEngine resultIndex=$index target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)}"
                 )
                 if (index >= 0) {
-                    val alreadySelected = subtitleTracks.getOrNull(index)?.isSelected == true
+                    val restoredTrack = subtitleTracks.getOrNull(index)
+                    val preferredNormalIndex = if (
+                        restoredTrack?.isForced == true &&
+                        !_uiState.value.subtitleStyle.useForcedSubtitles
+                    ) {
+                        findBestInternalSubtitleTrackIndex(
+                            subtitleTracks = subtitleTracks,
+                            targets = subtitleLanguageTargets(),
+                            normalOnly = true
+                        ).takeIf { candidateIndex ->
+                            candidateIndex >= 0 && subtitleTracks.getOrNull(candidateIndex)?.isForced != true
+                        }
+                    } else {
+                        null
+                    }
+                    val indexToRestore = preferredNormalIndex ?: index
+                    val alreadySelected = subtitleTracks.getOrNull(indexToRestore)?.isSelected == true
                     logSwitchTrace(
                         stage = "restore-subtitle-internal-match",
-                        message = "index=$index alreadySelected=$alreadySelected " +
-                            "matched=${subtitleTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
+                        message = "index=$index resolvedIndex=$indexToRestore alreadySelected=$alreadySelected " +
+                            "matched=${subtitleTracks.getOrNull(indexToRestore)?.let { describeTrackInfoForRestoreLog(it) }}"
                     )
                     if (!alreadySelected) {
-                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$index (re-applying)")
+                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$indexToRestore (re-applying)")
                         autoSubtitleSelected = true
-                        selectSubtitleTrack(index)
-                        updatedSubtitleIndex = index
+                        selectSubtitleTrack(indexToRestore)
+                        updatedSubtitleIndex = indexToRestore
                     } else {
-                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$index already selected, keeping for pipeline restart")
+                        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$indexToRestore already selected, keeping for pipeline restart")
                         autoSubtitleSelected = true
-                        updatedSubtitleIndex = index
+                        updatedSubtitleIndex = indexToRestore
                     }
                 } else {
                     val shouldDeferSwitchRestore = usingSwitchPending &&

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -786,7 +786,21 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         }
     }
 
-    when (val subtitleSelection = pending.subtitle) {
+    val shouldPreferForcedSubtitleAutoSelection = pending.subtitle != null &&
+        forcedSubtitleAutoSelectionTargetForCurrentAudio() != null
+    val subtitleToRestore = if (shouldPreferForcedSubtitleAutoSelection) {
+        logSwitchTrace(
+            stage = "restore-subtitle-skip",
+            message = "reason=forced-subtitle-auto-selection"
+        )
+        Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: subtitle skipped so forced subtitle auto-selection can run")
+        updatedPending = updatedPending.copy(subtitle = null)
+        null
+    } else {
+        pending.subtitle
+    }
+
+    when (val subtitleSelection = subtitleToRestore) {
         null -> Unit
         PlayerRuntimeController.RememberedSubtitleSelection.Disabled -> {
             val alreadyDisabled = subtitleTracks.none { it.isSelected }
@@ -976,6 +990,19 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
         )
         persistedTrackPreference = normalizedPending
+    }
+}
+
+private fun PlayerRuntimeController.forcedSubtitleAutoSelectionTargetForCurrentAudio(): String? {
+    val state = _uiState.value
+    if (!state.subtitleStyle.useForcedSubtitles) return null
+    val selectedAudioTrack = selectedAudioTrackForSubtitleMatching(state) ?: return null
+    val primaryTarget = subtitleLanguageTargets().firstOrNull()
+    return when {
+        primaryTarget != null && audioTrackMatchesLanguage(selectedAudioTrack, primaryTarget) -> primaryTarget
+        primaryTarget == null && selectedAudioMatchesResolvedPreferredAudio(selectedAudioTrack) ->
+            selectedAudioLanguageTarget(selectedAudioTrack)
+        else -> null
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1082,7 +1082,12 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
                     name = track.name,
                     trackId = track.trackId
                 )
-                if (variant != normalizedTarget && variant != track.language?.lowercase()) {
+                val genericPortugueseFallback = normalizedTarget == "pt-pt" && variant == "pt"
+                if (
+                    variant != normalizedTarget &&
+                    variant != track.language?.lowercase() &&
+                    !genericPortugueseFallback
+                ) {
                     // Single candidate is a different variant (e.g. PT-BR when we want PT).
                     // Skip it so the search can continue to secondary target or addon fallback.
                     continue

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1075,7 +1075,7 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
             // For regional targets, verify the single candidate is actually the right variant.
             // A track with language="por" matches both "pt" and "pt-br" by language code,
             // but may be the wrong accent based on its name tags.
-            if (normalizedTarget == "pt" || normalizedTarget == "es") {
+            if (normalizedTarget == "pt" || normalizedTarget == "pt-pt" || normalizedTarget == "es") {
                 val track = subtitleTracks[preferredCandidateIndexes.first()]
                 val variant = PlayerSubtitleUtils.detectTrackLanguageVariant(
                     language = track.language,
@@ -1091,7 +1091,7 @@ internal fun PlayerRuntimeController.findBestInternalSubtitleTrackIndex(
             return preferredCandidateIndexes.first()
         }
 
-        if (normalizedTarget == "pt" || normalizedTarget == "pt-br") {
+        if (normalizedTarget == "pt" || normalizedTarget == "pt-br" || normalizedTarget == "pt-pt") {
             val tieBroken = breakPortugueseSubtitleTie(
                 subtitleTracks = subtitleTracks,
                 candidateIndexes = preferredCandidateIndexes,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1498,7 +1498,7 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         subtitleTracks = state.subtitleTracks,
         targets = targets,
         forcedOnly = forcedOnly,
-        normalOnly = useForcedSubtitles && !forcedOnly,
+        normalOnly = !forcedOnly,
         selectedAudioTrack = selectedAudioTrack
     )
     if (internalIndex >= 0 && hasScannedTextTracksOnce) {
@@ -1655,6 +1655,16 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         autoSubtitleSelected = true
         Log.d(PlayerRuntimeController.TAG, "AUTO_SUB pick addon lang=${addonMatch.lang} id=${addonMatch.id}")
         selectAddonSubtitle(addonMatch)
+    } else if (!useForcedSubtitles && state.selectedSubtitleTrackIndex >= 0) {
+        val selectedInternal = state.subtitleTracks.getOrNull(state.selectedSubtitleTrackIndex)
+        if (selectedInternal?.isForced == true) {
+            Log.d(
+                PlayerRuntimeController.TAG,
+                "AUTO_SUB disable forced internal while forced subtitles are off index=${state.selectedSubtitleTrackIndex}"
+            )
+            disableSubtitles()
+            _uiState.update { it.copy(selectedSubtitleTrackIndex = -1, selectedAddonSubtitle = null) }
+        }
     } else {
         Log.d(PlayerRuntimeController.TAG, "AUTO_SUB no addon match for targets=$targets")
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1469,10 +1469,12 @@ internal fun PlayerRuntimeController.breakSpanishSubtitleTie(
 }
 
 internal fun PlayerRuntimeController.subtitleHasAnyTag(track: TrackInfo, tags: List<String>): Boolean {
-    val haystack = listOfNotNull(track.name, track.language, track.trackId)
-        .joinToString(" ")
-        .lowercase(Locale.ROOT)
-    return tags.any { tag -> haystack.contains(tag) }
+    return PlayerSubtitleUtils.containsAnyLanguageTag(
+        name = track.name,
+        language = track.language,
+        trackId = track.trackId,
+        tags = tags
+    )
 }
 
 internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailableTracks() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -236,11 +236,16 @@ internal object PlayerSubtitleUtils {
      */
     fun detectTrackLanguageVariant(language: String?, name: String?, trackId: String?): String {
         val normalizedLanguage = language?.let { normalizeLanguage(it) }
+        val descriptorText = searchableLanguageText(listOfNotNull(name, trackId).joinToString(" "))
         val haystack = searchableLanguageText(listOfNotNull(name, language, trackId).joinToString(" "))
+        val descriptorHasBrazilian = descriptorText.containsAnyTag(BRAZILIAN_TAGS)
+        val descriptorHasEuropeanPortuguese = descriptorText.containsAnyTag(EUROPEAN_PT_TAGS)
         val hasBrazilian = haystack.containsAnyTag(BRAZILIAN_TAGS)
         val hasEuropeanPortuguese = haystack.containsAnyTag(EUROPEAN_PT_TAGS)
         val isPortugueseTrack = normalizedLanguage?.base == "pt" ||
             haystack.containsAny("portuguese", "portugues")
+        if (descriptorHasBrazilian && !descriptorHasEuropeanPortuguese) return "pt-br"
+        if (isPortugueseTrack && descriptorHasEuropeanPortuguese && !descriptorHasBrazilian) return "pt-pt"
         if (!isPortugueseTrack && hasBrazilian && !hasEuropeanPortuguese) return "pt-br"
         if (isPortugueseTrack) {
             if (hasBrazilian && !hasEuropeanPortuguese) return "pt-br"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -11,6 +11,9 @@ internal object PlayerSubtitleUtils {
     const val LANGUAGE_MATCH_GENERIC_FALLBACK = 75
     const val LANGUAGE_MATCH_RELATED_VARIANT = 50
 
+    private val TRACK_TIME_REGEX = Regex("""\d+:\d+""")
+    private val TRACK_NUMBER_REGEX = Regex("""#?\d+""")
+
     data class NormalizedLanguage(
         val raw: String,
         val tag: String,
@@ -324,7 +327,7 @@ internal object PlayerSubtitleUtils {
     fun isTechnicalTrackLabel(value: String?): Boolean {
         if (value.isNullOrBlank()) return false
         val trimmed = value.trim()
-        return Regex("""\d+:\d+""").matches(trimmed) ||
-            Regex("""#?\d+""").matches(trimmed)
+        return TRACK_TIME_REGEX.matches(trimmed) ||
+            TRACK_NUMBER_REGEX.matches(trimmed)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -260,10 +260,10 @@ internal object PlayerSubtitleUtils {
     }
 
     internal val BRAZILIAN_TAGS = listOf(
-        "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil", "brasileiro"
+        "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil", "brasileiro", " br", "(br)"
     )
     internal val EUROPEAN_PT_TAGS = listOf(
-        "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu"
+        "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu", " eu", "(eu)"
     )
     internal val LATINO_TAGS = listOf(
         "es-419", "es_419", "es-la", "es-lat", "es-mx", "latino", "latinoamerica",
@@ -311,7 +311,14 @@ internal object PlayerSubtitleUtils {
     }
 
     private fun String.containsAnyTag(tags: List<String>): Boolean {
-        return tags.any { tag -> contains(searchableLanguageText(tag)) }
+        return tags.any { tag ->
+            val searchableTag = searchableLanguageText(tag)
+            if (searchableTag.length <= 2) {
+                Regex("""(^|\s)${Regex.escape(searchableTag)}($|\s)""").containsMatchIn(this)
+            } else {
+                contains(searchableTag)
+            }
+        }
     }
 
     fun isTechnicalTrackLabel(value: String?): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -217,7 +217,7 @@ internal object PlayerSubtitleUtils {
 
         val parts = canonicalCode.split('-').filter { it.isNotBlank() }
         val base = parts.firstOrNull() ?: return null
-        if (base.length !in 2..3) return null
+        if (base.length !in 2..3 || !base.all { it in 'a'..'z' }) return null
         return result(
             tag = canonicalCode,
             base = base,
@@ -312,5 +312,12 @@ internal object PlayerSubtitleUtils {
 
     private fun String.containsAnyTag(tags: List<String>): Boolean {
         return tags.any { tag -> contains(searchableLanguageText(tag)) }
+    }
+
+    fun isTechnicalTrackLabel(value: String?): Boolean {
+        if (value.isNullOrBlank()) return false
+        val trimmed = value.trim()
+        return Regex("""\d+:\d+""").matches(trimmed) ||
+            Regex("""#?\d+""").matches(trimmed)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -80,7 +80,9 @@ internal object PlayerSubtitleUtils {
         trackId: String?,
         target: String
     ): Int {
-        val scores = listOfNotNull(language, name, trackId)
+        val detectedVariant = detectTrackLanguageVariant(language, name, trackId)
+            .takeIf { it.isNotBlank() }
+        val scores = listOfNotNull(detectedVariant, language, name, trackId)
             .map { scoreLanguageMatch(it, target) }
         val bestSpecific = scores.maxOrNull() ?: 0
         if (bestSpecific >= LANGUAGE_MATCH_ALIAS) return bestSpecific
@@ -230,6 +232,26 @@ internal object PlayerSubtitleUtils {
      * or falls back to the base language code.
      */
     fun detectTrackLanguageVariant(language: String?, name: String?, trackId: String?): String {
+        val normalizedLanguage = language?.let { normalizeLanguage(it) }
+        val haystack = searchableLanguageText(listOfNotNull(name, language, trackId).joinToString(" "))
+        val hasBrazilian = haystack.containsAnyTag(BRAZILIAN_TAGS)
+        val hasEuropeanPortuguese = haystack.containsAnyTag(EUROPEAN_PT_TAGS)
+        val isPortugueseTrack = normalizedLanguage?.base == "pt" ||
+            haystack.containsAny("portuguese", "portugues")
+        if (isPortugueseTrack) {
+            if (hasBrazilian && !hasEuropeanPortuguese) return "pt-br"
+            if (hasEuropeanPortuguese && !hasBrazilian) return "pt-pt"
+        }
+
+        val hasLatino = haystack.containsAnyTag(LATINO_TAGS)
+        val hasCastilian = haystack.containsAnyTag(CASTILIAN_TAGS)
+        val isSpanishTrack = normalizedLanguage?.base == "es" ||
+            haystack.containsAny("spanish", "espanol")
+        if (isSpanishTrack) {
+            if (hasLatino && !hasCastilian) return "es-419"
+            if (hasCastilian && !hasLatino) return "es-es"
+        }
+
         return listOfNotNull(name, language, trackId)
             .mapNotNull { normalizeLanguage(it) }
             .maxByOrNull { if (it.isGeneric) 0 else 1 }
@@ -238,10 +260,10 @@ internal object PlayerSubtitleUtils {
     }
 
     internal val BRAZILIAN_TAGS = listOf(
-        "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil", "brasileiro", " br", "(br)"
+        "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil", "brasileiro"
     )
     internal val EUROPEAN_PT_TAGS = listOf(
-        "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu", " eu", "(eu)"
+        "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu"
     )
     internal val LATINO_TAGS = listOf(
         "es-419", "es_419", "es-la", "es-lat", "es-mx", "latino", "latinoamerica",
@@ -286,5 +308,9 @@ internal object PlayerSubtitleUtils {
 
     private fun String.containsAny(vararg values: String): Boolean {
         return values.any { value -> contains(value) }
+    }
+
+    private fun String.containsAnyTag(tags: List<String>): Boolean {
+        return tags.any { tag -> contains(searchableLanguageText(tag)) }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -282,6 +282,16 @@ internal object PlayerSubtitleUtils {
         "es-es", "es_es", "castilian", "castellano", "spain", "españa", "espana", "iberian"
     )
 
+    internal fun containsAnyLanguageTag(
+        name: String?,
+        language: String?,
+        trackId: String?,
+        tags: List<String>
+    ): Boolean {
+        val haystack = searchableLanguageText(listOfNotNull(name, language, trackId).joinToString(" "))
+        return haystack.containsAnyTag(tags)
+    }
+
     fun mimeTypeFromUrl(url: String): String {
         val normalizedPath = url
             .substringBefore('#')
@@ -306,7 +316,8 @@ internal object PlayerSubtitleUtils {
         val lower = value.lowercase(Locale.ROOT)
         val ascii = Normalizer.normalize(lower, Normalizer.Form.NFD)
             .replace(Regex("\\p{Mn}+"), "")
-        return "$lower $ascii"
+        val searchable = if (lower == ascii) lower else "$lower $ascii"
+        return searchable
             .replace('-', ' ')
             .replace('_', ' ')
             .replace('.', ' ')

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -241,6 +241,7 @@ internal object PlayerSubtitleUtils {
         val hasEuropeanPortuguese = haystack.containsAnyTag(EUROPEAN_PT_TAGS)
         val isPortugueseTrack = normalizedLanguage?.base == "pt" ||
             haystack.containsAny("portuguese", "portugues")
+        if (!isPortugueseTrack && hasBrazilian && !hasEuropeanPortuguese) return "pt-br"
         if (isPortugueseTrack) {
             if (hasBrazilian && !hasEuropeanPortuguese) return "pt-br"
             if (hasEuropeanPortuguese && !hasBrazilian) return "pt-pt"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -67,6 +67,7 @@ import com.nuvio.tv.domain.model.Subtitle
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
 import com.nuvio.tv.ui.theme.NuvioColors
+import java.util.Locale
 
 private const val SubtitleOffLanguageKey = "__off__"
 private const val SubtitleUnknownLanguageKey = "__unknown__"
@@ -1851,7 +1852,7 @@ private fun normalizeOverlayLanguageKey(language: String?): String {
     if (language.isNullOrBlank()) return SubtitleUnknownLanguageKey
     val normalized = PlayerSubtitleUtils.normalizeLanguageCode(language)
     return when (normalized) {
-        "pt-br", "es-419" -> normalized
+        "pt-br", "pt-pt", "es-419" -> normalized
         else -> normalized
             .substringBefore('-')
             .substringBefore('_')
@@ -1871,7 +1872,7 @@ private fun normalizeOverlayLanguageKeyForTrack(track: TrackInfo): String {
         trackId = track.trackId
     )
     return when (variant) {
-        "pt-br", "es-419" -> variant
+        "pt-br", "pt-pt", "es-419" -> variant
         else -> variant
             .substringBefore('-')
             .substringBefore('_')
@@ -1895,6 +1896,9 @@ private fun subtitleLanguageLabel(key: String): String {
     return when (key) {
         SubtitleOffLanguageKey -> Subtitle.languageCodeToName("none")
         SubtitleUnknownLanguageKey -> "Unknown"
+        "pt-pt" -> Locale.forLanguageTag("pt-PT")
+            .getDisplayName(Locale.getDefault())
+            .replaceFirstChar { it.uppercase() }
         else -> Subtitle.languageCodeToName(key)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -1764,7 +1764,7 @@ private fun buildSubtitleOptionRailItems(
             SubtitleOptionRailItem(
                 id = "internal:${track.index}",
                 kind = SubtitleOptionKind.INTERNAL,
-                title = track.name,
+                title = subtitleTrackDisplayName(track),
                 sourceLabel = builtInLabel,
                 meta = listOfNotNull(
                     track.codec,
@@ -1876,6 +1876,18 @@ private fun normalizeOverlayLanguageKeyForTrack(track: TrackInfo): String {
             .substringBefore('-')
             .substringBefore('_')
             .ifBlank { SubtitleUnknownLanguageKey }
+    }
+}
+
+private fun subtitleTrackDisplayName(track: TrackInfo): String {
+    val languageName = track.language
+        ?.takeIf { it.isNotBlank() && !it.equals("und", ignoreCase = true) }
+        ?.let { Subtitle.languageCodeToName(PlayerSubtitleUtils.normalizeLanguageCode(it)) }
+        ?.takeIf { it.isNotBlank() }
+    return if (PlayerSubtitleUtils.isTechnicalTrackLabel(track.name)) {
+        languageName ?: track.name
+    } else {
+        track.name
     }
 }
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -120,6 +120,8 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     fun `short Portuguese regional tags from embedded labels are detected`() {
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant(null, "Brazilian", "sub-0"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("und", "Brazilian", "sub-1"))
+        assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("pt-PT", "Brazilian", "sub-2"))
+        assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("pt-BR", "Iberian", "sub-3"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM BR", "sub-0"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (BR)", "sub-1"))
         assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM EU", "sub-2"))

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -211,8 +211,12 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     @Test
     fun `technical track ids are not treated as languages`() {
         assertEquals("", PlayerSubtitleUtils.detectTrackLanguageVariant(null, "0:6", "sub-6"))
+        assertEquals("nl", PlayerSubtitleUtils.detectTrackLanguageVariant("nl", "0:5", "sub-5"))
         assertEquals(0, PlayerSubtitleUtils.scoreLanguageMatch("0:6", "en"))
+        assertTrue(PlayerSubtitleUtils.isTechnicalTrackLabel("0:5"))
         assertTrue(PlayerSubtitleUtils.isTechnicalTrackLabel("0:6"))
+        assertTrue(PlayerSubtitleUtils.isTechnicalTrackLabel("0:7"))
+        assertTrue(PlayerSubtitleUtils.isTechnicalTrackLabel("0:8"))
     }
 
     private fun subtitle(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -208,6 +208,13 @@ class PlayerForcedSubtitleLanguageMatcherTest {
         assertEquals(0, PlayerSubtitleUtils.scoreLanguageMatch("Urdu", "hi"))
     }
 
+    @Test
+    fun `technical track ids are not treated as languages`() {
+        assertEquals("", PlayerSubtitleUtils.detectTrackLanguageVariant(null, "0:6", "sub-6"))
+        assertEquals(0, PlayerSubtitleUtils.scoreLanguageMatch("0:6", "en"))
+        assertTrue(PlayerSubtitleUtils.isTechnicalTrackLabel("0:6"))
+    }
+
     private fun subtitle(
         index: Int,
         name: String,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -150,10 +150,20 @@ class PlayerForcedSubtitleLanguageMatcherTest {
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("und", "Brazilian", "sub-1"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("pt-PT", "Brazilian", "sub-2"))
         assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("pt-BR", "Iberian", "sub-3"))
+        assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "European", "sub-4"))
+        assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "Portuguese Portugal", "sub-5"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM BR", "sub-0"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (BR)", "sub-1"))
         assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM EU", "sub-2"))
         assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (EU)", "sub-3"))
+        assertTrue(
+            PlayerSubtitleUtils.containsAnyLanguageTag(
+                name = "BTM pt-br",
+                language = "por",
+                trackId = "sub-4",
+                tags = PlayerSubtitleUtils.BRAZILIAN_TAGS
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -62,6 +62,34 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     }
 
     @Test
+    fun `English full subtitle is preferred over signs and songs when forced subtitles are off`() {
+        val selected = findBestInternalSubtitleTrackIndex(
+            subtitleTracks = listOf(
+                subtitle(index = 0, name = "English Signs & Songs Forced", language = "en", forced = true),
+                subtitle(index = 1, name = "English Full Subtitles [Asakura]", language = "en", forced = false)
+            ),
+            targets = listOf("en"),
+            normalOnly = true
+        )
+
+        assertEquals(1, selected)
+    }
+
+    @Test
+    fun `English forced subtitle is used when forced subtitles are on`() {
+        val selected = findBestForcedSubtitleTrackIndex(
+            subtitleTracks = listOf(
+                subtitle(index = 0, name = "English Signs & Songs Forced", language = "en", forced = true),
+                subtitle(index = 1, name = "English Full Subtitles [Asakura]", language = "en", forced = false)
+            ),
+            target = "en",
+            selectedAudioTrack = audio("en")
+        )
+
+        assertEquals(0, selected)
+    }
+
+    @Test
     fun `pt PT specific forced beats pt BR forced`() {
         val selected = findBestForcedSubtitleTrackIndex(
             subtitleTracks = listOf(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -92,6 +92,27 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     }
 
     @Test
+    fun `pt PT primary beats pt BR secondary for embedded generic Portuguese tracks`() {
+        val selected = findBestInternalSubtitleTrackIndex(
+            subtitleTracks = listOf(
+                subtitle(index = 0, name = "Brazilian", language = "por", forced = false),
+                subtitle(index = 1, name = "Iberian", language = "por", forced = false)
+            ),
+            targets = listOf("pt-PT", "pt-BR")
+        )
+
+        assertEquals(1, selected)
+    }
+
+    @Test
+    fun `short Portuguese regional tags from embedded labels are detected`() {
+        assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM BR", "sub-0"))
+        assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (BR)", "sub-1"))
+        assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM EU", "sub-2"))
+        assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (EU)", "sub-3"))
+    }
+
+    @Test
     fun `Spanish Latino uses generic Spanish forced subtitle before full subtitle`() {
         val selected = findBestForcedSubtitleTrackIndex(
             subtitleTracks = listOf(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -76,6 +76,22 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     }
 
     @Test
+    fun `pt PT forced uses bare embedded regional tags to avoid Brazilian`() {
+        val selected = findBestForcedSubtitleTrackIndex(
+            subtitleTracks = listOf(
+                subtitle(index = 0, name = "Brazilian", language = "por", forced = true),
+                subtitle(index = 1, name = "Iberian", language = "por", forced = true)
+            ),
+            target = "pt-PT",
+            selectedAudioTrack = audio("pt-PT")
+        )
+
+        assertEquals(1, selected)
+        assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "Brazilian", "sub-0"))
+        assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "Iberian", "sub-1"))
+    }
+
+    @Test
     fun `Spanish Latino uses generic Spanish forced subtitle before full subtitle`() {
         val selected = findBestForcedSubtitleTrackIndex(
             subtitleTracks = listOf(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -118,6 +118,8 @@ class PlayerForcedSubtitleLanguageMatcherTest {
 
     @Test
     fun `short Portuguese regional tags from embedded labels are detected`() {
+        assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant(null, "Brazilian", "sub-0"))
+        assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("und", "Brazilian", "sub-1"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM BR", "sub-0"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (BR)", "sub-1"))
         assertEquals("pt-pt", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM EU", "sub-2"))

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -120,6 +120,20 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     }
 
     @Test
+    fun `Portuguese forced preference chooses Iberian before Brazilian`() {
+        val selected = findBestForcedSubtitleTrackIndex(
+            subtitleTracks = listOf(
+                subtitle(index = 0, name = "Brazilian", language = "por", forced = true),
+                subtitle(index = 1, name = "Iberian", language = "por", forced = true)
+            ),
+            target = "pt",
+            selectedAudioTrack = audio("pt")
+        )
+
+        assertEquals(1, selected)
+    }
+
+    @Test
     fun `pt PT primary beats pt BR secondary for embedded generic Portuguese tracks`() {
         val selected = findBestInternalSubtitleTrackIndex(
             subtitleTracks = listOf(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerForcedSubtitleLanguageMatcherTest.kt
@@ -105,6 +105,18 @@ class PlayerForcedSubtitleLanguageMatcherTest {
     }
 
     @Test
+    fun `pt PT uses generic Portuguese subtitle when no regional track exists`() {
+        val selected = findBestInternalSubtitleTrackIndex(
+            subtitleTracks = listOf(
+                subtitle(index = 0, name = "Portuguese", language = "por", forced = false)
+            ),
+            targets = listOf("pt-PT")
+        )
+
+        assertEquals(0, selected)
+    }
+
+    @Test
     fun `short Portuguese regional tags from embedded labels are detected`() {
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM BR", "sub-0"))
         assertEquals("pt-br", PlayerSubtitleUtils.detectTrackLanguageVariant("por", "BTM (BR)", "sub-1"))


### PR DESCRIPTION
## Summary

Fixes recent subtitle selection and display regressions:
- Restore Portuguese regional subtitle handling from PRs #1083 and #1170 so `pt-BR`, `pt-PT`, `pob`, bare `BR`, bare `EU`, `Brazilian`, and `Iberian` embedded tags are distinguished correctly.
- Keep Brazilian Portuguese subtitles under `Português (Brasil)` instead of grouping them into the generic `Português` tab.
- Keep Iberian / European Portuguese subtitles in the normal `Português` tab and prefer them when Portuguese is primary and Portuguese (Brazil) is secondary.
- Prefer embedded label/id regional hints over conflicting raw language metadata, so labels like `Brazilian` and `Iberian` still classify correctly.
- Prevent technical track ids such as `0:5`, `0:6`, `0:7`, and `0:8` from appearing as subtitle language labels when language metadata is available.
- Ignore forced internal subtitle tracks when the forced subtitle setting is off, including fast subtitle startup loading.
- If a previously persisted internal subtitle is forced but forced subtitles are now off, restore the best normal preferred-language internal subtitle instead.
- Preserve per-content persisted full subtitle selections when forced subtitles are enabled; forced auto-selection no longer overrides a user’s saved full-subtitle choice for that item.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Recent forced subtitle and language matching changes regressed several subtitle behaviours.

Portuguese regional subtitle variants that were previously handled correctly by PRs #1083 and #1170, could be grouped together or selected incorrectly, especially for embedded subtitles using regional labels such as `BR`, `EU`, `pt-BR`, `pt-PT`, or `pob`. Embedded subtitle tracks named "Brazilian" could be grouped under generic Portuguese instead of Português (Brasil). The normalized tag matching path duplicated ASCII-only text and the overlay preserved `pt-br` but collapsed `pt-pt` back to generic `pt`, leaving runtime grouping inconsistent with variant detection.

Some embedded subtitle tracks also surfaced technical ids such as `0:6` in the subtitle menu instead of a readable language name, #1902 

Separately, when forced subtitles were disabled, forced internal tracks could still be auto-selected for preferred-language subtitle matching. This affected #1905, where `Signs & Songs Forced` could be selected even though the forced subtitle option was off.

## Issue or approval

Fixes #1905.

Also restores previously intended Portuguese regional subtitle behaviour from PRs #1083 and #1170.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This only changes subtitle language matching, forced subtitle auto-selection, persisted subtitle restoration interaction, and subtitle track display fallback.

It does not change touch anything else, like: playback lifecycle, subtitle rendering, provider loading, audio selection, player controls, layout styling, or remote navigation behaviour.

## Testing

- Tested build myself, but @skoruppa can you generate a build with secrets please so I can distribute to users who reported the issues?
- Added regression coverage for Portuguese regional subtitle matching:
  - `pt-BR` aliases including `pob`
  - `pt-PT` specific tracks
  - embedded bare `BR` and `EU` labels
  - `pt-PT` primary beating `pt-BR` secondary when both embedded variants exist
- Added regression coverage for technical subtitle labels such as `0:5`, `0:6`, `0:7`, and `0:8`.
- Verified code paths for:
  - forced subtitle auto-selection with forced option enabled
  - preferred subtitle auto-selection with forced option disabled
  - persisted subtitle restoration yielding to forced subtitle auto-selection
  - internal subtitle menu grouping and display-name fallback
- Ran `git diff --check`.

## Screenshots / Video

We're back to where we were before regarding technical ids not being displayed, pt-pt and pt-br use, and forced subtitles not used when setting is not on and a full subtitle option exists

## Breaking changes

None so far.

## Linked issues

Fixes #1905 (https://discord.com/channels/1379902184207941732/1502053669062054060), #1910 (https://discord.com/channels/1379902184207941732/1504976501324644473), #1902 (https://discord.com/channels/1379902184207941732/1505104332272439407)