### PR TITLE
fix(player): gate retry budget reset behind stable playback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -362,6 +362,7 @@ class PlayerRuntimeController(
     internal var errorRetryCount: Int = 0
     internal var consecutiveAutoPlayCount: Int = 0
     internal var errorRetryJob: Job? = null
+    internal var stableProgressResetJob: Job? = null
     internal var currentScrobbleItem: TraktScrobbleItem? = null
     internal var currentTraktEpisodeMapping: EpisodeMappingEntry? = null
     internal var currentTraktEpisodeMappingKey: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
 import com.nuvio.tv.R
@@ -12,6 +13,7 @@ import kotlinx.coroutines.launch
 private const val MAX_STARTUP_AUTO_RETRIES = 2
 private const val MAX_AUTO_RETRIES = 2
 private const val RETRY_DELAY_MS = 1_500L
+private const val STABLE_PROGRESS_RESET_DELAY_MS = 5_000L
 
 internal fun PlayerRuntimeController.showRecoveryOverlay() {
     _uiState.update { state ->
@@ -271,6 +273,35 @@ internal fun PlayerRuntimeController.resetErrorRetryState() {
     pendingAudioPcmFallbackRebuild = false
     errorRetryJob?.cancel()
     errorRetryJob = null
+}
+
+internal fun PlayerRuntimeController.scheduleStableProgressReset() {
+    stableProgressResetJob?.cancel()
+    stableProgressResetJob = scope.launch {
+        delay(STABLE_PROGRESS_RESET_DELAY_MS)
+        val player = _exoPlayer ?: return@launch
+        if (player.playbackState == Player.STATE_READY && player.isPlaying) {
+            resetErrorRetryState()
+        }
+    }
+}
+
+internal fun PlayerRuntimeController.cancelStableProgressReset() {
+    stableProgressResetJob?.cancel()
+    stableProgressResetJob = null
+}
+
+internal fun PlayerRuntimeController.refreshStableProgressResetGate() {
+    if (!hasRenderedFirstFrame) return
+    val player = _exoPlayer ?: return
+    val healthy = player.playbackState == Player.STATE_READY && player.isPlaying
+    if (healthy) {
+        if (stableProgressResetJob?.isActive != true) {
+            scheduleStableProgressReset()
+        }
+    } else {
+        cancelStableProgressReset()
+    }
 }
 
 /**

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -513,6 +513,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                             saveWatchProgress()
                             resetPostPlayStateAfterPlaybackEnded()
                         }
+
+                        refreshStableProgressResetGate()
                     }
 
                     override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -536,9 +538,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                             if (playbackState != Player.STATE_BUFFERING) {
                                 emitStopScrobbleForCurrentProgress()
                             }
-                            
+
                             saveWatchProgress()
                         }
+                        refreshStableProgressResetGate()
                     }
 
                     override fun onTracksChanged(tracks: Tracks) {
@@ -554,7 +557,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                             playWhenReady = true
                             play()
                         }
-                        resetErrorRetryState()
+                        refreshStableProgressResetGate()
                         // Restore speed after PCM fallback: audio sink is already
                         // configured in PCM mode and won't revert to passthrough.
                         if (hasTriedAudioPcmFallback) {
@@ -577,6 +580,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (isReleasingPlayer && error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) {
                             return
                         }
+                        cancelStableProgressReset()
                         val detailedError = error.toDisplayMessage(context)
 
                         // If the codec crashed while the app is in the background (e.g. another

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -46,6 +46,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     stillWatchingPromptJob = null
     errorRetryJob?.cancel()
     errorRetryJob = null
+    stableProgressResetJob?.cancel()
+    stableProgressResetJob = null
     releaseMpvPlayer()
     _exoPlayer?.let { player ->
         runCatching { player.playWhenReady = false }


### PR DESCRIPTION
## Summary
When MatroskaExtractor (or any source-level extractor) fails after the first frame has rendered, `resetErrorRetryState()` in `onRenderedFirstFrame` resets the retry budget on every player rebuild, creating an infinite retry loop. This PR gates the reset behind 5 seconds of continuous healthy playback so the budget can actually exhaust and surface the existing error dialog.

## PR type
- [x] Behavior bug/regression fix

## Why
The retry budget bounds repeated failures on the same stream. The bug: the budget was cleared every time a single video frame rendered, which happens after every re-prepare. For source-level parser errors that fail again at the same byte offset (Media3 1.8.0 MatroskaExtractor's "No valid varint length mask found" is the concrete case), the player retried, rendered one frame, got the budget reset, failed again, and looped endlessly with no error dialog ever shown.

The fix defers the reset until the player has been in `STATE_READY && isPlaying` continuously for 5 seconds. `onPlaybackStateChanged` and `onIsPlayingChanged` (re)arm or cancel the timer on state transitions, so any unhealthy interval (buffering, paused, error) restarts the window.

## Issue or approval
#2004 - reported and reproduced by me on my own Android TV device. Provider/source-dependent, only fires on certain files where Media3 1.8.0's EBML parser trips on cue-point indexing.

## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
Intentionally not in this PR:

- Fixing the upstream MatroskaExtractor varint bug (lives in Media3 1.8.0; a version bump would be a larger dependency change).
- Recovery via "retry from position 0 on detected cue-parse failure" (separate WIP branch for potential follow-up).
- Loosening auto-engine-switch to fire on post-first-frame errors (currently gated to startup-only by design).
- Any UI or copy changes to the error dialog.

Four files touched, all in `app/src/main/java/com/nuvio/tv/ui/screens/player/`:

- `PlayerRuntimeController.kt`, one new `Job` field for the deferred-reset timer.
- `PlayerRuntimeControllerErrorRecovery.kt`, three new helpers (`scheduleStableProgressReset`, `cancelStableProgressReset`, `refreshStableProgressResetGate`) and one delay constant.
- `PlayerRuntimeControllerInitialization.kt`, wires the helpers into existing `onRenderedFirstFrame`, `onPlayerError`, `onPlaybackStateChanged`, and `onIsPlayingChanged` callbacks.
- `PlayerRuntimeControllerLifecycle.kt`, cancels the timer on `releasePlayer`.

## Testing
Built `installFullDebug` on Raspberry Pi 5 (arm64-v8a, Android TV).

Repro stream: Source from *Parks and Recreation* S6E20 / S6E16 served by a source whose MKV trips Media3 1.8.0's EBML varint parser during cue-point indexing.

- **Before fix**, player retried forever, no error dialog. Logcat showed `Auto-retry 1/2` and `Auto-retry 2/2` cycling indefinitely as each newly rendered frame reset the budget.
- **After fix**, same two retry attempts logged, then the existing "Playback Error" dialog appears with "Go Back", the expected terminal-error UX.
- **Regression check on a normal stream**, plays end-to-end without interference. The 5-second timer arms once after the first frame, fires, resets the budget, no further intervention.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
#2004 