### PR TITLE
Fix: decouple "Still Watching" from auto-play-next

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAutoplaySessionRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAutoplaySessionRules.kt
@@ -1,6 +1,14 @@
 package com.nuvio.tv.ui.screens.player
 
+import com.nuvio.tv.data.local.StreamAutoPlayMode
+
 internal fun nextConsecutiveAutoPlayCount(
     currentCount: Int,
     isAutoPlay: Boolean,
 ): Int = if (isAutoPlay) currentCount + 1 else 0
+
+internal fun shouldAutoAdvanceAtEndOfEpisode(
+    streamAutoPlayNextEpisodeEnabled: Boolean,
+    streamAutoPlayMode: StreamAutoPlayMode,
+): Boolean = streamAutoPlayNextEpisodeEnabled ||
+    streamAutoPlayMode != StreamAutoPlayMode.MANUAL

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -330,7 +330,11 @@ internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionM
         _uiState.update {
             it.copy(postPlayMode = PostPlayMode.AutoPlay(nextEpisode = state.nextEpisode))
         }
-        if (state.nextEpisode.hasAired && streamAutoPlayNextEpisodeEnabledSetting) {
+        val shouldAutoAdvance = shouldAutoAdvanceAtEndOfEpisode(
+            streamAutoPlayNextEpisodeEnabled = streamAutoPlayNextEpisodeEnabledSetting,
+            streamAutoPlayMode = streamAutoPlayModeSetting,
+        )
+        if (state.nextEpisode.hasAired && shouldAutoAdvance) {
             playNextEpisode()
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -319,7 +319,6 @@ internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionM
 
     val shouldEnterStillWatching = shouldEnterStillWatchingPrompt(
         stillWatchingEnabled = stillWatchingEnabledSetting,
-        autoPlayNextEpisodeEnabled = streamAutoPlayNextEpisodeEnabledSetting,
         nextEpisodeHasAired = state.nextEpisode.hasAired,
         consecutiveAutoPlayCount = consecutiveAutoPlayCount,
         threshold = stillWatchingEpisodeThresholdSetting,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStillWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStillWatching.kt
@@ -10,12 +10,10 @@ private const val STILL_WATCHING_COUNTDOWN_TICK_MS = 1_000L
 
 internal fun shouldEnterStillWatchingPrompt(
     stillWatchingEnabled: Boolean,
-    autoPlayNextEpisodeEnabled: Boolean,
     nextEpisodeHasAired: Boolean,
     consecutiveAutoPlayCount: Int,
     threshold: Int,
 ): Boolean = stillWatchingEnabled &&
-    autoPlayNextEpisodeEnabled &&
     nextEpisodeHasAired &&
     consecutiveAutoPlayCount >= threshold
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -169,34 +169,32 @@ internal fun LazyListScope.autoPlaySettingsItems(
         )
     }
 
-    if (playerSettings.streamAutoPlayNextEpisodeEnabled) {
-        item(key = "still_watching_enabled") {
-            ToggleSettingsItem(
-                icon = Icons.Default.Visibility,
-                title = stringResource(R.string.still_watching_setting_title),
-                subtitle = stringResource(R.string.still_watching_setting_sub),
-                isChecked = playerSettings.stillWatchingEnabled,
-                onCheckedChange = onSetStillWatchingEnabled,
+    item(key = "still_watching_enabled") {
+        ToggleSettingsItem(
+            icon = Icons.Default.Visibility,
+            title = stringResource(R.string.still_watching_setting_title),
+            subtitle = stringResource(R.string.still_watching_setting_sub),
+            isChecked = playerSettings.stillWatchingEnabled,
+            onCheckedChange = onSetStillWatchingEnabled,
+            onFocused = onItemFocused
+        )
+    }
+
+    if (playerSettings.stillWatchingEnabled) {
+        item(key = "still_watching_threshold") {
+            val threshold = playerSettings.stillWatchingEpisodeThreshold
+            SliderSettingsItem(
+                icon = Icons.Default.Repeat,
+                title = stringResource(R.string.still_watching_threshold_title),
+                subtitle = stringResource(R.string.still_watching_threshold_sub),
+                value = threshold,
+                valueText = "$threshold",
+                minValue = 2,
+                maxValue = 6,
+                step = 1,
+                onValueChange = { onSetStillWatchingEpisodeThreshold(it) },
                 onFocused = onItemFocused
             )
-        }
-
-        if (playerSettings.stillWatchingEnabled) {
-            item(key = "still_watching_threshold") {
-                val threshold = playerSettings.stillWatchingEpisodeThreshold
-                SliderSettingsItem(
-                    icon = Icons.Default.Repeat,
-                    title = stringResource(R.string.still_watching_threshold_title),
-                    subtitle = stringResource(R.string.still_watching_threshold_sub),
-                    value = threshold,
-                    valueText = "$threshold",
-                    minValue = 2,
-                    maxValue = 6,
-                    step = 1,
-                    onValueChange = { onSetStillWatchingEpisodeThreshold(it) },
-                    onFocused = onItemFocused
-                )
-            }
         }
     }
 

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolverTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolverTest.kt
@@ -35,7 +35,7 @@ class TmdbCollectionSourceResolverTest {
 
     @Test
     fun `parseTmdbId accepts ids and tmdb urls`() {
-        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), mockk(relaxed = true), settings)
 
         assertEquals(123, resolver.parseTmdbId("123"))
         assertEquals(456, resolver.parseTmdbId("https://www.themoviedb.org/list/456-marvel"))
@@ -85,7 +85,7 @@ class TmdbCollectionSourceResolverTest {
                 totalPages = 3
             )
         )
-        val resolver = TmdbCollectionSourceResolver(api, settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), api, settings)
         val result = resolver.resolve(
             TmdbCollectionSource(
                 sourceType = TmdbCollectionSourceType.LIST,
@@ -112,7 +112,7 @@ class TmdbCollectionSourceResolverTest {
                 name = "Weekend Watchlist"
             )
         )
-        val resolver = TmdbCollectionSourceResolver(api, settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), api, settings)
 
         val metadata = resolver.listImportMetadata(44)
 
@@ -130,7 +130,7 @@ class TmdbCollectionSourceResolverTest {
                 backdropPath = "/collection-backdrop.jpg"
             )
         )
-        val resolver = TmdbCollectionSourceResolver(api, settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), api, settings)
 
         val metadata = resolver.collectionImportMetadata(10)
 
@@ -148,7 +148,7 @@ class TmdbCollectionSourceResolverTest {
                 logoPath = "/marvel.png"
             )
         )
-        val resolver = TmdbCollectionSourceResolver(api, settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), api, settings)
 
         val metadata = resolver.companyImportMetadata(420)
 
@@ -166,7 +166,7 @@ class TmdbCollectionSourceResolverTest {
                 logoPath = "/apple.png"
             )
         )
-        val resolver = TmdbCollectionSourceResolver(api, settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), api, settings)
 
         val metadata = resolver.networkImportMetadata(2552)
 
@@ -207,7 +207,7 @@ class TmdbCollectionSourceResolverTest {
                 )
             )
         }
-        val resolver = TmdbCollectionSourceResolver(api, settings)
+        val resolver = TmdbCollectionSourceResolver(mockk(relaxed = true), api, settings)
         val result = resolver.resolve(
             TmdbCollectionSource(
                 sourceType = TmdbCollectionSourceType.DISCOVER,

--- a/app/src/test/java/com/nuvio/tv/core/trakt/TraktPublicListSourceResolverTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/trakt/TraktPublicListSourceResolverTest.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.core.trakt
 
+import com.nuvio.tv.R
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.AuthSessionNoticeDataStore
 import com.nuvio.tv.data.local.TraktAuthDataStore
@@ -286,11 +287,20 @@ class TraktPublicListSourceResolverTest {
             )
         }
         val authService = TraktAuthService(
+            context = mockk(relaxed = true),
             traktApi = api,
             traktAuthDataStore = authStore,
             authSessionNoticeDataStore = mockk<AuthSessionNoticeDataStore>(relaxed = true)
         )
         return TraktPublicListSourceResolver(
+            appContext = mockk(relaxed = true) {
+                every { getString(R.string.collections_editor_trakt_items_count, any()) } answers {
+                    "${(args[1] as Array<*>)[0]} items"
+                }
+                every { getString(R.string.collections_editor_trakt_likes_count, any()) } answers {
+                    "${(args[1] as Array<*>)[0]} likes"
+                }
+            },
             traktApi = api,
             traktAuthService = authService
         )

--- a/app/src/test/java/com/nuvio/tv/data/local/CollectionsDataStoreSourceMigrationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/CollectionsDataStoreSourceMigrationTest.kt
@@ -1,11 +1,13 @@
 package com.nuvio.tv.data.local
 
+import com.nuvio.tv.R
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.domain.model.AddonCatalogCollectionSource
 import com.nuvio.tv.domain.model.TmdbCollectionMediaType
 import com.nuvio.tv.domain.model.TmdbCollectionSource
 import com.nuvio.tv.domain.model.TmdbCollectionSourceType
 import com.nuvio.tv.domain.model.TraktCollectionSource
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -13,6 +15,14 @@ import org.junit.Test
 
 class CollectionsDataStoreSourceMigrationTest {
     private val store = CollectionsDataStore(
+        appContext = mockk(relaxed = true) {
+            every {
+                getString(R.string.collections_import_error_missing_trakt_list_id, any(), any(), any())
+            } answers {
+                val a = args[1] as Array<*>
+                "Collection \"${a[0]}\", folder \"${a[1]}\", source ${a[2]}: missing Trakt list ID"
+            }
+        },
         factory = mockk<ProfileDataStoreFactory>(relaxed = true),
         profileManager = mockk<ProfileManager>(relaxed = true)
     )

--- a/app/src/test/java/com/nuvio/tv/data/repository/GitHubContributorsRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/GitHubContributorsRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.repository
 import com.nuvio.tv.data.remote.api.UniqueContributionsApi
 import com.nuvio.tv.data.remote.dto.UniqueContributionsResponseDto
 import com.nuvio.tv.data.remote.dto.UniqueContributorDto
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -18,6 +19,7 @@ class GitHubContributorsRepositoryTest {
     @Test
     fun `uses total contributions from unique contributions api and sorts descending`() = runTest {
         val repository = GitHubContributorsRepository(
+            appContext = mockk(relaxed = true),
             contributionsApi = FakeUniqueContributionsApi(
                 uniqueContributions = Response.success(
                     UniqueContributionsResponseDto(
@@ -45,6 +47,7 @@ class GitHubContributorsRepositoryTest {
     @Test
     fun `keeps duplicate names distinct when profiles differ`() = runTest {
         val repository = GitHubContributorsRepository(
+            appContext = mockk(relaxed = true),
             contributionsApi = FakeUniqueContributionsApi(
                 uniqueContributions = Response.success(
                     UniqueContributionsResponseDto(
@@ -68,6 +71,7 @@ class GitHubContributorsRepositoryTest {
     @Test
     fun `filters blank names and non-positive totals`() = runTest {
         val repository = GitHubContributorsRepository(
+            appContext = mockk(relaxed = true),
             contributionsApi = FakeUniqueContributionsApi(
                 uniqueContributions = Response.success(
                     UniqueContributionsResponseDto(
@@ -91,6 +95,7 @@ class GitHubContributorsRepositoryTest {
     @Test
     fun `fails when unique contributions api fails`() = runTest {
         val repository = GitHubContributorsRepository(
+            appContext = mockk(relaxed = true),
             contributionsApi = FakeUniqueContributionsApi(
                 uniqueContributions = errorResponse(500)
             ),
@@ -105,6 +110,7 @@ class GitHubContributorsRepositoryTest {
     @Test
     fun `fails without configured unique contributions base url`() = runTest {
         val repository = GitHubContributorsRepository(
+            appContext = mockk(relaxed = true),
             contributionsApi = FakeUniqueContributionsApi(
                 uniqueContributions = Response.success(UniqueContributionsResponseDto())
             ),

--- a/app/src/test/java/com/nuvio/tv/data/repository/SponsorsRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/SponsorsRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.repository
 import com.nuvio.tv.data.remote.api.SponsorsApi
 import com.nuvio.tv.data.remote.dto.SponsorDto
 import com.nuvio.tv.data.remote.dto.SponsorsResponseDto
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -18,6 +19,7 @@ class SponsorsRepositoryTest {
     @Test
     fun `sorts sponsors by newest first and drops invalid rows`() = runTest {
         val repository = SponsorsRepository(
+            appContext = mockk(relaxed = true),
             sponsorsApi = FakeSponsorsApi(
                 response = Response.success(
                     SponsorsResponseDto(
@@ -42,6 +44,7 @@ class SponsorsRepositoryTest {
     @Test
     fun `returns failure on api error`() = runTest {
         val repository = SponsorsRepository(
+            appContext = mockk(relaxed = true),
             sponsorsApi = FakeSponsorsApi(
                 response = Response.error(
                     500,

--- a/app/src/test/java/com/nuvio/tv/data/repository/SupportersRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/SupportersRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.repository
 import com.nuvio.tv.data.remote.api.DonationsApi
 import com.nuvio.tv.data.remote.dto.DonationDto
 import com.nuvio.tv.data.remote.dto.DonationsResponseDto
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -18,6 +19,7 @@ class SupportersRepositoryTest {
     @Test
     fun `sorts donations by most recent first and drops invalid rows`() = runTest {
         val repository = SupportersRepository(
+            appContext = mockk(relaxed = true),
             donationsApi = FakeDonationsApi(
                 response = Response.success(
                     DonationsResponseDto(
@@ -42,6 +44,7 @@ class SupportersRepositoryTest {
     @Test
     fun `returns failure on api error`() = runTest {
         val repository = SupportersRepository(
+            appContext = mockk(relaxed = true),
             donationsApi = FakeDonationsApi(
                 response = Response.error(
                     500,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/AutoplayTriggerConditionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/AutoplayTriggerConditionTest.kt
@@ -1,0 +1,59 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.data.local.StreamAutoPlayMode
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoplayTriggerConditionTest {
+
+    @Test
+    fun `auto-advance when only next-episode toggle is enabled`() {
+        assertTrue(
+            shouldAutoAdvanceAtEndOfEpisode(
+                streamAutoPlayNextEpisodeEnabled = true,
+                streamAutoPlayMode = StreamAutoPlayMode.MANUAL,
+            )
+        )
+    }
+
+    @Test
+    fun `auto-advance when stream auto-select is FIRST_STREAM and toggle is off`() {
+        assertTrue(
+            shouldAutoAdvanceAtEndOfEpisode(
+                streamAutoPlayNextEpisodeEnabled = false,
+                streamAutoPlayMode = StreamAutoPlayMode.FIRST_STREAM,
+            )
+        )
+    }
+
+    @Test
+    fun `auto-advance when stream auto-select is REGEX_MATCH and toggle is off`() {
+        assertTrue(
+            shouldAutoAdvanceAtEndOfEpisode(
+                streamAutoPlayNextEpisodeEnabled = false,
+                streamAutoPlayMode = StreamAutoPlayMode.REGEX_MATCH,
+            )
+        )
+    }
+
+    @Test
+    fun `auto-advance when both are enabled`() {
+        assertTrue(
+            shouldAutoAdvanceAtEndOfEpisode(
+                streamAutoPlayNextEpisodeEnabled = true,
+                streamAutoPlayMode = StreamAutoPlayMode.FIRST_STREAM,
+            )
+        )
+    }
+
+    @Test
+    fun `no auto-advance when toggle off and mode is MANUAL`() {
+        assertFalse(
+            shouldAutoAdvanceAtEndOfEpisode(
+                streamAutoPlayNextEpisodeEnabled = false,
+                streamAutoPlayMode = StreamAutoPlayMode.MANUAL,
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/StillWatchingGatingTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/StillWatchingGatingTest.kt
@@ -12,19 +12,6 @@ class StillWatchingGatingTest {
     fun `gating returns false when still-watching setting disabled`() {
         val result = shouldEnterStillWatchingPrompt(
             stillWatchingEnabled = false,
-            autoPlayNextEpisodeEnabled = true,
-            nextEpisodeHasAired = true,
-            consecutiveAutoPlayCount = 5,
-            threshold = 3,
-        )
-        assertFalse(result)
-    }
-
-    @Test
-    fun `gating returns false when auto-play next episode disabled`() {
-        val result = shouldEnterStillWatchingPrompt(
-            stillWatchingEnabled = true,
-            autoPlayNextEpisodeEnabled = false,
             nextEpisodeHasAired = true,
             consecutiveAutoPlayCount = 5,
             threshold = 3,
@@ -36,7 +23,6 @@ class StillWatchingGatingTest {
     fun `gating returns false when next episode has not aired`() {
         val result = shouldEnterStillWatchingPrompt(
             stillWatchingEnabled = true,
-            autoPlayNextEpisodeEnabled = true,
             nextEpisodeHasAired = false,
             consecutiveAutoPlayCount = 5,
             threshold = 3,
@@ -48,7 +34,6 @@ class StillWatchingGatingTest {
     fun `gating returns false when consecutive count below threshold`() {
         val result = shouldEnterStillWatchingPrompt(
             stillWatchingEnabled = true,
-            autoPlayNextEpisodeEnabled = true,
             nextEpisodeHasAired = true,
             consecutiveAutoPlayCount = 2,
             threshold = 3,
@@ -60,7 +45,6 @@ class StillWatchingGatingTest {
     fun `gating returns true when all conditions met`() {
         val result = shouldEnterStillWatchingPrompt(
             stillWatchingEnabled = true,
-            autoPlayNextEpisodeEnabled = true,
             nextEpisodeHasAired = true,
             consecutiveAutoPlayCount = 3,
             threshold = 3,


### PR DESCRIPTION
## Summary
Addresses two issues @skoruppa flagged in the review of #1799:

1. The "Are You Still Watching?" toggle was hidden when **Auto-play next episode** was off. The outer `if (streamAutoPlayNextEpisodeEnabled)` wrapper around the toggle and threshold slider is removed.
2. The prompt never fired when episodes advanced via stream auto-selection (FIRST_STREAM / REGEX_MATCH). `shouldEnterStillWatchingPrompt` no longer requires `streamAutoPlayNextEpisodeEnabled`, and the in-player auto-advance trigger now also fires when `streamAutoPlayMode != MANUAL`, routing that case through `playNextEpisode()` so `consecutiveAutoPlayCount` accumulates.

## PR type
- [x] Behavior bug/regression fix

## Why
@skoruppa noticed the prompt never appeared when they had auto-play-next off and stream auto-selection on. The gating helper prevented the in-player counter to not tick on the stream-auto-select path (which tears down `PlayerRuntimeController` between episodes and resets `consecutiveAutoPlayCount` to 0).

## Issue or approval
@skoruppa's review comment on #1799: <https://github.com/NuvioMedia/NuvioTV/pull/1799#issuecomment-4463724112>

## UI / behavior impact
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
- No new strings, no DataStore fields, no new components.
- `PlaybackAutoPlaySettings.kt` is structurally identical, only the outer `if` is removed. 
- Intentional UX shift for `auto-play-next OFF + mode = FIRST_STREAM / REGEX_MATCH`: in-player AutoPlay countdown card (~3s) between episodes instead of the brief Stream-screen flash. That path is now where the still-watching counter accumulates.

## Testing
Manually verified on Android TV (Raspberry Pi 5, Android 14, `:app:installFullDebug`):

- **Skoruppa scenario** (auto-play-next OFF, FIRST_STREAM, threshold 3), in-player AutoPlay countdown card appears between episodes, and the still-watching prompt fires after 3 consecutive auto-advances. Pre-fix this never fired.
- **Settings visibility**, "Still Watching" toggle visible regardless of auto-play-next state; threshold slider still hides under the inner `if (stillWatchingEnabled)` guard.
- **No regressions**, auto-play-next ON + MANUAL / FIRST_STREAM unchanged; auto-play-next OFF + MANUAL still drops to stream picker; end-of-season exits gracefully; prompt Continue / Exit paths intact; manually seeking or switching streams during a binge still resets `consecutiveAutoPlayCount`.

**JVM unit tests**: player passed existing unit test and added a new `AutoplayTriggerConditionTest` and the `StillWatchingGatingTest` was removed.

## Screenshots / Video
Behavioral change only. The only UI delta is the "Still Watching" toggle now appearing under Playback -> Auto-play when auto-play-next is off, same component, no longer gated.

## Breaking changes
None. No schema change, no field rename, no removed setting. `stillWatchingEnabled` still defaults off; users who never enabled it see no behavior change.

## Linked issues
#1799 review feedback: <https://github.com/NuvioMedia/NuvioTV/pull/1799#issuecomment-4463724112>