### PR TITLE
Fix first dialog click after CEC long press

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/NuvioDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/NuvioDialog.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.ui.components
 
+import android.os.SystemClock
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -43,6 +44,7 @@ fun NuvioDialog(
     content: @Composable ColumnScope.() -> Unit
 ) {
     var suppressNextKeyUp by remember { mutableStateOf(suppressFirstKeyUp) }
+    val openedAtMillis = remember { SystemClock.uptimeMillis() }
     val maxDialogHeight = (LocalConfiguration.current.screenHeightDp.dp - 48.dp).coerceAtLeast(320.dp)
 
     Dialog(onDismissRequest = onDismiss) {
@@ -59,7 +61,7 @@ fun NuvioDialog(
                     if (suppressNextKeyUp && native.action == AndroidKeyEvent.ACTION_UP) {
                         if (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU) {
                             suppressNextKeyUp = false
-                            return@onPreviewKeyEvent true
+                            return@onPreviewKeyEvent native.downTime <= openedAtMillis
                         }
                     }
                     false


### PR DESCRIPTION
## Summary
Bug fixed based on discord user [hypothesis](https://discord.com/channels/1379902184207941732/1504236074157998314/1507436552576303104)
<!-- What changed in this PR? -->
Fixes the first selection click being swallowed in dialogs opened from a CEC remote long press.
`NuvioDialog` now only suppresses a select/menu `ACTION_UP` if that key press started before the dialog opened. This keeps the existing protection against accidentally selecting an item immediately when a dialog appears, while allowing the first real click inside the dialog to work for CEC remote users.





## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why
Critical bug fix, my [previous PR](https://github.com/NuvioMedia/NuvioTV/pull/1898) added the long press for CEC remote users, but it introduced this bug.


<!-- Why this change is needed. Explain the critical bug or localization update. -->

## Issue or approval
None
<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->

## Reproduction steps
Use a CEC remote and after a long press the selection has to be pressed twice.
<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries
Only fixes this one issue, doesn't change the behaviour of "normal" remotes.
<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing
Two seperate discord users with a CEC remote verified that this fixed the problem.
[channel](https://discord.com/channels/1379902184207941732/1504236074157998314)

If anyone wants to do additional testing
https://pub-027987f53331437eab845bb5c496119d.r2.dev/app-full-armeabi-v7a-debug.apk
Downloader code: 3869505
<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video
Not a UI change
<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes
None
<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues
Fixes [this](https://discord.com/channels/1379902184207941732/1504236074157998314/1506055446614507582)
<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
