### PR TITLE
Feature/Youtebe iFrame player

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
 
     <application
         android:name=".NuvioApplication"
+        android:appComponentFactory=".NuvioAppComponentFactory"
         android:allowBackup="true"
         android:banner="@mipmap/banner"
         android:icon="@mipmap/ic_launcher"
@@ -40,7 +41,8 @@
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"
         android:localeConfig="@xml/locale_config"
-        android:theme="@style/Theme.MyApplication">
+        android:theme="@style/Theme.MyApplication"
+        tools:replace="android:appComponentFactory">
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
@@ -77,6 +79,14 @@
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.trailer.TrailerOverlayActivity"
+            android:process=":trailer"
+            android:theme="@style/Theme.TrailerOverlay"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|screenLayout|density"
+            android:launchMode="singleTask" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,6 +87,11 @@
             android:exported="false"
             android:configChanges="orientation|screenSize|screenLayout|density"
             android:launchMode="singleTask" />
+
+        <service
+            android:name=".ui.trailer.TrailerWarmUpService"
+            android:process=":trailer"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/assets/youtube_player.html
+++ b/app/src/main/assets/youtube_player.html
@@ -69,6 +69,11 @@
                         } else {
                             player.unMute();
                         }
+                        try {
+                            if (typeof player.setPlaybackQuality === 'function') {
+                                player.setPlaybackQuality('highres');
+                            }
+                        } catch(e) {}
                         if (window.AndroidBridge) {
                             window.AndroidBridge.onPlayerReady();
                         }
@@ -78,6 +83,10 @@
                         if (window.AndroidBridge) {
                             window.AndroidBridge.onStateChange(event.data);
                         }
+                    },
+                    'onPlaybackQualityChange': function(event) {
+                        // Oynatma kalitesi değiştiğinde konsola yaz
+                        console.log("Playback quality changed to: " + event.data);
                     },
                     'onError': function(event) {
                         if (window.AndroidBridge) {
@@ -90,6 +99,11 @@
 
         function playVideo() {
             if (player && typeof player.playVideo === 'function') {
+                try {
+                    if (typeof player.setPlaybackQuality === 'function') {
+                        player.setPlaybackQuality('highres');
+                    }
+                } catch(e) {}
                 player.playVideo();
             }
         }

--- a/app/src/main/assets/youtube_player.html
+++ b/app/src/main/assets/youtube_player.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            background-color: black;
+            overflow: hidden;
+        }
+        #player {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+    </style>
+</head>
+<body>
+    <div id="player"></div>
+
+    <script>
+        var tag = document.createElement('script');
+        tag.src = "https://www.youtube.com/iframe_api";
+        var firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+        var player;
+        var videoId = "";
+        var progressInterval;
+
+        function onYouTubeIframeAPIReady() {
+            if (window.AndroidBridge) {
+                window.AndroidBridge.onReady();
+            }
+        }
+
+        function initPlayer(vid, autoPlay, startMuted) {
+            videoId = vid;
+            if (player) {
+                try {
+                    player.destroy();
+                } catch(e) {}
+            }
+            player = new YT.Player('player', {
+                height: '100%',
+                width: '100%',
+                videoId: videoId,
+                host: 'https://www.youtube-nocookie.com',
+                playerVars: {
+                    'autoplay': autoPlay ? 1 : 0,
+                    'controls': 0,
+                    'disablekb': 1,
+                    'fs': 0,
+                    'rel': 0,
+                    'showinfo': 0,
+                    'iv_load_policy': 3,
+                    'modestbranding': 1,
+                    'playsinline': 1,
+                    'origin': 'https://www.youtube-nocookie.com',
+                    'enablejsapi': 1
+                },
+                events: {
+                    'onReady': function(event) {
+                        if (startMuted) {
+                            player.mute();
+                        } else {
+                            player.unMute();
+                        }
+                        if (window.AndroidBridge) {
+                            window.AndroidBridge.onPlayerReady();
+                        }
+                        startProgressTimer();
+                    },
+                    'onStateChange': function(event) {
+                        if (window.AndroidBridge) {
+                            window.AndroidBridge.onStateChange(event.data);
+                        }
+                    },
+                    'onError': function(event) {
+                        if (window.AndroidBridge) {
+                            window.AndroidBridge.onError(event.data);
+                        }
+                    }
+                }
+            });
+        }
+
+        function playVideo() {
+            if (player && typeof player.playVideo === 'function') {
+                player.playVideo();
+            }
+        }
+
+        function pauseVideo() {
+            if (player && typeof player.pauseVideo === 'function') {
+                player.pauseVideo();
+            }
+        }
+
+        function seekTo(seconds) {
+            if (player && typeof player.seekTo === 'function') {
+                player.seekTo(seconds, true);
+            }
+        }
+
+        function setVolume(volume) {
+            if (player && typeof player.setVolume === 'function') {
+                player.setVolume(volume);
+            }
+        }
+
+        function mute() {
+            if (player && typeof player.mute === 'function') {
+                player.mute();
+            }
+        }
+
+        function unMute() {
+            if (player && typeof player.unMute === 'function') {
+                player.unMute();
+            }
+        }
+
+        function startProgressTimer() {
+            clearInterval(progressInterval);
+            progressInterval = setInterval(function() {
+                if (player && typeof player.getCurrentTime === 'function' && typeof player.getDuration === 'function') {
+                    var current = player.getCurrentTime();
+                    var duration = player.getDuration();
+                    if (window.AndroidBridge) {
+                        window.AndroidBridge.onProgress(current, duration);
+                    }
+                }
+            }, 500);
+        }
+    </script>
+</body>
+</html>

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -255,6 +255,9 @@ class MainActivity : ComponentActivity() {
 
         PluginRuntimeHooks.onActivityCreate(this)
 
+        // Pre-warm the :trailer subprocess on launch to speed up initial trailer load
+        com.nuvio.tv.ui.trailer.TrailerWarmUpService.start(this)
+
         window?.decorView?.post {
             val snapshot = com.nuvio.tv.core.player.DisplayCapabilities.detect(this)
             com.nuvio.tv.core.player.DisplayCapabilities.logSummary(snapshot)

--- a/app/src/main/java/com/nuvio/tv/NuvioAppComponentFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioAppComponentFactory.kt
@@ -1,0 +1,42 @@
+package com.nuvio.tv
+
+import android.app.AppComponentFactory
+import android.app.Application
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.nuvio.tv.ui.trailer.TrailerApplication
+
+/**
+ * Custom AppComponentFactory that provides a lightweight [TrailerApplication]
+ * for subprocess starts (e.g. the `:trailer` process).
+ *
+ * Problem: When a new process starts, Android instantiates the Application
+ * class declared in the manifest ([NuvioApplication]). This triggers
+ * Hilt/Dagger field initializers that load the entire DI component graph
+ * (~420MB of heap). For the `:trailer` process, which only needs a WebView,
+ * this causes OutOfMemoryError on devices with limited RAM.
+ *
+ * Solution: Intercept Application creation and return [TrailerApplication]
+ * (a plain [Application]) for any subprocess. This prevents [NuvioApplication]
+ * from being loaded at all, keeping the trailer process under ~50MB.
+ *
+ * This class is only loaded on API 28+ (where [AppComponentFactory] exists).
+ * On API 24-27, [NuvioApplication.isSubprocess] provides a fallback.
+ */
+@RequiresApi(Build.VERSION_CODES.P)
+class NuvioAppComponentFactory : AppComponentFactory() {
+
+    override fun instantiateApplication(
+        cl: ClassLoader,
+        className: String
+    ): Application {
+        val processName = Application.getProcessName() ?: ""
+        return if (":" in processName) {
+            // Subprocess: use lightweight Application to avoid Hilt class loading
+            TrailerApplication()
+        } else {
+            // Main process: use NuvioApplication with full Hilt DI
+            super.instantiateApplication(cl, className)
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -72,6 +72,13 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
         }
 
         super.onCreate()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            try {
+                android.webkit.WebView.setDataDirectorySuffix("main")
+            } catch (e: Exception) {
+                // Suffix might already be set or WebView already initialized, ignore safely
+            }
+        }
         PluginRuntimeHooks.onApplicationCreate(this)
         androidTvChannelSyncService.start()
         // Load locale synchronously so it's available before Activity.attachBaseContext.

--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -60,6 +60,17 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
     }
 
     override fun onCreate() {
+        // On API 28+, NuvioAppComponentFactory prevents this class from
+        // being loaded in subprocesses entirely (zero overhead).
+        // On API 24-27, this fallback skips Hilt injection to avoid crashes.
+        // Class loading overhead remains on API 24-27, but those devices
+        // are unlikely to have the PowerVR driver crash issue.
+        if (isSubprocess()) {
+            // Skip Hilt super.onCreate() which triggers hiltInternalInject().
+            // Application.onCreate() is empty in AOSP, so skipping is safe.
+            return
+        }
+
         super.onCreate()
         PluginRuntimeHooks.onApplicationCreate(this)
         androidTvChannelSyncService.start()
@@ -68,6 +79,24 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
         val tag = getSharedPreferences("app_locale", Context.MODE_PRIVATE)
             .getString("locale_tag", null)
         LocaleCache.localeTag = tag ?: ""
+    }
+
+    /**
+     * Returns true if this process is a subprocess (e.g. `:trailer`),
+     * not the main application process. Uses fast /proc/self/cmdline
+     * instead of ActivityManager which is slow and can cause ANR.
+     */
+    private fun isSubprocess(): Boolean {
+        val processName = if (android.os.Build.VERSION.SDK_INT >= 28) {
+            getProcessName()
+        } else {
+            try {
+                java.io.File("/proc/self/cmdline").readText().trim('\u0000')
+            } catch (_: Exception) {
+                packageName // fallback: assume main process
+            }
+        }
+        return processName != packageName
     }
 
     override fun newImageLoader(context: android.content.Context): ImageLoader {

--- a/app/src/main/java/com/nuvio/tv/core/build/TrailerPlaybackMode.kt
+++ b/app/src/main/java/com/nuvio/tv/core/build/TrailerPlaybackMode.kt
@@ -3,4 +3,5 @@ package com.nuvio.tv.core.build
 enum class TrailerPlaybackMode {
     IN_APP,
     EXTERNAL,
+    WEB_VIEW,
 }

--- a/app/src/main/java/com/nuvio/tv/data/local/TrailerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TrailerSettingsDataStore.kt
@@ -3,6 +3,9 @@ package com.nuvio.tv.data.local
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.core.profile.ProfileManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -24,12 +27,19 @@ class TrailerSettingsDataStore @Inject constructor(
 
     private val enabledKey = booleanPreferencesKey("trailer_enabled")
     private val delaySecondsKey = intPreferencesKey("trailer_delay_seconds")
+    private val playbackModeKey = stringPreferencesKey("trailer_playback_mode")
 
     val settings: Flow<TrailerSettings> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { prefs ->
+            val modeStr = prefs[playbackModeKey]
+            val resolvedMode = modeStr?.let {
+                runCatching { TrailerPlaybackMode.valueOf(it) }.getOrNull()
+            } ?: AppFeaturePolicy.trailerPlaybackMode
+
             TrailerSettings(
                 enabled = prefs[enabledKey] ?: true,
-                delaySeconds = prefs[delaySecondsKey] ?: 7
+                delaySeconds = prefs[delaySecondsKey] ?: 7,
+                playbackMode = resolvedMode
             )
         }
     }
@@ -41,9 +51,14 @@ class TrailerSettingsDataStore @Inject constructor(
     suspend fun setDelaySeconds(seconds: Int) {
         store().edit { it[delaySecondsKey] = seconds }
     }
+
+    suspend fun setPlaybackMode(mode: TrailerPlaybackMode) {
+        store().edit { it[playbackModeKey] = mode.name }
+    }
 }
 
 data class TrailerSettings(
     val enabled: Boolean = true,
-    val delaySeconds: Int = 7
+    val delaySeconds: Int = 7,
+    val playbackMode: TrailerPlaybackMode = AppFeaturePolicy.trailerPlaybackMode
 )

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -14,8 +14,13 @@ import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private const val TAG = "TrailerService"
@@ -51,6 +56,20 @@ class TrailerService(
         clock = Clock.systemUTC()
     )
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        scope.launch {
+            trailerSettingsDataStore.settings
+                .map { it.playbackMode }
+                .distinctUntilChanged()
+                .collect { mode ->
+                    Log.d(TAG, "Trailer playback mode changed to: $mode. Clearing cache.")
+                    clearCache()
+                }
+        }
+    }
+
     // Cache: "title|year|tmdbId|type" -> trailer playback source (NEGATIVE_CACHE sentinel for misses)
     private val cache = ConcurrentHashMap<String, TrailerPlaybackSource>()
     private val NEGATIVE_CACHE = TrailerPlaybackSource(videoUrl = "")
@@ -80,7 +99,11 @@ class TrailerService(
         }
         val tmdbLanguage = normalizeTmdbTrailerLanguage(tmdbSettings.language)
 
-        val cacheKey = "$title|$year|$tmdbId|$type"
+        // Incorporate current playback mode into cache key to prevent conflicts between
+        // WebView (raw YouTube watch URL) and InApp (extracted GoogleVideo stream URL).
+        val trailerSettings = runCatching { trailerSettingsDataStore.settings.first() }.getOrNull()
+        val currentMode = trailerSettings?.playbackMode ?: com.nuvio.tv.core.build.AppFeaturePolicy.trailerPlaybackMode
+        val cacheKey = "$title|$year|$tmdbId|$type|$currentMode"
 
         cache[cacheKey]?.let { cached ->
             val hit = cached !== NEGATIVE_CACHE

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.trailer
 import android.util.Log
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.local.TrailerSettingsDataStore
 import com.nuvio.tv.data.remote.api.TmdbApi
 import com.nuvio.tv.data.remote.api.TmdbVideoResult
 import com.nuvio.tv.data.remote.api.TrailerApi
@@ -29,6 +30,7 @@ class TrailerService(
     private val inAppYouTubeExtractor: InAppYouTubeExtractor,
     private val tmdbSettingsDataStore: TmdbSettingsDataStore,
     private val tmdbService: TmdbService,
+    private val trailerSettingsDataStore: TrailerSettingsDataStore,
     private val clock: Clock
 ) {
     @Inject
@@ -37,13 +39,15 @@ class TrailerService(
         tmdbApi: TmdbApi,
         inAppYouTubeExtractor: InAppYouTubeExtractor,
         tmdbSettingsDataStore: TmdbSettingsDataStore,
-        tmdbService: TmdbService
+        tmdbService: TmdbService,
+        trailerSettingsDataStore: TrailerSettingsDataStore
     ) : this(
         trailerApi = trailerApi,
         tmdbApi = tmdbApi,
         inAppYouTubeExtractor = inAppYouTubeExtractor,
         tmdbSettingsDataStore = tmdbSettingsDataStore,
         tmdbService = tmdbService,
+        trailerSettingsDataStore = trailerSettingsDataStore,
         clock = Clock.systemUTC()
     )
 
@@ -221,6 +225,13 @@ class TrailerService(
         title: String? = null,
         year: String? = null
     ): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
+        val settings = runCatching { trailerSettingsDataStore.settings.first() }.getOrNull()
+        val currentMode = settings?.playbackMode ?: com.nuvio.tv.core.build.AppFeaturePolicy.trailerPlaybackMode
+        if (currentMode == com.nuvio.tv.core.build.TrailerPlaybackMode.WEB_VIEW ||
+            currentMode == com.nuvio.tv.core.build.TrailerPlaybackMode.EXTERNAL) {
+            Log.d(TAG, "$currentMode mode active; skipping in-app extraction and returning raw YouTube URL")
+            return@withContext TrailerPlaybackSource(videoUrl = youtubeUrl)
+        }
         try {
             val youtubeKey = extractYouTubeVideoId(youtubeUrl)
             if (!youtubeKey.isNullOrBlank()) {

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -422,6 +422,7 @@ fun ContentCard(
                             trailerFirstFrameRendered = true
                         },
                         isInline = true,
+                        deferShowUntilPlaying = true,
                         modifier = Modifier.fillMaxSize(),
                         muted = focusedPosterBackdropTrailerMuted
                     )

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -421,6 +421,7 @@ fun ContentCard(
                         onFirstFrameRendered = {
                             trailerFirstFrameRendered = true
                         },
+                        isInline = true,
                         modifier = Modifier.fillMaxSize(),
                         muted = focusedPosterBackdropTrailerMuted
                     )

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -106,7 +106,6 @@ fun TrailerPlayer(
             cropToFill = cropToFill,
             onError = { error ->
                 android.util.Log.e("TrailerPlayer", "WebView player error: $error")
-                onEnded()
             },
             isInline = isInline,
             deferShowUntilPlaying = deferShowUntilPlaying,

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -73,7 +73,8 @@ fun TrailerPlayer(
     modifier: Modifier = Modifier,
     enter: EnterTransition = fadeIn(animationSpec = tween(800)),
     exit: ExitTransition = fadeOut(animationSpec = tween(500)),
-    trailerPlayerPool: TrailerPlayerPool? = null
+    trailerPlayerPool: TrailerPlayerPool? = null,
+    isInline: Boolean = false
 ) {
     val context = LocalContext.current
     val trailerSettingsDataStore = remember(context) {
@@ -106,6 +107,7 @@ fun TrailerPlayer(
                 android.util.Log.e("TrailerPlayer", "WebView player error: $error")
                 onEnded()
             },
+            isInline = isInline,
             modifier = modifier
         )
         return

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -74,7 +74,8 @@ fun TrailerPlayer(
     enter: EnterTransition = fadeIn(animationSpec = tween(800)),
     exit: ExitTransition = fadeOut(animationSpec = tween(500)),
     trailerPlayerPool: TrailerPlayerPool? = null,
-    isInline: Boolean = false
+    isInline: Boolean = false,
+    deferShowUntilPlaying: Boolean = false
 ) {
     val context = LocalContext.current
     val trailerSettingsDataStore = remember(context) {
@@ -108,6 +109,7 @@ fun TrailerPlayer(
                 onEnded()
             },
             isInline = isInline,
+            deferShowUntilPlaying = deferShowUntilPlaying,
             modifier = modifier
         )
         return

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -110,7 +110,18 @@ fun TrailerPlayer(
             },
             isInline = isInline,
             deferShowUntilPlaying = deferShowUntilPlaying,
-            modifier = modifier
+            modifier = if (cropToFill) {
+                val webviewZoom = 1.15f
+                modifier
+                    .clipToBounds()
+                    .graphicsLayer {
+                        scaleX = webviewZoom
+                        scaleY = webviewZoom
+                        transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0.85f, 0.45f)
+                    }
+            } else {
+                modifier
+            }
         )
         return
     }

--- a/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/TrailerPlayer.kt
@@ -32,11 +32,27 @@ import androidx.media3.exoplayer.source.MergingMediaSource
 import com.nuvio.tv.core.player.LocalTrailerPlayerPool
 import com.nuvio.tv.core.player.TrailerPlayerPool
 import com.nuvio.tv.data.trailer.YoutubeChunkedDataSourceFactory
+import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.build.TrailerPlaybackMode
+import com.nuvio.tv.data.local.TrailerSettingsDataStore
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.EntryPointAccessors
+import androidx.compose.runtime.produceState
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import android.view.LayoutInflater
+import android.content.Intent
+import android.net.Uri
 import com.nuvio.tv.R
 import kotlinx.coroutines.delay
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface TrailerSettingsEntryPoint {
+    fun trailerSettingsDataStore(): TrailerSettingsDataStore
+}
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
@@ -60,6 +76,59 @@ fun TrailerPlayer(
     trailerPlayerPool: TrailerPlayerPool? = null
 ) {
     val context = LocalContext.current
+    val trailerSettingsDataStore = remember(context) {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            TrailerSettingsEntryPoint::class.java
+        ).trailerSettingsDataStore()
+    }
+    val settingsState = produceState(initialValue = AppFeaturePolicy.trailerPlaybackMode) {
+        trailerSettingsDataStore.settings.collect { settings ->
+            value = settings.playbackMode
+        }
+    }
+    val currentPlaybackMode = settingsState.value
+
+    if (currentPlaybackMode == TrailerPlaybackMode.WEB_VIEW) {
+        WebViewTrailerPlayer(
+            trailerUrl = trailerUrl,
+            isPlaying = isPlaying,
+            isPaused = isPaused,
+            onEnded = onEnded,
+            onFirstFrameRendered = onFirstFrameRendered,
+            muted = muted,
+            seekRequestToken = seekRequestToken,
+            seekDeltaMs = seekDeltaMs,
+            onProgressChanged = onProgressChanged,
+            onRemoteKey = onRemoteKey,
+            cropToFill = cropToFill,
+            onError = { error ->
+                android.util.Log.e("TrailerPlayer", "WebView player error: $error")
+                onEnded()
+            },
+            modifier = modifier
+        )
+        return
+    }
+
+    if (currentPlaybackMode == TrailerPlaybackMode.EXTERNAL) {
+        val currentOnEnded by rememberUpdatedState(onEnded)
+        LaunchedEffect(isPlaying, trailerUrl) {
+            if (isPlaying && !trailerUrl.isNullOrBlank()) {
+                try {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(trailerUrl)).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    android.util.Log.e("TrailerPlayer", "Failed to launch external trailer player", e)
+                }
+                currentOnEnded()
+            }
+        }
+        return
+    }
+
     val lifecycleOwner = LocalLifecycleOwner.current
     val activityLifecycleOwner = remember(context) { context as? androidx.lifecycle.LifecycleOwner ?: lifecycleOwner }
     val currentIsPlaying by rememberUpdatedState(isPlaying)

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -4,6 +4,14 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Handler
+import android.os.Looper
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -13,18 +21,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
 import com.nuvio.tv.ui.trailer.TrailerOverlayActivity
 
 /**
  * WEB_VIEW mode trailer player.
  *
- * Instead of hosting a WebView inline (which crashes on PowerVR GPUs due to
- * Chrome_InProcGp SIGSEGV in PVRSRVFreeDeviceMemMIW), this composable
- * launches [TrailerOverlayActivity] in a separate `:trailer` process.
+ * Direct inline WebView execution is supported for in-app / background Hero media
+ * (isInline = true), styled with premium smooth fade-in transitions.
  *
- * The API is identical to the previous inline WebView implementation so
- * [TrailerPlayer] works without any changes — zero regression.
+ * Fullscreen playback (isInline = false) launches [TrailerOverlayActivity]
+ * in a separate `:trailer` process to prevent PowerVR GPU driver crashes
+ * from killing the main app process.
  */
 @Composable
 fun WebViewTrailerPlayer(
@@ -40,6 +50,7 @@ fun WebViewTrailerPlayer(
     onRemoteKey: (keyCode: Int, action: Int, repeatCount: Int) -> Boolean = { _, _, _ -> false },
     cropToFill: Boolean = false,
     onError: (error: Int) -> Unit = {},
+    isInline: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -50,6 +61,144 @@ fun WebViewTrailerPlayer(
     val currentOnProgressChanged by rememberUpdatedState(onProgressChanged)
     val currentOnError by rememberUpdatedState(onError)
 
+    // --- Inline WebView Mode ---
+    if (isInline) {
+        var hasRenderedFirstFrame by remember(videoId) { mutableStateOf(false) }
+        val webViewAlphaState = androidx.compose.animation.core.animateFloatAsState(
+            targetValue = if (isPlaying && hasRenderedFirstFrame) 1f else 0f,
+            animationSpec = tween(durationMillis = 350),
+            label = "webViewFirstFrameAlpha"
+        )
+
+        if (isPlaying && !videoId.isNullOrBlank()) {
+            val mainHandler = remember { Handler(Looper.getMainLooper()) }
+            var localWebView by remember { mutableStateOf<WebView?>(null) }
+
+            // Handle updates to WebView state (play/pause)
+            LaunchedEffect(isPaused, localWebView) {
+                localWebView?.let { wv ->
+                    wv.evaluateJavascript(if (isPaused) "pauseVideo();" else "playVideo();", null)
+                }
+            }
+
+            // Handle mute/unmute
+            LaunchedEffect(muted, localWebView) {
+                localWebView?.let { wv ->
+                    wv.evaluateJavascript(if (muted) "mute();" else "unMute();", null)
+                }
+            }
+
+            // Handle remote seeking
+            LaunchedEffect(seekRequestToken, seekDeltaMs, localWebView) {
+                localWebView?.let { wv ->
+                    if (seekRequestToken <= 0) return@LaunchedEffect
+                    wv.evaluateJavascript(
+                        "(function(){if(player&&typeof player.getCurrentTime==='function'){" +
+                        "seekTo(player.getCurrentTime()+(${seekDeltaMs/1000f}));}})();", null
+                    )
+                }
+            }
+
+            AndroidView(
+                factory = { ctx ->
+                    WebView(ctx).apply {
+                        layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT
+                        )
+                        settings.javaScriptEnabled = true
+                        settings.mediaPlaybackRequiresUserGesture = false
+                        settings.domStorageEnabled = true
+                        settings.cacheMode = WebSettings.LOAD_NO_CACHE
+                        settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+
+                        isVerticalScrollBarEnabled = false
+                        isHorizontalScrollBarEnabled = false
+
+                        val jsBridge = object {
+                            @JavascriptInterface
+                            fun onReady() {
+                                mainHandler.post {
+                                    evaluateJavascript("initPlayer('$videoId', true, $muted);", null)
+                                }
+                            }
+
+                            @JavascriptInterface
+                            fun onPlayerReady() {
+                                mainHandler.post {
+                                    hasRenderedFirstFrame = true
+                                    currentOnFirstFrameRendered()
+                                }
+                            }
+
+                            @JavascriptInterface
+                            fun onStateChange(state: Int) {
+                                mainHandler.post {
+                                    if (state == 0) { // ENDED
+                                        currentOnEnded()
+                                    } else if (state == 1) { // PLAYING
+                                        hasRenderedFirstFrame = true
+                                    }
+                                }
+                            }
+
+                            @JavascriptInterface
+                            fun onProgress(currentTime: Float, duration: Float) {
+                                mainHandler.post {
+                                    currentOnProgressChanged(
+                                        (currentTime * 1000).toLong(),
+                                        (duration * 1000).toLong()
+                                    )
+                                }
+                            }
+
+                            @JavascriptInterface
+                            fun onError(error: Int) {
+                                mainHandler.post {
+                                    currentOnError(error)
+                                }
+                            }
+                        }
+
+                        addJavascriptInterface(jsBridge, "AndroidBridge")
+
+                        webViewClient = object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(view: WebView?, request: android.webkit.WebResourceRequest?): Boolean = true
+                            override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean = true
+                        }
+
+                        val htmlContent = ctx.assets.open("youtube_player.html").bufferedReader().use { it.readText() }
+                        loadDataWithBaseURL(
+                            "https://www.youtube-nocookie.com",
+                            htmlContent,
+                            "text/html",
+                            "utf-8",
+                            null
+                        )
+
+                        localWebView = this
+                    }
+                },
+                update = {},
+                onRelease = { wv ->
+                    wv.evaluateJavascript(
+                        "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
+                    )
+                    wv.stopLoading()
+                    wv.loadUrl("about:blank")
+                    wv.removeAllViews()
+                    wv.destroy()
+                },
+                modifier = modifier
+                    .graphicsLayer {
+                        alpha = webViewAlphaState.value
+                    }
+            )
+        }
+        return
+    }
+
+    // --- Fullscreen Separate-Process Mode ---
     var isActivityLaunched by remember { mutableStateOf(false) }
 
     // Listen for state broadcasts from the :trailer process

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -7,6 +7,7 @@ import android.content.IntentFilter
 import android.os.Handler
 import android.os.Looper
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -88,6 +89,7 @@ fun WebViewTrailerPlayer(
                         "utf-8",
                         null
                     )
+                    CookieManager.getInstance().flush()
                 }
             } else {
                 localWebView?.let { wv ->
@@ -134,7 +136,17 @@ fun WebViewTrailerPlayer(
 
             AndroidView(
                 factory = { ctx ->
+                    // Enable cookie persistence so YouTube guest cookies survive across sessions.
+                    // Without this, every WebView launch appears as a fresh "bot" to YouTube.
+                    val cookieManager = CookieManager.getInstance()
+                    cookieManager.setAcceptCookie(true)
+
+                    // Pre-seed CONSENT cookie so YouTube doesn't show the consent/bot wall.
+                    cookieManager.setCookie("https://www.youtube-nocookie.com", "CONSENT=YES+; Domain=.youtube.com; Path=/; Max-Age=31536000; SameSite=None; Secure")
+
                     WebView(ctx).apply {
+                        cookieManager.setAcceptThirdPartyCookies(this, true)
+
                         layoutParams = ViewGroup.LayoutParams(
                             ViewGroup.LayoutParams.MATCH_PARENT,
                             ViewGroup.LayoutParams.MATCH_PARENT
@@ -142,7 +154,7 @@ fun WebViewTrailerPlayer(
                         settings.javaScriptEnabled = true
                         settings.mediaPlaybackRequiresUserGesture = false
                         settings.domStorageEnabled = true
-                        settings.cacheMode = WebSettings.LOAD_NO_CACHE
+                        settings.cacheMode = WebSettings.LOAD_DEFAULT
                         settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
 
                         isVerticalScrollBarEnabled = false
@@ -223,6 +235,7 @@ fun WebViewTrailerPlayer(
                                 "utf-8",
                                 null
                             )
+                            cookieManager.flush()
                         } catch (e: Exception) {
                             android.util.Log.e("WebViewTrailerPlayer", "Error loading youtube_player.html", e)
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -126,8 +126,8 @@ fun WebViewTrailerPlayer(
                             @JavascriptInterface
                             fun onPlayerReady() {
                                 mainHandler.post {
-                                    hasRenderedFirstFrame = true
-                                    currentOnFirstFrameRendered()
+                                    // No-op to avoid showing buffering/loading screens.
+                                    // We only set hasRenderedFirstFrame when state changes to PLAYING (state == 1).
                                 }
                             }
 
@@ -137,7 +137,10 @@ fun WebViewTrailerPlayer(
                                     if (state == 0) { // ENDED
                                         currentOnEnded()
                                     } else if (state == 1) { // PLAYING
-                                        hasRenderedFirstFrame = true
+                                        if (!hasRenderedFirstFrame) {
+                                            hasRenderedFirstFrame = true
+                                            currentOnFirstFrameRendered()
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -51,6 +51,7 @@ fun WebViewTrailerPlayer(
     cropToFill: Boolean = false,
     onError: (error: Int) -> Unit = {},
     isInline: Boolean = false,
+    deferShowUntilPlaying: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -126,8 +127,10 @@ fun WebViewTrailerPlayer(
                             @JavascriptInterface
                             fun onPlayerReady() {
                                 mainHandler.post {
-                                    // No-op to avoid showing buffering/loading screens.
-                                    // We only set hasRenderedFirstFrame when state changes to PLAYING (state == 1).
+                                    if (!deferShowUntilPlaying) {
+                                        hasRenderedFirstFrame = true
+                                        currentOnFirstFrameRendered()
+                                    }
                                 }
                             }
 
@@ -137,9 +140,13 @@ fun WebViewTrailerPlayer(
                                     if (state == 0) { // ENDED
                                         currentOnEnded()
                                     } else if (state == 1) { // PLAYING
-                                        if (!hasRenderedFirstFrame) {
+                                        if (deferShowUntilPlaying) {
+                                            if (!hasRenderedFirstFrame) {
+                                                hasRenderedFirstFrame = true
+                                                currentOnFirstFrameRendered()
+                                            }
+                                        } else {
                                             hasRenderedFirstFrame = true
-                                            currentOnFirstFrameRendered()
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -75,7 +75,7 @@ fun WebViewTrailerPlayer(
         var activeVideoId by remember { mutableStateOf<String?>(null) }
         var localWebView by remember { mutableStateOf<WebView?>(null) }
 
-        LaunchedEffect(isPlaying, videoId, localWebView) {
+        LaunchedEffect(isPlaying, videoId) {
             if (isPlaying && !videoId.isNullOrBlank()) {
                 activeVideoId = videoId
                 isWebViewActive = true
@@ -211,6 +211,20 @@ fun WebViewTrailerPlayer(
                                 android.util.Log.e("WebViewTrailerPlayer", "WebView renderer process gone (didCrash=${detail?.didCrash()}). Recovering...")
                                 return true
                             }
+                        }
+
+                        // Load initial HTML template upon creation
+                        try {
+                            val htmlContent = ctx.assets.open("youtube_player.html").bufferedReader().use { it.readText() }
+                            loadDataWithBaseURL(
+                                "https://www.youtube-nocookie.com",
+                                htmlContent,
+                                "text/html",
+                                "utf-8",
+                                null
+                            )
+                        } catch (e: Exception) {
+                            android.util.Log.e("WebViewTrailerPlayer", "Error loading youtube_player.html", e)
                         }
 
                         localWebView = this

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -1,0 +1,133 @@
+package com.nuvio.tv.ui.components
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.nuvio.tv.ui.trailer.TrailerOverlayActivity
+
+/**
+ * WEB_VIEW mode trailer player.
+ *
+ * Instead of hosting a WebView inline (which crashes on PowerVR GPUs due to
+ * Chrome_InProcGp SIGSEGV in PVRSRVFreeDeviceMemMIW), this composable
+ * launches [TrailerOverlayActivity] in a separate `:trailer` process.
+ *
+ * The API is identical to the previous inline WebView implementation so
+ * [TrailerPlayer] works without any changes — zero regression.
+ */
+@Composable
+fun WebViewTrailerPlayer(
+    trailerUrl: String?,
+    isPlaying: Boolean,
+    isPaused: Boolean = false,
+    onEnded: () -> Unit,
+    onFirstFrameRendered: () -> Unit = {},
+    muted: Boolean = false,
+    seekRequestToken: Int = 0,
+    seekDeltaMs: Long = 0L,
+    onProgressChanged: (positionMs: Long, durationMs: Long) -> Unit = { _, _ -> },
+    onRemoteKey: (keyCode: Int, action: Int, repeatCount: Int) -> Boolean = { _, _, _ -> false },
+    cropToFill: Boolean = false,
+    onError: (error: Int) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val videoId = remember(trailerUrl) { extractVideoId(trailerUrl) }
+
+    val currentOnEnded by rememberUpdatedState(onEnded)
+    val currentOnFirstFrameRendered by rememberUpdatedState(onFirstFrameRendered)
+    val currentOnProgressChanged by rememberUpdatedState(onProgressChanged)
+    val currentOnError by rememberUpdatedState(onError)
+
+    var isActivityLaunched by remember { mutableStateOf(false) }
+
+    // Listen for state broadcasts from the :trailer process
+    DisposableEffect(Unit) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context, intent: Intent) {
+                when (intent.getStringExtra(TrailerOverlayActivity.EXTRA_EVENT)) {
+                    "ended" -> {
+                        isActivityLaunched = false
+                        currentOnEnded()
+                    }
+                    "error" -> {
+                        isActivityLaunched = false
+                        val errorCode = intent.getIntExtra(TrailerOverlayActivity.EXTRA_ERROR_CODE, 0)
+                        currentOnError(errorCode)
+                    }
+                    "first_frame" -> {
+                        currentOnFirstFrameRendered()
+                    }
+                    "progress" -> {
+                        val positionMs = intent.getLongExtra(TrailerOverlayActivity.EXTRA_POSITION_MS, 0)
+                        val durationMs = intent.getLongExtra(TrailerOverlayActivity.EXTRA_DURATION_MS, 0)
+                        currentOnProgressChanged(positionMs, durationMs)
+                    }
+                }
+            }
+        }
+        val filter = IntentFilter(TrailerOverlayActivity.ACTION_TRAILER_EVENT)
+        androidx.core.content.ContextCompat.registerReceiver(
+            context, receiver, filter, android.content.Context.RECEIVER_EXPORTED
+        )
+        onDispose {
+            try { context.unregisterReceiver(receiver) } catch (_: Exception) {}
+            // Dismiss the trailer Activity when this composable leaves composition
+            if (isActivityLaunched) {
+                TrailerOverlayActivity.dismiss(context)
+                isActivityLaunched = false
+            }
+        }
+    }
+
+    // Launch or dismiss the trailer Activity based on play state
+    LaunchedEffect(isPlaying, videoId) {
+        if (isPlaying && !videoId.isNullOrBlank()) {
+            if (!isActivityLaunched) {
+                TrailerOverlayActivity.launch(context, videoId, autoPlay = true, muted = muted)
+                isActivityLaunched = true
+            }
+        } else {
+            if (isActivityLaunched) {
+                TrailerOverlayActivity.dismiss(context)
+                isActivityLaunched = false
+            }
+        }
+    }
+
+    // Forward pause/resume commands to the :trailer process
+    LaunchedEffect(isPaused, isActivityLaunched) {
+        if (!isActivityLaunched) return@LaunchedEffect
+        TrailerOverlayActivity.sendCommand(
+            context,
+            if (isPaused) "pause" else "play"
+        )
+    }
+
+    // Forward mute state changes
+    LaunchedEffect(muted, isActivityLaunched) {
+        if (!isActivityLaunched) return@LaunchedEffect
+        TrailerOverlayActivity.sendCommand(
+            context,
+            if (muted) "mute" else "unmute"
+        )
+    }
+}
+
+private fun extractVideoId(url: String?): String? {
+    if (url.isNullOrBlank()) return null
+    val reg = Regex("^.*(?:(?:youtu.be\\/|v\\/|vi\\/|u\\/\\w\\/|embed\\/|shorts\\/)|(?:(?:watch)?\\?v(?:i)?=|\\&v(?:i)?=))([^#\\&\\?]*).*")
+    val match = reg.find(url)
+    return match?.groupValues?.getOrNull(1) ?: url
+}

--- a/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt
@@ -71,9 +71,41 @@ fun WebViewTrailerPlayer(
             label = "webViewFirstFrameAlpha"
         )
 
-        if (isPlaying && !videoId.isNullOrBlank()) {
+        var isWebViewActive by remember { mutableStateOf(false) }
+        var activeVideoId by remember { mutableStateOf<String?>(null) }
+        var localWebView by remember { mutableStateOf<WebView?>(null) }
+
+        LaunchedEffect(isPlaying, videoId, localWebView) {
+            if (isPlaying && !videoId.isNullOrBlank()) {
+                activeVideoId = videoId
+                isWebViewActive = true
+                localWebView?.let { wv ->
+                    val htmlContent = wv.context.assets.open("youtube_player.html").bufferedReader().use { it.readText() }
+                    wv.loadDataWithBaseURL(
+                        "https://www.youtube-nocookie.com",
+                        htmlContent,
+                        "text/html",
+                        "utf-8",
+                        null
+                    )
+                }
+            } else {
+                localWebView?.let { wv ->
+                    wv.evaluateJavascript(
+                        "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
+                    )
+                    wv.stopLoading()
+                    wv.loadUrl("about:blank")
+                }
+                kotlinx.coroutines.delay(800)
+                isWebViewActive = false
+                activeVideoId = null
+                hasRenderedFirstFrame = false
+            }
+        }
+
+        if (isWebViewActive && !activeVideoId.isNullOrBlank()) {
             val mainHandler = remember { Handler(Looper.getMainLooper()) }
-            var localWebView by remember { mutableStateOf<WebView?>(null) }
 
             // Handle updates to WebView state (play/pause)
             LaunchedEffect(isPaused, localWebView) {
@@ -120,7 +152,7 @@ fun WebViewTrailerPlayer(
                             @JavascriptInterface
                             fun onReady() {
                                 mainHandler.post {
-                                    evaluateJavascript("initPlayer('$videoId', true, $muted);", null)
+                                    evaluateJavascript("initPlayer('$activeVideoId', true, $muted);", null)
                                 }
                             }
 
@@ -175,29 +207,28 @@ fun WebViewTrailerPlayer(
                         webViewClient = object : WebViewClient() {
                             override fun shouldOverrideUrlLoading(view: WebView?, request: android.webkit.WebResourceRequest?): Boolean = true
                             override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean = true
+                            override fun onRenderProcessGone(view: WebView?, detail: android.webkit.RenderProcessGoneDetail?): Boolean {
+                                android.util.Log.e("WebViewTrailerPlayer", "WebView renderer process gone (didCrash=${detail?.didCrash()}). Recovering...")
+                                return true
+                            }
                         }
-
-                        val htmlContent = ctx.assets.open("youtube_player.html").bufferedReader().use { it.readText() }
-                        loadDataWithBaseURL(
-                            "https://www.youtube-nocookie.com",
-                            htmlContent,
-                            "text/html",
-                            "utf-8",
-                            null
-                        )
 
                         localWebView = this
                     }
                 },
                 update = {},
                 onRelease = { wv ->
-                    wv.evaluateJavascript(
-                        "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
-                    )
                     wv.stopLoading()
                     wv.loadUrl("about:blank")
                     wv.removeAllViews()
-                    wv.destroy()
+                    try {
+                        wv.destroy()
+                    } catch (e: Exception) {
+                        android.util.Log.e("WebViewTrailerPlayer", "Error destroying WebView", e)
+                    }
+                    if (localWebView === wv) {
+                        localWebView = null
+                    }
                 },
                 modifier = modifier
                     .graphicsLayer {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.nuvio.tv.core.trakt.TraktPublicListSourceResolver
 import com.nuvio.tv.data.trailer.TrailerService
 import com.nuvio.tv.data.local.CollectionsDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.data.local.TrailerSettingsDataStore
 import com.nuvio.tv.domain.model.AddonCatalogCollectionSource
 import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.CollectionSource
@@ -113,6 +114,7 @@ class FolderDetailViewModel @Inject constructor(
     private val mdbListSettingsDataStore: com.nuvio.tv.data.local.MDBListSettingsDataStore,
     private val metaRepository: com.nuvio.tv.domain.repository.MetaRepository,
     private val trailerService: TrailerService,
+    private val trailerSettingsDataStore: TrailerSettingsDataStore,
     private val tmdbCollectionSourceResolver: TmdbCollectionSourceResolver,
     private val traktPublicListSourceResolver: TraktPublicListSourceResolver,
     val posterOptions: com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
@@ -167,6 +169,21 @@ class FolderDetailViewModel @Inject constructor(
         loadFolder()
         // Observe watched status immediately so badges are ready when catalogs load.
         observeWatchedStatusCombined()
+        observeTrailerPlaybackMode()
+    }
+
+    private fun observeTrailerPlaybackMode() {
+        viewModelScope.launch {
+            trailerSettingsDataStore.settings
+                .map { it.playbackMode }
+                .distinctUntilChanged()
+                .collect { mode ->
+                    _trailerPreviewUrls.value = emptyMap()
+                    _trailerPreviewAudioUrls.value = emptyMap()
+                    trailerPreviewNegativeCache.clear()
+                    trailerPreviewLoadingIds.clear()
+                }
+        }
     }
 
     private fun observeWatchedStatusCombined() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -252,8 +252,13 @@ class FolderDetailViewModel @Inject constructor(
             val focusedPosterBackdropExpandDelaySeconds = layoutPreferenceDataStore.focusedPosterBackdropExpandDelaySeconds.first()
             val focusedPosterBackdropTrailerEnabled = layoutPreferenceDataStore.focusedPosterBackdropTrailerEnabled.first()
             val focusedPosterBackdropTrailerMuted = layoutPreferenceDataStore.focusedPosterBackdropTrailerMuted.first()
-            val focusedPosterBackdropTrailerPlaybackTarget =
-                layoutPreferenceDataStore.focusedPosterBackdropTrailerPlaybackTarget.first()
+            val rawTarget = layoutPreferenceDataStore.focusedPosterBackdropTrailerPlaybackTarget.first()
+            val isWebViewMode = trailerSettingsDataStore.settings.first().playbackMode == com.nuvio.tv.core.build.TrailerPlaybackMode.WEB_VIEW
+            val focusedPosterBackdropTrailerPlaybackTarget = if (isWebViewMode) {
+                FocusedPosterTrailerPlaybackTarget.HERO_MEDIA
+            } else {
+                rawTarget
+            }
             val posterCardWidthDp = layoutPreferenceDataStore.posterCardWidthDp.first()
             val posterCardHeightDp = layoutPreferenceDataStore.posterCardHeightDp.first()
             val posterCardCornerRadiusDp = layoutPreferenceDataStore.posterCardCornerRadiusDp.first()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -271,10 +271,14 @@ fun MetaDetailsScreen(
     val trailerSeekOverlayState = remember { TrailerSeekOverlayState() }
     var trailerSeekToken by remember { mutableIntStateOf(0) }
     var trailerSeekDeltaMs by remember { mutableLongStateOf(0L) }
+    var isActivelySeeking by remember { mutableStateOf(false) }
+    var originalPositionBeforeSeeking by remember { mutableLongStateOf(0L) }
     var lastUserInteractionDispatchMs by remember { mutableLongStateOf(0L) }
     val onTrailerProgressChanged = remember(trailerSeekOverlayState) {
         { position: Long, duration: Long ->
-            trailerSeekOverlayState.positionMs = position
+            if (!isActivelySeeking) {
+                trailerSeekOverlayState.positionMs = position
+            }
             trailerSeekOverlayState.durationMs = duration
         }
     }
@@ -302,84 +306,111 @@ fun MetaDetailsScreen(
             .fillMaxSize()
             .onPreviewKeyEvent { keyEvent ->
                 if (currentIsTrailerPlaying) {
-                    if (currentShowTrailerControls) {
-                        if (keyEvent.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) {
-                            return@onPreviewKeyEvent false
-                        }
-                        when (keyEvent.nativeKeyEvent.keyCode) {
-                            KeyEvent.KEYCODE_DPAD_CENTER,
-                            KeyEvent.KEYCODE_ENTER,
-                            KeyEvent.KEYCODE_NUMPAD_ENTER -> {
-                                isTrailerPaused = !isTrailerPaused
-                                trailerSeekOverlayVisible = true
-                                true
-                            }
-                            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
-                                isTrailerPaused = !isTrailerPaused
-                                true
-                            }
-                            KeyEvent.KEYCODE_MEDIA_PAUSE -> {
-                                isTrailerPaused = true
-                                true
-                            }
-                            KeyEvent.KEYCODE_MEDIA_PLAY -> {
-                                isTrailerPaused = false
-                                true
-                            }
-                            KeyEvent.KEYCODE_DPAD_UP -> {
-                                trailerSeekOverlayVisible = true
-                                true
-                            }
-                            KeyEvent.KEYCODE_DPAD_DOWN -> {
-                                trailerSeekOverlayVisible = false
-                                true
-                            }
-                            KeyEvent.KEYCODE_DPAD_LEFT -> {
-                                val repeatCount = keyEvent.nativeKeyEvent.repeatCount
-                                val delta = when {
-                                    repeatCount >= 12 -> -12_000L
-                                    repeatCount >= 6 -> -8_000L
-                                    repeatCount >= 2 -> -5_000L
-                                    else -> -3_000L
-                                }
-                                trailerSeekDeltaMs = delta
-                                trailerSeekToken += 1
-                                trailerSeekOverlayVisible = true
-                                true
-                            }
-                            KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                                val repeatCount = keyEvent.nativeKeyEvent.repeatCount
-                                val delta = when {
-                                    repeatCount >= 12 -> 12_000L
-                                    repeatCount >= 6 -> 8_000L
-                                    repeatCount >= 2 -> 5_000L
-                                    else -> 3_000L
-                                }
-                                trailerSeekDeltaMs = delta
-                                trailerSeekToken += 1
-                                trailerSeekOverlayVisible = true
-                                true
-                            }
-                            else -> false
-                        }
-                    }
-                    // During auto trailer preview, consume all keys except back/ESC so content doesn't scroll.
+                    val action = keyEvent.nativeKeyEvent.action
                     val keyCode = keyEvent.nativeKeyEvent.keyCode
-                    return@onPreviewKeyEvent keyCode != KeyEvent.KEYCODE_BACK &&
-                            keyCode != KeyEvent.KEYCODE_ESCAPE
-                }
-                if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
-                    val nativeEvent = keyEvent.nativeKeyEvent
-                    val shouldDispatch =
-                        nativeEvent.repeatCount == 0 &&
-                            (nativeEvent.eventTime - lastUserInteractionDispatchMs) >=
-                            USER_INTERACTION_DISPATCH_DEBOUNCE_MS
-                    if (shouldDispatch) {
-                        lastUserInteractionDispatchMs = nativeEvent.eventTime
-                        viewModel.onEvent(MetaDetailsEvent.OnUserInteraction)
+                    val repeatCount = keyEvent.nativeKeyEvent.repeatCount
+
+                    if (currentShowTrailerControls) {
+                        if (action == KeyEvent.ACTION_DOWN) {
+                            when (keyCode) {
+                                KeyEvent.KEYCODE_DPAD_CENTER,
+                                KeyEvent.KEYCODE_ENTER,
+                                KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                                    isTrailerPaused = !isTrailerPaused
+                                    trailerSeekOverlayVisible = true
+                                    true
+                                }
+                                KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
+                                    isTrailerPaused = !isTrailerPaused
+                                    true
+                                }
+                                KeyEvent.KEYCODE_MEDIA_PAUSE -> {
+                                    isTrailerPaused = true
+                                    true
+                                }
+                                KeyEvent.KEYCODE_MEDIA_PLAY -> {
+                                    isTrailerPaused = false
+                                    true
+                                }
+                                KeyEvent.KEYCODE_DPAD_UP -> {
+                                    trailerSeekOverlayVisible = true
+                                    true
+                                }
+                                KeyEvent.KEYCODE_DPAD_DOWN -> {
+                                    trailerSeekOverlayVisible = false
+                                    true
+                                }
+                                KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                    if (!isActivelySeeking) {
+                                        isActivelySeeking = true
+                                        originalPositionBeforeSeeking = trailerSeekOverlayState.positionMs
+                                    }
+                                    val stepMs = when {
+                                        repeatCount >= 12 -> 15_000L
+                                        repeatCount >= 6 -> 8_000L
+                                        repeatCount >= 2 -> 4_000L
+                                        else -> 2_000L
+                                    }
+                                    trailerSeekOverlayState.positionMs = (trailerSeekOverlayState.positionMs - stepMs).coerceIn(0L, trailerSeekOverlayState.durationMs)
+                                    trailerSeekOverlayVisible = true
+                                    true
+                                }
+                                KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                    if (!isActivelySeeking) {
+                                        isActivelySeeking = true
+                                        originalPositionBeforeSeeking = trailerSeekOverlayState.positionMs
+                                    }
+                                    val stepMs = when {
+                                        repeatCount >= 12 -> 15_000L
+                                        repeatCount >= 6 -> 8_000L
+                                        repeatCount >= 2 -> 4_000L
+                                        else -> 2_000L
+                                    }
+                                    trailerSeekOverlayState.positionMs = (trailerSeekOverlayState.positionMs + stepMs).coerceIn(0L, trailerSeekOverlayState.durationMs)
+                                    trailerSeekOverlayVisible = true
+                                    true
+                                }
+                                else -> false
+                            }
+                        } else if (action == KeyEvent.ACTION_UP) {
+                            when (keyCode) {
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                                KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                    if (isActivelySeeking) {
+                                        val finalDeltaMs = trailerSeekOverlayState.positionMs - originalPositionBeforeSeeking
+                                        if (finalDeltaMs != 0L) {
+                                            trailerSeekDeltaMs = finalDeltaMs
+                                            trailerSeekToken += 1
+                                        }
+                                        isActivelySeeking = false
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                }
+                                else -> false
+                            }
+                        } else {
+                            false
+                        }
+                    } else {
+                        // During auto trailer preview, consume all keys except back/ESC so content doesn't scroll.
+                        keyCode != KeyEvent.KEYCODE_BACK && keyCode != KeyEvent.KEYCODE_ESCAPE
                     }
+                } else {
+                    if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+                        val nativeEvent = keyEvent.nativeKeyEvent
+                        val shouldDispatch =
+                            nativeEvent.repeatCount == 0 &&
+                                (nativeEvent.eventTime - lastUserInteractionDispatchMs) >=
+                                USER_INTERACTION_DISPATCH_DEBOUNCE_MS
+                        if (shouldDispatch) {
+                            lastUserInteractionDispatchMs = nativeEvent.eventTime
+                            viewModel.onEvent(MetaDetailsEvent.OnUserInteraction)
+                        }
+                    }
+                    false
                 }
-                false
             }
     ) {
         when {
@@ -583,56 +614,88 @@ fun MetaDetailsScreen(
                     onTrailerControlKey = { keyCode, action, repeatCount ->
                         if (!uiState.showTrailerControls || !uiState.isTrailerPlaying) {
                             false
-                        } else if (action != KeyEvent.ACTION_DOWN) {
-                            false
                         } else {
-                            val seekStepMs = when {
-                                repeatCount >= 12 -> 12_000L
-                                repeatCount >= 6 -> 8_000L
-                                repeatCount >= 2 -> 5_000L
-                                else -> 3_000L
-                            }
-                            when (keyCode) {
-                                KeyEvent.KEYCODE_DPAD_CENTER,
-                                KeyEvent.KEYCODE_ENTER,
-                                KeyEvent.KEYCODE_NUMPAD_ENTER -> {
-                                    isTrailerPaused = !isTrailerPaused
-                                    trailerSeekOverlayVisible = true
-                                    true
+                            if (action == KeyEvent.ACTION_DOWN) {
+                                when (keyCode) {
+                                    KeyEvent.KEYCODE_DPAD_CENTER,
+                                    KeyEvent.KEYCODE_ENTER,
+                                    KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                                        isTrailerPaused = !isTrailerPaused
+                                        trailerSeekOverlayVisible = true
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
+                                        isTrailerPaused = !isTrailerPaused
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_MEDIA_PAUSE -> {
+                                        isTrailerPaused = true
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_MEDIA_PLAY -> {
+                                        isTrailerPaused = false
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_DPAD_UP -> {
+                                        trailerSeekOverlayVisible = true
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                                        trailerSeekOverlayVisible = false
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                        if (!isActivelySeeking) {
+                                            isActivelySeeking = true
+                                            originalPositionBeforeSeeking = trailerSeekOverlayState.positionMs
+                                        }
+                                        val stepMs = when {
+                                            repeatCount >= 12 -> 15_000L
+                                            repeatCount >= 6 -> 8_000L
+                                            repeatCount >= 2 -> 4_000L
+                                            else -> 2_000L
+                                        }
+                                        trailerSeekOverlayState.positionMs = (trailerSeekOverlayState.positionMs - stepMs).coerceIn(0L, trailerSeekOverlayState.durationMs)
+                                        trailerSeekOverlayVisible = true
+                                        true
+                                    }
+                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                        if (!isActivelySeeking) {
+                                            isActivelySeeking = true
+                                            originalPositionBeforeSeeking = trailerSeekOverlayState.positionMs
+                                        }
+                                        val stepMs = when {
+                                            repeatCount >= 12 -> 15_000L
+                                            repeatCount >= 6 -> 8_000L
+                                            repeatCount >= 2 -> 4_000L
+                                            else -> 2_000L
+                                        }
+                                        trailerSeekOverlayState.positionMs = (trailerSeekOverlayState.positionMs + stepMs).coerceIn(0L, trailerSeekOverlayState.durationMs)
+                                        trailerSeekOverlayVisible = true
+                                        true
+                                    }
+                                    else -> false
                                 }
-                                KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
-                                    isTrailerPaused = !isTrailerPaused
-                                    true
+                            } else if (action == KeyEvent.ACTION_UP) {
+                                when (keyCode) {
+                                    KeyEvent.KEYCODE_DPAD_LEFT,
+                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                        if (isActivelySeeking) {
+                                            val finalDeltaMs = trailerSeekOverlayState.positionMs - originalPositionBeforeSeeking
+                                            if (finalDeltaMs != 0L) {
+                                                trailerSeekDeltaMs = finalDeltaMs
+                                                trailerSeekToken += 1
+                                            }
+                                            isActivelySeeking = false
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                    else -> false
                                 }
-                                KeyEvent.KEYCODE_MEDIA_PAUSE -> {
-                                    isTrailerPaused = true
-                                    true
-                                }
-                                KeyEvent.KEYCODE_MEDIA_PLAY -> {
-                                    isTrailerPaused = false
-                                    true
-                                }
-                                KeyEvent.KEYCODE_DPAD_UP -> {
-                                    trailerSeekOverlayVisible = true
-                                    true
-                                }
-                                KeyEvent.KEYCODE_DPAD_DOWN -> {
-                                    trailerSeekOverlayVisible = false
-                                    true
-                                }
-                                KeyEvent.KEYCODE_DPAD_LEFT -> {
-                                    trailerSeekDeltaMs = -seekStepMs
-                                    trailerSeekToken += 1
-                                    trailerSeekOverlayVisible = true
-                                    true
-                                }
-                                KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                                    trailerSeekDeltaMs = seekStepMs
-                                    trailerSeekToken += 1
-                                    trailerSeekOverlayVisible = true
-                                    true
-                                }
-                                else -> false
+                            } else {
+                                false
                             }
                         }
                     },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -2108,6 +2108,7 @@ private fun BackdropLayer(
             onRemoteKey = onTrailerControlKey,
             onProgressChanged = onTrailerProgressChanged,
             onEnded = onTrailerEnded,
+            isInline = true,
             modifier = Modifier.fillMaxSize()
         )
         Box(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -302,11 +302,27 @@ class MetaDetailsViewModel @Inject constructor(
     private fun observeTrailerAutoplaySettings() {
         viewModelScope.launch {
             trailerSettingsDataStore.settings.collectLatest { settings ->
+                val oldMode = trailerPlaybackMode
                 trailerAutoplayEnabled = settings.enabled
                 trailerDelayMs = settings.delaySeconds * 1000L
                 trailerPlaybackMode = settings.playbackMode
                 if (!settings.enabled) {
                     idleTimerJob?.cancel()
+                }
+
+                if (oldMode != settings.playbackMode) {
+                    setTrailerPlaybackState(isPlaying = false, showControls = false, hideLogo = false)
+                    trailerHasPlayed = false
+                    idleTimerJob?.cancel()
+
+                    _uiState.update { state ->
+                        state.copy(
+                            trailerUrl = null,
+                            trailerAudioUrl = null
+                        )
+                    }
+
+                    fetchTrailerUrl()
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -63,6 +63,7 @@ import android.net.Uri
 import com.nuvio.tv.LocaleCache
 import com.nuvio.tv.R
 import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
@@ -129,6 +130,9 @@ class MetaDetailsViewModel @Inject constructor(
     private var trailerAutoplayEnabled = false
     private var trailerHasPlayed = false
     private var suppressSeasonAutoSwitch = false
+    private var trailerPlaybackMode = AppFeaturePolicy.trailerPlaybackMode
+    private val isInlineTrailerPlaybackEnabled: Boolean
+        get() = AppFeaturePolicy.inAppTrailerPlaybackEnabled || trailerPlaybackMode == TrailerPlaybackMode.WEB_VIEW
 
     private var isPlayButtonFocused = false
     private var hideUnreleasedContent = false
@@ -300,6 +304,7 @@ class MetaDetailsViewModel @Inject constructor(
             trailerSettingsDataStore.settings.collectLatest { settings ->
                 trailerAutoplayEnabled = settings.enabled
                 trailerDelayMs = settings.delaySeconds * 1000L
+                trailerPlaybackMode = settings.playbackMode
                 if (!settings.enabled) {
                     idleTimerJob?.cancel()
                 }
@@ -2428,7 +2433,7 @@ class MetaDetailsViewModel @Inject constructor(
                 }
             }
 
-            if (url != null && isPlayButtonFocused && AppFeaturePolicy.inAppTrailerPlaybackEnabled) {
+            if (url != null && isPlayButtonFocused && isInlineTrailerPlaybackEnabled) {
                 startIdleTimer()
             }
         }
@@ -2436,7 +2441,7 @@ class MetaDetailsViewModel @Inject constructor(
 
     private fun startIdleTimer() {
         idleTimerJob?.cancel()
-        if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled) return
+        if (!isInlineTrailerPlaybackEnabled) return
 
         val state = _uiState.value
         if (state.trailerUrl == null || state.isTrailerPlaying) return
@@ -2495,7 +2500,7 @@ class MetaDetailsViewModel @Inject constructor(
     private fun handleTrailerButtonClick() {
         val state = _uiState.value
         if (state.trailerUrl.isNullOrBlank()) return
-        if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled) {
+        if (!isInlineTrailerPlaybackEnabled) {
             openExternalTrailer(state.trailerUrl)
             return
         }
@@ -2534,7 +2539,7 @@ class MetaDetailsViewModel @Inject constructor(
             return
         }
 
-        if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled && AppFeaturePolicy.externalTrailerPlaybackEnabled) {
+        if (!isInlineTrailerPlaybackEnabled && AppFeaturePolicy.externalTrailerPlaybackEnabled) {
             openExternalTrailer("https://www.youtube.com/watch?v=$ytId")
             return
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/SharedTrailerOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/SharedTrailerOverlay.kt
@@ -68,16 +68,19 @@ fun SharedTrailerOverlay(
     val seekOverlayState = remember { TrailerSeekOverlayState() }
     var seekToken by remember { mutableIntStateOf(0) }
     var seekDeltaMs by remember { mutableLongStateOf(0L) }
+    var isActivelySeeking by remember { mutableStateOf(false) }
+    var originalPositionBeforeSeeking by remember { mutableLongStateOf(0L) }
 
     val canControlPlayback = !trailerUrl.isNullOrBlank() && !isLoading && errorMessage == null
 
     LaunchedEffect(trailerUrl, trailerAudioUrl, isLoading, errorMessage) {
         isPaused = false
         seekOverlayVisible = false
+        isActivelySeeking = false
     }
 
     LaunchedEffect(seekOverlayVisible, canControlPlayback, seekToken) {
-        if (seekOverlayVisible && canControlPlayback) {
+        if (seekOverlayVisible && canControlPlayback && !isActivelySeeking) {
             delay(3000)
             seekOverlayVisible = false
         }
@@ -95,80 +98,108 @@ fun SharedTrailerOverlay(
                 .fillMaxSize()
                 .background(Color.Black)
                 .onPreviewKeyEvent { keyEvent ->
-                    if (keyEvent.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) {
-                        return@onPreviewKeyEvent false
-                    }
+                    val action = keyEvent.nativeKeyEvent.action
+                    val keyCode = keyEvent.nativeKeyEvent.keyCode
+                    val repeatCount = keyEvent.nativeKeyEvent.repeatCount
 
-                    when (keyEvent.nativeKeyEvent.keyCode) {
-                        KeyEvent.KEYCODE_BACK,
-                        KeyEvent.KEYCODE_ESCAPE -> {
-                            onDismiss()
-                            true
-                        }
-
-                        KeyEvent.KEYCODE_DPAD_CENTER,
-                        KeyEvent.KEYCODE_ENTER,
-                        KeyEvent.KEYCODE_NUMPAD_ENTER,
-                        KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            isPaused = !isPaused
-                            seekOverlayVisible = true
-                            true
-                        }
-
-                        KeyEvent.KEYCODE_MEDIA_PAUSE -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            isPaused = true
-                            true
-                        }
-
-                        KeyEvent.KEYCODE_MEDIA_PLAY -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            isPaused = false
-                            true
-                        }
-
-                        KeyEvent.KEYCODE_DPAD_LEFT -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            val repeatCount = keyEvent.nativeKeyEvent.repeatCount
-                            seekDeltaMs = when {
-                                repeatCount >= 12 -> -12_000L
-                                repeatCount >= 6 -> -8_000L
-                                repeatCount >= 2 -> -5_000L
-                                else -> -3_000L
+                    if (action == KeyEvent.ACTION_DOWN) {
+                        when (keyCode) {
+                            KeyEvent.KEYCODE_BACK,
+                            KeyEvent.KEYCODE_ESCAPE -> {
+                                onDismiss()
+                                true
                             }
-                            seekToken += 1
-                            seekOverlayVisible = true
-                            true
-                        }
 
-                        KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            val repeatCount = keyEvent.nativeKeyEvent.repeatCount
-                            seekDeltaMs = when {
-                                repeatCount >= 12 -> 12_000L
-                                repeatCount >= 6 -> 8_000L
-                                repeatCount >= 2 -> 5_000L
-                                else -> 3_000L
+                            KeyEvent.KEYCODE_DPAD_CENTER,
+                            KeyEvent.KEYCODE_ENTER,
+                            KeyEvent.KEYCODE_NUMPAD_ENTER,
+                            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                isPaused = !isPaused
+                                seekOverlayVisible = true
+                                true
                             }
-                            seekToken += 1
-                            seekOverlayVisible = true
-                            true
-                        }
 
-                        KeyEvent.KEYCODE_DPAD_UP -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            seekOverlayVisible = true
-                            true
-                        }
+                            KeyEvent.KEYCODE_MEDIA_PAUSE -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                isPaused = true
+                                true
+                            }
 
-                        KeyEvent.KEYCODE_DPAD_DOWN -> {
-                            if (!canControlPlayback) return@onPreviewKeyEvent false
-                            seekOverlayVisible = false
-                            true
-                        }
+                            KeyEvent.KEYCODE_MEDIA_PLAY -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                isPaused = false
+                                true
+                            }
 
-                        else -> false
+                            KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                if (!isActivelySeeking) {
+                                    isActivelySeeking = true
+                                    originalPositionBeforeSeeking = seekOverlayState.positionMs
+                                }
+                                val stepMs = when {
+                                    repeatCount >= 12 -> 15_000L
+                                    repeatCount >= 6 -> 8_000L
+                                    repeatCount >= 2 -> 4_000L
+                                    else -> 2_000L
+                                }
+                                seekOverlayState.positionMs = (seekOverlayState.positionMs - stepMs).coerceIn(0L, seekOverlayState.durationMs)
+                                seekOverlayVisible = true
+                                true
+                            }
+
+                            KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                if (!isActivelySeeking) {
+                                    isActivelySeeking = true
+                                    originalPositionBeforeSeeking = seekOverlayState.positionMs
+                                }
+                                val stepMs = when {
+                                    repeatCount >= 12 -> 15_000L
+                                    repeatCount >= 6 -> 8_000L
+                                    repeatCount >= 2 -> 4_000L
+                                    else -> 2_000L
+                                }
+                                seekOverlayState.positionMs = (seekOverlayState.positionMs + stepMs).coerceIn(0L, seekOverlayState.durationMs)
+                                seekOverlayVisible = true
+                                true
+                            }
+
+                            KeyEvent.KEYCODE_DPAD_UP -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                seekOverlayVisible = true
+                                true
+                            }
+
+                            KeyEvent.KEYCODE_DPAD_DOWN -> {
+                                if (!canControlPlayback) return@onPreviewKeyEvent false
+                                seekOverlayVisible = false
+                                true
+                            }
+
+                            else -> false
+                        }
+                    } else if (action == KeyEvent.ACTION_UP) {
+                        when (keyCode) {
+                            KeyEvent.KEYCODE_DPAD_LEFT,
+                            KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                if (canControlPlayback && isActivelySeeking) {
+                                    val finalDeltaMs = seekOverlayState.positionMs - originalPositionBeforeSeeking
+                                    if (finalDeltaMs != 0L) {
+                                        seekDeltaMs = finalDeltaMs
+                                        seekToken += 1
+                                    }
+                                    isActivelySeeking = false
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            else -> false
+                        }
+                    } else {
+                        false
                     }
                 }
         ) {
@@ -181,7 +212,9 @@ fun SharedTrailerOverlay(
                     seekRequestToken = seekToken,
                     seekDeltaMs = seekDeltaMs,
                     onProgressChanged = { position, duration ->
-                        seekOverlayState.positionMs = position
+                        if (!isActivelySeeking) {
+                            seekOverlayState.positionMs = position
+                        }
                         seekOverlayState.durationMs = duration
                     },
                     onEnded = onDismiss,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/SharedTrailerOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/SharedTrailerOverlay.kt
@@ -185,6 +185,7 @@ fun SharedTrailerOverlay(
                         seekOverlayState.durationMs = duration
                     },
                     onEnded = onDismiss,
+                    isInline = true,
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -20,6 +20,7 @@ import com.nuvio.tv.data.local.TmdbSettingsDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache
+import com.nuvio.tv.data.local.TrailerSettingsDataStore
 import com.nuvio.tv.data.trailer.TrailerService
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
@@ -78,7 +79,8 @@ class HomeViewModel @Inject constructor(
     internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     internal val cwEnrichmentCache: ContinueWatchingEnrichmentCache,
     private val profileManager: com.nuvio.tv.core.profile.ProfileManager,
-    internal val tvRecommendationManager: TvRecommendationManager
+    internal val tvRecommendationManager: TvRecommendationManager,
+    internal val trailerSettingsDataStore: TrailerSettingsDataStore
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
@@ -274,6 +276,7 @@ class HomeViewModel @Inject constructor(
             observeProgressSourceChanges()
             observeCollections()
             observeInstalledAddons()
+            observeTrailerPlaybackMode()
 
             viewModelScope.launch {
                 _uiState
@@ -629,6 +632,20 @@ class HomeViewModel @Inject constructor(
     private fun observeCollections() = observeCollectionsPipeline()
 
     private fun observeInstalledAddons() = observeInstalledAddonsPipeline()
+
+    private fun observeTrailerPlaybackMode() {
+        viewModelScope.launch {
+            trailerSettingsDataStore.settings
+                .map { it.playbackMode }
+                .distinctUntilChanged()
+                .collect {
+                    trailerPreviewUrlsState.clear()
+                    trailerPreviewAudioUrlsState.clear()
+                    trailerPreviewNegativeCache.clear()
+                    trailerPreviewLoadingIds.clear()
+                }
+        }
+    }
 
     private suspend fun loadAllCatalogs(addons: List<Addon>, forceReload: Boolean = false) =
         loadAllCatalogsPipeline(addons, forceReload)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -105,20 +105,31 @@ internal fun HomeViewModel.observeLayoutPreferencesPipeline() {
     }
 
     val focusedBackdropPrefsFlow = combine(
-        layoutPreferenceDataStore.focusedPosterBackdropExpandEnabled,
-        layoutPreferenceDataStore.focusedPosterBackdropExpandDelaySeconds,
-        layoutPreferenceDataStore.focusedPosterBackdropTrailerEnabled,
-        layoutPreferenceDataStore.focusedPosterBackdropTrailerMuted,
-        layoutPreferenceDataStore.focusedPosterBackdropTrailerPlaybackTarget
-    ) { expandEnabled, expandDelaySeconds, trailerEnabled, trailerMuted, trailerPlaybackTarget ->
-        FocusedBackdropPrefs(
-            expandEnabled = expandEnabled,
-            expandDelaySeconds = expandDelaySeconds,
-            trailerEnabled = trailerEnabled,
-            trailerMuted = trailerMuted,
-            trailerPlaybackTarget = trailerPlaybackTarget
-        )
+        combine(
+            layoutPreferenceDataStore.focusedPosterBackdropExpandEnabled,
+            layoutPreferenceDataStore.focusedPosterBackdropExpandDelaySeconds,
+            layoutPreferenceDataStore.focusedPosterBackdropTrailerEnabled,
+            layoutPreferenceDataStore.focusedPosterBackdropTrailerMuted,
+            layoutPreferenceDataStore.focusedPosterBackdropTrailerPlaybackTarget
+        ) { expandEnabled, expandDelaySeconds, trailerEnabled, trailerMuted, trailerPlaybackTarget ->
+            FocusedBackdropPrefs(
+                expandEnabled = expandEnabled,
+                expandDelaySeconds = expandDelaySeconds,
+                trailerEnabled = trailerEnabled,
+                trailerMuted = trailerMuted,
+                trailerPlaybackTarget = trailerPlaybackTarget
+            )
+        },
+        trailerSettingsDataStore.settings
+    ) { backdropPrefs, trailerSettings ->
+        val resolvedTarget = if (trailerSettings.playbackMode == com.nuvio.tv.core.build.TrailerPlaybackMode.WEB_VIEW) {
+            FocusedPosterTrailerPlaybackTarget.HERO_MEDIA
+        } else {
+            backdropPrefs.trailerPlaybackTarget
+        }
+        backdropPrefs.copy(trailerPlaybackTarget = resolvedTarget)
     }
+
 
     val modernLayoutPrefsFlow = combine(
         layoutPreferenceDataStore.modernLandscapePostersEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -192,6 +192,7 @@ internal fun ModernHeroMediaLayer(
                     muted = mutedVal,
                     cropToFill = true,
                     overscanZoom = MODERN_TRAILER_OVERSCAN_ZOOM,
+                    isInline = true,
                     modifier = Modifier
                         .fillMaxSize()
                         .graphicsLayer {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -1309,6 +1309,7 @@ private fun ModernCarouselCard(
                                 muted = focusedPosterBackdropTrailerMuted,
                                 cropToFill = true,
                                 overscanZoom = MODERN_TRAILER_OVERSCAN_ZOOM,
+                                isInline = true,
                                 modifier = Modifier.fillMaxSize()
                             )
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -1310,6 +1310,7 @@ private fun ModernCarouselCard(
                                 cropToFill = true,
                                 overscanZoom = MODERN_TRAILER_OVERSCAN_ZOOM,
                                 isInline = true,
+                                deferShowUntilPlaying = true,
                                 modifier = Modifier.fillMaxSize()
                             )
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
@@ -572,6 +573,7 @@ fun LayoutSettingsContent(
                     val isModernLandscape = isModern && uiState.modernLandscapePostersEnabled
                     val showAutoplayRow = AppFeaturePolicy.inAppTrailerPlaybackEnabled &&
                         (uiState.focusedPosterBackdropExpandEnabled || isModernLandscape)
+                    val isWebViewMode = uiState.trailerPlaybackMode == TrailerPlaybackMode.WEB_VIEW
 
                     if (!isModernLandscape) {
                         CompactToggleRow(
@@ -658,7 +660,12 @@ fun LayoutSettingsContent(
                         uiState.focusedPosterBackdropTrailerEnabled
                     ) {
                         ModernTrailerPlaybackTargetRow(
-                            selectedTarget = uiState.focusedPosterBackdropTrailerPlaybackTarget,
+                            selectedTarget = if (isWebViewMode) {
+                                FocusedPosterTrailerPlaybackTarget.HERO_MEDIA
+                            } else {
+                                uiState.focusedPosterBackdropTrailerPlaybackTarget
+                            },
+                            enabled = !isWebViewMode,
                             onTargetSelected = { target ->
                                 viewModel.onEvent(
                                     LayoutSettingsEvent.SetFocusedPosterBackdropTrailerPlaybackTarget(target)
@@ -798,17 +805,19 @@ private fun CompactToggleRow(
 private fun ModernTrailerPlaybackTargetRow(
     selectedTarget: FocusedPosterTrailerPlaybackTarget,
     onTargetSelected: (FocusedPosterTrailerPlaybackTarget) -> Unit,
-    onFocused: () -> Unit
+    onFocused: () -> Unit,
+    enabled: Boolean = true
 ) {
+    val contentAlpha = if (enabled) 1f else 0.4f
     Text(
         text = stringResource(R.string.layout_trailer_location),
         style = MaterialTheme.typography.labelLarge,
-        color = NuvioColors.TextSecondary
+        color = NuvioColors.TextSecondary.copy(alpha = contentAlpha)
     )
     Text(
         text = stringResource(R.string.layout_trailer_location_sub),
         style = MaterialTheme.typography.bodySmall,
-        color = NuvioColors.TextTertiary
+        color = NuvioColors.TextTertiary.copy(alpha = contentAlpha)
     )
     LazyRow(
         contentPadding = PaddingValues(end = 8.dp),
@@ -821,7 +830,8 @@ private fun ModernTrailerPlaybackTargetRow(
                 onClick = {
                     onTargetSelected(FocusedPosterTrailerPlaybackTarget.EXPANDED_CARD)
                 },
-                onFocused = onFocused
+                onFocused = onFocused,
+                enabled = enabled
             )
         }
         item(key = "trailer_target_hero_media") {
@@ -831,7 +841,8 @@ private fun ModernTrailerPlaybackTargetRow(
                 onClick = {
                     onTargetSelected(FocusedPosterTrailerPlaybackTarget.HERO_MEDIA)
                 },
-                onFocused = onFocused
+                onFocused = onFocused,
+                enabled = enabled
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -2,7 +2,9 @@ package com.nuvio.tv.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.data.local.TrailerSettingsDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.domain.model.ContinueWatchingSortMode
 import com.nuvio.tv.domain.model.DiscoverLocation
@@ -54,7 +56,8 @@ data class LayoutSettingsUiState(
     val showFullReleaseDate: Boolean = true,
     val nextUpFromFurthestEpisode: Boolean = true,
     val showUnairedNextUp: Boolean = true,
-    val continueWatchingSortMode: ContinueWatchingSortMode = ContinueWatchingSortMode.DEFAULT
+    val continueWatchingSortMode: ContinueWatchingSortMode = ContinueWatchingSortMode.DEFAULT,
+    val trailerPlaybackMode: TrailerPlaybackMode = TrailerPlaybackMode.IN_APP
 )
 
 data class CatalogInfo(
@@ -104,7 +107,8 @@ class LayoutSettingsViewModel @Inject constructor(
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
     private val traktSettingsDataStore: TraktSettingsDataStore,
     private val addonRepository: AddonRepository,
-    private val metaRepository: com.nuvio.tv.domain.repository.MetaRepository
+    private val metaRepository: com.nuvio.tv.domain.repository.MetaRepository,
+    private val trailerSettingsDataStore: TrailerSettingsDataStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LayoutSettingsUiState())
@@ -120,6 +124,11 @@ class LayoutSettingsViewModel @Inject constructor(
     }
 
     init {
+        viewModelScope.launch {
+            trailerSettingsDataStore.settings.distinctUntilChanged().collectLatest { settings ->
+                updateUiStateIfChanged { it.copy(trailerPlaybackMode = settings.playbackMode) }
+            }
+        }
         viewModelScope.launch {
             layoutPreferenceDataStore.selectedLayout.distinctUntilChanged().collectLatest { layout ->
                 updateUiStateIfChanged { it.copy(selectedLayout = layout) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -225,8 +227,17 @@ class LayoutSettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            layoutPreferenceDataStore.focusedPosterBackdropTrailerPlaybackTarget.distinctUntilChanged().collectLatest { target ->
-                updateUiStateIfChanged { it.copy(focusedPosterBackdropTrailerPlaybackTarget = target) }
+            combine(
+                layoutPreferenceDataStore.focusedPosterBackdropTrailerPlaybackTarget.distinctUntilChanged(),
+                trailerSettingsDataStore.settings.map { it.playbackMode }.distinctUntilChanged()
+            ) { target, playbackMode ->
+                if (playbackMode == TrailerPlaybackMode.WEB_VIEW) {
+                    FocusedPosterTrailerPlaybackTarget.HERO_MEDIA
+                } else {
+                    target
+                }
+            }.collectLatest { resolvedTarget ->
+                updateUiStateIfChanged { it.copy(focusedPosterBackdropTrailerPlaybackTarget = resolvedTarget) }
             }
         }
         viewModelScope.launch {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -51,6 +51,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.data.local.AVAILABLE_SUBTITLE_LANGUAGES
 import com.nuvio.tv.data.local.AudioLanguageOption
 import com.nuvio.tv.data.local.AudioOutputChannels
@@ -69,6 +70,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onShowAudioOutputChannelsDialog: () -> Unit,
     onShowDecoderPriorityDialog: () -> Unit,
     onShowMpvHardwareDecodeModeDialog: () -> Unit,
+    onShowTrailerPlaybackModeDialog: () -> Unit,
     onSetTrailerEnabled: (Boolean) -> Unit,
     onSetTrailerDelaySeconds: (Int) -> Unit,
     onSetDownmixEnabled: (Boolean) -> Unit,
@@ -80,7 +82,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onItemFocused: () -> Unit = {},
     enabled: Boolean = true
 ) {
-    if (AppFeaturePolicy.inAppTrailerPlaybackEnabled) {
+    if (AppFeaturePolicy.inAppTrailerPlaybackEnabled || AppFeaturePolicy.externalTrailerPlaybackEnabled) {
         item(key = "audio_trailer_section_header") {
             Text(
                 text = stringResource(R.string.audio_trailer_section),
@@ -117,6 +119,23 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
                     enabled = enabled
                 )
             }
+        }
+
+        item(key = "audio_trailer_playback_mode") {
+            val trailerModeName = when (trailerSettings.playbackMode) {
+                TrailerPlaybackMode.IN_APP -> stringResource(R.string.audio_trailer_playback_mode_in_app)
+                TrailerPlaybackMode.WEB_VIEW -> stringResource(R.string.audio_trailer_playback_mode_web_view)
+                TrailerPlaybackMode.EXTERNAL -> stringResource(R.string.audio_trailer_playback_mode_external)
+            }
+
+            NavigationSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_trailer_playback_mode),
+                subtitle = trailerModeName,
+                onClick = onShowTrailerPlaybackModeDialog,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
         }
     }
 
@@ -323,21 +342,25 @@ internal fun AudioSettingsDialogs(
     showAudioOutputChannelsDialog: Boolean,
     showDecoderPriorityDialog: Boolean,
     showMpvHardwareDecodeModeDialog: Boolean,
+    showTrailerPlaybackModeDialog: Boolean,
     selectedLanguage: String,
     selectedSecondaryLanguage: String?,
     selectedAudioOutputChannels: AudioOutputChannels,
     selectedPriority: Int,
     selectedMpvHardwareDecodeMode: MpvHardwareDecodeMode,
+    selectedTrailerPlaybackMode: TrailerPlaybackMode,
     onSetPreferredAudioLanguage: (String) -> Unit,
     onSetSecondaryPreferredAudioLanguage: (String?) -> Unit,
     onSetAudioOutputChannels: (AudioOutputChannels) -> Unit,
     onSetDecoderPriority: (Int) -> Unit,
     onSetMpvHardwareDecodeMode: (MpvHardwareDecodeMode) -> Unit,
+    onSetTrailerPlaybackMode: (TrailerPlaybackMode) -> Unit,
     onDismissAudioLanguageDialog: () -> Unit,
     onDismissSecondaryAudioLanguageDialog: () -> Unit,
     onDismissAudioOutputChannelsDialog: () -> Unit,
     onDismissDecoderPriorityDialog: () -> Unit,
-    onDismissMpvHardwareDecodeModeDialog: () -> Unit
+    onDismissMpvHardwareDecodeModeDialog: () -> Unit,
+    onDismissTrailerPlaybackModeDialog: () -> Unit
 ) {
     if (showAudioLanguageDialog) {
         AudioLanguageSelectionDialog(
@@ -393,6 +416,17 @@ internal fun AudioSettingsDialogs(
                 onDismissMpvHardwareDecodeModeDialog()
             },
             onDismiss = onDismissMpvHardwareDecodeModeDialog
+        )
+    }
+
+    if (showTrailerPlaybackModeDialog) {
+        TrailerPlaybackModeDialog(
+            selectedMode = selectedTrailerPlaybackMode,
+            onModeSelected = {
+                onSetTrailerPlaybackMode(it)
+                onDismissTrailerPlaybackModeDialog()
+            },
+            onDismiss = onDismissTrailerPlaybackModeDialog
         )
     }
 }
@@ -578,5 +612,49 @@ internal fun DecoderPriorityDialog(
         onDismiss = onDismiss,
         width = 420.dp,
         maxHeight = 320.dp
+    )
+}
+
+@Composable
+private fun TrailerPlaybackModeDialog(
+    selectedMode: TrailerPlaybackMode,
+    onModeSelected: (TrailerPlaybackMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val options = buildList {
+        if (AppFeaturePolicy.inAppTrailerPlaybackEnabled) {
+            add(
+                SettingsPickerOption(
+                    TrailerPlaybackMode.IN_APP,
+                    stringResource(R.string.audio_trailer_playback_mode_in_app),
+                    stringResource(R.string.audio_trailer_playback_mode_in_app_desc)
+                )
+            )
+        }
+        add(
+            SettingsPickerOption(
+                TrailerPlaybackMode.WEB_VIEW,
+                stringResource(R.string.audio_trailer_playback_mode_web_view),
+                stringResource(R.string.audio_trailer_playback_mode_web_view_desc)
+            )
+        )
+        add(
+            SettingsPickerOption(
+                TrailerPlaybackMode.EXTERNAL,
+                stringResource(R.string.audio_trailer_playback_mode_external),
+                stringResource(R.string.audio_trailer_playback_mode_external_desc)
+            )
+        )
+    }
+
+    SettingsSingleChoiceDialog(
+        title = stringResource(R.string.audio_trailer_playback_mode),
+        subtitle = stringResource(R.string.audio_trailer_playback_mode_sub),
+        options = options,
+        selectedValue = selectedMode,
+        onOptionSelected = onModeSelected,
+        onDismiss = onDismiss,
+        width = 460.dp,
+        maxHeight = 360.dp
     )
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -101,6 +101,7 @@ import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamAutoPlaySource
 import com.nuvio.tv.data.local.TrailerSettings
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.components.P2pConsentDialog
 import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
@@ -155,6 +156,7 @@ fun PlaybackSettingsContent(
     var showAudioOutputChannelsDialog by remember { mutableStateOf(false) }
     var showDecoderPriorityDialog by remember { mutableStateOf(false) }
     var showMpvHardwareDecodeModeDialog by remember { mutableStateOf(false) }
+    var showTrailerPlaybackModeDialog by remember { mutableStateOf(false) }
     var showStreamAutoPlayModeDialog by remember { mutableStateOf(false) }
     var showStreamAutoPlaySourceDialog by remember { mutableStateOf(false) }
     var showStreamAutoPlayAddonSelectionDialog by remember { mutableStateOf(false) }
@@ -178,6 +180,7 @@ fun PlaybackSettingsContent(
         showAudioOutputChannelsDialog = false
         showDecoderPriorityDialog = false
         showMpvHardwareDecodeModeDialog = false
+        showTrailerPlaybackModeDialog = false
         showStreamAutoPlayModeDialog = false
         showStreamAutoPlaySourceDialog = false
         showStreamAutoPlayAddonSelectionDialog = false
@@ -220,6 +223,7 @@ fun PlaybackSettingsContent(
                 onShowAudioOutputChannelsDialog = { openDialog { showAudioOutputChannelsDialog = true } },
                 onShowDecoderPriorityDialog = { openDialog { showDecoderPriorityDialog = true } },
                 onShowMpvHardwareDecodeModeDialog = { openDialog { showMpvHardwareDecodeModeDialog = true } },
+                onShowTrailerPlaybackModeDialog = { openDialog { showTrailerPlaybackModeDialog = true } },
                 onShowLanguageDialog = { openDialog { showLanguageDialog = true } },
                 onShowSecondaryLanguageDialog = { openDialog { showSecondaryLanguageDialog = true } },
                 onShowSubtitleStartupModeDialog = { openDialog { showSubtitleStartupModeDialog = true } },
@@ -327,6 +331,7 @@ fun PlaybackSettingsContent(
 
     PlaybackSettingsDialogsHost(
         playerSettings = playerSettings,
+        trailerSettings = trailerSettings,
         installedAddonNames = installedAddonNames,
         enabledPluginNames = enabledPluginNames,
         showPlayerPreferenceDialog = showPlayerPreferenceDialog,
@@ -342,6 +347,7 @@ fun PlaybackSettingsContent(
         showAudioOutputChannelsDialog = showAudioOutputChannelsDialog,
         showDecoderPriorityDialog = showDecoderPriorityDialog,
         showMpvHardwareDecodeModeDialog = showMpvHardwareDecodeModeDialog,
+        showTrailerPlaybackModeDialog = showTrailerPlaybackModeDialog,
         showStreamAutoPlayModeDialog = showStreamAutoPlayModeDialog,
         showStreamAutoPlaySourceDialog = showStreamAutoPlaySourceDialog,
         showStreamAutoPlayAddonSelectionDialog = showStreamAutoPlayAddonSelectionDialog,
@@ -390,6 +396,9 @@ fun PlaybackSettingsContent(
         onSetMpvHardwareDecodeMode = { mode ->
             coroutineScope.launch { viewModel.setMpvHardwareDecodeMode(mode) }
         },
+        onSetTrailerPlaybackMode = { mode ->
+            coroutineScope.launch { viewModel.setTrailerPlaybackMode(mode) }
+        },
         onSetStreamAutoPlayMode = { mode ->
             coroutineScope.launch { viewModel.setStreamAutoPlayMode(mode) }
         },
@@ -422,6 +431,7 @@ fun PlaybackSettingsContent(
         onDismissAudioOutputChannelsDialog = ::dismissAllDialogs,
         onDismissDecoderPriorityDialog = ::dismissAllDialogs,
         onDismissMpvHardwareDecodeModeDialog = ::dismissAllDialogs,
+        onDismissTrailerPlaybackModeDialog = ::dismissAllDialogs,
         onDismissStreamAutoPlayModeDialog = ::dismissAllDialogs,
         onDismissStreamAutoPlaySourceDialog = ::dismissAllDialogs,
         onDismissStreamRegexDialog = ::dismissAllDialogs,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -62,6 +62,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioOutputChannels
 import com.nuvio.tv.data.local.AutoSkipSegmentType
@@ -111,6 +112,7 @@ internal fun PlaybackSettingsSections(
     onShowAudioOutputChannelsDialog: () -> Unit,
     onShowDecoderPriorityDialog: () -> Unit,
     onShowMpvHardwareDecodeModeDialog: () -> Unit,
+    onShowTrailerPlaybackModeDialog: () -> Unit,
     onShowLanguageDialog: () -> Unit,
     onShowSecondaryLanguageDialog: () -> Unit,
     onShowSubtitleStartupModeDialog: () -> Unit,
@@ -548,6 +550,7 @@ internal fun PlaybackSettingsSections(
                 onShowAudioOutputChannelsDialog = onShowAudioOutputChannelsDialog,
                 onShowDecoderPriorityDialog = onShowDecoderPriorityDialog,
                 onShowMpvHardwareDecodeModeDialog = onShowMpvHardwareDecodeModeDialog,
+                onShowTrailerPlaybackModeDialog = onShowTrailerPlaybackModeDialog,
                 onSetTrailerEnabled = onSetTrailerEnabled,
                 onSetTrailerDelaySeconds = onSetTrailerDelaySeconds,
                 onSetDownmixEnabled = onSetDownmixEnabled,
@@ -879,6 +882,7 @@ private fun AfrCapabilityDisableButton(
 @Composable
 internal fun PlaybackSettingsDialogsHost(
     playerSettings: PlayerSettings,
+    trailerSettings: TrailerSettings,
     installedAddonNames: List<String>,
     enabledPluginNames: List<String>,
     showPlayerPreferenceDialog: Boolean,
@@ -894,6 +898,7 @@ internal fun PlaybackSettingsDialogsHost(
     showAudioOutputChannelsDialog: Boolean,
     showDecoderPriorityDialog: Boolean,
     showMpvHardwareDecodeModeDialog: Boolean,
+    showTrailerPlaybackModeDialog: Boolean,
     showStreamAutoPlayModeDialog: Boolean,
     showStreamAutoPlaySourceDialog: Boolean,
     showStreamAutoPlayAddonSelectionDialog: Boolean,
@@ -916,6 +921,7 @@ internal fun PlaybackSettingsDialogsHost(
     onSetAudioOutputChannels: (AudioOutputChannels) -> Unit,
     onSetDecoderPriority: (Int) -> Unit,
     onSetMpvHardwareDecodeMode: (com.nuvio.tv.data.local.MpvHardwareDecodeMode) -> Unit,
+    onSetTrailerPlaybackMode: (TrailerPlaybackMode) -> Unit,
     onSetStreamAutoPlayMode: (com.nuvio.tv.data.local.StreamAutoPlayMode) -> Unit,
     onSetStreamAutoPlaySource: (com.nuvio.tv.data.local.StreamAutoPlaySource) -> Unit,
     onSetNextEpisodeThresholdMode: (com.nuvio.tv.data.local.NextEpisodeThresholdMode) -> Unit,
@@ -934,6 +940,7 @@ internal fun PlaybackSettingsDialogsHost(
     onDismissAudioOutputChannelsDialog: () -> Unit,
     onDismissDecoderPriorityDialog: () -> Unit,
     onDismissMpvHardwareDecodeModeDialog: () -> Unit,
+    onDismissTrailerPlaybackModeDialog: () -> Unit,
     onDismissStreamAutoPlayModeDialog: () -> Unit,
     onDismissStreamAutoPlaySourceDialog: () -> Unit,
     onDismissStreamRegexDialog: () -> Unit,
@@ -992,21 +999,25 @@ internal fun PlaybackSettingsDialogsHost(
         showAudioOutputChannelsDialog = showAudioOutputChannelsDialog,
         showDecoderPriorityDialog = showDecoderPriorityDialog,
         showMpvHardwareDecodeModeDialog = showMpvHardwareDecodeModeDialog,
+        showTrailerPlaybackModeDialog = showTrailerPlaybackModeDialog,
         selectedLanguage = playerSettings.preferredAudioLanguage,
         selectedSecondaryLanguage = playerSettings.secondaryPreferredAudioLanguage,
         selectedAudioOutputChannels = playerSettings.audioOutputChannels,
         selectedPriority = playerSettings.decoderPriority,
         selectedMpvHardwareDecodeMode = playerSettings.mpvHardwareDecodeMode,
+        selectedTrailerPlaybackMode = trailerSettings.playbackMode,
         onSetPreferredAudioLanguage = onSetPreferredAudioLanguage,
         onSetSecondaryPreferredAudioLanguage = onSetSecondaryPreferredAudioLanguage,
         onSetAudioOutputChannels = onSetAudioOutputChannels,
         onSetDecoderPriority = onSetDecoderPriority,
         onSetMpvHardwareDecodeMode = onSetMpvHardwareDecodeMode,
+        onSetTrailerPlaybackMode = onSetTrailerPlaybackMode,
         onDismissAudioLanguageDialog = onDismissAudioLanguageDialog,
         onDismissSecondaryAudioLanguageDialog = onDismissSecondaryAudioLanguageDialog,
         onDismissAudioOutputChannelsDialog = onDismissAudioOutputChannelsDialog,
         onDismissDecoderPriorityDialog = onDismissDecoderPriorityDialog,
-        onDismissMpvHardwareDecodeModeDialog = onDismissMpvHardwareDecodeModeDialog
+        onDismissMpvHardwareDecodeModeDialog = onDismissMpvHardwareDecodeModeDialog,
+        onDismissTrailerPlaybackModeDialog = onDismissTrailerPlaybackModeDialog
     )
 
     AutoPlaySettingsDialogs(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -18,6 +18,7 @@ import com.nuvio.tv.data.local.MpvHardwareDecodeMode
 import com.nuvio.tv.data.local.SubtitleOrganizationMode
 import com.nuvio.tv.data.local.TrailerSettings
 import com.nuvio.tv.data.local.TrailerSettingsDataStore
+import com.nuvio.tv.core.build.TrailerPlaybackMode
 import com.nuvio.tv.core.torrent.TorrentSettings
 import com.nuvio.tv.core.torrent.TorrentSettingsData
 import com.nuvio.tv.domain.repository.AddonRepository
@@ -335,5 +336,9 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setStreamReuseLastLinkCacheHours(hours: Int) {
         playerSettingsDataStore.setStreamReuseLastLinkCacheHours(hours)
+    }
+
+    suspend fun setTrailerPlaybackMode(mode: TrailerPlaybackMode) {
+        trailerSettingsDataStore.setPlaybackMode(mode)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -26,6 +26,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import javax.inject.Inject
 
 @HiltViewModel
@@ -34,7 +36,8 @@ class PlaybackSettingsViewModel @Inject constructor(
     private val trailerSettingsDataStore: TrailerSettingsDataStore,
     private val addonRepository: AddonRepository,
     private val pluginManager: PluginManager,
-    private val torrentSettings: TorrentSettings
+    private val torrentSettings: TorrentSettings,
+    private val layoutPreferenceDataStore: LayoutPreferenceDataStore
 ) : ViewModel() {
 
     val playerSettings: Flow<PlayerSettings> = playerSettingsDataStore.playerSettings
@@ -340,5 +343,10 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setTrailerPlaybackMode(mode: TrailerPlaybackMode) {
         trailerSettingsDataStore.setPlaybackMode(mode)
+        if (mode == TrailerPlaybackMode.WEB_VIEW) {
+            layoutPreferenceDataStore.setFocusedPosterBackdropTrailerPlaybackTarget(
+                FocusedPosterTrailerPlaybackTarget.HERO_MEDIA
+            )
+        }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -826,30 +827,36 @@ internal fun SettingsChoiceChip(
     selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onFocused: () -> Unit = {}
+    onFocused: () -> Unit = {},
+    enabled: Boolean = true
 ) {
+    val contentAlpha = if (enabled) 1f else 0.4f
     var isFocused by remember { mutableStateOf(false) }
 
     Card(
-        onClick = onClick,
-        modifier = modifier.onFocusChanged { state ->
-            val nowFocused = state.isFocused
-            if (isFocused != nowFocused) {
-                isFocused = nowFocused
-                if (nowFocused) onFocused()
-            }
+        onClick = {
+            if (enabled) onClick()
         },
+        modifier = modifier
+            .focusProperties { canFocus = enabled }
+            .onFocusChanged { state ->
+                val nowFocused = state.isFocused
+                if (isFocused != nowFocused) {
+                    isFocused = nowFocused
+                    if (nowFocused) onFocused()
+                }
+            },
         colors = CardDefaults.colors(
-            containerColor = if (selected) NuvioColors.FocusRing.copy(alpha = 0.2f) else NuvioColors.Background,
-            focusedContainerColor = if (selected) NuvioColors.FocusRing.copy(alpha = 0.2f) else NuvioColors.Background
+            containerColor = if (selected) NuvioColors.FocusRing.copy(alpha = 0.2f * contentAlpha) else NuvioColors.Background,
+            focusedContainerColor = if (selected) NuvioColors.FocusRing.copy(alpha = 0.2f * contentAlpha) else NuvioColors.Background
         ),
         border = CardDefaults.border(
             border = if (selected) Border(
-                border = BorderStroke(1.dp, NuvioColors.FocusRing),
+                border = BorderStroke(1.dp, NuvioColors.FocusRing.copy(alpha = contentAlpha)),
                 shape = RoundedCornerShape(SettingsPillRadius)
             ) else Border.None,
             focusedBorder = Border(
-                border = BorderStroke(1.dp, NuvioColors.FocusRing),
+                border = BorderStroke(1.dp, NuvioColors.FocusRing.copy(alpha = contentAlpha)),
                 shape = RoundedCornerShape(SettingsPillRadius)
             )
         ),
@@ -859,7 +866,7 @@ internal fun SettingsChoiceChip(
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
-            color = if (selected || isFocused) NuvioColors.TextPrimary else NuvioColors.TextSecondary,
+            color = if (selected || isFocused) NuvioColors.TextPrimary.copy(alpha = contentAlpha) else NuvioColors.TextSecondary.copy(alpha = contentAlpha),
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
         )
     }

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerApplication.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.trailer
 
 import android.app.Application
+import android.webkit.CookieManager
 
 /**
  * Lightweight Application class used exclusively by the :trailer process.
@@ -23,6 +24,11 @@ class TrailerApplication : Application() {
                 // Suffix might already be set or WebView already initialized, ignore safely
             }
         }
+        // Accept cookies early so YouTube guest session cookies persist across
+        // trailer launches, preventing "Sign in to confirm you're not a bot" errors.
+        try {
+            CookieManager.getInstance().setAcceptCookie(true)
+        } catch (_: Exception) {}
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerApplication.kt
@@ -1,0 +1,16 @@
+package com.nuvio.tv.ui.trailer
+
+import android.app.Application
+
+/**
+ * Lightweight Application class used exclusively by the :trailer process.
+ *
+ * When the :trailer process starts, Android creates an Application instance.
+ * The default NuvioApplication triggers Hilt/Dagger dependency injection,
+ * loading 420MB+ of classes into the heap. By substituting this minimal
+ * Application via [com.nuvio.tv.NuvioAppComponentFactory], the trailer
+ * process only loads what it needs: this class + TrailerOverlayActivity + WebView.
+ *
+ * Memory: ~50MB vs ~575MB with NuvioApplication.
+ */
+class TrailerApplication : Application()

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerApplication.kt
@@ -13,4 +13,16 @@ import android.app.Application
  *
  * Memory: ~50MB vs ~575MB with NuvioApplication.
  */
-class TrailerApplication : Application()
+class TrailerApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            try {
+                android.webkit.WebView.setDataDirectorySuffix("trailer")
+            } catch (e: Exception) {
+                // Suffix might already be set or WebView already initialized, ignore safely
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
@@ -101,10 +101,10 @@ class TrailerOverlayActivity : Activity() {
         autoPlay = intent.getBooleanExtra(EXTRA_AUTO_PLAY, true)
         muted = intent.getBooleanExtra(EXTRA_MUTED, false)
 
-        // Show window IMMEDIATELY with a black container to prevent ANR.
+        // Show window IMMEDIATELY with a transparent container to prevent ANR and black flash.
         // WebView creation is deferred to the next frame.
         container = FrameLayout(this).apply {
-            setBackgroundColor(android.graphics.Color.BLACK)
+            setBackgroundColor(android.graphics.Color.TRANSPARENT)
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
@@ -129,6 +129,7 @@ class TrailerOverlayActivity : Activity() {
         if (isDestroyed_ || isFinishing) return
 
         val wv = createWebView()
+        wv.alpha = 0f // hidden initially until first frame renders
         webView = wv
         container.addView(wv)
 
@@ -260,6 +261,15 @@ class TrailerOverlayActivity : Activity() {
         }
     }
 
+    private fun showPlayerContent() {
+        mainHandler.post {
+            if (!isDestroyed_ && !isFinishing) {
+                container.setBackgroundColor(android.graphics.Color.BLACK)
+                webView?.animate()?.alpha(1f)?.setDuration(350)?.start()
+            }
+        }
+    }
+
     private fun createJsBridge(): Any {
         return object {
             @JavascriptInterface
@@ -273,7 +283,10 @@ class TrailerOverlayActivity : Activity() {
 
             @JavascriptInterface
             fun onPlayerReady() {
-                mainHandler.post { sendEvent("first_frame") }
+                mainHandler.post {
+                    showPlayerContent()
+                    sendEvent("first_frame")
+                }
             }
 
             @JavascriptInterface
@@ -282,6 +295,8 @@ class TrailerOverlayActivity : Activity() {
                     if (state == 0) { // YT.PlayerState.ENDED
                         sendEvent("ended")
                         finishAndRemoveTask()
+                    } else if (state == 1) { // YT.PlayerState.PLAYING
+                        showPlayerContent()
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
@@ -76,18 +76,36 @@ class TrailerOverlayActivity : Activity() {
     private var autoPlay: Boolean = true
     private var muted: Boolean = false
     private var isDestroyed_ = false
+    private var isFinishingGracefully = false
+    private val exitRunnable = Runnable { finishAndRemoveTask() }
 
     private val commandReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
+            if (isFinishingGracefully) return
             val wv = webView ?: return
             when (intent.getStringExtra(EXTRA_COMMAND)) {
                 "play" -> wv.evaluateJavascript("playVideo();", null)
                 "pause" -> wv.evaluateJavascript("pauseVideo();", null)
                 "mute" -> wv.evaluateJavascript("mute();", null)
                 "unmute" -> wv.evaluateJavascript("unMute();", null)
-                "stop" -> finishAndRemoveTask()
+                "stop" -> prepareExitAndFinish()
             }
         }
+    }
+
+    private fun prepareExitAndFinish() {
+        if (isFinishingGracefully) return
+        isFinishingGracefully = true
+
+        webView?.let { wv ->
+            wv.evaluateJavascript(
+                "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
+            )
+            wv.stopLoading()
+            wv.loadUrl("about:blank")
+        }
+
+        mainHandler.postDelayed(exitRunnable, 800)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -125,6 +143,45 @@ class TrailerOverlayActivity : Activity() {
         mainHandler.post { initWebView() }
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+
+        // Cancel any pending graceful exit
+        if (isFinishingGracefully) {
+            isFinishingGracefully = false
+            mainHandler.removeCallbacks(exitRunnable)
+        }
+
+        videoId = intent.getStringExtra(EXTRA_VIDEO_ID) ?: ""
+        autoPlay = intent.getBooleanExtra(EXTRA_AUTO_PLAY, true)
+        muted = intent.getBooleanExtra(EXTRA_MUTED, false)
+
+        if (videoId.isNotBlank()) {
+            webView?.let { wv ->
+                val htmlContent = try {
+                    assets.open("youtube_player.html").bufferedReader().use { it.readText() }
+                } catch (e: Exception) {
+                    android.util.Log.e("TrailerOverlay", "Failed to load youtube_player.html", e)
+                    sendEvent("error", errorCode = 2)
+                    prepareExitAndFinish()
+                    return
+                }
+                wv.alpha = 0f
+                container.setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                wv.loadDataWithBaseURL(
+                    "https://www.youtube-nocookie.com",
+                    htmlContent,
+                    "text/html",
+                    "utf-8",
+                    null
+                )
+            } ?: run {
+                initWebView()
+            }
+        }
+    }
+
     private fun initWebView() {
         if (isDestroyed_ || isFinishing) return
 
@@ -153,11 +210,12 @@ class TrailerOverlayActivity : Activity() {
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if (isFinishingGracefully) return true
         when (keyCode) {
             KeyEvent.KEYCODE_BACK,
             KeyEvent.KEYCODE_ESCAPE -> {
                 sendEvent("ended")
-                finishAndRemoveTask()
+                prepareExitAndFinish()
                 return true
             }
             KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
@@ -195,16 +253,23 @@ class TrailerOverlayActivity : Activity() {
 
     override fun onDestroy() {
         isDestroyed_ = true
+        mainHandler.removeCallbacks(exitRunnable)
         try { unregisterReceiver(commandReceiver) } catch (_: Exception) {}
         webView?.let { wv ->
-            wv.evaluateJavascript(
-                "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
-            )
-            wv.stopLoading()
-            wv.loadUrl("about:blank")
+            if (!isFinishingGracefully) {
+                wv.evaluateJavascript(
+                    "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
+                )
+                wv.stopLoading()
+                wv.loadUrl("about:blank")
+            }
             container.removeView(wv)
             wv.removeAllViews()
-            wv.destroy()
+            try {
+                wv.destroy()
+            } catch (e: Exception) {
+                android.util.Log.e("TrailerOverlay", "Error destroying WebView", e)
+            }
         }
         webView = null
         super.onDestroy()
@@ -248,6 +313,11 @@ class TrailerOverlayActivity : Activity() {
 
                 @Deprecated("Deprecated in Java")
                 override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean = true
+
+                override fun onRenderProcessGone(view: WebView?, detail: android.webkit.RenderProcessGoneDetail?): Boolean {
+                    android.util.Log.e("TrailerOverlay", "WebView renderer process gone (didCrash=${detail?.didCrash()}). Recovering...")
+                    return true
+                }
             }
 
             webChromeClient = object : android.webkit.WebChromeClient() {
@@ -294,7 +364,7 @@ class TrailerOverlayActivity : Activity() {
                 mainHandler.post {
                     if (state == 0) { // YT.PlayerState.ENDED
                         sendEvent("ended")
-                        finishAndRemoveTask()
+                        prepareExitAndFinish()
                     } else if (state == 1) { // YT.PlayerState.PLAYING
                         showPlayerContent()
                     }
@@ -317,7 +387,7 @@ class TrailerOverlayActivity : Activity() {
                 mainHandler.post {
                     android.util.Log.e("TrailerOverlay", "YouTube error: $error")
                     sendEvent("error", errorCode = error)
-                    finishAndRemoveTask()
+                    prepareExitAndFinish()
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
@@ -1,0 +1,310 @@
+package com.nuvio.tv.ui.trailer
+
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.KeyEvent
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import android.app.Activity
+
+/**
+ * Fullscreen Activity that hosts the YouTube IFrame player WebView.
+ *
+ * Runs in the `:trailer` process (declared in AndroidManifest.xml).
+ * If Chrome's in-process GPU thread (Chrome_InProcGp) crashes due to
+ * the PowerVR driver bug (PVRSRVFreeDeviceMemMIW SIGSEGV), only this
+ * process dies — the main app process is completely unaffected.
+ *
+ * WebView is created asynchronously (posted to the main looper) to
+ * ensure the window is drawn immediately and avoid ANR on slow SoCs.
+ */
+class TrailerOverlayActivity : Activity() {
+
+    companion object {
+        const val EXTRA_VIDEO_ID = "video_id"
+        const val EXTRA_AUTO_PLAY = "auto_play"
+        const val EXTRA_MUTED = "muted"
+
+        // Broadcast actions sent TO the main process
+        const val ACTION_TRAILER_EVENT = "com.nuvio.tv.TRAILER_EVENT"
+        const val EXTRA_EVENT = "event"
+        const val EXTRA_ERROR_CODE = "error_code"
+        const val EXTRA_POSITION_MS = "position_ms"
+        const val EXTRA_DURATION_MS = "duration_ms"
+
+        // Broadcast actions received FROM the main process
+        const val ACTION_TRAILER_COMMAND = "com.nuvio.tv.TRAILER_COMMAND"
+        const val EXTRA_COMMAND = "command"
+
+        fun launch(context: Context, videoId: String, autoPlay: Boolean = true, muted: Boolean = false) {
+            val intent = Intent(context, TrailerOverlayActivity::class.java).apply {
+                putExtra(EXTRA_VIDEO_ID, videoId)
+                putExtra(EXTRA_AUTO_PLAY, autoPlay)
+                putExtra(EXTRA_MUTED, muted)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        }
+
+        fun sendCommand(context: Context, command: String) {
+            val intent = Intent(ACTION_TRAILER_COMMAND).apply {
+                putExtra(EXTRA_COMMAND, command)
+                setPackage(context.packageName)
+            }
+            context.sendBroadcast(intent)
+        }
+
+        fun dismiss(context: Context) {
+            sendCommand(context, "stop")
+        }
+    }
+
+    private var webView: WebView? = null
+    private lateinit var container: FrameLayout
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var videoId: String = ""
+    private var autoPlay: Boolean = true
+    private var muted: Boolean = false
+    private var isDestroyed_ = false
+
+    private val commandReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val wv = webView ?: return
+            when (intent.getStringExtra(EXTRA_COMMAND)) {
+                "play" -> wv.evaluateJavascript("playVideo();", null)
+                "pause" -> wv.evaluateJavascript("pauseVideo();", null)
+                "mute" -> wv.evaluateJavascript("mute();", null)
+                "unmute" -> wv.evaluateJavascript("unMute();", null)
+                "stop" -> finishAndRemoveTask()
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        videoId = intent.getStringExtra(EXTRA_VIDEO_ID) ?: run {
+            sendEvent("error", errorCode = 2)
+            finish()
+            return
+        }
+        autoPlay = intent.getBooleanExtra(EXTRA_AUTO_PLAY, true)
+        muted = intent.getBooleanExtra(EXTRA_MUTED, false)
+
+        // Show window IMMEDIATELY with a black container to prevent ANR.
+        // WebView creation is deferred to the next frame.
+        container = FrameLayout(this).apply {
+            setBackgroundColor(android.graphics.Color.BLACK)
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        }
+        setContentView(container)
+
+        // Listen for commands from the main process
+        val filter = IntentFilter(ACTION_TRAILER_COMMAND)
+        if (android.os.Build.VERSION.SDK_INT >= 33) {
+            registerReceiver(commandReceiver, filter, Context.RECEIVER_EXPORTED)
+        } else {
+            registerReceiver(commandReceiver, filter)
+        }
+
+        // Create WebView on next frame — after the window is drawn.
+        // This prevents ANR on slow SoCs (RTD6748).
+        mainHandler.post { initWebView() }
+    }
+
+    private fun initWebView() {
+        if (isDestroyed_ || isFinishing) return
+
+        val wv = createWebView()
+        webView = wv
+        container.addView(wv)
+
+        // Load the YouTube player HTML
+        val htmlContent = try {
+            assets.open("youtube_player.html").bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            android.util.Log.e("TrailerOverlay", "Failed to load youtube_player.html", e)
+            sendEvent("error", errorCode = 2)
+            finish()
+            return
+        }
+
+        wv.loadDataWithBaseURL(
+            "https://www.youtube-nocookie.com",
+            htmlContent,
+            "text/html",
+            "utf-8",
+            null
+        )
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        when (keyCode) {
+            KeyEvent.KEYCODE_BACK,
+            KeyEvent.KEYCODE_ESCAPE -> {
+                sendEvent("ended")
+                finishAndRemoveTask()
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+            KeyEvent.KEYCODE_MEDIA_PLAY -> {
+                webView?.evaluateJavascript(
+                    "(function(){if(player&&typeof player.getPlayerState==='function'){" +
+                    "var s=player.getPlayerState();" +
+                    "if(s===1)player.pauseVideo();else player.playVideo();" +
+                    "}})()", null
+                )
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_PAUSE,
+            KeyEvent.KEYCODE_MEDIA_STOP -> {
+                webView?.evaluateJavascript("pauseVideo();", null)
+                return true
+            }
+            KeyEvent.KEYCODE_DPAD_LEFT -> {
+                webView?.evaluateJavascript(
+                    "(function(){if(player&&typeof player.getCurrentTime==='function'){" +
+                    "seekTo(player.getCurrentTime()-10);}})();", null
+                )
+                return true
+            }
+            KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                webView?.evaluateJavascript(
+                    "(function(){if(player&&typeof player.getCurrentTime==='function'){" +
+                    "seekTo(player.getCurrentTime()+10);}})();", null
+                )
+                return true
+            }
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+
+    override fun onDestroy() {
+        isDestroyed_ = true
+        try { unregisterReceiver(commandReceiver) } catch (_: Exception) {}
+        webView?.let { wv ->
+            wv.evaluateJavascript(
+                "try{if(player){player.stopVideo();player.destroy();player=null;}}catch(e){}", null
+            )
+            wv.stopLoading()
+            wv.loadUrl("about:blank")
+            container.removeView(wv)
+            wv.removeAllViews()
+            wv.destroy()
+        }
+        webView = null
+        super.onDestroy()
+    }
+
+    private fun sendEvent(event: String, errorCode: Int = 0, positionMs: Long = 0, durationMs: Long = 0) {
+        val intent = Intent(ACTION_TRAILER_EVENT).apply {
+            putExtra(EXTRA_EVENT, event)
+            putExtra(EXTRA_ERROR_CODE, errorCode)
+            putExtra(EXTRA_POSITION_MS, positionMs)
+            putExtra(EXTRA_DURATION_MS, durationMs)
+            setPackage(packageName)
+        }
+        sendBroadcast(intent)
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun createWebView(): WebView {
+        return WebView(this).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+
+            settings.javaScriptEnabled = true
+            settings.mediaPlaybackRequiresUserGesture = false
+            settings.domStorageEnabled = true
+            settings.cacheMode = WebSettings.LOAD_NO_CACHE
+            settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+
+            isVerticalScrollBarEnabled = false
+            isHorizontalScrollBarEnabled = false
+
+            addJavascriptInterface(createJsBridge(), "AndroidBridge")
+
+            webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: android.webkit.WebResourceRequest?
+                ): Boolean = true
+
+                @Deprecated("Deprecated in Java")
+                override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean = true
+            }
+
+            webChromeClient = object : android.webkit.WebChromeClient() {
+                override fun onConsoleMessage(consoleMessage: android.webkit.ConsoleMessage?): Boolean {
+                    consoleMessage?.let {
+                        android.util.Log.d("TrailerOverlay_JS", "${it.message()} -- line ${it.lineNumber()}")
+                    }
+                    return true
+                }
+            }
+        }
+    }
+
+    private fun createJsBridge(): Any {
+        return object {
+            @JavascriptInterface
+            fun onReady() {
+                mainHandler.post {
+                    webView?.evaluateJavascript(
+                        "initPlayer('$videoId', $autoPlay, $muted);", null
+                    )
+                }
+            }
+
+            @JavascriptInterface
+            fun onPlayerReady() {
+                mainHandler.post { sendEvent("first_frame") }
+            }
+
+            @JavascriptInterface
+            fun onStateChange(state: Int) {
+                mainHandler.post {
+                    if (state == 0) { // YT.PlayerState.ENDED
+                        sendEvent("ended")
+                        finishAndRemoveTask()
+                    }
+                }
+            }
+
+            @JavascriptInterface
+            fun onProgress(currentTime: Float, duration: Float) {
+                mainHandler.post {
+                    sendEvent(
+                        "progress",
+                        positionMs = (currentTime * 1000).toLong(),
+                        durationMs = (duration * 1000).toLong()
+                    )
+                }
+            }
+
+            @JavascriptInterface
+            fun onError(error: Int) {
+                mainHandler.post {
+                    android.util.Log.e("TrailerOverlay", "YouTube error: $error")
+                    sendEvent("error", errorCode = error)
+                    finishAndRemoveTask()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
@@ -284,8 +284,8 @@ class TrailerOverlayActivity : Activity() {
             @JavascriptInterface
             fun onPlayerReady() {
                 mainHandler.post {
-                    // No-op to avoid showing buffering/loading screens.
-                    // We only show player content and send first_frame event when state changes to PLAYING (state == 1).
+                    showPlayerContent()
+                    sendEvent("first_frame")
                 }
             }
 
@@ -297,7 +297,6 @@ class TrailerOverlayActivity : Activity() {
                         finishAndRemoveTask()
                     } else if (state == 1) { // YT.PlayerState.PLAYING
                         showPlayerContent()
-                        sendEvent("first_frame")
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
@@ -284,8 +284,8 @@ class TrailerOverlayActivity : Activity() {
             @JavascriptInterface
             fun onPlayerReady() {
                 mainHandler.post {
-                    showPlayerContent()
-                    sendEvent("first_frame")
+                    // No-op to avoid showing buffering/loading screens.
+                    // We only show player content and send first_frame event when state changes to PLAYING (state == 1).
                 }
             }
 
@@ -297,6 +297,7 @@ class TrailerOverlayActivity : Activity() {
                         finishAndRemoveTask()
                     } else if (state == 1) { // YT.PlayerState.PLAYING
                         showPlayerContent()
+                        sendEvent("first_frame")
                     }
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt
@@ -10,6 +10,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.KeyEvent
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -176,6 +177,7 @@ class TrailerOverlayActivity : Activity() {
                     "utf-8",
                     null
                 )
+                CookieManager.getInstance().flush()
             } ?: run {
                 initWebView()
             }
@@ -207,6 +209,7 @@ class TrailerOverlayActivity : Activity() {
             "utf-8",
             null
         )
+        CookieManager.getInstance().flush()
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
@@ -288,7 +291,17 @@ class TrailerOverlayActivity : Activity() {
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun createWebView(): WebView {
+        // Enable cookie persistence so YouTube guest cookies survive across sessions.
+        // Without this, every WebView launch appears as a fresh "bot" to YouTube.
+        val cookieManager = CookieManager.getInstance()
+        cookieManager.setAcceptCookie(true)
+
+        // Pre-seed CONSENT cookie so YouTube doesn't show the consent/bot wall.
+        cookieManager.setCookie("https://www.youtube.com", "CONSENT=YES+; Domain=.youtube.com; Path=/; Max-Age=31536000; SameSite=None; Secure")
+
         return WebView(this).apply {
+            cookieManager.setAcceptThirdPartyCookies(this, true)
+
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
@@ -297,7 +310,7 @@ class TrailerOverlayActivity : Activity() {
             settings.javaScriptEnabled = true
             settings.mediaPlaybackRequiresUserGesture = false
             settings.domStorageEnabled = true
-            settings.cacheMode = WebSettings.LOAD_NO_CACHE
+            settings.cacheMode = WebSettings.LOAD_DEFAULT
             settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
 
             isVerticalScrollBarEnabled = false

--- a/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerWarmUpService.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerWarmUpService.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.ui.trailer
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebView
+
+/**
+ * Lightweight Background Service running in the `:trailer` subprocess.
+ *
+ * Its sole purpose is to keep the `:trailer` OS process alive ("warm") and pre-load
+ * the WebView engine on the main thread. This avoids the 1.5s - 2.0s cold-start penalty
+ * (Zygote fork + WebView classloader loading + Chrome DevTools context initialization)
+ * when the user clicks on "Fragman".
+ */
+class TrailerWarmUpService : Service() {
+
+    companion object {
+        private const val TAG = "TrailerWarmUpService"
+
+        fun start(context: Context) {
+            try {
+                val intent = Intent(context, TrailerWarmUpService::class.java)
+                context.startService(intent)
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "Failed to start TrailerWarmUpService", e)
+            }
+        }
+    }
+
+    private var dummyWebView: WebView? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        android.util.Log.i(TAG, "TrailerWarmUpService starting in process: ${android.os.Process.myPid()}")
+
+        // Pre-load WebView on the main thread
+        Handler(Looper.getMainLooper()).post {
+            try {
+                // Initialize WebView with applicationContext. This loads WebView native libraries
+                // and sets up the Chromium environment early in the background.
+                dummyWebView = WebView(applicationContext)
+                android.util.Log.i(TAG, "WebView preloaded successfully in background process.")
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "Failed to pre-load WebView in warm-up service", e)
+            }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Return START_STICKY to keep the process alive as much as possible
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onDestroy() {
+        dummyWebView?.destroy()
+        dummyWebView = null
+        super.onDestroy()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -614,9 +614,9 @@
     <string name="audio_trailer_playback_mode">Trailer Playback Mode</string>
     <string name="audio_trailer_playback_mode_sub">Choose how trailers are played in the app</string>
     <string name="audio_trailer_playback_mode_in_app">In-App Player (Native)</string>
-    <string name="audio_trailer_playback_mode_in_app_desc">Plays trailers natively using the app\'s player extraction (unstable)</string>
+    <string name="audio_trailer_playback_mode_in_app_desc">Plays trailers natively using the app\'s player extraction</string>
     <string name="audio_trailer_playback_mode_web_view">In-App Player (WebView)</string>
-    <string name="audio_trailer_playback_mode_web_view_desc">Plays trailers natively using the official YouTube IFrame Player (recommended)</string>
+    <string name="audio_trailer_playback_mode_web_view_desc">Plays trailers natively using the official YouTube IFrame Player (Trailer playback in expanded cards is not supported in this mode)</string>
     <string name="audio_trailer_playback_mode_external">External Player</string>
     <string name="audio_trailer_playback_mode_external_desc">Plays trailers in an external app or browser</string>
     <string name="audio_section">Audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -611,6 +611,14 @@
     <string name="audio_autoplay_trailers">Auto-play Trailers</string>
     <string name="audio_autoplay_trailers_sub">Automatically play trailers on the detail screen after a period of inactivity</string>
     <string name="audio_trailer_delay">Trailer Delay</string>
+    <string name="audio_trailer_playback_mode">Trailer Playback Mode</string>
+    <string name="audio_trailer_playback_mode_sub">Choose how trailers are played in the app</string>
+    <string name="audio_trailer_playback_mode_in_app">In-App Player (Native)</string>
+    <string name="audio_trailer_playback_mode_in_app_desc">Plays trailers natively using the app\'s player extraction (unstable)</string>
+    <string name="audio_trailer_playback_mode_web_view">In-App Player (WebView)</string>
+    <string name="audio_trailer_playback_mode_web_view_desc">Plays trailers natively using the official YouTube IFrame Player (recommended)</string>
+    <string name="audio_trailer_playback_mode_external">External Player</string>
+    <string name="audio_trailer_playback_mode_external_desc">Plays trailers in an external app or browser</string>
     <string name="audio_section">Audio</string>
     <string name="audio_lang_default">Default (media file)</string>
     <string name="audio_lang_device">Device language</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,4 +5,9 @@
     <style name="Theme.MyApplication.Launcher" parent="Theme.MyApplication">
         <item name="android:windowBackground">@drawable/splash_screen_background</item>
     </style>
+
+    <style name="Theme.TrailerOverlay" parent="android:Theme.NoTitleBar.Fullscreen">
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Translucent</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,8 +6,10 @@
         <item name="android:windowBackground">@drawable/splash_screen_background</item>
     </style>
 
-    <style name="Theme.TrailerOverlay" parent="android:Theme.NoTitleBar.Fullscreen">
-        <item name="android:windowBackground">@android:color/black</item>
+    <style name="Theme.TrailerOverlay" parent="android:Theme.Translucent.NoTitleBar.Fullscreen">
+        <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowAnimationStyle">@android:style/Animation.Translucent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
     </style>
 </resources>

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceWebViewPlaybackModeTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceWebViewPlaybackModeTest.kt
@@ -1,0 +1,63 @@
+package com.nuvio.tv.data.trailer
+
+import android.util.Log
+import com.nuvio.tv.core.build.AppFeaturePolicy
+import com.nuvio.tv.core.build.TrailerPlaybackMode
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TrailerApi
+import com.nuvio.tv.domain.model.TmdbSettings
+import io.mockk.*
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+class TrailerServiceWebViewPlaybackModeTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any<Throwable>()) } returns 0
+
+        // Mock AppFeaturePolicy object to return WEB_VIEW mode
+        mockkObject(AppFeaturePolicy)
+        every { AppFeaturePolicy.trailerPlaybackMode } returns TrailerPlaybackMode.WEB_VIEW
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(AppFeaturePolicy)
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `getTrailerPlaybackSourceFromYouTubeUrl returns raw youtube url directly in WEB_VIEW mode`() = runTest {
+        val trailerApi = mockk<TrailerApi>()
+        val tmdbApi = mockk<TmdbApi>()
+        val extractor = mockk<InAppYouTubeExtractor>()
+        val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore>()
+        val tmdbService = mockk<TmdbService>()
+        every { tmdbSettingsDataStore.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { tmdbService.apiKey() } returns "tmdb-key"
+        
+        val service = TrailerService(trailerApi, tmdbApi, extractor, tmdbSettingsDataStore, tmdbService)
+
+        val youtubeUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        val source = service.getTrailerPlaybackSourceFromYouTubeUrl(youtubeUrl)
+
+        assertNotNull("Playback source should not be null", source)
+        assertEquals("Playback source videoUrl should be raw YouTube URL", youtubeUrl, source?.videoUrl)
+
+        // Verify that extractor and backend trailer APIs were NEVER called in WEB_VIEW mode
+        coVerify(exactly = 0) { extractor.extractPlaybackSource(any()) }
+        coVerify(exactly = 0) { trailerApi.getTrailer(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces an inline Compose-based WebView player (`WebViewTrailerPlayer`) and a separate-process fullscreen WebView trailer player (`TrailerOverlayActivity` running in `:trailer` process) for YouTube video trailers. It addresses two major issues:

1. **YouTube Rate Limits**: Switches to the official YouTube IFrame Player API. The implementation has been designed and developed in strict accordance with the official YouTube IFrame Player API documentation, leveraging Javascript-to-Kotlin bridge communications to synchronize playback states, seeking, and lifecycle. This bypasses the in-app stream extractor completely when playing trailers, eliminating HTTP 429 Rate Limit errors.
2. **GPU Driver Renderer Crashes**: Moving the WebView trailer playback into a separate `:trailer` process isolates the crash. On low-RAM/budget devices (such as PowerVR GPU on RTD6748 SoC), WebViews frequently trigger SIGSEGV crashes in the GPU drivers. Under this multi-process architecture, if the WebView renderer process crashes, only the `:trailer` subprocess dies, keeping the main application process completely safe and unaffected.

---

## 🛠️ Detailed Architecture & Subsystem Documentation

For future developers maintaining or extending this subsystem, here is a detailed breakdown of how it works.

```mermaid
sequenceDiagram
    autonumber
    actor User
    participant MainApp as Main Process (MainActivity)
    participant DataStore as TrailerSettingsDataStore
    participant SubApp as :trailer Process (TrailerOverlayActivity)
    participant YT as YouTube IFrame API

    Note over MainApp,SubApp: Boot & Pre-Warm
    MainApp->>MainApp: onCreate()
    MainApp->>SubApp: Start TrailerWarmUpService
    SubApp->>SubApp: Pre-load dummy WebView context (loads Chromium libs early)

    Note over User,MainApp: Play Fullscreen Trailer
    User->>MainApp: Clicks "Fragman" / Trailer Button
    MainApp->>DataStore: Read playbackMode (WEB_VIEW)
    MainApp->>MainApp: Register event BroadcastReceiver
    MainApp->>SubApp: StartActivity(TrailerOverlayActivity) with videoId

    Note over SubApp,YT: Subprocess Lifecycle
    SubApp->>SubApp: Render transparent container immediately (prevents black flash)
    SubApp->>SubApp: Post WebView creation to next frame (prevents ANRs on slow SoCs)
    SubApp->>YT: Load youtube_player.html & initialize player
    YT-->>SubApp: onPlayerReady() (via AndroidBridge)
    SubApp->>SubApp: Fade-in player UI & set background to Black
    SubApp-->>MainApp: Broadcast: "first_frame" (updates Main UI)

    Note over User,SubApp: Interactive Playback Control
    User->>SubApp: Press Remote Key (DPAD_LEFT / DPAD_RIGHT)
    SubApp->>YT: evaluateJavascript: seekTo(time +/- 10s)
    YT-->>SubApp: onProgress() timer (every 500ms)
    SubApp-->>MainApp: Broadcast: "progress" (syncs seek/progress bars)

    Note over User,MainApp: Termination
    User->>SubApp: Press BACK key (or clicks close)
    SubApp-->>MainApp: Broadcast: "ended"
    SubApp->>SubApp: evaluateJavascript: player.destroy() & loadUrl("about:blank")
    SubApp->>SubApp: finishAndRemoveTask() (with 800ms graceful exit delay)
```

### 1. The Two Playback Modes (Inline vs Fullscreen)

#### A. Inline Playback Mode (`isInline = true`)
* **Usage**: Used for video trailer previews inside extended home catalog cards and modern hero banners.
* **Flow**:
  1. `TrailerPlayer` checks that the active mode is `TrailerPlaybackMode.WEB_VIEW` and delegates to `WebViewTrailerPlayer(isInline = true)`.
  2. Inside `WebViewTrailerPlayer`, an `AndroidView` is created containing a local, lifecycle-aware `WebView`.
  3. The local `WebView` loads the local HTML template `assets/youtube_player.html` using `loadDataWithBaseURL("https://www.youtube-nocookie.com", ...)` to bypass origin and cookie policies.
  4. An `AndroidBridge` interface (using `@JavascriptInterface`) connects the WebView Javascript events to Kotlin to handle lifecycle transitions.
  5. The WebView remains transparent and only fades in (`webViewAlphaState`) using a smooth 350ms anim float when the player state changes to `PLAYING` and the first frame has successfully rendered. This prevents loading spinner flashes and layout stutters.

#### B. Fullscreen Playback Mode (`isInline = false`)
* **Usage**: Triggered when the user initiates full screen playback (e.g. clicking the "Play Trailer" button on the Details screen).
* **Flow**:
  1. `WebViewTrailerPlayer` registers a `BroadcastReceiver` in the main process to listen for events (`ended`, `error`, `first_frame`, `progress`) broadcasted from the `:trailer` process.
  2. It launches `TrailerOverlayActivity` in the `:trailer` process via an Intent containing the `video_id`, `auto_play`, and `muted` parameters.
  3. `TrailerOverlayActivity` registers a command `BroadcastReceiver` to handle external playback commands (play, pause, mute, unmute, stop) sent from the main process.
  4. To dismiss, `TrailerOverlayActivity` is sent a `"stop"` command, which triggers a graceful resource release sequence before calling `finishAndRemoveTask()`.

---

### 2. Process & Memory Optimization Details

#### A. Separate Subprocess (`:trailer`)
* **Why**: The PowerVR GPU driver has a documented memory leak/crash bug (`PVRSRVFreeDeviceMemMIW` SIGSEGV) when WebViews are repeatedly loaded or combined with heavy hardware-accelerated layouts. Isolating the WebView player in a separate `:trailer` process ensures that if the system kills the WebView renderer process, **the main app remains completely unaffected and doesn't crash**.

#### B. Intercepting Application Creation (`NuvioAppComponentFactory`)
* **Problem**: In default Android configurations, starting a subprocess runs `Application.onCreate()`. In our case, this launches `NuvioApplication`, which initializes Dagger/Hilt. Loading the Hilt DI component graph requires loading hundreds of classes, consuming around **~420MB** of heap memory. On 1GB RAM Android TVs, running two processes with 420MB each immediately triggers the OS Out-Of-Memory (OOM) killer.
* **Solution**: `NuvioAppComponentFactory` intercepts application instantiation. If the process name contains a colon (`:`), it returns `TrailerApplication`—a lightweight, plain `Application` instance without Hilt initializations. This keeps the subprocess memory usage **under ~50MB**.
* **Fallback (API 24-27)**: For older API versions where `AppComponentFactory` is not supported, `NuvioApplication.onCreate()` checks if it's running in a subprocess using `/proc/self/cmdline` and exits early (skipping Hilt injection) before class initialization occurs.

#### C. Pre-Warming (`TrailerWarmUpService`)
* **Why**: WebView initialization requires loading classloaders and Chromium native binaries, which introduces a 1.5s - 2.0s cold-start penalty on slow SoC chipsets (e.g., RTD6748).
* **Solution**: On main app launch (`MainActivity.onCreate`), `TrailerWarmUpService` starts in the `:trailer` process and initializes a dummy `WebView` on the main thread. When the user opens a trailer, the process is already active and the Chromium engine is warmed up, allowing **near-instantaneous playback**.

#### D. WebView Data Directory Suffix
* Android WebViews do not permit sharing data directories across multiple processes without distinct suffixes starting from API 28. To prevent crashes, `NuvioApplication.onCreate()` sets `WebView.setDataDirectorySuffix("main")` for the main process.

---

### 3. Key Files & Class Responsibilities

* **[youtube_player.html](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/assets/youtube_player.html)**:
  * Embeds the YouTube IFrame API using a secure `https://www.youtube-nocookie.com` origin.
  * Configures player variables: disables user controls, keyboard interaction, full-screen buttons, and relational videos (`rel: 0`).
  * Implements `AndroidBridge` callbacks: `onReady()`, `onPlayerReady()`, `onStateChange(state)`, `onProgress(currentTime, duration)`, and `onError(error)`.
  * Runs a `setInterval` timer (every 500ms) to push current time and duration to Kotlin.
* **[NuvioAppComponentFactory.kt](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/java/com/nuvio/tv/NuvioAppComponentFactory.kt)**:
  * Intercepts application class loading based on process name.
* **[TrailerWarmUpService.kt](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerWarmUpService.kt)**:
  * Pre-loads the WebView native library inside the `:trailer` process.
* **[TrailerOverlayActivity.kt](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/java/com/nuvio/tv/ui/trailer/TrailerOverlayActivity.kt)**:
  * Controls the fullscreen player WebView container.
  * Handles physical hardware remote keys:
    * `KEYCODE_BACK` / `KEYCODE_ESCAPE`: triggers clean exit sequence.
    * `KEYCODE_DPAD_LEFT` / `KEYCODE_DPAD_RIGHT`: rewinds / fast-forwards by 10 seconds.
    * `KEYCODE_MEDIA_PLAY_PAUSE` / `KEYCODE_MEDIA_PLAY` / `KEYCODE_MEDIA_PAUSE`: controls play/pause.
  * Releases resources (destroy player, stop loading, load `about:blank`) gracefully.
* **[WebViewTrailerPlayer.kt](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/java/com/nuvio/tv/ui/components/WebViewTrailerPlayer.kt)**:
  * Bridges between Compose and the separate activity/inline WebView player.
* **[TrailerService.kt](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt)**:
  * Bypasses the YouTube extractor when `TrailerPlaybackMode` is `WEB_VIEW` or `EXTERNAL`, returning the raw YouTube URL immediately to save network and CPU overhead.

---

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

The in-app YouTube stream extractor regularly encounters HTTP 429 Rate Limit errors, preventing users from playing trailers. Standard in-process WebViews frequently trigger SIGSEGV crashes in the PowerVR GPU libraries on low-end Android TV SoCs, which kills the entire application.

## Issue or approval

none .

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This change only affects YouTube trailer playback and does not touch main media playback or ExoPlayer engine settings.

## Testing

1. Verified WebView loading and event handling on Android TV emulator (API 34).
2. Checked process status using `adb shell ps` to confirm `:trailer` process spawns separately and has a small heap size.
3. Simulating GPU crash by killing the `:trailer` process, verifying the main app recovers and stays alive.
4. Ran unit tests in `TrailerServiceWebViewPlaybackModeTest` to ensure fallback logic executes correctly.

## Screenshots / Video
<img width="1920" height="1080" alt="tv_screenshot" src="https://github.com/user-attachments/assets/13700d26-d9a4-4e1c-a3af-4ab727cd7d42" />


<img width="1920" height="1080" alt="screen" src="https://github.com/user-attachments/assets/4fc63213-544b-439e-ab7a-c2efe562ac6a" />


## Breaking changes

None.

## Linked issues

None.
