### PR TITLE
fix(i18n): replace awkward French 'par récence' with natural phrasing

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2293,7 +2293,7 @@
     <string name="layout_cw_sort_mode">Ordre de tri</string>
     <string name="layout_cw_sort_mode_sub">Comment les éléments Continuer à regarder sont organisés</string>
     <string name="layout_cw_sort_default">Par défaut</string>
-    <string name="layout_cw_sort_default_desc">Trier tous les éléments par récence</string>
+    <string name="layout_cw_sort_default_desc">Trier les éléments du plus récent au plus ancien</string>
     <string name="layout_cw_sort_streaming">Style streaming</string>
     <string name="layout_cw_sort_streaming_desc">Les éléments sortis d’abord, ceux à venir à la fin</string>
 


### PR DESCRIPTION
## Summary

The French description under Continue Watching → Sort Order → Default reads `Trier tous les éléments par récence`. The word `récence` is technically in the dictionary but is never used in everyday French — native readers find it meaningless. Replaced with `Trier les éléments du plus récent au plus ancien`, which conveys the same meaning naturally and parallels the contrasted "streaming style" option ("Les éléments sortis d'abord, ceux à venir à la fin").

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

A native French speaker reported the wording was unintelligible. Replacing it with `du plus récent au plus ancien` matches the wording used elsewhere in similar sort menus and reads as natural French.

## Issue or approval

No linked issue — localization-only wording fix reported by a French-speaking user.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only the `layout_cw_sort_default_desc` value in `values-fr/strings.xml` is changed.
- No layout/composable change.
- English and other locales are untouched.

## Testing

- `./gradlew :app:processFullDebugResources` — resources merge cleanly.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — localization-only wording fix.