### PR TITLE
fix(player): resolve settings migration timing race condition on cold start

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -17,8 +17,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -461,86 +462,92 @@ class PlayerSettingsDataStore @Inject constructor(
 
     init {
         ioScope.launch {
-            store().edit { prefs ->
-                val loadControlMigrated = prefs[migrationLoadControlDefaultsAlignedDoneKey] ?: false
-                if (!loadControlMigrated) {
-                    val currentMin = prefs[minBufferMsKey]
-                    val currentMax = prefs[maxBufferMsKey]
+            profileManager.activeProfileId.collect { pid ->
+                migrateProfile(pid)
+            }
+        }
+    }
 
-                    val legacyDefaultsDetected = (currentMin == null && currentMax == null) ||
-                        (currentMin == 15_000 && currentMax == 25_000)
+    private suspend fun migrateProfile(profileId: Int) {
+        factory.get(profileId, FEATURE).edit { prefs ->
+            val loadControlMigrated = prefs[migrationLoadControlDefaultsAlignedDoneKey] ?: false
+            if (!loadControlMigrated) {
+                val currentMin = prefs[minBufferMsKey]
+                val currentMax = prefs[maxBufferMsKey]
 
-                    if (legacyDefaultsDetected) {
-                        prefs[minBufferMsKey] = 50_000
-                        prefs[maxBufferMsKey] = 50_000
-                    }
+                val legacyDefaultsDetected = (currentMin == null && currentMax == null) ||
+                    (currentMin == 15_000 && currentMax == 25_000)
 
-                    prefs[migrationLoadControlDefaultsAlignedDoneKey] = true
+                if (legacyDefaultsDetected) {
+                    prefs[minBufferMsKey] = 50_000
+                    prefs[maxBufferMsKey] = 50_000
                 }
 
-                val min = prefs[minBufferMsKey]
-                val max = prefs[maxBufferMsKey]
-                if (min != null && max != null && max < min) {
-                    prefs[maxBufferMsKey] = min
-                }
+                prefs[migrationLoadControlDefaultsAlignedDoneKey] = true
+            }
 
-                val preferredAudioLanguage = prefs[preferredAudioLanguageKey]
-                if (preferredAudioLanguage != null) {
-                    val normalizedPreferredAudioLanguage =
-                        normalizeSelectableLanguageCode(preferredAudioLanguage)
-                    if (normalizedPreferredAudioLanguage != preferredAudioLanguage) {
-                        prefs[preferredAudioLanguageKey] = normalizedPreferredAudioLanguage
-                    }
-                }
+            val min = prefs[minBufferMsKey]
+            val max = prefs[maxBufferMsKey]
+            if (min != null && max != null && max < min) {
+                prefs[maxBufferMsKey] = min
+            }
 
-                val secondaryPreferredAudioLanguage = prefs[secondaryPreferredAudioLanguageKey]
-                if (secondaryPreferredAudioLanguage != null) {
-                    val normalizedSecondaryPreferredAudioLanguage =
-                        normalizeSecondaryAudioLanguageCode(secondaryPreferredAudioLanguage)
-                    if (normalizedSecondaryPreferredAudioLanguage != secondaryPreferredAudioLanguage) {
-                        if (normalizedSecondaryPreferredAudioLanguage != null) {
-                            prefs[secondaryPreferredAudioLanguageKey] = normalizedSecondaryPreferredAudioLanguage
-                        } else {
-                            prefs.remove(secondaryPreferredAudioLanguageKey)
-                        }
-                    }
+            val preferredAudioLanguage = prefs[preferredAudioLanguageKey]
+            if (preferredAudioLanguage != null) {
+                val normalizedPreferredAudioLanguage =
+                    normalizeSelectableLanguageCode(preferredAudioLanguage)
+                if (normalizedPreferredAudioLanguage != preferredAudioLanguage) {
+                    prefs[preferredAudioLanguageKey] = normalizedPreferredAudioLanguage
                 }
+            }
 
-                val preferredSubtitleLanguage = prefs[subtitlePreferredLanguageKey]
-                if (preferredSubtitleLanguage != null) {
-                    val normalizedPreferredSubtitleLanguage =
-                        normalizeSelectableLanguageCode(preferredSubtitleLanguage)
-                    if (normalizedPreferredSubtitleLanguage != preferredSubtitleLanguage) {
-                        prefs[subtitlePreferredLanguageKey] = normalizedPreferredSubtitleLanguage
+            val secondaryPreferredAudioLanguage = prefs[secondaryPreferredAudioLanguageKey]
+            if (secondaryPreferredAudioLanguage != null) {
+                val normalizedSecondaryPreferredAudioLanguage =
+                    normalizeSecondaryAudioLanguageCode(secondaryPreferredAudioLanguage)
+                if (normalizedSecondaryPreferredAudioLanguage != secondaryPreferredAudioLanguage) {
+                    if (normalizedSecondaryPreferredAudioLanguage != null) {
+                        prefs[secondaryPreferredAudioLanguageKey] = normalizedSecondaryPreferredAudioLanguage
+                    } else {
+                        prefs.remove(secondaryPreferredAudioLanguageKey)
                     }
                 }
+            }
 
-                val secondarySubtitleLanguage = prefs[subtitleSecondaryLanguageKey]
-                if (secondarySubtitleLanguage != null) {
-                    val normalizedSecondarySubtitleLanguage =
-                        normalizeSelectableLanguageCode(secondarySubtitleLanguage)
-                    if (normalizedSecondarySubtitleLanguage != secondarySubtitleLanguage) {
-                        prefs[subtitleSecondaryLanguageKey] = normalizedSecondarySubtitleLanguage
-                    }
-                }
-
+            val preferredSubtitleLanguage = prefs[subtitlePreferredLanguageKey]
+            if (preferredSubtitleLanguage != null) {
                 val normalizedPreferredSubtitleLanguage =
-                    preferredSubtitleLanguage?.let(::normalizeSelectableLanguageCode)
+                    normalizeSelectableLanguageCode(preferredSubtitleLanguage)
+                if (normalizedPreferredSubtitleLanguage != preferredSubtitleLanguage) {
+                    prefs[subtitlePreferredLanguageKey] = normalizedPreferredSubtitleLanguage
+                }
+            }
+
+            val secondarySubtitleLanguage = prefs[subtitleSecondaryLanguageKey]
+            if (secondarySubtitleLanguage != null) {
                 val normalizedSecondarySubtitleLanguage =
-                    secondarySubtitleLanguage?.let(::normalizeSelectableLanguageCode)
-                when {
-                    normalizedPreferredSubtitleLanguage == SUBTITLE_LANGUAGE_FORCED -> {
-                        prefs[subtitleUseForcedSubtitlesKey] = true
-                        val migratedPreferred = normalizedSecondarySubtitleLanguage
-                            ?.takeUnless { it == SUBTITLE_LANGUAGE_FORCED || it == "none" }
-                            ?: "en"
-                        prefs[subtitlePreferredLanguageKey] = migratedPreferred
-                        prefs.remove(subtitleSecondaryLanguageKey)
-                    }
-                    normalizedSecondarySubtitleLanguage == SUBTITLE_LANGUAGE_FORCED -> {
-                        prefs[subtitleUseForcedSubtitlesKey] = true
-                        prefs.remove(subtitleSecondaryLanguageKey)
-                    }
+                    normalizeSelectableLanguageCode(secondarySubtitleLanguage)
+                if (normalizedSecondarySubtitleLanguage != secondarySubtitleLanguage) {
+                    prefs[subtitleSecondaryLanguageKey] = normalizedSecondarySubtitleLanguage
+                }
+            }
+
+            val normalizedPreferredSubtitleLanguage =
+                preferredSubtitleLanguage?.let(::normalizeSelectableLanguageCode)
+            val normalizedSecondarySubtitleLanguage =
+                secondarySubtitleLanguage?.let(::normalizeSelectableLanguageCode)
+            when {
+                normalizedPreferredSubtitleLanguage == SUBTITLE_LANGUAGE_FORCED -> {
+                    prefs[subtitleUseForcedSubtitlesKey] = true
+                    val migratedPreferred = normalizedSecondarySubtitleLanguage
+                        ?.takeUnless { it == SUBTITLE_LANGUAGE_FORCED || it == "none" }
+                        ?: "en"
+                    prefs[subtitlePreferredLanguageKey] = migratedPreferred
+                    prefs.remove(subtitleSecondaryLanguageKey)
+                }
+                normalizedSecondarySubtitleLanguage == SUBTITLE_LANGUAGE_FORCED -> {
+                    prefs[subtitleUseForcedSubtitlesKey] = true
+                    prefs.remove(subtitleSecondaryLanguageKey)
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -12,10 +12,14 @@ import com.nuvio.tv.core.profile.ProfileManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import javax.inject.Inject
@@ -355,6 +359,7 @@ enum class LibassRenderType {
     OVERLAY_OPEN_GL    // Overlay OpenGL rendering (supports HDR, recommended)
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
 class PlayerSettingsDataStore @Inject constructor(
     private val factory: ProfileDataStoreFactory,
@@ -557,7 +562,8 @@ class PlayerSettingsDataStore @Inject constructor(
      * Flow of current player settings
      */
     val playerSettings: Flow<PlayerSettings> = profileManager.activeProfileId.flatMapLatest { pid ->
-        factory.get(pid, FEATURE).data.map { prefs ->
+        factory.get(pid, FEATURE).data.onStart { migrateProfile(pid) }
+    }.map { prefs ->
             PlayerSettings(
                 playerPreference = prefs[playerPreferenceKey]?.let {
                     runCatching { PlayerPreference.valueOf(it) }.getOrDefault(PlayerPreference.INTERNAL)
@@ -699,26 +705,25 @@ class PlayerSettingsDataStore @Inject constructor(
                 )
             )
         }
-    }
 
     /**
      * Flow for just the libass toggle
      */
     val useLibass: Flow<Boolean> = profileManager.activeProfileId.flatMapLatest { pid ->
-        factory.get(pid, FEATURE).data.map { prefs ->
-            prefs[useLibassKey] ?: false
-        }
+        factory.get(pid, FEATURE).data.onStart { migrateProfile(pid) }
+    }.map { prefs ->
+        prefs[useLibassKey] ?: false
     }
 
     /**
      * Flow for the libass render type
      */
     val libassRenderType: Flow<LibassRenderType> = profileManager.activeProfileId.flatMapLatest { pid ->
-        factory.get(pid, FEATURE).data.map { prefs ->
-            prefs[libassRenderTypeKey]?.let {
-                try { LibassRenderType.valueOf(it) } catch (e: Exception) { LibassRenderType.OVERLAY_OPEN_GL }
-            } ?: LibassRenderType.OVERLAY_OPEN_GL
-        }
+        factory.get(pid, FEATURE).data.onStart { migrateProfile(pid) }
+    }.map { prefs ->
+        prefs[libassRenderTypeKey]?.let {
+            try { LibassRenderType.valueOf(it) } catch (e: Exception) { LibassRenderType.OVERLAY_OPEN_GL }
+        } ?: LibassRenderType.OVERLAY_OPEN_GL
     }
 
     // Player preference setter


### PR DESCRIPTION
## Summary

Make player settings migrations profile-aware by listening to the active profile ID flow. This ensures that any new player updates, audio configurations, downmix normalizations, and subtitle preferences are successfully applied to all existing profiles.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Whenever a new app update was installed, users (even those with a single profile, Profile 1) experienced severe playback issues, audio sync errors, or complete player failures during the first playback attempts after update.

The only way users could temporarily resolve this was by performing a **clean install**. Clean installing solved the issue because it completely wiped the local storage (clearing the old DataStore files) and forced the newly installed app to create fresh settings files directly containing the correct new default configurations.

On standard updates, however, the existing local settings files are preserved and must undergo migration. Previously, the migration logic in `PlayerSettingsDataStore` was launched in an asynchronous background coroutine (`ioScope.launch`) inside the constructor (`init` block). Because this coroutine was completely non-blocking and was never awaited, the player initialization sequence in `PlayerRuntimeControllerInitialization.kt` immediately queried `playerSettingsDataStore.playerSettings.first()` and loaded the preferences **before** the migration task actually had time to run and write the new settings to the disk. 

As a result, the player loaded outdated preferences (such as obsolete audio settings and unmigrated configuration parameters) on cold start playbacks, leading to playback failures or stutters. This race condition occurred even for single-profile users.

This PR fixes the race condition by refactoring the player settings flows (`playerSettings`, `useLibass`, and `libassRenderType`) to sequentially invoke `migrateProfile(pid)` using the Flow's `.onStart` operator inside the `flatMapLatest` transform. This suspends the collector (such as `playerSettings.first()`) until the migration has completed, guaranteeing that the player only loads fully migrated, up-to-date preferences.

## Issue or approval

Reported by the user via DM 

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Strictly limits changes to `PlayerSettingsDataStore.kt` migration logic.
- Does not modify any visual layout, UI widgets, or core media renderers.

## Testing

- Ran `./gradlew :app:compileFullDebugKotlin` (Build completed successfully).
- Verified that switching profiles successfully triggers profile-scoped migrations dynamically.
- Verified that all local profile files are correctly migrated to modern settings defaults without requiring a clean install.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Reported by the user via DM 
