### PR TITLE
fix: avoid duplicate keys in episode ratings list

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
@@ -82,6 +82,7 @@ fun EpisodeRatingsSection(
     val episodesForSeason = remember(episodes, selectedSeason) {
         episodes
             .filter { it.season == selectedSeason && it.episode != null }
+            .distinctBy { it.season to it.episode }
             .sortedBy { it.episode }
     }
     val defaultChipColor = NuvioColors.BackgroundCard
@@ -96,6 +97,7 @@ fun EpisodeRatingsSection(
             val chipTextColor = rating?.let(::ratingTextColor) ?: defaultChipTextColor
             EpisodeRatingChipUi(
                 id = episode.id,
+                seasonNumber = season,
                 episodeNumber = episodeNumber,
                 ratingText = ratingText,
                 chipColor = chipColor,
@@ -228,7 +230,7 @@ fun EpisodeRatingsSection(
                     contentPadding = PaddingValues(horizontal = 48.dp, vertical = 6.dp),
                     horizontalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
-                    items(seasonRatings, key = { it.id }) { episodeRating ->
+                    items(seasonRatings, key = { "${it.seasonNumber}:${it.episodeNumber}" }) { episodeRating ->
                         val selectedSeasonUpRequester = firstItemFocusRequester ?: seasonFocusRequesters[selectedSeason]
 
                         Card(
@@ -299,6 +301,7 @@ private fun ratingTextColor(value: Double): Color {
 
 private data class EpisodeRatingChipUi(
     val id: String,
+    val seasonNumber: Int,
     val episodeNumber: Int,
     val ratingText: String,
     val chipColor: Color,


### PR DESCRIPTION
## Summary

Fixes a crash in the Ratings tab caused by duplicate LazyRow keys when episode data includes duplicate season/episode entries. The ratings list now de-duplicates episodes per season and uses a stable season+episode key for each chip.

## PR type

- [ ] Translation/localization only  
- [x] Critical bug fix  
- [ ] UI improvement — approved in #ISSUE_NUMBER  

## Why

Users reported a crash when opening the Ratings section for certain shows (e.g., “The Secret Files of Spy Dogs”). The crash is a `java.lang.IllegalArgumentException: Key ... was already used` from Compose, caused by duplicate items in the ratings list.

## Issue or approval

Reported by Badmannn on Discord (no issue link yet).  

## Reproduction steps

1. Open the show “The Secret Files of Spy Dogs.”
2. Navigate to the Ratings tab.
3. App crashes with duplicate LazyRow key error.

## UI / behavior impact

- [x] No UI change  
- [x] No behavior change  
- [ ] UI changed only to fix a documented glitch/bug  
- [ ] Behavior changed only to fix a documented bug/regression  
- [ ] UI change has explicit maintainer approval  

## Policy check

- [x] I have read and understood CONTRIBUTING.md.  
- [x] This PR fits the current PR policy: critical bug fix.  
- [x] This PR is small, focused, and limited to one issue.  
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.  
- [x] This PR includes a linked issue and testing notes.  
- [x] I listed the testing performed below.  

## Scope boundaries

Only EpisodeRatingsSection.kt is modified. No view models, repositories, or network layers changed.

## Testing

- User (badmannn) reproduced on his account and tested a debug APK on device. Confirmed the app no longer crashes.
- I confirmed no regressions on my device (general navigation + Ratings tab for other titles).

## Screenshots / Video

Not applicable (no UI change).

## Breaking changes

None.

## Linked issues

Reported on Discord by The Badmannn. Issue not created but if needed can be done.