### PR TITLE
Fix Trakt/CW regression - get rid of yield, move dispatcher back to Default and introduce of updateOptimisticProgressQuietly

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -90,7 +90,7 @@ class WatchProgressPreferences @Inject constructor(
             cachedProgressJson = json
             cachedProgressResult = result
             result
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(Dispatchers.Default)
     }
 
     @Volatile private var cachedRawProgressJson: String? = null
@@ -112,7 +112,7 @@ class WatchProgressPreferences @Inject constructor(
             cachedRawProgressJson = json
             cachedRawProgressResult = result
             result
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(Dispatchers.Default)
     }
 
     /**

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -49,7 +49,7 @@ class WatchedItemsPreferences @Inject constructor(
             raw.mapNotNull { json ->
                 runCatching { gson.fromJson(json, WatchedItem::class.java) }.getOrNull()
             }
-        }.flowOn(Dispatchers.IO) 
+        }.flowOn(Dispatchers.Default)
     }
 
     fun isWatched(contentId: String, season: Int? = null, episode: Int? = null): Flow<Boolean> {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -393,6 +393,35 @@ class TraktProgressService @Inject constructor(
         requestFastSync()
     }
 
+    /**
+     * Updates the optimistic progress state WITHOUT triggering a fast sync.
+     * Use this for periodic in-playback saves where we only need the local
+     * UI (Continue Watching) to reflect the current position, but don't need
+     * to force a full remote refresh cycle.
+     */
+    fun updateOptimisticProgressQuietly(progress: WatchProgress) {
+        val now = System.currentTimeMillis()
+        val derivedPercent = when {
+            progress.progressPercent != null -> progress.progressPercent
+            progress.duration > 0L -> ((progress.position.toFloat() / progress.duration.toFloat()) * 100f)
+            else -> null
+        }?.coerceIn(0f, 100f)
+
+        val optimistic = progress.copy(
+            progressPercent = derivedPercent,
+            source = WatchProgress.SOURCE_TRAKT_PLAYBACK
+        )
+
+        optimisticProgress.update { current ->
+            current.toMutableMap().apply {
+                this[progressKey(optimistic)] = OptimisticProgressEntry(
+                    progress = optimistic,
+                    expiresAtMs = now + optimisticTtlMs
+                )
+            }
+        }
+    }
+
     fun applyOptimisticRemoval(contentId: String, season: Int?, episode: Int?) {
         val contentKeyPrefix = contentId.trim()
         optimisticProgress.update { current ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -491,7 +491,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                                     progressPercent = 100f
                                 )
                             }
-                    }.flowOn(Dispatchers.IO) 
+                    }.flowOn(Dispatchers.Default)
                 }
             }
             .distinctUntilChanged()
@@ -707,7 +707,14 @@ class WatchProgressRepositoryImpl @Inject constructor(
         // Capture profile ID now so async operations target the correct profile.
         val profileId = profileManager.activeProfileId.value
         if (shouldUseTraktProgress()) {
-            traktProgressService.applyOptimisticProgress(progress)
+            // For periodic in-playback saves (syncRemote=false), only update the
+            // local optimistic state without triggering a full remote refresh cycle.
+            // This prevents Trakt API calls every 10s which cause CPU load and stutters.
+            if (syncRemote) {
+                traktProgressService.applyOptimisticProgress(progress)
+            } else {
+                traktProgressService.updateOptimisticProgressQuietly(progress)
+            }
             watchProgressPreferences.saveProgress(progress)
             if (progress.isCompleted()) {
                 val watchedItem = progress.toWatchedItem()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -536,9 +536,6 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         }
                     }
                     _initialCwResolved.value = true
-                    // Yield after large state update to let the UI thread process
-                    // the recomposition before we continue with heavy next-up work.
-                    kotlinx.coroutines.yield()
                     debug.recordInitialRendered(
                         count = initialItems.size,
                         elapsedMs = SystemClock.elapsedRealtime() - cycleStartMs

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -292,9 +292,6 @@ internal fun HomeViewModel.observeModernHomePresentationPipeline() {
                             state.copy(modernHomePresentation = warmStartPresentation)
                         }
                     }
-                    // Yield to allow the UI to render the warm-start rows before
-                    // building the full presentation, reducing jank on gate release.
-                    kotlinx.coroutines.yield()
                 }
 
                 val presentation = withContext(Dispatchers.Default) {


### PR DESCRIPTION
## Summary

Fix playback stutters and audio sync issues for Trakt users with large watch histories. The regression was introduced in PR #2023 by two changes:
1. Switching CPU-bound JSON parsing from Dispatchers.Default to Dispatchers.IO, causing thread contention with network operations on low-core TV devices
2. Adding yield() cancellation points inside collectLatest blocks, causing repeated heavy CW pipeline restarts when optimistic progress emissions overlapped

Additionally, periodic in-playback saves no longer trigger forced Trakt API refresh cycles (requestFastSync), eliminating unnecessary network load every 10 seconds during playback.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Users with Trakt connected (especially those with large histories, 600+ series) experienced micro-stutters, audio sync issues, and occasional buffering spinners during playback. The issue appeared immediately after connecting to Trakt and disappeared when signing out. Downgrading to 0.6.19 confirmed the regression.

## Issue or approval

Reported by user m1shka in Discord. Reproduced on benchmark builds - stutters start as soon as Trakt is connected, smooth playback immediately after signing out.

## Reproduction steps

1. Connect a Trakt account with large watch history (500+ series)
2. Start playback of any content
3. Observe micro-stutters starting a few seconds after playback begins
4. Audio sync issues appear shortly after
5. Sign out of Trakt - playback becomes smooth immediately

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change Trakt sync behavior for explicit user actions (pause, seek, exit) - those still trigger full sync
- Does not change CW pipeline logic or metadata hydration behavior
- Does not affect non-Trakt users

## Testing

- Tested with Trakt account connected on benchmark build
- Verified playback is smooth with no stutters after fix
- Verified CW updates correctly after exiting player
- Verified explicit saves (pause, seek, exit) still trigger proper Trakt sync
- Confirmed no regression in watched badges or CW items

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Discord report from m1shka - playback stutters with Trakt connected, regression from 0.6.19 to 0.6.20
