### PR TITLE
fix(i18n): translate 3 missing French strings (binge group reuse, debrid warning)

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -600,6 +600,8 @@
     <string name="autoplay_next_episode_sub">Démarrer automatiquement l’épisode suivant quand l’invite apparaît.</string>
     <string name="autoplay_prefer_binge_group">Préférer le groupe Binge (épisode suivant)</string>
     <string name="autoplay_prefer_binge_group_sub">Essayer d’abord le même profil de source (même addon/groupe de qualité) avant les règles normales de lecture automatique.</string>
+    <string name="autoplay_reuse_binge_group">Réutiliser le groupe Binge</string>
+    <string name="autoplay_reuse_binge_group_sub">Mémoriser et réutiliser le dernier groupe Binge entre les sessions (Continuer à regarder, Détails, etc.).</string>
     <string name="autoplay_threshold_pct">Pourcentage</string>
     <string name="autoplay_threshold_min">Minutes avant la fin</string>
     <string name="autoplay_threshold_mode">Mode du seuil de l’épisode suivant</string>
@@ -2376,6 +2378,7 @@
     <string name="debrid_prepare_instant_playback">Préparer les liens</string>
     <string name="debrid_prepare_instant_playback_description">Résoudre les premières sources avant le début de la lecture.</string>
     <string name="debrid_prepare_stream_count">Sources à préparer</string>
+    <string name="debrid_prepare_stream_count_warning">Utilise une valeur la plus faible possible. Les services Debrid peuvent limiter le nombre de liens résolus sur une période donnée. Ouvrir un film ou un épisode peut compter pour ces limites même sans appuyer sur Lecture, car les liens sont préparés à l’avance.</string>
     <string name="debrid_prepare_count_one">1 source</string>
     <string name="debrid_prepare_count_many">%1$d sources</string>
     <string name="debrid_stream_max_results_title">Résultats max</string>


### PR DESCRIPTION
## Summary

After recent merges to `dev` (debrid localization update and the autoplay binge-group reuse setting), an EN-vs-FR key diff on `values/strings.xml` vs `values-fr/strings.xml` found 3 keys with no French value, so French users see English fallbacks.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

The new strings were added upstream without a `values-fr` counterpart:

- `autoplay_reuse_binge_group` / `autoplay_reuse_binge_group_sub` — autoplay setting placed next to the existing `autoplay_prefer_binge_group` pair.
- `debrid_prepare_stream_count_warning` — rate-limit warning shown under the "Sources to prepare" picker on the Debrid screen.

## Issue or approval

No linked issue — localization-only fill of missing FR keys, found by a mechanical EN-vs-FR key diff on `dev`.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `values-fr/strings.xml` is changed; no other locale, no `values/strings.xml`, no code.
- No existing FR string is modified — only the 3 missing keys are added.
- Translations follow existing FR conventions (typographic apostrophe, `&#160;` NBSP, tutoiement) and reuse the "groupe Binge" phrasing already used for `autoplay_prefer_binge_group`.

## Testing

- `./gradlew :app:processFullDebugResources` — resources merge cleanly.
- Verified that EN and FR key sets are now identical (2158 keys each, no duplicates, no FR-only stale keys).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — localization-only fill of missing FR keys.