### PR TITLE
Fix/autoplay debrid resolve

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -251,6 +251,7 @@ class PlayerRuntimeController(
     internal var hideSubtitleDelayOverlayJob: Job? = null
     internal var subtitleAutoSyncLoadJob: Job? = null
     internal var nextEpisodeAutoPlayJob: Job? = null
+    internal var debridResolveJob: Job? = null
     internal var stillWatchingPromptJob: Job? = null
     internal var sourceStreamsJob: Job? = null
     internal var sourceChipErrorDismissJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.decoder.ffmpeg.FfmpegAudioRenderer
+import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.torrent.TorrentService
 import com.nuvio.tv.data.local.AutoSkipSegmentType
@@ -71,6 +72,7 @@ class PlayerRuntimeController(
     internal val tmdbService: com.nuvio.tv.core.tmdb.TmdbService,
     internal val tmdbMetadataService: com.nuvio.tv.core.tmdb.TmdbMetadataService,
     internal val tmdbSettingsDataStore: com.nuvio.tv.data.local.TmdbSettingsDataStore,
+    internal val directDebridResolver: DirectDebridResolver,
     savedStateHandle: SavedStateHandle,
     internal val scope: CoroutineScope
 ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -40,6 +40,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     delayMpvResumeSeekUntilVideoTrack = false
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null
+    debridResolveJob?.cancel()
+    debridResolveJob = null
     stillWatchingPromptJob?.cancel()
     stillWatchingPromptJob = null
     errorRetryJob?.cancel()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -503,12 +503,21 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
     val url = stream.getStreamUrl()
     if (url.isNullOrBlank()) {
         if (stream.isDirectDebrid()) {
-            scope.launch {
+            debridResolveJob?.cancel()
+            _uiState.update { it.copy(isLoadingSourceStreams = true, sourceStreamsError = null) }
+            debridResolveJob = scope.launch {
                 val resolved = resolveDirectDebridStreamIfNeeded(stream, currentSeason, currentEpisode)
                 if (resolved != null && !resolved.getStreamUrl().isNullOrBlank()) {
+                    debridResolveJob = null
                     switchToSourceStream(resolved)
                 } else {
-                    _uiState.update { it.copy(sourceStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
+                    debridResolveJob = null
+                    _uiState.update {
+                        it.copy(
+                            isLoadingSourceStreams = false,
+                            sourceStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)
+                        )
+                    }
                 }
             }
             return
@@ -812,12 +821,21 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
         if (stream.isDirectDebrid()) {
             val resolveSeason = forcedTargetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
             val resolveEpisode = forcedTargetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode
-            scope.launch {
+            debridResolveJob?.cancel()
+            _uiState.update { it.copy(isLoadingEpisodeStreams = true, episodeStreamsError = null) }
+            debridResolveJob = scope.launch {
                 val resolved = resolveDirectDebridStreamIfNeeded(stream, resolveSeason, resolveEpisode)
                 if (resolved != null && !resolved.getStreamUrl().isNullOrBlank()) {
+                    debridResolveJob = null
                     switchToEpisodeStream(resolved, forcedTargetVideo, isAutoPlay)
                 } else {
-                    _uiState.update { it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
+                    debridResolveJob = null
+                    _uiState.update {
+                        it.copy(
+                            isLoadingEpisodeStreams = false,
+                            episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)
+                        )
+                    }
                 }
             }
             return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.content.Intent
 import android.net.Uri
 import androidx.media3.common.util.UnstableApi
+import com.nuvio.tv.core.debrid.DirectDebridPlayableResult
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.player.StreamAutoPlaySelector
 import com.nuvio.tv.data.local.PlayerSettings
@@ -501,6 +502,17 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
 
     val url = stream.getStreamUrl()
     if (url.isNullOrBlank()) {
+        if (stream.isDirectDebrid()) {
+            scope.launch {
+                val resolved = resolveDirectDebridStreamIfNeeded(stream, currentSeason, currentEpisode)
+                if (resolved != null && !resolved.getStreamUrl().isNullOrBlank()) {
+                    switchToSourceStream(resolved)
+                } else {
+                    _uiState.update { it.copy(sourceStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
+                }
+            }
+            return
+        }
         _uiState.update { it.copy(sourceStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
         return
     }
@@ -797,6 +809,19 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
 
     val url = stream.getStreamUrl()
     if (url.isNullOrBlank()) {
+        if (stream.isDirectDebrid()) {
+            val resolveSeason = forcedTargetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
+            val resolveEpisode = forcedTargetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode
+            scope.launch {
+                val resolved = resolveDirectDebridStreamIfNeeded(stream, resolveSeason, resolveEpisode)
+                if (resolved != null && !resolved.getStreamUrl().isNullOrBlank()) {
+                    switchToEpisodeStream(resolved, forcedTargetVideo, isAutoPlay)
+                } else {
+                    _uiState.update { it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
+                }
+            }
+            return
+        }
         _uiState.update { it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_invalid_url)) }
         return
     }
@@ -995,6 +1020,20 @@ internal fun PlayerRuntimeController.showEpisodeStreamPicker(video: Video, force
     loadStreamsForEpisode(video = video, forceRefresh = forceRefresh)
 }
 
+internal suspend fun PlayerRuntimeController.resolveDirectDebridStreamIfNeeded(
+    stream: Stream,
+    season: Int?,
+    episode: Int?
+): Stream? {
+    if (!stream.isDirectDebrid() || stream.getStreamUrl() != null) return stream
+    return when (val result = directDebridResolver.resolveToPlayableStream(stream, season, episode)) {
+        is DirectDebridPlayableResult.Success -> result.stream
+        DirectDebridPlayableResult.MissingApiKey,
+        DirectDebridPlayableResult.Stale,
+        DirectDebridPlayableResult.Error -> null
+    }
+}
+
 internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = false) {
     val nextVideo = nextEpisodeVideo ?: return
     val type = contentType ?: return
@@ -1174,7 +1213,9 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                 }
             }
 
-            val streamToPlay = selectedStream
+            val streamToPlay = selectedStream?.let {
+                resolveDirectDebridStreamIfNeeded(it, nextVideo.season, nextVideo.episode)
+            }
             if (streamToPlay != null) {
                 val sourceName = (streamToPlay.name?.takeIf { it.isNotBlank() } ?: streamToPlay.addonName).trim()
                 for (remaining in 3 downTo 1) {
@@ -1213,7 +1254,7 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                 }
                 showEpisodeStreamPicker(
                     video = nextVideo,
-                    forceRefresh = lastError != null
+                    forceRefresh = lastError != null || selectedStream != null
                 )
             }
         } catch (e: CancellationException) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.exoplayer.ExoPlayer
+import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.torrent.TorrentService
 import com.nuvio.tv.core.torrent.TorrentSettings
@@ -55,6 +56,7 @@ class PlayerViewModel @Inject constructor(
     private val tmdbMetadataService: TmdbMetadataService,
     private val tmdbSettingsDataStore: TmdbSettingsDataStore,
     private val trailerPlayerPool: com.nuvio.tv.core.player.TrailerPlayerPool,
+    private val directDebridResolver: DirectDebridResolver,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -89,6 +91,7 @@ class PlayerViewModel @Inject constructor(
         tmdbService = tmdbService,
         tmdbMetadataService = tmdbMetadataService,
         tmdbSettingsDataStore = tmdbSettingsDataStore,
+        directDebridResolver = directDebridResolver,
         savedStateHandle = savedStateHandle,
         scope = viewModelScope
     )


### PR DESCRIPTION
## Summary

Wires `DirectDebridResolver` into the player's stream-switch paths so direct-debrid streams (e.g. Debrid Instant) get their URL resolved before playback. Without this, the autoplay countdown finishes and the in-player episode/source pickers accept the selection, but no new ExoPlayer is built because the selected stream's URL is still null when `switchToEpisodeStream` checks it.

## PR type

- [x] Behavior bug/regression fix

## Why
Direct-debrid streams (introduced by the recently merged in-house debrid integration in `041856a2`) carry a null `url` field until `DirectDebridResolver` materializes one. `StreamScreenViewModel` already does this resolution before navigating to the player, but the in-player handoff paths (`playNextEpisode`, `switchToEpisodeStream`, `switchToSourceStream`) bail at the `url.isNullOrBlank()` check. User-visible symptom: enable debrid, finish an episode, watch the autoplay countdown complete with no new playback. Reproducible 100% with Debrid Instant streams.

## Issue or approval
Fixes #1954.

## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
- Did not change `DirectDebridResolver` itself, despite spotting a pre-existing concern in its `finally` block (the suspending `mutex.withLock` cleanup can be skipped if the caller is cancelled mid-`await`, leaking the in-flight `Deferred`). Out of scope; for this fix.
- Did not modify `StreamAutoPlaySelector.isPlayable()`. Its existing contract ("direct-debrid streams are playable even with null URL") is intentional; the fix lives in the caller paths.
- Did not introduce a new full-screen "resolving stream" overlay in the player. The fix reuses the existing `isLoadingEpisodeStreams` / `isLoadingSourceStreams` flags so the panel's existing spinner shows during the resolve.

## Testing
Bug originally reproduced on release build `com.nuvio.tv` 0.6.18-beta per #1954. Fix verified on a debug build (`com.nuviodebug.com`) of the patched branch on Android TV (Raspberry Pi 5):

- **Autoplay with direct-debrid stream**, played *Reno 911!* s7e19 with a Debrid Instant stream and let the episode end naturally. Before the fix: autoplay countdown for s7e20 ran to completion, then the player sat idle at end of stream (logcat showed streams fetched, `AudioTrack: stop`, Trakt scrobble stop, then silence, no `ExoPlayerImpl: Init`). After the fix: `DirectDebridResolver` materializes the URL during the search window, `ExoPlayerImpl: Init` fires, s7e20 begins playing without user interaction.
- **In-player episodes panel**, selecting an unresolved direct-debrid stream shows the existing loading spinner during the resolve, then plays.
- **In-player sources panel**, same behavior.
- **Multi-clicks on an unresolved stream**, the `debridResolveJob` handle cancels the in-flight resolve (no parallel ExoPlayer rebuilds).
- **Non-debrid streams** unchanged behavior. `isDirectDebrid()` returns false, the new branch is skipped.

Build/install commands:
```
./gradlew :app:installFullDebug
```

## Screenshots / Video
Not a UI change. The fix reuses existing per-panel loading flags so the existing spinner appears during the resolve step. Happy to record a short video of the autoplay flow if helpful.

## Breaking changes
None.

## Linked issues
Fixes #1954.