### PR TITLE
fix(i18n): fix three awkward/incorrect French translations

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2336,7 +2336,7 @@
 
     <!-- Audio&#160;: downmix FFmpeg -->
     <string name="audio_enable_downmix_title">Activer le downmix</string>
-    <string name="audio_enable_downmix_subtitle">Utilise le chemin de downmix FFmpeg. Désactivé, l’audio suit le chemin Android/appareil précédent.</string>
+    <string name="audio_enable_downmix_subtitle">Utilise le chemin de downmix FFmpeg. Quand il est désactivé, l’audio suit le chemin Android/appareil précédent.</string>
     <string name="audio_number_of_channels">Nombre de canaux</string>
     <string name="audio_number_of_channels_desc">Définit la disposition des haut-parleurs utilisée pour le downmix FFmpeg.</string>
     <string name="audio_center_mix_label">Downmix&#160;: niveau du canal central</string>
@@ -2344,7 +2344,7 @@
     <string name="audio_center_mix_help">Niveau du canal central en dB par rapport aux métadonnées ou à la valeur par défaut (-3 dB)</string>
     <string name="audio_center_mix_unavailable">Le mixage du canal central n’est disponible que lorsque le downmix FFmpeg est actif.</string>
     <string name="audio_maintain_original_audio_on_downmix_title">Conserver l’audio d’origine lors du downmix</string>
-    <string name="audio_maintain_original_audio_on_downmix_subtitle">Désactivé, la normalisation du downmix peut réduire le volume global.</string>
+    <string name="audio_maintain_original_audio_on_downmix_subtitle">Quand il est désactivé, la normalisation du downmix peut réduire le volume global.</string>
 
     <!-- Debrid&#160;: intégration de comptes cloud (expérimental) -->
     <string name="settings_debrid_subtitle">Sources de comptes cloud expérimentales</string>
@@ -2378,7 +2378,7 @@
     <string name="debrid_prepare_instant_playback">Préparer les liens</string>
     <string name="debrid_prepare_instant_playback_description">Résoudre les premières sources avant le début de la lecture.</string>
     <string name="debrid_prepare_stream_count">Sources à préparer</string>
-    <string name="debrid_prepare_stream_count_warning">Utilise une valeur la plus faible possible. Les services Debrid peuvent limiter le nombre de liens résolus sur une période donnée. Ouvrir un film ou un épisode peut compter pour ces limites même sans appuyer sur Lecture, car les liens sont préparés à l’avance.</string>
+    <string name="debrid_prepare_stream_count_warning">Utilise une valeur plus faible si possible. Les services Debrid peuvent limiter le nombre de liens résolus sur une période donnée. Ouvrir un film ou un épisode peut compter dans ces limites même sans appuyer sur Lecture, car les liens sont préparés à l’avance.</string>
     <string name="debrid_prepare_count_one">1 source</string>
     <string name="debrid_prepare_count_many">%1$d sources</string>
     <string name="debrid_stream_max_results_title">Résultats max</string>


### PR DESCRIPTION
## Summary

A native French reader flagged three previously-merged strings that read poorly in French. All three are reworded in place without changing the intent.

| Key | Before | After | Why |
|---|---|---|---|
| `audio_enable_downmix_subtitle` | `…downmix FFmpeg. Désactivé, l'audio suit…` | `…downmix FFmpeg. Quand il est désactivé, l'audio suit…` | Bare `Désactivé,` reads as a telegraphic clipping; the rest of the file consistently uses `Quand désactivé,` / `lorsque …`. |
| `audio_maintain_original_audio_on_downmix_subtitle` | `Désactivé, la normalisation…` | `Quand il est désactivé, la normalisation…` | Same reason. |
| `debrid_prepare_stream_count_warning` | `Utilise une valeur la plus faible possible. … peut compter pour ces limites …` | `Utilise une valeur plus faible si possible. … peut compter dans ces limites …` | `une valeur la plus faible` mixes the indefinite article with a superlative and is ungrammatical in French; the EN source says `Use a lower count when possible`. `compter dans` is also the natural FR collocation for `count toward`. |

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

The three strings landed in earlier i18n batches and were reported by a native FR speaker as either ungrammatical or telegraphic. Fixing them aligns with the existing wording conventions of the FR strings file.

## Issue or approval

No linked issue — localization-only wording fixes reported by a French-speaking user.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `values-fr/strings.xml` is changed; three string values rewritten in place.
- No layout/composable change, no key added or removed.
- English and other locales are untouched.

## Testing

- `./gradlew :app:processFullDebugResources` — resources merge cleanly.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — localization-only wording fixes.