### PR TITLE
Feature/stream autoplay timeout cap

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -223,6 +223,9 @@ data class PlayerSettings(
             if (raw in STREAM_AUTOPLAY_TIMEOUT_VALUES) return raw
             return STREAM_AUTOPLAY_TIMEOUT_VALUES.minBy { kotlin.math.abs(it.toLong() - raw.toLong()) }
         }
+
+        fun isBoundedTimeout(timeoutSeconds: Int): Boolean =
+            timeoutSeconds > 0 && timeoutSeconds != STREAM_AUTOPLAY_TIMEOUT_UNLIMITED
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -216,6 +216,13 @@ data class PlayerSettings(
 
         val STREAM_AUTOPLAY_TIMEOUT_VALUES: List<Int> =
             listOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, STREAM_AUTOPLAY_TIMEOUT_UNLIMITED)
+
+        fun applyLegacyTimeoutSentinelMigration(stored: Int?): Int {
+            val raw = stored ?: 3
+            if (raw == 11) return STREAM_AUTOPLAY_TIMEOUT_UNLIMITED
+            if (raw in STREAM_AUTOPLAY_TIMEOUT_VALUES) return raw
+            return STREAM_AUTOPLAY_TIMEOUT_VALUES.minBy { kotlin.math.abs(it.toLong() - raw.toLong()) }
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -211,6 +211,11 @@ data class PlayerSettings(
         const val DEFAULT_STILL_WATCHING_EPISODE_THRESHOLD = 3
         const val MIN_STILL_WATCHING_EPISODE_THRESHOLD = 2
         const val MAX_STILL_WATCHING_EPISODE_THRESHOLD = 6
+
+        const val STREAM_AUTOPLAY_TIMEOUT_UNLIMITED = Int.MAX_VALUE
+
+        val STREAM_AUTOPLAY_TIMEOUT_VALUES: List<Int> =
+            listOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, STREAM_AUTOPLAY_TIMEOUT_UNLIMITED)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -221,7 +221,9 @@ data class PlayerSettings(
             val raw = stored ?: 3
             if (raw == 11) return STREAM_AUTOPLAY_TIMEOUT_UNLIMITED
             if (raw in STREAM_AUTOPLAY_TIMEOUT_VALUES) return raw
-            return STREAM_AUTOPLAY_TIMEOUT_VALUES.minBy { kotlin.math.abs(it.toLong() - raw.toLong()) }
+            return STREAM_AUTOPLAY_TIMEOUT_VALUES
+                .filter { it != STREAM_AUTOPLAY_TIMEOUT_UNLIMITED }
+                .minBy { kotlin.math.abs(it.toLong() - raw.toLong()) }
         }
 
         fun isBoundedTimeout(timeoutSeconds: Int): Boolean =

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -557,7 +557,9 @@ class PlayerSettingsDataStore @Inject constructor(
                 streamAutoPlayNextEpisodeEnabled = prefs[streamAutoPlayNextEpisodeEnabledKey] ?: false,
                 streamAutoPlayPreferBingeGroupForNextEpisode =
                     prefs[streamAutoPlayPreferBingeGroupForNextEpisodeKey] ?: true,
-                streamAutoPlayTimeoutSeconds = (prefs[streamAutoPlayTimeoutSecondsKey] ?: 3).coerceIn(0, 11),
+                streamAutoPlayTimeoutSeconds = PlayerSettings.applyLegacyTimeoutSentinelMigration(
+                    prefs[streamAutoPlayTimeoutSecondsKey]
+                ),
                 stillWatchingEnabled = prefs[stillWatchingEnabledKey] ?: false,
                 stillWatchingEpisodeThreshold = prefs[stillWatchingEpisodeThresholdKey]
                     ?.coerceIn(
@@ -833,7 +835,7 @@ class PlayerSettingsDataStore @Inject constructor(
 
     suspend fun setStreamAutoPlayTimeoutSeconds(seconds: Int) {
         store().edit { prefs ->
-            prefs[streamAutoPlayTimeoutSecondsKey] = seconds.coerceIn(0, 11)
+            prefs[streamAutoPlayTimeoutSecondsKey] = PlayerSettings.applyLegacyTimeoutSentinelMigration(seconds)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.player.StreamAutoPlaySelector
+import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamAutoPlaySource
 import com.nuvio.tv.data.local.toTrackPreference
@@ -1131,7 +1132,7 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
             }
 
             val timeoutMs = timeoutSeconds * 1_000L
-            if (timeoutMs > 0L && timeoutSeconds < 11) {
+            if (PlayerSettings.isBoundedTimeout(timeoutSeconds)) {
                 delay(timeoutMs)
                 timeoutElapsed = true
                 if (!autoSelectTriggered && lastSuccessData != null) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -142,18 +142,17 @@ internal fun LazyListScope.autoPlaySettingsItems(
         val timeoutSec = playerSettings.streamAutoPlayTimeoutSeconds
         val valueText = when (timeoutSec) {
             0 -> stringResource(R.string.autoplay_timeout_instant)
-            11 -> stringResource(R.string.autoplay_timeout_unlimited)
+            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED ->
+                stringResource(R.string.autoplay_timeout_unlimited)
             else -> "${timeoutSec}s"
         }
         SliderSettingsItem(
             icon = Icons.Default.Timer,
             title = stringResource(R.string.autoplay_timeout_title),
             subtitle = stringResource(R.string.autoplay_timeout_sub),
-            value = timeoutSec,
+            values = PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES,
+            selected = timeoutSec,
             valueText = valueText,
-            minValue = 0,
-            maxValue = 11,
-            step = 1,
             onValueChange = { onSetStreamAutoPlayTimeoutSeconds(it) },
             onFocused = onItemFocused
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -768,7 +768,6 @@ private fun SliderSettingsItemLayout(
     onDecrease: () -> Unit,
     onIncrease: () -> Unit,
     onFocused: () -> Unit,
-    extraModifier: Modifier = Modifier,
 ) {
     var isFocused by remember { mutableStateOf(false) }
     val contentAlpha = if (enabled) 1f else 0.4f
@@ -777,7 +776,6 @@ private fun SliderSettingsItemLayout(
         onClick = { },
         modifier = Modifier
             .fillMaxWidth()
-            .then(extraModifier)
             .onFocusChanged { state ->
                 val nowFocused = state.isFocused
                 if (isFocused != nowFocused) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -67,6 +67,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import com.nuvio.tv.R
 import androidx.compose.ui.text.input.KeyboardType
 import android.view.KeyEvent
@@ -715,6 +720,56 @@ internal fun SliderSettingsItem(
             if (newValue != value) onValueChange(newValue)
         },
         onFocused = onFocused,
+    )
+}
+
+@Composable
+internal fun SliderSettingsItem(
+    icon: ImageVector,
+    title: String,
+    values: List<Int>,
+    selected: Int,
+    valueText: String,
+    onValueChange: (Int) -> Unit,
+    subtitle: String? = null,
+    onFocused: () -> Unit = {},
+    enabled: Boolean = true,
+) {
+    require(values.isNotEmpty()) { "SliderSettingsItem.values must not be empty" }
+
+    val index = values.indexOf(selected).coerceAtLeast(0)
+    val lastIndex = values.lastIndex
+    val progress = if (lastIndex > 0) index.toFloat() / lastIndex.toFloat() else 0f
+
+    val accessibilityModifier = Modifier.semantics {
+        contentDescription = title
+        stateDescription = valueText
+        progressBarRangeInfo = ProgressBarRangeInfo(
+            current = index.toFloat(),
+            range = 0f..lastIndex.toFloat(),
+            steps = (lastIndex - 1).coerceAtLeast(0)
+        )
+    }
+
+    SliderSettingsItemLayout(
+        icon = icon,
+        title = title,
+        valueText = valueText,
+        subtitle = subtitle,
+        enabled = enabled,
+        progressFraction = progress,
+        onDecrease = {
+            val newIndex = (index - 1).coerceAtLeast(0)
+            val newValue = values[newIndex]
+            if (newValue != selected) onValueChange(newValue)
+        },
+        onIncrease = {
+            val newIndex = (index + 1).coerceAtMost(lastIndex)
+            val newValue = values[newIndex]
+            if (newValue != selected) onValueChange(newValue)
+        },
+        onFocused = onFocused,
+        extraModifier = accessibilityModifier,
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -67,11 +67,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.progressBarRangeInfo
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import com.nuvio.tv.R
 import androidx.compose.ui.text.input.KeyboardType
 import android.view.KeyEvent
@@ -741,16 +736,6 @@ internal fun SliderSettingsItem(
     val lastIndex = values.lastIndex
     val progress = if (lastIndex > 0) index.toFloat() / lastIndex.toFloat() else 0f
 
-    val accessibilityModifier = Modifier.semantics {
-        contentDescription = title
-        stateDescription = valueText
-        progressBarRangeInfo = ProgressBarRangeInfo(
-            current = index.toFloat(),
-            range = 0f..lastIndex.toFloat(),
-            steps = (lastIndex - 1).coerceAtLeast(0)
-        )
-    }
-
     SliderSettingsItemLayout(
         icon = icon,
         title = title,
@@ -769,7 +754,6 @@ internal fun SliderSettingsItem(
             if (newValue != selected) onValueChange(newValue)
         },
         onFocused = onFocused,
-        extraModifier = accessibilityModifier,
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -696,6 +696,41 @@ internal fun SliderSettingsItem(
     onFocused: () -> Unit = {},
     enabled: Boolean = true
 ) {
+    val span = (maxValue - minValue).toFloat()
+    val progress = if (span > 0f) (value - minValue).toFloat() / span else 0f
+
+    SliderSettingsItemLayout(
+        icon = icon,
+        title = title,
+        valueText = valueText,
+        subtitle = subtitle,
+        enabled = enabled,
+        progressFraction = progress,
+        onDecrease = {
+            val newValue = (value - step).coerceAtLeast(minValue)
+            if (newValue != value) onValueChange(newValue)
+        },
+        onIncrease = {
+            val newValue = (value + step).coerceAtMost(maxValue)
+            if (newValue != value) onValueChange(newValue)
+        },
+        onFocused = onFocused,
+    )
+}
+
+@Composable
+private fun SliderSettingsItemLayout(
+    icon: ImageVector,
+    title: String,
+    valueText: String,
+    subtitle: String?,
+    enabled: Boolean,
+    progressFraction: Float,
+    onDecrease: () -> Unit,
+    onIncrease: () -> Unit,
+    onFocused: () -> Unit,
+    extraModifier: Modifier = Modifier,
+) {
     var isFocused by remember { mutableStateOf(false) }
     val contentAlpha = if (enabled) 1f else 0.4f
 
@@ -703,6 +738,7 @@ internal fun SliderSettingsItem(
         onClick = { },
         modifier = Modifier
             .fillMaxWidth()
+            .then(extraModifier)
             .onFocusChanged { state ->
                 val nowFocused = state.isFocused
                 if (isFocused != nowFocused) {
@@ -715,13 +751,11 @@ internal fun SliderSettingsItem(
                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
                 when (event.nativeKeyEvent.keyCode) {
                     KeyEvent.KEYCODE_DPAD_LEFT -> {
-                        val newValue = (value - step).coerceAtLeast(minValue)
-                        if (newValue != value) onValueChange(newValue)
+                        onDecrease()
                         true
                     }
                     KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                        val newValue = (value + step).coerceAtMost(maxValue)
-                        if (newValue != value) onValueChange(newValue)
+                        onIncrease()
                         true
                     }
                     else -> false
@@ -789,21 +823,14 @@ internal fun SliderSettingsItem(
 
             Spacer(modifier = Modifier.height(10.dp))
 
-            // Custom slider controls for TV - use Row with focusable buttons
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                // Decrease button
                 var decreaseFocused by remember { mutableStateOf(false) }
                 Card(
-                    onClick = {
-                        if (enabled) {
-                            val newValue = (value - step).coerceAtLeast(minValue)
-                            onValueChange(newValue)
-                        }
-                    },
+                    onClick = { if (enabled) onDecrease() },
                     modifier = Modifier
                         .onFocusChanged { state ->
                             val nowFocused = state.isFocused
@@ -838,7 +865,6 @@ internal fun SliderSettingsItem(
                     }
                 }
 
-                // Progress bar
                 Box(
                     modifier = Modifier
                         .weight(1f)
@@ -846,25 +872,18 @@ internal fun SliderSettingsItem(
                         .clip(RoundedCornerShape(4.dp))
                         .background(NuvioColors.BackgroundElevated)
                 ) {
-                    val progress = ((value - minValue).toFloat() / (maxValue - minValue).toFloat()).coerceIn(0f, 1f)
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth(progress)
+                            .fillMaxWidth(progressFraction.coerceIn(0f, 1f))
                             .height(8.dp)
                             .clip(RoundedCornerShape(4.dp))
                             .background(NuvioColors.Primary.copy(alpha = contentAlpha))
                     )
                 }
 
-                // Increase button
                 var increaseFocused by remember { mutableStateOf(false) }
                 Card(
-                    onClick = {
-                        if (enabled) {
-                            val newValue = (value + step).coerceAtMost(maxValue)
-                            onValueChange(newValue)
-                        }
-                    },
+                    onClick = { if (enabled) onIncrease() },
                     modifier = Modifier
                         .onFocusChanged { state ->
                             val nowFocused = state.isFocused

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.core.torrent.TorrentSettings
 import com.nuvio.tv.core.player.StreamAutoPlayPolicy
 import com.nuvio.tv.core.player.StreamAutoPlaySelector
 import com.nuvio.tv.data.local.PlayerPreference
+import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamLinkCacheDataStore
@@ -450,7 +451,7 @@ class StreamScreenViewModel @Inject constructor(
 
             // After timeout: if streams arrived, auto-select now; if not, wait for first result from inner job
             val timeoutMs = playerSettings.streamAutoPlayTimeoutSeconds * 1_000L
-            if (timeoutMs > 0L && playerSettings.streamAutoPlayTimeoutSeconds < 11) {
+            if (PlayerSettings.isBoundedTimeout(playerSettings.streamAutoPlayTimeoutSeconds)) {
                 delay(timeoutMs)
             }
             timeoutElapsed = true

--- a/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
@@ -1,0 +1,70 @@
+package com.nuvio.tv.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlayerSettingsTimeoutMigrationTest {
+
+    @Test
+    fun `null stored value returns default of 3 seconds`() {
+        assertEquals(3, PlayerSettings.applyLegacyTimeoutSentinelMigration(null))
+    }
+
+    @Test
+    fun `legacy sentinel 11 translates to unlimited`() {
+        assertEquals(
+            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED,
+            PlayerSettings.applyLegacyTimeoutSentinelMigration(11)
+        )
+    }
+
+    @Test
+    fun `known value 5 passes through unchanged`() {
+        assertEquals(5, PlayerSettings.applyLegacyTimeoutSentinelMigration(5))
+    }
+
+    @Test
+    fun `known value 30 passes through unchanged`() {
+        assertEquals(30, PlayerSettings.applyLegacyTimeoutSentinelMigration(30))
+    }
+
+    @Test
+    fun `current sentinel passes through unchanged`() {
+        assertEquals(
+            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED,
+            PlayerSettings.applyLegacyTimeoutSentinelMigration(PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED)
+        )
+    }
+
+    @Test
+    fun `unknown value 12 snaps to nearest allowed - ties favor lower (10)`() {
+        // 12 is equidistant from 10 and 15; minBy returns the first match.
+        // 10 appears before 15 in STREAM_AUTOPLAY_TIMEOUT_VALUES, so we get 10.
+        assertEquals(10, PlayerSettings.applyLegacyTimeoutSentinelMigration(12))
+    }
+
+    @Test
+    fun `unknown value 13 snaps up to 15`() {
+        assertEquals(15, PlayerSettings.applyLegacyTimeoutSentinelMigration(13))
+    }
+
+    @Test
+    fun `unknown value 99 snaps down to 30`() {
+        assertEquals(30, PlayerSettings.applyLegacyTimeoutSentinelMigration(99))
+    }
+
+    @Test
+    fun `negative value snaps up to 0`() {
+        assertEquals(0, PlayerSettings.applyLegacyTimeoutSentinelMigration(-5))
+    }
+
+    @Test
+    fun `Int MAX_VALUE minus one snaps to unlimited`() {
+        // distance(MAX_VALUE - 1, 30) ~ Int.MAX_VALUE; distance(MAX_VALUE - 1, MAX_VALUE) = 1.
+        // Snaps to the sentinel.
+        assertEquals(
+            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED,
+            PlayerSettings.applyLegacyTimeoutSentinelMigration(Int.MAX_VALUE - 1)
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
@@ -57,12 +57,15 @@ class PlayerSettingsTimeoutMigrationTest {
     }
 
     @Test
-    fun `Int MAX_VALUE minus one snaps to unlimited`() {
-        // distance(MAX_VALUE - 1, 30) ~ Int.MAX_VALUE; distance(MAX_VALUE - 1, MAX_VALUE) = 1.
-        // Snaps to the sentinel.
+    fun `Int MAX_VALUE minus one snaps to 30`() {
         assertEquals(
-            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED,
+            30,
             PlayerSettings.applyLegacyTimeoutSentinelMigration(Int.MAX_VALUE - 1)
         )
+    }
+
+    @Test
+    fun `large unknown value snaps to 30 not unlimited`() {
+        assertEquals(30, PlayerSettings.applyLegacyTimeoutSentinelMigration(1_000_000))
     }
 }

--- a/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
@@ -29,6 +29,17 @@ class PlayerSettingsTimeoutMigrationTest {
     }
 
     @Test
+    fun `every entry in STREAM_AUTOPLAY_TIMEOUT_VALUES passes through unchanged`() {
+        PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES.forEach { value ->
+            assertEquals(
+                "value $value should pass through migration unchanged",
+                value,
+                PlayerSettings.applyLegacyTimeoutSentinelMigration(value)
+            )
+        }
+    }
+
+    @Test
     fun `current sentinel passes through unchanged`() {
         assertEquals(
             PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED,

--- a/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutMigrationTest.kt
@@ -37,9 +37,7 @@ class PlayerSettingsTimeoutMigrationTest {
     }
 
     @Test
-    fun `unknown value 12 snaps to nearest allowed - ties favor lower (10)`() {
-        // 12 is equidistant from 10 and 15; minBy returns the first match.
-        // 10 appears before 15 in STREAM_AUTOPLAY_TIMEOUT_VALUES, so we get 10.
+    fun `unknown value 12 snaps down to 10 (closer than 15)`() {
         assertEquals(10, PlayerSettings.applyLegacyTimeoutSentinelMigration(12))
     }
 

--- a/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutPredicateTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutPredicateTest.kt
@@ -41,4 +41,38 @@ class PlayerSettingsTimeoutPredicateTest {
         assertTrue(25 in list)
         assertTrue(30 in list)
     }
+
+    @Test
+    fun `isBoundedTimeout returns false for zero (instant)`() {
+        assertFalse(PlayerSettings.isBoundedTimeout(0))
+    }
+
+    @Test
+    fun `isBoundedTimeout returns true for 1 second`() {
+        assertTrue(PlayerSettings.isBoundedTimeout(1))
+    }
+
+    @Test
+    fun `isBoundedTimeout returns true for 10 seconds (old max)`() {
+        assertTrue(PlayerSettings.isBoundedTimeout(10))
+    }
+
+    @Test
+    fun `isBoundedTimeout returns true for new values 15 20 25 30`() {
+        assertTrue(PlayerSettings.isBoundedTimeout(15))
+        assertTrue(PlayerSettings.isBoundedTimeout(20))
+        assertTrue(PlayerSettings.isBoundedTimeout(25))
+        assertTrue(PlayerSettings.isBoundedTimeout(30))
+    }
+
+    @Test
+    fun `isBoundedTimeout returns false for the unlimited sentinel`() {
+        assertFalse(PlayerSettings.isBoundedTimeout(PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED))
+    }
+
+    @Test
+    fun `isBoundedTimeout returns false for negative values (defensive)`() {
+        assertFalse(PlayerSettings.isBoundedTimeout(-5))
+        assertFalse(PlayerSettings.isBoundedTimeout(-1))
+    }
 }

--- a/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutPredicateTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/PlayerSettingsTimeoutPredicateTest.kt
@@ -1,0 +1,44 @@
+package com.nuvio.tv.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayerSettingsTimeoutPredicateTest {
+
+    @Test
+    fun `value list last entry equals unlimited sentinel`() {
+        assertEquals(
+            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED,
+            PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES.last()
+        )
+    }
+
+    @Test
+    fun `value list is sorted ascending`() {
+        val list = PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES
+        assertEquals(list, list.sorted())
+    }
+
+    @Test
+    fun `value list contains zero (instant)`() {
+        assertTrue(0 in PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES)
+    }
+
+    @Test
+    fun `unlimited sentinel does not collide with a real value`() {
+        val withoutSentinel = PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES.dropLast(1)
+        assertFalse(PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED in withoutSentinel)
+    }
+
+    @Test
+    fun `value list contains expected ten-to-thirty entries`() {
+        val list = PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES
+        assertTrue(10 in list)
+        assertTrue(15 in list)
+        assertTrue(20 in list)
+        assertTrue(25 in list)
+        assertTrue(30 in list)
+    }
+}


### PR DESCRIPTION
## Summary
Raises the Stream Selection Timeout slider's upper bound from 10s to 30s with a non-linear discrete value list: `[Instant, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, Unlimited]`. The four new mid-range stops (15, 20, 25, 30) give users with slower addons a middle ground between "give up at 10s" and "Unlimited."

Touches data (`PlayerSettingsDataStore.kt`: sentinel, migration, predicate), runtime (two call sites swap `timeoutSeconds < 11` for `isBoundedTimeout()`), and UI (`PlaybackSettingsScreen.kt`: new discrete-value `SliderSettingsItem` overload). Legacy `11` sentinel migrates to `Int.MAX_VALUE`. No DataStore schema change.

## PR type
- [x] Approved larger or directional change

## Why
The 0-10s cap was set when addons returned streams in 1-3s. AIOStreams users (sequential Group 1 to Group 2 fan-out) routinely see 12-18s load times on obscure titles. At 10s, auto-play fires before Group 2 returns and picks from a thin pool. Users either accept worse auto-picks or set Instant and pick manually.

Raising to 30s lets Group 2 finish (~18s worst case) without forcing Unlimited. Non-linear stops: 1s in 0-10s, 5s in 10-30s. Keeps the slider usable at TV distance.

## Issue or approval
Issue #1926.

## UI / behavior impact
- [x] No UI change
- [x] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
- Only this slider's value range changes. The 7 sibling `SliderSettingsItem` call sites use the existing linear overload unchanged.
- No DataStore schema change. Stored values 0-10 and 11 round-trip correctly through the migration.
- No change to auto-play decision logic, `StreamAutoPlayPolicy`, `StreamAutoPlaySelector`, modes, source filtering, or addon-internal timeouts.

## Testing
Manually verified on Android TV (Raspberry Pi 5, LineageOS 21 / Android 14, `:app:installFullDebug`):

**Slider UI:** all 16 stops render in order. D-pad steps cleanly, no intermediate values. Default 3s on fresh install. Value label updates live.

**Runtime behavior:** Instant, 5s, 15s, 30s, Unlimited tested end-to-end against timestamped logs. All behaved as expected, no crashes or unexpected timing.

**Migration:** legacy `11` resolves to `STREAM_AUTOPLAY_TIMEOUT_UNLIMITED`. Known values pass through. Unknown snap to nearest valid (`12 -> 10`, `13 -> 15`, `99 -> 30`, `-5 -> 0`); sentinel excluded from snap pool so large values clamp to 30. `null` defaults to 3.

**Persistence:** all values survive force-stop + relaunch.

**Auto-play modes:** `FIRST_STREAM` works per above. `REGEX_MATCH` with an empty/invalid pattern bypasses direct auto-play immediately (manual picker). `REGEX_MATCH` with a valid but unmatching pattern falls through to manual picker after timeout. `MANUAL` unaffected.

**No regression:** picker, manual picking, and 7 sibling sliders unchanged. Two runtime call sites route through `isBoundedTimeout`; behavior preserved for legacy values (0-10, Unlimited) and intentionally engages the delay for the new values 15-30.

**JVM unit tests:** `PlayerSettingsTimeoutMigrationTest` (12) and `PlayerSettingsTimeoutPredicateTest` (11) cover migration paths, value list integrity, and predicate coverage.

### Note on the full unit test suite
Verified all new tests pass by temporarily moving 5 pre-existing broken test files out of the test sourceset (unrelated to my changes), running `./gradlew :app:testFullDebugUnitTest`, and restoring the files. All new tests passed.

## Screenshots / Video
Not a UI change. Slider visuals identical; only the value range expanded.

## Breaking changes
None. Legacy `11` migrates to `Int.MAX_VALUE` on first read. Stored values 0-10 round-trip identically. No schema change, no field rename. `streamAutoPlayTimeoutSeconds: Int` type and default (3) unchanged.

## Linked issues
#1926.
