### PR TITLE
Sync Debrid settings on Android TV

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -85,6 +85,7 @@ class ProfileSettingsSyncService @Inject constructor(
         "tmdb_settings",
         "mdblist_settings",
         "trakt_settings",
+        "debrid_settings",
         "animeskip_settings",
         "track_preference"
     )


### PR DESCRIPTION
## Summary

Fixed Android TV profile settings sync so Debrid settings are included in cloud sync.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Android TV stores Debrid settings under the `debrid_settings` feature, but that feature was missing from the profile settings sync feature list. As a result, Debrid API keys and stream formatting templates configured on another device were not pulled into Android TV.

## Issue or approval

Fixes #2079

## Reproduction steps

1. Configure Debrid settings, such as a Torbox API key or Debrid stream name template, on another synced device.
2. Open Android TV with the same synced profile.
3. Wait for profile settings sync to complete.
4. Open the Debrid settings section.
5. Observe that the Debrid settings are not restored on Android TV.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `debrid_settings` was added to the existing profile settings sync feature list. This does not add new settings, new UI, new sync behavior, or a new storage schema.

## Testing

- Verified `DebridSettingsDataStore` uses the `debrid_settings` feature name.
- Verified profile settings sync now includes the same feature name.
- Reviewed the change statically.
- Android compile was not run locally because Java Runtime was unavailable in this environment.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2079