### PR TITLE
Changes to next episode threshold

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -657,13 +657,13 @@ class PlayerSettingsDataStore @Inject constructor(
                         ?: prefs[nextEpisodeThresholdPercentLegacyKey]?.toFloat()
                         ?: 99f,
                     min = 97f,
-                    max = 99.5f
+                    max = 100f
                 ),
                 nextEpisodeThresholdMinutesBeforeEnd = normalizeHalfStep(
                     value = prefs[nextEpisodeThresholdMinutesBeforeEndKey]
                         ?: prefs[nextEpisodeThresholdMinutesBeforeEndLegacyKey]?.toFloat()
                         ?: 2f,
-                    min = 1f,
+                    min = 0f,
                     max = 3.5f
                 ),
                 streamReuseLastLinkEnabled = prefs[streamReuseLastLinkEnabledKey] ?: false,
@@ -997,7 +997,7 @@ class PlayerSettingsDataStore @Inject constructor(
             prefs[nextEpisodeThresholdPercentKey] = normalizeHalfStep(
                 value = percent,
                 min = 97f,
-                max = 99.5f
+                max = 100f
             )
         }
     }
@@ -1006,7 +1006,7 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             prefs[nextEpisodeThresholdMinutesBeforeEndKey] = normalizeHalfStep(
                 value = minutes,
-                min = 1f,
+                min = 0f,
                 max = 3.5f
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -43,11 +43,11 @@ object PlayerNextEpisodeRules {
             if (durationMs <= 0L) return false
             when (thresholdMode) {
                 NextEpisodeThresholdMode.PERCENTAGE -> {
-                    val clampedPercent = thresholdPercent.coerceIn(97f, 99.5f)
+                    val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
                     (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
                 }
                 NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
-                    val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(1f, 3.5f)
+                    val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
                     val remainingMs = durationMs - positionMs
                     remainingMs <= (clampedMinutes * 60_000f).toLong()
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -249,7 +249,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                     value = (playerSettings.nextEpisodeThresholdPercent * 2f).roundToInt(),
                     valueText = "${formatHalfStepValue(playerSettings.nextEpisodeThresholdPercent)}%",
                     minValue = 194,
-                    maxValue = 199,
+                    maxValue = 200,
                     step = 1,
                     onValueChange = { onSetNextEpisodeThresholdPercent(it / 2f) },
                     onFocused = onItemFocused
@@ -262,7 +262,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                     subtitle = stringResource(R.string.autoplay_threshold_pct_sub),
                     value = (playerSettings.nextEpisodeThresholdMinutesBeforeEnd * 2f).roundToInt(),
                     valueText = "${formatHalfStepValue(playerSettings.nextEpisodeThresholdMinutesBeforeEnd)} min",
-                    minValue = 2,
+                    minValue = 0,
                     maxValue = 7,
                     step = 1,
                     onValueChange = { onSetNextEpisodeThresholdMinutesBeforeEnd(it / 2f) },


### PR DESCRIPTION
## Summary

Made changes to the Playback Settings. I adjusted the threshold for auto-select next episode, both the minute and percentage option. I added a 0 minutes/ 0% option, so auto-select would start at the end of the episode.
## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [X] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

I recently implemented the 0 minutes/ 0% option on the mobile version. This would improve user experience and parity between the apps. It will allow users to set threshold percentage and minutes before end, so the next episode starts after playback has ended, and it adds a 0.5 minutes option, which was requested here #[885](https://github.com/NuvioMedia/NuvioMobile/issues/885)  on mobile repo

## Issue or approval

Fixes #1323

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [X] UI changed only to fix a documented glitch/bug
- [X] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [X] I have read and understood `CONTRIBUTING.md`.
- [X] This PR is small, focused, and limited to one problem.
- [X] This PR is not cosmetic-only.
- [X] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [X] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [X] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [X] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [X] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

I only added the 0 minutes before end/ 0% threshold option to the Playback settings.

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->
Tested in Android Studio running on Android 14, tested on Fire Tv Cube 2nd Gen.

## Screenshots / Video

<img width="1280" height="720" alt="PlaybackSettingsPercentage" src="https://github.com/user-attachments/assets/2e265fbd-f524-4a51-9d25-b2563d1a20e2" />

<img width="1280" height="720" alt="PlaybackSettingsMinutes" src="https://github.com/user-attachments/assets/87bd2f42-5b5d-4132-8407-77bfd28c575f" />

Video

https://github.com/user-attachments/assets/48617e26-ee5b-42b3-ae45-9e0a6a930b88



## Breaking changes

None.

## Linked issues

#1323