### PR TITLE
fix(player): resolve 24fps judder and duplicate AFR preflight execution

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -39,6 +39,11 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
         return
     }
 
+    if (_uiState.value.afrProbeRunning || _uiState.value.detectedFrameRateSource != null) {
+        Log.d(PlayerRuntimeController.TAG, "AFR preflight: already running or completed, skipping duplicate execution")
+        return
+    }
+
     _uiState.update {
         it.copy(
             detectedFrameRateRaw = 0f,
@@ -94,7 +99,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
             )
         }
 
-        val prefer23976ProbeBias = detection.raw in 23.95f..24.12f
+        val prefer23976ProbeBias = detection.raw in 23.95f..23.988f
         val targetFrameRate = FrameRateUtils.refineFrameRateForDisplay(
             activity = activity,
             detectedFps = detection.snapped,


### PR DESCRIPTION
## Summary

This PR resolves a critical playback judder issue caused by a frame rate matching mismatch and prevents duplicate AFR preflight execution during player startup.

1. **Refined 23.976 fps Probe Bias:** Narrowed the check range for `prefer23976ProbeBias` from `23.95f..24.12f` to `23.95f..23.988f`. This prevents exact `24.000` fps videos (very common on modern streaming sources like Netflix, Prime Video, etc. as Web-DLs) from being incorrectly forced to NTSC `23.976` Hz, which was causing intermittent screen judder/micro-stutter every ~41.7 seconds due to cumulative frame synchronization drift.
2. **Duplicate AFR Execution Guard:** Added a concurrency guard check at the start of `runAfrPreflightIfEnabled` that skips duplicate calls if `afrProbeRunning` is `true` or `detectedFrameRateSource` is already set. This prevents double display-mode switches and concurrent metadata probing during initial composition and configuration-change-induced recompositions.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

* **Stutter-Free Cinema Playback:** True `24.000` fps files played back at `23.976` Hz display refresh rates lead to a dropped or repeated video frame exactly once every ~41.7 seconds. Refining the bias range allows displays supporting `24.000` Hz to switch to the correct true rate.
* **Redundant Work/Re-execution:** Display refresh rate switching often triggers a configuration change, causing Jetpack Compose to recompose/re-initialize. Without a guard check, this recomposition starts a duplicate AFR preflight, leading to redundant metadata probing and multiple display mode switches.

## Issue or approval

Reported by the user via DM -  Resolves frame rate matching judder and double init behavior.

## Reproduction steps

1. Play a 1080p HEVC Web-DL file encoded at exactly `24.000` fps (such as `Off.Campus.S01E01...`).
2. Observe that the display switches refresh rate to `23.976` Hz instead of `24.000` Hz.
3. Watch playback for over 1 minute and notice a brief visual hitch/judder around the ~42-second mark.
4. Check the logs and see that `runAfrPreflightIfEnabled` executes twice due to double initialization during startup.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR is strictly confined to fixing the automatic frame rate matching preflight logic. It does not introduce any extra UI, player options, or general refactorings.

## Testing

* Tested on Android TV physical device.
* Verified that a `24.000` fps file now correctly triggers a switch to `24.000` Hz display refresh rate.
* Confirmed that a `23.976` fps file still matches to `23.976` Hz correctly.
* Checked that `runAfrPreflightIfEnabled` only executes once and skips duplicate calls on player recompositions.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Reported by the user via DM 
