### PR TITLE
i18n: extract 30 hardcoded Debrid stream filter strings to resources

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
@@ -283,8 +283,8 @@ fun DebridSettingsContent(
 
                         item(key = "debrid_per_resolution_limit") {
                             SettingsActionRow(
-                                title = "Per resolution limit",
-                                subtitle = "Cap repeated 2160p, 1080p, 720p results after sorting.",
+                                title = stringResource(R.string.debrid_stream_per_resolution_limit_title),
+                                subtitle = stringResource(R.string.debrid_stream_per_resolution_limit_subtitle),
                                 value = streamMaxResultsLabel(uiState.streamPreferences.maxPerResolution),
                                 onClick = { activeStreamPicker = DebridStreamPicker.MAX_PER_RESOLUTION },
                                 enabled = true
@@ -293,8 +293,8 @@ fun DebridSettingsContent(
 
                         item(key = "debrid_per_quality_limit") {
                             SettingsActionRow(
-                                title = "Per quality limit",
-                                subtitle = "Cap repeated BluRay, WEB-DL, REMUX results after sorting.",
+                                title = stringResource(R.string.debrid_stream_per_quality_limit_title),
+                                subtitle = stringResource(R.string.debrid_stream_per_quality_limit_subtitle),
                                 value = streamMaxResultsLabel(uiState.streamPreferences.maxPerQuality),
                                 onClick = { activeStreamPicker = DebridStreamPicker.MAX_PER_QUALITY },
                                 enabled = true
@@ -303,8 +303,8 @@ fun DebridSettingsContent(
 
                         item(key = "debrid_size_range") {
                             SettingsActionRow(
-                                title = "Size range",
-                                subtitle = "Filter streams by file size.",
+                                title = stringResource(R.string.debrid_stream_size_range_title),
+                                subtitle = stringResource(R.string.debrid_stream_size_range_subtitle),
                                 value = sizeRangeLabel(uiState.streamPreferences),
                                 onClick = { activeStreamPicker = DebridStreamPicker.SIZE_RANGE },
                                 enabled = true
@@ -415,7 +415,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_RESOLUTIONS -> DebridMultiChoiceDialog(
-            title = "Preferred resolutions",
+            title = stringResource(R.string.debrid_stream_resolutions_preferred),
             selectedValues = uiState.streamPreferences.preferredResolutions,
             values = DebridStreamResolution.defaultOrder,
             label = { it.label },
@@ -426,7 +426,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_RESOLUTIONS -> DebridMultiChoiceDialog(
-            title = "Required resolutions",
+            title = stringResource(R.string.debrid_stream_resolutions_required),
             selectedValues = uiState.streamPreferences.requiredResolutions,
             values = DebridStreamResolution.defaultOrder,
             label = { it.label },
@@ -437,7 +437,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_RESOLUTIONS -> DebridMultiChoiceDialog(
-            title = "Excluded resolutions",
+            title = stringResource(R.string.debrid_stream_resolutions_excluded),
             selectedValues = uiState.streamPreferences.excludedResolutions,
             values = DebridStreamResolution.defaultOrder,
             label = { it.label },
@@ -448,7 +448,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_QUALITIES -> DebridMultiChoiceDialog(
-            title = "Preferred qualities",
+            title = stringResource(R.string.debrid_stream_qualities_preferred),
             selectedValues = uiState.streamPreferences.preferredQualities,
             values = DebridStreamQuality.defaultOrder,
             label = { it.label },
@@ -459,7 +459,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_QUALITIES -> DebridMultiChoiceDialog(
-            title = "Required qualities",
+            title = stringResource(R.string.debrid_stream_qualities_required),
             selectedValues = uiState.streamPreferences.requiredQualities,
             values = DebridStreamQuality.defaultOrder,
             label = { it.label },
@@ -470,7 +470,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_QUALITIES -> DebridMultiChoiceDialog(
-            title = "Excluded qualities",
+            title = stringResource(R.string.debrid_stream_qualities_excluded),
             selectedValues = uiState.streamPreferences.excludedQualities,
             values = DebridStreamQuality.defaultOrder,
             label = { it.label },
@@ -481,7 +481,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_VISUAL_TAGS -> DebridMultiChoiceDialog(
-            title = "Preferred visual tags",
+            title = stringResource(R.string.debrid_stream_visual_tags_preferred),
             selectedValues = uiState.streamPreferences.preferredVisualTags,
             values = DebridStreamVisualTag.defaultOrder,
             label = { it.label },
@@ -492,7 +492,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_VISUAL_TAGS -> DebridMultiChoiceDialog(
-            title = "Required visual tags",
+            title = stringResource(R.string.debrid_stream_visual_tags_required),
             selectedValues = uiState.streamPreferences.requiredVisualTags,
             values = DebridStreamVisualTag.defaultOrder,
             label = { it.label },
@@ -503,7 +503,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_VISUAL_TAGS -> DebridMultiChoiceDialog(
-            title = "Excluded visual tags",
+            title = stringResource(R.string.debrid_stream_visual_tags_excluded),
             selectedValues = uiState.streamPreferences.excludedVisualTags,
             values = DebridStreamVisualTag.defaultOrder,
             label = { it.label },
@@ -514,7 +514,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_AUDIO_TAGS -> DebridMultiChoiceDialog(
-            title = "Preferred audio tags",
+            title = stringResource(R.string.debrid_stream_audio_tags_preferred),
             selectedValues = uiState.streamPreferences.preferredAudioTags,
             values = DebridStreamAudioTag.defaultOrder,
             label = { it.label },
@@ -525,7 +525,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_AUDIO_TAGS -> DebridMultiChoiceDialog(
-            title = "Required audio tags",
+            title = stringResource(R.string.debrid_stream_audio_tags_required),
             selectedValues = uiState.streamPreferences.requiredAudioTags,
             values = DebridStreamAudioTag.defaultOrder,
             label = { it.label },
@@ -536,7 +536,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_AUDIO_TAGS -> DebridMultiChoiceDialog(
-            title = "Excluded audio tags",
+            title = stringResource(R.string.debrid_stream_audio_tags_excluded),
             selectedValues = uiState.streamPreferences.excludedAudioTags,
             values = DebridStreamAudioTag.defaultOrder,
             label = { it.label },
@@ -547,7 +547,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_AUDIO_CHANNELS -> DebridMultiChoiceDialog(
-            title = "Preferred channels",
+            title = stringResource(R.string.debrid_stream_channels_preferred),
             selectedValues = uiState.streamPreferences.preferredAudioChannels,
             values = DebridStreamAudioChannel.defaultOrder,
             label = { it.label },
@@ -558,7 +558,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_AUDIO_CHANNELS -> DebridMultiChoiceDialog(
-            title = "Required channels",
+            title = stringResource(R.string.debrid_stream_channels_required),
             selectedValues = uiState.streamPreferences.requiredAudioChannels,
             values = DebridStreamAudioChannel.defaultOrder,
             label = { it.label },
@@ -569,7 +569,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_AUDIO_CHANNELS -> DebridMultiChoiceDialog(
-            title = "Excluded channels",
+            title = stringResource(R.string.debrid_stream_channels_excluded),
             selectedValues = uiState.streamPreferences.excludedAudioChannels,
             values = DebridStreamAudioChannel.defaultOrder,
             label = { it.label },
@@ -580,7 +580,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_ENCODES -> DebridMultiChoiceDialog(
-            title = "Preferred encodes",
+            title = stringResource(R.string.debrid_stream_encodes_preferred),
             selectedValues = uiState.streamPreferences.preferredEncodes,
             values = DebridStreamEncode.defaultOrder,
             label = { it.label },
@@ -591,7 +591,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_ENCODES -> DebridMultiChoiceDialog(
-            title = "Required encodes",
+            title = stringResource(R.string.debrid_stream_encodes_required),
             selectedValues = uiState.streamPreferences.requiredEncodes,
             values = DebridStreamEncode.defaultOrder,
             label = { it.label },
@@ -602,7 +602,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_ENCODES -> DebridMultiChoiceDialog(
-            title = "Excluded encodes",
+            title = stringResource(R.string.debrid_stream_encodes_excluded),
             selectedValues = uiState.streamPreferences.excludedEncodes,
             values = DebridStreamEncode.defaultOrder,
             label = { it.label },
@@ -613,7 +613,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.PREFERRED_LANGUAGES -> DebridMultiChoiceDialog(
-            title = "Preferred languages",
+            title = stringResource(R.string.debrid_stream_languages_preferred),
             selectedValues = uiState.streamPreferences.preferredLanguages,
             values = DebridStreamLanguage.entries,
             label = { it.label },
@@ -624,7 +624,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_LANGUAGES -> DebridMultiChoiceDialog(
-            title = "Required languages",
+            title = stringResource(R.string.debrid_stream_languages_required),
             selectedValues = uiState.streamPreferences.requiredLanguages,
             values = DebridStreamLanguage.entries,
             label = { it.label },
@@ -635,7 +635,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_LANGUAGES -> DebridMultiChoiceDialog(
-            title = "Excluded languages",
+            title = stringResource(R.string.debrid_stream_languages_excluded),
             selectedValues = uiState.streamPreferences.excludedLanguages,
             values = DebridStreamLanguage.entries,
             label = { it.label },
@@ -646,7 +646,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.REQUIRED_RELEASE_GROUPS -> DebridTextListDialog(
-            title = "Required release groups",
+            title = stringResource(R.string.debrid_stream_release_groups_required),
             selectedValues = uiState.streamPreferences.requiredReleaseGroups,
             onSelected = { value ->
                 viewModel.setStreamPreferences(uiState.streamPreferences.copy(requiredReleaseGroups = value))
@@ -655,7 +655,7 @@ fun DebridSettingsContent(
             onDismiss = { activeStreamPicker = null }
         )
         DebridStreamPicker.EXCLUDED_RELEASE_GROUPS -> DebridTextListDialog(
-            title = "Excluded release groups",
+            title = stringResource(R.string.debrid_stream_release_groups_excluded),
             selectedValues = uiState.streamPreferences.excludedReleaseGroups,
             onSelected = { value ->
                 viewModel.setStreamPreferences(uiState.streamPreferences.copy(excludedReleaseGroups = value))
@@ -827,7 +827,7 @@ private fun DebridSizeRangeDialog(
     )
 
     SettingsSingleChoiceDialog(
-        title = "Size range",
+        title = stringResource(R.string.debrid_stream_size_range_title),
         options = options.map { value ->
             SettingsPickerOption(value, sizeRangeLabel(value.first, value.second))
         },
@@ -883,7 +883,7 @@ private fun DebridTextListDialog(
     NuvioDialog(
         onDismiss = onDismiss,
         title = title,
-        subtitle = "Enter one group per line.",
+        subtitle = stringResource(R.string.debrid_stream_release_groups_input_subtitle),
         width = 560.dp,
         suppressFirstKeyUp = false
     ) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2410,6 +2410,39 @@
     <string name="debrid_stream_codec_h264">H.264 / AVC</string>
     <string name="debrid_stream_codec_hevc">HEVC / H.265</string>
     <string name="debrid_stream_codec_av1">AV1</string>
+
+    <!-- Debrid&#160;: dialogues de filtres de flux (limites, plage de taille, multi-choix) -->
+    <string name="debrid_stream_per_resolution_limit_title">Limite par résolution</string>
+    <string name="debrid_stream_per_resolution_limit_subtitle">Limite les résultats 2160p, 1080p, 720p répétés après tri.</string>
+    <string name="debrid_stream_per_quality_limit_title">Limite par qualité</string>
+    <string name="debrid_stream_per_quality_limit_subtitle">Limite les résultats BluRay, WEB-DL, REMUX répétés après tri.</string>
+    <string name="debrid_stream_size_range_title">Plage de taille</string>
+    <string name="debrid_stream_size_range_subtitle">Filtrer les flux par taille de fichier.</string>
+    <string name="debrid_stream_resolutions_preferred">Résolutions préférées</string>
+    <string name="debrid_stream_resolutions_required">Résolutions requises</string>
+    <string name="debrid_stream_resolutions_excluded">Résolutions exclues</string>
+    <string name="debrid_stream_qualities_preferred">Qualités préférées</string>
+    <string name="debrid_stream_qualities_required">Qualités requises</string>
+    <string name="debrid_stream_qualities_excluded">Qualités exclues</string>
+    <string name="debrid_stream_visual_tags_preferred">Tags visuels préférés</string>
+    <string name="debrid_stream_visual_tags_required">Tags visuels requis</string>
+    <string name="debrid_stream_visual_tags_excluded">Tags visuels exclus</string>
+    <string name="debrid_stream_audio_tags_preferred">Tags audio préférés</string>
+    <string name="debrid_stream_audio_tags_required">Tags audio requis</string>
+    <string name="debrid_stream_audio_tags_excluded">Tags audio exclus</string>
+    <string name="debrid_stream_channels_preferred">Canaux préférés</string>
+    <string name="debrid_stream_channels_required">Canaux requis</string>
+    <string name="debrid_stream_channels_excluded">Canaux exclus</string>
+    <string name="debrid_stream_encodes_preferred">Encodages préférés</string>
+    <string name="debrid_stream_encodes_required">Encodages requis</string>
+    <string name="debrid_stream_encodes_excluded">Encodages exclus</string>
+    <string name="debrid_stream_languages_preferred">Langues préférées</string>
+    <string name="debrid_stream_languages_required">Langues requises</string>
+    <string name="debrid_stream_languages_excluded">Langues exclues</string>
+    <string name="debrid_stream_release_groups_required">Groupes de release requis</string>
+    <string name="debrid_stream_release_groups_excluded">Groupes de release exclus</string>
+    <string name="debrid_stream_release_groups_input_subtitle">Saisis un groupe par ligne.</string>
+
     <string name="debrid_formatter_title">Éditeur web</string>
     <string name="debrid_formatter_subtitle">Configure l’affichage des sources, les filtres et le tri depuis un autre appareil.</string>
     <string name="debrid_formatter_configure">Ouvrir l’éditeur web</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -975,6 +975,39 @@
     <string name="debrid_stream_codec_h264">H.264 / AVC</string>
     <string name="debrid_stream_codec_hevc">HEVC / H.265</string>
     <string name="debrid_stream_codec_av1">AV1</string>
+
+    <!-- Debrid stream filter dialogs (per-resolution / quality / size / multi-choice pickers) -->
+    <string name="debrid_stream_per_resolution_limit_title">Per resolution limit</string>
+    <string name="debrid_stream_per_resolution_limit_subtitle">Cap repeated 2160p, 1080p, 720p results after sorting.</string>
+    <string name="debrid_stream_per_quality_limit_title">Per quality limit</string>
+    <string name="debrid_stream_per_quality_limit_subtitle">Cap repeated BluRay, WEB-DL, REMUX results after sorting.</string>
+    <string name="debrid_stream_size_range_title">Size range</string>
+    <string name="debrid_stream_size_range_subtitle">Filter streams by file size.</string>
+    <string name="debrid_stream_resolutions_preferred">Preferred resolutions</string>
+    <string name="debrid_stream_resolutions_required">Required resolutions</string>
+    <string name="debrid_stream_resolutions_excluded">Excluded resolutions</string>
+    <string name="debrid_stream_qualities_preferred">Preferred qualities</string>
+    <string name="debrid_stream_qualities_required">Required qualities</string>
+    <string name="debrid_stream_qualities_excluded">Excluded qualities</string>
+    <string name="debrid_stream_visual_tags_preferred">Preferred visual tags</string>
+    <string name="debrid_stream_visual_tags_required">Required visual tags</string>
+    <string name="debrid_stream_visual_tags_excluded">Excluded visual tags</string>
+    <string name="debrid_stream_audio_tags_preferred">Preferred audio tags</string>
+    <string name="debrid_stream_audio_tags_required">Required audio tags</string>
+    <string name="debrid_stream_audio_tags_excluded">Excluded audio tags</string>
+    <string name="debrid_stream_channels_preferred">Preferred channels</string>
+    <string name="debrid_stream_channels_required">Required channels</string>
+    <string name="debrid_stream_channels_excluded">Excluded channels</string>
+    <string name="debrid_stream_encodes_preferred">Preferred encodes</string>
+    <string name="debrid_stream_encodes_required">Required encodes</string>
+    <string name="debrid_stream_encodes_excluded">Excluded encodes</string>
+    <string name="debrid_stream_languages_preferred">Preferred languages</string>
+    <string name="debrid_stream_languages_required">Required languages</string>
+    <string name="debrid_stream_languages_excluded">Excluded languages</string>
+    <string name="debrid_stream_release_groups_required">Required release groups</string>
+    <string name="debrid_stream_release_groups_excluded">Excluded release groups</string>
+    <string name="debrid_stream_release_groups_input_subtitle">Enter one group per line.</string>
+
     <string name="debrid_formatter_title">Web editor</string>
     <string name="debrid_formatter_subtitle">Configure source display, filters, and sorting from another device.</string>
     <string name="debrid_formatter_configure">Open web editor</string>


### PR DESCRIPTION
## Summary

`DebridSettingsScreen` had 30 user-facing strings hardcoded as Kotlin literals (action-row titles/subtitles, multi-choice dialog titles, and the release-groups input subtitle), so they were stuck in English regardless of the app language. Extracted them to `values/strings.xml` and added matching French translations.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

A code-side scan for user-facing hardcoded strings (`title = "..."`, `subtitle = "..."`) found 30 occurrences in `DebridSettingsScreen.kt` that were never wrapped in `stringResource()` and therefore never translatable. Every other screen on `dev` already routes through resources, so this PR just brings Debrid stream filters in line.

## Issue or approval

No linked issue — localization-only externalization of literals already shown in the app, found by a mechanical code scan.

## Reproduction steps

1. Set the app language to Français.
2. Open Settings → Debrid → scroll to **Per resolution limit** / **Per quality limit** / **Size range** rows.
3. Click any of them or any **Preferred/Required/Excluded ...** picker.
4. Observe that the row title, subtitle, and dialog title remain in English until this PR is merged.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `DebridSettingsScreen.kt`, `values/strings.xml`, `values-fr/strings.xml` are touched.
- The 30 new EN values match the previous Kotlin literals byte-for-byte (no copy edits). FR translations follow the existing `debrid_*` style: typographic apostrophe, `&#160;` NBSP, tutoiement, technical terms kept (`BluRay`, `WEB-DL`, `REMUX`, `release groups`, `tags`, `flux`).
- Key naming follows the existing `debrid_stream_<feature>_<part>` convention used by `debrid_stream_min_quality_*`, `debrid_stream_codec_*`, etc.
- Brand-name labels (`Trakt`, `TMDB`, `MDBList`, `Anime-Skip`) found by the same scan are intentionally not extracted — they would be the same string in every locale.
- No layout/composable change, no behavior change, no other screen modified.

## Testing

- `./gradlew :app:assembleFullDebug` — resources merge cleanly, full APK builds.
- Verified the 30 new EN keys appear once each, FR has 30 matching keys, no duplicate keys introduced on either side.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — localization-only externalization of literals.