### PR TITLE
Fix watched toggle, hero enrichment, Torbox subtitles, SPL mapping

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/TorboxDto.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/TorboxDto.kt
@@ -38,7 +38,7 @@ data class TorboxTorrentFileDto(
     @Json(name = "mimetype") val mimeType: String? = null,
     @Json(name = "size") val size: Long? = null
 ) {
-    fun displayName(): String = listOfNotNull(name, shortName, absolutePath)
+    fun displayName(): String = listOfNotNull(shortName, name?.substringAfterLast('/'), absolutePath?.substringAfterLast('/'))
         .firstOrNull { it.isNotBlank() }
         .orEmpty()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -422,12 +422,15 @@ fun HomeScreen(
         val item = selectedPoster.item
         val statusKey = homeItemStatusKey(item.id, item.apiType)
         val isMovie = item.apiType.equals("movie", ignoreCase = true)
+        val isSeries = item.apiType.equals("series", ignoreCase = true) ||
+            item.apiType.equals("tv", ignoreCase = true)
         HomePosterOptionsDialog(
             title = item.name,
             isInLibrary = uiState.posterLibraryMembership[statusKey] == true,
             isLibraryPending = statusKey in uiState.posterLibraryPending,
             showManageLists = uiState.librarySourceMode == LibrarySourceMode.TRAKT,
             isMovie = isMovie,
+            isSeries = isSeries,
             isWatched = movieWatchedStatus[statusKey] == true,
             isWatchedPending = statusKey in uiState.movieWatchedPending,
             onDismiss = { posterOptionsTarget = null },
@@ -444,7 +447,11 @@ fun HomeScreen(
                 posterOptionsTarget = null
             },
             onToggleWatched = {
-                viewModel.togglePosterMovieWatched(item)
+                if (isMovie) {
+                    viewModel.togglePosterMovieWatched(item)
+                } else {
+                    viewModel.togglePosterSeriesWatched(item)
+                }
                 posterOptionsTarget = null
             }
         )
@@ -648,6 +655,7 @@ private fun HomePosterOptionsDialog(
     isLibraryPending: Boolean,
     showManageLists: Boolean,
     isMovie: Boolean,
+    isSeries: Boolean = false,
     isWatched: Boolean,
     isWatchedPending: Boolean,
     onDismiss: () -> Unit,
@@ -701,7 +709,7 @@ private fun HomePosterOptionsDialog(
             )
         }
 
-        if (isMovie) {
+        if (isMovie || isSeries) {
             Button(
                 onClick = onToggleWatched,
                 enabled = !isWatchedPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -83,7 +83,7 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
-        internal const val STARTUP_GRACE_PERIOD_MS = 3_000L
+        internal const val STARTUP_GRACE_PERIOD_MS = 1_500L
         internal const val CONTINUE_WATCHING_ENRICHMENT_GRACE_PERIOD_MS = 1_000L
         private const val CONTINUE_WATCHING_WINDOW_MS = 30L * 24 * 60 * 60 * 1000
         private const val MAX_RECENT_PROGRESS_ITEMS = 300
@@ -220,6 +220,8 @@ class HomeViewModel @Inject constructor(
     internal val fullyWatchedSeriesIds get() = watchedSeriesStateHolder
     internal var tmdbEnrichFocusJob: Job? = null
     internal var pendingTmdbEnrichItemId: String? = null
+    /** Item that was focused during startup grace period — will be enriched once grace ends. */
+    internal var deferredEnrichItem: MetaPreview? = null
     internal var adjacentItemPrefetchJob: Job? = null
     internal var pendingAdjacentPrefetchItemId: String? = null
     internal val posterLibraryObserverJobs = mutableMapOf<String, Job>()
@@ -348,6 +350,11 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             delay(STARTUP_GRACE_PERIOD_MS)
             startupGracePeriodActive = false
+            // Trigger enrichment for the initial focused item once grace ends.
+            deferredEnrichItem?.let { item ->
+                deferredEnrichItem = null
+                onItemFocusPipeline(item)
+            }
         }
 
         // Observe manual cache clear from Advanced settings.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
@@ -211,7 +211,7 @@ fun HomeViewModel.togglePosterMovieWatched(item: MetaPreview) {
     }
 
     viewModelScope.launch {
-        val currentlyWatched = _movieWatchedStatus.value[statusKey] == true
+        val currentlyWatched = _uiState.value.movieWatchedStatus[statusKey] == true
         runCatching {
             if (currentlyWatched) {
                 watchProgressRepository.removeFromHistory(item.id, videoId = item.imdbId)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
@@ -246,6 +246,94 @@ private fun buildCompletedMovieProgress(item: MetaPreview): WatchProgress {
     )
 }
 
+fun HomeViewModel.togglePosterSeriesWatched(item: MetaPreview) {
+    val isSeries = item.apiType.equals("series", ignoreCase = true) ||
+        item.apiType.equals("tv", ignoreCase = true)
+    if (!isSeries) return
+    val statusKey = homeItemStatusKey(item.id, item.apiType)
+    if (statusKey in _uiState.value.movieWatchedPending) return
+
+    val currentlyWatched = _uiState.value.movieWatchedStatus[statusKey] == true
+
+    // Optimistically update the UI immediately
+    _uiState.update { state ->
+        state.copy(
+            movieWatchedPending = state.movieWatchedPending + statusKey,
+            movieWatchedStatus = state.movieWatchedStatus + (statusKey to !currentlyWatched)
+        )
+    }
+
+    viewModelScope.launch {
+        runCatching {
+            if (currentlyWatched) {
+                unmarkSeriesWatched(item)
+            } else {
+                markSeriesWatched(item)
+            }
+        }.onFailure { error ->
+            Log.w(HomeViewModel.TAG, "Failed to toggle series watched for ${item.id}: ${error.message}")
+            // Revert optimistic update on failure
+            _uiState.update { state ->
+                state.copy(
+                    movieWatchedStatus = state.movieWatchedStatus + (statusKey to currentlyWatched)
+                )
+            }
+        }
+        _uiState.update { state ->
+            state.copy(movieWatchedPending = state.movieWatchedPending - statusKey)
+        }
+    }
+}
+
+private suspend fun HomeViewModel.markSeriesWatched(item: MetaPreview) {
+    val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
+    if (episodes.isEmpty()) return
+
+    val progressList = episodes.map { video ->
+        WatchProgress(
+            contentId = item.id,
+            contentType = item.apiType,
+            name = item.name,
+            poster = item.poster,
+            backdrop = item.backdropUrl,
+            logo = item.logo,
+            videoId = video.id,
+            season = video.season,
+            episode = video.episode,
+            episodeTitle = video.title,
+            position = 1L,
+            duration = 1L,
+            lastWatched = System.currentTimeMillis(),
+            progressPercent = 100f
+        )
+    }
+    watchProgressRepository.markAsCompletedBatch(progressList)
+}
+
+private suspend fun HomeViewModel.unmarkSeriesWatched(item: MetaPreview) {
+    val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
+    if (episodes.isEmpty()) return
+
+    val episodePairs = episodes.map { it.season!! to it.episode!! }
+    watchProgressRepository.removeFromHistoryBatch(
+        contentId = item.id,
+        videoId = item.imdbId,
+        episodes = episodePairs
+    )
+}
+
+private suspend fun HomeViewModel.fetchSeriesEpisodes(item: MetaPreview): List<com.nuvio.tv.domain.model.Video> {
+    val type = if (item.apiType.equals("tv", ignoreCase = true)) "series" else item.apiType
+    var episodes: List<com.nuvio.tv.domain.model.Video> = emptyList()
+    metaRepository.getMetaFromPrimaryAddon(type, item.id)
+        .collect { networkResult ->
+            if (networkResult is com.nuvio.tv.core.network.NetworkResult.Success) {
+                episodes = networkResult.data.videos
+            }
+        }
+    return episodes
+}
+
 private fun MetaPreview.toLibraryEntryInput(addonBaseUrl: String?): LibraryEntryInput {
     val year = Regex("(\\d{4})").find(releaseInfo ?: "")
         ?.groupValues

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -426,7 +426,10 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
 }
 
 internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
-    if (startupGracePeriodActive) return
+    if (startupGracePeriodActive) {
+        deferredEnrichItem = item
+        return
+    }
     if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) return
     if (pendingTmdbEnrichItemId == item.id) return
 

--- a/app/src/main/java/com/nuvio/tv/ui/util/LanguageUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/LanguageUtils.kt
@@ -35,6 +35,7 @@ internal val LANGUAGE_OVERRIDES = mapOf(
     "rus" to "ru",
     "pol" to "pl",
     "spa" to "es",
+    "spl" to "es-419",
     "es-419" to "es-419",
     "es_419" to "es-419",
     "es-la" to "es-419",


### PR DESCRIPTION
## Summary

- Fix addon subtitles not loading for Torbox Instant - filename was passed with full path (folder/file) causing subtitle addons to fail on the extra "/"
- Fix unmarking movies as watched from home screen long-press menu
- Fix empty hero content on app start when enrichment is enabled and no Continue Watching
- Add "spl" language code mapping to Spanish (Latin America) for subtitle matching
- Add mark/unmark series as watched from home screen long-press menu

## PR type

- [x] Critical bug fix

## Why

Multiple bugs affecting core UX:
1. Torbox Instant subtitle addons failed because filename contained a path separator (folder/file.mkv) - addons rejected the "/" in the filename
2. Unmarking movies as watched did nothing - the toggle read watched state from a stale source (`_movieWatchedStatus`) while the UI read from `_uiState.movieWatchedStatus`, causing the logic to call `markAsCompleted` instead of `removeFromHistory`
3. Hero section stayed blank on app start for users without Continue Watching when enrichment was enabled - the 3s startup grace period blocked `onItemFocus`, so enrichment never triggered for the initial focused item
4. Subtitles tagged as "spl" (common OpenSubtitles code for Spanish Latin America) were not matched to the correct language group
5. No way to mark/unmark entire series as watched from home - only movies had this option

## Issue or approval

Fixes #2071
Fixes #2082

## Reproduction steps

**Torbox Instant subtitles bug:**
1. Play content via Torbox Instant where the file is inside a subfolder
2. Subtitle addons fail to load - filename passed as "folder/file.mkv" instead of "file.mkv"

**Unmark movie bug:**
1. Long-press a catalog movie on home screen
2. Select "Mark as watched"
3. Long-press same movie again
4. Select "Mark as unwatched"
5. Nothing happens - movie stays marked as watched

**Empty hero bug:**
1. Clear app data (no CW progress saved)
2. Enable "Prefer meta from external addon" in settings
3. Open app
4. Hero section is blank despite focus being on first catalog item

**SPL subtitle bug:**
1. Install addon that returns subtitles with language code "spl"
2. Set preferred subtitle language to Spanish (Latin America)
3. Subtitles are not auto-selected / shown under wrong language group

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Coil/image memory optimizations from earlier in the session are NOT included in this PR (separate concern)
- Series mark-as-watched fetches episodes from primary addon only - does not aggregate from multiple addons
- Season 0 (specials) is excluded from batch mark/unmark operations
- Torbox fix only strips the path prefix from filename - no other debrid service changes

## Testing

- Tested Torbox Instant: played file inside subfolder -> subtitle addons now receive clean filename without path separator
- Tested unmark movie: long-press -> mark watched -> long-press -> mark unwatched -> checkmark disappears correctly
- Tested hero enrichment: cleared app data (no CW progress), enabled external meta preference, cold start -> hero populates after ~1.5s grace period
- Tested SPL mapping: verified `normalizeLanguageCode("spl")` returns "es-419" and `matchesLanguageCode("spl", "es-419")` returns true
- Tested series mark watched: long-press series -> mark as watched -> all episodes (except S0) marked, checkmark appears immediately
- Tested series unmark watched: long-press watched series -> mark as unwatched -> checkmark disappears, episodes unmarked in details
- Tested with Trakt disabled (Nuvio sync only)
- Device: Android TV emulator API 34, physical TCL TV

## Screenshots / Video

Not a UI change (existing dialog gains one additional option for series items).

## Breaking changes

None.

## Linked issues

Fixes #2071
Fixes #2082
