### PR TITLE
i18n(fr): extract 7 remaining hardcoded strings + refactor safeApiCall with Context

### DIFF
--- a/app/src/full/java/com/nuvio/tv/updater/UpdateViewModel.kt
+++ b/app/src/full/java/com/nuvio/tv/updater/UpdateViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.R
 import com.nuvio.tv.updater.model.AppUpdate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -79,7 +80,7 @@ class UpdateViewModel @Inject constructor(
                             update = null,
                             isUpdateAvailable = false,
                             showDialog = force, // show error dialog if user forced a check
-                            errorMessage = e.message ?: "Update check failed"
+                            errorMessage = e.message ?: context.getString(R.string.update_error_check_failed)
                         )
                     }
                 }
@@ -138,7 +139,7 @@ class UpdateViewModel @Inject constructor(
                             isDownloading = false,
                             downloadProgress = null,
                             downloadedApkPath = null,
-                            errorMessage = e.message ?: "Download failed"
+                            errorMessage = e.message ?: context.getString(R.string.update_error_download_failed)
                         )
                     }
                 }
@@ -149,7 +150,7 @@ class UpdateViewModel @Inject constructor(
         val apkPath = _uiState.value.downloadedApkPath ?: return
         val apkFile = File(apkPath)
         if (!apkFile.exists()) {
-            _uiState.update { it.copy(errorMessage = "Downloaded file is missing") }
+            _uiState.update { it.copy(errorMessage = context.getString(R.string.update_error_apk_missing)) }
             return
         }
 

--- a/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryRepository.kt
@@ -1,16 +1,20 @@
 package com.nuvio.tv.core.cloud
 
+import android.content.Context
+import com.nuvio.tv.R
 import com.nuvio.tv.core.debrid.DebridProviderCapability
 import com.nuvio.tv.core.debrid.DebridProviders
 import com.nuvio.tv.core.debrid.DebridServiceCredential
 import com.nuvio.tv.core.debrid.supports
 import com.nuvio.tv.data.local.DebridSettingsDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.first
 
 @Singleton
 class CloudLibraryRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val dataStore: DebridSettingsDataStore,
     torboxApi: TorboxCloudLibraryProviderApi,
     premiumizeApi: PremiumizeCloudLibraryProviderApi
@@ -31,7 +35,10 @@ class CloudLibraryRepository @Inject constructor(
             if (api == null) {
                 return@map CloudLibraryProviderState(
                     provider = credential.provider,
-                    errorMessage = "Cloud library is not available for ${credential.provider.displayName}."
+                    errorMessage = context.getString(
+                        R.string.cloud_library_error_provider_unavailable,
+                        credential.provider.displayName
+                    )
                 )
             }
 
@@ -67,7 +74,9 @@ class CloudLibraryRepository @Inject constructor(
         if (!file.playable) return CloudLibraryPlaybackResult.NotPlayable
         val settings = dataStore.settings.first()
         if (!settings.cloudLibraryEnabled) {
-            return CloudLibraryPlaybackResult.Failed("Cloud library is disabled.")
+            return CloudLibraryPlaybackResult.Failed(
+                context.getString(R.string.cloud_library_error_disabled)
+            )
         }
         val credential = DebridProviders.configuredServices(settings)
             .firstOrNull { credential -> credential.provider.id == item.providerId }

--- a/app/src/main/java/com/nuvio/tv/core/network/SafeApiCall.kt
+++ b/app/src/main/java/com/nuvio/tv/core/network/SafeApiCall.kt
@@ -1,18 +1,23 @@
 package com.nuvio.tv.core.network
 
+import android.content.Context
+import com.nuvio.tv.R
 import retrofit2.Response
 
-suspend fun <T> safeApiCall(apiCall: suspend () -> Response<T>): NetworkResult<T> {
+suspend fun <T> safeApiCall(
+    context: Context,
+    apiCall: suspend () -> Response<T>
+): NetworkResult<T> {
     return try {
         val response = apiCall()
         if (response.isSuccessful) {
             response.body()?.let {
                 NetworkResult.Success(it)
-            } ?: NetworkResult.Error("Empty response body")
+            } ?: NetworkResult.Error(context.getString(R.string.network_error_empty_response_body))
         } else {
             NetworkResult.Error(response.message(), response.code())
         }
     } catch (e: Exception) {
-        NetworkResult.Error(e.message ?: "Unknown error occurred")
+        NetworkResult.Error(e.message ?: context.getString(R.string.network_error_unknown))
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -210,7 +210,7 @@ class AddonRepositoryImpl @Inject constructor(
         val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
         val manifestUrl = "$basePath/manifest.json$baseQuery"
 
-        return when (val result = safeApiCall { api.getManifest(manifestUrl) }) {
+        return when (val result = safeApiCall(context) { api.getManifest(manifestUrl) }) {
             is NetworkResult.Success -> {
                 val addon = result.data.toDomain(cleanBaseUrl)
                 manifestCache[cleanBaseUrl] = addon

--- a/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/CatalogRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.repository
 
+import android.content.Context
 import android.util.Log
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.network.safeApiCall
@@ -8,6 +9,7 @@ import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.repository.CatalogRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.net.URLEncoder
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 
 @Singleton
 class CatalogRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val api: AddonApi
 ) : CatalogRepository {
     companion object {
@@ -42,7 +45,7 @@ class CatalogRepositoryImpl @Inject constructor(
             "Fetching catalog addonId=$addonId addonName=$addonName type=$type catalogId=$catalogId skip=$skip skipStep=$skipStep supportsSkip=$supportsSkip url=$url"
         )
 
-        when (val result = safeApiCall { api.getCatalog(url) }) {
+        when (val result = safeApiCall(context) { api.getCatalog(url) }) {
             is NetworkResult.Success -> {
                 val items = result.data.metas.map { it.toDomain() }.distinctBy { it.id }
                 Log.d(

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -78,7 +78,7 @@ class MetaRepositoryImpl @Inject constructor(
         val deferred = inFlightMeta.getOrPut(cacheKey) {
             repositoryScope.async {
                 try {
-                    when (val result = safeApiCall { api.getMeta(url) }) {
+                    when (val result = safeApiCall(context) { api.getMeta(url) }) {
                         is NetworkResult.Success -> {
                             val metaDto = result.data.meta ?: return@async null
                             val meta = metaDto.toDomain(context.getString(R.string.episodes_episode))
@@ -159,7 +159,7 @@ class MetaRepositoryImpl @Inject constructor(
             for (addon in fallbackAddons) {
                 attemptedAddonNames += addon.displayName
                 val url = buildMetaUrl(addon.baseUrl, requestedType, id)
-                when (val result = safeApiCall { api.getMeta(url) }) {
+                when (val result = safeApiCall(context) { api.getMeta(url) }) {
                     is NetworkResult.Success -> {
                         val metaDto = result.data.meta
                         if (metaDto != null) {
@@ -200,7 +200,7 @@ class MetaRepositoryImpl @Inject constructor(
                     for ((addon, candidateType) in prioritizedCandidates) {
                         val url = buildMetaUrl(addon.baseUrl, candidateType, id)
                         Log.d(TAG, "Trying meta addonId=${addon.id} addonName=${addon.name} type=$candidateType id=$id url=$url")
-                        when (val result = safeApiCall { api.getMeta(url) }) {
+                        when (val result = safeApiCall(context) { api.getMeta(url) }) {
                             is NetworkResult.Success -> {
                                 val metaDto = result.data.meta
                                 if (metaDto != null) {
@@ -278,7 +278,7 @@ class MetaRepositoryImpl @Inject constructor(
         val deferred = inFlightPrimaryMeta.getOrPut(cacheKey) {
             repositoryScope.async {
                 try {
-                    when (val result = safeApiCall { api.getMeta(url) }) {
+                    when (val result = safeApiCall(context) { api.getMeta(url) }) {
                         is NetworkResult.Success -> {
                             val metaDto = result.data.meta ?: return@async null
                             val meta = metaDto.toDomain(context.getString(R.string.episodes_episode))

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -401,7 +401,7 @@ class StreamRepositoryImpl @Inject constructor(
             else -> null
         }
 
-        return when (val result = safeApiCall { api.getStreams(streamUrl) }) {
+        return when (val result = safeApiCall(context) { api.getStreams(streamUrl) }) {
             is NetworkResult.Success -> {
                 val streams = result.data.streams?.map { 
                     it.toDomain(addonName, addonLogo) 
@@ -471,7 +471,7 @@ class StreamRepositoryImpl @Inject constructor(
         val metaUrl = "$basePath/meta/$encodedType/$encodedMetaId.json$baseQuery"
         Log.d(TAG, "Fetching inline streams via meta type=$type metaId=$metaId videoId=$videoId url=$metaUrl")
         return try {
-            when (val result = safeApiCall { api.getMeta(metaUrl) }) {
+            when (val result = safeApiCall(context) { api.getMeta(metaUrl) }) {
                 is NetworkResult.Success -> {
                     val metaDto = result.data.meta ?: return emptyList()
                     val matchingVideo = metaDto.videos?.firstOrNull { it.id == videoId }

--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.repository
 
+import android.content.Context
 import android.util.Log
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.network.safeApiCall
@@ -9,6 +10,7 @@ import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.Subtitle
 import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.domain.repository.SubtitleRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -20,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 class SubtitleRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val api: AddonApi,
     private val addonRepository: AddonRepositoryImpl
 ) : SubtitleRepository {
@@ -157,7 +160,7 @@ class SubtitleRepositoryImpl @Inject constructor(
         Log.d(TAG, "Fetching subtitles from ${addon.name}: $subtitleUrl")
         
         return try {
-            when (val result = safeApiCall { api.getSubtitles(subtitleUrl) }) {
+            when (val result = safeApiCall(context) { api.getSubtitles(subtitleUrl) }) {
                 is NetworkResult.Success -> {
                     val subtitles = result.data.subtitles?.mapNotNull { dto ->
                         Subtitle(

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1510,6 +1510,12 @@
     <string name="update_open_settings">Ouvrir les paramètres</string>
     <string name="update_install">Installer</string>
     <string name="update_ignore">Ignorer</string>
+
+    <!-- Erreurs du flow de mise à jour -->
+    <string name="update_error_check_failed">Échec de la vérification des mises à jour</string>
+    <string name="update_error_download_failed">Échec du téléchargement</string>
+    <string name="update_error_apk_missing">Fichier téléchargé introuvable</string>
+
     <string name="watchlist_added">Ajouté à la liste de suivi</string>
     <string name="watchlist_removed">Retiré de la liste de suivi</string>
 
@@ -2515,4 +2521,8 @@
     <string name="cloud_library_type_usenet">Usenet</string>
     <string name="cloud_library_type_web">Web</string>
     <string name="cloud_library_type_files">Fichiers</string>
+
+    <!-- Erreurs du dépôt Bibliothèque cloud -->
+    <string name="cloud_library_error_provider_unavailable">Bibliothèque cloud indisponible pour %1$s.</string>
+    <string name="cloud_library_error_disabled">La bibliothèque cloud est désactivée.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1635,6 +1635,10 @@
     <string name="cloud_library_type_web">Web</string>
     <string name="cloud_library_type_files">Files</string>
 
+    <!-- Cloud library repository errors -->
+    <string name="cloud_library_error_provider_unavailable">Cloud library is not available for %1$s.</string>
+    <string name="cloud_library_error_disabled">Cloud library is disabled.</string>
+
     <!-- AccountSettingsContent -->
     <string name="account_loading">Loading\u2026</string>
     <string name="account_sync_description">Sync your library, watch progress, addons, and plugins across devices.</string>
@@ -1828,6 +1832,12 @@
     <string name="update_open_settings">Open Settings</string>
     <string name="update_install">Install</string>
     <string name="update_ignore">Ignore</string>
+
+    <!-- Update flow errors -->
+    <string name="update_error_check_failed">Update check failed</string>
+    <string name="update_error_download_failed">Download failed</string>
+    <string name="update_error_apk_missing">Downloaded file is missing</string>
+
     <string name="watchlist_added">Added to watchlist</string>
     <string name="watchlist_removed">Removed from watchlist</string>
 


### PR DESCRIPTION
## Summary

Extracts the 7 last user-facing hardcoded English strings detected by a deep audit pass, and refactors the top-level `safeApiCall` suspend function to accept a `Context` parameter so it can finally use the `network_error_*` string resources that already existed in `values/strings.xml` and `values-fr/strings.xml` but were dead code (never referenced from any call site).

Parity: EN=2247 / FR=2247 (zero missing, zero orphan).

The hardcoded literals were:
1. `SafeApiCall.kt:11` — "Empty response body" (NetworkResult.Error fallback)
2. `SafeApiCall.kt:16` — "Unknown error occurred" (catch-all fallback)
3. `UpdateViewModel.kt:82` — "Update check failed" (UpdateUiState.errorMessage fallback)
4. `UpdateViewModel.kt:141` — "Download failed" (UpdateUiState.errorMessage fallback)
5. `UpdateViewModel.kt:152` — "Downloaded file is missing" (UpdateUiState.errorMessage)
6. `CloudLibraryRepository.kt:34` — "Cloud library is not available for ${displayName}." (CloudLibraryProviderState.errorMessage)
7. `CloudLibraryRepository.kt:70` — "Cloud library is disabled." (CloudLibraryPlaybackResult.Failed message)

All seven were confirmed to flow into UI state (verified by tracing usages to LibraryScreen, the Update dialog, and the ViewModels that surface `NetworkResult.Error.message` in their UI state).

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

The audit caught 7 user-facing English strings that previous extraction passes had missed because they live in non-obvious places (top-level fun, sealed class error states, repository defaults). Two of them (`network_error_empty_response_body`, `network_error_unknown`) were particularly wasteful: the EN and FR string resources already existed but were never used because `safeApiCall` had no `Context` to call `getString()`. This PR turns that latent i18n work into actually-shipped localization, and closes the remaining gap in the French translation.

## Issue or approval

No linked issue - localization-only update.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The English wording of all 7 extracted strings stays identical (the EN resource values match the previous literals character-for-character). On the FR locale, users now see translated text where previously they saw the English fallback. The `safeApiCall` signature change is internal — all 9 call sites are updated in the same commit. No visual or interaction change.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

The `safeApiCall` signature change is technically a refactor, but it is the minimal change required to make string-resource-based localization work for top-level suspend functions that previously had no `Context`. It is not a drive-by — the two pre-existing FR strings (`network_error_*`) are unusable without it.

## Scope boundaries

Intentionally not changed in this PR:
- The actual error handling logic in any of the 5 repositories — only the literal strings inside `NetworkResult.Error(...)` / `errorMessage = ...` / `CloudLibraryPlaybackResult.Failed(...)` are replaced; control flow, retry behavior, logging are untouched.
- The English wording of the 7 strings (kept verbatim in `values/strings.xml` so any other locale that picks them up via translation workflow keeps the same source).
- The 16 `throw IllegalStateException(...)` messages in `AuthManager`, `Trakt*Service`, `DebridSettingsViewModel`, etc. — they carry technical English messages but are only logged or propagated to crash reporting, never displayed to the user. Out of scope.
- The mix of 104 raw NBSP characters vs 59 `&#160;` entities in `values-fr/strings.xml` — both are valid Android XML; cosmetic harmonization can be a separate pass.
- The slight inconsistency between `debrid_formatter_qr_instruction` ("QR code") and the rest of the project ("code QR") — pre-existing, out of scope.
- Other locales (only EN and FR are touched in this PR; nl/it/de/sv/pt-rBR/etc. will inherit the 5 new keys via the existing translation workflow and stay in EN until translators pick them up).

## Testing

Build verification:
- `./gradlew :app:compileFullDebugKotlin` passes (exit 0) on the consolidated branch with all 10 files in place
- `xmllint --noout` passes on both `values/strings.xml` and `values-fr/strings.xml`

Parity and structure:
- `<string>` count: EN=2247 / FR=2247 (verified with `grep -c '<string '`)
- `<plurals>` count: 1 / 1
- Key diff via `comm -23` / `comm -13` on sorted key lists: 0 missing in FR, 0 orphan in FR
- All 5 newly added keys (`update_error_check_failed`, `update_error_download_failed`, `update_error_apk_missing`, `cloud_library_error_provider_unavailable`, `cloud_library_error_disabled`) exist in both EN and FR

Style and typography audit on the full FR file:
- 0 escaped apostrophes `\'` (all use `’` U+2019 typographic apostrophe per project convention)
- 0 ASCII three-dot `...` (all use `…` U+2026 or `…`)
- 0 strings with simple ASCII space before `; : ! ? »` (all use NBSP `&#160;` or ` ` per project convention)
- 0 mojibake / double-encoding patterns detected
- 0 missing accents on capitals (`É`, `À`, `Ç`, `È` used where required)
- Hunspell `fr_FR` returns 0 spelling errors on the 5 new strings
- Tutoiement style consistent: 0 occurrences of « vous+verbe », « votre/vos », « Veuillez » introduced
- Terminology consistency (script that flags same EN → different FR): 0 incoherences introduced; "Bibliothèque cloud" matches existing `debrid_cloud_library`, "Échec de la/du..." matches 8+ existing patterns

Refactor verification:
- All 9 `safeApiCall { ... }` call sites updated to `safeApiCall(context) { ... }` (verified by grep)
- `MetaRepositoryImpl` (4 sites), `StreamRepositoryImpl` (2), `AddonRepositoryImpl` (1) already had `@ApplicationContext private val context: Context` injected
- `CatalogRepositoryImpl` and `SubtitleRepositoryImpl` constructors received `@ApplicationContext private val context: Context` as their first param (Hilt graph unchanged)
- `CloudLibraryRepository` constructor received `@ApplicationContext private val context: Context` as first param

Manual UI smoke test still TODO on a Fire TV / Ugoos device with FR locale active:
- Trigger an addon manifest fetch failure → verify the toast/snackbar shows the translated network error
- Trigger an update check while offline → verify the dialog shows « Échec de la vérification des mises à jour »
- Trigger an APK download failure → verify « Échec du téléchargement »
- Disable Cloud library, then try to play a cloud file → verify « La bibliothèque cloud est désactivée. »
- Connect a Debrid provider without cloud library capability → verify « Bibliothèque cloud indisponible pour {provider}. »

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

The `safeApiCall` signature change is technically an API surface change for any out-of-tree consumer that wires this top-level fun directly, but all in-tree call sites are updated in this same commit. If a downstream fork uses `safeApiCall { ... }`, they will need to add `context` as the first argument when they next rebase — but that is a trivial mechanical change.

## Linked issues

No linked issue - localization-only update.