### PR TITLE
Fix player exit from CW, sync push after pull, parental guide setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -331,12 +331,16 @@ class StartupSyncService @Inject constructor(
                 try {
                     val remoteWatchedItems = watchedItemsSyncService.pullFromRemote().getOrElse { throw it }
                     Log.d(TAG, "Pulled ${remoteWatchedItems.size} watched items from remote")
-                    watchedItemsPreferences.replaceWithRemoteItems(
+                    val hadUnsyncedItems = watchedItemsPreferences.replaceWithRemoteItems(
                         remoteWatchedItems,
                         lastSuccessfulPushMs = watchedItemsSyncService.lastSuccessfulPushMs
                     )
                     watchProgressRepository.hasCompletedInitialWatchedItemsPull = true
                     Log.d(TAG, "Reconciled local watched items with ${remoteWatchedItems.size} remote items")
+                    if (hadUnsyncedItems) {
+                        Log.d(TAG, "Detected unsynced watched items, pushing to remote")
+                        watchedItemsSyncService.pushToRemote()
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to pull watched items, continuing with other syncs", e)
                 }
@@ -345,12 +349,16 @@ class StartupSyncService @Inject constructor(
                 try {
                     val remoteEntries = watchProgressSyncService.pullFromRemote().getOrElse { throw it }
                     Log.d(TAG, "Pulled ${remoteEntries.size} watch progress entries from remote")
-                    watchProgressPreferences.mergeRemoteEntries(
+                    val hadUnsyncedProgress = watchProgressPreferences.mergeRemoteEntries(
                         remoteEntries.toMap(),
                         lastSuccessfulPushMs = watchProgressSyncService.lastSuccessfulPushMs
                     )
                     watchProgressRepository.hasCompletedInitialPull = true
                     Log.d(TAG, "Merged local watch progress with ${remoteEntries.size} remote entries")
+                    if (hadUnsyncedProgress) {
+                        Log.d(TAG, "Detected unsynced watch progress, pushing to remote")
+                        watchProgressSyncService.pushToRemote()
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to pull watch progress, continuing", e)
                 } finally {
@@ -362,12 +370,16 @@ class StartupSyncService @Inject constructor(
                 try {
                     val remoteWatchedItems = watchedItemsSyncService.pullFromRemote().getOrElse { throw it }
                     Log.d(TAG, "Pulled ${remoteWatchedItems.size} watched items from remote")
-                    watchedItemsPreferences.replaceWithRemoteItems(
+                    val hadUnsyncedItems = watchedItemsPreferences.replaceWithRemoteItems(
                         remoteWatchedItems,
                         lastSuccessfulPushMs = watchedItemsSyncService.lastSuccessfulPushMs
                     )
                     watchProgressRepository.hasCompletedInitialWatchedItemsPull = true
                     Log.d(TAG, "Reconciled local watched items with ${remoteWatchedItems.size} remote items")
+                    if (hadUnsyncedItems) {
+                        Log.d(TAG, "Detected unsynced watched items (Trakt mode), pushing to remote")
+                        watchedItemsSyncService.pushToRemote()
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to pull watched items, continuing with Trakt library mode", e)
                 }

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -180,6 +180,7 @@ data class PlayerSettings(
     val pauseOverlayEnabled: Boolean = true,
     val osdClockEnabled: Boolean = true,
     val skipIntroEnabled: Boolean = true,
+    val parentalGuideEnabled: Boolean = true,
     val autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet(),
     // Dolby Vision Profile 7 → HEVC fallback (requires forked ExoPlayer)
     val mapDV7ToHevc: Boolean = false,
@@ -339,6 +340,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val pauseOverlayEnabledKey = booleanPreferencesKey("pause_overlay_enabled")
     private val osdClockEnabledKey = booleanPreferencesKey("osd_clock_enabled")
     private val skipIntroEnabledKey = booleanPreferencesKey("skip_intro_enabled")
+    private val parentalGuideEnabledKey = booleanPreferencesKey("parental_guide_enabled")
     private val autoSkipSegmentTypesKey = stringSetPreferencesKey("auto_skip_segment_types")
     private val mapDV7ToHevcKey = booleanPreferencesKey("map_dv7_to_hevc")
     private val mpvHardwareDecodeModeKey = stringPreferencesKey("mpv_hardware_decode_mode")
@@ -516,6 +518,7 @@ class PlayerSettingsDataStore @Inject constructor(
                 pauseOverlayEnabled = prefs[pauseOverlayEnabledKey] ?: true,
                 osdClockEnabled = prefs[osdClockEnabledKey] ?: true,
                 skipIntroEnabled = prefs[skipIntroEnabledKey] ?: true,
+                parentalGuideEnabled = prefs[parentalGuideEnabledKey] ?: true,
                 autoSkipSegmentTypes = prefs[autoSkipSegmentTypesKey]
                     ?.mapNotNull(AutoSkipSegmentType::fromStoredValue)
                     ?.toSet()
@@ -729,6 +732,12 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setSkipIntroEnabled(enabled: Boolean) {
         store().edit { prefs ->
             prefs[skipIntroEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setParentalGuideEnabled(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[parentalGuideEnabledKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -268,7 +268,8 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Merges remote entries into local storage. Newer lastWatched wins per key.
      */
-    suspend fun mergeRemoteEntries(remoteEntries: Map<String, WatchProgress>, lastSuccessfulPushMs: Long = 0L) {
+    suspend fun mergeRemoteEntries(remoteEntries: Map<String, WatchProgress>, lastSuccessfulPushMs: Long = 0L): Boolean {
+        var preservedLocalItems = false
         Log.d("WatchProgressPrefs", "mergeRemoteEntries: ${remoteEntries.size} remote entries, lastPushMs=$lastSuccessfulPushMs")
         store().edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
@@ -284,6 +285,7 @@ class WatchProgressPreferences @Inject constructor(
                     val localEntry = local[key]
                     if (localEntry != null && localEntry.lastWatched > lastSuccessfulPushMs) {
                         Log.d("WatchProgressPrefs", "  preserved key=$key (lastWatched=${localEntry.lastWatched} > lastPush=$lastSuccessfulPushMs)")
+                        preservedLocalItems = true
                     } else {
                         local.remove(key)
                         Log.d("WatchProgressPrefs", "  removed key=$key (not in remote)")
@@ -298,6 +300,7 @@ class WatchProgressPreferences @Inject constructor(
                     Log.d("WatchProgressPrefs", "  merged key=$key (existing=${existing != null})")
                 } else {
                     Log.d("WatchProgressPrefs", "  skipped key=$key (local is newer)")
+                    preservedLocalItems = true
                 }
             }
 
@@ -305,6 +308,7 @@ class WatchProgressPreferences @Inject constructor(
             Log.d("WatchProgressPrefs", "mergeRemoteEntries: ${pruned.size} entries after prune, writing to DataStore")
             preferences[watchProgressKey] = gson.toJson(pruned)
         }
+        return preservedLocalItems
     }
 
     suspend fun replaceWithRemoteEntries(remoteEntries: Map<String, WatchProgress>) {

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -163,7 +163,8 @@ class WatchedItemsPreferences @Inject constructor(
         }
     }
 
-    suspend fun replaceWithRemoteItems(remoteItems: List<WatchedItem>, lastSuccessfulPushMs: Long = 0L) {
+    suspend fun replaceWithRemoteItems(remoteItems: List<WatchedItem>, lastSuccessfulPushMs: Long = 0L): Boolean {
+        var preservedLocalItems = false
         store().edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             if (remoteItems.isEmpty() && current.isNotEmpty()) {
@@ -185,6 +186,7 @@ class WatchedItemsPreferences @Inject constructor(
                     val key = Triple(localItem.contentId, localItem.season, localItem.episode)
                     if (key !in deduped && localItem.watchedAt > lastSuccessfulPushMs) {
                         deduped[key] = localItem
+                        preservedLocalItems = true
                         Log.d(TAG, "replaceWithRemoteItems: preserved local item ${localItem.contentId} s${localItem.season}e${localItem.episode} (watchedAt=${localItem.watchedAt} > lastPush=$lastSuccessfulPushMs)")
                     }
                 }
@@ -193,6 +195,7 @@ class WatchedItemsPreferences @Inject constructor(
                 .map { gson.toJson(it) }
                 .toSet()
         }
+        return preservedLocalItems
     }
 
     suspend fun clearAll() {

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -109,11 +109,14 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 if (isSyncingFromRemote || !hasCompletedInitialPull || !authManager.isAuthenticated) continue
                 watchProgressSyncService.pullFromRemote()
                     .onSuccess { entries ->
-                        watchProgressPreferences.mergeRemoteEntries(
+                        val hadUnsynced = watchProgressPreferences.mergeRemoteEntries(
                             entries.toMap(),
                             lastSuccessfulPushMs = watchProgressSyncService.lastSuccessfulPushMs
                         )
                         Log.d(TAG, "Periodic Nuvio Sync pull: merged ${entries.size} entries")
+                        if (hadUnsynced) {
+                            watchProgressSyncService.pushToRemote()
+                        }
                     }
                     .onFailure { Log.w(TAG, "Periodic Nuvio Sync pull failed", it) }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -848,12 +848,69 @@ fun NuvioNavHost(
                                 detailEntry.savedStateHandle["heroRestoreToken"] = token
                                 navController.popBackStack(Screen.Detail.route, inclusive = false)
                             } else {
-                                navController.popBackStack(Screen.Stream.route, inclusive = true)
+                                val contentId = args?.getString("contentId").orEmpty()
+                                val contentType = args?.getString("contentType").orEmpty()
+                                val returnToHomeOnBack = args?.getString("returnToHomeOnBack")
+                                    ?.toBooleanStrictOrNull() == true
+                                if (contentId.isNotBlank()) {
+                                    navController.navigate(
+                                        Screen.Detail.createRoute(
+                                            itemId = contentId,
+                                            itemType = contentType,
+                                            addonBaseUrl = null,
+                                            returnToHomeOnBack = returnToHomeOnBack
+                                        )
+                                    ) {
+                                        popUpTo(Screen.Player.route) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                } else {
+                                    val poppedToStream = navController.popBackStack(Screen.Stream.route, inclusive = true)
+                                    if (!poppedToStream) {
+                                        navController.popBackStack()
+                                    }
+                                }
                             }
                         } else {
-                            val poppedToDetail = navController.popBackStack(Screen.Detail.route, inclusive = false)
-                            if (!poppedToDetail) {
-                                navController.popBackStack(Screen.Stream.route, inclusive = true)
+                            val contentId = args?.getString("contentId").orEmpty()
+                            val contentType = args?.getString("contentType").orEmpty()
+                            val returnToHomeOnBack = args?.getString("returnToHomeOnBack")
+                                ?.toBooleanStrictOrNull() == true
+                            val focusSeason = args?.getString("season")?.toIntOrNull()
+                            val focusEpisode = args?.getString("episode")?.toIntOrNull()
+                            if (contentId.isNotBlank()) {
+                                val detailEntry = navController.currentBackStack.value
+                                    .lastOrNull {
+                                        val itemId = it.arguments?.getString("itemId").orEmpty()
+                                        val itemType = it.arguments?.getString("itemType").orEmpty()
+                                        it.destination.route?.startsWith("detail/") == true &&
+                                            itemId == contentId &&
+                                            (itemType.isBlank() || contentType.isBlank() || itemType.equals(contentType, ignoreCase = true))
+                                    }
+                                if (detailEntry != null) {
+                                    detailEntry.savedStateHandle["returnFocusSeason"] = focusSeason
+                                    detailEntry.savedStateHandle["returnFocusEpisode"] = focusEpisode
+                                    navController.popBackStack(Screen.Detail.route, inclusive = false)
+                                } else {
+                                    navController.navigate(
+                                        Screen.Detail.createRoute(
+                                            itemId = contentId,
+                                            itemType = contentType,
+                                            addonBaseUrl = null,
+                                            returnFocusSeason = focusSeason,
+                                            returnFocusEpisode = focusEpisode,
+                                            returnToHomeOnBack = returnToHomeOnBack
+                                        )
+                                    ) {
+                                        popUpTo(Screen.Player.route) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                }
+                            } else {
+                                val poppedToStream = navController.popBackStack(Screen.Stream.route, inclusive = true)
+                                if (!poppedToStream) {
+                                    navController.popBackStack()
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -608,7 +608,10 @@ class AccountViewModel @Inject constructor(
                 watchProgressRepository.isSyncingFromRemote = true
                 val remoteEntries = watchProgressSyncService.pullFromRemote().getOrElse { throw it }
                 Log.d("AccountViewModel", "pullRemoteData: pulled ${remoteEntries.size} watch progress entries")
-                watchProgressPreferences.replaceWithRemoteEntries(remoteEntries.toMap())
+                watchProgressPreferences.mergeRemoteEntries(
+                    remoteEntries.toMap(),
+                    lastSuccessfulPushMs = watchProgressSyncService.lastSuccessfulPushMs
+                )
                 Log.d("AccountViewModel", "pullRemoteData: reconciled local watch progress with ${remoteEntries.size} remote entries")
                 watchProgressRepository.isSyncingFromRemote = false
 
@@ -633,8 +636,11 @@ class AccountViewModel @Inject constructor(
                 watchProgressRepository.isSyncingFromRemote = true
                 val remoteEntries = watchProgressSyncService.pullFromRemote().getOrElse { throw it }
                 Log.d("AccountViewModel", "pullRemoteData: pulled ${remoteEntries.size} watch progress entries in Trakt mode")
-                watchProgressPreferences.replaceWithRemoteEntries(remoteEntries.toMap())
-                Log.d("AccountViewModel", "pullRemoteData: replaced local watch progress with ${remoteEntries.size} remote entries")
+                watchProgressPreferences.mergeRemoteEntries(
+                    remoteEntries.toMap(),
+                    lastSuccessfulPushMs = watchProgressSyncService.lastSuccessfulPushMs
+                )
+                Log.d("AccountViewModel", "pullRemoteData: merged local watch progress with ${remoteEntries.size} remote entries")
                 watchProgressRepository.isSyncingFromRemote = false
 
                 val remoteWatchedItems = watchedItemsSyncService.pullFromRemote().getOrElse { throw it }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -277,6 +277,7 @@ class PlayerRuntimeController(
     
     internal var skipIntervals: List<SkipInterval> = emptyList()
     internal var skipIntroEnabled: Boolean = true
+    internal var parentalGuideEnabled: Boolean = true
     internal var autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet()
     internal var playerSettingsInitialized: Boolean = false
     internal var skipIntroFetchedKey: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -412,6 +412,7 @@ internal fun PlayerRuntimeController.initializePlayer(
 
                 addListener(object : Player.Listener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (isReleasingPlayer) return
                         val playerDuration = duration
                         if (playerDuration > lastKnownDuration) {
                             lastKnownDuration = playerDuration

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -409,6 +409,7 @@ internal fun PlayerRuntimeController.tryShowParentalGuide() {
 }
 
 internal fun PlayerRuntimeController.fetchParentalGuide(id: String?, type: String?, season: Int?, episode: Int?) {
+    if (!parentalGuideEnabled) return
     if (id.isNullOrBlank()) return
 
     val imdbId = id.split(":").firstOrNull()?.takeIf { it.startsWith("tt") } ?: return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -373,6 +373,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
 
             val wasEnabled = skipIntroEnabled
             skipIntroEnabled = settings.skipIntroEnabled
+            parentalGuideEnabled = settings.parentalGuideEnabled
             autoSkipSegmentTypes = settings.autoSkipSegmentTypes
             playerSettingsInitialized = true
             if (!skipIntroEnabled) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -154,8 +154,8 @@ fun PlayerScreen(
     var subtitleDelayAutoSyncFocused by remember { mutableStateOf(false) }
     var subtitleTimingConsumeNextConfirmKeyUp by remember { mutableStateOf(false) }
     val exitPlayer: () -> Unit = {
-        viewModel.stopAndRelease()
         val timeline = viewModel.playbackTimeline.value
+        viewModel.stopAndRelease()
         val completed = timeline.duration > 0L &&
             (timeline.currentPosition.toFloat() / timeline.duration.toFloat()) >= WatchProgress.COMPLETED_THRESHOLD
         onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL, completed)
@@ -911,8 +911,8 @@ fun PlayerScreen(
                     val url = viewModel.getCurrentStreamUrl()
                     val title = uiState.title
                     val headers = viewModel.getCurrentHeaders()
-                    viewModel.stopAndRelease()
                     val timeline = viewModel.playbackTimeline.value
+                    viewModel.stopAndRelease()
                     val completed = timeline.duration > 0L &&
                         (timeline.currentPosition.toFloat() / timeline.duration.toFloat()) >= WatchProgress.COMPLETED_THRESHOLD
                     onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL, completed)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -260,6 +260,7 @@ fun PlaybackSettingsContent(
                 onSetPauseOverlayEnabled = { enabled -> coroutineScope.launch { viewModel.setPauseOverlayEnabled(enabled) } },
                 onSetOsdClockEnabled = { enabled -> coroutineScope.launch { viewModel.setOsdClockEnabled(enabled) } },
                 onSetSkipIntroEnabled = { enabled -> coroutineScope.launch { viewModel.setSkipIntroEnabled(enabled) } },
+                onSetParentalGuideEnabled = { enabled -> coroutineScope.launch { viewModel.setParentalGuideEnabled(enabled) } },
                 onSetAutoSkipSegmentTypeEnabled = { segmentType, enabled ->
                     coroutineScope.launch { viewModel.setAutoSkipSegmentTypeEnabled(segmentType, enabled) }
                 },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -136,6 +136,7 @@ internal fun PlaybackSettingsSections(
     onSetPauseOverlayEnabled: (Boolean) -> Unit,
     onSetOsdClockEnabled: (Boolean) -> Unit,
     onSetSkipIntroEnabled: (Boolean) -> Unit,
+    onSetParentalGuideEnabled: (Boolean) -> Unit,
     onSetAutoSkipSegmentTypeEnabled: (AutoSkipSegmentType, Boolean) -> Unit,
     onSetFrameRateMatchingMode: (FrameRateMatchingMode) -> Unit,
     onSetResolutionMatchingEnabled: (Boolean) -> Unit,
@@ -336,6 +337,18 @@ internal fun PlaybackSettingsSections(
                     subtitle = stringResource(R.string.playback_skip_intro_sub),
                     isChecked = playerSettings.skipIntroEnabled,
                     onCheckedChange = onSetSkipIntroEnabled,
+                    onFocused = { focusedSection = PlaybackSection.GENERAL },
+                    enabled = !generalUi.isExternalPlayer
+                )
+            }
+
+            item(key = "general_parental_guide") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.Info,
+                    title = stringResource(R.string.playback_parental_guide),
+                    subtitle = stringResource(R.string.playback_parental_guide_sub),
+                    isChecked = playerSettings.parentalGuideEnabled,
+                    onCheckedChange = onSetParentalGuideEnabled,
                     onFocused = { focusedSection = PlaybackSection.GENERAL },
                     enabled = !generalUi.isExternalPlayer
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -129,6 +129,10 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setSkipIntroEnabled(enabled)
     }
 
+    suspend fun setParentalGuideEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setParentalGuideEnabled(enabled)
+    }
+
     suspend fun setAutoSkipSegmentTypeEnabled(segmentType: AutoSkipSegmentType, enabled: Boolean) {
         playerSettingsDataStore.setAutoSkipSegmentTypeEnabled(segmentType, enabled)
     }

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -800,6 +800,10 @@
     <string name="next_episode_finding_source">Szukanie źródła…</string>
     <string name="next_episode_playing_via">Odtwarzanie przez %1$s za %2$ds</string>
     <string name="next_episode_play">Odtwórz</string>
+    <string name="player_next_episode_prompt_title">Kontynuować oglądanie?</string>
+    <string name="player_next_episode_prompt_message">Czy chcesz odtworzyć następny odcinek?</string>
+    <string name="player_next_episode_prompt_yes">Tak</string>
+    <string name="player_next_episode_prompt_no">Nie, wróć do szczegółów</string>
     <string name="next_episode_unaired">Niewyemitowany</string>
     <string name="next_episode_not_aired_yet">Następny odcinek nie został jeszcze wyemitowany</string>
     <string name="skip_intro">Pomiń czołówkę</string>
@@ -915,6 +919,10 @@
     <string name="plugin_providers_section">Dostawcy (%1$d)</string>
     <string name="plugin_title">Wtyczki</string>
     <string name="plugin_subtitle">Zarządzaj lokalnymi scraperami i dostawcami</string>
+    <string name="plugin_enable_plugins_title">Włącz dostawców wtyczek globalnie</string>
+    <string name="plugin_enable_plugins_subtitle">Używaj dostawców wtyczek podczas wyszukiwania strumieni</string>
+    <string name="plugin_group_by_repository_title">Grupuj dostawców wtyczek wg repozytorium</string>
+    <string name="plugin_group_by_repository_subtitle">W Strumieniach pokazuj jednego dostawcę na repozytorium zamiast jednego na źródło</string>
     <string name="plugin_add_repository">Dodaj repozytorium</string>
     <string name="plugin_add_btn">Dodaj</string>
     <string name="plugin_manage_from_phone_title">Zarządzaj z telefonu</string>
@@ -1145,6 +1153,7 @@
     <string name="tmdb_entity_rail_popular">Popularne</string>
     <string name="tmdb_entity_rail_top_rated">Najwyżej oceniane</string>
     <string name="tmdb_entity_rail_recent">Ostatnie</string>
+    <string name="tmdb_entity_rail_most_voted">Najwięcej głosów</string>
     <string name="tmdb_entity_empty_title">Nie znaleziono tytułów</string>
     <string name="tmdb_entity_empty_subtitle">TMDB nie ma obecnie przeglądanych tytułów dla tego wyboru.</string>
 
@@ -1461,6 +1470,9 @@
 
     <!-- Collection Management -->
     <string name="collections_header">Kolekcje</string>
+    <string name="collections_delete_confirm_title">Usunąć kolekcję?</string>
+    <string name="collections_delete_confirm">Usuń</string>
+    <string name="collections_delete_confirm_subtitle">Spowoduje to trwałe usunięcie \"%1$s\". Tej operacji nie można cofnąć.</string>
     <string name="collections_empty">Brak kolekcji. Utwórz jedną, aby uporządkować katalogi.</string>
     <string name="collections_new">Nowa kolekcja</string>
     <string name="collections_import">Importuj</string>
@@ -1712,6 +1724,8 @@
     <string name="collection_editor_choice_both">Oba</string>
     <string name="collection_editor_folder_count_one">%1$d element</string>
     <string name="collection_editor_folder_count_other">%1$d elementów</string>
+    <string name="collections_editor_delete_folder_title">Usunąć folder?</string>
+    <string name="collections_editor_delete_folder_subtitle">Spowoduje to trwałe usunięcie \"%1$s\" i jego zawartości.</string>
     <string name="collection_editor_remove_cd">Usuń</string>
     <string name="collection_editor_resolved_trakt_list">Rozwiązana lista Trakt</string>
     <string name="collection_editor_trakt_name_placeholder">Weekend Watch, Award Winners</string>
@@ -1786,6 +1800,13 @@
     <string name="collections_editor_tmdb_rating_max_placeholder">10</string>
     <string name="collections_editor_tmdb_rating_min_placeholder">7.0</string>
     <string name="collections_editor_tmdb_tv_title_placeholder">Best Action Movies, Korean Dramas, 2024 Animation</string>
+    <string name="collections_editor_tmdb_watch_region">Region oglądania</string>
+    <string name="collections_editor_tmdb_watch_region_helper">Kod kraju ISO 3166-1, w którym tytuł jest dostępny. Przykład: US, GB.</string>
+    <string name="collections_editor_tmdb_quick_watch_regions">Szybki wybór regionu</string>
+    <string name="collections_editor_tmdb_watch_providers">ID dostawców oglądania</string>
+    <string name="collections_editor_tmdb_watch_providers_helper">Użyj ID dostawców TMDB. Oddziel przecinkami dla AND lub pionowymi kreskami dla OR.</string>
+    <string name="collections_editor_tmdb_watch_providers_placeholder">8|337|350</string>
+    <string name="collections_editor_tmdb_quick_watch_providers">Szybki wybór platformy</string>
     <string name="collections_editor_tmdb_votes_min_placeholder">100</string>
     <string name="collections_editor_tmdb_year_placeholder">2024</string>
     <string name="collections_editor_trakt_ascending">Rosnąco</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -176,7 +176,7 @@
     <string name="playback_skip_intro">Pomiń intro</string>
     <string name="playback_skip_intro_sub">Używaj introdb.app do wykrywania intro i podsumowań.</string>
     <string name="playback_parental_guide">Ostrzeżenie o charakterze treści</string>
-    <string name="playback_parental_guide_sub">Pokaż ostrzeżenie o nagości, przemocy i wulgarności przed odtwarzaniem.</string>
+    <string name="playback_parental_guide_sub">Pokaż ostrzeżenie o nagości, przemocy i wulgarności na początku odtwarzania.</string>
     <string name="playback_auto_frame_rate">Auto częstotliwość odświeżania</string>
     <string name="playback_section_player">Odtwarzacz i wybór źródła</string>
     <string name="playback_section_player_desc">Preferencje odtwarzacza, auto-play i filtrowanie źródeł.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -175,6 +175,8 @@
     <string name="playback_osd_clock">Zegar OSD</string>
     <string name="playback_skip_intro">Pomiń intro</string>
     <string name="playback_skip_intro_sub">Używaj introdb.app do wykrywania intro i podsumowań.</string>
+    <string name="playback_parental_guide">Ostrzeżenie o charakterze treści</string>
+    <string name="playback_parental_guide_sub">Pokaż ostrzeżenie o nagości, przemocy i wulgarności przed odtwarzaniem.</string>
     <string name="playback_auto_frame_rate">Auto częstotliwość odświeżania</string>
     <string name="playback_section_player">Odtwarzacz i wybór źródła</string>
     <string name="playback_section_player_desc">Preferencje odtwarzacza, auto-play i filtrowanie źródeł.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -548,6 +548,8 @@
     <string name="playback_osd_clock">OSD Clock</string>
     <string name="playback_skip_intro">Skip Intro</string>
     <string name="playback_skip_intro_sub">Use introdb.app to detect intros and recaps.</string>
+    <string name="playback_parental_guide">Content Warnings</string>
+    <string name="playback_parental_guide_sub">Show parental guidance overlay when playback starts.</string>
     <string name="playback_auto_skip_segments">Automatic Skipping</string>
     <string name="playback_auto_skip_segments_sub">Choose which segments skip automatically.</string>
     <string name="auto_skip_intro">Intro / Opening</string>


### PR DESCRIPTION
## Summary

- Fix unsynced watch progress and watched items not being pushed to remote after pull
- Fix player stuck on last frame after movie/episode ends when launched from Continue Watching
- Add Parental Guide toggle setting (Playback -> General, under Skip Intro)
- Add missing Polish translations 

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

1. **Sync push after pull**: After pulling remote watch progress/watched items, locally preserved items (newer than last push) were never pushed back. This caused data loss when switching devices - local progress that hadn't been synced yet was silently dropped.
2. **Player exit bug**: When playback finishes from Continue Watching, the player stays stuck on the last frame. Three root causes: `stopAndRelease()` resets the timeline before `playbackCompleted` is calculated, `onPlaybackEnded` doesn't handle missing Detail on back stack (CW flow is Home -> Stream -> Player, no Detail), and ExoPlayer's `STATE_IDLE` during release resets `playbackEnded` cancelling the exit effect.
3. **Parental Guide setting**: The content warnings overlay had no user toggle - users couldn't disable it.
4. **Translations**: added missing Polish strings for collections, plugins, TMDB filters, and next episode prompt.

## Issue or approval

No linked issue - sync issue discovered during testing, player exit bug (#282). Parental guide setting is a logical addition to existing feature

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Sync fix only adds a push after pull when unsynced local items are detected; no changes to merge/reconciliation logic itself
- Player exit fix only affects navigation after playback ends, not during playback
- Parental guide setting only skips the API fetch when disabled
- AccountViewModel now uses `mergeRemoteEntries` instead of `replaceWithRemoteEntries` for consistency

## Testing

- Sync: added local watch progress, pulled remote -> verified local items pushed back to remote
- Sync: periodic pull with unsynced items -> push triggered automatically
- Launched movie from Continue Watching -> let it end -> player exits to Detail (previously stuck)
- Pressed back at >90% from CW -> navigates to Detail correctly
- Last episode of season from CW -> exits correctly after end
- Normal flow from Detail -> Stream -> Player -> back/end still works as before
- Parental Guide toggle off -> overlay no longer shown on playback start
- Parental Guide toggle on -> overlay appears as before
- Tested on physical Android TV device

## Screenshots / Video

Not a UI change (new toggle follows existing ToggleSettingsItem pattern identical to Skip Intro).

## Breaking changes

None.

## Linked issues

No linked issue - sync issue found during testing, player exit bug reported by beta tester on Discord.
