### PR TITLE
fix(i18n): add 156 missing French translations

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2226,4 +2226,102 @@
     <string name="trakt_related_error_request_failed">Échec du chargement des contenus similaires Trakt</string>
     <string name="trakt_comments_error_request_failed">Échec de la requête de commentaires Trakt</string>
     <string name="trakt_library_error_fetch_list_items">Échec de la récupération des éléments de la liste</string>
+
+    <!-- Épisodes&#160;: marquage des saisons précédentes -->
+    <string name="episodes_mark_previous_seasons_watched">Marquer les saisons précédentes comme vues</string>
+    <string name="detail_all_previous_seasons_watched">Toutes les saisons précédentes déjà vues</string>
+
+    <!-- Rail entité TMDB -->
+    <string name="tmdb_entity_rail_most_voted">Les plus votés</string>
+
+    <!-- Éditeur de collection&#160;: régions et fournisseurs de visionnage TMDB -->
+    <string name="collections_editor_tmdb_watch_region">Région de visionnage</string>
+    <string name="collections_editor_tmdb_watch_region_helper">Code pays ISO 3166-1 où le titre est disponible. Exemple&#160;: US, GB.</string>
+    <string name="collections_editor_tmdb_quick_watch_regions">Régions de visionnage rapides</string>
+    <string name="collections_editor_tmdb_watch_providers">ID de fournisseurs de visionnage</string>
+    <string name="collections_editor_tmdb_watch_providers_helper">Utilise les ID de fournisseurs de visionnage TMDB. Sépare-les par des virgules pour ET, ou par des barres verticales pour OU.</string>
+    <string name="collections_editor_tmdb_watch_providers_placeholder">8|337|350</string>
+    <string name="collections_editor_tmdb_quick_watch_providers">Fournisseurs de visionnage rapides</string>
+
+    <!-- Licences &amp; attributions -->
+    <string name="about_licenses_attributions">Licences &amp; attributions</string>
+    <string name="about_licenses_attributions_subtitle">Sources de données, remerciements et licences Android</string>
+    <string name="licenses_attributions_title">Licences &amp; attributions</string>
+    <string name="licenses_attributions_subtitle">Fournisseurs de données, crédits de services et licences de lecture Android utilisés par Nuvio TV.</string>
+    <string name="licenses_attributions_section_app">LICENCE DE L’APPLICATION</string>
+    <string name="licenses_attributions_section_data">DONNÉES &amp; SERVICES</string>
+    <string name="licenses_attributions_section_playback">LICENCES DE LECTURE ANDROID</string>
+    <string name="licenses_attributions_nuvio_title">Nuvio TV</string>
+    <string name="licenses_attributions_nuvio_body">Le code source et les conditions de licence sont disponibles dans le dépôt du projet. Distribué sous licence GNU General Public License v3.0.</string>
+    <string name="licenses_attributions_tmdb_title">The Movie Database (TMDB)</string>
+    <string name="licenses_attributions_tmdb_body">Nuvio utilise l’API TMDB pour les métadonnées de films et de séries, les visuels, les bandes-annonces, la distribution, les détails de production, les collections et les recommandations. Ce produit utilise l’API TMDB mais n’est ni approuvé ni certifié par TMDB.</string>
+    <string name="licenses_attributions_trakt_title">Trakt</string>
+    <string name="licenses_attributions_trakt_body">Nuvio se connecte à Trakt pour l’authentification du compte, l’historique de visionnage, la synchronisation de la progression, les données de bibliothèque, les notes, les listes et les commentaires. Nuvio n’est ni affilié à Trakt ni approuvé par Trakt.</string>
+    <string name="licenses_attributions_mdblist_title">MDBList</string>
+    <string name="licenses_attributions_mdblist_body">Nuvio utilise MDBList pour les notes et les données de fournisseurs de scores externes. Nuvio n’est ni affilié à MDBList ni approuvé par MDBList.</string>
+    <string name="licenses_attributions_introdb_title">IntroDB</string>
+    <string name="licenses_attributions_introdb_body">Nuvio utilise l’API IntroDB pour les horodatages d’intro, de résumé, de générique et d’aperçu fournis par la communauté et utilisés par les commandes de saut. Nuvio n’est ni affilié à IntroDB ni approuvé par IntroDB.</string>
+    <string name="licenses_attributions_imdb_title">Jeux de données non commerciaux IMDb</string>
+    <string name="licenses_attributions_imdb_body">Nuvio utilise les jeux de données non commerciaux IMDb, dont title.ratings.tsv.gz, pour les notes et le nombre de votes IMDb. Informations fournies par IMDb (https://www.imdb.com). Utilisées avec autorisation. Les données IMDb sont destinées à un usage personnel et non commercial, conformément aux conditions d’IMDb.</string>
+    <string name="licenses_attributions_exoplayer_title">AndroidX Media3 ExoPlayer 1.8.0</string>
+    <string name="licenses_attributions_exoplayer_body">Utilisé comme moteur de lecture Android. Distribué sous licence Apache, version 2.0.</string>
+    <string name="licenses_attributions_libmpv_title">libmpv / libmpv-android</string>
+    <string name="licenses_attributions_libmpv_body">Utilisé comme moteur de lecture Android. Le wrapper libmpv-android est distribué sous licence MIT&#160;; mpv/libmpv et les composants natifs intégrés conservent leurs conditions de licence d’origine.</string>
+
+    <!-- Lecture&#160;: avertissements de contenu -->
+    <string name="playback_parental_guide">Avertissements de contenu</string>
+    <string name="playback_parental_guide_sub">Afficher l’avertissement de contrôle parental au démarrage de la lecture.</string>
+
+    <!-- Mise en page&#160;: emplacement de Découvrir -->
+    <string name="layout_discover_location_action">Emplacement de Découvrir</string>
+    <string name="layout_discover_location_dialog_title">Emplacement de Découvrir</string>
+    <string name="layout_discover_location_in_search">Afficher dans Recherche</string>
+    <string name="layout_discover_location_in_search_desc">Découvrir apparaît dans l’onglet Recherche.</string>
+    <string name="layout_discover_location_in_sidebar">Afficher dans le panneau latéral</string>
+    <string name="layout_discover_location_in_sidebar_desc">Découvrir dispose de son propre élément dans le panneau latéral.</string>
+
+    <!-- Mise en page&#160;: tri de Continuer à regarder -->
+    <string name="layout_cw_sort_mode">Ordre de tri</string>
+    <string name="layout_cw_sort_mode_sub">Comment les éléments Continuer à regarder sont organisés</string>
+    <string name="layout_cw_sort_default">Par défaut</string>
+    <string name="layout_cw_sort_default_desc">Trier tous les éléments par récence</string>
+    <string name="layout_cw_sort_streaming">Style streaming</string>
+    <string name="layout_cw_sort_streaming_desc">Les éléments sortis d’abord, ceux à venir à la fin</string>
+
+    <!-- Trakt&#160;: source des recommandations Similaires -->
+    <string name="trakt_more_like_this_source_title">Source de la section Similaires</string>
+    <string name="trakt_more_like_this_source_subtitle">Choisis la provenance des recommandations sur les pages de détails</string>
+    <string name="trakt_more_like_this_source_dialog_title">Source de la section Similaires</string>
+    <string name="trakt_more_like_this_source_dialog_subtitle">Sélectionne la source des recommandations affichées sur les pages de détails.</string>
+    <string name="trakt_more_like_this_source_trakt">Trakt</string>
+    <string name="trakt_more_like_this_source_tmdb">TMDB</string>
+
+    <!-- Lecteur&#160;: invite épisode suivant -->
+    <string name="player_next_episode_prompt_title">Continuer le visionnage&#160;?</string>
+    <string name="player_next_episode_prompt_message">Veux-tu lire l’épisode suivant&#160;?</string>
+    <string name="player_next_episode_prompt_yes">Oui</string>
+    <string name="player_next_episode_prompt_no">Non, revenir aux détails</string>
+
+    <!-- Lecteur&#160;: invite « Tu regardes toujours » -->
+    <string name="still_watching_title">Tu regardes toujours&#160;?</string>
+    <string name="still_watching_continue">Lire</string>
+    <string name="still_watching_exit">Quitter</string>
+    <string name="still_watching_countdown">Arrêt dans %1$d</string>
+    <string name="still_watching_setting_title">Tu regardes toujours&#160;?</string>
+    <string name="still_watching_setting_sub">Demander après plusieurs épisodes lus automatiquement à la suite.</string>
+    <string name="still_watching_threshold_title">Seuil d’épisodes</string>
+    <string name="still_watching_threshold_sub">Nombre d’épisodes lus automatiquement avant de demander.</string>
+
+    <!-- Plugins&#160;: paramètres globaux -->
+    <string name="plugin_enable_plugins_title">Activer les fournisseurs de plugins globalement</string>
+    <string name="plugin_enable_plugins_subtitle">Utiliser les fournisseurs de plugins lors de la recherche de flux</string>
+    <string name="plugin_group_by_repository_title">Grouper les fournisseurs de plugins par dépôt</string>
+    <string name="plugin_group_by_repository_subtitle">Dans Flux, afficher un fournisseur par dépôt au lieu d’un par source</string>
+
+    <!-- Collections&#160;: confirmation de suppression -->
+    <string name="collections_delete_confirm_title">Supprimer la collection&#160;?</string>
+    <string name="collections_delete_confirm">Supprimer</string>
+    <string name="collections_delete_confirm_subtitle">Cela supprimera définitivement «&#160;%1$s&#160;». Cette action est irréversible.</string>
+    <string name="collections_editor_delete_folder_title">Supprimer le dossier&#160;?</string>
+    <string name="collections_editor_delete_folder_subtitle">Cela supprimera définitivement «&#160;%1$s&#160;» et son contenu.</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds the 74 French string resources that existed in `values/strings.xml` but had no `values-fr/strings.xml` counterpart, so French users were seeing English fallbacks.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

Several recently merged features shipped English-only strings. A key-by-key diff of `values/strings.xml` against `values-fr/strings.xml` on `dev` found 74 keys missing their French value, surfacing English text inside an otherwise French UI.

Areas covered: Licenses & Attribution screen, TMDB watch-provider / watch-region collection filters, Discover location settings, Continue Watching sort modes, More Like This source picker, next-episode and "still watching" playback prompts, plugin global settings, collection/folder delete confirmations, and a few episode/rail labels.

## Issue or approval

No linked issue — localization-only fill of missing FR keys, found by a mechanical EN-vs-FR key diff on `dev`.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `values-fr/strings.xml` is changed; no other locale, no `values/strings.xml`, no code.
- No existing FR string is modified — only the 74 missing keys are appended.
- Translations follow the existing FR conventions: typographic apostrophe, `&#160;` NBSP before `:` `?` `;`, `« »` quotes, tutoiement, no inclusive spelling.

## Testing

- `./gradlew :app:assembleFullDebug` — resource merge/optimize passes, APK builds.
- Verified post-change that the EN and FR key sets are now identical (2071 keys each, no duplicates, no FR-only stale keys).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — localization-only fill of missing FR keys.