### PR TITLE
fix(trakt): localize Trakt library and related titles via TMDB

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -57,6 +57,49 @@ class TmdbMetadataService(
     private val entityHeaderCache = ConcurrentHashMap<String, TmdbEntityHeader>()
     private val entityRailCache = ConcurrentHashMap<String, List<MetaPreview>>()
     private val entityBrowseCache = ConcurrentHashMap<String, TmdbEntityBrowseData>()
+    private val localizedTitleCache = ConcurrentHashMap<String, String>()
+
+    /**
+     * Fetches a localized display title for a TMDB id. Used to translate Trakt-sourced
+     * metadata (related titles, library sync) that otherwise defaults to English.
+     */
+    suspend fun fetchLocalizedTitle(
+        tmdbId: Int,
+        contentType: ContentType,
+        language: String
+    ): String? = withContext(ioDispatcher) {
+        val normalizedLanguage = normalizeTmdbLanguage(language)
+        if (normalizedLanguage.equals("en", ignoreCase = true) ||
+            normalizedLanguage.startsWith("en-", ignoreCase = true)
+        ) {
+            return@withContext null
+        }
+
+        val cacheKey = "$tmdbId:${contentType.name}:$normalizedLanguage:title"
+        localizedTitleCache[cacheKey]?.let { return@withContext it }
+
+        val tmdbType = when (contentType) {
+            ContentType.SERIES, ContentType.TV -> "tv"
+            else -> "movie"
+        }
+
+        try {
+            val details = when (tmdbType) {
+                "tv" -> tmdbApi.getTvDetails(tmdbId, TMDB_API_KEY, normalizedLanguage).body()
+                else -> tmdbApi.getMovieDetails(tmdbId, TMDB_API_KEY, normalizedLanguage).body()
+            }
+            val title = (details?.title ?: details?.name)?.trim()?.takeIf { it.isNotBlank() }
+            if (title != null) {
+                localizedTitleCache[cacheKey] = title
+            }
+            title
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch localized title for tmdb:$tmdbId: ${e.message}")
+            null
+        }
+    }
 
     suspend fun fetchEnrichment(
         tmdbId: String,

--- a/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLanguage.kt
+++ b/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLanguage.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.core.trakt
+
+import com.nuvio.tv.LocaleCache
+import com.nuvio.tv.data.local.TraktMetadataLanguageSource
+import java.util.Locale
+
+/**
+ * Resolves which language code to use when localizing Trakt-sourced titles via TMDB.
+ */
+object TraktMetadataLanguage {
+
+    fun resolve(
+        source: TraktMetadataLanguageSource,
+        tmdbLanguage: String,
+        localeTag: String = LocaleCache.localeTag
+    ): String {
+        val raw = when (source) {
+            TraktMetadataLanguageSource.INTERFACE -> localeTagToLanguage(localeTag)
+            TraktMetadataLanguageSource.TMDB -> tmdbLanguage
+        }
+        return normalizeLanguage(raw)
+    }
+
+    fun isEnglish(language: String): Boolean {
+        val code = language.trim().substringBefore("-").lowercase(Locale.US)
+        return code == "en"
+    }
+
+    private fun localeTagToLanguage(localeTag: String): String {
+        val tag = localeTag.trim()
+            .takeIf { it.isNotBlank() && it != LocaleCache.UNSET }
+            ?: Locale.getDefault().toLanguageTag()
+        return normalizeLanguage(tag)
+    }
+
+    private fun normalizeLanguage(language: String): String {
+        val raw = language.trim().replace('_', '-').takeIf { it.isNotBlank() } ?: return "en"
+        val parts = raw.split("-")
+        return if (parts.size == 2) {
+            "${parts[0].lowercase(Locale.US)}-${parts[1].uppercase(Locale.US)}"
+        } else {
+            raw.lowercase(Locale.US)
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLocalizationService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLocalizationService.kt
@@ -1,0 +1,94 @@
+package com.nuvio.tv.core.trakt
+
+import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.local.TraktMetadataLanguageSource
+import com.nuvio.tv.data.local.TraktSettingsDataStore
+import com.nuvio.tv.data.repository.parseContentIds
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.LibraryEntry
+import com.nuvio.tv.domain.model.MetaPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TraktMetadataLocalizationService @Inject constructor(
+    private val tmdbMetadataService: TmdbMetadataService,
+    private val traktSettingsDataStore: TraktSettingsDataStore,
+    private val tmdbSettingsDataStore: TmdbSettingsDataStore
+) {
+    suspend fun localizePreviews(items: List<MetaPreview>): List<MetaPreview> {
+        val language = resolveLanguage() ?: return items
+        if (TraktMetadataLanguage.isEnglish(language)) return items
+        return localizePreviews(items, language)
+    }
+
+    suspend fun localizeLibraryEntries(entries: List<LibraryEntry>): List<LibraryEntry> {
+        val language = resolveLanguage() ?: return entries
+        if (TraktMetadataLanguage.isEnglish(language)) return entries
+        return localizeLibraryEntries(entries, language)
+    }
+
+    suspend fun resolveLanguage(): String? {
+        val source = traktSettingsDataStore.metadataLanguageSource.first()
+        val tmdbLanguage = tmdbSettingsDataStore.settings.first().language
+        return TraktMetadataLanguage.resolve(source, tmdbLanguage)
+    }
+
+    private suspend fun localizePreviews(
+        items: List<MetaPreview>,
+        language: String
+    ): List<MetaPreview> = coroutineScope {
+        val semaphore = Semaphore(LOCALIZATION_CONCURRENCY)
+        items.map { item ->
+            async {
+                val tmdbId = item.resolveTmdbIdForLocalization() ?: return@async item
+                val localizedTitle = semaphore.withPermit {
+                    tmdbMetadataService.fetchLocalizedTitle(
+                        tmdbId = tmdbId,
+                        contentType = item.type,
+                        language = language
+                    )
+                } ?: return@async item
+                if (localizedTitle.equals(item.name, ignoreCase = true)) item
+                else item.copy(name = localizedTitle)
+            }
+        }.awaitAll()
+    }
+
+    private suspend fun localizeLibraryEntries(
+        entries: List<LibraryEntry>,
+        language: String
+    ): List<LibraryEntry> = coroutineScope {
+        val semaphore = Semaphore(LOCALIZATION_CONCURRENCY)
+        entries.map { entry ->
+            async {
+                val tmdbId = entry.tmdbId ?: parseContentIds(entry.id).tmdb ?: return@async entry
+                val contentType = ContentType.fromString(entry.type)
+                val localizedTitle = semaphore.withPermit {
+                    tmdbMetadataService.fetchLocalizedTitle(
+                        tmdbId = tmdbId,
+                        contentType = contentType,
+                        language = language
+                    )
+                } ?: return@async entry
+                if (localizedTitle.equals(entry.name, ignoreCase = true)) entry
+                else entry.copy(name = localizedTitle)
+            }
+        }.awaitAll()
+    }
+
+    private fun MetaPreview.resolveTmdbIdForLocalization(): Int? {
+        return tmdbId ?: parseContentIds(id).tmdb
+    }
+
+    companion object {
+        private const val LOCALIZATION_CONCURRENCY = 6
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/trakt/TraktPublicListSourceResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/core/trakt/TraktPublicListSourceResolver.kt
@@ -49,7 +49,8 @@ data class TraktPublicListSearchResult(
 class TraktPublicListSourceResolver @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val traktApi: TraktApi,
-    private val traktAuthService: TraktAuthService
+    private val traktAuthService: TraktAuthService,
+    private val traktMetadataLocalizationService: TraktMetadataLocalizationService
 ) {
     private fun string(resId: Int): String = appContext.getString(resId)
     private fun string(resId: Int, vararg args: Any): String = appContext.getString(resId, *args)
@@ -74,9 +75,11 @@ class TraktPublicListSourceResolver @Inject constructor(
                 val pageCountHeader = response.headers()["X-Pagination-Page-Count"]
                 if (!response.isSuccessful) error(errorMessageFor(response.code(), string(R.string.collections_editor_error_load_trakt_list)))
                 val rawItems = response.body().orEmpty()
-                val items = rawItems
-                    .mapNotNull { it.toPreview(source.mediaType) }
-                    .distinctBy { "${it.apiType}:${it.id}" }
+                val items = traktMetadataLocalizationService.localizePreviews(
+                    rawItems
+                        .mapNotNull { it.toPreview(source.mediaType) }
+                        .distinctBy { "${it.apiType}:${it.id}" }
+                )
                 val pageCount = pageCountHeader?.toIntOrNull() ?: page
                 row(
                     source = source.copy(
@@ -203,6 +206,7 @@ class TraktPublicListSourceResolver @Inject constructor(
             released = released,
             country = country,
             imdbId = ids?.imdb?.takeIf { it.isNotBlank() },
+            tmdbId = ids?.tmdb,
             slug = ids?.slug?.takeIf { it.isNotBlank() },
             landscapePoster = images.traktBestBackdropUrl(),
             rawPosterUrl = images.traktPosterUrl()
@@ -238,6 +242,7 @@ class TraktPublicListSourceResolver @Inject constructor(
             released = firstAired,
             country = country,
             imdbId = ids?.imdb?.takeIf { it.isNotBlank() },
+            tmdbId = ids?.tmdb,
             slug = ids?.slug?.takeIf { it.isNotBlank() },
             landscapePoster = images.traktBestBackdropUrl(),
             rawPosterUrl = images.traktPosterUrl()

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
@@ -30,6 +30,13 @@ enum class MoreLikeThisSourcePreference {
     TMDB
 }
 
+enum class TraktMetadataLanguageSource {
+    /** Use the app interface language (LocaleCache). */
+    INTERFACE,
+    /** Use the TMDB language configured in TMDB settings. */
+    TMDB
+}
+
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class TraktSettingsDataStore @Inject constructor(
@@ -45,6 +52,7 @@ class TraktSettingsDataStore @Inject constructor(
         val DEFAULT_WATCH_PROGRESS_SOURCE = WatchProgressSource.TRAKT
         val DEFAULT_LIBRARY_SOURCE_MODE = LibrarySourceMode.TRAKT
         val DEFAULT_MORE_LIKE_THIS_SOURCE = MoreLikeThisSourcePreference.TRAKT
+        val DEFAULT_METADATA_LANGUAGE_SOURCE = TraktMetadataLanguageSource.INTERFACE
         const val MIN_CONTINUE_WATCHING_DAYS_CAP = 7
         const val MAX_CONTINUE_WATCHING_DAYS_CAP = 365
     }
@@ -60,6 +68,7 @@ class TraktSettingsDataStore @Inject constructor(
     private val watchProgressSourceKey = stringPreferencesKey("watch_progress_source")
     private val librarySourceModeKey = stringPreferencesKey("library_source_mode")
     private val moreLikeThisSourceKey = stringPreferencesKey("more_like_this_source")
+    private val metadataLanguageSourceKey = stringPreferencesKey("metadata_language_source")
 
     val continueWatchingDaysCap: Flow<Int> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { prefs ->
@@ -189,6 +198,21 @@ class TraktSettingsDataStore @Inject constructor(
     suspend fun setMoreLikeThisSource(source: MoreLikeThisSourcePreference) {
         store().edit { prefs ->
             prefs[moreLikeThisSourceKey] = source.name
+        }
+    }
+
+    val metadataLanguageSource: Flow<TraktMetadataLanguageSource> =
+        profileManager.activeProfileId.flatMapLatest { pid ->
+            factory.get(pid, FEATURE).data.map { prefs ->
+                val stored = prefs[metadataLanguageSourceKey]
+                TraktMetadataLanguageSource.entries.firstOrNull { it.name == stored }
+                    ?: DEFAULT_METADATA_LANGUAGE_SOURCE
+            }
+        }
+
+    suspend fun setMetadataLanguageSource(source: TraktMetadataLanguageSource) {
+        store().edit { prefs ->
+            prefs[metadataLanguageSourceKey] = source.name
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.repository
 import android.content.Context
 import com.nuvio.tv.R
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.trakt.TraktMetadataLocalizationService
 import com.nuvio.tv.core.trakt.traktBestBackdropUrl
 import com.nuvio.tv.core.trakt.traktBestLogoUrl
 import com.nuvio.tv.core.trakt.traktBestPosterUrl
@@ -48,7 +49,8 @@ class TraktLibraryService @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService,
-    private val profileManager: ProfileManager
+    private val profileManager: ProfileManager,
+    private val traktMetadataLocalizationService: TraktMetadataLocalizationService
 ) {
     private data class Snapshot(
         val listTabs: List<LibraryListTab> = emptyList(),
@@ -506,10 +508,17 @@ class TraktLibraryService @Inject constructor(
             }
         }
 
+        val localizedAllEntries = traktMetadataLocalizationService.localizeLibraryEntries(allEntries)
+        val localizedById = localizedAllEntries.associateBy { contentKey(it.id, it.type) }
+
         return Snapshot(
             listTabs = tabs,
-            entriesByList = entriesByList,
-            allEntries = allEntries,
+            entriesByList = entriesByList.mapValues { (_, entries) ->
+                entries.map { entry ->
+                    localizedById[contentKey(entry.id, entry.type)] ?: entry
+                }
+            },
+            allEntries = localizedAllEntries,
             membershipByContent = membership.mapValues { it.value.toSet() },
             updatedAtMs = System.currentTimeMillis()
         )

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktRelatedService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktRelatedService.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.repository
 
+import com.nuvio.tv.core.trakt.TraktMetadataLocalizationService
 import com.nuvio.tv.core.trakt.traktBestBackdropUrl
 import com.nuvio.tv.core.trakt.traktBestLandscapeUrl
 import com.nuvio.tv.core.trakt.traktBestLogoUrl
@@ -34,7 +35,8 @@ internal data class ResolvedRelatedTarget(
 class TraktRelatedService @Inject constructor(
     @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val traktApi: TraktApi,
-    private val traktAuthService: TraktAuthService
+    private val traktAuthService: TraktAuthService,
+    private val traktMetadataLocalizationService: TraktMetadataLocalizationService
 ) {
     private data class TimedCache(
         val items: List<MetaPreview>,
@@ -50,10 +52,14 @@ class TraktRelatedService @Inject constructor(
         forceRefresh: Boolean = false
     ): List<MetaPreview> {
         val target = resolveRelatedTarget(meta, fallbackItemId, fallbackItemType) ?: return emptyList()
+        val metadataLanguage = traktMetadataLocalizationService.resolveLanguage().orEmpty()
         val cacheKey = buildString {
             append(target.type.apiValue)
             append("|")
             append(target.pathId)
+            append("|")
+            append(metadataLanguage)
+            append("|v2")
         }
 
         if (!forceRefresh) {
@@ -113,8 +119,9 @@ class TraktRelatedService @Inject constructor(
         }
 
         val distinctItems = items.distinctBy { "${it.apiType}:${it.id}" }
-        cache[cacheKey] = TimedCache(items = distinctItems, updatedAtMs = System.currentTimeMillis())
-        return distinctItems
+        val localizedItems = traktMetadataLocalizationService.localizePreviews(distinctItems)
+        cache[cacheKey] = TimedCache(items = localizedItems, updatedAtMs = System.currentTimeMillis())
+        return localizedItems
     }
 
     private suspend fun resolveRelatedTarget(
@@ -290,6 +297,7 @@ private fun toMetaPreviewInternal(
         released = releaseDate?.trim()?.takeIf { it.isNotBlank() },
         country = countryValue?.trim()?.takeIf { it.isNotBlank() },
         imdbId = ids?.imdb?.takeIf { it.isNotBlank() },
+        tmdbId = ids?.tmdb,
         slug = ids?.slug?.takeIf { it.isNotBlank() },
         landscapePoster = background,
         rawPosterUrl = poster

--- a/app/src/main/java/com/nuvio/tv/domain/model/MetaPreview.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/MetaPreview.kt
@@ -23,6 +23,8 @@ data class MetaPreview(
     val released: String? = null,
     val country: String? = null,
     val imdbId: String? = null,
+    /** TMDB numeric id when known (e.g. from Trakt ids); used for localized title lookup. */
+    val tmdbId: Int? = null,
     val slug: String? = null,
     val landscapePoster: String? = null,
     val rawPosterUrl: String? = null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktScreen.kt
@@ -59,6 +59,7 @@ import com.nuvio.tv.core.qr.QrCodeGenerator
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressSource
 import com.nuvio.tv.data.local.MoreLikeThisSourcePreference
+import com.nuvio.tv.data.local.TraktMetadataLanguageSource
 import com.nuvio.tv.data.repository.TraktProgressService
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.ui.components.NuvioDialog
@@ -79,6 +80,7 @@ fun TraktScreen(
     var showWatchProgressDialog by remember { mutableStateOf(false) }
     var showLibrarySourceDialog by remember { mutableStateOf(false) }
     var showMoreLikeThisSourceDialog by remember { mutableStateOf(false) }
+    var showMetadataLanguageDialog by remember { mutableStateOf(false) }
     val strAllHistory = stringResource(R.string.trakt_all_history)
     val strDaysFormat = stringResource(R.string.trakt_days_format)
     val strWatchProgressTrakt = stringResource(R.string.trakt_watch_progress_source_trakt)
@@ -111,6 +113,14 @@ fun TraktScreen(
         when (source) {
             MoreLikeThisSourcePreference.TRAKT -> strMoreLikeThisTrakt
             MoreLikeThisSourcePreference.TMDB -> strMoreLikeThisTmdb
+        }
+    }
+    val strMetadataLanguageInterface = stringResource(R.string.trakt_metadata_language_interface)
+    val strMetadataLanguageTmdb = stringResource(R.string.trakt_metadata_language_tmdb)
+    val metadataLanguageFormatter: (TraktMetadataLanguageSource) -> String = { source ->
+        when (source) {
+            TraktMetadataLanguageSource.INTERFACE -> strMetadataLanguageInterface
+            TraktMetadataLanguageSource.TMDB -> strMetadataLanguageTmdb
         }
     }
     val continueWatchingDayOptions = remember {
@@ -339,6 +349,12 @@ fun TraktScreen(
                         value = moreLikeThisSourceFormatter(uiState.moreLikeThisSource),
                         onClick = { showMoreLikeThisSourceDialog = true }
                     )
+                    SettingsActionRow(
+                        title = stringResource(R.string.trakt_metadata_language_title),
+                        subtitle = stringResource(R.string.trakt_metadata_language_subtitle),
+                        value = metadataLanguageFormatter(uiState.metadataLanguageSource),
+                        onClick = { showMetadataLanguageDialog = true }
+                    )
                 }
 
                 if (uiState.mode != TraktConnectionMode.CONNECTED) {
@@ -479,6 +495,75 @@ fun TraktScreen(
             width = 620.dp,
             maxHeight = 320.dp
         )
+    }
+
+    if (showMetadataLanguageDialog) {
+        NuvioDialog(
+            onDismiss = { showMetadataLanguageDialog = false },
+            title = stringResource(R.string.trakt_metadata_language_dialog_title),
+            subtitle = stringResource(R.string.trakt_metadata_language_dialog_subtitle),
+            width = 620.dp,
+            suppressFirstKeyUp = false
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = {
+                        viewModel.onMetadataLanguageSourceSelected(TraktMetadataLanguageSource.INTERFACE)
+                        showMetadataLanguageDialog = false
+                    },
+                    colors = ButtonDefaults.colors(
+                        containerColor = if (uiState.metadataLanguageSource == TraktMetadataLanguageSource.INTERFACE) {
+                            NuvioColors.Primary
+                        } else {
+                            NuvioColors.BackgroundCard
+                        },
+                        contentColor = if (uiState.metadataLanguageSource == TraktMetadataLanguageSource.INTERFACE) {
+                            Color.Black
+                        } else {
+                            NuvioColors.TextPrimary
+                        }
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.trakt_metadata_language_interface))
+                }
+                Button(
+                    onClick = {
+                        viewModel.onMetadataLanguageSourceSelected(TraktMetadataLanguageSource.TMDB)
+                        showMetadataLanguageDialog = false
+                    },
+                    colors = ButtonDefaults.colors(
+                        containerColor = if (uiState.metadataLanguageSource == TraktMetadataLanguageSource.TMDB) {
+                            NuvioColors.Primary
+                        } else {
+                            NuvioColors.BackgroundCard
+                        },
+                        contentColor = if (uiState.metadataLanguageSource == TraktMetadataLanguageSource.TMDB) {
+                            Color.Black
+                        } else {
+                            NuvioColors.TextPrimary
+                        }
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.trakt_metadata_language_tmdb))
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Button(
+                        onClick = { showMetadataLanguageDialog = false },
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioColors.BackgroundCard,
+                            contentColor = NuvioColors.TextPrimary
+                        )
+                    ) {
+                        Text(stringResource(R.string.action_cancel))
+                    }
+                }
+            }
+        }
     }
 
     if (showDisconnectConfirm) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -10,10 +10,12 @@ import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktAuthState
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.MoreLikeThisSourcePreference
+import com.nuvio.tv.data.local.TraktMetadataLanguageSource
 import com.nuvio.tv.data.local.WatchProgressSource
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.local.WatchedSeriesStateHolder
 import com.nuvio.tv.data.repository.TraktAuthService
+import com.nuvio.tv.data.repository.TraktLibraryService
 import com.nuvio.tv.data.repository.TraktProgressService
 import com.nuvio.tv.data.repository.TraktTokenPollResult
 import com.nuvio.tv.domain.model.LibrarySourceMode
@@ -54,7 +56,9 @@ data class TraktUiState(
     val connectedStats: TraktProgressService.TraktCachedStats? = null,
     val statusMessage: String? = null,
     val errorMessage: String? = null,
-    val moreLikeThisSource: MoreLikeThisSourcePreference = TraktSettingsDataStore.DEFAULT_MORE_LIKE_THIS_SOURCE
+    val moreLikeThisSource: MoreLikeThisSourcePreference = TraktSettingsDataStore.DEFAULT_MORE_LIKE_THIS_SOURCE,
+    val metadataLanguageSource: TraktMetadataLanguageSource =
+        TraktSettingsDataStore.DEFAULT_METADATA_LANGUAGE_SOURCE
 )
 
 @HiltViewModel
@@ -63,6 +67,7 @@ class TraktViewModel @Inject constructor(
     private val traktAuthDataStore: TraktAuthDataStore,
     private val traktProgressService: TraktProgressService,
     private val traktSettingsDataStore: TraktSettingsDataStore,
+    private val traktLibraryService: TraktLibraryService,
     private val startupSyncService: StartupSyncService,
     private val watchedItemsPreferences: WatchedItemsPreferences,
     private val watchedItemsSyncService: WatchedItemsSyncService,
@@ -118,6 +123,19 @@ class TraktViewModel @Inject constructor(
         viewModelScope.launch {
             traktSettingsDataStore.setMoreLikeThisSource(source)
             _uiState.update { it.copy(moreLikeThisSource = source) }
+        }
+    }
+
+    fun onMetadataLanguageSourceSelected(source: TraktMetadataLanguageSource) {
+        viewModelScope.launch {
+            traktSettingsDataStore.setMetadataLanguageSource(source)
+            traktLibraryService.refreshNow()
+            _uiState.update {
+                it.copy(
+                    metadataLanguageSource = source,
+                    statusMessage = context.getString(R.string.trakt_metadata_language_updated)
+                )
+            }
         }
     }
 
@@ -280,19 +298,25 @@ class TraktViewModel @Inject constructor(
     private fun observeSettings() {
         viewModelScope.launch {
             combine(
-                traktSettingsDataStore.continueWatchingDaysCap,
-                traktSettingsDataStore.showMetaComments,
-                traktSettingsDataStore.watchProgressSource,
-                traktSettingsDataStore.librarySourceMode,
-                traktSettingsDataStore.moreLikeThisSource
-            ) { daysCap, showMetaComments, watchProgressSource, librarySourceMode, moreLikeThisSource ->
-                SettingsSnapshot(
-                    continueWatchingDaysCap = daysCap,
-                    showMetaComments = showMetaComments,
-                    watchProgressSource = watchProgressSource,
-                    librarySourceMode = librarySourceMode,
-                    moreLikeThisSource = moreLikeThisSource
-                )
+                combine(
+                    traktSettingsDataStore.continueWatchingDaysCap,
+                    traktSettingsDataStore.showMetaComments,
+                    traktSettingsDataStore.watchProgressSource,
+                    traktSettingsDataStore.librarySourceMode,
+                    traktSettingsDataStore.moreLikeThisSource
+                ) { daysCap, showMetaComments, watchProgressSource, librarySourceMode, moreLikeThisSource ->
+                    SettingsSnapshot(
+                        continueWatchingDaysCap = daysCap,
+                        showMetaComments = showMetaComments,
+                        watchProgressSource = watchProgressSource,
+                        librarySourceMode = librarySourceMode,
+                        moreLikeThisSource = moreLikeThisSource,
+                        metadataLanguageSource = TraktSettingsDataStore.DEFAULT_METADATA_LANGUAGE_SOURCE
+                    )
+                },
+                traktSettingsDataStore.metadataLanguageSource
+            ) { snapshot, metadataLanguageSource ->
+                snapshot.copy(metadataLanguageSource = metadataLanguageSource)
             }.collectLatest { snapshot ->
                 _uiState.update {
                     it.copy(
@@ -300,7 +324,8 @@ class TraktViewModel @Inject constructor(
                         showMetaComments = snapshot.showMetaComments,
                         watchProgressSource = snapshot.watchProgressSource,
                         librarySourceMode = snapshot.librarySourceMode,
-                        moreLikeThisSource = snapshot.moreLikeThisSource
+                        moreLikeThisSource = snapshot.moreLikeThisSource,
+                        metadataLanguageSource = snapshot.metadataLanguageSource
                     )
                 }
             }
@@ -312,7 +337,8 @@ class TraktViewModel @Inject constructor(
         val showMetaComments: Boolean,
         val watchProgressSource: WatchProgressSource,
         val librarySourceMode: LibrarySourceMode,
-        val moreLikeThisSource: MoreLikeThisSourcePreference
+        val moreLikeThisSource: MoreLikeThisSourcePreference,
+        val metadataLanguageSource: TraktMetadataLanguageSource
     )
 
     private fun applyAuthState(authState: TraktAuthState) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -849,6 +849,13 @@
     <string name="trakt_library_source_nuvio_selected">Bibliothèque Nuvio sélectionnée</string>
     <string name="trakt_setting_on">Activé</string>
     <string name="trakt_setting_off">Désactivé</string>
+    <string name="trakt_metadata_language_title">Langue des titres Trakt</string>
+    <string name="trakt_metadata_language_subtitle">Langue utilisée pour la bibliothèque Trakt et les titres similaires</string>
+    <string name="trakt_metadata_language_dialog_title">Langue des titres Trakt</string>
+    <string name="trakt_metadata_language_dialog_subtitle">Choisir la langue utilisée pour charger les titres depuis Trakt.</string>
+    <string name="trakt_metadata_language_interface">Interface de l\'application</string>
+    <string name="trakt_metadata_language_tmdb">Paramètres TMDB</string>
+    <string name="trakt_metadata_language_updated">Langue des titres Trakt mise à jour</string>
     <string name="trakt_watch_progress_trakt_selected">Source de progression définie sur Trakt</string>
     <string name="trakt_watch_progress_nuvio_selected">Source de progression définie sur Nuvio Sync</string>
     <string name="trakt_continue_watching_window">Période de Continuer à regarder</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1067,6 +1067,13 @@
     <string name="trakt_more_like_this_source_dialog_subtitle">Select the source for recommendations shown on detail pages.</string>
     <string name="trakt_more_like_this_source_trakt">Trakt</string>
     <string name="trakt_more_like_this_source_tmdb">TMDB</string>
+    <string name="trakt_metadata_language_title">Trakt title language</string>
+    <string name="trakt_metadata_language_subtitle">Language used for Trakt library and similar titles</string>
+    <string name="trakt_metadata_language_dialog_title">Trakt title language</string>
+    <string name="trakt_metadata_language_dialog_subtitle">Choose which language to use when loading titles from Trakt.</string>
+    <string name="trakt_metadata_language_interface">App interface</string>
+    <string name="trakt_metadata_language_tmdb">TMDB settings</string>
+    <string name="trakt_metadata_language_updated">Trakt title language updated</string>
     <string name="trakt_cached_label">Cached</string>
     <string name="trakt_stat_movies">Movies</string>
     <string name="trakt_stat_shows">Shows</string>


### PR DESCRIPTION
## Summary

Trakt-sourced metadata (library sync and "More like this" when using Trakt as the source) now shows localized titles via TMDB, using either the app interface language or the TMDB language from settings.

Adds `TraktMetadataLocalizationService`, stores `tmdbId` on `MetaPreview` for related titles (fixes TMDB lookup when content ids are IMDb-based), and a new Trakt setting: **Trakt title language** (interface vs TMDB).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Trakt API returns English titles by default. With Trakt library sync or Trakt as the "More like this" source, non-English UI users still see English names in the Library tab and in similar-titles rows, while TMDB-backed flows already respect the configured language.

This addresses the report in [#967](https://github.com/NuvioMedia/NuvioTV/issues/967) (Trakt library titles appear untranslated compared to Continue Watching).

## Issue or approval

Fixes [#967](https://github.com/NuvioMedia/NuvioTV/issues/967) — implements the localization described in that request (Trakt library and related titles via TMDB).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

*(New Trakt settings row for metadata language — see Screenshots.)*

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change Trakt OAuth, sync protocol, or "More like this" provider selection (Trakt vs TMDB).
- Does not add Trakt translation API calls; localization uses existing TMDB `fetchLocalizedTitle` when a TMDB id is available.
- English UI / English language setting: no extra TMDB title calls (unchanged behavior).
- Posters are not changed in this PR (titles only; posters were out of scope for #967).
- `local.dev.properties` / local `gradle.properties` JDK paths not included.
- `app/build.gradle.kts` debug `local.dev.properties` wiring for Trakt/TMDB not included in this PR.

## Testing

**Build:** `./gradlew :app:assembleFullDebug` — success.

**Manual (Android TV / emulator):**
1. Trakt connected; UI language set to French.
2. **Settings → Trakt → Trakt title language:** "App interface" — Library (Trakt source) shows French titles.
3. Content detail → **Similar** tab with More Like This source = **Trakt** — related titles in French.
4. Switch setting to **TMDB settings** — titles follow TMDB language setting.
5. Items without a TMDB id fall back to the original Trakt title (no crash).

**Device:** local `fullDebug` (`com.nuviodebug.com`), tested with prod-like Supabase/Trakt/TMDB config.

## Screenshots / Video

1. Trakt settings showing the new **Trakt title language** option.
<img width="1920" height="1080" alt="nuvio-screenshot" src="https://github.com/user-attachments/assets/37e3e059-789c-46b5-8625-eaf8afa5d94d" />
2. Library (Trakt source) with French titles.
<img width="1920" height="1080" alt="nuvio-screenshot-2" src="https://github.com/user-attachments/assets/8c6e7b8b-3e6d-486c-9170-ef0a4ed6aca5" />
3. Detail page **Similar** row with French titles (Trakt source).
<img width="1920" height="1080" alt="nuvio-screenshot-3" src="https://github.com/user-attachments/assets/e265a055-bd47-47d5-9fda-412f77b893b9" />

## Breaking changes

None.

## Linked issues

Fixes #967