### PR TITLE
feat: relative air date labels for Continue Watching

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -76,6 +76,7 @@ import java.util.concurrent.TimeUnit
 import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
+import com.nuvio.tv.ui.util.computeAirDateBadgeText
 
 private val CwCardShape = RoundedCornerShape(12.dp)
 private val CwClipShape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
@@ -296,7 +297,6 @@ fun ContinueWatchingCard(
             null
         }
     }
-    val strAirsDate = stringResource(R.string.cw_airs_date, nextUp?.airDateLabel ?: "")
     val strUpcoming = stringResource(R.string.cw_upcoming)
     val strNextUp = stringResource(R.string.cw_next_up)
     val strNewEpisode = stringResource(R.string.cw_new_episode)
@@ -309,7 +309,7 @@ fun ContinueWatchingCard(
         if (info.isReleaseAlert) {
             if (info.isNewSeasonRelease) strNewSeason else strNewEpisode
         } else if (!info.hasAired) {
-            info.airDateLabel?.let { strAirsDate } ?: strUpcoming
+            computeAirDateBadgeText(cardContext, info.released, info.airDateLabel) ?: strUpcoming
         } else {
             strNextUp
         }
@@ -380,7 +380,7 @@ fun ContinueWatchingCard(
     val effectiveImageModel = if (usesFallbackImage) fallbackImageModel else imageModel
     val titleText = remember(progress, nextUp) { progress?.name ?: nextUp?.name.orEmpty() }
     val context = LocalContext.current
-    val strAirsDateForEpisode = nextUp?.airDateLabel?.let { stringResource(R.string.cw_airs_date, it) }
+    val strAirsDateForEpisode = computeAirDateBadgeText(context, nextUp?.released, nextUp?.airDateLabel)
     val episodeTitle = remember(progress, nextUp, context, strAirsDateForEpisode) {
         when {
             progress != null -> progress.episodeTitle?.localizeEpisodeTitle(context)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -13,6 +13,7 @@ import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.model.normalizeLanguageCode
 import com.nuvio.tv.domain.model.countryToLanguageCode
+import com.nuvio.tv.ui.util.parseEpisodeReleaseDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
@@ -2534,26 +2535,6 @@ private fun HomeViewModel.publishBadgeUpdate(
         }
     }
     fullyWatchedSeriesIds.updateWithValidation(merged, allValidatedIds, revalidateAt)
-}
-
-private fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
-    if (raw.isNullOrBlank()) return null
-    val value = raw.trim()
-    val zone = ZoneId.systemDefault()
-
-    return runCatching {
-        Instant.parse(value).atZone(zone).toLocalDate()
-    }.getOrNull() ?: runCatching {
-        OffsetDateTime.parse(value).atZoneSameInstant(zone).toLocalDate()
-    }.getOrNull() ?: runCatching {
-        LocalDateTime.parse(value).toLocalDate()
-    }.getOrNull() ?: runCatching {
-        LocalDate.parse(value)
-    }.getOrNull() ?: runCatching {
-        val datePortion = Regex("\\b\\d{4}-\\d{2}-\\d{2}\\b").find(value)?.value
-            ?: return@runCatching null
-        LocalDate.parse(datePortion)
-    }.getOrNull()
 }
 
 private fun parseEpisodeReleaseInstant(raw: String?): Instant? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -11,6 +11,7 @@ import com.nuvio.tv.domain.model.CollectionFolder
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
+import com.nuvio.tv.ui.util.computeAirDateBadgeText
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.R
 import com.nuvio.tv.ui.components.formatContinueWatchingProgressLabel
@@ -292,7 +293,7 @@ internal fun buildContinueWatchingItem(
                     context.getString(R.string.cw_new_episode)
                 }
             } else if (!item.info.hasAired) {
-                item.info.airDateLabel?.let { context.getString(R.string.cw_airs_date, it) }
+                computeAirDateBadgeText(context, item.info.released, item.info.airDateLabel)
                     ?: context.getString(R.string.cw_upcoming)
             } else {
                 context.getString(R.string.cw_next_up)

--- a/app/src/main/java/com/nuvio/tv/ui/util/AirDateUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/AirDateUtils.kt
@@ -1,0 +1,56 @@
+package com.nuvio.tv.ui.util
+
+import android.content.Context
+import com.nuvio.tv.R
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+internal fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
+    if (raw.isNullOrBlank()) return null
+    val value = raw.trim()
+    val zone = ZoneId.systemDefault()
+
+    return runCatching {
+        Instant.parse(value).atZone(zone).toLocalDate()
+    }.getOrNull() ?: runCatching {
+        OffsetDateTime.parse(value).atZoneSameInstant(zone).toLocalDate()
+    }.getOrNull() ?: runCatching {
+        LocalDateTime.parse(value).toLocalDate()
+    }.getOrNull() ?: runCatching {
+        LocalDate.parse(value)
+    }.getOrNull() ?: runCatching {
+        val datePortion = Regex("\\b\\d{4}-\\d{2}-\\d{2}\\b").find(value)?.value
+            ?: return@runCatching null
+        LocalDate.parse(datePortion)
+    }.getOrNull()
+}
+
+internal fun computeAirDateBadgeText(
+    context: Context,
+    releasedIso: String?,
+    airDateLabel: String?
+): String? {
+    if (releasedIso.isNullOrBlank()) {
+        return airDateLabel?.let { context.getString(R.string.cw_airs_date, it) }
+    }
+
+    val releaseDate = parseEpisodeReleaseDate(releasedIso) ?: return null
+    val today = LocalDate.now(ZoneId.systemDefault())
+    val daysUntil = ChronoUnit.DAYS.between(today, releaseDate)
+
+    return when {
+        daysUntil < 0 -> null
+        daysUntil == 0L -> context.getString(R.string.cw_airs_today)
+        daysUntil == 1L -> context.getString(R.string.cw_airs_tomorrow)
+        daysUntil in 2..7 -> context.resources.getQuantityString(
+            R.plurals.cw_airs_in_days,
+            daysUntil.toInt(),
+            daysUntil.toInt()
+        )
+        else -> airDateLabel?.let { context.getString(R.string.cw_airs_date, it) }
+    }
+}

--- a/app/src/main/res/values-ar/Strings.xml
+++ b/app/src/main/res/values-ar/Strings.xml
@@ -115,6 +115,16 @@
     <string name="cw_min_left">متبقي %1$d د</string>
     <string name="cw_almost_done">على وشك الانتهاء</string>
     <string name="cw_airs_date">يُعرض في %1$s</string>
+    <string name="cw_airs_today">يُعرض اليوم</string>
+    <string name="cw_airs_tomorrow">يُعرض غداً</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="zero">يُعرض بعد %d يوم</item>
+        <item quantity="one">يُعرض بعد يوم</item>
+        <item quantity="two">يُعرض بعد يومين</item>
+        <item quantity="few">يُعرض بعد %d أيام</item>
+        <item quantity="many">يُعرض بعد %d يوماً</item>
+        <item quantity="other">يُعرض بعد %d يوم</item>
+    </plurals>
     <string name="cw_action_go_to_details">التفاصيل</string>
     <string name="cw_action_start_from_beginning">البدء من البداية</string>
     <string name="cw_action_remove">إزالة</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -151,6 +151,13 @@
     <string name="cw_min_left">faltan %1$dm</string>
     <string name="cw_almost_done">Casi termina</string>
     <string name="cw_airs_date">Se emite el %1$s</string>
+    <string name="cw_airs_today">Se emite hoy</string>
+    <string name="cw_airs_tomorrow">Se emite mañana</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Se emite en %d día</item>
+        <item quantity="many">Se emite en %d días</item>
+        <item quantity="other">Se emite en %d días</item>
+    </plurals>
     <string name="cw_action_go_to_details">Ir a los detalles</string>
     <string name="cw_action_start_from_beginning">Empezar desde el principio</string>
     <string name="cw_action_remove">Eliminar</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -115,6 +115,13 @@
     <string name="cw_min_left">Preostalo %1$dm</string>
     <string name="cw_almost_done">Skoro gotovo</string>
     <string name="cw_airs_date">Prikazuje se %1$s</string>
+    <string name="cw_airs_today">Prikazuje se danas</string>
+    <string name="cw_airs_tomorrow">Prikazuje se sutra</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Prikazuje se za %d dan</item>
+        <item quantity="few">Prikazuje se za %d dana</item>
+        <item quantity="other">Prikazuje se za %d dana</item>
+    </plurals>
     <string name="cw_action_go_to_details">Idi na detalje</string>
     <string name="cw_action_start_from_beginning">Počni ispočetka</string>
     <string name="cw_action_remove">Ukloni</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -151,6 +151,14 @@
     <string name="cw_min_left">Zbývá %1$dm</string>
     <string name="cw_almost_done">Téměř dokončeno</string>
     <string name="cw_airs_date">Vysílá se %1$s</string>
+    <string name="cw_airs_today">Vysílá se dnes</string>
+    <string name="cw_airs_tomorrow">Vysílá se zítra</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Vysílá se za %d den</item>
+        <item quantity="few">Vysílá se za %d dny</item>
+        <item quantity="many">Vysílá se za %d dní</item>
+        <item quantity="other">Vysílá se za %d dní</item>
+    </plurals>
     <string name="cw_action_go_to_details">Přejít na podrobnosti</string>
     <string name="cw_action_start_from_beginning">Přehrát od začátku</string>
     <string name="cw_action_remove">Odebrat</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,6 +58,12 @@
     <string name="cw_min_left">%1$dm verbleibend</string>
     <string name="cw_almost_done">Fast fertig</string>
     <string name="cw_airs_date">Ausstrahlung am %1$s</string>
+    <string name="cw_airs_today">Ausstrahlung heute</string>
+    <string name="cw_airs_tomorrow">Ausstrahlung morgen</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Ausstrahlung in %d Tag</item>
+        <item quantity="other">Ausstrahlung in %d Tagen</item>
+    </plurals>
     <string name="cw_action_go_to_details">Zu den Details gehen</string>
     <string name="cw_action_start_from_beginning">Von Anfang an starten</string>
     <string name="cw_action_remove">Entfernen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -151,6 +151,12 @@
     <string name="cw_min_left">%1$d λεπ. απομένουν</string>
     <string name="cw_almost_done">Σχεδόν τελείωσε</string>
     <string name="cw_airs_date">Πρεμιέρα %1$s</string>
+    <string name="cw_airs_today">Πρεμιέρα σήμερα</string>
+    <string name="cw_airs_tomorrow">Πρεμιέρα αύριο</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Πρεμιέρα σε %d ημέρα</item>
+        <item quantity="other">Πρεμιέρα σε %d ημέρες</item>
+    </plurals>
     <string name="cw_action_go_to_details">Μετάβαση σε λεπτομέρειες</string>
     <string name="cw_action_start_from_beginning">Έναρξη από την αρχή</string>
     <string name="cw_action_remove">Αφαίρεση</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -59,6 +59,13 @@
     <string name="cw_min_left">%1$dm restantes</string>
     <string name="cw_almost_done">Casi terminado</string>
     <string name="cw_airs_date">Se transmite %1$s</string>
+    <string name="cw_airs_today">Se transmite hoy</string>
+    <string name="cw_airs_tomorrow">Se transmite mañana</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Se transmite dentro de %d día</item>
+        <item quantity="many">Se transmite dentro de %d días</item>
+        <item quantity="other">Se transmite dentro de %d días</item>
+    </plurals>
     <string name="cw_action_go_to_details">Ir a detalles</string>
     <string name="cw_action_start_from_beginning">Empezar desde el principio</string>
     <string name="cw_action_remove">Eliminar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -149,6 +149,13 @@
     <string name="cw_min_left">%1$dm restantes</string>
     <string name="cw_almost_done">Presque terminé</string>
     <string name="cw_airs_date">Diffusion le %1$s</string>
+    <string name="cw_airs_today">Diffusion aujourd\'hui</string>
+    <string name="cw_airs_tomorrow">Diffusion demain</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Diffusion dans %d jour</item>
+        <item quantity="many">Diffusion dans %d jours</item>
+        <item quantity="other">Diffusion dans %d jours</item>
+    </plurals>
     <string name="cw_action_go_to_details">Voir les détails</string>
     <string name="cw_action_start_from_beginning">Revoir depuis le début</string>
     <string name="cw_action_remove">Supprimer</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -50,6 +50,12 @@
     <string name="cw_min_left">%1$dm बाकी</string>
     <string name="cw_almost_done">लगभग पूरा</string>
     <string name="cw_airs_date">%1$s को प्रसारित होगा</string>
+    <string name="cw_airs_today">आज प्रसारित होगा</string>
+    <string name="cw_airs_tomorrow">कल प्रसारित होगा</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">%d दिन में प्रसारित होगा</item>
+        <item quantity="other">%d दिनों में प्रसारित होगा</item>
+    </plurals>
     <string name="cw_action_go_to_details">विवरण देखें</string>
     <string name="cw_action_start_from_beginning">शुरुआत से चलाएँ</string>
     <string name="cw_action_remove">हटाएँ</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -151,6 +151,12 @@
     <string name="cw_min_left">%1$d perc van hátra</string>
     <string name="cw_almost_done">Mindjárt kész</string>
     <string name="cw_airs_date">Premier: %1$s</string>
+    <string name="cw_airs_today">Premier: ma</string>
+    <string name="cw_airs_tomorrow">Premier: holnap</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Premier: %d nap múlva</item>
+        <item quantity="other">Premier: %d nap múlva</item>
+    </plurals>
     <string name="cw_action_go_to_details">Részletek</string>
     <string name="cw_action_start_from_beginning">Indítás elölről</string>
     <string name="cw_action_remove">Eltávolítás</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -151,6 +151,11 @@
     <string name="cw_min_left">Sisa %1$d mnt</string>
     <string name="cw_almost_done">Hampir selesai</string>
     <string name="cw_airs_date">Tayang %1$s</string>
+    <string name="cw_airs_today">Tayang hari ini</string>
+    <string name="cw_airs_tomorrow">Tayang besok</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="other">Tayang dalam %d hari</item>
+    </plurals>
     <string name="cw_action_go_to_details">Lihat detail</string>
     <string name="cw_action_start_from_beginning">Mulai dari awal</string>
     <string name="cw_action_remove">Hapus</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -115,6 +115,13 @@
 <string name="cw_min_left">%1$dm rimanenti</string>
 <string name="cw_almost_done">Quasi fatto</string>
 <string name="cw_airs_date">In onda il %1$s</string>
+<string name="cw_airs_today">In onda oggi</string>
+<string name="cw_airs_tomorrow">In onda domani</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">In onda tra %d giorno</item>
+        <item quantity="many">In onda tra %d giorni</item>
+        <item quantity="other">In onda tra %d giorni</item>
+    </plurals>
 <string name="cw_action_go_to_details">Vai ai dettagli</string>
 <string name="cw_action_start_from_beginning">Comincia dall\'inizio</string>
 <string name="cw_action_remove">Rimuovi</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -53,6 +53,14 @@
     <string name="cw_min_left">נותרו %1$dד׳</string>
     <string name="cw_almost_done">כמעט סיום</string>
     <string name="cw_airs_date">שידור ב-%1$s</string>
+    <string name="cw_airs_today">שידור היום</string>
+    <string name="cw_airs_tomorrow">שידור מחר</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">שידור בעוד יום</item>
+        <item quantity="two">שידור בעוד יומיים</item>
+        <item quantity="many">שידור בעוד %d ימים</item>
+        <item quantity="other">שידור בעוד %d יום</item>
+    </plurals>
     <string name="cw_action_go_to_details">עבור לפרטים</string>
     <string name="cw_action_start_from_beginning">התחל מהתחלה</string>
     <string name="cw_action_remove">הסר</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,6 +58,11 @@
     <string name="cw_min_left">残り%1$d分</string>
     <string name="cw_almost_done">もうすぐ終了</string>
     <string name="cw_airs_date">%1$s 放送予定</string>
+    <string name="cw_airs_today">本日放送</string>
+    <string name="cw_airs_tomorrow">明日放送</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="other">%d日後に放送</item>
+    </plurals>
     <string name="cw_action_go_to_details">詳細へ</string>
     <string name="cw_action_start_from_beginning">最初から再生</string>
     <string name="cw_action_remove">削除</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -50,6 +50,14 @@
     <string name="cw_min_left">Liko %1$dm</string>
     <string name="cw_almost_done">Beveik baigta</string>
     <string name="cw_airs_date">Pasirodo %1$s</string>
+    <string name="cw_airs_today">Pasirodo šiandien</string>
+    <string name="cw_airs_tomorrow">Pasirodo rytoj</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Pasirodo po %d dienos</item>
+        <item quantity="few">Pasirodo po %d dienų</item>
+        <item quantity="many">Pasirodo po %d dienos</item>
+        <item quantity="other">Pasirodo po %d dienų</item>
+    </plurals>
     <string name="cw_action_go_to_details">Eiti į informaciją</string>
     <string name="cw_action_start_from_beginning">Pradėti iš pradžių</string>
     <string name="cw_action_remove">Pašalinti</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,6 +21,12 @@
     <string name="cw_min_left">%1$dm resterend</string>
     <string name="cw_almost_done">Bijna afgelopen</string>
     <string name="cw_airs_date">Uitgezonden op %1$s</string>
+    <string name="cw_airs_today">Vandaag uitgezonden</string>
+    <string name="cw_airs_tomorrow">Morgen uitgezonden</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Uitgezonden over %d dag</item>
+        <item quantity="other">Uitgezonden over %d dagen</item>
+    </plurals>
     <string name="cw_action_go_to_details">Ga naar details</string>
     <string name="cw_action_start_from_beginning">Start vanaf het begin</string>
     <string name="cw_action_remove">Verwijder</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -58,6 +58,12 @@
     <string name="cw_min_left">%1$dm igjen</string>
     <string name="cw_almost_done">Nesten ferdig</string>
     <string name="cw_airs_date">Sendinger %1$s</string>
+    <string name="cw_airs_today">Sendes i dag</string>
+    <string name="cw_airs_tomorrow">Sendes i morgen</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Sendes om %d dag</item>
+        <item quantity="other">Sendes om %d dager</item>
+    </plurals>
     <string name="cw_action_go_to_details">Gå til detaljer</string>
     <string name="cw_action_start_from_beginning">Start fra begynnelsen</string>
     <string name="cw_action_remove">Fjern</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -20,6 +20,14 @@
     <string name="cw_min_left">Zostało %1$dm</string>
     <string name="cw_almost_done">Prawie koniec</string>
     <string name="cw_airs_date">Emisja %1$s</string>
+    <string name="cw_airs_today">Emisja dzisiaj</string>
+    <string name="cw_airs_tomorrow">Emisja jutro</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Emisja za %d dzień</item>
+        <item quantity="few">Emisja za %d dni</item>
+        <item quantity="many">Emisja za %d dni</item>
+        <item quantity="other">Emisja za %d dni</item>
+    </plurals>
     <string name="cw_action_go_to_details">Przejdź do szczegółów</string>
     <string name="cw_action_remove">Usuń</string>
     <string name="cw_dialog_subtitle">Wybierz co chcesz zrobić z tym elementem.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -151,6 +151,13 @@
     <string name="cw_min_left">%1$dmin restantes</string>
     <string name="cw_almost_done">Quase acabando</string>
     <string name="cw_airs_date">Disponível em %1$s</string>
+    <string name="cw_airs_today">Disponível hoje</string>
+    <string name="cw_airs_tomorrow">Disponível amanhã</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Disponível em %d dia</item>
+        <item quantity="many">Disponível em %d dias</item>
+        <item quantity="other">Disponível em %d dias</item>
+    </plurals>
     <string name="cw_action_go_to_details">Ver detalhes</string>
     <string name="cw_action_start_from_beginning">Assistir do início</string>
     <string name="cw_action_remove">Remover</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -115,6 +115,13 @@
     <string name="cw_min_left">faltam %1$dm</string>
     <string name="cw_almost_done">Quase a terminar</string>
     <string name="cw_airs_date">Sairá a %1$s</string>
+    <string name="cw_airs_today">Sairá hoje</string>
+    <string name="cw_airs_tomorrow">Sairá amanhã</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Sairá dentro de %d dia</item>
+        <item quantity="many">Sairá dentro de %d dias</item>
+        <item quantity="other">Sairá dentro de %d dias</item>
+    </plurals>
     <string name="cw_action_go_to_details">Ir para detalhes</string>
     <string name="cw_action_start_from_beginning">Ver do início</string>
     <string name="cw_action_remove">Remover</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -20,6 +20,13 @@
     <string name="cw_min_left">%1$dm rămase</string>
     <string name="cw_almost_done">Aproape gata</string>
     <string name="cw_airs_date">Difuzat %1$s</string>
+    <string name="cw_airs_today">Difuzat astăzi</string>
+    <string name="cw_airs_tomorrow">Difuzat mâine</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Difuzat în %d zi</item>
+        <item quantity="few">Difuzat în %d zile</item>
+        <item quantity="other">Difuzat în %d de zile</item>
+    </plurals>
     <string name="cw_action_go_to_details">Accesează detalii</string>
     <string name="cw_action_start_from_beginning">Începe de la început</string>
     <string name="cw_action_remove">Elimină</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -115,6 +115,14 @@
     <string name="cw_min_left">Осталось %1$d мин</string>
     <string name="cw_almost_done">Почти закончено</string>
     <string name="cw_airs_date">Выходит %1$s</string>
+    <string name="cw_airs_today">Выходит сегодня</string>
+    <string name="cw_airs_tomorrow">Выходит завтра</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Выходит через %d день</item>
+        <item quantity="few">Выходит через %d дня</item>
+        <item quantity="many">Выходит через %d дней</item>
+        <item quantity="other">Выходит через %d дней</item>
+    </plurals>
     <string name="cw_action_go_to_details">Перейти к деталям</string>
     <string name="cw_action_start_from_beginning">Начать сначала</string>
     <string name="cw_action_remove">Удалить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -115,6 +115,14 @@
     <string name="cw_min_left">Zostáva %1$dm</string>
     <string name="cw_almost_done">Takmer hotovo</string>
     <string name="cw_airs_date">Vysiela sa %1$s</string>
+    <string name="cw_airs_today">Vysiela sa dnes</string>
+    <string name="cw_airs_tomorrow">Vysiela sa zajtra</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Vysiela sa za %d deň</item>
+        <item quantity="few">Vysiela sa za %d dni</item>
+        <item quantity="many">Vysiela sa za %d dní</item>
+        <item quantity="other">Vysiela sa za %d dní</item>
+    </plurals>
     <string name="cw_action_go_to_details">Prejsť na detaily</string>
     <string name="cw_action_start_from_beginning">Začať od začiatku</string>
     <string name="cw_action_remove">Odobrať</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -148,6 +148,14 @@
     <string name="cw_min_left">Še %1$dm</string>
     <string name="cw_almost_done">Skoraj pri koncu</string>														  												  
     <string name="cw_airs_date">Na sporedu %1$s</string>
+    <string name="cw_airs_today">Na sporedu danes</string>
+    <string name="cw_airs_tomorrow">Na sporedu jutri</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Na sporedu čez %d dan</item>
+        <item quantity="two">Na sporedu čez %d dneva</item>
+        <item quantity="few">Na sporedu čez %d dni</item>
+        <item quantity="other">Na sporedu čez %d dni</item>
+    </plurals>
     <string name="cw_action_go_to_details">Pojdi na podrobnosti</string>
     <string name="cw_action_start_from_beginning">Začni od začetka</string>											   
 	<string name="cw_action_remove">Odstrani</string>											   

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -53,6 +53,12 @@
     <string name="cw_min_left">%1$dm kvar</string>
     <string name="cw_almost_done">Nästan färdig</string>
     <string name="cw_airs_date">Sänds %1$s</string>
+    <string name="cw_airs_today">Sänds idag</string>
+    <string name="cw_airs_tomorrow">Sänds imorgon</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Sänds om %d dag</item>
+        <item quantity="other">Sänds om %d dagar</item>
+    </plurals>
     <string name="cw_action_go_to_details">Gå till detaljer</string>
     <string name="cw_action_start_from_beginning">Börja om från början</string>
     <string name="cw_action_remove">Ta bort</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -151,6 +151,12 @@
     <string name="cw_min_left">%1$d dk kaldı</string>
     <string name="cw_almost_done">Neredeyse bitti</string>
     <string name="cw_airs_date">Yayın tarihi: %1$s</string>
+    <string name="cw_airs_today">Bugün yayında</string>
+    <string name="cw_airs_tomorrow">Yarın yayında</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Yayın tarihi: %d gün sonra</item>
+        <item quantity="other">Yayın tarihi: %d gün sonra</item>
+    </plurals>
     <string name="cw_action_go_to_details">Detaylara git</string>
     <string name="cw_action_start_from_beginning">Baştan başla</string>
     <string name="cw_action_remove">Kaldır</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -21,6 +21,11 @@
     <string name="cw_min_left">Còn %1$dp</string>
     <string name="cw_almost_done">Sắp xong rồi</string>
     <string name="cw_airs_date">Phát sóng %1$s</string>
+    <string name="cw_airs_today">Phát sóng hôm nay</string>
+    <string name="cw_airs_tomorrow">Phát sóng ngày mai</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="other">Phát sóng trong %d ngày nữa</item>
+    </plurals>
     <string name="cw_action_go_to_details">Xem chi tiết</string>
     <string name="cw_action_start_from_beginning">Xem từ đầu</string>
     <string name="cw_action_remove">Xoá</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,12 @@
     <string name="cw_min_left">%1$dm left</string>
     <string name="cw_almost_done">Almost done</string>
     <string name="cw_airs_date">Airs %1$s</string>
+    <string name="cw_airs_today">Airs today</string>
+    <string name="cw_airs_tomorrow">Airs tomorrow</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Airs in %d day</item>
+        <item quantity="other">Airs in %d days</item>
+    </plurals>
     <string name="cw_action_go_to_details">Go to details</string>
     <string name="cw_action_start_from_beginning">Start from beginning</string>
     <string name="cw_action_remove">Remove</string>


### PR DESCRIPTION
## Summary

Replaces the absolute "Airs May 20" badge on Continue Watching cards with relative labels when the air date is within 7 days:

| Days until air | Display |
|---|---|
| 0 | Airs today |
| 1 | Airs tomorrow |
| 2-7 | Airs in X days |
| 8+ | Airs May 20 (unchanged) |

## Changes

- **New `AirDateUtils.kt`** -- shared utility with `parseEpisodeReleaseDate` (extracted from ViewModel) and `computeAirDateBadgeText()`
- **`ContinueWatchingSection.kt`** -- classic CW badge and episode title fallback now use `computeAirDateBadgeText`
- **`ModernHomeModels.kt`** -- modern CW hero subtitle now uses `computeAirDateBadgeText`
- **`HomeViewModelContinueWatching.kt`** -- removed private `parseEpisodeReleaseDate`, imports shared version
- **28 locale files** -- added `cw_airs_today`, `cw_airs_tomorrow` strings and `cw_airs_in_days` plurals with proper plural forms per language (Czech: one/few/many, Russian: one/few/many, Arabic: zero/one/two/few/many/other, etc.)

## i18n

All 28 supported locales have translations. Android's `<plurals>` resource handles grammatical number agreement automatically per CLDR rules -- e.g., Czech "Vysila se za 2 dny" vs "Vysila se za 5 dni".
