### PR TITLE
Fix Android TV Debrid stream presentation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamFormatter.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamFormatter.kt
@@ -86,7 +86,7 @@ class DebridStreamFormatter @Inject constructor(
             "service.cached" to serviceCached(stream, resolve),
             "service.shortName" to serviceShortName(stream, resolve),
             "service.name" to serviceName(stream, resolve),
-            "addon.name" to "Nuvio Direct Debrid"
+            "addon.name" to stream.addonName
         )
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -178,16 +178,10 @@ class StreamRepositoryImpl @Inject constructor(
                 // Emit results as they arrive
                 for (result in resultChannel) {
                     val checkingResult = localDebridAvailabilityService.markChecking(listOf(result)).firstOrNull() ?: result
-                    mergePresentedResult(accumulatedResults, checkingResult)
-                    emit(NetworkResult.Success(accumulatedResults.toList()))
-                    Log.d(TAG, "Emitted ${accumulatedResults.size} addon(s), latest: ${checkingResult.addonName} with ${checkingResult.streams.size} streams")
-
                     val checkedResult = localDebridAvailabilityService.annotateCachedAvailability(listOf(checkingResult)).firstOrNull() ?: checkingResult
-                    if (checkedResult != checkingResult) {
-                        mergePresentedResult(accumulatedResults, checkedResult)
-                        emit(NetworkResult.Success(accumulatedResults.toList()))
-                        Log.d(TAG, "Emitted debrid cache status for ${checkedResult.addonName} with ${checkedResult.streams.size} streams")
-                    }
+                    mergePresentedResult(accumulatedResults, checkedResult)
+                    emit(NetworkResult.Success(accumulatedResults.toList()))
+                    Log.d(TAG, "Emitted ${accumulatedResults.size} addon(s), latest: ${checkedResult.addonName} with ${checkedResult.streams.size} streams")
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixed Android TV Debrid stream presentation so original addon streams are not briefly shown before Debrid filtering, and Debrid title templates use the actual addon name.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When Debrid resolving was enabled, Android TV emitted an intermediate stream list while cache status was still `CHECKING`. That could briefly show the original addon stream list before replacing it with the Debrid-presented result.

Also, the Debrid stream title template value `addon.name` was hardcoded to `Nuvio Direct Debrid` instead of using the actual stream addon name.

## Issue or approval

Fixes #2077

## Reproduction steps

1. Enable Debrid resolving on Android TV.
2. Open a movie or episode with torrent streams from an installed addon.
3. Observe that original addon streams can briefly appear before the Debrid-filtered stream list replaces them.
4. Configure a Debrid stream name template that includes `addon.name`.
5. Observe that the rendered title uses `Nuvio Direct Debrid` instead of the actual addon name.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes the Debrid stream presentation path:
- avoids emitting the intermediate `CHECKING` stream list
- uses `stream.addonName` for the `addon.name` template value

It does not add new Debrid features, new UI, new sorting/filtering options, or unrelated stream selection changes.

## Testing

- Reviewed the stream emission path in `StreamRepositoryImpl`.
- Verified Debrid presentation is still applied through the existing `DebridStreamPresentation` path.
- Verified `addon.name` now uses the stream addon name, matching the source stream metadata.
- Android compile was not run locally because Java Runtime was unavailable in this environment.

## Screenshots / Video

No screenshot/video available from this environment. This PR fixes a visible transient stream-list glitch and template label bug; reproduction steps are listed above.

## Breaking changes

None.

## Linked issues

Fixes #2077