### PR TITLE
Fix audio amplification PCM fallback behavior

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -54,11 +54,9 @@ internal fun PlayerRuntimeController.skipInterval(interval: SkipInterval): Boole
 
 internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     val clampedDb = db.coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
-    val isAudioPathActive = ffmpegAudioRenderer?.isAudioPathActive() == true
+    val isAudioAmplificationAvailable = isUsingMpvEngine() || _exoPlayer != null
     val wasActive = gainAudioProcessor.isGainEnabled()
-    gainAudioProcessor.setGainDb(
-        if (isAudioPathActive) clampedDb else AUDIO_AMPLIFICATION_MIN_DB
-    )
+    gainAudioProcessor.setGainDb(if (isAudioAmplificationAvailable) clampedDb else AUDIO_AMPLIFICATION_MIN_DB)
     val isActiveNow = gainAudioProcessor.isGainEnabled()
 
     if (wasActive != isActiveNow && !isUsingMpvEngine()) {
@@ -74,7 +72,7 @@ internal fun PlayerRuntimeController.applyAudioAmplification(db: Int) {
     _uiState.update {
         it.copy(
             audioAmplificationDb = clampedDb,
-            isAudioAmplificationAvailable = isAudioPathActive || isUsingMpvEngine()
+            isAudioAmplificationAvailable = isAudioAmplificationAvailable
         )
     }
 }
@@ -92,15 +90,13 @@ internal fun PlayerRuntimeController.updateAudioControlAvailability(
     selectedAudioIndex: Int = _uiState.value.selectedAudioTrackIndex
 ) {
     val selectedTrack = audioTracks.getOrNull(selectedAudioIndex)
-    val isAudioAmplificationAvailable =
-        isUsingMpvEngine() || ffmpegAudioRenderer?.isAudioPathActive() == true
-    val shouldApplyExoGain = ffmpegAudioRenderer?.isAudioPathActive() == true
+    val isAudioAmplificationAvailable = isUsingMpvEngine() || _exoPlayer != null
     val isCenterMixAvailable =
         ffmpegAudioRenderer?.isCenterMixActive() == true && (selectedTrack?.channelCount ?: 0) > 2
     val clampedDb = _uiState.value.audioAmplificationDb
         .coerceIn(AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB)
     gainAudioProcessor.setGainDb(
-        if (shouldApplyExoGain) clampedDb else AUDIO_AMPLIFICATION_MIN_DB
+        if (isAudioAmplificationAvailable) clampedDb else AUDIO_AMPLIFICATION_MIN_DB
     )
     _uiState.update { state ->
         state.copy(


### PR DESCRIPTION
## Summary

Fixes audio-processing regressions in the player audio path.

This PR keeps amplification as a best-effort PCM processor instead of forcing the player to switch from passthrough/direct playback into PCM. It also keeps Center Mix scoped to the FFmpeg downmix path only, so normal playback behavior is preserved when downmix is not active.

Key points:
- Amplification no longer forces PCM playback.
- Amplification is allowed to try on the active player output; if the audio path does not pass through PCM processors, it simply has no effect.
- Center Mix remains available only when FFmpeg downmix is actively being used.
- Avoids changing passthrough/direct decoder selection just because the OSD amplification value changes.
- Keeps the fix focused on avoiding audio-path regressions.

## PR type

- [X] Reproducible bug fix
- [ ] UI glitch/bug fix
- [] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Changing amplification from the OSD could incorrectly alter the audio playback path by forcing PCM output. That is risky for users relying on passthrough/direct playback or hardware audio handling.

The intended behavior is that amplification should only affect audio when the current path is already processable as PCM. It should not silently switch decoder/output mode. If the current path cannot be processed, changing the amplification value should not break or reload audio playback.

## Issue or approval

Fixes the audio playback regression reported during testing of the Center Mix / amplification branch.
https://discord.com/channels/1379902184207941732/1505986658636665044

## UI / behavior impact

- [X] No UI change
- [ ] No behavior change
- [] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR does not add new UI polish or change.

It intentionally does not force PCM playback for amplification. Amplification remains best-effort: it applies when the active audio path goes through PCM processing, otherwise it leaves playback unchanged.

## Testing

Tested and checked that Amplification works.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

https://discord.com/channels/1379902184207941732/1505986658636665044