### PR TITLE
feat: DV7 Profile 7 to 8.1 conversion, buffer track, and custom playback buffer engine

### DIFF
--- a/DV7/libdovi/android-arm64/include/libdovi/rpu_parser.h
+++ b/DV7/libdovi/android-arm64/include/libdovi/rpu_parser.h
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef DOVI_H
+#define DOVI_H
+
+
+#define RPU_PARSER_MAJOR 3
+#define RPU_PARSER_MINOR 3
+#define RPU_PARSER_PATCH 2
+
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define DoviNUM_COMPONENTS 3
+
+/**
+ * Opaque Dolby Vision RPU.
+ *
+ * Use dovi_rpu_free to free.
+ * It should be freed regardless of whether or not an error occurred.
+ */
+typedef struct DoviRpuOpaque DoviRpuOpaque;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const uint8_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviData;
+
+/**
+ * C struct for rpu_data_header()
+ */
+typedef struct {
+    /**
+     * Profile guessed from the values in the header
+     */
+    uint8_t guessed_profile;
+    /**
+     * Enhancement layer type (FEL or MEL) if the RPU is profile 7
+     * null pointer if not profile 7
+     */
+    const char *el_type;
+    /**
+     * Deprecated since 3.2.0
+     * The field is not actually part of the RPU header
+     */
+    uint8_t rpu_nal_prefix;
+    uint8_t rpu_type;
+    uint16_t rpu_format;
+    uint8_t vdr_rpu_profile;
+    uint8_t vdr_rpu_level;
+    bool vdr_seq_info_present_flag;
+    bool chroma_resampling_explicit_filter_flag;
+    uint8_t coefficient_data_type;
+    uint64_t coefficient_log2_denom;
+    uint8_t vdr_rpu_normalized_idc;
+    bool bl_video_full_range_flag;
+    uint64_t bl_bit_depth_minus8;
+    uint64_t el_bit_depth_minus8;
+    uint64_t vdr_bit_depth_minus8;
+    bool spatial_resampling_filter_flag;
+    uint8_t reserved_zero_3bits;
+    bool el_spatial_resampling_filter_flag;
+    bool disable_residual_flag;
+    bool vdr_dm_metadata_present_flag;
+    bool use_prev_vdr_rpu_flag;
+    uint64_t prev_vdr_rpu_id;
+} DoviRpuDataHeader;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint16_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU16Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU64Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const int64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviI64Data;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviI64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data2D;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviU64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data2D;
+
+typedef struct {
+    DoviU64Data poly_order_minus1;
+    DoviData linear_interp_flag;
+    DoviI64Data2D poly_coef_int;
+    DoviU64Data2D poly_coef;
+} DoviPolynomialCurve;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of I64Data2D structs
+     */
+    const DoviI64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data3D;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of U64Data2D structs
+     */
+    const DoviU64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data3D;
+
+typedef struct {
+    DoviData mmr_order_minus1;
+    DoviI64Data mmr_constant_int;
+    DoviU64Data mmr_constant;
+    DoviI64Data3D mmr_coef_int;
+    DoviU64Data3D mmr_coef;
+} DoviMMRCurve;
+
+typedef struct {
+    /**
+     * [2, 9]
+     */
+    uint64_t num_pivots_minus2;
+    DoviU16Data pivots;
+    /**
+     * Consistent for a component
+     * Luma (component 0): Polynomial = 0
+     * Chroma (components 1 and 2): MMR = 1
+     */
+    uint8_t mapping_idc;
+    /**
+     * mapping_idc = 0, null pointer otherwise
+     */
+    const DoviPolynomialCurve *polynomial;
+    /**
+     * mapping_idc = 1, null pointer otherwise
+     */
+    const DoviMMRCurve *mmr;
+} DoviReshapingCurve;
+
+/**
+ * C struct for rpu_data_nlq()
+ */
+typedef struct {
+    uint16_t nlq_offset[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max_int[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold[DoviNUM_COMPONENTS];
+} DoviRpuDataNlq;
+
+/**
+ * C struct for rpu_data_mapping()
+ */
+typedef struct {
+    uint64_t vdr_rpu_id;
+    uint64_t mapping_color_space;
+    uint64_t mapping_chroma_format_idc;
+    uint64_t num_x_partitions_minus1;
+    uint64_t num_y_partitions_minus1;
+    DoviReshapingCurve curves[DoviNUM_COMPONENTS];
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_method_idc;
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_num_pivots_minus2;
+    /**
+     * Length of zero when not present. Only present in profile 4 and 7.
+     */
+    DoviU16Data nlq_pred_pivot_value;
+    /**
+     * Pointer to `RpuDataNlq` struct, null if not dual layer profile
+     */
+    const DoviRpuDataNlq *nlq;
+} DoviRpuDataMapping;
+
+/**
+ * Statistical analysis of the frame: min, max, avg brightness.
+ */
+typedef struct {
+    uint16_t min_pq;
+    uint16_t max_pq;
+    uint16_t avg_pq;
+} DoviExtMetadataBlockLevel1;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ */
+typedef struct {
+    uint16_t target_max_pq;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    int16_t ms_weight;
+} DoviExtMetadataBlockLevel2;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel2 structs
+     */
+    const DoviExtMetadataBlockLevel2 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel2BlockList;
+
+/**
+ * Level 1 offsets.
+ */
+typedef struct {
+    uint16_t min_pq_offset;
+    uint16_t max_pq_offset;
+    uint16_t avg_pq_offset;
+} DoviExtMetadataBlockLevel3;
+
+/**
+ * Something about temporal stability
+ */
+typedef struct {
+    uint16_t anchor_pq;
+    uint16_t anchor_power;
+} DoviExtMetadataBlockLevel4;
+
+/**
+ * Active area of the picture (letterbox, aspect ratio)
+ */
+typedef struct {
+    uint16_t active_area_left_offset;
+    uint16_t active_area_right_offset;
+    uint16_t active_area_top_offset;
+    uint16_t active_area_bottom_offset;
+} DoviExtMetadataBlockLevel5;
+
+/**
+ * ST2086/HDR10 metadata fallback
+ */
+typedef struct {
+    uint16_t max_display_mastering_luminance;
+    uint16_t min_display_mastering_luminance;
+    uint16_t max_content_light_level;
+    uint16_t max_frame_average_light_level;
+} DoviExtMetadataBlockLevel6;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ * For CM v4.0, L8 metadata only is present and used to compute L2
+ *
+ * This block can have varying byte lengths: 10, 12, 13, 19, 25
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 10: ms_weight
+ *     - 12: target_mid_contrast
+ *     - 13: clip_trim
+ *     - 19: saturation_vector_field[0-5]
+ *     - 25: hue_vector_field[0-5]
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    uint16_t ms_weight;
+    uint16_t target_mid_contrast;
+    uint16_t clip_trim;
+    uint8_t saturation_vector_field0;
+    uint8_t saturation_vector_field1;
+    uint8_t saturation_vector_field2;
+    uint8_t saturation_vector_field3;
+    uint8_t saturation_vector_field4;
+    uint8_t saturation_vector_field5;
+    uint8_t hue_vector_field0;
+    uint8_t hue_vector_field1;
+    uint8_t hue_vector_field2;
+    uint8_t hue_vector_field3;
+    uint8_t hue_vector_field4;
+    uint8_t hue_vector_field5;
+} DoviExtMetadataBlockLevel8;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel8 structs
+     */
+    const DoviExtMetadataBlockLevel8 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel8BlockList;
+
+/**
+ * Source/mastering display color primaries
+ *
+ * This block can have varying byte lengths: 1 or 17
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 1: source_primary_index
+ *     - 17: source_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t source_primary_index;
+    uint16_t source_primary_red_x;
+    uint16_t source_primary_red_y;
+    uint16_t source_primary_green_x;
+    uint16_t source_primary_green_y;
+    uint16_t source_primary_blue_x;
+    uint16_t source_primary_blue_y;
+    uint16_t source_primary_white_x;
+    uint16_t source_primary_white_y;
+} DoviExtMetadataBlockLevel9;
+
+/**
+ * Custom target display information
+ *
+ * This block can have varying byte lengths: 5 or 21
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 5: target_primary_index
+ *     - 21: target_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t target_max_pq;
+    uint16_t target_min_pq;
+    uint8_t target_primary_index;
+    uint16_t target_primary_red_x;
+    uint16_t target_primary_red_y;
+    uint16_t target_primary_green_x;
+    uint16_t target_primary_green_y;
+    uint16_t target_primary_blue_x;
+    uint16_t target_primary_blue_y;
+    uint16_t target_primary_white_x;
+    uint16_t target_primary_white_y;
+} DoviExtMetadataBlockLevel10;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel10 structs
+     */
+    const DoviExtMetadataBlockLevel10 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel10BlockList;
+
+/**
+ * Content type metadata level
+ */
+typedef struct {
+    uint8_t content_type;
+    uint8_t whitepoint;
+    bool reference_mode_flag;
+    uint8_t reserved_byte2;
+    uint8_t reserved_byte3;
+} DoviExtMetadataBlockLevel11;
+
+/**
+ * Metadata level present in CM v4.0
+ */
+typedef struct {
+    uint8_t dm_mode;
+    uint8_t dm_version_index;
+} DoviExtMetadataBlockLevel254;
+
+/**
+ * Metadata level optionally present in CM v2.9.
+ * Different display modes (calibration/verify/bypass), debugging
+ */
+typedef struct {
+    uint8_t dm_run_mode;
+    uint8_t dm_run_version;
+    uint8_t dm_debug0;
+    uint8_t dm_debug1;
+    uint8_t dm_debug2;
+    uint8_t dm_debug3;
+} DoviExtMetadataBlockLevel255;
+
+/**
+ * C struct for the list of ext_metadata_block()
+ */
+typedef struct {
+    /**
+     * Number of metadata blocks
+     */
+    uint64_t num_ext_blocks;
+    const DoviExtMetadataBlockLevel1 *level1;
+    DoviLevel2BlockList level2;
+    const DoviExtMetadataBlockLevel3 *level3;
+    const DoviExtMetadataBlockLevel4 *level4;
+    const DoviExtMetadataBlockLevel5 *level5;
+    const DoviExtMetadataBlockLevel6 *level6;
+    DoviLevel8BlockList level8;
+    const DoviExtMetadataBlockLevel9 *level9;
+    DoviLevel10BlockList level10;
+    const DoviExtMetadataBlockLevel11 *level11;
+    const DoviExtMetadataBlockLevel254 *level254;
+    const DoviExtMetadataBlockLevel255 *level255;
+} DoviDmData;
+
+/**
+ * C struct for vdr_dm_data()
+ */
+typedef struct {
+    bool compressed;
+    uint64_t affected_dm_metadata_id;
+    uint64_t current_dm_metadata_id;
+    uint64_t scene_refresh_flag;
+    int16_t ycc_to_rgb_coef0;
+    int16_t ycc_to_rgb_coef1;
+    int16_t ycc_to_rgb_coef2;
+    int16_t ycc_to_rgb_coef3;
+    int16_t ycc_to_rgb_coef4;
+    int16_t ycc_to_rgb_coef5;
+    int16_t ycc_to_rgb_coef6;
+    int16_t ycc_to_rgb_coef7;
+    int16_t ycc_to_rgb_coef8;
+    uint32_t ycc_to_rgb_offset0;
+    uint32_t ycc_to_rgb_offset1;
+    uint32_t ycc_to_rgb_offset2;
+    int16_t rgb_to_lms_coef0;
+    int16_t rgb_to_lms_coef1;
+    int16_t rgb_to_lms_coef2;
+    int16_t rgb_to_lms_coef3;
+    int16_t rgb_to_lms_coef4;
+    int16_t rgb_to_lms_coef5;
+    int16_t rgb_to_lms_coef6;
+    int16_t rgb_to_lms_coef7;
+    int16_t rgb_to_lms_coef8;
+    uint16_t signal_eotf;
+    uint16_t signal_eotf_param0;
+    uint16_t signal_eotf_param1;
+    uint32_t signal_eotf_param2;
+    uint8_t signal_bit_depth;
+    uint8_t signal_color_space;
+    uint8_t signal_chroma_format;
+    uint8_t signal_full_range_flag;
+    uint16_t source_min_pq;
+    uint16_t source_max_pq;
+    uint16_t source_diagonal;
+    DoviDmData dm_data;
+} DoviVdrDmData;
+
+/**
+ * Heap allocated list of valid RPU pointers
+ */
+typedef struct {
+    DoviRpuOpaque *const *list;
+    size_t len;
+    const char *error;
+} DoviRpuOpaqueList;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision RPU from unescaped byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_rpu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a AV1 ITU-T T.35 metadata OBU byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_itu_t35_dovi_metadata_obu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a (possibly) escaped HEVC UNSPEC 62 NAL unit byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_unspec62_nalu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ * Avoid using on opaque pointers obtained through `dovi_parse_rpu_bin_file`.
+ *
+ * Free the RpuOpaque
+ */
+void dovi_rpu_free(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the last logged error for the RpuOpaque operations.
+ *
+ * On invalid parsing, an error is added.
+ * The user should manually verify if there is an error, as the parsing does not return an error code.
+ */
+const char *dovi_rpu_get_error(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The data pointer should exist, and be allocated by Rust.
+ *
+ * Free a Data buffer
+ */
+void dovi_data_free(const DoviData *data);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as a byte buffer.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_rpu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU, escapes the bytes for HEVC and prepends the buffer with 0x7C01.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_unspec62_nalu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ * The mode must be between 0 and 4.
+ *
+ * Converts the RPU to be compatible with a different Dolby Vision profile.
+ * Possible modes:
+ *     - 0: Don't modify the RPU
+ *     - 1: Converts the RPU to be MEL compatible
+ *     - 2: Converts the RPU to be profile 8.1 compatible. Both luma and chroma mapping curves are set to no-op.
+ *          This mode handles source profiles 5, 7 and 8.
+ *     - 3: Converts to static profile 8.4
+ *     - 4: Converts to profile 8.1 preserving luma and chroma mapping. Old mode 2 behaviour.
+ *
+ * If an error occurs, it is logged to RpuOpaque.error.
+ * Returns 0 if successful, -1 otherwise.
+ */
+int32_t dovi_convert_rpu_with_mode(DoviRpuOpaque *ptr,
+                                   uint8_t mode);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RPU header struct.
+ */
+const DoviRpuDataHeader *dovi_rpu_get_header(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RPU header.
+ */
+void dovi_rpu_free_header(const DoviRpuDataHeader *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RpuDataMapping struct.
+ */
+const DoviRpuDataMapping *dovi_rpu_get_data_mapping(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RpuDataMapping.
+ */
+void dovi_rpu_free_data_mapping(const DoviRpuDataMapping *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi VdrDmData struct.
+ */
+const DoviVdrDmData *dovi_rpu_get_vdr_dm_data(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the VdrDmData struct.
+ */
+void dovi_rpu_free_vdr_dm_data(const DoviVdrDmData *ptr);
+
+/**
+ * # Safety
+ * The pointer to the file path must be valid.
+ *
+ * Parses an existing RPU binary file.
+ *
+ * Returns the heap allocated `DoviRpuList` as a pointer.
+ * The returned pointer may be null, or the list could be empty if an error occurred.
+ */
+const DoviRpuOpaqueList *dovi_parse_rpu_bin_file(const char *path);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the DoviRpuOpaqueList struct.
+ */
+void dovi_rpu_list_free(const DoviRpuOpaqueList *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Sets the L5 metadata active area offsets.
+ * If there is no L5 block present, it is created with the offsets.
+ */
+int32_t dovi_rpu_set_active_area_offsets(DoviRpuOpaque *ptr,
+                                         uint16_t left,
+                                         uint16_t right,
+                                         uint16_t top,
+                                         uint16_t bottom);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Converts the existing reshaping/mapping to become no-op.
+ */
+int32_t dovi_rpu_remove_mapping(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as `itu_t_t35_payload_bytes` for AV1 ITU-T T.35 metadata OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_payload(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU a complete AV1 `metadata_itut_t35()` OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_complete(DoviRpuOpaque *ptr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* DOVI_H */

--- a/DV7/libdovi/android-armeabi-v7a/include/libdovi/rpu_parser.h
+++ b/DV7/libdovi/android-armeabi-v7a/include/libdovi/rpu_parser.h
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef DOVI_H
+#define DOVI_H
+
+
+#define RPU_PARSER_MAJOR 3
+#define RPU_PARSER_MINOR 3
+#define RPU_PARSER_PATCH 2
+
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define DoviNUM_COMPONENTS 3
+
+/**
+ * Opaque Dolby Vision RPU.
+ *
+ * Use dovi_rpu_free to free.
+ * It should be freed regardless of whether or not an error occurred.
+ */
+typedef struct DoviRpuOpaque DoviRpuOpaque;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const uint8_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviData;
+
+/**
+ * C struct for rpu_data_header()
+ */
+typedef struct {
+    /**
+     * Profile guessed from the values in the header
+     */
+    uint8_t guessed_profile;
+    /**
+     * Enhancement layer type (FEL or MEL) if the RPU is profile 7
+     * null pointer if not profile 7
+     */
+    const char *el_type;
+    /**
+     * Deprecated since 3.2.0
+     * The field is not actually part of the RPU header
+     */
+    uint8_t rpu_nal_prefix;
+    uint8_t rpu_type;
+    uint16_t rpu_format;
+    uint8_t vdr_rpu_profile;
+    uint8_t vdr_rpu_level;
+    bool vdr_seq_info_present_flag;
+    bool chroma_resampling_explicit_filter_flag;
+    uint8_t coefficient_data_type;
+    uint64_t coefficient_log2_denom;
+    uint8_t vdr_rpu_normalized_idc;
+    bool bl_video_full_range_flag;
+    uint64_t bl_bit_depth_minus8;
+    uint64_t el_bit_depth_minus8;
+    uint64_t vdr_bit_depth_minus8;
+    bool spatial_resampling_filter_flag;
+    uint8_t reserved_zero_3bits;
+    bool el_spatial_resampling_filter_flag;
+    bool disable_residual_flag;
+    bool vdr_dm_metadata_present_flag;
+    bool use_prev_vdr_rpu_flag;
+    uint64_t prev_vdr_rpu_id;
+} DoviRpuDataHeader;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint16_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU16Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU64Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const int64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviI64Data;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviI64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data2D;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviU64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data2D;
+
+typedef struct {
+    DoviU64Data poly_order_minus1;
+    DoviData linear_interp_flag;
+    DoviI64Data2D poly_coef_int;
+    DoviU64Data2D poly_coef;
+} DoviPolynomialCurve;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of I64Data2D structs
+     */
+    const DoviI64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data3D;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of U64Data2D structs
+     */
+    const DoviU64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data3D;
+
+typedef struct {
+    DoviData mmr_order_minus1;
+    DoviI64Data mmr_constant_int;
+    DoviU64Data mmr_constant;
+    DoviI64Data3D mmr_coef_int;
+    DoviU64Data3D mmr_coef;
+} DoviMMRCurve;
+
+typedef struct {
+    /**
+     * [2, 9]
+     */
+    uint64_t num_pivots_minus2;
+    DoviU16Data pivots;
+    /**
+     * Consistent for a component
+     * Luma (component 0): Polynomial = 0
+     * Chroma (components 1 and 2): MMR = 1
+     */
+    uint8_t mapping_idc;
+    /**
+     * mapping_idc = 0, null pointer otherwise
+     */
+    const DoviPolynomialCurve *polynomial;
+    /**
+     * mapping_idc = 1, null pointer otherwise
+     */
+    const DoviMMRCurve *mmr;
+} DoviReshapingCurve;
+
+/**
+ * C struct for rpu_data_nlq()
+ */
+typedef struct {
+    uint16_t nlq_offset[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max_int[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold[DoviNUM_COMPONENTS];
+} DoviRpuDataNlq;
+
+/**
+ * C struct for rpu_data_mapping()
+ */
+typedef struct {
+    uint64_t vdr_rpu_id;
+    uint64_t mapping_color_space;
+    uint64_t mapping_chroma_format_idc;
+    uint64_t num_x_partitions_minus1;
+    uint64_t num_y_partitions_minus1;
+    DoviReshapingCurve curves[DoviNUM_COMPONENTS];
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_method_idc;
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_num_pivots_minus2;
+    /**
+     * Length of zero when not present. Only present in profile 4 and 7.
+     */
+    DoviU16Data nlq_pred_pivot_value;
+    /**
+     * Pointer to `RpuDataNlq` struct, null if not dual layer profile
+     */
+    const DoviRpuDataNlq *nlq;
+} DoviRpuDataMapping;
+
+/**
+ * Statistical analysis of the frame: min, max, avg brightness.
+ */
+typedef struct {
+    uint16_t min_pq;
+    uint16_t max_pq;
+    uint16_t avg_pq;
+} DoviExtMetadataBlockLevel1;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ */
+typedef struct {
+    uint16_t target_max_pq;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    int16_t ms_weight;
+} DoviExtMetadataBlockLevel2;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel2 structs
+     */
+    const DoviExtMetadataBlockLevel2 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel2BlockList;
+
+/**
+ * Level 1 offsets.
+ */
+typedef struct {
+    uint16_t min_pq_offset;
+    uint16_t max_pq_offset;
+    uint16_t avg_pq_offset;
+} DoviExtMetadataBlockLevel3;
+
+/**
+ * Something about temporal stability
+ */
+typedef struct {
+    uint16_t anchor_pq;
+    uint16_t anchor_power;
+} DoviExtMetadataBlockLevel4;
+
+/**
+ * Active area of the picture (letterbox, aspect ratio)
+ */
+typedef struct {
+    uint16_t active_area_left_offset;
+    uint16_t active_area_right_offset;
+    uint16_t active_area_top_offset;
+    uint16_t active_area_bottom_offset;
+} DoviExtMetadataBlockLevel5;
+
+/**
+ * ST2086/HDR10 metadata fallback
+ */
+typedef struct {
+    uint16_t max_display_mastering_luminance;
+    uint16_t min_display_mastering_luminance;
+    uint16_t max_content_light_level;
+    uint16_t max_frame_average_light_level;
+} DoviExtMetadataBlockLevel6;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ * For CM v4.0, L8 metadata only is present and used to compute L2
+ *
+ * This block can have varying byte lengths: 10, 12, 13, 19, 25
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 10: ms_weight
+ *     - 12: target_mid_contrast
+ *     - 13: clip_trim
+ *     - 19: saturation_vector_field[0-5]
+ *     - 25: hue_vector_field[0-5]
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    uint16_t ms_weight;
+    uint16_t target_mid_contrast;
+    uint16_t clip_trim;
+    uint8_t saturation_vector_field0;
+    uint8_t saturation_vector_field1;
+    uint8_t saturation_vector_field2;
+    uint8_t saturation_vector_field3;
+    uint8_t saturation_vector_field4;
+    uint8_t saturation_vector_field5;
+    uint8_t hue_vector_field0;
+    uint8_t hue_vector_field1;
+    uint8_t hue_vector_field2;
+    uint8_t hue_vector_field3;
+    uint8_t hue_vector_field4;
+    uint8_t hue_vector_field5;
+} DoviExtMetadataBlockLevel8;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel8 structs
+     */
+    const DoviExtMetadataBlockLevel8 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel8BlockList;
+
+/**
+ * Source/mastering display color primaries
+ *
+ * This block can have varying byte lengths: 1 or 17
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 1: source_primary_index
+ *     - 17: source_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t source_primary_index;
+    uint16_t source_primary_red_x;
+    uint16_t source_primary_red_y;
+    uint16_t source_primary_green_x;
+    uint16_t source_primary_green_y;
+    uint16_t source_primary_blue_x;
+    uint16_t source_primary_blue_y;
+    uint16_t source_primary_white_x;
+    uint16_t source_primary_white_y;
+} DoviExtMetadataBlockLevel9;
+
+/**
+ * Custom target display information
+ *
+ * This block can have varying byte lengths: 5 or 21
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 5: target_primary_index
+ *     - 21: target_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t target_max_pq;
+    uint16_t target_min_pq;
+    uint8_t target_primary_index;
+    uint16_t target_primary_red_x;
+    uint16_t target_primary_red_y;
+    uint16_t target_primary_green_x;
+    uint16_t target_primary_green_y;
+    uint16_t target_primary_blue_x;
+    uint16_t target_primary_blue_y;
+    uint16_t target_primary_white_x;
+    uint16_t target_primary_white_y;
+} DoviExtMetadataBlockLevel10;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel10 structs
+     */
+    const DoviExtMetadataBlockLevel10 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel10BlockList;
+
+/**
+ * Content type metadata level
+ */
+typedef struct {
+    uint8_t content_type;
+    uint8_t whitepoint;
+    bool reference_mode_flag;
+    uint8_t reserved_byte2;
+    uint8_t reserved_byte3;
+} DoviExtMetadataBlockLevel11;
+
+/**
+ * Metadata level present in CM v4.0
+ */
+typedef struct {
+    uint8_t dm_mode;
+    uint8_t dm_version_index;
+} DoviExtMetadataBlockLevel254;
+
+/**
+ * Metadata level optionally present in CM v2.9.
+ * Different display modes (calibration/verify/bypass), debugging
+ */
+typedef struct {
+    uint8_t dm_run_mode;
+    uint8_t dm_run_version;
+    uint8_t dm_debug0;
+    uint8_t dm_debug1;
+    uint8_t dm_debug2;
+    uint8_t dm_debug3;
+} DoviExtMetadataBlockLevel255;
+
+/**
+ * C struct for the list of ext_metadata_block()
+ */
+typedef struct {
+    /**
+     * Number of metadata blocks
+     */
+    uint64_t num_ext_blocks;
+    const DoviExtMetadataBlockLevel1 *level1;
+    DoviLevel2BlockList level2;
+    const DoviExtMetadataBlockLevel3 *level3;
+    const DoviExtMetadataBlockLevel4 *level4;
+    const DoviExtMetadataBlockLevel5 *level5;
+    const DoviExtMetadataBlockLevel6 *level6;
+    DoviLevel8BlockList level8;
+    const DoviExtMetadataBlockLevel9 *level9;
+    DoviLevel10BlockList level10;
+    const DoviExtMetadataBlockLevel11 *level11;
+    const DoviExtMetadataBlockLevel254 *level254;
+    const DoviExtMetadataBlockLevel255 *level255;
+} DoviDmData;
+
+/**
+ * C struct for vdr_dm_data()
+ */
+typedef struct {
+    bool compressed;
+    uint64_t affected_dm_metadata_id;
+    uint64_t current_dm_metadata_id;
+    uint64_t scene_refresh_flag;
+    int16_t ycc_to_rgb_coef0;
+    int16_t ycc_to_rgb_coef1;
+    int16_t ycc_to_rgb_coef2;
+    int16_t ycc_to_rgb_coef3;
+    int16_t ycc_to_rgb_coef4;
+    int16_t ycc_to_rgb_coef5;
+    int16_t ycc_to_rgb_coef6;
+    int16_t ycc_to_rgb_coef7;
+    int16_t ycc_to_rgb_coef8;
+    uint32_t ycc_to_rgb_offset0;
+    uint32_t ycc_to_rgb_offset1;
+    uint32_t ycc_to_rgb_offset2;
+    int16_t rgb_to_lms_coef0;
+    int16_t rgb_to_lms_coef1;
+    int16_t rgb_to_lms_coef2;
+    int16_t rgb_to_lms_coef3;
+    int16_t rgb_to_lms_coef4;
+    int16_t rgb_to_lms_coef5;
+    int16_t rgb_to_lms_coef6;
+    int16_t rgb_to_lms_coef7;
+    int16_t rgb_to_lms_coef8;
+    uint16_t signal_eotf;
+    uint16_t signal_eotf_param0;
+    uint16_t signal_eotf_param1;
+    uint32_t signal_eotf_param2;
+    uint8_t signal_bit_depth;
+    uint8_t signal_color_space;
+    uint8_t signal_chroma_format;
+    uint8_t signal_full_range_flag;
+    uint16_t source_min_pq;
+    uint16_t source_max_pq;
+    uint16_t source_diagonal;
+    DoviDmData dm_data;
+} DoviVdrDmData;
+
+/**
+ * Heap allocated list of valid RPU pointers
+ */
+typedef struct {
+    DoviRpuOpaque *const *list;
+    size_t len;
+    const char *error;
+} DoviRpuOpaqueList;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision RPU from unescaped byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_rpu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a AV1 ITU-T T.35 metadata OBU byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_itu_t35_dovi_metadata_obu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a (possibly) escaped HEVC UNSPEC 62 NAL unit byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_unspec62_nalu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ * Avoid using on opaque pointers obtained through `dovi_parse_rpu_bin_file`.
+ *
+ * Free the RpuOpaque
+ */
+void dovi_rpu_free(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the last logged error for the RpuOpaque operations.
+ *
+ * On invalid parsing, an error is added.
+ * The user should manually verify if there is an error, as the parsing does not return an error code.
+ */
+const char *dovi_rpu_get_error(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The data pointer should exist, and be allocated by Rust.
+ *
+ * Free a Data buffer
+ */
+void dovi_data_free(const DoviData *data);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as a byte buffer.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_rpu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU, escapes the bytes for HEVC and prepends the buffer with 0x7C01.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_unspec62_nalu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ * The mode must be between 0 and 4.
+ *
+ * Converts the RPU to be compatible with a different Dolby Vision profile.
+ * Possible modes:
+ *     - 0: Don't modify the RPU
+ *     - 1: Converts the RPU to be MEL compatible
+ *     - 2: Converts the RPU to be profile 8.1 compatible. Both luma and chroma mapping curves are set to no-op.
+ *          This mode handles source profiles 5, 7 and 8.
+ *     - 3: Converts to static profile 8.4
+ *     - 4: Converts to profile 8.1 preserving luma and chroma mapping. Old mode 2 behaviour.
+ *
+ * If an error occurs, it is logged to RpuOpaque.error.
+ * Returns 0 if successful, -1 otherwise.
+ */
+int32_t dovi_convert_rpu_with_mode(DoviRpuOpaque *ptr,
+                                   uint8_t mode);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RPU header struct.
+ */
+const DoviRpuDataHeader *dovi_rpu_get_header(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RPU header.
+ */
+void dovi_rpu_free_header(const DoviRpuDataHeader *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RpuDataMapping struct.
+ */
+const DoviRpuDataMapping *dovi_rpu_get_data_mapping(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RpuDataMapping.
+ */
+void dovi_rpu_free_data_mapping(const DoviRpuDataMapping *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi VdrDmData struct.
+ */
+const DoviVdrDmData *dovi_rpu_get_vdr_dm_data(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the VdrDmData struct.
+ */
+void dovi_rpu_free_vdr_dm_data(const DoviVdrDmData *ptr);
+
+/**
+ * # Safety
+ * The pointer to the file path must be valid.
+ *
+ * Parses an existing RPU binary file.
+ *
+ * Returns the heap allocated `DoviRpuList` as a pointer.
+ * The returned pointer may be null, or the list could be empty if an error occurred.
+ */
+const DoviRpuOpaqueList *dovi_parse_rpu_bin_file(const char *path);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the DoviRpuOpaqueList struct.
+ */
+void dovi_rpu_list_free(const DoviRpuOpaqueList *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Sets the L5 metadata active area offsets.
+ * If there is no L5 block present, it is created with the offsets.
+ */
+int32_t dovi_rpu_set_active_area_offsets(DoviRpuOpaque *ptr,
+                                         uint16_t left,
+                                         uint16_t right,
+                                         uint16_t top,
+                                         uint16_t bottom);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Converts the existing reshaping/mapping to become no-op.
+ */
+int32_t dovi_rpu_remove_mapping(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as `itu_t_t35_payload_bytes` for AV1 ITU-T T.35 metadata OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_payload(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU a complete AV1 `metadata_itut_t35()` OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_complete(DoviRpuOpaque *ptr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* DOVI_H */

--- a/DV7/libdovi/android-x86/include/libdovi/rpu_parser.h
+++ b/DV7/libdovi/android-x86/include/libdovi/rpu_parser.h
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef DOVI_H
+#define DOVI_H
+
+
+#define RPU_PARSER_MAJOR 3
+#define RPU_PARSER_MINOR 3
+#define RPU_PARSER_PATCH 2
+
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define DoviNUM_COMPONENTS 3
+
+/**
+ * Opaque Dolby Vision RPU.
+ *
+ * Use dovi_rpu_free to free.
+ * It should be freed regardless of whether or not an error occurred.
+ */
+typedef struct DoviRpuOpaque DoviRpuOpaque;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const uint8_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviData;
+
+/**
+ * C struct for rpu_data_header()
+ */
+typedef struct {
+    /**
+     * Profile guessed from the values in the header
+     */
+    uint8_t guessed_profile;
+    /**
+     * Enhancement layer type (FEL or MEL) if the RPU is profile 7
+     * null pointer if not profile 7
+     */
+    const char *el_type;
+    /**
+     * Deprecated since 3.2.0
+     * The field is not actually part of the RPU header
+     */
+    uint8_t rpu_nal_prefix;
+    uint8_t rpu_type;
+    uint16_t rpu_format;
+    uint8_t vdr_rpu_profile;
+    uint8_t vdr_rpu_level;
+    bool vdr_seq_info_present_flag;
+    bool chroma_resampling_explicit_filter_flag;
+    uint8_t coefficient_data_type;
+    uint64_t coefficient_log2_denom;
+    uint8_t vdr_rpu_normalized_idc;
+    bool bl_video_full_range_flag;
+    uint64_t bl_bit_depth_minus8;
+    uint64_t el_bit_depth_minus8;
+    uint64_t vdr_bit_depth_minus8;
+    bool spatial_resampling_filter_flag;
+    uint8_t reserved_zero_3bits;
+    bool el_spatial_resampling_filter_flag;
+    bool disable_residual_flag;
+    bool vdr_dm_metadata_present_flag;
+    bool use_prev_vdr_rpu_flag;
+    uint64_t prev_vdr_rpu_id;
+} DoviRpuDataHeader;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint16_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU16Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU64Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const int64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviI64Data;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviI64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data2D;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviU64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data2D;
+
+typedef struct {
+    DoviU64Data poly_order_minus1;
+    DoviData linear_interp_flag;
+    DoviI64Data2D poly_coef_int;
+    DoviU64Data2D poly_coef;
+} DoviPolynomialCurve;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of I64Data2D structs
+     */
+    const DoviI64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data3D;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of U64Data2D structs
+     */
+    const DoviU64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data3D;
+
+typedef struct {
+    DoviData mmr_order_minus1;
+    DoviI64Data mmr_constant_int;
+    DoviU64Data mmr_constant;
+    DoviI64Data3D mmr_coef_int;
+    DoviU64Data3D mmr_coef;
+} DoviMMRCurve;
+
+typedef struct {
+    /**
+     * [2, 9]
+     */
+    uint64_t num_pivots_minus2;
+    DoviU16Data pivots;
+    /**
+     * Consistent for a component
+     * Luma (component 0): Polynomial = 0
+     * Chroma (components 1 and 2): MMR = 1
+     */
+    uint8_t mapping_idc;
+    /**
+     * mapping_idc = 0, null pointer otherwise
+     */
+    const DoviPolynomialCurve *polynomial;
+    /**
+     * mapping_idc = 1, null pointer otherwise
+     */
+    const DoviMMRCurve *mmr;
+} DoviReshapingCurve;
+
+/**
+ * C struct for rpu_data_nlq()
+ */
+typedef struct {
+    uint16_t nlq_offset[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max_int[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold[DoviNUM_COMPONENTS];
+} DoviRpuDataNlq;
+
+/**
+ * C struct for rpu_data_mapping()
+ */
+typedef struct {
+    uint64_t vdr_rpu_id;
+    uint64_t mapping_color_space;
+    uint64_t mapping_chroma_format_idc;
+    uint64_t num_x_partitions_minus1;
+    uint64_t num_y_partitions_minus1;
+    DoviReshapingCurve curves[DoviNUM_COMPONENTS];
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_method_idc;
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_num_pivots_minus2;
+    /**
+     * Length of zero when not present. Only present in profile 4 and 7.
+     */
+    DoviU16Data nlq_pred_pivot_value;
+    /**
+     * Pointer to `RpuDataNlq` struct, null if not dual layer profile
+     */
+    const DoviRpuDataNlq *nlq;
+} DoviRpuDataMapping;
+
+/**
+ * Statistical analysis of the frame: min, max, avg brightness.
+ */
+typedef struct {
+    uint16_t min_pq;
+    uint16_t max_pq;
+    uint16_t avg_pq;
+} DoviExtMetadataBlockLevel1;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ */
+typedef struct {
+    uint16_t target_max_pq;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    int16_t ms_weight;
+} DoviExtMetadataBlockLevel2;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel2 structs
+     */
+    const DoviExtMetadataBlockLevel2 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel2BlockList;
+
+/**
+ * Level 1 offsets.
+ */
+typedef struct {
+    uint16_t min_pq_offset;
+    uint16_t max_pq_offset;
+    uint16_t avg_pq_offset;
+} DoviExtMetadataBlockLevel3;
+
+/**
+ * Something about temporal stability
+ */
+typedef struct {
+    uint16_t anchor_pq;
+    uint16_t anchor_power;
+} DoviExtMetadataBlockLevel4;
+
+/**
+ * Active area of the picture (letterbox, aspect ratio)
+ */
+typedef struct {
+    uint16_t active_area_left_offset;
+    uint16_t active_area_right_offset;
+    uint16_t active_area_top_offset;
+    uint16_t active_area_bottom_offset;
+} DoviExtMetadataBlockLevel5;
+
+/**
+ * ST2086/HDR10 metadata fallback
+ */
+typedef struct {
+    uint16_t max_display_mastering_luminance;
+    uint16_t min_display_mastering_luminance;
+    uint16_t max_content_light_level;
+    uint16_t max_frame_average_light_level;
+} DoviExtMetadataBlockLevel6;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ * For CM v4.0, L8 metadata only is present and used to compute L2
+ *
+ * This block can have varying byte lengths: 10, 12, 13, 19, 25
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 10: ms_weight
+ *     - 12: target_mid_contrast
+ *     - 13: clip_trim
+ *     - 19: saturation_vector_field[0-5]
+ *     - 25: hue_vector_field[0-5]
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    uint16_t ms_weight;
+    uint16_t target_mid_contrast;
+    uint16_t clip_trim;
+    uint8_t saturation_vector_field0;
+    uint8_t saturation_vector_field1;
+    uint8_t saturation_vector_field2;
+    uint8_t saturation_vector_field3;
+    uint8_t saturation_vector_field4;
+    uint8_t saturation_vector_field5;
+    uint8_t hue_vector_field0;
+    uint8_t hue_vector_field1;
+    uint8_t hue_vector_field2;
+    uint8_t hue_vector_field3;
+    uint8_t hue_vector_field4;
+    uint8_t hue_vector_field5;
+} DoviExtMetadataBlockLevel8;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel8 structs
+     */
+    const DoviExtMetadataBlockLevel8 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel8BlockList;
+
+/**
+ * Source/mastering display color primaries
+ *
+ * This block can have varying byte lengths: 1 or 17
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 1: source_primary_index
+ *     - 17: source_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t source_primary_index;
+    uint16_t source_primary_red_x;
+    uint16_t source_primary_red_y;
+    uint16_t source_primary_green_x;
+    uint16_t source_primary_green_y;
+    uint16_t source_primary_blue_x;
+    uint16_t source_primary_blue_y;
+    uint16_t source_primary_white_x;
+    uint16_t source_primary_white_y;
+} DoviExtMetadataBlockLevel9;
+
+/**
+ * Custom target display information
+ *
+ * This block can have varying byte lengths: 5 or 21
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 5: target_primary_index
+ *     - 21: target_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t target_max_pq;
+    uint16_t target_min_pq;
+    uint8_t target_primary_index;
+    uint16_t target_primary_red_x;
+    uint16_t target_primary_red_y;
+    uint16_t target_primary_green_x;
+    uint16_t target_primary_green_y;
+    uint16_t target_primary_blue_x;
+    uint16_t target_primary_blue_y;
+    uint16_t target_primary_white_x;
+    uint16_t target_primary_white_y;
+} DoviExtMetadataBlockLevel10;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel10 structs
+     */
+    const DoviExtMetadataBlockLevel10 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel10BlockList;
+
+/**
+ * Content type metadata level
+ */
+typedef struct {
+    uint8_t content_type;
+    uint8_t whitepoint;
+    bool reference_mode_flag;
+    uint8_t reserved_byte2;
+    uint8_t reserved_byte3;
+} DoviExtMetadataBlockLevel11;
+
+/**
+ * Metadata level present in CM v4.0
+ */
+typedef struct {
+    uint8_t dm_mode;
+    uint8_t dm_version_index;
+} DoviExtMetadataBlockLevel254;
+
+/**
+ * Metadata level optionally present in CM v2.9.
+ * Different display modes (calibration/verify/bypass), debugging
+ */
+typedef struct {
+    uint8_t dm_run_mode;
+    uint8_t dm_run_version;
+    uint8_t dm_debug0;
+    uint8_t dm_debug1;
+    uint8_t dm_debug2;
+    uint8_t dm_debug3;
+} DoviExtMetadataBlockLevel255;
+
+/**
+ * C struct for the list of ext_metadata_block()
+ */
+typedef struct {
+    /**
+     * Number of metadata blocks
+     */
+    uint64_t num_ext_blocks;
+    const DoviExtMetadataBlockLevel1 *level1;
+    DoviLevel2BlockList level2;
+    const DoviExtMetadataBlockLevel3 *level3;
+    const DoviExtMetadataBlockLevel4 *level4;
+    const DoviExtMetadataBlockLevel5 *level5;
+    const DoviExtMetadataBlockLevel6 *level6;
+    DoviLevel8BlockList level8;
+    const DoviExtMetadataBlockLevel9 *level9;
+    DoviLevel10BlockList level10;
+    const DoviExtMetadataBlockLevel11 *level11;
+    const DoviExtMetadataBlockLevel254 *level254;
+    const DoviExtMetadataBlockLevel255 *level255;
+} DoviDmData;
+
+/**
+ * C struct for vdr_dm_data()
+ */
+typedef struct {
+    bool compressed;
+    uint64_t affected_dm_metadata_id;
+    uint64_t current_dm_metadata_id;
+    uint64_t scene_refresh_flag;
+    int16_t ycc_to_rgb_coef0;
+    int16_t ycc_to_rgb_coef1;
+    int16_t ycc_to_rgb_coef2;
+    int16_t ycc_to_rgb_coef3;
+    int16_t ycc_to_rgb_coef4;
+    int16_t ycc_to_rgb_coef5;
+    int16_t ycc_to_rgb_coef6;
+    int16_t ycc_to_rgb_coef7;
+    int16_t ycc_to_rgb_coef8;
+    uint32_t ycc_to_rgb_offset0;
+    uint32_t ycc_to_rgb_offset1;
+    uint32_t ycc_to_rgb_offset2;
+    int16_t rgb_to_lms_coef0;
+    int16_t rgb_to_lms_coef1;
+    int16_t rgb_to_lms_coef2;
+    int16_t rgb_to_lms_coef3;
+    int16_t rgb_to_lms_coef4;
+    int16_t rgb_to_lms_coef5;
+    int16_t rgb_to_lms_coef6;
+    int16_t rgb_to_lms_coef7;
+    int16_t rgb_to_lms_coef8;
+    uint16_t signal_eotf;
+    uint16_t signal_eotf_param0;
+    uint16_t signal_eotf_param1;
+    uint32_t signal_eotf_param2;
+    uint8_t signal_bit_depth;
+    uint8_t signal_color_space;
+    uint8_t signal_chroma_format;
+    uint8_t signal_full_range_flag;
+    uint16_t source_min_pq;
+    uint16_t source_max_pq;
+    uint16_t source_diagonal;
+    DoviDmData dm_data;
+} DoviVdrDmData;
+
+/**
+ * Heap allocated list of valid RPU pointers
+ */
+typedef struct {
+    DoviRpuOpaque *const *list;
+    size_t len;
+    const char *error;
+} DoviRpuOpaqueList;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision RPU from unescaped byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_rpu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a AV1 ITU-T T.35 metadata OBU byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_itu_t35_dovi_metadata_obu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a (possibly) escaped HEVC UNSPEC 62 NAL unit byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_unspec62_nalu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ * Avoid using on opaque pointers obtained through `dovi_parse_rpu_bin_file`.
+ *
+ * Free the RpuOpaque
+ */
+void dovi_rpu_free(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the last logged error for the RpuOpaque operations.
+ *
+ * On invalid parsing, an error is added.
+ * The user should manually verify if there is an error, as the parsing does not return an error code.
+ */
+const char *dovi_rpu_get_error(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The data pointer should exist, and be allocated by Rust.
+ *
+ * Free a Data buffer
+ */
+void dovi_data_free(const DoviData *data);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as a byte buffer.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_rpu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU, escapes the bytes for HEVC and prepends the buffer with 0x7C01.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_unspec62_nalu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ * The mode must be between 0 and 4.
+ *
+ * Converts the RPU to be compatible with a different Dolby Vision profile.
+ * Possible modes:
+ *     - 0: Don't modify the RPU
+ *     - 1: Converts the RPU to be MEL compatible
+ *     - 2: Converts the RPU to be profile 8.1 compatible. Both luma and chroma mapping curves are set to no-op.
+ *          This mode handles source profiles 5, 7 and 8.
+ *     - 3: Converts to static profile 8.4
+ *     - 4: Converts to profile 8.1 preserving luma and chroma mapping. Old mode 2 behaviour.
+ *
+ * If an error occurs, it is logged to RpuOpaque.error.
+ * Returns 0 if successful, -1 otherwise.
+ */
+int32_t dovi_convert_rpu_with_mode(DoviRpuOpaque *ptr,
+                                   uint8_t mode);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RPU header struct.
+ */
+const DoviRpuDataHeader *dovi_rpu_get_header(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RPU header.
+ */
+void dovi_rpu_free_header(const DoviRpuDataHeader *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RpuDataMapping struct.
+ */
+const DoviRpuDataMapping *dovi_rpu_get_data_mapping(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RpuDataMapping.
+ */
+void dovi_rpu_free_data_mapping(const DoviRpuDataMapping *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi VdrDmData struct.
+ */
+const DoviVdrDmData *dovi_rpu_get_vdr_dm_data(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the VdrDmData struct.
+ */
+void dovi_rpu_free_vdr_dm_data(const DoviVdrDmData *ptr);
+
+/**
+ * # Safety
+ * The pointer to the file path must be valid.
+ *
+ * Parses an existing RPU binary file.
+ *
+ * Returns the heap allocated `DoviRpuList` as a pointer.
+ * The returned pointer may be null, or the list could be empty if an error occurred.
+ */
+const DoviRpuOpaqueList *dovi_parse_rpu_bin_file(const char *path);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the DoviRpuOpaqueList struct.
+ */
+void dovi_rpu_list_free(const DoviRpuOpaqueList *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Sets the L5 metadata active area offsets.
+ * If there is no L5 block present, it is created with the offsets.
+ */
+int32_t dovi_rpu_set_active_area_offsets(DoviRpuOpaque *ptr,
+                                         uint16_t left,
+                                         uint16_t right,
+                                         uint16_t top,
+                                         uint16_t bottom);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Converts the existing reshaping/mapping to become no-op.
+ */
+int32_t dovi_rpu_remove_mapping(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as `itu_t_t35_payload_bytes` for AV1 ITU-T T.35 metadata OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_payload(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU a complete AV1 `metadata_itut_t35()` OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_complete(DoviRpuOpaque *ptr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* DOVI_H */

--- a/DV7/libdovi/android-x86_64/include/libdovi/rpu_parser.h
+++ b/DV7/libdovi/android-x86_64/include/libdovi/rpu_parser.h
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef DOVI_H
+#define DOVI_H
+
+
+#define RPU_PARSER_MAJOR 3
+#define RPU_PARSER_MINOR 3
+#define RPU_PARSER_PATCH 2
+
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define DoviNUM_COMPONENTS 3
+
+/**
+ * Opaque Dolby Vision RPU.
+ *
+ * Use dovi_rpu_free to free.
+ * It should be freed regardless of whether or not an error occurred.
+ */
+typedef struct DoviRpuOpaque DoviRpuOpaque;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const uint8_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviData;
+
+/**
+ * C struct for rpu_data_header()
+ */
+typedef struct {
+    /**
+     * Profile guessed from the values in the header
+     */
+    uint8_t guessed_profile;
+    /**
+     * Enhancement layer type (FEL or MEL) if the RPU is profile 7
+     * null pointer if not profile 7
+     */
+    const char *el_type;
+    /**
+     * Deprecated since 3.2.0
+     * The field is not actually part of the RPU header
+     */
+    uint8_t rpu_nal_prefix;
+    uint8_t rpu_type;
+    uint16_t rpu_format;
+    uint8_t vdr_rpu_profile;
+    uint8_t vdr_rpu_level;
+    bool vdr_seq_info_present_flag;
+    bool chroma_resampling_explicit_filter_flag;
+    uint8_t coefficient_data_type;
+    uint64_t coefficient_log2_denom;
+    uint8_t vdr_rpu_normalized_idc;
+    bool bl_video_full_range_flag;
+    uint64_t bl_bit_depth_minus8;
+    uint64_t el_bit_depth_minus8;
+    uint64_t vdr_bit_depth_minus8;
+    bool spatial_resampling_filter_flag;
+    uint8_t reserved_zero_3bits;
+    bool el_spatial_resampling_filter_flag;
+    bool disable_residual_flag;
+    bool vdr_dm_metadata_present_flag;
+    bool use_prev_vdr_rpu_flag;
+    uint64_t prev_vdr_rpu_id;
+} DoviRpuDataHeader;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint16_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU16Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer. Can be null if length is zero.
+     */
+    const uint64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviU64Data;
+
+/**
+ * Struct representing a data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the data buffer
+     */
+    const int64_t *data;
+    /**
+     * Data buffer size
+     */
+    size_t len;
+} DoviI64Data;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviI64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data2D;
+
+/**
+ * Struct representing a 2D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of Data structs
+     */
+    const DoviU64Data *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data2D;
+
+typedef struct {
+    DoviU64Data poly_order_minus1;
+    DoviData linear_interp_flag;
+    DoviI64Data2D poly_coef_int;
+    DoviU64Data2D poly_coef;
+} DoviPolynomialCurve;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of I64Data2D structs
+     */
+    const DoviI64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviI64Data3D;
+
+/**
+ * Struct representing a 3D data buffer
+ */
+typedef struct {
+    /**
+     * Pointer to the list of U64Data2D structs
+     */
+    const DoviU64Data2D *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviU64Data3D;
+
+typedef struct {
+    DoviData mmr_order_minus1;
+    DoviI64Data mmr_constant_int;
+    DoviU64Data mmr_constant;
+    DoviI64Data3D mmr_coef_int;
+    DoviU64Data3D mmr_coef;
+} DoviMMRCurve;
+
+typedef struct {
+    /**
+     * [2, 9]
+     */
+    uint64_t num_pivots_minus2;
+    DoviU16Data pivots;
+    /**
+     * Consistent for a component
+     * Luma (component 0): Polynomial = 0
+     * Chroma (components 1 and 2): MMR = 1
+     */
+    uint8_t mapping_idc;
+    /**
+     * mapping_idc = 0, null pointer otherwise
+     */
+    const DoviPolynomialCurve *polynomial;
+    /**
+     * mapping_idc = 1, null pointer otherwise
+     */
+    const DoviMMRCurve *mmr;
+} DoviReshapingCurve;
+
+/**
+ * C struct for rpu_data_nlq()
+ */
+typedef struct {
+    uint16_t nlq_offset[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max_int[DoviNUM_COMPONENTS];
+    uint64_t vdr_in_max[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_slope[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold_int[DoviNUM_COMPONENTS];
+    uint64_t linear_deadzone_threshold[DoviNUM_COMPONENTS];
+} DoviRpuDataNlq;
+
+/**
+ * C struct for rpu_data_mapping()
+ */
+typedef struct {
+    uint64_t vdr_rpu_id;
+    uint64_t mapping_color_space;
+    uint64_t mapping_chroma_format_idc;
+    uint64_t num_x_partitions_minus1;
+    uint64_t num_y_partitions_minus1;
+    DoviReshapingCurve curves[DoviNUM_COMPONENTS];
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_method_idc;
+    /**
+     * Set to -1 to represent Option::None
+     */
+    int32_t nlq_num_pivots_minus2;
+    /**
+     * Length of zero when not present. Only present in profile 4 and 7.
+     */
+    DoviU16Data nlq_pred_pivot_value;
+    /**
+     * Pointer to `RpuDataNlq` struct, null if not dual layer profile
+     */
+    const DoviRpuDataNlq *nlq;
+} DoviRpuDataMapping;
+
+/**
+ * Statistical analysis of the frame: min, max, avg brightness.
+ */
+typedef struct {
+    uint16_t min_pq;
+    uint16_t max_pq;
+    uint16_t avg_pq;
+} DoviExtMetadataBlockLevel1;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ */
+typedef struct {
+    uint16_t target_max_pq;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    int16_t ms_weight;
+} DoviExtMetadataBlockLevel2;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel2 structs
+     */
+    const DoviExtMetadataBlockLevel2 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel2BlockList;
+
+/**
+ * Level 1 offsets.
+ */
+typedef struct {
+    uint16_t min_pq_offset;
+    uint16_t max_pq_offset;
+    uint16_t avg_pq_offset;
+} DoviExtMetadataBlockLevel3;
+
+/**
+ * Something about temporal stability
+ */
+typedef struct {
+    uint16_t anchor_pq;
+    uint16_t anchor_power;
+} DoviExtMetadataBlockLevel4;
+
+/**
+ * Active area of the picture (letterbox, aspect ratio)
+ */
+typedef struct {
+    uint16_t active_area_left_offset;
+    uint16_t active_area_right_offset;
+    uint16_t active_area_top_offset;
+    uint16_t active_area_bottom_offset;
+} DoviExtMetadataBlockLevel5;
+
+/**
+ * ST2086/HDR10 metadata fallback
+ */
+typedef struct {
+    uint16_t max_display_mastering_luminance;
+    uint16_t min_display_mastering_luminance;
+    uint16_t max_content_light_level;
+    uint16_t max_frame_average_light_level;
+} DoviExtMetadataBlockLevel6;
+
+/**
+ * Creative intent trim passes per target display peak brightness
+ * For CM v4.0, L8 metadata only is present and used to compute L2
+ *
+ * This block can have varying byte lengths: 10, 12, 13, 19, 25
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 10: ms_weight
+ *     - 12: target_mid_contrast
+ *     - 13: clip_trim
+ *     - 19: saturation_vector_field[0-5]
+ *     - 25: hue_vector_field[0-5]
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t trim_slope;
+    uint16_t trim_offset;
+    uint16_t trim_power;
+    uint16_t trim_chroma_weight;
+    uint16_t trim_saturation_gain;
+    uint16_t ms_weight;
+    uint16_t target_mid_contrast;
+    uint16_t clip_trim;
+    uint8_t saturation_vector_field0;
+    uint8_t saturation_vector_field1;
+    uint8_t saturation_vector_field2;
+    uint8_t saturation_vector_field3;
+    uint8_t saturation_vector_field4;
+    uint8_t saturation_vector_field5;
+    uint8_t hue_vector_field0;
+    uint8_t hue_vector_field1;
+    uint8_t hue_vector_field2;
+    uint8_t hue_vector_field3;
+    uint8_t hue_vector_field4;
+    uint8_t hue_vector_field5;
+} DoviExtMetadataBlockLevel8;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel8 structs
+     */
+    const DoviExtMetadataBlockLevel8 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel8BlockList;
+
+/**
+ * Source/mastering display color primaries
+ *
+ * This block can have varying byte lengths: 1 or 17
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 1: source_primary_index
+ *     - 17: source_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t source_primary_index;
+    uint16_t source_primary_red_x;
+    uint16_t source_primary_red_y;
+    uint16_t source_primary_green_x;
+    uint16_t source_primary_green_y;
+    uint16_t source_primary_blue_x;
+    uint16_t source_primary_blue_y;
+    uint16_t source_primary_white_x;
+    uint16_t source_primary_white_y;
+} DoviExtMetadataBlockLevel9;
+
+/**
+ * Custom target display information
+ *
+ * This block can have varying byte lengths: 5 or 21
+ * Depending on the length, the fields parsed default to zero and may not be set.
+ * Up to (including):
+ *     - 5: target_primary_index
+ *     - 21: target_primary_{red,green,blue,white}_{x,y}
+ */
+typedef struct {
+    uint64_t length;
+    uint8_t target_display_index;
+    uint16_t target_max_pq;
+    uint16_t target_min_pq;
+    uint8_t target_primary_index;
+    uint16_t target_primary_red_x;
+    uint16_t target_primary_red_y;
+    uint16_t target_primary_green_x;
+    uint16_t target_primary_green_y;
+    uint16_t target_primary_blue_x;
+    uint16_t target_primary_blue_y;
+    uint16_t target_primary_white_x;
+    uint16_t target_primary_white_y;
+} DoviExtMetadataBlockLevel10;
+
+typedef struct {
+    /**
+     * Pointer to the list of ExtMetadataBlockLevel10 structs
+     */
+    const DoviExtMetadataBlockLevel10 *const *list;
+    /**
+     * List length
+     */
+    size_t len;
+} DoviLevel10BlockList;
+
+/**
+ * Content type metadata level
+ */
+typedef struct {
+    uint8_t content_type;
+    uint8_t whitepoint;
+    bool reference_mode_flag;
+    uint8_t reserved_byte2;
+    uint8_t reserved_byte3;
+} DoviExtMetadataBlockLevel11;
+
+/**
+ * Metadata level present in CM v4.0
+ */
+typedef struct {
+    uint8_t dm_mode;
+    uint8_t dm_version_index;
+} DoviExtMetadataBlockLevel254;
+
+/**
+ * Metadata level optionally present in CM v2.9.
+ * Different display modes (calibration/verify/bypass), debugging
+ */
+typedef struct {
+    uint8_t dm_run_mode;
+    uint8_t dm_run_version;
+    uint8_t dm_debug0;
+    uint8_t dm_debug1;
+    uint8_t dm_debug2;
+    uint8_t dm_debug3;
+} DoviExtMetadataBlockLevel255;
+
+/**
+ * C struct for the list of ext_metadata_block()
+ */
+typedef struct {
+    /**
+     * Number of metadata blocks
+     */
+    uint64_t num_ext_blocks;
+    const DoviExtMetadataBlockLevel1 *level1;
+    DoviLevel2BlockList level2;
+    const DoviExtMetadataBlockLevel3 *level3;
+    const DoviExtMetadataBlockLevel4 *level4;
+    const DoviExtMetadataBlockLevel5 *level5;
+    const DoviExtMetadataBlockLevel6 *level6;
+    DoviLevel8BlockList level8;
+    const DoviExtMetadataBlockLevel9 *level9;
+    DoviLevel10BlockList level10;
+    const DoviExtMetadataBlockLevel11 *level11;
+    const DoviExtMetadataBlockLevel254 *level254;
+    const DoviExtMetadataBlockLevel255 *level255;
+} DoviDmData;
+
+/**
+ * C struct for vdr_dm_data()
+ */
+typedef struct {
+    bool compressed;
+    uint64_t affected_dm_metadata_id;
+    uint64_t current_dm_metadata_id;
+    uint64_t scene_refresh_flag;
+    int16_t ycc_to_rgb_coef0;
+    int16_t ycc_to_rgb_coef1;
+    int16_t ycc_to_rgb_coef2;
+    int16_t ycc_to_rgb_coef3;
+    int16_t ycc_to_rgb_coef4;
+    int16_t ycc_to_rgb_coef5;
+    int16_t ycc_to_rgb_coef6;
+    int16_t ycc_to_rgb_coef7;
+    int16_t ycc_to_rgb_coef8;
+    uint32_t ycc_to_rgb_offset0;
+    uint32_t ycc_to_rgb_offset1;
+    uint32_t ycc_to_rgb_offset2;
+    int16_t rgb_to_lms_coef0;
+    int16_t rgb_to_lms_coef1;
+    int16_t rgb_to_lms_coef2;
+    int16_t rgb_to_lms_coef3;
+    int16_t rgb_to_lms_coef4;
+    int16_t rgb_to_lms_coef5;
+    int16_t rgb_to_lms_coef6;
+    int16_t rgb_to_lms_coef7;
+    int16_t rgb_to_lms_coef8;
+    uint16_t signal_eotf;
+    uint16_t signal_eotf_param0;
+    uint16_t signal_eotf_param1;
+    uint32_t signal_eotf_param2;
+    uint8_t signal_bit_depth;
+    uint8_t signal_color_space;
+    uint8_t signal_chroma_format;
+    uint8_t signal_full_range_flag;
+    uint16_t source_min_pq;
+    uint16_t source_max_pq;
+    uint16_t source_diagonal;
+    DoviDmData dm_data;
+} DoviVdrDmData;
+
+/**
+ * Heap allocated list of valid RPU pointers
+ */
+typedef struct {
+    DoviRpuOpaque *const *list;
+    size_t len;
+    const char *error;
+} DoviRpuOpaqueList;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision RPU from unescaped byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_rpu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a AV1 ITU-T T.35 metadata OBU byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_itu_t35_dovi_metadata_obu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the data must be valid.
+ *
+ * Parse a Dolby Vision from a (possibly) escaped HEVC UNSPEC 62 NAL unit byte buffer.
+ * Adds an error if the parsing fails.
+ */
+DoviRpuOpaque *dovi_parse_unspec62_nalu(const uint8_t *buf, size_t len);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ * Avoid using on opaque pointers obtained through `dovi_parse_rpu_bin_file`.
+ *
+ * Free the RpuOpaque
+ */
+void dovi_rpu_free(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the last logged error for the RpuOpaque operations.
+ *
+ * On invalid parsing, an error is added.
+ * The user should manually verify if there is an error, as the parsing does not return an error code.
+ */
+const char *dovi_rpu_get_error(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The data pointer should exist, and be allocated by Rust.
+ *
+ * Free a Data buffer
+ */
+void dovi_data_free(const DoviData *data);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as a byte buffer.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_rpu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU, escapes the bytes for HEVC and prepends the buffer with 0x7C01.
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_unspec62_nalu(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ * The mode must be between 0 and 4.
+ *
+ * Converts the RPU to be compatible with a different Dolby Vision profile.
+ * Possible modes:
+ *     - 0: Don't modify the RPU
+ *     - 1: Converts the RPU to be MEL compatible
+ *     - 2: Converts the RPU to be profile 8.1 compatible. Both luma and chroma mapping curves are set to no-op.
+ *          This mode handles source profiles 5, 7 and 8.
+ *     - 3: Converts to static profile 8.4
+ *     - 4: Converts to profile 8.1 preserving luma and chroma mapping. Old mode 2 behaviour.
+ *
+ * If an error occurs, it is logged to RpuOpaque.error.
+ * Returns 0 if successful, -1 otherwise.
+ */
+int32_t dovi_convert_rpu_with_mode(DoviRpuOpaque *ptr,
+                                   uint8_t mode);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RPU header struct.
+ */
+const DoviRpuDataHeader *dovi_rpu_get_header(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RPU header.
+ */
+void dovi_rpu_free_header(const DoviRpuDataHeader *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi RpuDataMapping struct.
+ */
+const DoviRpuDataMapping *dovi_rpu_get_data_mapping(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the RpuDataMapping.
+ */
+void dovi_rpu_free_data_mapping(const DoviRpuDataMapping *ptr);
+
+/**
+ * # Safety
+ * The pointer to the opaque struct must be valid.
+ *
+ * Get the DoVi VdrDmData struct.
+ */
+const DoviVdrDmData *dovi_rpu_get_vdr_dm_data(const DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the VdrDmData struct.
+ */
+void dovi_rpu_free_vdr_dm_data(const DoviVdrDmData *ptr);
+
+/**
+ * # Safety
+ * The pointer to the file path must be valid.
+ *
+ * Parses an existing RPU binary file.
+ *
+ * Returns the heap allocated `DoviRpuList` as a pointer.
+ * The returned pointer may be null, or the list could be empty if an error occurred.
+ */
+const DoviRpuOpaqueList *dovi_parse_rpu_bin_file(const char *path);
+
+/**
+ * # Safety
+ * The pointer to the struct must be valid.
+ *
+ * Frees the memory used by the DoviRpuOpaqueList struct.
+ */
+void dovi_rpu_list_free(const DoviRpuOpaqueList *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Sets the L5 metadata active area offsets.
+ * If there is no L5 block present, it is created with the offsets.
+ */
+int32_t dovi_rpu_set_active_area_offsets(DoviRpuOpaque *ptr,
+                                         uint16_t left,
+                                         uint16_t right,
+                                         uint16_t top,
+                                         uint16_t bottom);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Converts the existing reshaping/mapping to become no-op.
+ */
+int32_t dovi_rpu_remove_mapping(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU as `itu_t_t35_payload_bytes` for AV1 ITU-T T.35 metadata OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_payload(DoviRpuOpaque *ptr);
+
+/**
+ * # Safety
+ * The struct pointer must be valid.
+ *
+ * Writes the encoded RPU a complete AV1 `metadata_itut_t35()` OBU
+ * If an error occurs in the writing, it is logged to RpuOpaque.error
+ */
+const DoviData *dovi_write_av1_rpu_metadata_obu_t35_complete(DoviRpuOpaque *ptr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* DOVI_H */

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,26 @@
     alias(libs.plugins.kotlin.serialization)
 }
 
+import java.io.File
 import java.util.Properties
+
+fun parseBooleanProperty(value: String?): Boolean {
+    val normalized = value?.trim()?.lowercase() ?: return false
+    return normalized == "1" || normalized == "true" || normalized == "yes" || normalized == "on"
+}
+
+fun resolveProperty(dev: Properties, local: Properties, key: String, fallback: String = ""): String {
+    return dev.getProperty(key)?.trim()?.takeIf { it.isNotBlank() }
+        ?: local.getProperty(key)?.trim()?.takeIf { it.isNotBlank() }
+        ?: fallback
+}
+
+fun cmakePath(path: String): String {
+    if (path.isBlank()) return ""
+    val file = File(path)
+    val resolved = if (file.isAbsolute) file else rootProject.file(path)
+    return resolved.absolutePath.replace("\\", "/")
+}
 
 val localProperties = Properties().apply {
     val localPropertiesFile = rootProject.file("local.properties")
@@ -23,6 +42,19 @@ val devProperties = Properties().apply {
         load(devPropertiesFile.inputStream())
     }
 }
+
+val enableDoviNative = parseBooleanProperty(
+    resolveProperty(devProperties, localProperties, "DOVI_NATIVE_ENABLED")
+)
+val doviExtractorHookReady = parseBooleanProperty(
+    resolveProperty(devProperties, localProperties, "DOVI_EXTRACTOR_HOOK_READY")
+)
+val doviEnableRealLink = parseBooleanProperty(
+    resolveProperty(devProperties, localProperties, "DOVI_ENABLE_REAL_LINK")
+)
+val doviStaticLibPath = resolveProperty(devProperties, localProperties, "DOVI_LIBDOVI_STATIC_LIB")
+val doviIncludeDirPath = resolveProperty(devProperties, localProperties, "DOVI_LIBDOVI_INCLUDE_DIR")
+val doviPrebuiltRootPath = resolveProperty(devProperties, localProperties, "DOVI_LIBDOVI_PREBUILT_ROOT")
 
 fun env(name: String): String? = providers.environmentVariable(name).orNull
 
@@ -70,6 +102,20 @@ android {
         buildConfigField("String", "TRAKT_REDIRECT_URI", "\"${localProperties.getProperty("TRAKT_REDIRECT_URI", "urn:ietf:wg:oauth:2.0:oob")}\"")
         buildConfigField("String", "TMDB_API_KEY", "\"${localProperties.getProperty("TMDB_API_KEY", "")}\"")
         buildConfigField("String", "TV_LOGIN_WEB_BASE_URL", "\"${localProperties.getProperty("TV_LOGIN_WEB_BASE_URL", "https://app.nuvio.tv/tv-login")}\"")
+        buildConfigField("boolean", "DOVI_NATIVE_ENABLED", enableDoviNative.toString())
+        buildConfigField("boolean", "DOVI_EXTRACTOR_HOOK_READY", doviExtractorHookReady.toString())
+        if (enableDoviNative) {
+            externalNativeBuild {
+                cmake {
+                    arguments(
+                        "-DDOVI_ENABLE_LIBDOVI=${if (doviEnableRealLink) "ON" else "OFF"}",
+                        "-DDOVI_LIBDOVI_STATIC_LIB=${cmakePath(doviStaticLibPath)}",
+                        "-DDOVI_LIBDOVI_INCLUDE_DIR=${cmakePath(doviIncludeDirPath)}",
+                        "-DDOVI_LIBDOVI_PREBUILT_ROOT=${cmakePath(doviPrebuiltRootPath)}"
+                    )
+                }
+            }
+        }
         buildConfigField("String", "DONATIONS_BASE_URL", "\"${localProperties.getProperty("DONATIONS_BASE_URL", "")}\"")
         buildConfigField("String", "DONATIONS_DONATE_URL", "\"${localProperties.getProperty("DONATIONS_DONATE_URL", "")}\"")
         buildConfigField("String", "AVATAR_PUBLIC_BASE_URL", "\"${localProperties.getProperty("AVATAR_PUBLIC_BASE_URL", "")}\"")
@@ -97,6 +143,14 @@ android {
             buildConfigField("boolean", "FEATURE_IN_APP_UPDATES_ENABLED", "false")
             buildConfigField("boolean", "FEATURE_IN_APP_TRAILERS_ENABLED", "false")
             buildConfigField("boolean", "FEATURE_EXTERNAL_TRAILERS_ENABLED", "true")
+        }
+    }
+
+    if (enableDoviNative) {
+        externalNativeBuild {
+            cmake {
+                path = file("src/main/cpp/CMakeLists.txt")
+            }
         }
     }
 
@@ -240,7 +294,8 @@ composeCompiler {
     stabilityConfigurationFiles.add(rootProject.layout.projectDirectory.file("compose_stability_config.conf"))
 }
 
-// Globally exclude stock media3-exoplayer and media3-ui — replaced by forked local AARs
+// Globally exclude stock media3-exoplayer and media3-ui — replaced by the
+// prebuilt forked AARs (lib-exoplayer-release.aar / lib-ui-release.aar).
 configurations.all {
     exclude(group = "androidx.media3", module = "media3-exoplayer")
     exclude(group = "androidx.media3", module = "media3-ui")
@@ -259,6 +314,12 @@ baselineProfile {
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     val composeBom = platform("androidx.compose:compose-bom:2026.01.01")
+
+    // Source-retention nullness annotations (MonotonicNonNull / RequiresNonNull /
+    // EnsuresNonNull) used by the vendored Matroska extractor in
+    // com.nuvio.tv.core.player.dvmkv. Media3 keeps these compileOnly in its own
+    // build, so they aren't on our classpath via the prebuilt AARs.
+    compileOnly("org.checkerframework:checker-qual:3.43.0")
 
     baselineProfile(project(":baselineprofile"))
     implementation(libs.androidx.core.ktx)
@@ -310,9 +371,9 @@ dependencies {
     // ViewModel
     implementation(libs.lifecycle.viewmodel.compose)
 
-    // Media3 ExoPlayer — using custom forked ExoPlayer from local AARs (like Just Player)
-    // The forked lib-exoplayer-release.aar replaces stock media3-exoplayer (globally excluded above)
-    // lib-ui-release.aar replaces stock media3-ui (globally excluded above)
+    // Media3 core modules. media3-exoplayer and media3-ui are globally excluded
+    // (above) and replaced by the prebuilt forked AARs below; everything else is
+    // stock Maven.
     implementation(libs.media3.exoplayer.hls)
     implementation(libs.media3.exoplayer.dash)
     implementation(libs.media3.exoplayer.smoothstreaming)
@@ -325,7 +386,6 @@ dependencies {
     implementation(libs.media3.container)
     implementation(libs.media3.extractor)
 
-    
     // Local AAR libraries from forked ExoPlayer (matching Just Player setup):
     // - lib-exoplayer-release.aar    — Custom forked ExoPlayer core (replaces media3-exoplayer)
     // - lib-ui-release.aar           — Custom forked ExoPlayer UI
@@ -391,7 +451,7 @@ dependencies {
 
     // Performance profiling
     implementation("androidx.metrics:metrics-performance:1.0.0-rc01")  // JankStats
-    debugImplementation("androidx.compose.runtime:runtime-tracing")     
+    debugImplementation("androidx.compose.runtime:runtime-tracing")
 
     add("fullImplementation", "org.webjars.npm:crypto-js:4.2.0")
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(dovi_bridge LANGUAGES C CXX)
+
+option(DOVI_ENABLE_LIBDOVI "Link against a real libdovi static library" OFF)
+set(DOVI_LIBDOVI_STATIC_LIB "" CACHE FILEPATH "Path to libdovi static archive (.a)")
+set(DOVI_LIBDOVI_INCLUDE_DIR "" CACHE PATH "Path to libdovi C headers")
+set(DOVI_LIBDOVI_PREBUILT_ROOT "" CACHE PATH "Root path containing ABI folders for prebuilt libdovi artifacts")
+
+add_library(
+    dovi_bridge
+    SHARED
+    dovi_bridge.cpp
+)
+
+find_library(log-lib log)
+
+target_compile_features(dovi_bridge PRIVATE cxx_std_17)
+target_compile_options(dovi_bridge PRIVATE -Wall -Wextra -Wno-unused-parameter)
+
+set(_dovi_resolved_static_lib "")
+set(_dovi_resolved_include_dir "")
+
+if (DOVI_ENABLE_LIBDOVI)
+    if (EXISTS "${DOVI_LIBDOVI_STATIC_LIB}")
+        set(_dovi_resolved_static_lib "${DOVI_LIBDOVI_STATIC_LIB}")
+        if (EXISTS "${DOVI_LIBDOVI_INCLUDE_DIR}")
+            set(_dovi_resolved_include_dir "${DOVI_LIBDOVI_INCLUDE_DIR}")
+        endif()
+    else()
+        set(_dovi_prebuilt_root "${DOVI_LIBDOVI_PREBUILT_ROOT}")
+        if (NOT _dovi_prebuilt_root)
+            get_filename_component(_repo_root "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+            set(_dovi_prebuilt_root "${_repo_root}/DV7/libdovi")
+        endif()
+
+        set(_dovi_abi_dir "")
+        if (ANDROID_ABI STREQUAL "arm64-v8a")
+            set(_dovi_abi_dir "android-arm64")
+        elseif (ANDROID_ABI STREQUAL "armeabi-v7a")
+            set(_dovi_abi_dir "android-armeabi-v7a")
+        elseif (ANDROID_ABI STREQUAL "x86")
+            set(_dovi_abi_dir "android-x86")
+        elseif (ANDROID_ABI STREQUAL "x86_64")
+            set(_dovi_abi_dir "android-x86_64")
+        endif()
+
+        if (_dovi_abi_dir)
+            set(_dovi_candidate_static_lib "${_dovi_prebuilt_root}/${_dovi_abi_dir}/lib/libdovi.a")
+            set(_dovi_candidate_include_dir "${_dovi_prebuilt_root}/${_dovi_abi_dir}/include")
+            if (EXISTS "${_dovi_candidate_static_lib}")
+                set(_dovi_resolved_static_lib "${_dovi_candidate_static_lib}")
+                if (EXISTS "${_dovi_candidate_include_dir}")
+                    set(_dovi_resolved_include_dir "${_dovi_candidate_include_dir}")
+                endif()
+            endif()
+        endif()
+    endif()
+endif()
+
+if (DOVI_ENABLE_LIBDOVI
+    AND EXISTS "${_dovi_resolved_static_lib}")
+    add_library(dovi_static STATIC IMPORTED)
+    set_target_properties(dovi_static PROPERTIES IMPORTED_LOCATION "${_dovi_resolved_static_lib}")
+    if (EXISTS "${_dovi_resolved_include_dir}")
+        target_include_directories(dovi_bridge PRIVATE "${_dovi_resolved_include_dir}")
+    endif()
+    target_compile_definitions(dovi_bridge PRIVATE DOVI_REAL_LINKED=1)
+    message(STATUS "libdovi enabled for ABI=${ANDROID_ABI} lib=${_dovi_resolved_static_lib}")
+    target_link_libraries(dovi_bridge dovi_static ${log-lib})
+else()
+    target_compile_definitions(dovi_bridge PRIVATE DOVI_REAL_LINKED=0)
+    if (DOVI_ENABLE_LIBDOVI)
+        message(WARNING "libdovi requested but no static library resolved for ABI=${ANDROID_ABI}. Using stub mode.")
+    endif()
+    target_link_libraries(dovi_bridge ${log-lib})
+endif()

--- a/app/src/main/cpp/dovi_bridge.cpp
+++ b/app/src/main/cpp/dovi_bridge.cpp
@@ -1,0 +1,197 @@
+#include <jni.h>
+#include <android/log.h>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#define LOG_TAG "DoviBridgeNative"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
+
+#ifndef DOVI_REAL_LINKED
+#define DOVI_REAL_LINKED 0
+#endif
+
+#if DOVI_REAL_LINKED
+extern "C" {
+typedef struct DoviRpuOpaque DoviRpuOpaque;
+typedef struct DoviData {
+    const uint8_t* data;
+    size_t len;
+} DoviData;
+
+DoviRpuOpaque* dovi_parse_unspec62_nalu(const uint8_t* buf, size_t len);
+DoviRpuOpaque* dovi_parse_rpu(const uint8_t* buf, size_t len);
+const char* dovi_rpu_get_error(const DoviRpuOpaque* ptr);
+void dovi_rpu_free(DoviRpuOpaque* ptr);
+int32_t dovi_convert_rpu_with_mode(DoviRpuOpaque* ptr, uint8_t mode);
+const DoviData* dovi_write_unspec62_nalu(DoviRpuOpaque* ptr);
+void dovi_data_free(const DoviData* data);
+}
+
+static inline bool dovi_has_error(const DoviRpuOpaque* rpu, std::string* out_error) {
+    if (rpu == nullptr) {
+        if (out_error != nullptr) {
+            *out_error = "null-rpu";
+        }
+        return true;
+    }
+
+    const char* error = dovi_rpu_get_error(rpu);
+    if (error == nullptr || error[0] == '\0') {
+        return false;
+    }
+
+    if (out_error != nullptr) {
+        *out_error = error;
+    }
+    return true;
+}
+
+static inline DoviRpuOpaque* dovi_parse_any_rpu(const std::vector<uint8_t>& payload, std::string* out_error) {
+    if (payload.empty()) {
+        if (out_error != nullptr) {
+            *out_error = "empty-input";
+        }
+        return nullptr;
+    }
+
+    std::string parse_error;
+    DoviRpuOpaque* parsed = dovi_parse_unspec62_nalu(payload.data(), payload.size());
+    if (parsed != nullptr && !dovi_has_error(parsed, &parse_error)) {
+        return parsed;
+    }
+    if (parsed != nullptr) {
+        dovi_rpu_free(parsed);
+    }
+
+    parsed = dovi_parse_rpu(payload.data(), payload.size());
+    if (parsed != nullptr && !dovi_has_error(parsed, &parse_error)) {
+        return parsed;
+    }
+    if (parsed != nullptr) {
+        dovi_rpu_free(parsed);
+    }
+
+    if (out_error != nullptr) {
+        *out_error = parse_error.empty() ? "failed-parse-rpu" : parse_error;
+    }
+    return nullptr;
+}
+
+static inline uint8_t map_conversion_mode(jint mode) {
+    switch (mode) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+            return static_cast<uint8_t>(mode);
+        case 5:
+            return 4U;
+        default:
+            return 2U;
+    }
+}
+#endif
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_nuvio_tv_core_player_DoviBridge_nativeGetBridgeVersion(JNIEnv* env, jclass /* clazz */) {
+#if DOVI_REAL_LINKED
+    return env->NewStringUTF("dovi-bridge-libdovi-capi-0.2");
+#else
+    return env->NewStringUTF("dovi-bridge-stub-0.1");
+#endif
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_nuvio_tv_core_player_DoviBridge_nativeIsConversionPathReady(
+    JNIEnv* /* env */,
+    jclass /* clazz */
+) {
+#if DOVI_REAL_LINKED
+    LOGI("native conversion path: libdovi linked (real mode)");
+    return JNI_TRUE;
+#else
+    LOGI("native conversion path not linked (stub mode)");
+    return JNI_FALSE;
+#endif
+}
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_nuvio_tv_core_player_DoviBridge_nativeConvertDv7RpuToDv81(
+    JNIEnv* env,
+    jclass /* clazz */,
+    jbyteArray payload,
+    jint mode
+) {
+#if DOVI_REAL_LINKED
+    if (payload == nullptr) return nullptr;
+    const jsize len = env->GetArrayLength(payload);
+    if (len <= 0) return nullptr;
+
+    std::vector<uint8_t> input(static_cast<size_t>(len));
+    env->GetByteArrayRegion(payload, 0, len, reinterpret_cast<jbyte*>(input.data()));
+
+    std::string parse_error;
+    DoviRpuOpaque* rpu = dovi_parse_any_rpu(input, &parse_error);
+    if (rpu == nullptr) {
+        LOGW("libdovi parse failed: %s", parse_error.c_str());
+        return nullptr;
+    }
+
+    const uint8_t conversion_mode = map_conversion_mode(mode);
+    if (dovi_convert_rpu_with_mode(rpu, conversion_mode) < 0) {
+        std::string convert_error;
+        dovi_has_error(rpu, &convert_error);
+        LOGW(
+            "libdovi convert failed (mode=%u): %s",
+            static_cast<unsigned int>(conversion_mode),
+            convert_error.empty() ? "unknown" : convert_error.c_str()
+        );
+        dovi_rpu_free(rpu);
+        return nullptr;
+    }
+
+    const DoviData* out_data = dovi_write_unspec62_nalu(rpu);
+    if (out_data == nullptr || out_data->data == nullptr || out_data->len == 0U) {
+        std::string write_error;
+        dovi_has_error(rpu, &write_error);
+        LOGW("libdovi write failed: %s", write_error.empty() ? "unknown" : write_error.c_str());
+        if (out_data != nullptr) {
+            dovi_data_free(out_data);
+        }
+        dovi_rpu_free(rpu);
+        return nullptr;
+    }
+
+    if (out_data->len > static_cast<size_t>(INT32_MAX)) {
+        LOGW("libdovi output too large: %zu", out_data->len);
+        dovi_data_free(out_data);
+        dovi_rpu_free(rpu);
+        return nullptr;
+    }
+
+    jbyteArray out = env->NewByteArray(static_cast<jsize>(out_data->len));
+    if (out == nullptr) {
+        dovi_data_free(out_data);
+        dovi_rpu_free(rpu);
+        return nullptr;
+    }
+
+    env->SetByteArrayRegion(
+        out,
+        0,
+        static_cast<jsize>(out_data->len),
+        reinterpret_cast<const jbyte*>(out_data->data)
+    );
+    dovi_data_free(out_data);
+    dovi_rpu_free(rpu);
+    // No per-frame log here: it runs once per frame and floods logcat.
+    return out;
+#else
+    LOGI("nativeConvertDv7RpuToDv81 called in stub mode; returning null");
+    return nullptr;
+#endif
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/BitrateAwareLoadControl.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/BitrateAwareLoadControl.kt
@@ -1,0 +1,76 @@
+package com.nuvio.tv.core.player
+
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.analytics.PlayerId
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection
+import androidx.media3.exoplayer.upstream.DefaultAllocator
+
+/**
+ * DefaultLoadControl with a byte target tied to the device memory budget, and a back
+ * buffer / budget that can be adjusted at runtime once we know whether the stream is
+ * really DV7.
+ *
+ * On a DV-capable display AUTO arms conversion for every file, but most never actually
+ * convert. So we build with the full budget and the user's back buffer, then tighten
+ * only for confirmed DV7 via the override setters below.
+ */
+@UnstableApi
+class BitrateAwareLoadControl(
+    minBufferMs: Int,
+    maxBufferMs: Int,
+    bufferForPlaybackMs: Int,
+    bufferForPlaybackAfterRebufferMs: Int,
+    prioritizeTimeOverSizeThresholds: Boolean,
+    backBufferDurationMs: Int,
+    retainBackBufferFromKeyframe: Boolean,
+    /** Memory ceiling in bytes. */
+    private val budgetBytes: Long
+) : DefaultLoadControl(
+    DefaultAllocator(/* trimOnReset= */ true, C.DEFAULT_BUFFER_SEGMENT_SIZE),
+    minBufferMs,
+    maxBufferMs,
+    bufferForPlaybackMs,
+    bufferForPlaybackAfterRebufferMs,
+    /* targetBufferBytes= */ C.LENGTH_UNSET,
+    prioritizeTimeOverSizeThresholds,
+    backBufferDurationMs,
+    retainBackBufferFromKeyframe
+) {
+
+    // Effective back buffer (µs) when >= 0, else the constructed value. The player polls
+    // getBackBufferDurationUs, so this can change mid-playback.
+    @Volatile
+    private var backBufferOverrideUs: Long = -1L
+
+    /** Set the back buffer at runtime; negative restores the constructed value. */
+    fun setBackBufferDurationOverrideMs(ms: Int) {
+        backBufferOverrideUs = if (ms < 0) -1L else ms.toLong() * 1000L
+    }
+
+    // Effective byte budget when >= 0, else the constructed budget. Re-read on track
+    // (re)selection, so this can change mid-playback.
+    @Volatile
+    private var budgetBytesOverride: Long = -1L
+
+    /** Set the byte budget at runtime; negative restores the constructed budget. */
+    fun setBudgetBytesOverride(bytes: Long) {
+        budgetBytesOverride = if (bytes < 0L) -1L else bytes
+    }
+
+    override fun getBackBufferDurationUs(playerId: PlayerId): Long {
+        val override = backBufferOverrideUs
+        return if (override >= 0L) override else super.getBackBufferDurationUs(playerId)
+    }
+
+    override fun calculateTargetBufferBytes(
+        trackSelectionArray: Array<out ExoTrackSelection?>
+    ): Int {
+        // Target = the memory budget. Time (Max Buffer Duration) is the real limit; this is
+        // just the memory cap. Sizing from advertised bitrate starved variable-bitrate peaks,
+        // so let high-bitrate fill up to the budget and low-bitrate stop at the time limit.
+        val effectiveBudget = if (budgetBytesOverride >= 0L) budgetBytesOverride else budgetBytes
+        return effectiveBudget.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
@@ -139,9 +139,10 @@ internal data class DolbyVisionConversionConfig(
 
     /**
      * DV5 via the toggle is signal-only (codec rewritten to 8.1, profile-5 RPU kept). A
-     * libdovi RPU rewrite runs only when a mode is forced in Advanced. DV7 always converts.
+     * libdovi RPU rewrite runs only when a mode is forced in Advanced, OR when the user
+     * explicitly chose Convert to DV8.1 with DV5 enabled. DV7 always converts.
      */
-    val convertDv5Rpu: Boolean get() = forcedMode in 0..4
+    val convertDv5Rpu: Boolean get() = forcedMode in 0..4 || (dv5Enabled && manualDv81)
 
     /** True when a track of [profile] should be converted. */
     fun shouldConvert(profile: Int?): Boolean {

--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
@@ -1,0 +1,547 @@
+package com.nuvio.tv.core.player
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.common.DataReader
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.ParsableByteArray
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.Extractor
+import androidx.media3.extractor.ExtractorInput
+import androidx.media3.extractor.ExtractorOutput
+import androidx.media3.extractor.ExtractorsFactory
+import androidx.media3.extractor.PositionHolder
+import androidx.media3.extractor.SeekMap
+import androidx.media3.extractor.TrackOutput
+import androidx.media3.extractor.text.DefaultSubtitleParserFactory
+import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor as DvMatroskaExtractor
+import java.io.EOFException
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * App-level Dolby Vision Profile 7 to 8.1 conversion that needs no forked Media3.
+ *
+ * It wraps a stock [ExtractorsFactory] and, for video tracks of containers whose
+ * RPU rides in-band as NAL units (MP4 / fMP4 = length-delimited, TS = Annex-B),
+ * intercepts the sample stream at the [TrackOutput] level and rewrites the
+ * Dolby Vision RPU NAL (type 62) via [DoviBridge], drops the enhancement-layer
+ * NAL units, and rewrites the codec string (dvhe.07 becomes dvhe.08).
+ *
+ * Matroska is special: the RPU arrives as BlockAdditional data that stock Media3
+ * discards before any TrackOutput, so for MKV this factory swaps in the vendored
+ * [com.nuvio.tv.core.player.dvmkv.MatroskaExtractor], which surfaces the RPU through
+ * [DolbyVisionMatroskaTransformer].
+ *
+ * For any non-DV7 content (or when [config] is inactive) every wrapper is a strict
+ * pass-through, so normal playback of all formats is unaffected.
+ */
+@UnstableApi
+internal class DolbyVisionExtractorsFactory(
+    private val delegate: ExtractorsFactory,
+    private val config: DolbyVisionConversionConfig
+) : ExtractorsFactory {
+
+    override fun createExtractors(): Array<Extractor> =
+        delegate.createExtractors().map(::wrap).toTypedArray()
+
+    override fun createExtractors(
+        uri: Uri,
+        responseHeaders: Map<String, List<String>>
+    ): Array<Extractor> =
+        delegate.createExtractors(uri, responseHeaders).map(::wrap).toTypedArray()
+
+    private fun wrap(extractor: Extractor): Extractor {
+        if (!config.active) return extractor
+        // Matroska: the DV7 RPU rides in BlockAdditional, which the stock
+        // MatroskaExtractor discards before any TrackOutput. Swap it for the
+        // vendored extractor that surfaces the RPU through a transformer.
+        if (extractor.javaClass.name == STOCK_MATROSKA_EXTRACTOR) {
+            return DvMatroskaExtractor(
+                DefaultSubtitleParserFactory(),
+                /* flags= */ 0,
+                DolbyVisionMatroskaTransformer(config)
+            )
+        }
+        val nalFormat = nalFormatFor(extractor) ?: return extractor
+        return DolbyVisionExtractor(extractor, config, nalFormat)
+    }
+
+    private fun nalFormatFor(extractor: Extractor): NalFormat? {
+        val name = extractor.javaClass.name
+        return when {
+            // RPU is in-band in the sample for these containers, so reachable here.
+            name.contains("FragmentedMp4Extractor") -> NalFormat.LENGTH_DELIMITED
+            name.contains("Mp4Extractor") -> NalFormat.LENGTH_DELIMITED
+            name.contains("TsExtractor") -> NalFormat.ANNEX_B
+            else -> null
+        }
+    }
+
+    private companion object {
+        const val STOCK_MATROSKA_EXTRACTOR = "androidx.media3.extractor.mkv.MatroskaExtractor"
+    }
+}
+
+/** How HEVC NAL units are framed in the sample stream for a given container. */
+internal enum class NalFormat { ANNEX_B, LENGTH_DELIMITED }
+
+/**
+ * Per-playback DV7 to 8.1 conversion diagnostics, fed by the factory/transformer and read
+ * by the player diagnostics. Reset per playback alongside the DoviBridge counters.
+ */
+internal object DolbyVisionConversionStats {
+    private val codecStringRewriteCount = AtomicLong(0)
+    @Volatile private var lastSourceProfile: Int? = null
+    @Volatile private var lastConversionMode: Int? = null
+
+    fun reset() {
+        codecStringRewriteCount.set(0)
+        lastSourceProfile = null
+        lastConversionMode = null
+    }
+
+    /** Records the SOURCE DV profile (pre-conversion), e.g. 7. */
+    fun recordSourceProfile(profile: Int?) {
+        if (profile != null) lastSourceProfile = profile
+    }
+
+    fun recordConversionMode(mode: Int) {
+        lastConversionMode = mode
+    }
+
+    fun recordCodecStringRewrite() {
+        codecStringRewriteCount.incrementAndGet()
+    }
+
+    fun getCodecStringRewriteCount(): Long = codecStringRewriteCount.get()
+    fun getLastSourceProfile(): Int? = lastSourceProfile
+    fun getLastSelectedConversionMode(): Int? = lastConversionMode
+}
+
+/**
+ * Drives the per-stream conversion decision. Mirrors the auto-pick used by the
+ * extractor hook installer: profile-7 default = mode 1 (ToMel); profile-7 with
+ * preserve-mapping = mode 5 (8.1 preserve); profile 5 = mode 3; a [forcedMode]
+ * in 0..4 overrides all of it.
+ */
+internal data class DolbyVisionConversionConfig(
+    val active: Boolean,
+    val forcedMode: Int = -1,
+    val preserveMapping: Boolean = false,
+    val dv5Enabled: Boolean = false,
+    /** True when the user explicitly chose "Convert to DV8.1" (not AUTO). */
+    val manualDv81: Boolean = false
+) {
+    /** Manual mode-2 default with per-RPU fallback to mode 1 (not for AUTO / forced). */
+    val allowMode2Fallback: Boolean get() = manualDv81 && forcedMode !in 0..4
+
+    /**
+     * DV5 via the toggle is signal-only (codec rewritten to 8.1, profile-5 RPU kept). A
+     * libdovi RPU rewrite runs only when a mode is forced in Advanced. DV7 always converts.
+     */
+    val convertDv5Rpu: Boolean get() = forcedMode in 0..4
+
+    /** True when a track of [profile] should be converted. */
+    fun shouldConvert(profile: Int?): Boolean {
+        if (!active) return false
+        return when (profile) {
+            7 -> true
+            // DV5 is already single-layer; only convert it when the user explicitly chose
+            // Convert to DV8.1. AUTO leaves DV5 alone (converting it breaks colors).
+            5 -> dv5Enabled && manualDv81
+            else -> false
+        }
+    }
+
+    /** libdovi conversion mode to use for [profile]. */
+    fun conversionMode(profile: Int?): Int {
+        if (forcedMode in 0..4) return forcedMode
+        return when {
+            (profile == 7 || profile == null) && preserveMapping -> 5
+            profile == 5 -> 3
+            manualDv81 -> 2 // manual Convert to DV8.1 prefers mode 2 (falls back to 1)
+            else -> 1       // AUTO convert stays on mode 1
+        }
+    }
+}
+
+/** Wraps an [Extractor] to inject a DV-rewriting [ExtractorOutput]. */
+@UnstableApi
+private class DolbyVisionExtractor(
+    private val delegate: Extractor,
+    private val config: DolbyVisionConversionConfig,
+    private val nalFormat: NalFormat
+) : Extractor {
+
+    override fun init(output: ExtractorOutput) {
+        delegate.init(DolbyVisionExtractorOutput(output, config, nalFormat))
+    }
+
+    @Throws(IOException::class)
+    override fun sniff(input: ExtractorInput): Boolean = delegate.sniff(input)
+
+    @Throws(IOException::class)
+    override fun read(input: ExtractorInput, seekPosition: PositionHolder): Int =
+        delegate.read(input, seekPosition)
+
+    override fun seek(position: Long, timeUs: Long) = delegate.seek(position, timeUs)
+
+    override fun release() = delegate.release()
+
+    override fun getUnderlyingImplementation(): Extractor = delegate.underlyingImplementation
+}
+
+/** Wraps an [ExtractorOutput] to swap video [TrackOutput]s for DV-rewriting ones. */
+@UnstableApi
+private class DolbyVisionExtractorOutput(
+    private val delegate: ExtractorOutput,
+    private val config: DolbyVisionConversionConfig,
+    private val nalFormat: NalFormat
+) : ExtractorOutput {
+
+    override fun track(id: Int, type: Int): TrackOutput {
+        val track = delegate.track(id, type)
+        return if (type == C.TRACK_TYPE_VIDEO) {
+            DolbyVisionTrackOutput(track, config, nalFormat)
+        } else {
+            track
+        }
+    }
+
+    override fun endTracks() = delegate.endTracks()
+
+    override fun seekMap(seekMap: SeekMap) = delegate.seekMap(seekMap)
+}
+
+/**
+ * The actual RPU-rewriting [TrackOutput]. Buffers a sample's bytes and, on
+ * [sampleMetadata], rewrites the DV RPU NAL (and drops EL NAL units) before
+ * forwarding to the delegate. A no-op pass-through unless the track is a DV
+ * profile the config wants converted.
+ */
+@UnstableApi
+private class DolbyVisionTrackOutput(
+    private val delegate: TrackOutput,
+    private val config: DolbyVisionConversionConfig,
+    private val nalFormat: NalFormat
+) : TrackOutput {
+
+    private val scratch = ParsableByteArray()
+    private var pendingBuf = ByteArray(0)
+    private var pendingLen = 0
+    private var inputScratch = ByteArray(0)
+    private var outBuf = ByteArray(0)
+    private var outLen = 0
+
+    private var converting = false
+    private var rewriteSamples = false
+    private var profile: Int? = null
+    private var codecs: String? = null
+    private var nalLengthFieldLength = 4
+
+    private fun ensurePendingCapacity(extra: Int) {
+        val need = pendingLen + extra
+        if (pendingBuf.size < need) {
+            var newSize = if (pendingBuf.isEmpty()) 16 * 1024 else pendingBuf.size
+            while (newSize < need) newSize = newSize shl 1
+            pendingBuf = pendingBuf.copyOf(newSize)
+        }
+    }
+
+    private fun ensureInputScratch(size: Int) {
+        if (inputScratch.size < size) {
+            var newSize = if (inputScratch.isEmpty()) 16 * 1024 else inputScratch.size
+            while (newSize < size) newSize = newSize shl 1
+            inputScratch = ByteArray(newSize)
+        }
+    }
+
+    private fun outReset() {
+        outLen = 0
+    }
+
+    private fun outEnsureCapacity(extra: Int) {
+        val need = outLen + extra
+        if (outBuf.size < need) {
+            var newSize = if (outBuf.isEmpty()) 16 * 1024 else outBuf.size
+            while (newSize < need) newSize = newSize shl 1
+            outBuf = outBuf.copyOf(newSize)
+        }
+    }
+
+    private fun outWrite(src: ByteArray, srcPos: Int, len: Int) {
+        if (len <= 0) return
+        outEnsureCapacity(len)
+        System.arraycopy(src, srcPos, outBuf, outLen, len)
+        outLen += len
+    }
+
+    private fun outWriteLengthPrefix(value: Int, lengthFieldLength: Int) {
+        outEnsureCapacity(lengthFieldLength)
+        for (i in lengthFieldLength - 1 downTo 0) {
+            outBuf[outLen] = ((value ushr (i * 8)) and 0xFF).toByte()
+            outLen += 1
+        }
+    }
+
+    override fun durationUs(durationUs: Long) = delegate.durationUs(durationUs)
+
+    override fun format(format: Format) {
+        profile = parseDvProfile(format.codecs)
+        converting = config.shouldConvert(profile)
+        // Signal-only DV5 (toggle) just relabels the codec; its samples pass through
+        // untouched, so skip the per-sample buffer/scan entirely.
+        rewriteSamples = converting && !(profile == 5 && !config.convertDv5Rpu)
+        nalLengthFieldLength = parseNalLengthFieldLength(format)
+        var outFormat = format
+        if (converting) {
+            DolbyVisionConversionStats.recordSourceProfile(profile)
+            val rewritten = rewriteDvCodecString(format.codecs)
+            if (rewritten != null && rewritten != format.codecs) {
+                outFormat = format.buildUpon().setCodecs(rewritten).build()
+                DolbyVisionConversionStats.recordCodecStringRewrite()
+            }
+        }
+        codecs = outFormat.codecs
+        delegate.format(outFormat)
+    }
+
+    @Throws(IOException::class)
+    override fun sampleData(
+        input: DataReader,
+        length: Int,
+        allowEndOfInput: Boolean,
+        sampleDataPart: Int
+    ): Int {
+        if (!rewriteSamples) return delegate.sampleData(input, length, allowEndOfInput, sampleDataPart)
+        ensureInputScratch(length)
+        val read = input.read(inputScratch, 0, length)
+        if (read == C.RESULT_END_OF_INPUT) {
+            if (allowEndOfInput) return C.RESULT_END_OF_INPUT
+            throw EOFException()
+        }
+        if (read <= 0) return read
+        if (sampleDataPart == TrackOutput.SAMPLE_DATA_PART_MAIN) {
+            ensurePendingCapacity(read)
+            System.arraycopy(inputScratch, 0, pendingBuf, pendingLen, read)
+            pendingLen += read
+        } else {
+            scratch.reset(inputScratch, read)
+            delegate.sampleData(scratch, read, sampleDataPart)
+        }
+        return read
+    }
+
+    override fun sampleData(
+        data: ParsableByteArray,
+        length: Int,
+        sampleDataPart: Int
+    ) {
+        if (!rewriteSamples || sampleDataPart != TrackOutput.SAMPLE_DATA_PART_MAIN || length <= 0) {
+            delegate.sampleData(data, length, sampleDataPart)
+            return
+        }
+        ensurePendingCapacity(length)
+        data.readBytes(pendingBuf, pendingLen, length)
+        pendingLen += length
+    }
+
+    override fun sampleMetadata(
+        timeUs: Long,
+        flags: Int,
+        size: Int,
+        offset: Int,
+        cryptoData: TrackOutput.CryptoData?
+    ) {
+        if (!rewriteSamples || pendingLen == 0) {
+            delegate.sampleMetadata(timeUs, flags, size, offset, cryptoData)
+            return
+        }
+        // `offset` = trailing buffered bytes that belong to the NEXT sample. Keep
+        // them in `pending` and rewrite only this sample's bytes. We deliver the
+        // rewritten sample fresh and pass offset 0 (nothing delivered after it),
+        // which keeps sizing correct even when the rewrite changes the length.
+        val carrySize = offset.coerceIn(0, pendingLen)
+        val sampleEnd = pendingLen - carrySize
+        val rewrittenLen = when (nalFormat) {
+            NalFormat.ANNEX_B -> rewriteAnnexB(pendingBuf, sampleEnd)
+            NalFormat.LENGTH_DELIMITED -> rewriteLengthDelimited(pendingBuf, sampleEnd, nalLengthFieldLength)
+        }
+        val useRewritten = rewrittenLen > 0
+        val outputData = if (useRewritten) outBuf else pendingBuf
+        val outputLen = if (useRewritten) rewrittenLen else sampleEnd
+        scratch.reset(outputData, outputLen)
+        delegate.sampleData(scratch, outputLen)
+        delegate.sampleMetadata(timeUs, flags, outputLen, 0, cryptoData)
+        if (carrySize > 0) {
+            System.arraycopy(pendingBuf, sampleEnd, pendingBuf, 0, carrySize)
+        }
+        pendingLen = carrySize
+    }
+
+    // ── Length-delimited (MP4 / fMP4) ──
+    private fun rewriteLengthDelimited(sample: ByteArray, sampleLen: Int, lengthFieldLength: Int): Int {
+        if (sampleLen < lengthFieldLength) return -1
+        outReset()
+        var changed = false
+        var pos = 0
+        while (pos + lengthFieldLength <= sampleLen) {
+            var nalSize = 0
+            for (i in 0 until lengthFieldLength) {
+                nalSize = (nalSize shl 8) or (sample[pos + i].toInt() and 0xFF)
+            }
+            val nalStart = pos + lengthFieldLength
+            if (nalSize <= 0 || nalStart + nalSize > sampleLen) return -1
+            val nalType = nalUnitTypeAt(sample, nalStart)
+            val layerId = nuhLayerIdAt(sample, nalStart, nalSize)
+            when {
+                // Enhancement-layer NAL that isn't the RPU: drop it.
+                layerId > 0 && nalType != NAL_TYPE_DV_RPU -> changed = true
+                // RPU NAL: copy out just this small NAL, convert, normalize layer id.
+                nalType == NAL_TYPE_DV_RPU -> {
+                    val nal = sample.copyOfRange(nalStart, nalStart + nalSize)
+                    val transformed = normalizeNuhLayerIdToZero(convertDvRpu(nal) ?: nal)
+                    if (transformed !== nal) changed = true
+                    outWriteLengthPrefix(transformed.size, lengthFieldLength)
+                    outWrite(transformed, 0, transformed.size)
+                }
+                // Base-layer NAL: forward straight from the sample buffer, no copy.
+                else -> {
+                    outWriteLengthPrefix(nalSize, lengthFieldLength)
+                    outWrite(sample, nalStart, nalSize)
+                }
+            }
+            pos = nalStart + nalSize
+        }
+        if (pos != sampleLen) return -1
+        return if (changed) outLen else 0
+    }
+
+    // ── Annex-B (TS) ── ported from H265Reader.DolbyVisionTransformingTrackOutput
+    private fun rewriteAnnexB(sample: ByteArray, sampleLen: Int): Int {
+        outReset()
+        var scan = 0
+        var changed = false
+        while (scan < sampleLen) {
+            val start = findStartCode(sample, scan, sampleLen)
+            if (start < 0) break
+            var next = findStartCode(sample, start + 3, sampleLen)
+            if (next < 0) next = sampleLen
+            if (start > scan) outWrite(sample, scan, start - scan)
+            val scLen = startCodeLength(sample, start, next)
+            val payloadOffset = start + scLen
+            if (payloadOffset >= next) {
+                outWrite(sample, start, next - start)
+            } else {
+                val nalSize = next - payloadOffset
+                val nalType = nalUnitTypeAt(sample, payloadOffset)
+                val layerId = nuhLayerIdAt(sample, payloadOffset, nalSize)
+                when {
+                    // Enhancement-layer NAL that isn't the RPU: drop it.
+                    layerId > 0 && nalType != NAL_TYPE_DV_RPU -> changed = true
+                    // RPU NAL: copy out just this small NAL, convert, normalize layer id.
+                    nalType == NAL_TYPE_DV_RPU -> {
+                        val nal = sample.copyOfRange(payloadOffset, next)
+                        val transformed = normalizeNuhLayerIdToZero(convertDvRpu(nal) ?: nal)
+                        if (transformed !== nal) changed = true
+                        outWrite(sample, start, scLen)
+                        outWrite(transformed, 0, transformed.size)
+                    }
+                    // Base-layer NAL: forward start code + payload straight from the buffer.
+                    else -> outWrite(sample, start, next - start)
+                }
+            }
+            scan = next
+        }
+        if (scan < sampleLen) outWrite(sample, scan, sampleLen - scan)
+        return if (changed) outLen else 0
+    }
+
+    private fun convertDvRpu(nal: ByteArray): ByteArray? {
+        val mode = config.conversionMode(profile)
+        var converted = DoviBridge.convertDv7RpuToDv81(nal, mode)?.takeIf { it.isNotEmpty() }
+        if (converted != null) {
+            DolbyVisionConversionStats.recordConversionMode(mode)
+        } else if (config.allowMode2Fallback && mode == 2) {
+            converted = DoviBridge.convertDv7RpuToDv81(nal, 1)?.takeIf { it.isNotEmpty() }
+            if (converted != null) DolbyVisionConversionStats.recordConversionMode(1)
+        }
+        return converted
+    }
+
+    private companion object {
+        const val NAL_TYPE_DV_RPU = 62
+
+        fun nalUnitTypeAt(data: ByteArray, offset: Int): Int =
+            (data[offset].toInt() ushr 1) and 0x3F
+
+        fun nuhLayerIdAt(data: ByteArray, offset: Int, nalSize: Int): Int {
+            if (nalSize < 2) return 0
+            val b0 = data[offset].toInt() and 0x01
+            val b1 = data[offset + 1].toInt() and 0xF8
+            return (b0 shl 5) or (b1 ushr 3)
+        }
+
+        fun parseDvProfile(codecs: String?): Int? {
+            if (codecs.isNullOrBlank()) return null
+            val m = Regex("^(?:dvhe|dvav|dvh1|dva1)\\.(\\d+)\\.")
+                .find(codecs.trim().lowercase()) ?: return null
+            return m.groupValues[1].toIntOrNull()
+        }
+
+        /** dvhe.05/.07.xx becomes dvhe.08.xx so the Format advertises single-layer 8.1. */
+        fun rewriteDvCodecString(codecs: String?): String? {
+            if (codecs.isNullOrBlank()) return null
+            return Regex("(?i)(dvhe|dvav|dvh1|dva1)\\.0[57]\\.")
+                .replace(codecs) { mr -> "${mr.groupValues[1]}.08." }
+        }
+
+        fun parseNalLengthFieldLength(format: Format): Int {
+            // HEVC hvcC: lengthSizeMinusOne is the low 2 bits of the byte at
+            // index 21. Fall back to the near-universal 4 if not parseable.
+            val csd = format.initializationData.firstOrNull() ?: return 4
+            if (csd.size <= 21) return 4
+            // Only trust it if this looks like an hvcC (configurationVersion == 1).
+            if (csd[0].toInt() != 1) return 4
+            return (csd[21].toInt() and 0x03) + 1
+        }
+
+        fun nuhLayerId(nal: ByteArray): Int {
+            if (nal.size < 2) return 0
+            val b0 = nal[0].toInt() and 0x01
+            val b1 = nal[1].toInt() and 0xF8
+            return (b0 shl 5) or (b1 ushr 3)
+        }
+
+        fun normalizeNuhLayerIdToZero(nal: ByteArray): ByteArray {
+            if (nal.size < 2 || nuhLayerId(nal) == 0) return nal
+            val copy = nal.copyOf()
+            copy[0] = (copy[0].toInt() and 0xFE).toByte()
+            copy[1] = (copy[1].toInt() and 0x07).toByte()
+            return copy
+        }
+
+        fun findStartCode(data: ByteArray, from: Int, limit: Int): Int {
+            var i = from
+            while (i + 2 < limit) {
+                if (data[i].toInt() == 0 && data[i + 1].toInt() == 0) {
+                    if (data[i + 2].toInt() == 1) return i
+                    if (i + 3 < limit && data[i + 2].toInt() == 0 && data[i + 3].toInt() == 1) return i
+                }
+                i++
+            }
+            return -1
+        }
+
+        fun startCodeLength(data: ByteArray, startCodeOffset: Int, limit: Int): Int {
+            return if (startCodeOffset + 3 < limit &&
+                data[startCodeOffset].toInt() == 0 &&
+                data[startCodeOffset + 1].toInt() == 0 &&
+                data[startCodeOffset + 2].toInt() == 0 &&
+                data[startCodeOffset + 3].toInt() == 1
+            ) 4 else 3
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionMatroskaTransformer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionMatroskaTransformer.kt
@@ -1,0 +1,277 @@
+package com.nuvio.tv.core.player
+
+import androidx.media3.common.util.ParsableByteArray
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.container.DolbyVisionConfig
+import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor
+import java.io.ByteArrayOutputStream
+
+/**
+ * App-level (AAR mode) implementation of the vendored Matroska extractor's
+ * [MatroskaExtractor.DolbyVisionSampleTransformer] seam.
+ *
+ * Performs the DV7 to DV8.1 conversion for MKV, wired to [DoviBridge]. The
+ * extractor calls:
+ *
+ *  - [onDolbyVisionBlockAdditionalData] when it reads the DV7 enhancement-layer
+ *    RPU from a Matroska BlockAdditional; we convert it to an 8.1 RPU NAL.
+ *  - [transformHevcSample] just before committing the HEVC sample; we rewrite
+ *    the base-layer NALs (dropping EL NALs, converting any in-band RPU) and
+ *    append the converted BlockAdditional RPU.
+ *  - [onDolbyVisionCodecString] when building the output Format; dvhe.07/dvh1.07
+ *    becomes dvhe.08/dvh1.08 to advertise single-layer 8.1.
+ *
+ * Mode selection, the manual-DV8.1 mode-2 default and its per-RPU fallback to
+ * mode 1 all come from [config], so behaviour matches the MP4/TS path in
+ * [DolbyVisionExtractorsFactory].
+ */
+@UnstableApi
+internal class DolbyVisionMatroskaTransformer(
+    private val config: DolbyVisionConversionConfig
+) : MatroskaExtractor.DolbyVisionSampleTransformer {
+
+    private var lastTransformedLength = 0
+
+    // Reused across samples; grows to the largest frame once.
+    private val scratch = ExposedByteArrayOutputStream(64 * 1024)
+
+    private class ExposedByteArrayOutputStream(size: Int) : ByteArrayOutputStream(size) {
+        fun backingArray(): ByteArray = buf
+    }
+
+    override fun onDolbyVisionBlockAdditionalData(
+        blockAdditionalData: ByteArray?,
+        blockAddIdType: Int,
+        dolbyVisionConfigBytes: ByteArray?
+    ): ByteArray? {
+        if (blockAdditionalData == null) return null
+        val profile = resolveProfile(null, dolbyVisionConfigBytes)
+        if (!config.shouldConvert(profile)) return null
+        return convertRpuNal(blockAdditionalData, config.conversionMode(profile))
+    }
+
+    override fun onHevcSample(
+        sampleSizeBytes: Int,
+        blockAdditionalData: ByteArray?,
+        dolbyVisionConfigBytes: ByteArray?
+    ) {
+        // Telemetry-only seam; nothing to do.
+    }
+
+    override fun lastTransformedSampleLength(): Int = lastTransformedLength
+
+    override fun transformHevcSample(
+        sampleLengthDelimitedData: ByteArray?,
+        sampleLength: Int,
+        nalUnitLengthFieldLength: Int,
+        blockAdditionalData: ByteArray?,
+        dolbyVisionConfigBytes: ByteArray?
+    ): ByteArray? {
+        val sample = sampleLengthDelimitedData ?: return null
+        val profile = resolveProfile(null, dolbyVisionConfigBytes)
+        if (!config.shouldConvert(profile)) return null
+        // DV5 signal-only unless a mode is forced in Advanced; keep the profile-5 RPU.
+        if (profile == 5 && !config.convertDv5Rpu) return null
+        val mode = config.conversionMode(profile)
+        val baseChanged = rewriteMp4HevcSampleInto(sample, sampleLength, nalUnitLengthFieldLength, mode)
+
+        if (blockAdditionalData == null) {
+            return if (baseChanged) finishScratch() else null
+        }
+
+        // `blockAdditionalData` is the pending value produced by onDolbyVisionBlockAdditionalData
+        // (already an 8.1 RPU). Re-running conversion is a no-op (libdovi returns null for non-DV7
+        // input), so we fall back to the already-converted bytes.
+        val convertedBlockAdditional = convertRpuNal(blockAdditionalData, mode) ?: blockAdditionalData
+        if (!baseChanged) {
+            scratch.reset()
+            scratch.write(sample, 0, sampleLength)
+        }
+        return if (appendLengthDelimitedNalToScratch(convertedBlockAdditional, nalUnitLengthFieldLength)) {
+            finishScratch()
+        } else {
+            null
+        }
+    }
+
+    private fun finishScratch(): ByteArray {
+        lastTransformedLength = scratch.size()
+        return scratch.backingArray()
+    }
+
+    override fun onDolbyVisionCodecString(
+        codecs: String?,
+        dolbyVisionConfigBytes: ByteArray?
+    ): String? {
+        val profile = resolveProfile(codecs, dolbyVisionConfigBytes)
+        if (!config.shouldConvert(profile)) return null
+        DolbyVisionConversionStats.recordSourceProfile(profile)
+        val normalized = normalizeDolbyVisionCodecString(codecs)
+        return if (normalized != null && normalized != codecs) {
+            DolbyVisionConversionStats.recordCodecStringRewrite()
+            normalized
+        } else {
+            null
+        }
+    }
+
+    // ── Conversion + NAL helpers ──
+
+    private fun convertRpuNal(nal: ByteArray, primaryMode: Int): ByteArray? {
+        val primary = DoviBridge.convertDv7RpuToDv81(nal, primaryMode)?.takeIf { it.isNotEmpty() }
+        if (primary != null) {
+            DolbyVisionConversionStats.recordConversionMode(primaryMode)
+            return primary
+        }
+        if (config.allowMode2Fallback && primaryMode == 2) {
+            val fallback = DoviBridge.convertDv7RpuToDv81(nal, 1)?.takeIf { it.isNotEmpty() }
+            if (fallback != null) DolbyVisionConversionStats.recordConversionMode(1)
+            return fallback
+        }
+        return null
+    }
+
+    private fun rewriteMp4HevcSampleInto(
+        sample: ByteArray,
+        sampleLength: Int,
+        nalUnitLengthFieldLength: Int,
+        mode: Int
+    ): Boolean {
+        if (nalUnitLengthFieldLength !in 1..4) return false
+        var offset = 0
+        var changed = false
+        val out = scratch
+        out.reset()
+        while (offset + nalUnitLengthFieldLength <= sampleLength) {
+            val nalSize = readLengthField(sample, offset, nalUnitLengthFieldLength)
+            if (nalSize < 0) return false
+            offset += nalUnitLengthFieldLength
+            if (offset + nalSize > sampleLength) return false
+            val nalType = if (nalSize >= 1) nalUnitTypeAt(sample, offset) else -1
+            val layerId = nuhLayerIdAt(sample, offset, nalSize)
+            when {
+                // Enhancement-layer NAL that isn't the RPU: drop it.
+                layerId > 0 && nalType != NAL_TYPE_UNSPEC62 -> changed = true
+                // RPU NAL: copy out just this small NAL, convert, normalize layer id.
+                nalType == NAL_TYPE_UNSPEC62 -> {
+                    val rpu = sample.copyOfRange(offset, offset + nalSize)
+                    val convertedNal = normalizeNuhLayerIdToZero(convertRpuNal(rpu, mode) ?: rpu)
+                    if (convertedNal !== rpu) changed = true
+                    if (!writeLengthField(out, convertedNal.size, nalUnitLengthFieldLength)) return false
+                    out.write(convertedNal)
+                }
+                // Base-layer NAL: forward straight from the sample buffer, no copy.
+                else -> {
+                    if (!writeLengthField(out, nalSize, nalUnitLengthFieldLength)) return false
+                    out.write(sample, offset, nalSize)
+                }
+            }
+            offset += nalSize
+        }
+        if (offset != sampleLength) return false
+        if (!changed) return false
+        return out.size() > 0
+    }
+
+    private fun appendLengthDelimitedNalToScratch(
+        nalPayload: ByteArray,
+        nalUnitLengthFieldLength: Int
+    ): Boolean {
+        if (nalUnitLengthFieldLength !in 1..4 || nalPayload.isEmpty()) return false
+        val maxNalSize = when (nalUnitLengthFieldLength) {
+            1 -> 0xFF
+            2 -> 0xFFFF
+            3 -> 0xFFFFFF
+            else -> Int.MAX_VALUE
+        }
+        if (nalPayload.size > maxNalSize) return false
+        if (!writeLengthField(scratch, nalPayload.size, nalUnitLengthFieldLength)) return false
+        scratch.write(nalPayload)
+        return true
+    }
+
+    private fun normalizeDolbyVisionCodecString(codecs: String?): String? {
+        val raw = codecs?.trim().orEmpty()
+        if (raw.isEmpty()) return null
+        val parts = raw.split('.').toMutableList()
+        if (parts.size < 2) return null
+        val prefix = parts[0].lowercase()
+        if (prefix != "dvhe" && prefix != "dvh1") return null
+        val profileValue = parts[1].toIntOrNull() ?: return null
+        if (profileValue != 5 && profileValue != 7) return null
+        val width = parts[1].length.coerceAtLeast(2)
+        parts[1] = "8".padStart(width, '0')
+        return parts.joinToString(".")
+    }
+
+    private fun resolveProfile(codecs: String?, configBytes: ByteArray?): Int? {
+        resolveProfileFromCodecString(codecs)?.let { return it }
+        if (configBytes == null || configBytes.isEmpty()) return null
+        return runCatching {
+            DolbyVisionConfig.parse(ParsableByteArray(configBytes))?.profile
+        }.getOrNull()
+    }
+
+    private fun resolveProfileFromCodecString(codecs: String?): Int? {
+        val raw = codecs?.trim().orEmpty()
+        if (raw.isEmpty()) return null
+        val parts = raw.split('.')
+        if (parts.size < 2) return null
+        val prefix = parts[0].lowercase()
+        if (prefix != "dvhe" && prefix != "dvh1") return null
+        return parts[1].toIntOrNull()
+    }
+
+    private fun nalUnitTypeAt(sample: ByteArray, offset: Int): Int =
+        (sample[offset].toInt() ushr 1) and 0x3F
+
+    private fun nuhLayerIdAt(sample: ByteArray, offset: Int, nalSize: Int): Int {
+        if (nalSize < 2) return 0
+        val b0 = sample[offset].toInt() and 0x01
+        val b1 = sample[offset + 1].toInt() and 0xF8
+        return (b0 shl 5) or (b1 ushr 3)
+    }
+
+    private fun getNuhLayerId(nalPayload: ByteArray): Int {
+        if (nalPayload.size < 2) return 0
+        val b0 = nalPayload[0].toInt() and 0x01
+        val b1 = nalPayload[1].toInt() and 0xF8
+        return (b0 shl 5) or (b1 ushr 3)
+    }
+
+    private fun normalizeNuhLayerIdToZero(nalPayload: ByteArray): ByteArray {
+        if (nalPayload.size < 2 || getNuhLayerId(nalPayload) == 0) return nalPayload
+        val out = nalPayload.copyOf()
+        out[0] = (out[0].toInt() and 0xFE).toByte()
+        out[1] = (out[1].toInt() and 0x07).toByte()
+        return out
+    }
+
+    private fun readLengthField(data: ByteArray, offset: Int, lengthBytes: Int): Int {
+        var value = 0
+        for (i in 0 until lengthBytes) {
+            value = (value shl 8) or (data[offset + i].toInt() and 0xFF)
+        }
+        return value
+    }
+
+    private fun writeLengthField(out: ByteArrayOutputStream, value: Int, lengthBytes: Int): Boolean {
+        if (value < 0) return false
+        val maxNalSize = when (lengthBytes) {
+            1 -> 0xFF
+            2 -> 0xFFFF
+            3 -> 0xFFFFFF
+            4 -> Int.MAX_VALUE
+            else -> return false
+        }
+        if (value > maxNalSize) return false
+        for (shift in (lengthBytes - 1) downTo 0) {
+            out.write((value ushr (shift * 8)) and 0xFF)
+        }
+        return true
+    }
+
+    private companion object {
+        const val NAL_TYPE_UNSPEC62 = 62
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/DoviBridge.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DoviBridge.kt
@@ -1,0 +1,227 @@
+package com.nuvio.tv.core.player
+
+import android.util.Log
+import com.nuvio.tv.BuildConfig
+import java.util.concurrent.atomic.AtomicLong
+
+object DoviBridge {
+    private const val TAG = "DoviBridge"
+    private const val LIB_NAME = "dovi_bridge"
+
+    data class RealtimeConversionProbe(
+        val supported: Boolean,
+        val reason: String,
+        val bridgeVersion: String?,
+        val extractorHookReady: Boolean,
+        val selfTest: SelfTestResult
+    )
+
+    data class SelfTestResult(
+        val passed: Boolean,
+        val reason: String,
+        val inputBytes: Int,
+        val outputBytes: Int
+    )
+
+    private val nativeLoaded: Boolean by lazy { loadNativeLibrary() }
+    private var cachedSelfTestResult: SelfTestResult? = null
+    private val conversionCallCount = AtomicLong(0L)
+    private val conversionSuccessCount = AtomicLong(0L)
+
+    val isNativeEnabledInBuild: Boolean
+        get() = BuildConfig.DOVI_NATIVE_ENABLED
+
+    val isExtractorHookReadyInBuild: Boolean
+        get() = BuildConfig.DOVI_EXTRACTOR_HOOK_READY
+
+    val isLibraryLoaded: Boolean
+        get() = nativeLoaded
+
+    fun isAvailable(): Boolean = isNativeEnabledInBuild && nativeLoaded
+
+    fun getBridgeVersionOrNull(): String? {
+        if (!isAvailable()) return null
+        return runCatching { nativeGetBridgeVersion() }
+            .onFailure { Log.w(TAG, "Failed to read bridge version: ${it.message}") }
+            .getOrNull()
+    }
+
+    fun probeRealtimeConversionSupport(streamUrl: String): RealtimeConversionProbe {
+        if (!isNativeEnabledInBuild) {
+            return RealtimeConversionProbe(
+                supported = false,
+                reason = "native-disabled-in-build",
+                bridgeVersion = null,
+                extractorHookReady = isExtractorHookReadyInBuild,
+                selfTest = SelfTestResult(
+                    passed = false,
+                    reason = "not-run",
+                    inputBytes = 0,
+                    outputBytes = 0
+                )
+            )
+        }
+        if (!nativeLoaded) {
+            return RealtimeConversionProbe(
+                supported = false,
+                reason = "native-library-load-failed",
+                bridgeVersion = null,
+                extractorHookReady = isExtractorHookReadyInBuild,
+                selfTest = SelfTestResult(
+                    passed = false,
+                    reason = "not-run",
+                    inputBytes = 0,
+                    outputBytes = 0
+                )
+            )
+        }
+        if (!isExtractorHookReadyInBuild) {
+            return RealtimeConversionProbe(
+                supported = false,
+                reason = "extractor-hook-not-integrated",
+                bridgeVersion = getBridgeVersionOrNull(),
+                extractorHookReady = false,
+                selfTest = runStartupSelfTest(streamUrl)
+            )
+        }
+
+        val bridgeVersion = runCatching { nativeGetBridgeVersion() }
+            .onFailure { Log.w(TAG, "probe version failed host=${streamUrl.safeHost()}: ${it.message}") }
+            .getOrNull()
+
+        val ready = runCatching { nativeIsConversionPathReady() }
+            .onFailure { Log.w(TAG, "probe readiness failed host=${streamUrl.safeHost()}: ${it.message}") }
+            .getOrDefault(false)
+
+        val selfTest = runStartupSelfTest(streamUrl)
+        if (!selfTest.passed) {
+            return RealtimeConversionProbe(
+                supported = false,
+                reason = "self-test-failed:${selfTest.reason}",
+                bridgeVersion = bridgeVersion,
+                extractorHookReady = true,
+                selfTest = selfTest
+            )
+        }
+
+        return if (ready) {
+            RealtimeConversionProbe(
+                supported = true,
+                reason = "ready",
+                bridgeVersion = bridgeVersion,
+                extractorHookReady = true,
+                selfTest = selfTest
+            )
+        } else {
+            RealtimeConversionProbe(
+                supported = false,
+                reason = "bridge-reports-not-ready",
+                bridgeVersion = bridgeVersion,
+                extractorHookReady = true,
+                selfTest = selfTest
+            )
+        }
+    }
+
+    fun runStartupSelfTest(streamUrl: String): SelfTestResult {
+        cachedSelfTestResult?.let { return it }
+        if (!isAvailable()) {
+            return SelfTestResult(
+                passed = false,
+                reason = "native-unavailable",
+                inputBytes = 0,
+                outputBytes = 0
+            )
+        }
+
+        val payload = byteArrayOf(
+            0x7c, 0x01, 0x20, 0x40,
+            0x21, 0x33, 0x55, 0x77, 0x11, 0x02, 0x06, 0x10
+        )
+        val output = convertDv7RpuToDv81(payload, mode = 2)
+        val result = if (output != null && output.isNotEmpty()) {
+            SelfTestResult(
+                passed = true,
+                reason = if (output.contentEquals(payload)) {
+                    "bridge-path-ok-passthrough"
+                } else {
+                    "bridge-path-ok-transformed"
+                },
+                inputBytes = payload.size,
+                outputBytes = output.size
+            )
+        } else if (runCatching { nativeIsConversionPathReady() }.getOrDefault(false)) {
+            // The synthetic payload is not guaranteed to be a valid single-frame RPU.
+            // If the native bridge reports ready, do not hard-disable runtime probing here.
+            SelfTestResult(
+                passed = true,
+                reason = "bridge-ready-selftest-unverifiable",
+                inputBytes = payload.size,
+                outputBytes = output?.size ?: 0
+            )
+        } else {
+            SelfTestResult(
+                passed = false,
+                reason = "null-or-empty-output",
+                inputBytes = payload.size,
+                outputBytes = output?.size ?: 0
+            )
+        }
+
+        cachedSelfTestResult = result
+        Log.i(
+            TAG,
+            "Self-test host=${streamUrl.safeHost()} passed=${result.passed} " +
+                "reason=${result.reason} bytes=${result.inputBytes}->${result.outputBytes}"
+        )
+        return result
+    }
+
+    fun resetRuntimeCounters() {
+        conversionCallCount.set(0L)
+        conversionSuccessCount.set(0L)
+    }
+
+    fun getConversionCallCount(): Long = conversionCallCount.get()
+
+    fun getConversionSuccessCount(): Long = conversionSuccessCount.get()
+
+    fun convertDv7RpuToDv81(payload: ByteArray, mode: Int = 1): ByteArray? {
+        if (!isAvailable() || payload.isEmpty()) return null
+        conversionCallCount.incrementAndGet()
+        val converted = runCatching { nativeConvertDv7RpuToDv81(payload, mode) }
+            .onFailure { Log.w(TAG, "Conversion failed: ${it.message}") }
+            .getOrNull()
+        if (converted != null && converted.isNotEmpty()) {
+            conversionSuccessCount.incrementAndGet()
+        }
+        return converted
+    }
+
+    private fun loadNativeLibrary(): Boolean {
+        if (!isNativeEnabledInBuild) {
+            return false
+        }
+        return try {
+            System.loadLibrary(LIB_NAME)
+            Log.i(TAG, "Loaded native library: $LIB_NAME")
+            true
+        } catch (t: Throwable) {
+            Log.w(TAG, "Failed to load native library $LIB_NAME: ${t.message}")
+            false
+        }
+    }
+
+    private fun String.safeHost(): String {
+        return runCatching { android.net.Uri.parse(this).host ?: "unknown" }.getOrDefault("unknown")
+    }
+
+    @JvmStatic
+    private external fun nativeGetBridgeVersion(): String
+
+    @JvmStatic
+    private external fun nativeIsConversionPathReady(): Boolean
+
+    @JvmStatic
+    private external fun nativeConvertDv7RpuToDv81(payload: ByteArray, mode: Int): ByteArray?
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/ChunkIndexProvider.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/ChunkIndexProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law of agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.extractor.ChunkIndex;
+
+/**
+ * An interface for objects that can provide a {@link ChunkIndex}.
+ *
+ * <p>This should be implemented by classes, typically a {@link SeekMap}, that are used in contexts
+ * where a {@link ChunkIndex} is required to access sample-level information. For example, chunk
+ * sources for adaptive streaming formats like DASH require a {@code ChunkIndex} to locate samples
+ * within a media segment.
+ */
+@UnstableApi
+public interface ChunkIndexProvider {
+
+  /**
+   * Returns a {@link ChunkIndex} for use by chunk-based media sources, or {@code null} if not
+   * applicable.
+   */
+  @Nullable
+  ChunkIndex getChunkIndex();
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DefaultEbmlReader.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DefaultEbmlReader.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import androidx.annotation.IntDef;
+import androidx.media3.common.C;
+import androidx.media3.common.ParserException;
+import androidx.media3.extractor.ExtractorInput;
+import java.io.EOFException;
+import java.io.IOException;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayDeque;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.RequiresNonNull;
+
+/** Default implementation of {@link EbmlReader}. */
+/* package */ final class DefaultEbmlReader implements EbmlReader {
+
+  @Documented
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(TYPE_USE)
+  @IntDef({ELEMENT_STATE_READ_ID, ELEMENT_STATE_READ_CONTENT_SIZE, ELEMENT_STATE_READ_CONTENT})
+  private @interface ElementState {}
+
+  private static final int ELEMENT_STATE_READ_ID = 0;
+  private static final int ELEMENT_STATE_READ_CONTENT_SIZE = 1;
+  private static final int ELEMENT_STATE_READ_CONTENT = 2;
+
+  private static final int MAX_ID_BYTES = 4;
+  private static final int MAX_LENGTH_BYTES = 8;
+
+  private static final int MAX_INTEGER_ELEMENT_SIZE_BYTES = 8;
+  private static final int VALID_FLOAT32_ELEMENT_SIZE_BYTES = 4;
+  private static final int VALID_FLOAT64_ELEMENT_SIZE_BYTES = 8;
+
+  private final byte[] scratch;
+  private final ArrayDeque<MasterElement> masterElementsStack;
+  private final VarintReader varintReader;
+
+  private @MonotonicNonNull EbmlProcessor processor;
+  private @ElementState int elementState;
+  private int elementId;
+  private long elementContentSize;
+
+  public DefaultEbmlReader() {
+    scratch = new byte[8];
+    masterElementsStack = new ArrayDeque<>();
+    varintReader = new VarintReader();
+  }
+
+  @Override
+  public void init(EbmlProcessor processor) {
+    this.processor = processor;
+  }
+
+  @Override
+  public void reset() {
+    elementState = ELEMENT_STATE_READ_ID;
+    masterElementsStack.clear();
+    varintReader.reset();
+  }
+
+  @Override
+  public boolean read(ExtractorInput input) throws IOException {
+    checkNotNull(processor);
+    while (true) {
+      MasterElement head = masterElementsStack.peek();
+      if (head != null && input.getPosition() >= head.elementEndPosition) {
+        processor.endMasterElement(masterElementsStack.pop().elementId);
+        return true;
+      }
+
+      if (elementState == ELEMENT_STATE_READ_ID) {
+        long result = varintReader.readUnsignedVarint(input, true, false, MAX_ID_BYTES);
+        if (result == C.RESULT_MAX_LENGTH_EXCEEDED) {
+          result = maybeResyncToNextLevel1Element(input);
+        }
+        if (result == C.RESULT_END_OF_INPUT) {
+          return false;
+        }
+        // Element IDs are at most 4 bytes, so we can cast to integers.
+        elementId = (int) result;
+        elementState = ELEMENT_STATE_READ_CONTENT_SIZE;
+      }
+
+      if (elementState == ELEMENT_STATE_READ_CONTENT_SIZE) {
+        elementContentSize = varintReader.readUnsignedVarint(input, false, true, MAX_LENGTH_BYTES);
+        elementState = ELEMENT_STATE_READ_CONTENT;
+      }
+
+      @EbmlProcessor.ElementType int type = processor.getElementType(elementId);
+      switch (type) {
+        case EbmlProcessor.ELEMENT_TYPE_MASTER:
+          long elementContentPosition = input.getPosition();
+          long elementEndPosition = elementContentPosition + elementContentSize;
+          masterElementsStack.push(new MasterElement(elementId, elementEndPosition));
+          processor.startMasterElement(elementId, elementContentPosition, elementContentSize);
+          elementState = ELEMENT_STATE_READ_ID;
+          return true;
+        case EbmlProcessor.ELEMENT_TYPE_UNSIGNED_INT:
+          if (elementContentSize > MAX_INTEGER_ELEMENT_SIZE_BYTES) {
+            throw ParserException.createForMalformedContainer(
+                "Invalid integer size: " + elementContentSize, /* cause= */ null);
+          }
+          processor.integerElement(elementId, readInteger(input, (int) elementContentSize));
+          elementState = ELEMENT_STATE_READ_ID;
+          return true;
+        case EbmlProcessor.ELEMENT_TYPE_FLOAT:
+          if (elementContentSize != VALID_FLOAT32_ELEMENT_SIZE_BYTES
+              && elementContentSize != VALID_FLOAT64_ELEMENT_SIZE_BYTES) {
+            throw ParserException.createForMalformedContainer(
+                "Invalid float size: " + elementContentSize, /* cause= */ null);
+          }
+          processor.floatElement(elementId, readFloat(input, (int) elementContentSize));
+          elementState = ELEMENT_STATE_READ_ID;
+          return true;
+        case EbmlProcessor.ELEMENT_TYPE_STRING:
+          if (elementContentSize > Integer.MAX_VALUE) {
+            throw ParserException.createForMalformedContainer(
+                "String element size: " + elementContentSize, /* cause= */ null);
+          }
+          processor.stringElement(elementId, readString(input, (int) elementContentSize));
+          elementState = ELEMENT_STATE_READ_ID;
+          return true;
+        case EbmlProcessor.ELEMENT_TYPE_BINARY:
+          processor.binaryElement(elementId, (int) elementContentSize, input);
+          elementState = ELEMENT_STATE_READ_ID;
+          return true;
+        case EbmlProcessor.ELEMENT_TYPE_UNKNOWN:
+          input.skipFully((int) elementContentSize);
+          elementState = ELEMENT_STATE_READ_ID;
+          break;
+        default:
+          throw ParserException.createForMalformedContainer(
+              "Invalid element type " + type, /* cause= */ null);
+      }
+    }
+  }
+
+  /**
+   * Does a byte by byte search to try and find the next level 1 element. This method is called if
+   * some invalid data is encountered in the parser.
+   *
+   * @param input The {@link ExtractorInput} from which data has to be read.
+   * @return id of the next level 1 element that has been found.
+   * @throws EOFException If the end of input was encountered when searching for the next level 1
+   *     element.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  @RequiresNonNull("processor")
+  private long maybeResyncToNextLevel1Element(ExtractorInput input) throws IOException {
+    input.resetPeekPosition();
+    while (true) {
+      input.peekFully(scratch, 0, MAX_ID_BYTES);
+      int varintLength = VarintReader.parseUnsignedVarintLength(scratch[0]);
+      if (varintLength != C.LENGTH_UNSET && varintLength <= MAX_ID_BYTES) {
+        int potentialId = (int) VarintReader.assembleVarint(scratch, varintLength, false);
+        if (processor.isLevel1Element(potentialId)) {
+          input.skipFully(varintLength);
+          return potentialId;
+        }
+      }
+      input.skipFully(1);
+    }
+  }
+
+  /**
+   * Reads and returns an integer of length {@code byteLength} from the {@link ExtractorInput}.
+   *
+   * @param input The {@link ExtractorInput} from which to read.
+   * @param byteLength The length of the integer being read.
+   * @return The read integer value.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  private long readInteger(ExtractorInput input, int byteLength) throws IOException {
+    input.readFully(scratch, 0, byteLength);
+    long value = 0;
+    for (int i = 0; i < byteLength; i++) {
+      value = (value << 8) | (scratch[i] & 0xFF);
+    }
+    return value;
+  }
+
+  /**
+   * Reads and returns a float of length {@code byteLength} from the {@link ExtractorInput}.
+   *
+   * @param input The {@link ExtractorInput} from which to read.
+   * @param byteLength The length of the float being read.
+   * @return The read float value.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  private double readFloat(ExtractorInput input, int byteLength) throws IOException {
+    long integerValue = readInteger(input, byteLength);
+    double floatValue;
+    if (byteLength == VALID_FLOAT32_ELEMENT_SIZE_BYTES) {
+      floatValue = Float.intBitsToFloat((int) integerValue);
+    } else {
+      floatValue = Double.longBitsToDouble(integerValue);
+    }
+    return floatValue;
+  }
+
+  /**
+   * Reads a string of length {@code byteLength} from the {@link ExtractorInput}. Zero padding is
+   * removed, so the returned string may be shorter than {@code byteLength}.
+   *
+   * @param input The {@link ExtractorInput} from which to read.
+   * @param byteLength The length of the string being read, including zero padding.
+   * @return The read string value.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  private static String readString(ExtractorInput input, int byteLength) throws IOException {
+    if (byteLength == 0) {
+      return "";
+    }
+    byte[] stringBytes = new byte[byteLength];
+    input.readFully(stringBytes, 0, byteLength);
+    // Remove zero padding.
+    int trimmedLength = byteLength;
+    while (trimmedLength > 0 && stringBytes[trimmedLength - 1] == 0) {
+      trimmedLength--;
+    }
+    return new String(stringBytes, 0, trimmedLength);
+  }
+
+  /**
+   * Used in {@link #masterElementsStack} to track when the current master element ends, so that
+   * {@link EbmlProcessor#endMasterElement(int)} can be called.
+   */
+  private static final class MasterElement {
+
+    private final int elementId;
+    private final long elementEndPosition;
+
+    private MasterElement(int elementId, long elementEndPosition) {
+      this.elementId = elementId;
+      this.elementEndPosition = elementEndPosition;
+    }
+  }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DolbyVisionCompatibility.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DolbyVisionCompatibility.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.Format;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Runtime compatibility helpers for Dolby Vision to HEVC fallback flows.
+ *
+ * <p>This class intentionally stores transformer hooks as raw {@link Object} references so that
+ * shared modules can exchange hook instances without introducing module dependency cycles.
+ */
+@UnstableApi
+public final class DolbyVisionCompatibility {
+
+  private static volatile boolean mapDv7ToHevcEnabled;
+  @Nullable private static volatile Object matroskaDolbyVisionSampleTransformer;
+  @Nullable private static volatile Object mp4DolbyVisionSampleTransformer;
+  @Nullable private static volatile Object fragmentedMp4DolbyVisionSampleTransformer;
+  @Nullable private static volatile Object tsDolbyVisionNalTransformer;
+
+  public static void setMapDv7ToHevcEnabled(boolean enabled) {
+    mapDv7ToHevcEnabled = enabled;
+  }
+
+  public static boolean isMapDv7ToHevcEnabled() {
+    return mapDv7ToHevcEnabled;
+  }
+
+  public static boolean shouldMapDolbyVisionProfile7(
+      @Nullable String sampleMimeType, @Nullable String codecs) {
+    if (!mapDv7ToHevcEnabled) {
+      return false;
+    }
+    if (sampleMimeType != null && !Objects.equals(sampleMimeType, MimeTypes.VIDEO_DOLBY_VISION)) {
+      return false;
+    }
+    if (codecs == null || codecs.trim().isEmpty()) {
+      // If we already know this is a Dolby Vision track by mime type, allow fallback mapping even
+      // without an explicit codec string.
+      return Objects.equals(sampleMimeType, MimeTypes.VIDEO_DOLBY_VISION);
+    }
+    return extractDolbyVisionCodec(codecs) != null;
+  }
+
+  public static boolean isDolbyVisionProfile7(@Nullable String codecs) {
+    @Nullable String dvCodecs = extractDolbyVisionCodec(codecs);
+    if (dvCodecs == null) {
+      return false;
+    }
+    String[] parts = dvCodecs.split("\\.");
+    if (parts.length < 2) {
+      return false;
+    }
+    int profile = parseIntOrUnset(parts[1]);
+    return profile == 7;
+  }
+
+  @Nullable
+  public static String chooseHevcCodecsString(
+      @Nullable String codecs, @Nullable String supplementalCodecs) {
+    if (isHevcCodecsString(codecs)) {
+      return codecs;
+    }
+    if (isHevcCodecsString(supplementalCodecs)) {
+      return supplementalCodecs;
+    }
+    return null;
+  }
+
+  public static void setMatroskaDolbyVisionSampleTransformer(@Nullable Object transformer) {
+    matroskaDolbyVisionSampleTransformer = transformer;
+  }
+
+  @Nullable
+  public static Object getMatroskaDolbyVisionSampleTransformer() {
+    return matroskaDolbyVisionSampleTransformer;
+  }
+
+  public static void setMp4DolbyVisionSampleTransformer(@Nullable Object transformer) {
+    mp4DolbyVisionSampleTransformer = transformer;
+  }
+
+  @Nullable
+  public static Object getMp4DolbyVisionSampleTransformer() {
+    return mp4DolbyVisionSampleTransformer;
+  }
+
+  public static void setFragmentedMp4DolbyVisionSampleTransformer(@Nullable Object transformer) {
+    fragmentedMp4DolbyVisionSampleTransformer = transformer;
+  }
+
+  @Nullable
+  public static Object getFragmentedMp4DolbyVisionSampleTransformer() {
+    return fragmentedMp4DolbyVisionSampleTransformer;
+  }
+
+  public static void setTsDolbyVisionNalTransformer(@Nullable Object transformer) {
+    tsDolbyVisionNalTransformer = transformer;
+  }
+
+  @Nullable
+  public static Object getTsDolbyVisionNalTransformer() {
+    return tsDolbyVisionNalTransformer;
+  }
+
+  private static boolean isHevcCodecsString(@Nullable String codecs) {
+    if (codecs == null) {
+      return false;
+    }
+    String trimmed = codecs.trim();
+    return trimmed.startsWith("hvc1") || trimmed.startsWith("hev1");
+  }
+
+  @Nullable
+  private static String extractDolbyVisionCodec(@Nullable String codecs) {
+    if (codecs == null) {
+      return null;
+    }
+    String[] codecParts = Util.splitCodecs(codecs);
+    for (int i = 0; i < codecParts.length; i++) {
+      String codec = codecParts[i].trim().toLowerCase(Locale.US);
+      if (codec.startsWith("dvhe") || codec.startsWith("dvh1")) {
+        return codec;
+      }
+    }
+    return null;
+  }
+
+  private static int parseIntOrUnset(String value) {
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      return Format.NO_VALUE;
+    }
+  }
+
+  private DolbyVisionCompatibility() {}
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/EbmlProcessor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/EbmlProcessor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import androidx.annotation.IntDef;
+import androidx.media3.common.ParserException;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.extractor.ExtractorInput;
+import java.io.IOException;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Defines EBML element IDs/types and processes events. */
+@UnstableApi
+public interface EbmlProcessor {
+
+  /**
+   * EBML element types. One of {@link #ELEMENT_TYPE_UNKNOWN}, {@link #ELEMENT_TYPE_MASTER}, {@link
+   * #ELEMENT_TYPE_UNSIGNED_INT}, {@link #ELEMENT_TYPE_STRING}, {@link #ELEMENT_TYPE_BINARY} or
+   * {@link #ELEMENT_TYPE_FLOAT}.
+   */
+  @Documented
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(TYPE_USE)
+  @IntDef({
+    ELEMENT_TYPE_UNKNOWN,
+    ELEMENT_TYPE_MASTER,
+    ELEMENT_TYPE_UNSIGNED_INT,
+    ELEMENT_TYPE_STRING,
+    ELEMENT_TYPE_BINARY,
+    ELEMENT_TYPE_FLOAT
+  })
+  @interface ElementType {}
+
+  /** Type for unknown elements. */
+  int ELEMENT_TYPE_UNKNOWN = 0;
+
+  /** Type for elements that contain child elements. */
+  int ELEMENT_TYPE_MASTER = 1;
+
+  /** Type for integer value elements of up to 8 bytes. */
+  int ELEMENT_TYPE_UNSIGNED_INT = 2;
+
+  /** Type for string elements. */
+  int ELEMENT_TYPE_STRING = 3;
+
+  /** Type for binary elements. */
+  int ELEMENT_TYPE_BINARY = 4;
+
+  /** Type for IEEE floating point value elements of either 4 or 8 bytes. */
+  int ELEMENT_TYPE_FLOAT = 5;
+
+  /**
+   * Maps an element ID to a corresponding type.
+   *
+   * <p>If {@link #ELEMENT_TYPE_UNKNOWN} is returned then the element is skipped. Note that all
+   * children of a skipped element are also skipped.
+   *
+   * @param id The element ID to map.
+   * @return One of {@link #ELEMENT_TYPE_UNKNOWN}, {@link #ELEMENT_TYPE_MASTER}, {@link
+   *     #ELEMENT_TYPE_UNSIGNED_INT}, {@link #ELEMENT_TYPE_STRING}, {@link #ELEMENT_TYPE_BINARY} and
+   *     {@link #ELEMENT_TYPE_FLOAT}.
+   */
+  @ElementType
+  int getElementType(int id);
+
+  /**
+   * Checks if the given id is that of a level 1 element.
+   *
+   * @param id The element ID.
+   * @return Whether the given id is that of a level 1 element.
+   */
+  boolean isLevel1Element(int id);
+
+  /**
+   * Called when the start of a master element is encountered.
+   *
+   * <p>Following events should be considered as taking place within this element until a matching
+   * call to {@link #endMasterElement(int)} is made.
+   *
+   * <p>Note that it is possible for another master element of the same element ID to be nested
+   * within itself.
+   *
+   * @param id The element ID.
+   * @param contentPosition The position of the start of the element's content in the stream.
+   * @param contentSize The size of the element's content in bytes.
+   * @throws ParserException If a parsing error occurs.
+   */
+  void startMasterElement(int id, long contentPosition, long contentSize) throws ParserException;
+
+  /**
+   * Called when the end of a master element is encountered.
+   *
+   * @param id The element ID.
+   * @throws ParserException If a parsing error occurs.
+   */
+  void endMasterElement(int id) throws ParserException;
+
+  /**
+   * Called when an integer element is encountered.
+   *
+   * @param id The element ID.
+   * @param value The integer value that the element contains.
+   * @throws ParserException If a parsing error occurs.
+   */
+  void integerElement(int id, long value) throws ParserException;
+
+  /**
+   * Called when a float element is encountered.
+   *
+   * @param id The element ID.
+   * @param value The float value that the element contains
+   * @throws ParserException If a parsing error occurs.
+   */
+  void floatElement(int id, double value) throws ParserException;
+
+  /**
+   * Called when a string element is encountered.
+   *
+   * @param id The element ID.
+   * @param value The string value that the element contains.
+   * @throws ParserException If a parsing error occurs.
+   */
+  void stringElement(int id, String value) throws ParserException;
+
+  /**
+   * Called when a binary element is encountered.
+   *
+   * <p>The element header (containing the element ID and content size) will already have been read.
+   * Implementations are required to consume the whole remainder of the element, which is {@code
+   * contentSize} bytes in length, before returning. Implementations are permitted to fail (by
+   * throwing an exception) having partially consumed the data, however if they do this, they must
+   * consume the remainder of the content when called again.
+   *
+   * @param id The element ID.
+   * @param contentsSize The element's content size.
+   * @param input The {@link ExtractorInput} from which data should be read.
+   * @throws ParserException If a parsing error occurs.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  void binaryElement(int id, int contentsSize, ExtractorInput input) throws IOException;
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/EbmlReader.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/EbmlReader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.media3.common.ParserException;
+import androidx.media3.extractor.ExtractorInput;
+import java.io.IOException;
+
+/**
+ * Event-driven EBML reader that delivers events to an {@link EbmlProcessor}.
+ *
+ * <p>EBML can be summarized as a binary XML format somewhat similar to Protocol Buffers. It was
+ * originally designed for the Matroska container format. More information about EBML and Matroska
+ * is available <a href="http://www.matroska.org/technical/specs/index.html">here</a>.
+ */
+/* package */ interface EbmlReader {
+
+  /**
+   * Initializes the extractor with an {@link EbmlProcessor}.
+   *
+   * @param processor An {@link EbmlProcessor} to process events.
+   */
+  void init(EbmlProcessor processor);
+
+  /**
+   * Resets the state of the reader.
+   *
+   * <p>Subsequent calls to {@link #read(ExtractorInput)} will start reading a new EBML structure
+   * from scratch.
+   */
+  void reset();
+
+  /**
+   * Reads from an {@link ExtractorInput}, invoking an event callback if possible.
+   *
+   * @param input The {@link ExtractorInput} from which data should be read.
+   * @return True if data can continue to be read. False if the end of the input was encountered.
+   * @throws ParserException If parsing fails.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  boolean read(ExtractorInput input) throws IOException;
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -1,0 +1,3448 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import android.util.Pair;
+import android.util.SparseArray;
+import androidx.annotation.CallSuper;
+import androidx.annotation.IntDef;
+import androidx.annotation.Nullable;
+import androidx.media3.common.C;
+import androidx.media3.common.ColorInfo;
+import androidx.media3.common.DrmInitData;
+import androidx.media3.common.DrmInitData.SchemeData;
+import androidx.media3.common.Format;
+import androidx.media3.common.Metadata;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.ParserException;
+import androidx.media3.common.util.Log;
+import androidx.media3.common.util.NullableType;
+import androidx.media3.common.util.ParsableByteArray;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
+import androidx.media3.container.DolbyVisionConfig;
+import androidx.media3.container.NalUnitUtil;
+import androidx.media3.extractor.AacUtil;
+import androidx.media3.extractor.AvcConfig;
+import androidx.media3.extractor.ChunkIndex;
+import androidx.media3.extractor.DtsUtil;
+import androidx.media3.extractor.Extractor;
+import androidx.media3.extractor.ExtractorInput;
+import androidx.media3.extractor.ExtractorOutput;
+import androidx.media3.extractor.ExtractorsFactory;
+import androidx.media3.extractor.HevcConfig;
+import androidx.media3.extractor.MpegAudioUtil;
+import androidx.media3.extractor.PositionHolder;
+import androidx.media3.extractor.SeekMap;
+import androidx.media3.extractor.SeekPoint;
+import androidx.media3.extractor.TrackOutput;
+import androidx.media3.extractor.TrueHdSampleRechunker;
+import androidx.media3.extractor.text.SubtitleParser;
+import androidx.media3.extractor.text.SubtitleTranscodingExtractorOutput;
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.RequiresNonNull;
+
+/** Extracts data from the Matroska and WebM container formats. */
+@UnstableApi
+public class MatroskaExtractor implements Extractor {
+
+  /**
+   * Creates a factory for {@link MatroskaExtractor} instances with the provided {@link
+   * SubtitleParser.Factory}.
+   */
+  public static ExtractorsFactory newFactory(SubtitleParser.Factory subtitleParserFactory) {
+    return () -> new Extractor[] {new MatroskaExtractor(subtitleParserFactory)};
+  }
+
+  /**
+   * Creates a factory for {@link MatroskaExtractor} instances with the provided {@link
+   * SubtitleParser.Factory} and optional Dolby Vision sample hook.
+   */
+  public static ExtractorsFactory newFactory(
+      SubtitleParser.Factory subtitleParserFactory,
+      @Nullable DolbyVisionSampleTransformer dolbyVisionSampleTransformer) {
+    return () ->
+        new Extractor[] {
+          new MatroskaExtractor(subtitleParserFactory, /* flags= */ 0, dolbyVisionSampleTransformer)
+        };
+  }
+
+  /**
+   * Flags controlling the behavior of the extractor. Possible flag values are {@link
+   * #FLAG_DISABLE_SEEK_FOR_CUES} and {#FLAG_EMIT_RAW_SUBTITLE_DATA}.
+   */
+  @Documented
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(TYPE_USE)
+  @IntDef(
+      flag = true,
+      value = {FLAG_DISABLE_SEEK_FOR_CUES, FLAG_EMIT_RAW_SUBTITLE_DATA})
+  public @interface Flags {}
+
+  /**
+   * Hook invoked for Dolby Vision related Matroska data.
+   *
+   * <p>This is a phase-2 integration seam for DV7 conversion experiments. The extractor keeps
+   * existing behavior unless this hook is provided.
+   */
+  public interface DolbyVisionSampleTransformer {
+
+    /**
+     * Called when Dolby Vision BlockAdditional data is encountered for an HEVC track.
+     *
+     * @param blockAdditionalData Block additional payload bytes.
+     * @param blockAddIdType Dolby Vision BlockAddIdType ({@code dvcc}/{@code dvvc}).
+     * @param dolbyVisionConfigBytes Track-level Dolby Vision config bytes, if available.
+     * @return Payload to retain for the associated sample, or null to keep original data.
+     */
+    @Nullable
+    default byte[] onDolbyVisionBlockAdditionalData(
+        byte[] blockAdditionalData, int blockAddIdType, @Nullable byte[] dolbyVisionConfigBytes) {
+      return null;
+    }
+
+    /**
+     * Called before writing an HEVC sample that has pending Dolby Vision block-additional bytes.
+     *
+     * <p>Current spike wiring is telemetry/inspection only. A future phase may allow replacing the
+     * sample payload at this point.
+     */
+    default void onHevcSample(
+        int sampleSizeBytes,
+        @Nullable byte[] blockAdditionalData,
+        @Nullable byte[] dolbyVisionConfigBytes) {}
+
+    /**
+     * Optionally rewrites an HEVC sample payload.
+     *
+     * <p>Reads the first {@code sampleLength} bytes of {@code sampleLengthDelimitedData}. A non-null
+     * result is the transformer's reusable buffer, valid for {@link #lastTransformedSampleLength()}
+     * bytes and only until the next call; null keeps the original payload.
+     *
+     * @param sampleLengthDelimitedData Sample payload in length-delimited NAL format.
+     * @param sampleLength Number of valid bytes in {@code sampleLengthDelimitedData}.
+     * @param nalUnitLengthFieldLength Length field size in bytes.
+     * @param blockAdditionalData Block additional payload associated with this sample.
+     * @param dolbyVisionConfigBytes Track-level Dolby Vision config bytes, if available.
+     * @return Reusable buffer with the rewritten sample, or null to keep original.
+     */
+    @Nullable
+    default byte[] transformHevcSample(
+        byte[] sampleLengthDelimitedData,
+        int sampleLength,
+        int nalUnitLengthFieldLength,
+        @Nullable byte[] blockAdditionalData,
+        @Nullable byte[] dolbyVisionConfigBytes) {
+      return null;
+    }
+
+    /** Valid byte count of the buffer returned by the last {@link #transformHevcSample} call. */
+    default int lastTransformedSampleLength() {
+      return 0;
+    }
+
+    /**
+     * Optionally rewrites Dolby Vision codec signaling for output {@link Format}.
+     *
+     * <p>This is used when sample-level metadata conversion changes the effective Dolby Vision
+     * profile (for example DV7 to DV8.1), but container-level codec signaling would otherwise still
+     * advertise the source profile.
+     *
+     * @param codecs Existing codec string (for example {@code dvhe.07.06}).
+     * @param dolbyVisionConfigBytes Track-level Dolby Vision config bytes, if available.
+     * @return Replacement codec string, or null to keep original signaling.
+     */
+    @Nullable
+    default String onDolbyVisionCodecString(
+        @Nullable String codecs, @Nullable byte[] dolbyVisionConfigBytes) {
+      return null;
+    }
+  }
+
+  /**
+   * Flag to disable seeking for cues.
+   *
+   * <p>Normally (i.e. when this flag is not set) the extractor will seek to the cues element if its
+   * position is specified in the seek head and if it's after the first cluster. Setting this flag
+   * disables seeking to the cues element. If the cues element is after the first cluster then the
+   * media is treated as being unseekable.
+   */
+  public static final int FLAG_DISABLE_SEEK_FOR_CUES = 1;
+
+  /**
+   * Flag to use the source subtitle formats without modification. If unset, subtitles will be
+   * transcoded to {@link MimeTypes#APPLICATION_MEDIA3_CUES} during extraction.
+   */
+  public static final int FLAG_EMIT_RAW_SUBTITLE_DATA = 1 << 1; // 2
+
+  /**
+   * @deprecated Use {@link #newFactory(SubtitleParser.Factory)} instead.
+   */
+  @Deprecated
+  public static final ExtractorsFactory FACTORY =
+      () ->
+          new Extractor[] {
+            new MatroskaExtractor(SubtitleParser.Factory.UNSUPPORTED, FLAG_EMIT_RAW_SUBTITLE_DATA)
+          };
+
+  private static final String TAG = "MatroskaExtractor";
+
+  private static final int UNSET_ENTRY_ID = -1;
+
+  private static final int BLOCK_STATE_START = 0;
+  private static final int BLOCK_STATE_HEADER = 1;
+  private static final int BLOCK_STATE_DATA = 2;
+
+  private static final String DOC_TYPE_MATROSKA = "matroska";
+  private static final String DOC_TYPE_WEBM = "webm";
+  private static final String CODEC_ID_VP8 = "V_VP8";
+  private static final String CODEC_ID_VP9 = "V_VP9";
+  private static final String CODEC_ID_AV1 = "V_AV1";
+  private static final String CODEC_ID_MPEG2 = "V_MPEG2";
+  private static final String CODEC_ID_MPEG4_SP = "V_MPEG4/ISO/SP";
+  private static final String CODEC_ID_MPEG4_ASP = "V_MPEG4/ISO/ASP";
+  private static final String CODEC_ID_MPEG4_AP = "V_MPEG4/ISO/AP";
+  private static final String CODEC_ID_H264 = "V_MPEG4/ISO/AVC";
+  private static final String CODEC_ID_H265 = "V_MPEGH/ISO/HEVC";
+  private static final String CODEC_ID_FOURCC = "V_MS/VFW/FOURCC";
+  private static final String CODEC_ID_THEORA = "V_THEORA";
+  private static final String CODEC_ID_VORBIS = "A_VORBIS";
+  private static final String CODEC_ID_OPUS = "A_OPUS";
+  private static final String CODEC_ID_AAC = "A_AAC";
+  private static final String CODEC_ID_MP2 = "A_MPEG/L2";
+  private static final String CODEC_ID_MP3 = "A_MPEG/L3";
+  private static final String CODEC_ID_AC3 = "A_AC3";
+  private static final String CODEC_ID_E_AC3 = "A_EAC3";
+  private static final String CODEC_ID_TRUEHD = "A_TRUEHD";
+  private static final String CODEC_ID_DTS = "A_DTS";
+  private static final String CODEC_ID_DTS_EXPRESS = "A_DTS/EXPRESS";
+  private static final String CODEC_ID_DTS_LOSSLESS = "A_DTS/LOSSLESS";
+  private static final String CODEC_ID_FLAC = "A_FLAC";
+  private static final String CODEC_ID_ACM = "A_MS/ACM";
+  private static final String CODEC_ID_PCM_INT_LIT = "A_PCM/INT/LIT";
+  private static final String CODEC_ID_PCM_INT_BIG = "A_PCM/INT/BIG";
+  private static final String CODEC_ID_PCM_FLOAT = "A_PCM/FLOAT/IEEE";
+  private static final String CODEC_ID_SUBRIP = "S_TEXT/UTF8";
+  private static final String CODEC_ID_ASS = "S_TEXT/ASS";
+  private static final String CODEC_ID_SSA = "S_TEXT/SSA";
+  private static final String CODEC_ID_VTT = "S_TEXT/WEBVTT";
+  private static final String CODEC_ID_VOBSUB = "S_VOBSUB";
+  private static final String CODEC_ID_PGS = "S_HDMV/PGS";
+  private static final String CODEC_ID_DVBSUB = "S_DVBSUB";
+
+  private static final int VORBIS_MAX_INPUT_SIZE = 8192;
+  private static final int OPUS_MAX_INPUT_SIZE = 5760;
+  private static final int ENCRYPTION_IV_SIZE = 8;
+
+  private static final int ID_EBML = 0x1A45DFA3;
+  private static final int ID_EBML_READ_VERSION = 0x42F7;
+  private static final int ID_DOC_TYPE = 0x4282;
+  private static final int ID_DOC_TYPE_READ_VERSION = 0x4285;
+  private static final int ID_SEGMENT = 0x18538067;
+  private static final int ID_SEGMENT_INFO = 0x1549A966;
+  private static final int ID_SEEK_HEAD = 0x114D9B74;
+  private static final int ID_SEEK = 0x4DBB;
+  private static final int ID_SEEK_ID = 0x53AB;
+  private static final int ID_SEEK_POSITION = 0x53AC;
+  private static final int ID_INFO = 0x1549A966;
+  private static final int ID_TIMECODE_SCALE = 0x2AD7B1;
+  private static final int ID_DURATION = 0x4489;
+  private static final int ID_CLUSTER = 0x1F43B675;
+  private static final int ID_TIME_CODE = 0xE7;
+  private static final int ID_SIMPLE_BLOCK = 0xA3;
+  private static final int ID_BLOCK_GROUP = 0xA0;
+  private static final int ID_BLOCK = 0xA1;
+  private static final int ID_BLOCK_DURATION = 0x9B;
+  private static final int ID_BLOCK_ADDITIONS = 0x75A1;
+  private static final int ID_BLOCK_MORE = 0xA6;
+  private static final int ID_BLOCK_ADD_ID = 0xEE;
+  private static final int ID_BLOCK_ADDITIONAL = 0xA5;
+  private static final int ID_REFERENCE_BLOCK = 0xFB;
+  private static final int ID_TRACKS = 0x1654AE6B;
+  private static final int ID_TRACK_ENTRY = 0xAE;
+  private static final int ID_TRACK_NUMBER = 0xD7;
+  private static final int ID_TRACK_TYPE = 0x83;
+  private static final int ID_FLAG_DEFAULT = 0x88;
+  private static final int ID_FLAG_FORCED = 0x55AA;
+  private static final int ID_DEFAULT_DURATION = 0x23E383;
+  private static final int ID_MAX_BLOCK_ADDITION_ID = 0x55EE;
+  private static final int ID_BLOCK_ADDITION_MAPPING = 0x41E4;
+  private static final int ID_BLOCK_ADD_ID_TYPE = 0x41E7;
+  private static final int ID_BLOCK_ADD_ID_EXTRA_DATA = 0x41ED;
+  private static final int ID_NAME = 0x536E;
+  private static final int ID_CODEC_ID = 0x86;
+  private static final int ID_CODEC_PRIVATE = 0x63A2;
+  private static final int ID_CODEC_DELAY = 0x56AA;
+  private static final int ID_SEEK_PRE_ROLL = 0x56BB;
+  private static final int ID_DISCARD_PADDING = 0x75A2;
+  private static final int ID_VIDEO = 0xE0;
+  private static final int ID_PIXEL_WIDTH = 0xB0;
+  private static final int ID_PIXEL_HEIGHT = 0xBA;
+  private static final int ID_DISPLAY_WIDTH = 0x54B0;
+  private static final int ID_DISPLAY_HEIGHT = 0x54BA;
+  private static final int ID_DISPLAY_UNIT = 0x54B2;
+  private static final int ID_AUDIO = 0xE1;
+  private static final int ID_CHANNELS = 0x9F;
+  private static final int ID_AUDIO_BIT_DEPTH = 0x6264;
+  private static final int ID_SAMPLING_FREQUENCY = 0xB5;
+  private static final int ID_CONTENT_ENCODINGS = 0x6D80;
+  private static final int ID_CONTENT_ENCODING = 0x6240;
+  private static final int ID_CONTENT_ENCODING_ORDER = 0x5031;
+  private static final int ID_CONTENT_ENCODING_SCOPE = 0x5032;
+  private static final int ID_CONTENT_COMPRESSION = 0x5034;
+  private static final int ID_CONTENT_COMPRESSION_ALGORITHM = 0x4254;
+  private static final int ID_CONTENT_COMPRESSION_SETTINGS = 0x4255;
+  private static final int ID_CONTENT_ENCRYPTION = 0x5035;
+  private static final int ID_CONTENT_ENCRYPTION_ALGORITHM = 0x47E1;
+  private static final int ID_CONTENT_ENCRYPTION_KEY_ID = 0x47E2;
+  private static final int ID_CONTENT_ENCRYPTION_AES_SETTINGS = 0x47E7;
+  private static final int ID_CONTENT_ENCRYPTION_AES_SETTINGS_CIPHER_MODE = 0x47E8;
+  private static final int ID_CUES = 0x1C53BB6B;
+  private static final int ID_CUE_POINT = 0xBB;
+  private static final int ID_CUE_TIME = 0xB3;
+  private static final int ID_CUE_TRACK = 0xF7;
+  private static final int ID_CUE_TRACK_POSITIONS = 0xB7;
+  private static final int ID_CUE_CLUSTER_POSITION = 0xF1;
+  private static final int ID_CUE_RELATIVE_POSITION = 0xF0;
+  private static final int ID_LANGUAGE = 0x22B59C;
+  private static final int ID_PROJECTION = 0x7670;
+  private static final int ID_PROJECTION_TYPE = 0x7671;
+  private static final int ID_PROJECTION_PRIVATE = 0x7672;
+  private static final int ID_PROJECTION_POSE_YAW = 0x7673;
+  private static final int ID_PROJECTION_POSE_PITCH = 0x7674;
+  private static final int ID_PROJECTION_POSE_ROLL = 0x7675;
+  private static final int ID_STEREO_MODE = 0x53B8;
+  private static final int ID_COLOUR = 0x55B0;
+  private static final int ID_COLOUR_RANGE = 0x55B9;
+  private static final int ID_COLOUR_BITS_PER_CHANNEL = 0x55B2;
+  private static final int ID_COLOUR_TRANSFER = 0x55BA;
+  private static final int ID_COLOUR_PRIMARIES = 0x55BB;
+  private static final int ID_MAX_CLL = 0x55BC;
+  private static final int ID_MAX_FALL = 0x55BD;
+  private static final int ID_MASTERING_METADATA = 0x55D0;
+  private static final int ID_PRIMARY_R_CHROMATICITY_X = 0x55D1;
+  private static final int ID_PRIMARY_R_CHROMATICITY_Y = 0x55D2;
+  private static final int ID_PRIMARY_G_CHROMATICITY_X = 0x55D3;
+  private static final int ID_PRIMARY_G_CHROMATICITY_Y = 0x55D4;
+  private static final int ID_PRIMARY_B_CHROMATICITY_X = 0x55D5;
+  private static final int ID_PRIMARY_B_CHROMATICITY_Y = 0x55D6;
+  private static final int ID_WHITE_POINT_CHROMATICITY_X = 0x55D7;
+  private static final int ID_WHITE_POINT_CHROMATICITY_Y = 0x55D8;
+  private static final int ID_LUMNINANCE_MAX = 0x55D9;
+  private static final int ID_LUMNINANCE_MIN = 0x55DA;
+
+  /**
+   * BlockAddID value for ITU T.35 metadata in a VP9 track. See also
+   * https://www.webmproject.org/docs/container/.
+   */
+  private static final int BLOCK_ADDITIONAL_ID_VP9_ITU_T_35 = 4;
+
+  /**
+   * BlockAddIdType value for Dolby Vision configuration with profile <= 7. See also
+   * https://www.matroska.org/technical/codec_specs.html.
+   */
+  private static final int BLOCK_ADD_ID_TYPE_DVCC = 0x64766343;
+
+  /**
+   * BlockAddIdType value for Dolby Vision configuration with profile > 7. See also
+   * https://www.matroska.org/technical/codec_specs.html.
+   */
+  private static final int BLOCK_ADD_ID_TYPE_DVVC = 0x64767643;
+
+  private static final int LACING_NONE = 0;
+  private static final int LACING_XIPH = 1;
+  private static final int LACING_FIXED_SIZE = 2;
+  private static final int LACING_EBML = 3;
+
+  private static final int FOURCC_COMPRESSION_DIVX = 0x58564944;
+  private static final int FOURCC_COMPRESSION_H263 = 0x33363248;
+  private static final int FOURCC_COMPRESSION_VC1 = 0x31435657;
+
+  /** The maximum number of chunks to scan when searching for a thumbnail. */
+  private static final int MAX_CHUNKS_TO_SCAN_FOR_THUMBNAIL = 20;
+
+  /** The maximum duration to scan for a thumbnail, in microseconds. */
+  private static final long MAX_DURATION_US_TO_SCAN_FOR_THUMBNAIL = 10_000_000L;
+
+  /**
+   * A template for the prefix that must be added to each subrip sample.
+   *
+   * <p>The display time of each subtitle is passed as {@code timeUs} to {@link
+   * TrackOutput#sampleMetadata}. The start and end timecodes in this template are relative to
+   * {@code timeUs}. Hence the start timecode is always zero. The 12 byte end timecode starting at
+   * {@link #SUBRIP_PREFIX_END_TIMECODE_OFFSET} is set to a placeholder value, and must be replaced
+   * with the duration of the subtitle.
+   *
+   * <p>Equivalent to the UTF-8 string: "1\n00:00:00,000 --> 00:00:00,000\n".
+   */
+  private static final byte[] SUBRIP_PREFIX =
+      new byte[] {
+        49, 10, 48, 48, 58, 48, 48, 58, 48, 48, 44, 48, 48, 48, 32, 45, 45, 62, 32, 48, 48, 58, 48,
+        48, 58, 48, 48, 44, 48, 48, 48, 10
+      };
+
+  /** The byte offset of the end timecode in {@link #SUBRIP_PREFIX}. */
+  private static final int SUBRIP_PREFIX_END_TIMECODE_OFFSET = 19;
+
+  /**
+   * The value by which to divide a time in microseconds to convert it to the unit of the last value
+   * in a subrip timecode (milliseconds).
+   */
+  private static final long SUBRIP_TIMECODE_LAST_VALUE_SCALING_FACTOR = 1000;
+
+  /** The format of a subrip timecode. */
+  private static final String SUBRIP_TIMECODE_FORMAT = "%02d:%02d:%02d,%03d";
+
+  /** Matroska specific format line for SSA subtitles. */
+  private static final byte[] SSA_DIALOGUE_FORMAT =
+      Util.getUtf8Bytes(
+          "Format: Start, End, "
+              + "ReadOrder, Layer, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
+
+  /**
+   * A template for the prefix that must be added to each SSA sample.
+   *
+   * <p>The display time of each subtitle is passed as {@code timeUs} to {@link
+   * TrackOutput#sampleMetadata}. The start and end timecodes in this template are relative to
+   * {@code timeUs}. Hence the start timecode is always zero. The 12 byte end timecode starting at
+   * {@link #SUBRIP_PREFIX_END_TIMECODE_OFFSET} is set to a placeholder value, and must be replaced
+   * with the duration of the subtitle.
+   *
+   * <p>Equivalent to the UTF-8 string: "Dialogue: 0:00:00:00,0:00:00:00,".
+   */
+  private static final byte[] SSA_PREFIX =
+      new byte[] {
+        68, 105, 97, 108, 111, 103, 117, 101, 58, 32, 48, 58, 48, 48, 58, 48, 48, 58, 48, 48, 44,
+        48, 58, 48, 48, 58, 48, 48, 58, 48, 48, 44
+      };
+
+  /** The byte offset of the end timecode in {@link #SSA_PREFIX}. */
+  private static final int SSA_PREFIX_END_TIMECODE_OFFSET = 21;
+
+  /**
+   * The value by which to divide a time in microseconds to convert it to the unit of the last value
+   * in an SSA timecode (1/100ths of a second).
+   */
+  private static final long SSA_TIMECODE_LAST_VALUE_SCALING_FACTOR = 10_000;
+
+  /** The format of an SSA timecode. */
+  private static final String SSA_TIMECODE_FORMAT = "%01d:%02d:%02d:%02d";
+
+  /**
+   * A template for the prefix that must be added to each VTT sample.
+   *
+   * <p>The display time of each subtitle is passed as {@code timeUs} to {@link
+   * TrackOutput#sampleMetadata}. The start and end timecodes in this template are relative to
+   * {@code timeUs}. Hence the start timecode is always zero. The 12 byte end timecode starting at
+   * {@link #VTT_PREFIX_END_TIMECODE_OFFSET} is set to a placeholder value, and must be replaced
+   * with the duration of the subtitle.
+   *
+   * <p>Equivalent to the UTF-8 string: "WEBVTT\n\n00:00:00.000 --> 00:00:00.000\n".
+   */
+  private static final byte[] VTT_PREFIX =
+      new byte[] {
+        87, 69, 66, 86, 84, 84, 10, 10, 48, 48, 58, 48, 48, 58, 48, 48, 46, 48, 48, 48, 32, 45, 45,
+        62, 32, 48, 48, 58, 48, 48, 58, 48, 48, 46, 48, 48, 48, 10
+      };
+
+  /** The byte offset of the end timecode in {@link #VTT_PREFIX}. */
+  private static final int VTT_PREFIX_END_TIMECODE_OFFSET = 25;
+
+  /**
+   * The value by which to divide a time in microseconds to convert it to the unit of the last value
+   * in a VTT timecode (milliseconds).
+   */
+  private static final long VTT_TIMECODE_LAST_VALUE_SCALING_FACTOR = 1000;
+
+  /** The format of a VTT timecode. */
+  private static final String VTT_TIMECODE_FORMAT = "%02d:%02d:%02d.%03d";
+
+  /** The length in bytes of a WAVEFORMATEX structure. */
+  private static final int WAVE_FORMAT_SIZE = 18;
+
+  /** Format tag indicating a WAVEFORMATEXTENSIBLE structure. */
+  private static final int WAVE_FORMAT_EXTENSIBLE = 0xFFFE;
+
+  /** Format tag for PCM. */
+  private static final int WAVE_FORMAT_PCM = 1;
+
+  /** Sub format for PCM. */
+  private static final UUID WAVE_SUBFORMAT_PCM = new UUID(0x0100000000001000L, 0x800000AA00389B71L);
+
+  /** Some HTC devices signal rotation in track names. */
+  private static final Map<String, Integer> TRACK_NAME_TO_ROTATION_DEGREES;
+
+  static {
+    Map<String, Integer> trackNameToRotationDegrees = new HashMap<>();
+    trackNameToRotationDegrees.put("htc_video_rotA-000", 0);
+    trackNameToRotationDegrees.put("htc_video_rotA-090", 90);
+    trackNameToRotationDegrees.put("htc_video_rotA-180", 180);
+    trackNameToRotationDegrees.put("htc_video_rotA-270", 270);
+    TRACK_NAME_TO_ROTATION_DEGREES = Collections.unmodifiableMap(trackNameToRotationDegrees);
+  }
+
+  private final EbmlReader reader;
+  private final VarintReader varintReader;
+  private final SparseArray<Track> tracks;
+  private final boolean seekForCuesEnabled;
+  private final boolean parseSubtitlesDuringExtraction;
+  private final SubtitleParser.Factory subtitleParserFactory;
+  @Nullable private final DolbyVisionSampleTransformer dolbyVisionSampleTransformer;
+
+  // Temporary arrays.
+  private final ParsableByteArray nalStartCode;
+  private final ParsableByteArray nalLength;
+  private final ParsableByteArray scratch;
+  private final ParsableByteArray vorbisNumPageSamples;
+  private final ParsableByteArray seekEntryIdBytes;
+  private final ParsableByteArray sampleStrippedBytes;
+  private final ParsableByteArray subtitleSample;
+  private final ParsableByteArray encryptionInitializationVector;
+  private final ParsableByteArray encryptionSubsampleData;
+  private final ParsableByteArray supplementalData;
+  private @MonotonicNonNull ByteBuffer encryptionSubsampleDataBuffer;
+
+  // Reused per-sample read buffer for Dolby Vision conversion; grows to the largest sample.
+  private byte[] dolbyVisionSampleBuffer = new byte[0];
+
+  private long segmentContentSize;
+  private long segmentContentPosition = C.INDEX_UNSET;
+  private long timecodeScale = C.TIME_UNSET;
+  private long durationTimecode = C.TIME_UNSET;
+  private long durationUs = C.TIME_UNSET;
+  private boolean isWebm;
+  private boolean pendingEndTracks;
+
+  // The track corresponding to the current TrackEntry element, or null.
+  @Nullable private Track currentTrack;
+
+  // Whether a seek map has been sent to the output.
+  private boolean sentSeekMap;
+
+  // Master seek entry related elements.
+  private int seekEntryId;
+  private long seekEntryPosition;
+
+  // Cue related elements.
+  private final SparseArray<List<MatroskaSeekMap.CuePointData>> perTrackCues;
+  private boolean inCuesElement;
+  private long currentCueTimeUs = C.TIME_UNSET;
+  private int currentCueTrackNumber = C.INDEX_UNSET;
+  private long currentCueClusterPosition = C.INDEX_UNSET;
+  private long currentCueRelativePosition = C.INDEX_UNSET;
+  private int primarySeekTrackNumber = C.INDEX_UNSET;
+  private boolean seekForCues;
+  private long cuesContentPosition = C.INDEX_UNSET;
+  private long seekPositionAfterBuildingCues = C.INDEX_UNSET;
+  private long clusterTimecodeUs = C.TIME_UNSET;
+
+  // Reading state.
+  private boolean haveOutputSample;
+
+  // Block reading state.
+  private int blockState;
+  private long blockTimeUs;
+  private long blockDurationUs;
+  private int blockSampleIndex;
+  private int blockSampleCount;
+  private int[] blockSampleSizes;
+  private int blockTrackNumber;
+  private int blockTrackNumberLength;
+  private @C.BufferFlags int blockFlags;
+  private int blockAdditionalId;
+  private boolean blockHasReferenceBlock;
+  private long blockGroupDiscardPaddingNs;
+
+  // Sample writing state.
+  private int sampleBytesRead;
+  private int sampleBytesWritten;
+  private int sampleCurrentNalBytesRemaining;
+  private boolean sampleEncodingHandled;
+  private boolean sampleSignalByteRead;
+  private boolean samplePartitionCountRead;
+  private int samplePartitionCount;
+  private byte sampleSignalByte;
+  private boolean sampleInitializationVectorRead;
+
+  // Extractor outputs.
+  private @MonotonicNonNull ExtractorOutput extractorOutput;
+
+  /**
+   * @deprecated Use {@link #MatroskaExtractor(SubtitleParser.Factory)} instead.
+   */
+  @Deprecated
+  public MatroskaExtractor() {
+    this(
+        new DefaultEbmlReader(),
+        FLAG_EMIT_RAW_SUBTITLE_DATA,
+        SubtitleParser.Factory.UNSUPPORTED,
+        /* dolbyVisionSampleTransformer= */ null);
+  }
+
+  /**
+   * @deprecated Use {@link #MatroskaExtractor(SubtitleParser.Factory, int)} instead.
+   */
+  @Deprecated
+  public MatroskaExtractor(@Flags int flags) {
+    this(
+        new DefaultEbmlReader(),
+        flags | FLAG_EMIT_RAW_SUBTITLE_DATA,
+        SubtitleParser.Factory.UNSUPPORTED,
+        /* dolbyVisionSampleTransformer= */ null);
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param subtitleParserFactory The {@link SubtitleParser.Factory} for parsing subtitles during
+   *     extraction.
+   */
+  public MatroskaExtractor(SubtitleParser.Factory subtitleParserFactory) {
+    this(
+        new DefaultEbmlReader(),
+        /* flags= */ 0,
+        subtitleParserFactory,
+        /* dolbyVisionSampleTransformer= */ null);
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param subtitleParserFactory The {@link SubtitleParser.Factory} for parsing subtitles during
+   *     extraction.
+   * @param flags Flags that control the extractor's behavior.
+   */
+  public MatroskaExtractor(SubtitleParser.Factory subtitleParserFactory, @Flags int flags) {
+    this(
+        new DefaultEbmlReader(),
+        flags,
+        subtitleParserFactory,
+        /* dolbyVisionSampleTransformer= */ null);
+  }
+
+  /**
+   * Constructs an instance with an optional Dolby Vision sample hook.
+   *
+   * @param subtitleParserFactory The {@link SubtitleParser.Factory} for parsing subtitles during
+   *     extraction.
+   * @param flags Flags that control the extractor's behavior.
+   * @param dolbyVisionSampleTransformer Optional hook for DV sample processing.
+   */
+  public MatroskaExtractor(
+      SubtitleParser.Factory subtitleParserFactory,
+      @Flags int flags,
+      @Nullable DolbyVisionSampleTransformer dolbyVisionSampleTransformer) {
+    this(new DefaultEbmlReader(), flags, subtitleParserFactory, dolbyVisionSampleTransformer);
+  }
+
+  /* package */ MatroskaExtractor(
+      EbmlReader reader, @Flags int flags, SubtitleParser.Factory subtitleParserFactory) {
+    this(
+        reader,
+        flags,
+        subtitleParserFactory,
+        /* dolbyVisionSampleTransformer= */ null);
+  }
+
+  /* package */ MatroskaExtractor(
+      EbmlReader reader,
+      @Flags int flags,
+      SubtitleParser.Factory subtitleParserFactory,
+      @Nullable DolbyVisionSampleTransformer dolbyVisionSampleTransformer) {
+    this.reader = reader;
+    this.reader.init(new InnerEbmlProcessor());
+    this.subtitleParserFactory = subtitleParserFactory;
+    this.dolbyVisionSampleTransformer = dolbyVisionSampleTransformer;
+    this.perTrackCues = new SparseArray<>();
+    seekForCuesEnabled = (flags & FLAG_DISABLE_SEEK_FOR_CUES) == 0;
+    parseSubtitlesDuringExtraction = (flags & FLAG_EMIT_RAW_SUBTITLE_DATA) == 0;
+    varintReader = new VarintReader();
+    tracks = new SparseArray<>();
+    scratch = new ParsableByteArray(4);
+    vorbisNumPageSamples = new ParsableByteArray(ByteBuffer.allocate(4).putInt(-1).array());
+    seekEntryIdBytes = new ParsableByteArray(4);
+    nalStartCode = new ParsableByteArray(NalUnitUtil.NAL_START_CODE);
+    nalLength = new ParsableByteArray(4);
+    sampleStrippedBytes = new ParsableByteArray();
+    subtitleSample = new ParsableByteArray();
+    encryptionInitializationVector = new ParsableByteArray(ENCRYPTION_IV_SIZE);
+    encryptionSubsampleData = new ParsableByteArray();
+    supplementalData = new ParsableByteArray();
+    blockSampleSizes = new int[1];
+    pendingEndTracks = true;
+  }
+
+  @Override
+  public final boolean sniff(ExtractorInput input) throws IOException {
+    return new Sniffer().sniff(input);
+  }
+
+  @Override
+  public final void init(ExtractorOutput output) {
+    extractorOutput =
+        parseSubtitlesDuringExtraction
+            ? new SubtitleTranscodingExtractorOutput(output, subtitleParserFactory)
+            : output;
+  }
+
+  @CallSuper
+  @Override
+  public void seek(long position, long timeUs) {
+    clusterTimecodeUs = C.TIME_UNSET;
+    blockState = BLOCK_STATE_START;
+    reader.reset();
+    varintReader.reset();
+    resetWriteSampleData();
+    inCuesElement = false;
+    currentCueTimeUs = C.TIME_UNSET;
+    currentCueTrackNumber = C.INDEX_UNSET;
+    currentCueClusterPosition = C.INDEX_UNSET;
+    currentCueRelativePosition = C.INDEX_UNSET;
+    // To prevent creating duplicate cue points on a re-parse, clear any existing cue data if the
+    // seek map has not yet been sent. Once sent, the cue data is considered final, and subsequent
+    // Cues elements will be ignored by the parsing logic.
+    if (!sentSeekMap) {
+      perTrackCues.clear();
+    }
+    for (int i = 0; i < tracks.size(); i++) {
+      tracks.valueAt(i).reset();
+    }
+  }
+
+  @Override
+  public final void release() {
+    // Do nothing
+  }
+
+  @Override
+  public final int read(ExtractorInput input, PositionHolder seekPosition) throws IOException {
+    haveOutputSample = false;
+    boolean continueReading = true;
+    while (continueReading && !haveOutputSample) {
+      continueReading = reader.read(input);
+      if (continueReading && maybeSeekForCues(seekPosition, input.getPosition())) {
+        return Extractor.RESULT_SEEK;
+      }
+    }
+    if (!continueReading) {
+      for (int i = 0; i < tracks.size(); i++) {
+        Track track = tracks.valueAt(i);
+        track.assertOutputInitialized();
+        track.outputPendingSampleMetadata();
+      }
+      return Extractor.RESULT_END_OF_INPUT;
+    }
+    return Extractor.RESULT_CONTINUE;
+  }
+
+  /**
+   * Maps an element ID to a corresponding type.
+   *
+   * @see EbmlProcessor#getElementType(int)
+   */
+  @CallSuper
+  protected @EbmlProcessor.ElementType int getElementType(int id) {
+    switch (id) {
+      case ID_EBML:
+      case ID_SEGMENT:
+      case ID_SEEK_HEAD:
+      case ID_SEEK:
+      case ID_INFO:
+      case ID_CLUSTER:
+      case ID_TRACKS:
+      case ID_TRACK_ENTRY:
+      case ID_BLOCK_ADDITION_MAPPING:
+      case ID_AUDIO:
+      case ID_VIDEO:
+      case ID_CONTENT_ENCODINGS:
+      case ID_CONTENT_ENCODING:
+      case ID_CONTENT_COMPRESSION:
+      case ID_CONTENT_ENCRYPTION:
+      case ID_CONTENT_ENCRYPTION_AES_SETTINGS:
+      case ID_CUES:
+      case ID_CUE_POINT:
+      case ID_CUE_TRACK_POSITIONS:
+      case ID_BLOCK_GROUP:
+      case ID_BLOCK_ADDITIONS:
+      case ID_BLOCK_MORE:
+      case ID_PROJECTION:
+      case ID_COLOUR:
+      case ID_MASTERING_METADATA:
+        return EbmlProcessor.ELEMENT_TYPE_MASTER;
+      case ID_EBML_READ_VERSION:
+      case ID_DOC_TYPE_READ_VERSION:
+      case ID_SEEK_POSITION:
+      case ID_TIMECODE_SCALE:
+      case ID_TIME_CODE:
+      case ID_BLOCK_DURATION:
+      case ID_PIXEL_WIDTH:
+      case ID_PIXEL_HEIGHT:
+      case ID_DISPLAY_WIDTH:
+      case ID_DISPLAY_HEIGHT:
+      case ID_DISPLAY_UNIT:
+      case ID_TRACK_NUMBER:
+      case ID_TRACK_TYPE:
+      case ID_FLAG_DEFAULT:
+      case ID_FLAG_FORCED:
+      case ID_DEFAULT_DURATION:
+      case ID_MAX_BLOCK_ADDITION_ID:
+      case ID_BLOCK_ADD_ID_TYPE:
+      case ID_CODEC_DELAY:
+      case ID_SEEK_PRE_ROLL:
+      case ID_DISCARD_PADDING:
+      case ID_CHANNELS:
+      case ID_AUDIO_BIT_DEPTH:
+      case ID_CONTENT_ENCODING_ORDER:
+      case ID_CONTENT_ENCODING_SCOPE:
+      case ID_CONTENT_COMPRESSION_ALGORITHM:
+      case ID_CONTENT_ENCRYPTION_ALGORITHM:
+      case ID_CONTENT_ENCRYPTION_AES_SETTINGS_CIPHER_MODE:
+      case ID_CUE_TIME:
+      case ID_CUE_CLUSTER_POSITION:
+      case ID_CUE_RELATIVE_POSITION:
+      case ID_CUE_TRACK:
+      case ID_REFERENCE_BLOCK:
+      case ID_STEREO_MODE:
+      case ID_COLOUR_BITS_PER_CHANNEL:
+      case ID_COLOUR_RANGE:
+      case ID_COLOUR_TRANSFER:
+      case ID_COLOUR_PRIMARIES:
+      case ID_MAX_CLL:
+      case ID_MAX_FALL:
+      case ID_PROJECTION_TYPE:
+      case ID_BLOCK_ADD_ID:
+        return EbmlProcessor.ELEMENT_TYPE_UNSIGNED_INT;
+      case ID_DOC_TYPE:
+      case ID_NAME:
+      case ID_CODEC_ID:
+      case ID_LANGUAGE:
+        return EbmlProcessor.ELEMENT_TYPE_STRING;
+      case ID_SEEK_ID:
+      case ID_BLOCK_ADD_ID_EXTRA_DATA:
+      case ID_CONTENT_COMPRESSION_SETTINGS:
+      case ID_CONTENT_ENCRYPTION_KEY_ID:
+      case ID_SIMPLE_BLOCK:
+      case ID_BLOCK:
+      case ID_CODEC_PRIVATE:
+      case ID_PROJECTION_PRIVATE:
+      case ID_BLOCK_ADDITIONAL:
+        return EbmlProcessor.ELEMENT_TYPE_BINARY;
+      case ID_DURATION:
+      case ID_SAMPLING_FREQUENCY:
+      case ID_PRIMARY_R_CHROMATICITY_X:
+      case ID_PRIMARY_R_CHROMATICITY_Y:
+      case ID_PRIMARY_G_CHROMATICITY_X:
+      case ID_PRIMARY_G_CHROMATICITY_Y:
+      case ID_PRIMARY_B_CHROMATICITY_X:
+      case ID_PRIMARY_B_CHROMATICITY_Y:
+      case ID_WHITE_POINT_CHROMATICITY_X:
+      case ID_WHITE_POINT_CHROMATICITY_Y:
+      case ID_LUMNINANCE_MAX:
+      case ID_LUMNINANCE_MIN:
+      case ID_PROJECTION_POSE_YAW:
+      case ID_PROJECTION_POSE_PITCH:
+      case ID_PROJECTION_POSE_ROLL:
+        return EbmlProcessor.ELEMENT_TYPE_FLOAT;
+      default:
+        return EbmlProcessor.ELEMENT_TYPE_UNKNOWN;
+    }
+  }
+
+  /**
+   * Checks if the given id is that of a level 1 element.
+   *
+   * @see EbmlProcessor#isLevel1Element(int)
+   */
+  @CallSuper
+  protected boolean isLevel1Element(int id) {
+    return id == ID_SEGMENT_INFO || id == ID_CLUSTER || id == ID_CUES || id == ID_TRACKS;
+  }
+
+  /**
+   * Called when the start of a master element is encountered.
+   *
+   * @see EbmlProcessor#startMasterElement(int, long, long)
+   */
+  @CallSuper
+  protected void startMasterElement(int id, long contentPosition, long contentSize)
+      throws ParserException {
+    assertInitialized();
+    switch (id) {
+      case ID_SEGMENT:
+        if (segmentContentPosition != C.INDEX_UNSET && segmentContentPosition != contentPosition) {
+          throw ParserException.createForMalformedContainer(
+              "Multiple Segment elements not supported", /* cause= */ null);
+        }
+        segmentContentPosition = contentPosition;
+        segmentContentSize = contentSize;
+        break;
+      case ID_SEEK:
+        seekEntryId = UNSET_ENTRY_ID;
+        seekEntryPosition = C.INDEX_UNSET;
+        break;
+      case ID_CUES:
+        if (!sentSeekMap) {
+          inCuesElement = true;
+        }
+        break;
+      case ID_CUE_POINT:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          currentCueTimeUs = C.TIME_UNSET;
+        }
+        break;
+      case ID_CUE_TRACK_POSITIONS:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          currentCueTrackNumber = C.INDEX_UNSET;
+          currentCueClusterPosition = C.INDEX_UNSET;
+          currentCueRelativePosition = C.INDEX_UNSET;
+        }
+        break;
+      case ID_CLUSTER:
+        if (!sentSeekMap) {
+          // We need to build cues before parsing the cluster.
+          if (seekForCuesEnabled && cuesContentPosition != C.INDEX_UNSET) {
+            // We know where the Cues element is located. Seek to request it.
+            seekForCues = true;
+          } else {
+            // We don't know where the Cues element is located. It's most likely omitted. Allow
+            // playback, but disable seeking.
+            extractorOutput.seekMap(new SeekMap.Unseekable(durationUs));
+            sentSeekMap = true;
+          }
+        }
+        break;
+      case ID_BLOCK_GROUP:
+        blockHasReferenceBlock = false;
+        blockGroupDiscardPaddingNs = 0L;
+        break;
+      case ID_CONTENT_ENCODING:
+        // TODO: check and fail if more than one content encoding is present.
+        break;
+      case ID_CONTENT_ENCRYPTION:
+        getCurrentTrack(id).hasContentEncryption = true;
+        break;
+      case ID_TRACK_ENTRY:
+        currentTrack = new Track();
+        currentTrack.isWebm = isWebm;
+        break;
+      case ID_MASTERING_METADATA:
+        getCurrentTrack(id).hasColorInfo = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Called when the end of a master element is encountered.
+   *
+   * @see EbmlProcessor#endMasterElement(int)
+   */
+  @CallSuper
+  protected void endMasterElement(int id) throws ParserException {
+    assertInitialized();
+    switch (id) {
+      case ID_SEGMENT_INFO:
+        if (timecodeScale == C.TIME_UNSET) {
+          // timecodeScale was omitted. Use the default value.
+          timecodeScale = 1000000;
+        }
+        if (durationTimecode != C.TIME_UNSET) {
+          durationUs = scaleTimecodeToUs(durationTimecode);
+        }
+        break;
+      case ID_SEEK:
+        if (seekEntryId == UNSET_ENTRY_ID || seekEntryPosition == C.INDEX_UNSET) {
+          throw ParserException.createForMalformedContainer(
+              "Mandatory element SeekID or SeekPosition not found", /* cause= */ null);
+        }
+        if (seekEntryId == ID_CUES) {
+          cuesContentPosition = seekEntryPosition;
+        }
+        break;
+      case ID_CUES:
+        if (!sentSeekMap) {
+          boolean hasAnyCues = false;
+          for (int i = 0; i < perTrackCues.size(); i++) {
+            if (!perTrackCues.valueAt(i).isEmpty()) {
+              hasAnyCues = true;
+              break;
+            }
+          }
+          if (!hasAnyCues || durationUs == C.TIME_UNSET) {
+            // Cues are missing, empty, or duration is unknown.
+            extractorOutput.seekMap(new SeekMap.Unseekable(durationUs));
+          } else {
+            for (int i = 0; i < perTrackCues.size(); i++) {
+              Collections.sort(perTrackCues.valueAt(i));
+            }
+            MatroskaSeekMap seekMap =
+                new MatroskaSeekMap(
+                    perTrackCues,
+                    durationUs,
+                    primarySeekTrackNumber,
+                    segmentContentPosition,
+                    segmentContentSize);
+            extractorOutput.seekMap(seekMap);
+          }
+          sentSeekMap = true;
+          inCuesElement = false;
+          for (int i = 0; i < tracks.size(); i++) {
+            Track track = tracks.valueAt(i);
+            track.maybeAddThumbnailMetadata(
+                perTrackCues, durationUs, segmentContentPosition, segmentContentSize);
+            if (!track.waitingForDtsAnalysis) {
+              track.assertOutputInitialized();
+              track.output.format(checkNotNull(track.format));
+            }
+          }
+          maybeEndTracks();
+        }
+        break;
+      case ID_CUE_TRACK_POSITIONS:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          if (currentCueTimeUs != C.TIME_UNSET
+              && currentCueTrackNumber != C.INDEX_UNSET
+              && currentCueClusterPosition != C.INDEX_UNSET) {
+            List<MatroskaSeekMap.CuePointData> trackCues = perTrackCues.get(currentCueTrackNumber);
+            if (trackCues == null) {
+              trackCues = new ArrayList<>();
+              perTrackCues.put(currentCueTrackNumber, trackCues);
+            }
+            trackCues.add(
+                new MatroskaSeekMap.CuePointData(
+                    currentCueTimeUs,
+                    /* clusterPosition= */ segmentContentPosition + currentCueClusterPosition,
+                    /* relativePosition= */ currentCueRelativePosition));
+          }
+        }
+        break;
+      case ID_BLOCK_GROUP:
+        if (blockState != BLOCK_STATE_DATA) {
+          // We've skipped this block (due to incompatible track number).
+          return;
+        }
+        Track track = tracks.get(blockTrackNumber);
+        track.assertOutputInitialized();
+        if (blockGroupDiscardPaddingNs > 0L && CODEC_ID_OPUS.equals(track.codecId)) {
+          // For Opus, attach DiscardPadding to the block group samples as supplemental data.
+          supplementalData.reset(
+              ByteBuffer.allocate(8)
+                  .order(ByteOrder.LITTLE_ENDIAN)
+                  .putLong(blockGroupDiscardPaddingNs)
+                  .array());
+        }
+
+        // Commit sample metadata.
+        int sampleOffset = 0;
+        for (int i = 0; i < blockSampleCount; i++) {
+          sampleOffset += blockSampleSizes[i];
+        }
+        for (int i = 0; i < blockSampleCount; i++) {
+          long sampleTimeUs = blockTimeUs + (i * track.defaultSampleDurationNs) / 1000;
+          int sampleFlags = blockFlags;
+          if (i == 0 && !blockHasReferenceBlock) {
+            // If the ReferenceBlock element was not found in this block, then the first frame is a
+            // keyframe.
+            sampleFlags |= C.BUFFER_FLAG_KEY_FRAME;
+          }
+          int sampleSize = blockSampleSizes[i];
+          sampleOffset -= sampleSize; // The offset is to the end of the sample.
+          commitSampleToOutput(track, sampleTimeUs, sampleFlags, sampleSize, sampleOffset);
+        }
+        blockState = BLOCK_STATE_START;
+        break;
+      case ID_CONTENT_ENCODING:
+        assertInTrackEntry(id);
+        if (currentTrack.hasContentEncryption) {
+          if (currentTrack.cryptoData == null) {
+            throw ParserException.createForMalformedContainer(
+                "Encrypted Track found but ContentEncKeyID was not found", /* cause= */ null);
+          }
+          currentTrack.drmInitData =
+              new DrmInitData(
+                  new SchemeData(
+                      C.UUID_NIL, MimeTypes.VIDEO_WEBM, currentTrack.cryptoData.encryptionKey));
+        }
+        break;
+      case ID_CONTENT_ENCODINGS:
+        assertInTrackEntry(id);
+        if (currentTrack.hasContentEncryption && currentTrack.sampleStrippedBytes != null) {
+          throw ParserException.createForMalformedContainer(
+              "Combining encryption and compression is not supported", /* cause= */ null);
+        }
+        break;
+      case ID_TRACK_ENTRY:
+        Track currentTrack = checkNotNull(this.currentTrack);
+        if (currentTrack.codecId == null) {
+          throw ParserException.createForMalformedContainer(
+              "CodecId is missing in TrackEntry element", /* cause= */ null);
+        } else {
+          if (isCodecSupported(currentTrack.codecId)) {
+            currentTrack.initializeFormat(currentTrack.number, dolbyVisionSampleTransformer);
+            currentTrack.output = extractorOutput.track(currentTrack.number, currentTrack.type);
+            tracks.put(currentTrack.number, currentTrack);
+          }
+        }
+        this.currentTrack = null;
+        break;
+      case ID_TRACKS:
+        if (tracks.size() == 0) {
+          throw ParserException.createForMalformedContainer(
+              "No valid tracks were found", /* cause= */ null);
+        }
+
+        // Determine the track to use for default seeking.
+        int defaultVideoTrackNumber = C.INDEX_UNSET;
+        int firstVideoTrackNumber = C.INDEX_UNSET;
+        int defaultAudioTrackNumber = C.INDEX_UNSET;
+        int firstAudioTrackNumber = C.INDEX_UNSET;
+
+        // If we're not going to seek for cues, output the formats immediately.
+        boolean mayBeSendFormatsEarly = !seekForCuesEnabled || cuesContentPosition == C.INDEX_UNSET;
+
+        for (int i = 0; i < tracks.size(); i++) {
+          Track trackItem = tracks.valueAt(i);
+
+          @C.TrackType int trackType = trackItem.type;
+          if (trackType == C.TRACK_TYPE_VIDEO) {
+            if (trackItem.flagDefault) {
+              defaultVideoTrackNumber = trackItem.number;
+            }
+            if (firstVideoTrackNumber == C.INDEX_UNSET) {
+              firstVideoTrackNumber = trackItem.number;
+            }
+          } else if (trackType == C.TRACK_TYPE_AUDIO) {
+            if (trackItem.flagDefault) {
+              defaultAudioTrackNumber = trackItem.number;
+            }
+            if (firstAudioTrackNumber == C.INDEX_UNSET) {
+              firstAudioTrackNumber = trackItem.number;
+            }
+          }
+
+          if (mayBeSendFormatsEarly) {
+            trackItem.assertOutputInitialized();
+            if (!trackItem.waitingForDtsAnalysis) {
+              trackItem.output.format(checkNotNull(trackItem.format));
+            }
+          }
+        }
+
+        if (defaultVideoTrackNumber != C.INDEX_UNSET) {
+          primarySeekTrackNumber = defaultVideoTrackNumber;
+        } else if (firstVideoTrackNumber != C.INDEX_UNSET) {
+          primarySeekTrackNumber = firstVideoTrackNumber;
+        } else if (defaultAudioTrackNumber != C.INDEX_UNSET) {
+          primarySeekTrackNumber = defaultAudioTrackNumber;
+        } else if (firstAudioTrackNumber != C.INDEX_UNSET) {
+          primarySeekTrackNumber = firstAudioTrackNumber;
+        } else {
+          primarySeekTrackNumber = tracks.size() > 0 ? tracks.valueAt(0).number : C.INDEX_UNSET;
+        }
+
+        if (mayBeSendFormatsEarly) {
+          maybeEndTracks();
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Called when an integer element is encountered.
+   *
+   * @see EbmlProcessor#integerElement(int, long)
+   */
+  @CallSuper
+  protected void integerElement(int id, long value) throws ParserException {
+    switch (id) {
+      case ID_EBML_READ_VERSION:
+        // Validate that EBMLReadVersion is supported. This extractor only supports v1.
+        if (value != 1) {
+          throw ParserException.createForMalformedContainer(
+              "EBMLReadVersion " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_DOC_TYPE_READ_VERSION:
+        // Validate that DocTypeReadVersion is supported. This extractor only supports up to v2.
+        if (value < 1 || value > 2) {
+          throw ParserException.createForMalformedContainer(
+              "DocTypeReadVersion " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_SEEK_POSITION:
+        // Seek Position is the relative offset beginning from the Segment. So to get absolute
+        // offset from the beginning of the file, we need to add segmentContentPosition to it.
+        seekEntryPosition = value + segmentContentPosition;
+        break;
+      case ID_TIMECODE_SCALE:
+        timecodeScale = value;
+        break;
+      case ID_PIXEL_WIDTH:
+        getCurrentTrack(id).width = (int) value;
+        break;
+      case ID_PIXEL_HEIGHT:
+        getCurrentTrack(id).height = (int) value;
+        break;
+      case ID_DISPLAY_WIDTH:
+        getCurrentTrack(id).displayWidth = (int) value;
+        break;
+      case ID_DISPLAY_HEIGHT:
+        getCurrentTrack(id).displayHeight = (int) value;
+        break;
+      case ID_DISPLAY_UNIT:
+        getCurrentTrack(id).displayUnit = (int) value;
+        break;
+      case ID_TRACK_NUMBER:
+        getCurrentTrack(id).number = (int) value;
+        break;
+      case ID_FLAG_DEFAULT:
+        getCurrentTrack(id).flagDefault = value == 1;
+        break;
+      case ID_FLAG_FORCED:
+        getCurrentTrack(id).flagForced = value == 1;
+        break;
+      case ID_TRACK_TYPE:
+        int matroskaTrackType = (int) value;
+        switch (matroskaTrackType) {
+          case 1: // Matroska video
+            getCurrentTrack(id).type = C.TRACK_TYPE_VIDEO;
+            break;
+          case 2: // Matroska audio
+            getCurrentTrack(id).type = C.TRACK_TYPE_AUDIO;
+            break;
+          case 17: // Matroska subtitle
+            getCurrentTrack(id).type = C.TRACK_TYPE_TEXT;
+            break;
+          case 33: // Matroska metadata
+            getCurrentTrack(id).type = C.TRACK_TYPE_METADATA;
+            break;
+          default:
+            getCurrentTrack(id).type = C.TRACK_TYPE_UNKNOWN;
+            break;
+        }
+        break;
+      case ID_DEFAULT_DURATION:
+        getCurrentTrack(id).defaultSampleDurationNs = (int) value;
+        break;
+      case ID_MAX_BLOCK_ADDITION_ID:
+        getCurrentTrack(id).maxBlockAdditionId = (int) value;
+        break;
+      case ID_BLOCK_ADD_ID_TYPE:
+        getCurrentTrack(id).blockAddIdType = (int) value;
+        break;
+      case ID_CODEC_DELAY:
+        getCurrentTrack(id).codecDelayNs = value;
+        break;
+      case ID_SEEK_PRE_ROLL:
+        getCurrentTrack(id).seekPreRollNs = value;
+        break;
+      case ID_DISCARD_PADDING:
+        blockGroupDiscardPaddingNs = value;
+        break;
+      case ID_CHANNELS:
+        getCurrentTrack(id).channelCount = (int) value;
+        break;
+      case ID_AUDIO_BIT_DEPTH:
+        getCurrentTrack(id).audioBitDepth = (int) value;
+        break;
+      case ID_REFERENCE_BLOCK:
+        blockHasReferenceBlock = true;
+        break;
+      case ID_CONTENT_ENCODING_ORDER:
+        // This extractor only supports one ContentEncoding element and hence the order has to be 0.
+        if (value != 0) {
+          throw ParserException.createForMalformedContainer(
+              "ContentEncodingOrder " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_CONTENT_ENCODING_SCOPE:
+        // This extractor only supports the scope of all frames.
+        if (value != 1) {
+          throw ParserException.createForMalformedContainer(
+              "ContentEncodingScope " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_CONTENT_COMPRESSION_ALGORITHM:
+        // This extractor only supports header stripping.
+        if (value != 3) {
+          throw ParserException.createForMalformedContainer(
+              "ContentCompAlgo " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_CONTENT_ENCRYPTION_ALGORITHM:
+        // Only the value 5 (AES) is allowed according to the WebM specification.
+        if (value != 5) {
+          throw ParserException.createForMalformedContainer(
+              "ContentEncAlgo " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_CONTENT_ENCRYPTION_AES_SETTINGS_CIPHER_MODE:
+        // Only the value 1 is allowed according to the WebM specification.
+        if (value != 1) {
+          throw ParserException.createForMalformedContainer(
+              "AESSettingsCipherMode " + value + " not supported", /* cause= */ null);
+        }
+        break;
+      case ID_CUE_TIME:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          currentCueTimeUs = scaleTimecodeToUs(value);
+        }
+        break;
+      case ID_CUE_TRACK:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          currentCueTrackNumber = (int) value;
+        }
+        break;
+      case ID_CUE_CLUSTER_POSITION:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          if (currentCueClusterPosition == C.INDEX_UNSET) {
+            currentCueClusterPosition = value;
+          }
+        }
+        break;
+      case ID_CUE_RELATIVE_POSITION:
+        if (!sentSeekMap) {
+          assertInCues(id);
+          if (currentCueRelativePosition == C.INDEX_UNSET) {
+            currentCueRelativePosition = value;
+          }
+        }
+        break;
+      case ID_TIME_CODE:
+        clusterTimecodeUs = scaleTimecodeToUs(value);
+        break;
+      case ID_BLOCK_DURATION:
+        blockDurationUs = scaleTimecodeToUs(value);
+        break;
+      case ID_STEREO_MODE:
+        int layout = (int) value;
+        assertInTrackEntry(id);
+        switch (layout) {
+          case 0:
+            currentTrack.stereoMode = C.STEREO_MODE_MONO;
+            break;
+          case 1:
+            currentTrack.stereoMode = C.STEREO_MODE_LEFT_RIGHT;
+            break;
+          case 3:
+            currentTrack.stereoMode = C.STEREO_MODE_TOP_BOTTOM;
+            break;
+          case 15:
+            currentTrack.stereoMode = C.STEREO_MODE_STEREO_MESH;
+            break;
+          default:
+            break;
+        }
+        break;
+      case ID_COLOUR_PRIMARIES:
+        assertInTrackEntry(id);
+        currentTrack.hasColorInfo = true;
+        int colorSpace = ColorInfo.isoColorPrimariesToColorSpace((int) value);
+        if (colorSpace != Format.NO_VALUE) {
+          currentTrack.colorSpace = colorSpace;
+        }
+        break;
+      case ID_COLOUR_TRANSFER:
+        assertInTrackEntry(id);
+        int colorTransfer = ColorInfo.isoTransferCharacteristicsToColorTransfer((int) value);
+        if (colorTransfer != Format.NO_VALUE) {
+          currentTrack.colorTransfer = colorTransfer;
+        }
+        break;
+      case ID_COLOUR_BITS_PER_CHANNEL:
+        assertInTrackEntry(id);
+        currentTrack.hasColorInfo = true;
+        currentTrack.bitsPerChannel = (int) value;
+        break;
+      case ID_COLOUR_RANGE:
+        assertInTrackEntry(id);
+        switch ((int) value) {
+          case 1: // Broadcast range.
+            currentTrack.colorRange = C.COLOR_RANGE_LIMITED;
+            break;
+          case 2:
+            currentTrack.colorRange = C.COLOR_RANGE_FULL;
+            break;
+          default:
+            break;
+        }
+        break;
+      case ID_MAX_CLL:
+        getCurrentTrack(id).maxContentLuminance = (int) value;
+        break;
+      case ID_MAX_FALL:
+        getCurrentTrack(id).maxFrameAverageLuminance = (int) value;
+        break;
+      case ID_PROJECTION_TYPE:
+        assertInTrackEntry(id);
+        switch ((int) value) {
+          case 0:
+            currentTrack.projectionType = C.PROJECTION_RECTANGULAR;
+            break;
+          case 1:
+            currentTrack.projectionType = C.PROJECTION_EQUIRECTANGULAR;
+            break;
+          case 2:
+            currentTrack.projectionType = C.PROJECTION_CUBEMAP;
+            break;
+          case 3:
+            currentTrack.projectionType = C.PROJECTION_MESH;
+            break;
+          default:
+            break;
+        }
+        break;
+      case ID_BLOCK_ADD_ID:
+        blockAdditionalId = (int) value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Called when a float element is encountered.
+   *
+   * @see EbmlProcessor#floatElement(int, double)
+   */
+  @CallSuper
+  protected void floatElement(int id, double value) throws ParserException {
+    switch (id) {
+      case ID_DURATION:
+        durationTimecode = (long) value;
+        break;
+      case ID_SAMPLING_FREQUENCY:
+        getCurrentTrack(id).sampleRate = (int) value;
+        break;
+      case ID_PRIMARY_R_CHROMATICITY_X:
+        getCurrentTrack(id).primaryRChromaticityX = (float) value;
+        break;
+      case ID_PRIMARY_R_CHROMATICITY_Y:
+        getCurrentTrack(id).primaryRChromaticityY = (float) value;
+        break;
+      case ID_PRIMARY_G_CHROMATICITY_X:
+        getCurrentTrack(id).primaryGChromaticityX = (float) value;
+        break;
+      case ID_PRIMARY_G_CHROMATICITY_Y:
+        getCurrentTrack(id).primaryGChromaticityY = (float) value;
+        break;
+      case ID_PRIMARY_B_CHROMATICITY_X:
+        getCurrentTrack(id).primaryBChromaticityX = (float) value;
+        break;
+      case ID_PRIMARY_B_CHROMATICITY_Y:
+        getCurrentTrack(id).primaryBChromaticityY = (float) value;
+        break;
+      case ID_WHITE_POINT_CHROMATICITY_X:
+        getCurrentTrack(id).whitePointChromaticityX = (float) value;
+        break;
+      case ID_WHITE_POINT_CHROMATICITY_Y:
+        getCurrentTrack(id).whitePointChromaticityY = (float) value;
+        break;
+      case ID_LUMNINANCE_MAX:
+        getCurrentTrack(id).maxMasteringLuminance = (float) value;
+        break;
+      case ID_LUMNINANCE_MIN:
+        getCurrentTrack(id).minMasteringLuminance = (float) value;
+        break;
+      case ID_PROJECTION_POSE_YAW:
+        getCurrentTrack(id).projectionPoseYaw = (float) value;
+        break;
+      case ID_PROJECTION_POSE_PITCH:
+        getCurrentTrack(id).projectionPosePitch = (float) value;
+        break;
+      case ID_PROJECTION_POSE_ROLL:
+        getCurrentTrack(id).projectionPoseRoll = (float) value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Called when a string element is encountered.
+   *
+   * @see EbmlProcessor#stringElement(int, String)
+   */
+  @CallSuper
+  protected void stringElement(int id, String value) throws ParserException {
+    switch (id) {
+      case ID_DOC_TYPE:
+        // Validate that DocType is supported.
+        if (!DOC_TYPE_WEBM.equals(value) && !DOC_TYPE_MATROSKA.equals(value)) {
+          throw ParserException.createForMalformedContainer(
+              "DocType " + value + " not supported", /* cause= */ null);
+        }
+        isWebm = Objects.equals(value, DOC_TYPE_WEBM);
+        break;
+      case ID_NAME:
+        getCurrentTrack(id).name = value;
+        break;
+      case ID_CODEC_ID:
+        getCurrentTrack(id).codecId = value;
+        break;
+      case ID_LANGUAGE:
+        getCurrentTrack(id).language = value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Called when a binary element is encountered.
+   *
+   * @see EbmlProcessor#binaryElement(int, int, ExtractorInput)
+   */
+  @CallSuper
+  protected void binaryElement(int id, int contentSize, ExtractorInput input) throws IOException {
+    switch (id) {
+      case ID_SEEK_ID:
+        Arrays.fill(seekEntryIdBytes.getData(), (byte) 0);
+        input.readFully(seekEntryIdBytes.getData(), 4 - contentSize, contentSize);
+        seekEntryIdBytes.setPosition(0);
+        seekEntryId = (int) seekEntryIdBytes.readUnsignedInt();
+        break;
+      case ID_BLOCK_ADD_ID_EXTRA_DATA:
+        handleBlockAddIDExtraData(getCurrentTrack(id), input, contentSize);
+        break;
+      case ID_CODEC_PRIVATE:
+        assertInTrackEntry(id);
+        currentTrack.codecPrivate = new byte[contentSize];
+        input.readFully(currentTrack.codecPrivate, 0, contentSize);
+        break;
+      case ID_PROJECTION_PRIVATE:
+        assertInTrackEntry(id);
+        currentTrack.projectionData = new byte[contentSize];
+        input.readFully(currentTrack.projectionData, 0, contentSize);
+        break;
+      case ID_CONTENT_COMPRESSION_SETTINGS:
+        assertInTrackEntry(id);
+        // This extractor only supports header stripping, so the payload is the stripped bytes.
+        currentTrack.sampleStrippedBytes = new byte[contentSize];
+        input.readFully(currentTrack.sampleStrippedBytes, 0, contentSize);
+        break;
+      case ID_CONTENT_ENCRYPTION_KEY_ID:
+        byte[] encryptionKey = new byte[contentSize];
+        input.readFully(encryptionKey, 0, contentSize);
+        getCurrentTrack(id).cryptoData =
+            new TrackOutput.CryptoData(
+                C.CRYPTO_MODE_AES_CTR, encryptionKey, 0, 0); // We assume patternless AES-CTR.
+        break;
+      case ID_SIMPLE_BLOCK:
+      case ID_BLOCK:
+        // Please refer to http://www.matroska.org/technical/specs/index.html#simpleblock_structure
+        // and http://matroska.org/technical/specs/index.html#block_structure
+        // for info about how data is organized in SimpleBlock and Block elements respectively. They
+        // differ only in the way flags are specified.
+
+        if (blockState == BLOCK_STATE_START) {
+          blockTrackNumber = (int) varintReader.readUnsignedVarint(input, false, true, 8);
+          blockTrackNumberLength = varintReader.getLastLength();
+          blockDurationUs = C.TIME_UNSET;
+          blockState = BLOCK_STATE_HEADER;
+          scratch.reset(/* limit= */ 0);
+        }
+
+        Track track = tracks.get(blockTrackNumber);
+
+        // Ignore the block if we don't know about the track to which it belongs.
+        if (track == null) {
+          input.skipFully(contentSize - blockTrackNumberLength);
+          blockState = BLOCK_STATE_START;
+          return;
+        }
+
+        track.assertOutputInitialized();
+
+        if (blockState == BLOCK_STATE_HEADER) {
+          // Read the relative timecode (2 bytes) and flags (1 byte).
+          readScratch(input, 3);
+          int lacing = (scratch.getData()[2] & 0x06) >> 1;
+          if (lacing == LACING_NONE) {
+            blockSampleCount = 1;
+            blockSampleSizes = ensureArrayCapacity(blockSampleSizes, 1);
+            blockSampleSizes[0] = contentSize - blockTrackNumberLength - 3;
+          } else {
+            // Read the sample count (1 byte).
+            readScratch(input, 4);
+            blockSampleCount = (scratch.getData()[3] & 0xFF) + 1;
+            blockSampleSizes = ensureArrayCapacity(blockSampleSizes, blockSampleCount);
+            if (lacing == LACING_FIXED_SIZE) {
+              int blockLacingSampleSize =
+                  (contentSize - blockTrackNumberLength - 4) / blockSampleCount;
+              Arrays.fill(blockSampleSizes, 0, blockSampleCount, blockLacingSampleSize);
+            } else if (lacing == LACING_XIPH) {
+              int totalSamplesSize = 0;
+              int headerSize = 4;
+              for (int sampleIndex = 0; sampleIndex < blockSampleCount - 1; sampleIndex++) {
+                blockSampleSizes[sampleIndex] = 0;
+                int byteValue;
+                do {
+                  readScratch(input, ++headerSize);
+                  byteValue = scratch.getData()[headerSize - 1] & 0xFF;
+                  blockSampleSizes[sampleIndex] += byteValue;
+                } while (byteValue == 0xFF);
+                totalSamplesSize += blockSampleSizes[sampleIndex];
+              }
+              blockSampleSizes[blockSampleCount - 1] =
+                  contentSize - blockTrackNumberLength - headerSize - totalSamplesSize;
+            } else if (lacing == LACING_EBML) {
+              int totalSamplesSize = 0;
+              int headerSize = 4;
+              for (int sampleIndex = 0; sampleIndex < blockSampleCount - 1; sampleIndex++) {
+                blockSampleSizes[sampleIndex] = 0;
+                readScratch(input, ++headerSize);
+                if (scratch.getData()[headerSize - 1] == 0) {
+                  throw ParserException.createForMalformedContainer(
+                      "No valid varint length mask found", /* cause= */ null);
+                }
+                long readValue = 0;
+                for (int i = 0; i < 8; i++) {
+                  int lengthMask = 1 << (7 - i);
+                  if ((scratch.getData()[headerSize - 1] & lengthMask) != 0) {
+                    int readPosition = headerSize - 1;
+                    headerSize += i;
+                    readScratch(input, headerSize);
+                    readValue = (scratch.getData()[readPosition++] & 0xFF) & ~lengthMask;
+                    while (readPosition < headerSize) {
+                      readValue <<= 8;
+                      readValue |= (scratch.getData()[readPosition++] & 0xFF);
+                    }
+                    // The first read value is the first size. Later values are signed offsets.
+                    if (sampleIndex > 0) {
+                      readValue -= (1L << (6 + i * 7)) - 1;
+                    }
+                    break;
+                  }
+                }
+                if (readValue < Integer.MIN_VALUE || readValue > Integer.MAX_VALUE) {
+                  throw ParserException.createForMalformedContainer(
+                      "EBML lacing sample size out of range.", /* cause= */ null);
+                }
+                int intReadValue = (int) readValue;
+                blockSampleSizes[sampleIndex] =
+                    sampleIndex == 0
+                        ? intReadValue
+                        : blockSampleSizes[sampleIndex - 1] + intReadValue;
+                totalSamplesSize += blockSampleSizes[sampleIndex];
+              }
+              blockSampleSizes[blockSampleCount - 1] =
+                  contentSize - blockTrackNumberLength - headerSize - totalSamplesSize;
+            } else {
+              // Lacing is always in the range 0--3.
+              throw ParserException.createForMalformedContainer(
+                  "Unexpected lacing value: " + lacing, /* cause= */ null);
+            }
+          }
+
+          int timecode = (scratch.getData()[0] << 8) | (scratch.getData()[1] & 0xFF);
+          blockTimeUs = clusterTimecodeUs + scaleTimecodeToUs(timecode);
+          boolean isKeyframe =
+              track.type == C.TRACK_TYPE_AUDIO
+                  || (id == ID_SIMPLE_BLOCK && (scratch.getData()[2] & 0x80) == 0x80);
+          blockFlags = isKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
+          blockState = BLOCK_STATE_DATA;
+          blockSampleIndex = 0;
+        }
+
+        if (id == ID_SIMPLE_BLOCK) {
+          // For SimpleBlock, we can write sample data and immediately commit the corresponding
+          // sample metadata.
+          while (blockSampleIndex < blockSampleCount) {
+            int sampleSize =
+                writeSampleData(
+                    input, track, blockSampleSizes[blockSampleIndex], /* isBlockGroup= */ false);
+            long sampleTimeUs =
+                blockTimeUs + (blockSampleIndex * track.defaultSampleDurationNs) / 1000;
+            commitSampleToOutput(track, sampleTimeUs, blockFlags, sampleSize, /* offset= */ 0);
+            blockSampleIndex++;
+          }
+          blockState = BLOCK_STATE_START;
+        } else {
+          // For Block, we need to wait until the end of the BlockGroup element before committing
+          // sample metadata. This is so that we can handle ReferenceBlock (which can be used to
+          // infer whether the first sample in the block is a keyframe), and BlockAdditions (which
+          // can contain additional sample data to append) contained in the block group. Just output
+          // the sample data, storing the final sample sizes for when we commit the metadata.
+          while (blockSampleIndex < blockSampleCount) {
+            blockSampleSizes[blockSampleIndex] =
+                writeSampleData(
+                    input, track, blockSampleSizes[blockSampleIndex], /* isBlockGroup= */ true);
+            blockSampleIndex++;
+          }
+        }
+
+        break;
+      case ID_BLOCK_ADDITIONAL:
+        if (blockState != BLOCK_STATE_DATA) {
+          return;
+        }
+        handleBlockAdditionalData(
+            tracks.get(blockTrackNumber), blockAdditionalId, input, contentSize);
+        break;
+      default:
+        throw ParserException.createForMalformedContainer(
+            "Unexpected id: " + id, /* cause= */ null);
+    }
+  }
+
+  protected void handleBlockAddIDExtraData(Track track, ExtractorInput input, int contentSize)
+      throws IOException {
+    if (track.blockAddIdType == BLOCK_ADD_ID_TYPE_DVVC
+        || track.blockAddIdType == BLOCK_ADD_ID_TYPE_DVCC) {
+      track.dolbyVisionConfigBytes = new byte[contentSize];
+      input.readFully(track.dolbyVisionConfigBytes, 0, contentSize);
+    } else {
+      // Unhandled BlockAddIDExtraData.
+      input.skipFully(contentSize);
+    }
+  }
+
+  /**
+   * Vendored copy of {@code DtsUtil.isSampleDtsHd} (a post-1.8.0 API not present in the stock
+   * media3 this app links against in AAR mode). Relies only on long-standing public {@link DtsUtil}
+   * APIs ({@code getFrameType}, {@code getDtsFrameSize}, {@code FRAME_TYPE_*}). Peeks the sample to
+   * decide whether a DTS track carries a DTS-HD extension substream.
+   */
+  private static boolean isSampleDtsHd(ExtractorInput input, int sampleSize) throws IOException {
+    ParsableByteArray sampleData = new ParsableByteArray(sampleSize);
+    if (!input.peekFully(
+        sampleData.getData(), /* offset= */ 0, sampleSize, /* allowEndOfInput= */ true)) {
+      return false;
+    }
+    input.resetPeekPosition();
+    // Equivalent to the post-1.8.0 ParsableByteArray.peekInt(): read the leading
+    // int without consuming it (the 10-byte header is read from position 0 next).
+    int word = sampleData.readInt();
+    sampleData.setPosition(0);
+    if (DtsUtil.getFrameType(word) == DtsUtil.FRAME_TYPE_CORE) {
+      if (sampleData.bytesLeft() < 10) {
+        return false;
+      }
+      byte[] header = new byte[10];
+      sampleData.readBytes(header, /* offset= */ 0, /* length= */ 10);
+      sampleData.setPosition(0);
+      int frameSize = DtsUtil.getDtsFrameSize(header);
+      if (frameSize <= 0 || sampleData.bytesLeft() < frameSize + 4) {
+        return false;
+      }
+      sampleData.skipBytes(frameSize);
+      word = sampleData.readInt();
+      return DtsUtil.getFrameType(word) == DtsUtil.FRAME_TYPE_EXTENSION_SUBSTREAM;
+    }
+    return false;
+  }
+
+  protected void handleBlockAdditionalData(
+      Track track, int blockAdditionalId, ExtractorInput input, int contentSize)
+      throws IOException {
+    if (blockAdditionalId == BLOCK_ADDITIONAL_ID_VP9_ITU_T_35
+        && CODEC_ID_VP9.equals(track.codecId)) {
+      supplementalData.reset(contentSize);
+      input.readFully(supplementalData.getData(), 0, contentSize);
+    } else if (CODEC_ID_H265.equals(track.codecId)
+        && (track.blockAddIdType == BLOCK_ADD_ID_TYPE_DVVC
+            || track.blockAddIdType == BLOCK_ADD_ID_TYPE_DVCC)) {
+      byte[] blockAdditionalData = new byte[contentSize];
+      input.readFully(blockAdditionalData, 0, contentSize);
+      track.pendingDolbyVisionBlockAdditionalData = blockAdditionalData;
+
+      if (dolbyVisionSampleTransformer != null) {
+        try {
+          byte[] transformed =
+              dolbyVisionSampleTransformer.onDolbyVisionBlockAdditionalData(
+                  blockAdditionalData, track.blockAddIdType, track.dolbyVisionConfigBytes);
+          if (transformed != null) {
+            track.pendingDolbyVisionBlockAdditionalData = transformed;
+          }
+        } catch (RuntimeException e) {
+          Log.w(
+              TAG,
+              "DolbyVisionSampleTransformer.onDolbyVisionBlockAdditionalData failed: "
+                  + e.getMessage());
+        }
+      }
+    } else {
+      // Unhandled block additional data.
+      input.skipFully(contentSize);
+    }
+  }
+
+  @EnsuresNonNull("currentTrack")
+  private void assertInTrackEntry(int id) throws ParserException {
+    if (currentTrack == null) {
+      throw ParserException.createForMalformedContainer(
+          "Element " + id + " must be in a TrackEntry", /* cause= */ null);
+    }
+  }
+
+  private void assertInCues(int id) throws ParserException {
+    if (!inCuesElement) {
+      throw ParserException.createForMalformedContainer(
+          "Element " + id + " must be in a Cues", /* cause= */ null);
+    }
+  }
+
+  /**
+   * Returns the track corresponding to the current TrackEntry element.
+   *
+   * @throws ParserException if the element id is not in a TrackEntry.
+   */
+  protected Track getCurrentTrack(int currentElementId) throws ParserException {
+    assertInTrackEntry(currentElementId);
+    return currentTrack;
+  }
+
+  @RequiresNonNull("#1.output")
+  private void commitSampleToOutput(
+      Track track, long timeUs, @C.BufferFlags int flags, int size, int offset) {
+    if (track.trueHdSampleRechunker != null) {
+      track.trueHdSampleRechunker.sampleMetadata(
+          track.output, timeUs, flags, size, offset, track.cryptoData);
+    } else {
+      if (CODEC_ID_SUBRIP.equals(track.codecId)
+          || CODEC_ID_ASS.equals(track.codecId)
+          || CODEC_ID_SSA.equals(track.codecId)
+          || CODEC_ID_VTT.equals(track.codecId)) {
+        if (blockSampleCount > 1) {
+          Log.w(TAG, "Skipping subtitle sample in laced block.");
+        } else if (blockDurationUs == C.TIME_UNSET) {
+          Log.w(TAG, "Skipping subtitle sample with no duration.");
+        } else {
+          setSubtitleEndTime(track.codecId, blockDurationUs, subtitleSample.getData());
+          // The Matroska spec doesn't clearly define whether subtitle samples are null-terminated
+          // or the sample should instead be sized precisely. We truncate the sample at a null-byte
+          // to gracefully handle null-terminated strings followed by garbage bytes.
+          for (int i = subtitleSample.getPosition(); i < subtitleSample.limit(); i++) {
+            if (subtitleSample.getData()[i] == 0) {
+              subtitleSample.setLimit(i);
+              break;
+            }
+          }
+          // Note: If we ever want to support DRM protected subtitles then we'll need to output the
+          // appropriate encryption data here.
+          track.output.sampleData(subtitleSample, subtitleSample.limit());
+          size += subtitleSample.limit();
+        }
+      }
+
+      if ((flags & C.BUFFER_FLAG_HAS_SUPPLEMENTAL_DATA) != 0) {
+        if (blockSampleCount > 1) {
+          // There were multiple samples in the block. Appending the additional data to the last
+          // sample doesn't make sense. Skip instead.
+          supplementalData.reset(/* limit= */ 0);
+        } else {
+          // Append supplemental data.
+          int supplementalDataSize = supplementalData.limit();
+          track.output.sampleData(
+              supplementalData, supplementalDataSize, TrackOutput.SAMPLE_DATA_PART_SUPPLEMENTAL);
+          size += supplementalDataSize;
+        }
+      }
+      track.output.sampleMetadata(timeUs, flags, size, offset, track.cryptoData);
+    }
+    if (CODEC_ID_H265.equals(track.codecId)) {
+      track.pendingDolbyVisionBlockAdditionalData = null;
+    }
+    haveOutputSample = true;
+  }
+
+  /**
+   * Ensures {@link #scratch} contains at least {@code requiredLength} bytes of data, reading from
+   * the extractor input if necessary.
+   */
+  private void readScratch(ExtractorInput input, int requiredLength) throws IOException {
+    if (scratch.limit() >= requiredLength) {
+      return;
+    }
+    if (scratch.capacity() < requiredLength) {
+      scratch.ensureCapacity(max(scratch.capacity() * 2, requiredLength));
+    }
+    input.readFully(scratch.getData(), scratch.limit(), requiredLength - scratch.limit());
+    scratch.setLimit(requiredLength);
+  }
+
+  /**
+   * Writes data for a single sample to the track output.
+   *
+   * @param input The input from which to read sample data.
+   * @param track The track to output the sample to.
+   * @param size The size of the sample data on the input side.
+   * @param isBlockGroup Whether the samples are from a BlockGroup.
+   * @return The final size of the written sample.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  @RequiresNonNull("#2.output")
+  private int writeSampleData(ExtractorInput input, Track track, int size, boolean isBlockGroup)
+      throws IOException {
+    boolean deferSupplementalMainSampleSizePrefix = false;
+    if (CODEC_ID_SUBRIP.equals(track.codecId)) {
+      writeSubtitleSampleData(input, SUBRIP_PREFIX, size);
+      return finishWriteSampleData();
+    } else if (CODEC_ID_ASS.equals(track.codecId) || CODEC_ID_SSA.equals(track.codecId)) {
+      writeSubtitleSampleData(input, SSA_PREFIX, size);
+      return finishWriteSampleData();
+    } else if (CODEC_ID_VTT.equals(track.codecId)) {
+      writeSubtitleSampleData(input, VTT_PREFIX, size);
+      return finishWriteSampleData();
+    }
+
+    if (track.waitingForDtsAnalysis) {
+      checkNotNull(track.format);
+      // NOTE: DtsUtil.isSampleDtsHd(ExtractorInput, int) is a post-1.8.0 API absent
+      // from the stock media3 we link against in AAR mode, so it is vendored as
+      // isSampleDtsHd(...) below (it only relies on long-standing public DtsUtil
+      // APIs). This preserves DTS-HD MA detection / passthrough for MKV.
+      if (isSampleDtsHd(input, size)) {
+        track.format = track.format.buildUpon().setSampleMimeType(MimeTypes.AUDIO_DTS_HD).build();
+      }
+      track.output.format(track.format);
+      track.waitingForDtsAnalysis = false;
+      maybeEndTracks();
+    }
+
+    TrackOutput output = track.output;
+    if (!sampleEncodingHandled) {
+      if (track.hasContentEncryption) {
+        // If the sample is encrypted, read its encryption signal byte and set the IV size.
+        // Clear the encrypted flag.
+        blockFlags &= ~C.BUFFER_FLAG_ENCRYPTED;
+        if (!sampleSignalByteRead) {
+          input.readFully(scratch.getData(), 0, 1);
+          sampleBytesRead++;
+          if ((scratch.getData()[0] & 0x80) == 0x80) {
+            throw ParserException.createForMalformedContainer(
+                "Extension bit is set in signal byte", /* cause= */ null);
+          }
+          sampleSignalByte = scratch.getData()[0];
+          sampleSignalByteRead = true;
+        }
+        boolean isEncrypted = (sampleSignalByte & 0x01) == 0x01;
+        if (isEncrypted) {
+          boolean hasSubsampleEncryption = (sampleSignalByte & 0x02) == 0x02;
+          blockFlags |= C.BUFFER_FLAG_ENCRYPTED;
+          if (!sampleInitializationVectorRead) {
+            input.readFully(encryptionInitializationVector.getData(), 0, ENCRYPTION_IV_SIZE);
+            sampleBytesRead += ENCRYPTION_IV_SIZE;
+            sampleInitializationVectorRead = true;
+            // Write the signal byte, containing the IV size and the subsample encryption flag.
+            scratch.getData()[0] =
+                (byte) (ENCRYPTION_IV_SIZE | (hasSubsampleEncryption ? 0x80 : 0x00));
+            scratch.setPosition(0);
+            output.sampleData(scratch, 1, TrackOutput.SAMPLE_DATA_PART_ENCRYPTION);
+            sampleBytesWritten++;
+            // Write the IV.
+            encryptionInitializationVector.setPosition(0);
+            output.sampleData(
+                encryptionInitializationVector,
+                ENCRYPTION_IV_SIZE,
+                TrackOutput.SAMPLE_DATA_PART_ENCRYPTION);
+            sampleBytesWritten += ENCRYPTION_IV_SIZE;
+          }
+          if (hasSubsampleEncryption) {
+            if (!samplePartitionCountRead) {
+              input.readFully(scratch.getData(), 0, 1);
+              sampleBytesRead++;
+              scratch.setPosition(0);
+              samplePartitionCount = scratch.readUnsignedByte();
+              samplePartitionCountRead = true;
+            }
+            int samplePartitionDataSize = samplePartitionCount * 4;
+            scratch.reset(samplePartitionDataSize);
+            input.readFully(scratch.getData(), 0, samplePartitionDataSize);
+            sampleBytesRead += samplePartitionDataSize;
+            short subsampleCount = (short) (1 + (samplePartitionCount / 2));
+            int subsampleDataSize = 2 + 6 * subsampleCount;
+            if (encryptionSubsampleDataBuffer == null
+                || encryptionSubsampleDataBuffer.capacity() < subsampleDataSize) {
+              encryptionSubsampleDataBuffer = ByteBuffer.allocate(subsampleDataSize);
+            }
+            encryptionSubsampleDataBuffer.position(0);
+            encryptionSubsampleDataBuffer.putShort(subsampleCount);
+            // Loop through the partition offsets and write out the data in the way ExoPlayer
+            // wants it (ISO 23001-7 Part 7):
+            //   2 bytes - sub sample count.
+            //   for each sub sample:
+            //     2 bytes - clear data size.
+            //     4 bytes - encrypted data size.
+            int partitionOffset = 0;
+            for (int i = 0; i < samplePartitionCount; i++) {
+              int previousPartitionOffset = partitionOffset;
+              partitionOffset = scratch.readUnsignedIntToInt();
+              if ((i % 2) == 0) {
+                encryptionSubsampleDataBuffer.putShort(
+                    (short) (partitionOffset - previousPartitionOffset));
+              } else {
+                encryptionSubsampleDataBuffer.putInt(partitionOffset - previousPartitionOffset);
+              }
+            }
+            int finalPartitionSize = size - sampleBytesRead - partitionOffset;
+            if ((samplePartitionCount % 2) == 1) {
+              encryptionSubsampleDataBuffer.putInt(finalPartitionSize);
+            } else {
+              encryptionSubsampleDataBuffer.putShort((short) finalPartitionSize);
+              encryptionSubsampleDataBuffer.putInt(0);
+            }
+            encryptionSubsampleData.reset(encryptionSubsampleDataBuffer.array(), subsampleDataSize);
+            output.sampleData(
+                encryptionSubsampleData,
+                subsampleDataSize,
+                TrackOutput.SAMPLE_DATA_PART_ENCRYPTION);
+            sampleBytesWritten += subsampleDataSize;
+          }
+        }
+      } else if (track.sampleStrippedBytes != null) {
+        // If the sample has header stripping, prepare to read/output the stripped bytes first.
+        sampleStrippedBytes.reset(track.sampleStrippedBytes, track.sampleStrippedBytes.length);
+      }
+
+      if (track.samplesHaveSupplementalData(isBlockGroup)) {
+        blockFlags |= C.BUFFER_FLAG_HAS_SUPPLEMENTAL_DATA;
+        supplementalData.reset(/* limit= */ 0);
+        // If there is supplemental data, the structure of the sample data is:
+        // encryption data (if any) || sample size (4 bytes) || sample data || supplemental data
+        deferSupplementalMainSampleSizePrefix =
+            CODEC_ID_H265.equals(track.codecId) && dolbyVisionSampleTransformer != null;
+        if (!deferSupplementalMainSampleSizePrefix) {
+          int sampleSize = size + sampleStrippedBytes.limit() - sampleBytesRead;
+          writeSupplementalMainSampleSizePrefix(output, sampleSize);
+          sampleBytesWritten += 4;
+        }
+      }
+
+      sampleEncodingHandled = true;
+    }
+    size += sampleStrippedBytes.limit();
+    if (CODEC_ID_H265.equals(track.codecId) && dolbyVisionSampleTransformer != null) {
+      try {
+        // Phase-2 seam: sample event is surfaced here. Payload replacement is added in a later
+        // step once DV conversion is wired for full HEVC access units.
+        dolbyVisionSampleTransformer.onHevcSample(
+            size, track.pendingDolbyVisionBlockAdditionalData, track.dolbyVisionConfigBytes);
+      } catch (RuntimeException e) {
+        Log.w(TAG, "DolbyVisionSampleTransformer.onHevcSample failed: " + e.getMessage());
+      }
+    }
+
+    if (CODEC_ID_H265.equals(track.codecId) && dolbyVisionSampleTransformer != null) {
+      int remainingSampleBytes = size - sampleBytesRead;
+      if (dolbyVisionSampleBuffer.length < remainingSampleBytes) {
+        dolbyVisionSampleBuffer = new byte[remainingSampleBytes];
+      }
+      byte[] sampleLengthDelimitedData = dolbyVisionSampleBuffer;
+      writeToTarget(input, sampleLengthDelimitedData, /* offset= */ 0, remainingSampleBytes);
+      sampleBytesRead += remainingSampleBytes;
+
+      byte[] payloadToWrite = sampleLengthDelimitedData;
+      int payloadLength = remainingSampleBytes;
+      try {
+        byte[] transformedPayload =
+            dolbyVisionSampleTransformer.transformHevcSample(
+                sampleLengthDelimitedData,
+                remainingSampleBytes,
+                track.nalUnitLengthFieldLength,
+                track.pendingDolbyVisionBlockAdditionalData,
+                track.dolbyVisionConfigBytes);
+        if (transformedPayload != null) {
+          payloadToWrite = transformedPayload;
+          payloadLength = dolbyVisionSampleTransformer.lastTransformedSampleLength();
+        }
+      } catch (RuntimeException e) {
+        Log.w(TAG, "DolbyVisionSampleTransformer.transformHevcSample failed: " + e.getMessage());
+      }
+
+      if (deferSupplementalMainSampleSizePrefix) {
+        byte[] annexBSample =
+            convertLengthDelimitedSampleToAnnexB(
+                payloadToWrite, payloadLength, track.nalUnitLengthFieldLength, track.codecId);
+        writeSupplementalMainSampleSizePrefix(output, annexBSample.length);
+        sampleBytesWritten += 4;
+        ParsableByteArray annexBData = new ParsableByteArray(annexBSample);
+        output.sampleData(annexBData, annexBSample.length);
+        sampleBytesWritten += annexBSample.length;
+      } else {
+        int bytesWritten =
+            writeLengthDelimitedSampleAsAnnexB(
+                output, payloadToWrite, payloadLength, track.nalUnitLengthFieldLength, track.codecId);
+        sampleBytesWritten += bytesWritten;
+      }
+    } else if (CODEC_ID_H264.equals(track.codecId) || CODEC_ID_H265.equals(track.codecId)) {
+      // TODO: Deduplicate with Mp4Extractor.
+
+      // Zero the top three bytes of the array that we'll use to decode nal unit lengths, in case
+      // they're only 1 or 2 bytes long.
+      byte[] nalLengthData = nalLength.getData();
+      nalLengthData[0] = 0;
+      nalLengthData[1] = 0;
+      nalLengthData[2] = 0;
+      int nalUnitLengthFieldLength = track.nalUnitLengthFieldLength;
+      int nalUnitLengthFieldLengthDiff = 4 - track.nalUnitLengthFieldLength;
+      // NAL units are length delimited, but the decoder requires start code delimited units.
+      // Loop until we've written the sample to the track output, replacing length delimiters with
+      // start codes as we encounter them.
+      while (sampleBytesRead < size) {
+        if (sampleCurrentNalBytesRemaining == 0) {
+          // Read the NAL length so that we know where we find the next one.
+          writeToTarget(
+              input, nalLengthData, nalUnitLengthFieldLengthDiff, nalUnitLengthFieldLength);
+          sampleBytesRead += nalUnitLengthFieldLength;
+          nalLength.setPosition(0);
+          sampleCurrentNalBytesRemaining = nalLength.readUnsignedIntToInt();
+          // Write a start code for the current NAL unit.
+          nalStartCode.setPosition(0);
+          output.sampleData(nalStartCode, 4);
+          sampleBytesWritten += 4;
+        } else {
+          // Write the payload of the NAL unit.
+          int bytesWritten = writeToOutput(input, output, sampleCurrentNalBytesRemaining);
+          sampleBytesRead += bytesWritten;
+          sampleBytesWritten += bytesWritten;
+          sampleCurrentNalBytesRemaining -= bytesWritten;
+        }
+      }
+    } else {
+      if (track.trueHdSampleRechunker != null) {
+        checkState(sampleStrippedBytes.limit() == 0);
+        track.trueHdSampleRechunker.startSample(input);
+      }
+      while (sampleBytesRead < size) {
+        int bytesWritten = writeToOutput(input, output, size - sampleBytesRead);
+        sampleBytesRead += bytesWritten;
+        sampleBytesWritten += bytesWritten;
+      }
+    }
+
+    if (CODEC_ID_VORBIS.equals(track.codecId)) {
+      // Vorbis decoder in android MediaCodec [1] expects the last 4 bytes of the sample to be the
+      // number of samples in the current page. This definition holds good only for Ogg and
+      // irrelevant for Matroska. So we always set this to -1 (the decoder will ignore this value if
+      // we set it to -1). The android platform media extractor [2] does the same.
+      // [1]
+      // https://android.googlesource.com/platform/frameworks/av/+/lollipop-release/media/libstagefright/codecs/vorbis/dec/SoftVorbis.cpp#314
+      // [2]
+      // https://android.googlesource.com/platform/frameworks/av/+/lollipop-release/media/libstagefright/NuMediaExtractor.cpp#474
+      vorbisNumPageSamples.setPosition(0);
+      output.sampleData(vorbisNumPageSamples, 4);
+      sampleBytesWritten += 4;
+    }
+
+    return finishWriteSampleData();
+  }
+
+  private int writeLengthDelimitedSampleAsAnnexB(
+      TrackOutput output,
+      byte[] sampleLengthDelimitedData,
+      int dataLength,
+      int nalUnitLengthFieldLength,
+      String codecId)
+      throws ParserException {
+    if (nalUnitLengthFieldLength <= 0 || nalUnitLengthFieldLength > 4) {
+      throw ParserException.createForMalformedContainer(
+          "Invalid NAL length field size for " + codecId + ": " + nalUnitLengthFieldLength,
+          /* cause= */ null);
+    }
+
+    ParsableByteArray source = new ParsableByteArray(sampleLengthDelimitedData, dataLength);
+    int bytesWritten = 0;
+    while (source.bytesLeft() > 0) {
+      if (source.bytesLeft() < nalUnitLengthFieldLength) {
+        throw ParserException.createForMalformedContainer(
+            "Truncated NAL length for " + codecId, /* cause= */ null);
+      }
+
+      int nalLength = 0;
+      for (int i = 0; i < nalUnitLengthFieldLength; i++) {
+        nalLength = (nalLength << 8) | source.readUnsignedByte();
+      }
+
+      if (nalLength < 0 || source.bytesLeft() < nalLength) {
+        throw ParserException.createForMalformedContainer(
+            "Invalid NAL length for " + codecId + ": " + nalLength, /* cause= */ null);
+      }
+
+      nalStartCode.setPosition(0);
+      output.sampleData(nalStartCode, 4);
+      bytesWritten += 4;
+      output.sampleData(source, nalLength);
+      bytesWritten += nalLength;
+    }
+
+    return bytesWritten;
+  }
+
+  private byte[] convertLengthDelimitedSampleToAnnexB(
+      byte[] sampleLengthDelimitedData, int dataLength, int nalUnitLengthFieldLength, String codecId)
+      throws ParserException {
+    if (nalUnitLengthFieldLength <= 0 || nalUnitLengthFieldLength > 4) {
+      throw ParserException.createForMalformedContainer(
+          "Invalid NAL length field size for " + codecId + ": " + nalUnitLengthFieldLength,
+          /* cause= */ null);
+    }
+
+    ParsableByteArray source = new ParsableByteArray(sampleLengthDelimitedData, dataLength);
+    ByteArrayOutputStream output = new ByteArrayOutputStream(dataLength + 64);
+    while (source.bytesLeft() > 0) {
+      if (source.bytesLeft() < nalUnitLengthFieldLength) {
+        throw ParserException.createForMalformedContainer(
+            "Truncated NAL length for " + codecId, /* cause= */ null);
+      }
+      int nalLength = 0;
+      for (int i = 0; i < nalUnitLengthFieldLength; i++) {
+        nalLength = (nalLength << 8) | source.readUnsignedByte();
+      }
+      if (nalLength < 0 || source.bytesLeft() < nalLength) {
+        throw ParserException.createForMalformedContainer(
+            "Invalid NAL length for " + codecId + ": " + nalLength, /* cause= */ null);
+      }
+      output.write(NalUnitUtil.NAL_START_CODE, 0, NalUnitUtil.NAL_START_CODE.length);
+      output.write(source.getData(), source.getPosition(), nalLength);
+      source.skipBytes(nalLength);
+    }
+    return output.toByteArray();
+  }
+
+  private void writeSupplementalMainSampleSizePrefix(TrackOutput output, int sampleSize) {
+    scratch.reset(/* limit= */ 4);
+    scratch.getData()[0] = (byte) ((sampleSize >> 24) & 0xFF);
+    scratch.getData()[1] = (byte) ((sampleSize >> 16) & 0xFF);
+    scratch.getData()[2] = (byte) ((sampleSize >> 8) & 0xFF);
+    scratch.getData()[3] = (byte) (sampleSize & 0xFF);
+    output.sampleData(scratch, 4, TrackOutput.SAMPLE_DATA_PART_SUPPLEMENTAL);
+  }
+
+  /**
+   * Called by {@link #writeSampleData(ExtractorInput, Track, int, boolean)} when the sample has
+   * been written. Returns the final sample size and resets state for the next sample.
+   */
+  private int finishWriteSampleData() {
+    int sampleSize = sampleBytesWritten;
+    resetWriteSampleData();
+    return sampleSize;
+  }
+
+  /** Resets state used by {@link #writeSampleData(ExtractorInput, Track, int, boolean)}. */
+  private void resetWriteSampleData() {
+    sampleBytesRead = 0;
+    sampleBytesWritten = 0;
+    sampleCurrentNalBytesRemaining = 0;
+    sampleEncodingHandled = false;
+    sampleSignalByteRead = false;
+    samplePartitionCountRead = false;
+    samplePartitionCount = 0;
+    sampleSignalByte = (byte) 0;
+    sampleInitializationVectorRead = false;
+    sampleStrippedBytes.reset(/* limit= */ 0);
+  }
+
+  private void writeSubtitleSampleData(ExtractorInput input, byte[] samplePrefix, int size)
+      throws IOException {
+    int sizeWithPrefix = samplePrefix.length + size;
+    if (subtitleSample.capacity() < sizeWithPrefix) {
+      // Initialize subripSample to contain the required prefix and have space to hold a subtitle
+      // twice as long as this one.
+      subtitleSample.reset(Arrays.copyOf(samplePrefix, sizeWithPrefix + size));
+    } else {
+      System.arraycopy(samplePrefix, 0, subtitleSample.getData(), 0, samplePrefix.length);
+    }
+    input.readFully(subtitleSample.getData(), samplePrefix.length, size);
+    subtitleSample.setPosition(0);
+    subtitleSample.setLimit(sizeWithPrefix);
+    // Defer writing the data to the track output. We need to modify the sample data by setting
+    // the correct end timecode, which we might not have yet.
+  }
+
+  /**
+   * Overwrites the end timecode in {@code subtitleData} with the correctly formatted time derived
+   * from {@code durationUs}.
+   *
+   * <p>See documentation on {@link #SSA_DIALOGUE_FORMAT} and {@link #SUBRIP_PREFIX} for why we use
+   * the duration as the end timecode.
+   *
+   * @param codecId The subtitle codec; must be {@link #CODEC_ID_SUBRIP}, {@link #CODEC_ID_ASS},
+   *     {@link #CODEC_ID_SSA} or {@link #CODEC_ID_VTT}.
+   * @param durationUs The duration of the sample, in microseconds.
+   * @param subtitleData The subtitle sample in which to overwrite the end timecode (output
+   *     parameter).
+   */
+  private static void setSubtitleEndTime(String codecId, long durationUs, byte[] subtitleData) {
+    byte[] endTimecode;
+    int endTimecodeOffset;
+    switch (codecId) {
+      case CODEC_ID_SUBRIP:
+        endTimecode =
+            formatSubtitleTimecode(
+                durationUs, SUBRIP_TIMECODE_FORMAT, SUBRIP_TIMECODE_LAST_VALUE_SCALING_FACTOR);
+        endTimecodeOffset = SUBRIP_PREFIX_END_TIMECODE_OFFSET;
+        break;
+      case CODEC_ID_ASS:
+      case CODEC_ID_SSA:
+        endTimecode =
+            formatSubtitleTimecode(
+                durationUs, SSA_TIMECODE_FORMAT, SSA_TIMECODE_LAST_VALUE_SCALING_FACTOR);
+        endTimecodeOffset = SSA_PREFIX_END_TIMECODE_OFFSET;
+        break;
+      case CODEC_ID_VTT:
+        endTimecode =
+            formatSubtitleTimecode(
+                durationUs, VTT_TIMECODE_FORMAT, VTT_TIMECODE_LAST_VALUE_SCALING_FACTOR);
+        endTimecodeOffset = VTT_PREFIX_END_TIMECODE_OFFSET;
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+    System.arraycopy(endTimecode, 0, subtitleData, endTimecodeOffset, endTimecode.length);
+  }
+
+  /**
+   * Formats {@code timeUs} using {@code timecodeFormat}, and sets it as the end timecode in {@code
+   * subtitleSampleData}.
+   */
+  private static byte[] formatSubtitleTimecode(
+      long timeUs, String timecodeFormat, long lastTimecodeValueScalingFactor) {
+    checkArgument(timeUs != C.TIME_UNSET);
+    byte[] timeCodeData;
+    int hours = (int) (timeUs / (3600 * C.MICROS_PER_SECOND));
+    timeUs -= (hours * 3600L * C.MICROS_PER_SECOND);
+    int minutes = (int) (timeUs / (60 * C.MICROS_PER_SECOND));
+    timeUs -= (minutes * 60L * C.MICROS_PER_SECOND);
+    int seconds = (int) (timeUs / C.MICROS_PER_SECOND);
+    timeUs -= (seconds * C.MICROS_PER_SECOND);
+    int lastValue = (int) (timeUs / lastTimecodeValueScalingFactor);
+    timeCodeData =
+        Util.getUtf8Bytes(
+            String.format(Locale.US, timecodeFormat, hours, minutes, seconds, lastValue));
+    return timeCodeData;
+  }
+
+  /**
+   * Writes {@code length} bytes of sample data into {@code target} at {@code offset}, consisting of
+   * pending {@link #sampleStrippedBytes} and any remaining data read from {@code input}.
+   */
+  private void writeToTarget(ExtractorInput input, byte[] target, int offset, int length)
+      throws IOException {
+    int pendingStrippedBytes = min(length, sampleStrippedBytes.bytesLeft());
+    input.readFully(target, offset + pendingStrippedBytes, length - pendingStrippedBytes);
+    if (pendingStrippedBytes > 0) {
+      sampleStrippedBytes.readBytes(target, offset, pendingStrippedBytes);
+    }
+  }
+
+  /**
+   * Outputs up to {@code length} bytes of sample data to {@code output}, consisting of either
+   * {@link #sampleStrippedBytes} or data read from {@code input}.
+   */
+  private int writeToOutput(ExtractorInput input, TrackOutput output, int length)
+      throws IOException {
+    int bytesWritten;
+    int strippedBytesLeft = sampleStrippedBytes.bytesLeft();
+    if (strippedBytesLeft > 0) {
+      bytesWritten = min(length, strippedBytesLeft);
+      output.sampleData(sampleStrippedBytes, bytesWritten);
+    } else {
+      bytesWritten = output.sampleData(input, length, false);
+    }
+    return bytesWritten;
+  }
+
+  /**
+   * Updates the position of the holder to Cues element's position if the extractor configuration
+   * permits use of master seek entry. After building Cues sets the holder's position back to where
+   * it was before.
+   *
+   * @param seekPosition The holder whose position will be updated.
+   * @param currentPosition Current position of the input.
+   * @return Whether the seek position was updated.
+   */
+  private boolean maybeSeekForCues(PositionHolder seekPosition, long currentPosition) {
+    if (seekForCues) {
+      seekPositionAfterBuildingCues = currentPosition;
+      seekPosition.position = cuesContentPosition;
+      seekForCues = false;
+      return true;
+    }
+    // After parsing Cues, seek back to original position if available. We will not do this unless
+    // we seeked to get to the Cues in the first place.
+    if (sentSeekMap && seekPositionAfterBuildingCues != C.INDEX_UNSET) {
+      seekPosition.position = seekPositionAfterBuildingCues;
+      seekPositionAfterBuildingCues = C.INDEX_UNSET;
+      return true;
+    }
+    return false;
+  }
+
+  private long scaleTimecodeToUs(long unscaledTimecode) throws ParserException {
+    if (timecodeScale == C.TIME_UNSET) {
+      throw ParserException.createForMalformedContainer(
+          "Can't scale timecode prior to timecodeScale being set.", /* cause= */ null);
+    }
+    return Util.scaleLargeTimestamp(unscaledTimecode, timecodeScale, 1000);
+  }
+
+  private static boolean isCodecSupported(String codecId) {
+    switch (codecId) {
+      case CODEC_ID_VP8:
+      case CODEC_ID_VP9:
+      case CODEC_ID_AV1:
+      case CODEC_ID_MPEG2:
+      case CODEC_ID_MPEG4_SP:
+      case CODEC_ID_MPEG4_ASP:
+      case CODEC_ID_MPEG4_AP:
+      case CODEC_ID_H264:
+      case CODEC_ID_H265:
+      case CODEC_ID_FOURCC:
+      case CODEC_ID_THEORA:
+      case CODEC_ID_OPUS:
+      case CODEC_ID_VORBIS:
+      case CODEC_ID_AAC:
+      case CODEC_ID_MP2:
+      case CODEC_ID_MP3:
+      case CODEC_ID_AC3:
+      case CODEC_ID_E_AC3:
+      case CODEC_ID_TRUEHD:
+      case CODEC_ID_DTS:
+      case CODEC_ID_DTS_EXPRESS:
+      case CODEC_ID_DTS_LOSSLESS:
+      case CODEC_ID_FLAC:
+      case CODEC_ID_ACM:
+      case CODEC_ID_PCM_INT_LIT:
+      case CODEC_ID_PCM_INT_BIG:
+      case CODEC_ID_PCM_FLOAT:
+      case CODEC_ID_SUBRIP:
+      case CODEC_ID_ASS:
+      case CODEC_ID_SSA:
+      case CODEC_ID_VTT:
+      case CODEC_ID_VOBSUB:
+      case CODEC_ID_PGS:
+      case CODEC_ID_DVBSUB:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Returns an array that can store (at least) {@code length} elements, which will be either a new
+   * array or {@code array} if it's not null and large enough.
+   */
+  private static int[] ensureArrayCapacity(@Nullable int[] array, int length) {
+    if (array == null) {
+      return new int[length];
+    } else if (array.length >= length) {
+      return array;
+    } else {
+      // Double the size to avoid allocating constantly if the required length increases gradually.
+      return new int[max(array.length * 2, length)];
+    }
+  }
+
+  @EnsuresNonNull("extractorOutput")
+  private void assertInitialized() {
+    checkNotNull(extractorOutput);
+  }
+
+  private void maybeEndTracks() {
+    if (!pendingEndTracks) {
+      return;
+    }
+    for (int i = 0; i < tracks.size(); i++) {
+      if (tracks.valueAt(i).waitingForDtsAnalysis) {
+        return;
+      }
+    }
+    checkNotNull(extractorOutput).endTracks();
+    pendingEndTracks = false;
+  }
+
+  /** Passes events through to the outer {@link MatroskaExtractor}. */
+  private final class InnerEbmlProcessor implements EbmlProcessor {
+
+    @Override
+    public @ElementType int getElementType(int id) {
+      return MatroskaExtractor.this.getElementType(id);
+    }
+
+    @Override
+    public boolean isLevel1Element(int id) {
+      return MatroskaExtractor.this.isLevel1Element(id);
+    }
+
+    @Override
+    public void startMasterElement(int id, long contentPosition, long contentSize)
+        throws ParserException {
+      MatroskaExtractor.this.startMasterElement(id, contentPosition, contentSize);
+    }
+
+    @Override
+    public void endMasterElement(int id) throws ParserException {
+      MatroskaExtractor.this.endMasterElement(id);
+    }
+
+    @Override
+    public void integerElement(int id, long value) throws ParserException {
+      MatroskaExtractor.this.integerElement(id, value);
+    }
+
+    @Override
+    public void floatElement(int id, double value) throws ParserException {
+      MatroskaExtractor.this.floatElement(id, value);
+    }
+
+    @Override
+    public void stringElement(int id, String value) throws ParserException {
+      MatroskaExtractor.this.stringElement(id, value);
+    }
+
+    @Override
+    public void binaryElement(int id, int contentsSize, ExtractorInput input) throws IOException {
+      MatroskaExtractor.this.binaryElement(id, contentsSize, input);
+    }
+  }
+
+  /** Holds data corresponding to a single track. */
+  protected static final class Track {
+
+    private static final int DISPLAY_UNIT_PIXELS = 0;
+    private static final int MAX_CHROMATICITY = 50_000; // Defined in CTA-861.3.
+
+    /** Default max content light level (CLL) that should be encoded into hdrStaticInfo. */
+    private static final int DEFAULT_MAX_CLL = 1000; // nits.
+
+    /** Default frame-average light level (FALL) that should be encoded into hdrStaticInfo. */
+    private static final int DEFAULT_MAX_FALL = 200; // nits.
+
+    // Common elements.
+    public boolean isWebm;
+    public @MonotonicNonNull String name;
+    public @MonotonicNonNull String codecId;
+    public int number;
+    public @C.TrackType int type;
+    public int defaultSampleDurationNs;
+    public int maxBlockAdditionId;
+    private int blockAddIdType;
+    public boolean hasContentEncryption;
+    public byte @MonotonicNonNull [] sampleStrippedBytes;
+    public TrackOutput.@MonotonicNonNull CryptoData cryptoData;
+    public byte @MonotonicNonNull [] codecPrivate;
+    public @MonotonicNonNull DrmInitData drmInitData;
+
+    // Video elements.
+    public int width = Format.NO_VALUE;
+    public int height = Format.NO_VALUE;
+    public int bitsPerChannel = Format.NO_VALUE;
+    public int displayWidth = Format.NO_VALUE;
+    public int displayHeight = Format.NO_VALUE;
+    public int displayUnit = DISPLAY_UNIT_PIXELS;
+    public @C.Projection int projectionType = Format.NO_VALUE;
+    public float projectionPoseYaw = 0f;
+    public float projectionPosePitch = 0f;
+    public float projectionPoseRoll = 0f;
+    public byte @MonotonicNonNull [] projectionData = null;
+    public @C.StereoMode int stereoMode = Format.NO_VALUE;
+    public boolean hasColorInfo = false;
+    public @C.ColorSpace int colorSpace = Format.NO_VALUE;
+    public @C.ColorTransfer int colorTransfer = Format.NO_VALUE;
+    public @C.ColorRange int colorRange = Format.NO_VALUE;
+    public int maxContentLuminance = DEFAULT_MAX_CLL;
+    public int maxFrameAverageLuminance = DEFAULT_MAX_FALL;
+    public float primaryRChromaticityX = Format.NO_VALUE;
+    public float primaryRChromaticityY = Format.NO_VALUE;
+    public float primaryGChromaticityX = Format.NO_VALUE;
+    public float primaryGChromaticityY = Format.NO_VALUE;
+    public float primaryBChromaticityX = Format.NO_VALUE;
+    public float primaryBChromaticityY = Format.NO_VALUE;
+    public float whitePointChromaticityX = Format.NO_VALUE;
+    public float whitePointChromaticityY = Format.NO_VALUE;
+    public float maxMasteringLuminance = Format.NO_VALUE;
+    public float minMasteringLuminance = Format.NO_VALUE;
+    public byte @MonotonicNonNull [] dolbyVisionConfigBytes;
+    public byte @MonotonicNonNull [] pendingDolbyVisionBlockAdditionalData;
+
+    // Audio elements. Initially set to their default values.
+    public int channelCount = 1;
+    public int audioBitDepth = Format.NO_VALUE;
+    public int sampleRate = 8000;
+    public long codecDelayNs = 0;
+    public long seekPreRollNs = 0;
+    public @MonotonicNonNull TrueHdSampleRechunker trueHdSampleRechunker;
+    public boolean waitingForDtsAnalysis = false;
+
+    // Text elements.
+    public boolean flagForced;
+
+    // Common track elements.
+    public boolean flagDefault = true;
+    private String language = "eng";
+
+    // Set when the output is initialized. nalUnitLengthFieldLength is only set for H264/H265.
+    public @MonotonicNonNull TrackOutput output;
+    public @MonotonicNonNull Format format;
+    public int nalUnitLengthFieldLength;
+
+    /** Builds the {@link Format} for the track. */
+    @RequiresNonNull("codecId")
+    public void initializeFormat(
+        int trackId, @Nullable DolbyVisionSampleTransformer dolbyVisionSampleTransformer)
+        throws ParserException {
+      String mimeType;
+      int maxInputSize = Format.NO_VALUE;
+      @C.PcmEncoding int pcmEncoding = Format.NO_VALUE;
+      @Nullable List<byte[]> initializationData = null;
+      @Nullable String codecs = null;
+      switch (codecId) {
+        case CODEC_ID_VP8:
+          mimeType = MimeTypes.VIDEO_VP8;
+          break;
+        case CODEC_ID_VP9:
+          mimeType = MimeTypes.VIDEO_VP9;
+          initializationData = codecPrivate == null ? null : ImmutableList.of(codecPrivate);
+          break;
+        case CODEC_ID_AV1:
+          mimeType = MimeTypes.VIDEO_AV1;
+          initializationData = codecPrivate == null ? null : ImmutableList.of(codecPrivate);
+          break;
+        case CODEC_ID_MPEG2:
+          mimeType = MimeTypes.VIDEO_MPEG2;
+          break;
+        case CODEC_ID_MPEG4_SP:
+        case CODEC_ID_MPEG4_ASP:
+        case CODEC_ID_MPEG4_AP:
+          mimeType = MimeTypes.VIDEO_MP4V;
+          initializationData =
+              codecPrivate == null ? null : Collections.singletonList(codecPrivate);
+          break;
+        case CODEC_ID_H264:
+          mimeType = MimeTypes.VIDEO_H264;
+          AvcConfig avcConfig = AvcConfig.parse(new ParsableByteArray(getCodecPrivate(codecId)));
+          initializationData = avcConfig.initializationData;
+          nalUnitLengthFieldLength = avcConfig.nalUnitLengthFieldLength;
+          codecs = avcConfig.codecs;
+          break;
+        case CODEC_ID_H265:
+          mimeType = MimeTypes.VIDEO_H265;
+          HevcConfig hevcConfig = HevcConfig.parse(new ParsableByteArray(getCodecPrivate(codecId)));
+          initializationData = hevcConfig.initializationData;
+          nalUnitLengthFieldLength = hevcConfig.nalUnitLengthFieldLength;
+          codecs = hevcConfig.codecs;
+          break;
+        case CODEC_ID_FOURCC:
+          Pair<String, @NullableType List<byte[]>> pair =
+              parseFourCcPrivate(new ParsableByteArray(getCodecPrivate(codecId)));
+          mimeType = pair.first;
+          initializationData = pair.second;
+          break;
+        case CODEC_ID_THEORA:
+          // TODO: This can be set to the real mimeType if/when we work out what initializationData
+          // should be set to for this case.
+          mimeType = MimeTypes.VIDEO_UNKNOWN;
+          break;
+        case CODEC_ID_VORBIS:
+          mimeType = MimeTypes.AUDIO_VORBIS;
+          maxInputSize = VORBIS_MAX_INPUT_SIZE;
+          initializationData = parseVorbisCodecPrivate(getCodecPrivate(codecId));
+          break;
+        case CODEC_ID_OPUS:
+          mimeType = MimeTypes.AUDIO_OPUS;
+          maxInputSize = OPUS_MAX_INPUT_SIZE;
+          initializationData = new ArrayList<>(3);
+          initializationData.add(getCodecPrivate(codecId));
+          initializationData.add(
+              ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(codecDelayNs).array());
+          initializationData.add(
+              ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(seekPreRollNs).array());
+          break;
+        case CODEC_ID_AAC:
+          mimeType = MimeTypes.AUDIO_AAC;
+          initializationData = Collections.singletonList(getCodecPrivate(codecId));
+          AacUtil.Config aacConfig = AacUtil.parseAudioSpecificConfig(codecPrivate);
+          // Update sampleRate and channelCount from the AudioSpecificConfig initialization data,
+          // which is more reliable. See [Internal: b/10903778].
+          sampleRate = aacConfig.sampleRateHz;
+          channelCount = aacConfig.channelCount;
+          codecs = aacConfig.codecs;
+          break;
+        case CODEC_ID_MP2:
+          mimeType = MimeTypes.AUDIO_MPEG_L2;
+          maxInputSize = MpegAudioUtil.MAX_FRAME_SIZE_BYTES;
+          break;
+        case CODEC_ID_MP3:
+          mimeType = MimeTypes.AUDIO_MPEG;
+          maxInputSize = MpegAudioUtil.MAX_FRAME_SIZE_BYTES;
+          break;
+        case CODEC_ID_AC3:
+          mimeType = MimeTypes.AUDIO_AC3;
+          break;
+        case CODEC_ID_E_AC3:
+          mimeType = MimeTypes.AUDIO_E_AC3;
+          break;
+        case CODEC_ID_TRUEHD:
+          mimeType = MimeTypes.AUDIO_TRUEHD;
+          trueHdSampleRechunker = new TrueHdSampleRechunker();
+          break;
+        case CODEC_ID_DTS:
+        case CODEC_ID_DTS_EXPRESS:
+          mimeType = MimeTypes.AUDIO_DTS; // temporary
+          waitingForDtsAnalysis = true;
+          break;
+        case CODEC_ID_DTS_LOSSLESS:
+          mimeType = MimeTypes.AUDIO_DTS_HD;
+          break;
+        case CODEC_ID_FLAC:
+          mimeType = MimeTypes.AUDIO_FLAC;
+          initializationData = Collections.singletonList(getCodecPrivate(codecId));
+          break;
+        case CODEC_ID_ACM:
+          mimeType = MimeTypes.AUDIO_RAW;
+          if (parseMsAcmCodecPrivate(new ParsableByteArray(getCodecPrivate(codecId)))) {
+            pcmEncoding = Util.getPcmEncoding(audioBitDepth);
+            if (pcmEncoding == C.ENCODING_INVALID) {
+              pcmEncoding = Format.NO_VALUE;
+              mimeType = MimeTypes.AUDIO_UNKNOWN;
+              Log.w(
+                  TAG,
+                  "Unsupported PCM bit depth: "
+                      + audioBitDepth
+                      + ". Setting mimeType to "
+                      + mimeType);
+            }
+          } else {
+            mimeType = MimeTypes.AUDIO_UNKNOWN;
+            Log.w(TAG, "Non-PCM MS/ACM is unsupported. Setting mimeType to " + mimeType);
+          }
+          break;
+        case CODEC_ID_PCM_INT_LIT:
+          mimeType = MimeTypes.AUDIO_RAW;
+          pcmEncoding = Util.getPcmEncoding(audioBitDepth);
+          if (pcmEncoding == C.ENCODING_INVALID) {
+            pcmEncoding = Format.NO_VALUE;
+            mimeType = MimeTypes.AUDIO_UNKNOWN;
+            Log.w(
+                TAG,
+                "Unsupported little endian PCM bit depth: "
+                    + audioBitDepth
+                    + ". Setting mimeType to "
+                    + mimeType);
+          }
+          break;
+        case CODEC_ID_PCM_INT_BIG:
+          mimeType = MimeTypes.AUDIO_RAW;
+          if (audioBitDepth == 8) {
+            pcmEncoding = C.ENCODING_PCM_8BIT;
+          } else if (audioBitDepth == 16) {
+            pcmEncoding = C.ENCODING_PCM_16BIT_BIG_ENDIAN;
+          } else if (audioBitDepth == 24) {
+            pcmEncoding = C.ENCODING_PCM_24BIT_BIG_ENDIAN;
+          } else if (audioBitDepth == 32) {
+            pcmEncoding = C.ENCODING_PCM_32BIT_BIG_ENDIAN;
+          } else {
+            pcmEncoding = Format.NO_VALUE;
+            mimeType = MimeTypes.AUDIO_UNKNOWN;
+            Log.w(
+                TAG,
+                "Unsupported big endian PCM bit depth: "
+                    + audioBitDepth
+                    + ". Setting mimeType to "
+                    + mimeType);
+          }
+          break;
+        case CODEC_ID_PCM_FLOAT:
+          mimeType = MimeTypes.AUDIO_RAW;
+          if (audioBitDepth == 32) {
+            pcmEncoding = C.ENCODING_PCM_FLOAT;
+          } else {
+            pcmEncoding = Format.NO_VALUE;
+            mimeType = MimeTypes.AUDIO_UNKNOWN;
+            Log.w(
+                TAG,
+                "Unsupported floating point PCM bit depth: "
+                    + audioBitDepth
+                    + ". Setting mimeType to "
+                    + mimeType);
+          }
+          break;
+        case CODEC_ID_SUBRIP:
+          mimeType = MimeTypes.APPLICATION_SUBRIP;
+          break;
+        case CODEC_ID_ASS:
+        case CODEC_ID_SSA:
+          mimeType = MimeTypes.TEXT_SSA;
+          initializationData = ImmutableList.of(SSA_DIALOGUE_FORMAT, getCodecPrivate(codecId));
+          break;
+        case CODEC_ID_VTT:
+          mimeType = MimeTypes.TEXT_VTT;
+          break;
+        case CODEC_ID_VOBSUB:
+          mimeType = MimeTypes.APPLICATION_VOBSUB;
+          initializationData = ImmutableList.of(getCodecPrivate(codecId));
+          break;
+        case CODEC_ID_PGS:
+          mimeType = MimeTypes.APPLICATION_PGS;
+          break;
+        case CODEC_ID_DVBSUB:
+          mimeType = MimeTypes.APPLICATION_DVBSUBS;
+          // Init data: composition_page (2), ancillary_page (2)
+          byte[] initializationDataBytes = new byte[4];
+          System.arraycopy(getCodecPrivate(codecId), 0, initializationDataBytes, 0, 4);
+          initializationData = ImmutableList.of(initializationDataBytes);
+          break;
+        default:
+          throw ParserException.createForMalformedContainer(
+              "Unrecognized codec identifier.", /* cause= */ null);
+      }
+
+      if (dolbyVisionConfigBytes != null) {
+        @Nullable
+        DolbyVisionConfig dolbyVisionConfig =
+            DolbyVisionConfig.parse(new ParsableByteArray(this.dolbyVisionConfigBytes));
+        if (dolbyVisionConfig != null) {
+          codecs = dolbyVisionConfig.codecs;
+          mimeType = MimeTypes.VIDEO_DOLBY_VISION;
+          if (dolbyVisionSampleTransformer != null) {
+            @Nullable
+            String transformedCodecs =
+                dolbyVisionSampleTransformer.onDolbyVisionCodecString(
+                    codecs, this.dolbyVisionConfigBytes);
+            if (transformedCodecs != null && !transformedCodecs.isEmpty()) {
+              codecs = transformedCodecs;
+            }
+          }
+        }
+      }
+      if (DolbyVisionCompatibility.shouldMapDolbyVisionProfile7(mimeType, codecs)) {
+        // NOTE: Vendored for app-level (AAR) DV7 use. The original called
+        // NalUnitUtil.getH265BaseLayerCodecsString(initializationData) (a
+        // post-1.8.0 API absent from the stock media3 we link against). This
+        // HEVC-fallback branch is gated by mapDv7ToHevcEnabled (never enabled
+        // in the conversion path), so we use the self-contained codec mapping.
+        mimeType = MimeTypes.VIDEO_H265;
+        codecs = DolbyVisionCompatibility.chooseHevcCodecsString(codecs, null);
+      }
+
+      @C.SelectionFlags int selectionFlags = 0;
+      selectionFlags |= flagDefault ? C.SELECTION_FLAG_DEFAULT : 0;
+      selectionFlags |= flagForced ? C.SELECTION_FLAG_FORCED : 0;
+
+      Format.Builder formatBuilder = new Format.Builder();
+      // TODO: Consider reading the name elements of the tracks and, if present, incorporating them
+      // into the trackId passed when creating the formats.
+      if (MimeTypes.isAudio(mimeType)) {
+        formatBuilder
+            .setChannelCount(channelCount)
+            .setSampleRate(sampleRate)
+            .setPcmEncoding(pcmEncoding);
+      } else if (MimeTypes.isVideo(mimeType)) {
+        if (displayUnit == Track.DISPLAY_UNIT_PIXELS) {
+          displayWidth = displayWidth == Format.NO_VALUE ? width : displayWidth;
+          displayHeight = displayHeight == Format.NO_VALUE ? height : displayHeight;
+        }
+        float pixelWidthHeightRatio = Format.NO_VALUE;
+        if (displayWidth != Format.NO_VALUE && displayHeight != Format.NO_VALUE) {
+          pixelWidthHeightRatio = ((float) (height * displayWidth)) / (width * displayHeight);
+        }
+        @Nullable ColorInfo colorInfo = null;
+        if (hasColorInfo) {
+          @Nullable byte[] hdrStaticInfo = getHdrStaticInfo();
+          colorInfo =
+              new ColorInfo.Builder()
+                  .setColorSpace(colorSpace)
+                  .setColorRange(colorRange)
+                  .setColorTransfer(colorTransfer)
+                  .setHdrStaticInfo(hdrStaticInfo)
+                  .setLumaBitdepth(bitsPerChannel)
+                  .setChromaBitdepth(bitsPerChannel)
+                  .build();
+        }
+        int rotationDegrees = Format.NO_VALUE;
+
+        if (name != null && TRACK_NAME_TO_ROTATION_DEGREES.containsKey(name)) {
+          rotationDegrees = TRACK_NAME_TO_ROTATION_DEGREES.get(name);
+        }
+        if (projectionType == C.PROJECTION_RECTANGULAR
+            && Float.compare(projectionPoseYaw, 0f) == 0
+            && Float.compare(projectionPosePitch, 0f) == 0) {
+          // The range of projectionPoseRoll is [-180, 180].
+          if (Float.compare(projectionPoseRoll, 0f) == 0) {
+            rotationDegrees = 0;
+          } else if (Float.compare(projectionPoseRoll, 90f) == 0) {
+            rotationDegrees = 90;
+          } else if (Float.compare(projectionPoseRoll, -180f) == 0
+              || Float.compare(projectionPoseRoll, 180f) == 0) {
+            rotationDegrees = 180;
+          } else if (Float.compare(projectionPoseRoll, -90f) == 0) {
+            rotationDegrees = 270;
+          }
+        }
+        formatBuilder
+            .setWidth(width)
+            .setHeight(height)
+            .setPixelWidthHeightRatio(pixelWidthHeightRatio)
+            .setRotationDegrees(rotationDegrees)
+            .setProjectionData(projectionData)
+            .setStereoMode(stereoMode)
+            .setColorInfo(colorInfo);
+      } else if (MimeTypes.APPLICATION_SUBRIP.equals(mimeType)
+          || MimeTypes.TEXT_SSA.equals(mimeType)
+          || MimeTypes.TEXT_VTT.equals(mimeType)
+          || MimeTypes.APPLICATION_VOBSUB.equals(mimeType)
+          || MimeTypes.APPLICATION_PGS.equals(mimeType)
+          || MimeTypes.APPLICATION_DVBSUBS.equals(mimeType)) {
+      } else {
+        throw ParserException.createForMalformedContainer(
+            "Unexpected MIME type.", /* cause= */ null);
+      }
+
+      if (name != null && !TRACK_NAME_TO_ROTATION_DEGREES.containsKey(name)) {
+        formatBuilder.setLabel(name);
+      }
+
+      format =
+          formatBuilder
+              .setId(trackId)
+              .setContainerMimeType(isWebm ? MimeTypes.VIDEO_WEBM : MimeTypes.VIDEO_MATROSKA)
+              .setSampleMimeType(mimeType)
+              .setMaxInputSize(maxInputSize)
+              .setLanguage(language)
+              .setSelectionFlags(selectionFlags)
+              .setInitializationData(initializationData)
+              .setCodecs(codecs)
+              .setDrmInitData(drmInitData)
+              .build();
+    }
+
+    /** Forces any pending sample metadata to be flushed to the output. */
+    @RequiresNonNull("output")
+    public void outputPendingSampleMetadata() {
+      if (trueHdSampleRechunker != null) {
+        trueHdSampleRechunker.outputPendingSampleMetadata(output, cryptoData);
+      }
+    }
+
+    /** Resets any state stored in the track in response to a seek. */
+    public void reset() {
+      if (trueHdSampleRechunker != null) {
+        trueHdSampleRechunker.reset();
+      }
+      pendingDolbyVisionBlockAdditionalData = null;
+    }
+
+    /**
+     * Returns true if supplemental data will be attached to the samples.
+     *
+     * @param isBlockGroup Whether the samples are from a BlockGroup.
+     */
+    private boolean samplesHaveSupplementalData(boolean isBlockGroup) {
+      if (CODEC_ID_OPUS.equals(codecId)) {
+        // At the end of a BlockGroup, a positive DiscardPadding value will be written out as
+        // supplemental data for Opus codec. Otherwise (i.e. DiscardPadding <= 0) supplemental data
+        // size will be 0.
+        return isBlockGroup;
+      }
+      return maxBlockAdditionId > 0;
+    }
+
+    /** Returns the HDR Static Info as defined in CTA-861.3. */
+    @Nullable
+    private byte[] getHdrStaticInfo() {
+      // Are all fields present.
+      if (primaryRChromaticityX == Format.NO_VALUE
+          || primaryRChromaticityY == Format.NO_VALUE
+          || primaryGChromaticityX == Format.NO_VALUE
+          || primaryGChromaticityY == Format.NO_VALUE
+          || primaryBChromaticityX == Format.NO_VALUE
+          || primaryBChromaticityY == Format.NO_VALUE
+          || whitePointChromaticityX == Format.NO_VALUE
+          || whitePointChromaticityY == Format.NO_VALUE
+          || maxMasteringLuminance == Format.NO_VALUE
+          || minMasteringLuminance == Format.NO_VALUE) {
+        return null;
+      }
+
+      byte[] hdrStaticInfoData = new byte[25];
+      ByteBuffer hdrStaticInfo = ByteBuffer.wrap(hdrStaticInfoData).order(ByteOrder.LITTLE_ENDIAN);
+      hdrStaticInfo.put((byte) 0); // Type.
+      hdrStaticInfo.putShort((short) ((primaryRChromaticityX * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((primaryRChromaticityY * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((primaryGChromaticityX * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((primaryGChromaticityY * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((primaryBChromaticityX * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((primaryBChromaticityY * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((whitePointChromaticityX * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) ((whitePointChromaticityY * MAX_CHROMATICITY) + 0.5f));
+      hdrStaticInfo.putShort((short) (maxMasteringLuminance + 0.5f));
+      hdrStaticInfo.putShort((short) (minMasteringLuminance + 0.5f));
+      hdrStaticInfo.putShort((short) maxContentLuminance);
+      hdrStaticInfo.putShort((short) maxFrameAverageLuminance);
+      return hdrStaticInfoData;
+    }
+
+    /**
+     * Finds the best thumbnail timestamp from the cue points and adds it to the track's format as
+     * {@link ThumbnailMetadata}.
+     */
+    private void maybeAddThumbnailMetadata(
+        SparseArray<List<MatroskaSeekMap.CuePointData>> perTrackCues,
+        long durationUs,
+        long segmentContentPosition,
+        long segmentContentSize) {
+      if (type != C.TRACK_TYPE_VIDEO) {
+        return;
+      }
+
+      List<MatroskaSeekMap.CuePointData> cuePoints = perTrackCues.get(number);
+      if (cuePoints == null || cuePoints.isEmpty()) {
+        return;
+      }
+
+      long thumbnailTimestampUs =
+          findBestThumbnailPresentationTimeUs(
+              cuePoints, durationUs, segmentContentPosition, segmentContentSize);
+
+      if (thumbnailTimestampUs != C.TIME_UNSET) {
+        Metadata existingMetadata = checkNotNull(format).metadata;
+        ThumbnailMetadata thumbnailMetadata = new ThumbnailMetadata(thumbnailTimestampUs);
+        Metadata newMetadata =
+            (existingMetadata == null)
+                ? new Metadata(thumbnailMetadata)
+                : existingMetadata.copyWithAppendedEntries(thumbnailMetadata);
+        format = format.buildUpon().setMetadata(newMetadata).build();
+      }
+    }
+
+    /**
+     * Finds the best thumbnail timestamp from the provided cue points.
+     *
+     * <p>The heuristic seeks to find a visually interesting frame by assuming that a larger chunk
+     * size corresponds to a more complex and representative frame. It calculates an approximate
+     * bitrate for each chunk and selects the timestamp of the chunk with the highest bitrate.
+     */
+    private static long findBestThumbnailPresentationTimeUs(
+        List<MatroskaSeekMap.CuePointData> cuePoints,
+        long durationUs,
+        long segmentContentPosition,
+        long segmentContentSize) {
+      if (cuePoints.isEmpty()) {
+        return C.TIME_UNSET;
+      }
+
+      double maxBitrate = 0;
+      int bestCueIndex = -1;
+      int scanLimit = min(cuePoints.size(), MAX_CHUNKS_TO_SCAN_FOR_THUMBNAIL);
+
+      for (int i = 0; i < scanLimit; i++) {
+        MatroskaSeekMap.CuePointData cue = cuePoints.get(i);
+
+        if (cue.timeUs > MAX_DURATION_US_TO_SCAN_FOR_THUMBNAIL) {
+          break;
+        }
+
+        long bytesBetweenCues;
+        long durationBetweenCuesUs;
+
+        if (i < cuePoints.size() - 1) {
+          MatroskaSeekMap.CuePointData nextCue = cuePoints.get(i + 1);
+          bytesBetweenCues =
+              (nextCue.clusterPosition + nextCue.relativePosition)
+                  - (cue.clusterPosition + cue.relativePosition);
+          durationBetweenCuesUs = nextCue.timeUs - cue.timeUs;
+        } else {
+          // Last cue point
+          bytesBetweenCues =
+              (segmentContentPosition + segmentContentSize)
+                  - (cue.clusterPosition + cue.relativePosition);
+          durationBetweenCuesUs = durationUs - cue.timeUs;
+        }
+
+        if (durationBetweenCuesUs > 0) {
+          // This is an approximation of the bitrate for thumbnail heuristic.
+          double bitrate = (double) bytesBetweenCues / durationBetweenCuesUs;
+          if (bitrate > maxBitrate) {
+            maxBitrate = bitrate;
+            bestCueIndex = i;
+          }
+        }
+      }
+
+      return bestCueIndex == -1 ? C.TIME_UNSET : cuePoints.get(bestCueIndex).timeUs;
+    }
+
+    /**
+     * Builds initialization data for a {@link Format} from FourCC codec private data.
+     *
+     * @return The codec MIME type and initialization data. If the compression type is not supported
+     *     then the MIME type is set to {@link MimeTypes#VIDEO_UNKNOWN} and the initialization data
+     *     is {@code null}.
+     * @throws ParserException If the initialization data could not be built.
+     */
+    private static Pair<String, @NullableType List<byte[]>> parseFourCcPrivate(
+        ParsableByteArray buffer) throws ParserException {
+      try {
+        buffer.skipBytes(16); // size(4), width(4), height(4), planes(2), bitcount(2).
+        long compression = buffer.readLittleEndianUnsignedInt();
+        if (compression == FOURCC_COMPRESSION_DIVX) {
+          return new Pair<>(MimeTypes.VIDEO_DIVX, null);
+        } else if (compression == FOURCC_COMPRESSION_H263) {
+          return new Pair<>(MimeTypes.VIDEO_H263, null);
+        } else if (compression == FOURCC_COMPRESSION_VC1) {
+          // Search for the initialization data from the end of the BITMAPINFOHEADER. The last 20
+          // bytes of which are: sizeImage(4), xPel/m (4), yPel/m (4), clrUsed(4), clrImportant(4).
+          int startOffset = buffer.getPosition() + 20;
+          byte[] bufferData = buffer.getData();
+          for (int offset = startOffset; offset < bufferData.length - 4; offset++) {
+            if (bufferData[offset] == 0x00
+                && bufferData[offset + 1] == 0x00
+                && bufferData[offset + 2] == 0x01
+                && bufferData[offset + 3] == 0x0F) {
+              // We've found the initialization data.
+              byte[] initializationData = Arrays.copyOfRange(bufferData, offset, bufferData.length);
+              return new Pair<>(MimeTypes.VIDEO_VC1, Collections.singletonList(initializationData));
+            }
+          }
+          throw ParserException.createForMalformedContainer(
+              "Failed to find FourCC VC1 initialization data", /* cause= */ null);
+        }
+      } catch (ArrayIndexOutOfBoundsException e) {
+        throw ParserException.createForMalformedContainer(
+            "Error parsing FourCC private data", /* cause= */ null);
+      }
+
+      Log.w(TAG, "Unknown FourCC. Setting mimeType to " + MimeTypes.VIDEO_UNKNOWN);
+      return new Pair<>(MimeTypes.VIDEO_UNKNOWN, null);
+    }
+
+    /**
+     * Builds initialization data for a {@link Format} from Vorbis codec private data.
+     *
+     * @return The initialization data for the {@link Format}.
+     * @throws ParserException If the initialization data could not be built.
+     */
+    private static List<byte[]> parseVorbisCodecPrivate(byte[] codecPrivate)
+        throws ParserException {
+      try {
+        if (codecPrivate[0] != 0x02) {
+          throw ParserException.createForMalformedContainer(
+              "Error parsing vorbis codec private", /* cause= */ null);
+        }
+        int offset = 1;
+        int vorbisInfoLength = 0;
+        while ((codecPrivate[offset] & 0xFF) == 0xFF) {
+          vorbisInfoLength += 0xFF;
+          offset++;
+        }
+        vorbisInfoLength += codecPrivate[offset++] & 0xFF;
+
+        int vorbisSkipLength = 0;
+        while ((codecPrivate[offset] & 0xFF) == 0xFF) {
+          vorbisSkipLength += 0xFF;
+          offset++;
+        }
+        vorbisSkipLength += codecPrivate[offset++] & 0xFF;
+
+        if (codecPrivate[offset] != 0x01) {
+          throw ParserException.createForMalformedContainer(
+              "Error parsing vorbis codec private", /* cause= */ null);
+        }
+        byte[] vorbisInfo = new byte[vorbisInfoLength];
+        System.arraycopy(codecPrivate, offset, vorbisInfo, 0, vorbisInfoLength);
+        offset += vorbisInfoLength;
+        if (codecPrivate[offset] != 0x03) {
+          throw ParserException.createForMalformedContainer(
+              "Error parsing vorbis codec private", /* cause= */ null);
+        }
+        offset += vorbisSkipLength;
+        if (codecPrivate[offset] != 0x05) {
+          throw ParserException.createForMalformedContainer(
+              "Error parsing vorbis codec private", /* cause= */ null);
+        }
+        byte[] vorbisBooks = new byte[codecPrivate.length - offset];
+        System.arraycopy(codecPrivate, offset, vorbisBooks, 0, codecPrivate.length - offset);
+        List<byte[]> initializationData = new ArrayList<>(2);
+        initializationData.add(vorbisInfo);
+        initializationData.add(vorbisBooks);
+        return initializationData;
+      } catch (ArrayIndexOutOfBoundsException e) {
+        throw ParserException.createForMalformedContainer(
+            "Error parsing vorbis codec private", /* cause= */ null);
+      }
+    }
+
+    /**
+     * Parses an MS/ACM codec private, returning whether it indicates PCM audio.
+     *
+     * @return Whether the codec private indicates PCM audio.
+     * @throws ParserException If a parsing error occurs.
+     */
+    private static boolean parseMsAcmCodecPrivate(ParsableByteArray buffer) throws ParserException {
+      try {
+        int formatTag = buffer.readLittleEndianUnsignedShort();
+        if (formatTag == WAVE_FORMAT_PCM) {
+          return true;
+        } else if (formatTag == WAVE_FORMAT_EXTENSIBLE) {
+          buffer.setPosition(WAVE_FORMAT_SIZE + 6); // unionSamples(2), channelMask(4)
+          return buffer.readLong() == WAVE_SUBFORMAT_PCM.getMostSignificantBits()
+              && buffer.readLong() == WAVE_SUBFORMAT_PCM.getLeastSignificantBits();
+        } else {
+          return false;
+        }
+      } catch (ArrayIndexOutOfBoundsException e) {
+        throw ParserException.createForMalformedContainer(
+            "Error parsing MS/ACM codec private", /* cause= */ null);
+      }
+    }
+
+    /**
+     * Checks that the track has an output.
+     *
+     * <p>It is unfortunately not possible to mark {@link MatroskaExtractor#tracks} as only
+     * containing tracks with output with the nullness checker. This method is used to check that
+     * fact at runtime.
+     */
+    @EnsuresNonNull("output")
+    private void assertOutputInitialized() {
+      checkNotNull(output);
+    }
+
+    @EnsuresNonNull("codecPrivate")
+    private byte[] getCodecPrivate(String codecId) throws ParserException {
+      if (codecPrivate == null) {
+        throw ParserException.createForMalformedContainer(
+            "Missing CodecPrivate for codec " + codecId, /* cause= */ null);
+      }
+      return codecPrivate;
+    }
+  }
+
+  private static final class MatroskaSeekMap implements TrackAwareSeekMap, ChunkIndexProvider {
+
+    @Nullable private final ChunkIndex chunkIndex;
+    private final SparseArray<List<CuePointData>> perTrackCues;
+    private final long durationUs;
+    private final int primarySeekTrackNumber;
+
+    public MatroskaSeekMap(
+        SparseArray<List<CuePointData>> perTrackCues,
+        long durationUs,
+        int primarySeekTrackNumber,
+        long segmentContentPosition,
+        long segmentContentSize) {
+      this.perTrackCues = perTrackCues;
+      this.durationUs = durationUs;
+      this.primarySeekTrackNumber = primarySeekTrackNumber;
+      this.chunkIndex =
+          buildChunkIndex(
+              perTrackCues,
+              durationUs,
+              primarySeekTrackNumber,
+              segmentContentPosition,
+              segmentContentSize);
+    }
+
+    @Override
+    public boolean isSeekable() {
+      // The media is seekable overall only if the primary seek track has cue points.
+      return isSeekable(primarySeekTrackNumber);
+    }
+
+    @Override
+    public boolean isSeekable(int trackId) {
+      List<CuePointData> cuePoints = perTrackCues.get(trackId);
+      return cuePoints != null && !cuePoints.isEmpty();
+    }
+
+    @Override
+    public long getDurationUs() {
+      return durationUs;
+    }
+
+    @Override
+    public SeekPoints getSeekPoints(long timeUs) {
+      if (chunkIndex != null) {
+        return chunkIndex.getSeekPoints(timeUs);
+      }
+      return new SeekPoints(SeekPoint.START);
+    }
+
+    @Override
+    public SeekPoints getSeekPoints(long timeUs, int trackId) {
+      List<CuePointData> cuePoints = perTrackCues.get(trackId);
+      if ((cuePoints == null || cuePoints.isEmpty()) && trackId != primarySeekTrackNumber) {
+        cuePoints = perTrackCues.get(primarySeekTrackNumber);
+      }
+      if (cuePoints == null || cuePoints.isEmpty()) {
+        return new SeekPoints(SeekPoint.START);
+      }
+
+      int bestIndex =
+          Util.binarySearchFloor(
+              cuePoints,
+              new CuePointData(timeUs, C.INDEX_UNSET, C.INDEX_UNSET),
+              /* inclusive= */ true,
+              /* stayInBounds= */ false);
+
+      if (bestIndex != -1) {
+        CuePointData bestCue = cuePoints.get(bestIndex);
+        SeekPoint firstPoint = new SeekPoint(bestCue.timeUs, bestCue.clusterPosition);
+
+        if (bestCue.timeUs < timeUs && bestIndex + 1 < cuePoints.size()) {
+          CuePointData nextCue = cuePoints.get(bestIndex + 1);
+          SeekPoint secondPoint = new SeekPoint(nextCue.timeUs, nextCue.clusterPosition);
+          return new SeekPoints(firstPoint, secondPoint);
+        } else {
+          return new SeekPoints(firstPoint);
+        }
+      } else {
+        CuePointData firstCue = cuePoints.get(0);
+        return new SeekPoints(new SeekPoint(firstCue.timeUs, firstCue.clusterPosition));
+      }
+    }
+
+    @Override
+    @Nullable
+    public ChunkIndex getChunkIndex() {
+      return chunkIndex;
+    }
+
+    @Nullable
+    private static ChunkIndex buildChunkIndex(
+        SparseArray<List<CuePointData>> perTrackCues,
+        long durationUs,
+        int primarySeekTrackNumber,
+        long segmentContentPosition,
+        long segmentContentSize) {
+      List<CuePointData> primaryTrackCuePoints = perTrackCues.get(primarySeekTrackNumber);
+      if (primaryTrackCuePoints == null || primaryTrackCuePoints.isEmpty()) {
+        return null;
+      }
+
+      int cuePointsSize = primaryTrackCuePoints.size();
+      int[] sizes = new int[cuePointsSize];
+      long[] offsets = new long[cuePointsSize];
+      long[] durationsUs = new long[cuePointsSize];
+      long[] timesUs = new long[cuePointsSize];
+
+      for (int i = 0; i < cuePointsSize; i++) {
+        CuePointData cue = primaryTrackCuePoints.get(i);
+        timesUs[i] = cue.timeUs;
+        offsets[i] = cue.clusterPosition;
+      }
+
+      for (int i = 0; i < cuePointsSize - 1; i++) {
+        sizes[i] = (int) (offsets[i + 1] - offsets[i]);
+        durationsUs[i] = timesUs[i + 1] - timesUs[i];
+      }
+
+      // Start from the last cue point and move backward until a valid duration is found.
+      int lastValidIndex = cuePointsSize - 1;
+      while (lastValidIndex > 0 && timesUs[lastValidIndex] >= durationUs) {
+        lastValidIndex--;
+      }
+
+      // Calculate sizes and durations for the last valid index
+      sizes[lastValidIndex] =
+          (int) (segmentContentPosition + segmentContentSize - offsets[lastValidIndex]);
+      durationsUs[lastValidIndex] = durationUs - timesUs[lastValidIndex];
+
+      // If trailing cue points were found, truncate the arrays to the last valid index.
+      if (lastValidIndex < cuePointsSize - 1) {
+        Log.w(TAG, "Discarding trailing cue points with timestamps greater than total duration.");
+        sizes = Arrays.copyOf(sizes, lastValidIndex + 1);
+        offsets = Arrays.copyOf(offsets, lastValidIndex + 1);
+        durationsUs = Arrays.copyOf(durationsUs, lastValidIndex + 1);
+        timesUs = Arrays.copyOf(timesUs, lastValidIndex + 1);
+      }
+
+      return new ChunkIndex(sizes, offsets, durationsUs, timesUs);
+    }
+
+    private static final class CuePointData implements Comparable<CuePointData> {
+      /** The timestamp of the cue point, in microseconds. */
+      private final long timeUs;
+
+      /** The absolute byte offset of the start of the cluster containing this cue point. */
+      private final long clusterPosition;
+
+      /**
+       * The relative byte offset of the cue point's data block within its cluster.
+       *
+       * <p>Note: For seeking, use {@link #clusterPosition} to prevent A/V desync.
+       */
+      private final long relativePosition;
+
+      private CuePointData(long timeUs, long clusterPosition, long relativePosition) {
+        this.timeUs = timeUs;
+        this.clusterPosition = clusterPosition;
+        this.relativePosition = relativePosition;
+      }
+
+      @Override
+      public int compareTo(CuePointData other) {
+        return Long.compare(timeUs, other.timeUs);
+      }
+
+      @Override
+      public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+          return true;
+        }
+        if (!(obj instanceof CuePointData)) {
+          return false;
+        }
+        CuePointData other = (CuePointData) obj;
+        return this.timeUs == other.timeUs
+            && this.clusterPosition == other.clusterPosition
+            && this.relativePosition == other.relativePosition;
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(timeUs, clusterPosition, relativePosition);
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -2854,6 +2854,20 @@ public class MatroskaExtractor implements Extractor {
             }
           }
         }
+      } else if (dolbyVisionSampleTransformer != null && codecs != null) {
+        String lower = codecs.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("dvhe.")
+            || lower.startsWith("dvh1.")
+            || lower.startsWith("dvav.")
+            || lower.startsWith("dva1.")) {
+          @Nullable
+          String transformedCodecs =
+              dolbyVisionSampleTransformer.onDolbyVisionCodecString(codecs, null);
+          if (transformedCodecs != null && !transformedCodecs.isEmpty()) {
+            codecs = transformedCodecs;
+            mimeType = MimeTypes.VIDEO_DOLBY_VISION;
+          }
+        }
       }
       if (DolbyVisionCompatibility.shouldMapDolbyVisionProfile7(mimeType, codecs)) {
         // NOTE: Vendored for app-level (AAR) DV7 use. The original called

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/Sniffer.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/Sniffer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.media3.common.C;
+import androidx.media3.common.util.ParsableByteArray;
+import androidx.media3.extractor.Extractor;
+import androidx.media3.extractor.ExtractorInput;
+import java.io.IOException;
+
+/**
+ * Utility class that peeks from the input stream in order to determine whether it appears to be
+ * compatible input for this extractor.
+ */
+/* package */ final class Sniffer {
+
+  /** The number of bytes to search for a valid header in {@link #sniff(ExtractorInput)}. */
+  private static final int SEARCH_LENGTH = 1024;
+
+  private static final int ID_EBML = 0x1A45DFA3;
+
+  private final ParsableByteArray scratch;
+  private int peekLength;
+
+  public Sniffer() {
+    scratch = new ParsableByteArray(8);
+  }
+
+  /** See {@link Extractor#sniff(ExtractorInput)}. */
+  public boolean sniff(ExtractorInput input) throws IOException {
+    long inputLength = input.getLength();
+    int bytesToSearch =
+        (int)
+            (inputLength == C.LENGTH_UNSET || inputLength > SEARCH_LENGTH
+                ? SEARCH_LENGTH
+                : inputLength);
+    // Find four bytes equal to ID_EBML near the start of the input.
+    input.peekFully(scratch.getData(), 0, 4);
+    long tag = scratch.readUnsignedInt();
+    peekLength = 4;
+    while (tag != ID_EBML) {
+      if (++peekLength == bytesToSearch) {
+        return false;
+      }
+      input.peekFully(scratch.getData(), 0, 1);
+      tag = (tag << 8) & 0xFFFFFF00;
+      tag |= scratch.getData()[0] & 0xFF;
+    }
+
+    // Read the size of the EBML header and make sure it is within the stream.
+    long headerSize = readUint(input);
+    long headerStart = peekLength;
+    if (headerSize == Long.MIN_VALUE
+        || (inputLength != C.LENGTH_UNSET && headerStart + headerSize >= inputLength)) {
+      return false;
+    }
+
+    // Read the payload elements in the EBML header.
+    while (peekLength < headerStart + headerSize) {
+      long id = readUint(input);
+      if (id == Long.MIN_VALUE) {
+        return false;
+      }
+      long size = readUint(input);
+      if (size < 0 || size > Integer.MAX_VALUE) {
+        return false;
+      }
+      if (size != 0) {
+        int sizeInt = (int) size;
+        input.advancePeekPosition(sizeInt);
+        peekLength += sizeInt;
+      }
+    }
+    return peekLength == headerStart + headerSize;
+  }
+
+  /** Peeks a variable-length unsigned EBML integer from the input. */
+  private long readUint(ExtractorInput input) throws IOException {
+    input.peekFully(scratch.getData(), 0, 1);
+    int value = scratch.getData()[0] & 0xFF;
+    if (value == 0) {
+      return Long.MIN_VALUE;
+    }
+    int mask = 0x80;
+    int length = 0;
+    while ((value & mask) == 0) {
+      mask >>= 1;
+      length++;
+    }
+    value &= ~mask;
+    input.peekFully(scratch.getData(), 1, length);
+    for (int i = 0; i < length; i++) {
+      value <<= 8;
+      value += scratch.getData()[i + 1] & 0xFF;
+    }
+    peekLength += length + 1;
+    return value;
+  }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/ThumbnailMetadata.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/ThumbnailMetadata.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.Metadata;
+import androidx.media3.common.util.UnstableApi;
+import com.google.common.primitives.Longs;
+
+/** Stores the presentation timestamp of a thumbnail. */
+@UnstableApi
+public final class ThumbnailMetadata implements Metadata.Entry {
+
+  /** The presentation timestamp of the thumbnail, in microseconds. */
+  public final long presentationTimeUs;
+
+  /**
+   * Creates an instance.
+   *
+   * @param presentationTimeUs The presentation timestamp of the thumbnail, in microseconds.
+   */
+  public ThumbnailMetadata(long presentationTimeUs) {
+    this.presentationTimeUs = presentationTimeUs;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ThumbnailMetadata that = (ThumbnailMetadata) o;
+    return presentationTimeUs == that.presentationTimeUs;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Longs.hashCode(presentationTimeUs);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ThumbnailMetadata: presentationTimeUs=" + presentationTimeUs;
+  }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/TrackAwareSeekMap.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/TrackAwareSeekMap.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.extractor.SeekMap;
+
+/** A {@link SeekMap} that also allows seeking based on a specific track ID. */
+@UnstableApi
+public interface TrackAwareSeekMap extends SeekMap {
+
+  /**
+   * Returns whether seeking is possible for the given track ID.
+   *
+   * <p>This method is similar to {@link #isSeekable()}, but allows specifying a {@code trackId}.
+   * The {@code trackId} is the same ID passed to {@link ExtractorOutput#track(int, int)}.
+   *
+   * @param trackId The ID of the track.
+   * @return Whether seeking is possible for the track.
+   */
+  boolean isSeekable(int trackId);
+
+  /**
+   * Obtains seek points for the specified seek time in microseconds, using cue points from a
+   * specific track.
+   *
+   * <p>This method is similar to {@link #getSeekPoints(long)}, but allows specifying a {@code
+   * trackId}. The {@code trackId} is the same ID passed to {@link ExtractorOutput#track(int, int)}.
+   * If the given {@code trackId} does not have any associated cue points, the implementation may
+   * fall back to using a default or primary track.
+   *
+   * @param timeUs A seek time in microseconds.
+   * @param trackId The ID of the track to use for finding seek points.
+   * @return The corresponding seek points.
+   */
+  SeekPoints getSeekPoints(long timeUs, int trackId);
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/VarintReader.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/VarintReader.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.media3.common.C;
+import androidx.media3.extractor.ExtractorInput;
+import java.io.EOFException;
+import java.io.IOException;
+
+/** Reads EBML variable-length integers (varints) from an {@link ExtractorInput}. */
+/* package */ final class VarintReader {
+
+  private static final int STATE_BEGIN_READING = 0;
+  private static final int STATE_READ_CONTENTS = 1;
+
+  /**
+   * The first byte of a variable-length integer (varint) will have one of these bit masks
+   * indicating the total length in bytes.
+   *
+   * <p>{@code 0x80} is a one-byte integer, {@code 0x40} is two bytes, and so on up to eight bytes.
+   */
+  private static final long[] VARINT_LENGTH_MASKS =
+      new long[] {0x80L, 0x40L, 0x20L, 0x10L, 0x08L, 0x04L, 0x02L, 0x01L};
+
+  private final byte[] scratch;
+
+  private int state;
+  private int length;
+
+  public VarintReader() {
+    scratch = new byte[8];
+  }
+
+  /** Resets the reader to start reading a new variable-length integer. */
+  public void reset() {
+    state = STATE_BEGIN_READING;
+    length = 0;
+  }
+
+  /**
+   * Reads an EBML variable-length integer (varint) from an {@link ExtractorInput} such that reading
+   * can be resumed later if an error occurs having read only some of it.
+   *
+   * <p>If an value is successfully read, then the reader will automatically reset itself ready to
+   * read another value.
+   *
+   * <p>If an {@link IOException} is thrown, the read can be resumed later by calling this method
+   * again, passing an {@link ExtractorInput} providing data starting where the previous one left
+   * off.
+   *
+   * @param input The {@link ExtractorInput} from which the integer should be read.
+   * @param allowEndOfInput True if encountering the end of the input having read no data is
+   *     allowed, and should result in {@link C#RESULT_END_OF_INPUT} being returned. False if it
+   *     should be considered an error, causing an {@link EOFException} to be thrown.
+   * @param removeLengthMask Removes the variable-length integer length mask from the value.
+   * @param maximumAllowedLength Maximum allowed length of the variable integer to be read.
+   * @return The read value, or {@link C#RESULT_END_OF_INPUT} if {@code allowEndOfStream} is true
+   *     and the end of the input was encountered, or {@link C#RESULT_MAX_LENGTH_EXCEEDED} if the
+   *     length of the varint exceeded maximumAllowedLength.
+   * @throws IOException If an error occurs reading from the input.
+   */
+  public long readUnsignedVarint(
+      ExtractorInput input,
+      boolean allowEndOfInput,
+      boolean removeLengthMask,
+      int maximumAllowedLength)
+      throws IOException {
+    if (state == STATE_BEGIN_READING) {
+      // Read the first byte to establish the length.
+      if (!input.readFully(scratch, 0, 1, allowEndOfInput)) {
+        return C.RESULT_END_OF_INPUT;
+      }
+      int firstByte = scratch[0] & 0xFF;
+      length = parseUnsignedVarintLength(firstByte);
+      if (length == C.LENGTH_UNSET) {
+        throw new IllegalStateException("No valid varint length mask found");
+      }
+      state = STATE_READ_CONTENTS;
+    }
+
+    if (length > maximumAllowedLength) {
+      state = STATE_BEGIN_READING;
+      return C.RESULT_MAX_LENGTH_EXCEEDED;
+    }
+
+    if (length != 1) {
+      // Read the remaining bytes.
+      input.readFully(scratch, 1, length - 1);
+    }
+
+    state = STATE_BEGIN_READING;
+    return assembleVarint(scratch, length, removeLengthMask);
+  }
+
+  /** Returns the number of bytes occupied by the most recently parsed varint. */
+  public int getLastLength() {
+    return length;
+  }
+
+  /**
+   * Parses and the length of the varint given the first byte.
+   *
+   * @param firstByte First byte of the varint.
+   * @return Length of the varint beginning with the given byte if it was valid, {@link
+   *     C#LENGTH_UNSET} otherwise.
+   */
+  public static int parseUnsignedVarintLength(int firstByte) {
+    int varIntLength = C.LENGTH_UNSET;
+    for (int i = 0; i < VARINT_LENGTH_MASKS.length; i++) {
+      if ((VARINT_LENGTH_MASKS[i] & firstByte) != 0) {
+        varIntLength = i + 1;
+        break;
+      }
+    }
+    return varIntLength;
+  }
+
+  /**
+   * Assemble a varint from the given byte array.
+   *
+   * @param varintBytes Bytes that make up the varint.
+   * @param varintLength Length of the varint to assemble.
+   * @param removeLengthMask Removes the variable-length integer length mask from the value.
+   * @return Parsed and assembled varint.
+   */
+  public static long assembleVarint(
+      byte[] varintBytes, int varintLength, boolean removeLengthMask) {
+    long varint = varintBytes[0] & 0xFFL;
+    if (removeLengthMask) {
+      varint &= ~VARINT_LENGTH_MASKS[varintLength - 1];
+    }
+    for (int i = 1; i < varintLength; i++) {
+      varint = (varint << 8) | (varintBytes[i] & 0xFFL);
+    }
+    return varint;
+  }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/package-info.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * App-level (AAR mode) vendored Matroska extractor.
+ *
+ * <p>This package is a self-contained copy of AndroidX Media3's Matroska extractor and its
+ * supporting EBML readers, relocated out of {@code androidx.media3.extractor.mkv} so it can be
+ * compiled into the app alongside the stock prebuilt Media3 AARs. It exposes a {@link
+ * com.nuvio.tv.core.player.dvmkv.MatroskaExtractor.DolbyVisionSampleTransformer} seam that the
+ * app wires to the libdovi bridge to perform DV7 to DV8.1 conversion for MKV, whose RPU rides
+ * in BlockAdditional and is otherwise discarded by the stock extractor.
+ */
+package com.nuvio.tv.core.player.dvmkv;

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.player.LastPlaybackDiagnostics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -146,14 +147,26 @@ data class SubtitleStyleSettings(
  * Data class representing buffer settings
  */
 data class BufferSettings(
-    val minBufferMs: Int = 50_000,
-    val maxBufferMs: Int = 50_000,
-    val bufferForPlaybackMs: Int = 2_500,
-    val bufferForPlaybackAfterRebufferMs: Int = 5_000,
-    val targetBufferSizeMb: Int = 0, // 0 = ExoPlayer default
-    val backBufferDurationMs: Int = 0,
+    val minBufferMs: Int = DEFAULT_MIN_BUFFER_MS,
+    val maxBufferMs: Int = DEFAULT_MAX_BUFFER_MS,
+    val bufferForPlaybackMs: Int = DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+    val bufferForPlaybackAfterRebufferMs: Int = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+    val targetBufferSizeMb: Int = DEFAULT_TARGET_BUFFER_SIZE_MB,
+    val backBufferDurationMs: Int = DEFAULT_BACK_BUFFER_DURATION_MS,
     val retainBackBufferFromKeyframe: Boolean = false
-)
+) {
+    companion object {
+        const val DEFAULT_MIN_BUFFER_MS = 15_000
+        const val DEFAULT_MAX_BUFFER_MS = 45_000
+        const val DEFAULT_BUFFER_FOR_PLAYBACK_MS = 5_000
+        const val DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 3_000
+        const val DEFAULT_TARGET_BUFFER_SIZE_MB: Int = 150
+        // Media3 reserves additional bytes for back buffer as a fraction of
+        // targetBufferBytes. 15s default keeps peak heap within Fire TV class
+        // limits while still covering 3 default 5s seek-back presses.
+        const val DEFAULT_BACK_BUFFER_DURATION_MS = 15_000
+    }
+}
 
 /**
  * Available audio language options
@@ -221,8 +234,16 @@ data class PlayerSettings(
     val skipIntroEnabled: Boolean = true,
     val parentalGuideEnabled: Boolean = true,
     val autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet(),
-    // Dolby Vision Profile 7 → HEVC fallback (requires forked ExoPlayer)
-    val mapDV7ToHevc: Boolean = false,
+    // Dolby Vision settings (libdovi conversion). dv7HandlingMode == HDR10_BASE_LAYER
+    // replaces the legacy mapDV7ToHevc boolean (strip DV7, play HEVC base layer).
+    val dv5ToDv81Enabled: Boolean = false,
+    val dv7ToDv81PreserveMappingEnabled: Boolean = false,
+    val dv7HandlingMode: Dv7HandlingMode = Dv7HandlingMode.AUTO,
+    // Experimental libdovi conversion-mode override. -1 = auto (use the
+    // profile-driven auto-pick); 0..4 = force that exact libdovi mode
+    // (0 copy, 1 MEL, 2 8.1 no-op, 3 8.4 static, 4 8.1 preserve-mapping).
+    // Only honored when dv7HandlingMode is OFF or DV81_LIBDOVI.
+    val dv7LibdoviModeOverride: Int = -1,
     val mpvHardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE,
     // Display settings
     val frameRateMatchingMode: FrameRateMatchingMode = FrameRateMatchingMode.OFF,
@@ -245,7 +266,23 @@ data class PlayerSettings(
     val streamReuseLastLinkEnabled: Boolean = false,
     val streamReuseLastLinkCacheHours: Int = 24,
     val subtitleOrganizationMode: SubtitleOrganizationMode = SubtitleOrganizationMode.NONE,
+
+    // Networking
+    val bufferEngineEnabled: Boolean = false,
+    val parallelNetworkEnabled: Boolean = false,
+    /** When true the device memory budget caps the buffer; when false Target Buffer Size drives it. */
+    val bufferBudgetManaged: Boolean = DEFAULT_BUFFER_BUDGET_MANAGED,
+    /** When true, target buffer slider max is raised to 2GB regardless of device memory. */
+    val allowLargeTargetBuffer: Boolean = DEFAULT_ALLOW_LARGE_TARGET_BUFFER,
+    val vodCacheEnabled: Boolean = DEFAULT_VOD_CACHE_ENABLED,
+    val vodCacheSizeMode: VodCacheSizeMode = DEFAULT_VOD_CACHE_SIZE_MODE,
+    val vodCacheSizeMb: Int = DEFAULT_VOD_CACHE_SIZE_MB,
+    val useParallelConnections: Boolean = DEFAULT_USE_PARALLEL_CONNECTIONS,
+    val parallelConnectionCount: Int = DEFAULT_PARALLEL_CONNECTION_COUNT,
+    val parallelChunkSizeMb: Int = DEFAULT_PARALLEL_CHUNK_SIZE_MB,
+
     val addonSubtitleStartupMode: AddonSubtitleStartupMode = AddonSubtitleStartupMode.ALL_SUBTITLES,
+    val enableBufferLogs: Boolean = false,
     val resizeMode: Int = 0
 ) {
     companion object {
@@ -269,50 +306,55 @@ data class PlayerSettings(
 
         fun isBoundedTimeout(timeoutSeconds: Int): Boolean =
             timeoutSeconds > 0 && timeoutSeconds != STREAM_AUTOPLAY_TIMEOUT_UNLIMITED
+
+        const val DEFAULT_BUFFER_BUDGET_MANAGED = true
+        const val DEFAULT_ALLOW_LARGE_TARGET_BUFFER = false
+        const val LARGE_TARGET_BUFFER_MAX_MB = 2048
+        const val DEFAULT_VOD_CACHE_ENABLED = true
+        const val DEFAULT_VOD_CACHE_SIZE_MB = 500
+        const val MIN_VOD_CACHE_SIZE_MB = 100
+        const val MAX_VOD_CACHE_SIZE_MB = 65_536
+        val DEFAULT_VOD_CACHE_SIZE_MODE: VodCacheSizeMode = VodCacheSizeMode.AUTO
+        const val DEFAULT_USE_PARALLEL_CONNECTIONS = false
+        const val DEFAULT_PARALLEL_CONNECTION_COUNT = 2
+        const val DEFAULT_PARALLEL_CHUNK_SIZE_MB = 16
+        const val MIN_PARALLEL_CONNECTION_COUNT = 2
+        const val MAX_PARALLEL_CONNECTION_COUNT = 4
+        const val MIN_PARALLEL_CHUNK_SIZE_MB = 8
+        const val MAX_PARALLEL_CHUNK_SIZE_MB = 128
     }
 }
 
 enum class StreamAutoPlayMode {
-    MANUAL,
-    FIRST_STREAM,
-    REGEX_MATCH
+    MANUAL, FIRST_STREAM, REGEX_MATCH
 }
 
 enum class StreamAutoPlaySource {
-    ALL_SOURCES,
-    INSTALLED_ADDONS_ONLY,
-    ENABLED_PLUGINS_ONLY
+    ALL_SOURCES, INSTALLED_ADDONS_ONLY, ENABLED_PLUGINS_ONLY
+}
+
+enum class VodCacheSizeMode {
+    AUTO, MANUAL
 }
 
 enum class FrameRateMatchingMode {
-    OFF,
-    START,
-    START_STOP
+    OFF, START, START_STOP
 }
 
 enum class NextEpisodeThresholdMode {
-    PERCENTAGE,
-    MINUTES_BEFORE_END
+    PERCENTAGE, MINUTES_BEFORE_END
 }
 
 enum class SubtitleOrganizationMode {
-    NONE,
-    BY_LANGUAGE,
-    BY_ADDON
+    NONE, BY_LANGUAGE, BY_ADDON
 }
 
 enum class AddonSubtitleStartupMode {
-    FAST_STARTUP,
-    PREFERRED_ONLY,
-    ALL_SUBTITLES
+    FAST_STARTUP, PREFERRED_ONLY, ALL_SUBTITLES
 }
 
 enum class MpvHardwareDecodeMode {
-    LEGACY_DIRECT_COPY,
-    AUTO_SAFE,
-    HARDWARE_COPY,
-    HARDWARE_DIRECT,
-    DISABLED
+    LEGACY_DIRECT_COPY, AUTO_SAFE, HARDWARE_COPY, HARDWARE_DIRECT, DISABLED
 }
 
 enum class AutoSkipSegmentType(val storedValue: String) {
@@ -334,9 +376,7 @@ enum class AutoSkipSegmentType(val storedValue: String) {
 }
 
 enum class PlayerPreference {
-    INTERNAL,
-    EXTERNAL,
-    ASK_EVERY_TIME
+    INTERNAL, EXTERNAL, ASK_EVERY_TIME
 }
 
 enum class InternalPlayerEngine {
@@ -345,18 +385,37 @@ enum class InternalPlayerEngine {
     AUTO
 }
 
-/**
- * Enum representing the different libass render types
- * Maps to io.github.peerless2012.ass.media.type.AssRenderType
- */
 enum class LibassRenderType {
-    CUES,              // Standard SubtitleView rendering (no animation support)
-    EFFECTS_CANVAS,    // Effect-based Canvas rendering (supports animations)
-    EFFECTS_OPEN_GL,   // Effect-based OpenGL rendering (supports animations, faster)
-    OVERLAY_CANVAS,    // Overlay Canvas rendering (supports HDR)
-    OVERLAY_OPEN_GL    // Overlay OpenGL rendering (supports HDR, recommended)
+    CUES, EFFECTS_CANVAS, EFFECTS_OPEN_GL, OVERLAY_CANVAS, OVERLAY_OPEN_GL
 }
+/**
+ * How DV7 streams should be handled at playback time.
+ *
+ * AUTO is the recommended default; it queries display capabilities and
+ * routes via [com.nuvio.tv.core.player.DolbyVisionBaseLayerPolicy].
+ *
+ * The other three values bypass the policy and apply unconditionally:
+ * - HDR10_BASE_LAYER: always strip DV, play HEVC base layer
+ * - DV81_LIBDOVI: libdovi DV7 to DV8.1 conversion
+ * - OFF: pass DV7 through untouched (may glitch on hardware lacking DV7 support)
+ */
+enum class Dv7HandlingMode {
+    AUTO,
+    HDR10_BASE_LAYER,
+    DV81_LIBDOVI,
+    OFF;
 
+    companion object {
+        /** Tolerant string parser used by the DataStore. */
+        fun fromStoredString(value: String?): Dv7HandlingMode = when (value) {
+            AUTO.name -> AUTO
+            HDR10_BASE_LAYER.name -> HDR10_BASE_LAYER
+            DV81_LIBDOVI.name -> DV81_LIBDOVI
+            OFF.name -> OFF
+            else -> AUTO
+        }
+    }
+}
 @OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
 class PlayerSettingsDataStore @Inject constructor(
@@ -376,17 +435,12 @@ class PlayerSettingsDataStore @Inject constructor(
 
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    // Player preference key
+    // Keys
     private val playerPreferenceKey = stringPreferencesKey("player_preference")
     private val internalPlayerEngineKey = stringPreferencesKey("internal_player_engine")
-    private val autoSwitchInternalPlayerOnErrorKey =
-        booleanPreferencesKey("auto_switch_internal_player_on_error")
-
-    // Libass settings keys
+    private val autoSwitchInternalPlayerOnErrorKey = booleanPreferencesKey("auto_switch_internal_player_on_error")
     private val useLibassKey = booleanPreferencesKey("use_libass")
     private val libassRenderTypeKey = stringPreferencesKey("libass_render_type")
-
-    // Audio settings keys
     private val decoderPriorityKey = intPreferencesKey("decoder_priority")
     private val downmixEnabledKey = booleanPreferencesKey("downmix_enabled")
     private val audioOutputChannelsKey = stringPreferencesKey("audio_output_channels")
@@ -409,7 +463,17 @@ class PlayerSettingsDataStore @Inject constructor(
     private val skipIntroEnabledKey = booleanPreferencesKey("skip_intro_enabled")
     private val parentalGuideEnabledKey = booleanPreferencesKey("parental_guide_enabled")
     private val autoSkipSegmentTypesKey = stringSetPreferencesKey("auto_skip_segment_types")
-    private val mapDV7ToHevcKey = booleanPreferencesKey("map_dv7_to_hevc")
+
+    // DV Keys
+    // NOTE: pref-key STRINGS retain the legacy `experimental_*` names so users upgrading
+    // from older versions don't lose their saved DV5/preserve-mapping toggle state. Only
+    // the Kotlin var names here and the PlayerSettings field names were de-experimentalized.
+    private val dv5ToDv81EnabledKey = booleanPreferencesKey("experimental_dv5_to_dv81_enabled")
+    private val dv7ToDv81PreserveMappingEnabledKey = booleanPreferencesKey("experimental_dv7_to_dv81_preserve_mapping_enabled")
+    private val dv7HandlingModeKey = stringPreferencesKey("dv7_handling_mode")
+    // Legacy "DV7 - HEVC" boolean, read only to migrate existing users to HDR10_BASE_LAYER.
+    private val legacyMapDv7ToHevcKey = booleanPreferencesKey("map_dv7_to_hevc")
+    private val dv7LibdoviModeOverrideKey = intPreferencesKey("dv7_libdovi_mode_override")
     private val mpvHardwareDecodeModeKey = stringPreferencesKey("mpv_hardware_decode_mode")
     private val frameRateMatchingKey = booleanPreferencesKey("frame_rate_matching")
     private val frameRateMatchingModeKey = stringPreferencesKey("frame_rate_matching_mode")
@@ -433,12 +497,27 @@ class PlayerSettingsDataStore @Inject constructor(
     private val streamReuseLastLinkEnabledKey = booleanPreferencesKey("stream_reuse_last_link_enabled")
     private val streamReuseLastLinkCacheHoursKey = intPreferencesKey("stream_reuse_last_link_cache_hours")
     private val subtitleOrganizationModeKey = stringPreferencesKey("subtitle_organization_mode")
+
+    // Network Keys
+    private val vodCacheEnabledKey = booleanPreferencesKey("vod_cache_enabled")
+    private val vodCacheSizeModeKey = stringPreferencesKey("vod_cache_size_mode")
+    private val vodCacheSizeMbKey = intPreferencesKey("vod_cache_size_mb")
+    private val useParallelConnectionsKey = booleanPreferencesKey("use_parallel_connections")
+    private val bufferEngineEnabledKey = booleanPreferencesKey("buffer_engine_enabled")
+    private val parallelNetworkEnabledKey = booleanPreferencesKey("parallel_network_enabled")
+    private val allowLargeTargetBufferKey = booleanPreferencesKey("allow_large_target_buffer")
+    private val bufferBudgetManagedKey = booleanPreferencesKey("buffer_budget_managed")
+    private val parallelConnectionCountKey = intPreferencesKey("parallel_connection_count")
+    private val parallelChunkSizeMbKey = intPreferencesKey("parallel_chunk_size_mb")
+    private val lastPlaybackDiagnosticsKey = stringPreferencesKey("last_playback_diagnostics_json")
+
     private val addonSubtitleStartupModeKey = stringPreferencesKey("addon_subtitle_startup_mode")
     private val addonSubtitleStartupModeAutoPreferredKey =
         booleanPreferencesKey("addon_subtitle_startup_mode_auto_preferred")
+    private val enableBufferLogsKey = booleanPreferencesKey("enable_buffer_logs")
     private val resizeModeKey = intPreferencesKey("resize_mode")
 
-    // Subtitle style settings keys
+    // Subtitle style keys
     private val subtitlePreferredLanguageKey = stringPreferencesKey("subtitle_preferred_language")
     private val subtitleSecondaryLanguageKey = stringPreferencesKey("subtitle_secondary_language")
     private val subtitleUseForcedSubtitlesKey = booleanPreferencesKey("subtitle_use_forced_subtitles")
@@ -462,7 +541,15 @@ class PlayerSettingsDataStore @Inject constructor(
     private val retainBackBufferFromKeyframeKey = booleanPreferencesKey("retain_back_buffer_from_keyframe")
 
     private val migrationLoadControlDefaultsAlignedDoneKey = booleanPreferencesKey("migration_load_control_defaults_aligned_done")
-
+    private val migrationLoadControlDefaultsRetunedDoneKey = booleanPreferencesKey("migration_load_control_defaults_retuned_done")
+    private val migrationLoadControlMinBufferRetunedDoneKey = booleanPreferencesKey("migration_load_control_min_buffer_retuned_done")
+    private val migrationVodCacheSplitDoneKey = booleanPreferencesKey("migration_vod_cache_split_done")
+    private val migrationBackBufferDurationBumpedDoneKey = booleanPreferencesKey("migration_back_buffer_duration_bumped_done")
+    private val migrationMaxBufferBumpedDoneKey = booleanPreferencesKey("migration_max_buffer_bumped_done")
+    private val migrationTargetBufferSizeBumpedDoneKey = booleanPreferencesKey("migration_target_buffer_size_bumped_done")
+    private val migrationAfterRebufferLoweredDoneKey = booleanPreferencesKey("migration_after_rebuffer_lowered_done")
+    private val migrationBackBufferDurationReducedDoneKey = booleanPreferencesKey("migration_back_buffer_duration_reduced_done")
+    private val migrationTargetBufferSizeReducedDoneKey = booleanPreferencesKey("migration_target_buffer_size_reduced_done")
     init {
         ioScope.launch {
             profileManager.activeProfileId.collect { pid ->
@@ -473,49 +560,154 @@ class PlayerSettingsDataStore @Inject constructor(
 
     private suspend fun migrateProfile(profileId: Int) {
         factory.get(profileId, FEATURE).edit { prefs ->
-            val loadControlMigrated = prefs[migrationLoadControlDefaultsAlignedDoneKey] ?: false
-            if (!loadControlMigrated) {
-                val currentMin = prefs[minBufferMsKey]
-                val currentMax = prefs[maxBufferMsKey]
-
-                val legacyDefaultsDetected = (currentMin == null && currentMax == null) ||
-                    (currentMin == 15_000 && currentMax == 25_000)
-
-                if (legacyDefaultsDetected) {
-                    prefs[minBufferMsKey] = 50_000
-                    prefs[maxBufferMsKey] = 50_000
+                val loadControlMigrated = prefs[migrationLoadControlDefaultsAlignedDoneKey] ?: false
+                if (!loadControlMigrated) {
+                    val currentMin = prefs[minBufferMsKey]
+                    val currentMax = prefs[maxBufferMsKey]
+                    val legacyDefaultsDetected = (currentMin == null && currentMax == null) || (currentMin == 15_000 && currentMax == 25_000)
+                    if (legacyDefaultsDetected) {
+                        prefs[minBufferMsKey] = BufferSettings.DEFAULT_MIN_BUFFER_MS
+                        prefs[maxBufferMsKey] = BufferSettings.DEFAULT_MAX_BUFFER_MS
+                    }
+                    prefs[migrationLoadControlDefaultsAlignedDoneKey] = true
                 }
 
-                prefs[migrationLoadControlDefaultsAlignedDoneKey] = true
-            }
+                val loadControlRetuned = prefs[migrationLoadControlDefaultsRetunedDoneKey] ?: false
+                if (!loadControlRetuned) {
+                    val currentMin = prefs[minBufferMsKey]
+                    val currentMax = prefs[maxBufferMsKey]
+                    val currentPlayback = prefs[bufferForPlaybackMsKey]
+                    val currentPlaybackAfterRebuffer = prefs[bufferForPlaybackAfterRebufferMsKey]
+                    val currentTargetBuffer = prefs[targetBufferSizeMbKey]
 
-            val min = prefs[minBufferMsKey]
-            val max = prefs[maxBufferMsKey]
-            if (min != null && max != null && max < min) {
-                prefs[maxBufferMsKey] = min
-            }
+                    val previousDefaultsDetected = currentMin == 50_000 && currentMax == 50_000 && currentPlayback == 2_500 && currentPlaybackAfterRebuffer == 5_000 && currentTargetBuffer == 0
+                    val olderDefaultsDetected = currentMin == 15_000 && currentMax == 25_000
 
-            val preferredAudioLanguage = prefs[preferredAudioLanguageKey]
-            if (preferredAudioLanguage != null) {
-                val normalizedPreferredAudioLanguage =
-                    normalizeSelectableLanguageCode(preferredAudioLanguage)
-                if (normalizedPreferredAudioLanguage != preferredAudioLanguage) {
-                    prefs[preferredAudioLanguageKey] = normalizedPreferredAudioLanguage
+                    if (previousDefaultsDetected || olderDefaultsDetected) {
+                        prefs[minBufferMsKey] = BufferSettings.DEFAULT_MIN_BUFFER_MS
+                        prefs[maxBufferMsKey] = BufferSettings.DEFAULT_MAX_BUFFER_MS
+                        prefs[bufferForPlaybackMsKey] = BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_MS
+                        prefs[bufferForPlaybackAfterRebufferMsKey] = BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
+                        prefs[targetBufferSizeMbKey] = BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB
+                    }
+                    prefs[migrationLoadControlDefaultsRetunedDoneKey] = true
                 }
-            }
 
-            val secondaryPreferredAudioLanguage = prefs[secondaryPreferredAudioLanguageKey]
-            if (secondaryPreferredAudioLanguage != null) {
-                val normalizedSecondaryPreferredAudioLanguage =
-                    normalizeSecondaryAudioLanguageCode(secondaryPreferredAudioLanguage)
-                if (normalizedSecondaryPreferredAudioLanguage != secondaryPreferredAudioLanguage) {
-                    if (normalizedSecondaryPreferredAudioLanguage != null) {
-                        prefs[secondaryPreferredAudioLanguageKey] = normalizedSecondaryPreferredAudioLanguage
-                    } else {
-                        prefs.remove(secondaryPreferredAudioLanguageKey)
+                val minBufferRetuned = prefs[migrationLoadControlMinBufferRetunedDoneKey] ?: false
+                if (!minBufferRetuned) {
+                    val currentMin = prefs[minBufferMsKey]
+                    val currentMax = prefs[maxBufferMsKey]
+                    val currentPlayback = prefs[bufferForPlaybackMsKey]
+                    val currentPlaybackAfterRebuffer = prefs[bufferForPlaybackAfterRebufferMsKey]
+                    val currentTargetBuffer = prefs[targetBufferSizeMbKey]
+                    val currentBackBuffer = prefs[backBufferDurationMsKey]
+                    val currentRetainBackBuffer = prefs[retainBackBufferFromKeyframeKey]
+
+                    val previousRetunedDefaultsDetected = currentMin == 50_000 && currentMax == 50_000 && currentPlayback == BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_MS && currentPlaybackAfterRebuffer == BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS && currentTargetBuffer == BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB && (currentBackBuffer == null || currentBackBuffer == BufferSettings.DEFAULT_BACK_BUFFER_DURATION_MS) && (currentRetainBackBuffer == null || !currentRetainBackBuffer)
+
+                    if (previousRetunedDefaultsDetected) prefs[minBufferMsKey] = BufferSettings.DEFAULT_MIN_BUFFER_MS
+                    prefs[migrationLoadControlMinBufferRetunedDoneKey] = true
+                }
+
+                // VOD cache split: previously the disk cache was implicitly on with the
+                // parallel-network section. Now it has its own toggle, defaulting to on.
+                val vodCacheSplitMigrated = prefs[migrationVodCacheSplitDoneKey] ?: false
+                if (!vodCacheSplitMigrated) {
+                    if (prefs[vodCacheEnabledKey] == null) {
+                        prefs[vodCacheEnabledKey] = PlayerSettings.DEFAULT_VOD_CACHE_ENABLED
+                    }
+                    prefs[migrationVodCacheSplitDoneKey] = true
+                }
+
+                // Back buffer bump from prior 10s default.
+                val backBufferBumped = prefs[migrationBackBufferDurationBumpedDoneKey] ?: false
+                if (!backBufferBumped) {
+                    val currentBackBuffer = prefs[backBufferDurationMsKey]
+                    if (currentBackBuffer == null || currentBackBuffer == 10_000) {
+                        prefs[backBufferDurationMsKey] = BufferSettings.DEFAULT_BACK_BUFFER_DURATION_MS
+                    }
+                    prefs[migrationBackBufferDurationBumpedDoneKey] = true
+                }
+
+                // Max buffer bump from prior 30s default.
+                val maxBufferBumped = prefs[migrationMaxBufferBumpedDoneKey] ?: false
+                if (!maxBufferBumped) {
+                    val currentMax = prefs[maxBufferMsKey]
+                    if (currentMax == null || currentMax == 30_000) {
+                        prefs[maxBufferMsKey] = BufferSettings.DEFAULT_MAX_BUFFER_MS
+                    }
+                    prefs[migrationMaxBufferBumpedDoneKey] = true
+                }
+
+                // Target buffer bump from prior 100MB default.
+                val targetBufferBumped = prefs[migrationTargetBufferSizeBumpedDoneKey] ?: false
+                if (!targetBufferBumped) {
+                    val currentTarget = prefs[targetBufferSizeMbKey]
+                    if (currentTarget == null || currentTarget == 100) {
+                        prefs[targetBufferSizeMbKey] = BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB
+                    }
+                    prefs[migrationTargetBufferSizeBumpedDoneKey] = true
+                }
+
+                // After-rebuffer threshold lowered from prior 5s default for faster resume.
+                val afterRebufferLowered = prefs[migrationAfterRebufferLoweredDoneKey] ?: false
+                if (!afterRebufferLowered) {
+                    val currentAfter = prefs[bufferForPlaybackAfterRebufferMsKey]
+                    if (currentAfter == null || currentAfter == 5_000) {
+                        prefs[bufferForPlaybackAfterRebufferMsKey] = BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
+                    }
+                    prefs[migrationAfterRebufferLoweredDoneKey] = true
+                }
+
+                // Back buffer reduced from interim 30s due to heap pressure on high-bitrate content.
+                val backBufferReduced = prefs[migrationBackBufferDurationReducedDoneKey] ?: false
+                if (!backBufferReduced) {
+                    val currentBack = prefs[backBufferDurationMsKey]
+                    if (currentBack == null || currentBack == 30_000) {
+                        prefs[backBufferDurationMsKey] = BufferSettings.DEFAULT_BACK_BUFFER_DURATION_MS
+                    }
+                    prefs[migrationBackBufferDurationReducedDoneKey] = true
+                }
+
+                // Corrects users from a 125 interim build back to the 150 default.
+                val targetBufferCorrected = prefs[migrationTargetBufferSizeReducedDoneKey] ?: false
+                if (!targetBufferCorrected) {
+                    val currentTarget = prefs[targetBufferSizeMbKey]
+                    if (currentTarget == 125) {
+                        prefs[targetBufferSizeMbKey] = BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB
+                    }
+                    prefs[migrationTargetBufferSizeReducedDoneKey] = true
+                }
+
+                val min = prefs[minBufferMsKey]
+                val max = prefs[maxBufferMsKey]
+                if (min != null && max != null && max < min) prefs[maxBufferMsKey] = min
+
+                prefs[vodCacheSizeMbKey]?.let { current ->
+                    val normalized = current.coerceIn(PlayerSettings.MIN_VOD_CACHE_SIZE_MB, PlayerSettings.MAX_VOD_CACHE_SIZE_MB)
+                    if (normalized != current) prefs[vodCacheSizeMbKey] = normalized
+                }
+                prefs[vodCacheSizeModeKey]?.let { raw ->
+                    val normalized = runCatching { VodCacheSizeMode.valueOf(raw) }.getOrDefault(PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MODE).name
+                    if (normalized != raw) prefs[vodCacheSizeModeKey] = normalized
+                }
+
+                val preferredAudioLanguage = prefs[preferredAudioLanguageKey]
+                if (preferredAudioLanguage != null) {
+                    val normalizedPreferredAudioLanguage = normalizeSelectableLanguageCode(preferredAudioLanguage)
+                    if (normalizedPreferredAudioLanguage != preferredAudioLanguage) {
+                        prefs[preferredAudioLanguageKey] = normalizedPreferredAudioLanguage
                     }
                 }
-            }
+
+                val secondaryPreferredAudioLanguage = prefs[secondaryPreferredAudioLanguageKey]
+                if (secondaryPreferredAudioLanguage != null) {
+                    val normalizedSecondaryPreferredAudioLanguage = normalizeSecondaryAudioLanguageCode(secondaryPreferredAudioLanguage)
+                    if (normalizedSecondaryPreferredAudioLanguage != secondaryPreferredAudioLanguage) {
+                        if (normalizedSecondaryPreferredAudioLanguage != null) prefs[secondaryPreferredAudioLanguageKey] = normalizedSecondaryPreferredAudioLanguage
+                        else prefs.remove(secondaryPreferredAudioLanguageKey)
+                    }
+                }
 
             val preferredSubtitleLanguage = prefs[subtitlePreferredLanguageKey]
             if (preferredSubtitleLanguage != null) {
@@ -615,15 +807,19 @@ class PlayerSettingsDataStore @Inject constructor(
                     ?.mapNotNull(AutoSkipSegmentType::fromStoredValue)
                     ?.toSet()
                     ?: emptySet(),
-                mapDV7ToHevc = prefs[mapDV7ToHevcKey] ?: false,
+                dv5ToDv81Enabled = prefs[dv5ToDv81EnabledKey] ?: false,
+                dv7ToDv81PreserveMappingEnabled = prefs[dv7ToDv81PreserveMappingEnabledKey] ?: false,
+                dv7HandlingMode = when {
+                    prefs[dv7HandlingModeKey] != null ->
+                        Dv7HandlingMode.fromStoredString(prefs[dv7HandlingModeKey])
+                    prefs[legacyMapDv7ToHevcKey] == true -> Dv7HandlingMode.HDR10_BASE_LAYER
+                    else -> Dv7HandlingMode.AUTO
+                },
+                dv7LibdoviModeOverride = (prefs[dv7LibdoviModeOverrideKey] ?: -1).coerceIn(-1, 4),
                 mpvHardwareDecodeMode = parseMpvHardwareDecodeMode(prefs[mpvHardwareDecodeModeKey]),
                 frameRateMatchingMode = prefs[frameRateMatchingModeKey]?.let {
                     runCatching { FrameRateMatchingMode.valueOf(it) }.getOrNull()
-                } ?: if (prefs[frameRateMatchingKey] == true) {
-                    FrameRateMatchingMode.START_STOP
-                } else {
-                    FrameRateMatchingMode.OFF
-                },
+                } ?: if (prefs[frameRateMatchingKey] == true) FrameRateMatchingMode.START_STOP else FrameRateMatchingMode.OFF,
                 resolutionMatchingEnabled = prefs[resolutionMatchingEnabledKey] ?: false,
                 streamAutoPlayMode = prefs[streamAutoPlayModeKey]?.let {
                     runCatching { StreamAutoPlayMode.valueOf(it) }.getOrDefault(StreamAutoPlayMode.MANUAL)
@@ -669,7 +865,20 @@ class PlayerSettingsDataStore @Inject constructor(
                 streamReuseLastLinkEnabled = prefs[streamReuseLastLinkEnabledKey] ?: false,
                 streamReuseLastLinkCacheHours = (prefs[streamReuseLastLinkCacheHoursKey] ?: 24).coerceIn(1, 168),
                 subtitleOrganizationMode = parseSubtitleOrganizationMode(prefs[subtitleOrganizationModeKey]),
+                vodCacheEnabled = prefs[vodCacheEnabledKey] ?: PlayerSettings.DEFAULT_VOD_CACHE_ENABLED,
+                vodCacheSizeMode = prefs[vodCacheSizeModeKey]?.let {
+                    runCatching { VodCacheSizeMode.valueOf(it) }.getOrDefault(PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MODE)
+                } ?: PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MODE,
+                vodCacheSizeMb = (prefs[vodCacheSizeMbKey] ?: PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MB).coerceIn(PlayerSettings.MIN_VOD_CACHE_SIZE_MB, PlayerSettings.MAX_VOD_CACHE_SIZE_MB),
+                useParallelConnections = prefs[useParallelConnectionsKey] ?: PlayerSettings.DEFAULT_USE_PARALLEL_CONNECTIONS,
+                bufferEngineEnabled = prefs[bufferEngineEnabledKey] ?: false,
+                parallelNetworkEnabled = prefs[parallelNetworkEnabledKey] ?: false,
+                allowLargeTargetBuffer = prefs[allowLargeTargetBufferKey] ?: PlayerSettings.DEFAULT_ALLOW_LARGE_TARGET_BUFFER,
+                bufferBudgetManaged = prefs[bufferBudgetManagedKey] ?: PlayerSettings.DEFAULT_BUFFER_BUDGET_MANAGED,
+                parallelConnectionCount = (prefs[parallelConnectionCountKey] ?: PlayerSettings.DEFAULT_PARALLEL_CONNECTION_COUNT).coerceIn(PlayerSettings.MIN_PARALLEL_CONNECTION_COUNT, PlayerSettings.MAX_PARALLEL_CONNECTION_COUNT),
+                parallelChunkSizeMb = (prefs[parallelChunkSizeMbKey] ?: PlayerSettings.DEFAULT_PARALLEL_CHUNK_SIZE_MB).coerceIn(PlayerSettings.MIN_PARALLEL_CHUNK_SIZE_MB, PlayerSettings.MAX_PARALLEL_CHUNK_SIZE_MB),
                 addonSubtitleStartupMode = parseAddonSubtitleStartupMode(prefs[addonSubtitleStartupModeKey]),
+                enableBufferLogs = prefs[enableBufferLogsKey] ?: false,
                 resizeMode = (prefs[resizeModeKey] ?: 0).coerceIn(0, 4),
                 subtitleStyle = SubtitleStyleSettings(
                     preferredLanguage = normalizeSubtitlePreferredLanguageForRead(
@@ -693,35 +902,36 @@ class PlayerSettingsDataStore @Inject constructor(
                     outlineWidth = prefs[subtitleOutlineWidthKey] ?: 2
                 ),
                 bufferSettings = BufferSettings(
-                    minBufferMs = prefs[minBufferMsKey] ?: 50_000,
-                    maxBufferMs = prefs[maxBufferMsKey] ?: 50_000,
-                    bufferForPlaybackMs = prefs[bufferForPlaybackMsKey] ?: 2_500,
-                    bufferForPlaybackAfterRebufferMs = prefs[bufferForPlaybackAfterRebufferMsKey] ?: 5_000,
-                    targetBufferSizeMb = prefs[targetBufferSizeMbKey] ?: 0,
-                    backBufferDurationMs = prefs[backBufferDurationMsKey] ?: 0,
+                    minBufferMs = prefs[minBufferMsKey] ?: BufferSettings.DEFAULT_MIN_BUFFER_MS,
+                    maxBufferMs = prefs[maxBufferMsKey] ?: BufferSettings.DEFAULT_MAX_BUFFER_MS,
+                    bufferForPlaybackMs = prefs[bufferForPlaybackMsKey] ?: BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+                    bufferForPlaybackAfterRebufferMs = prefs[bufferForPlaybackAfterRebufferMsKey] ?: BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+                    targetBufferSizeMb = prefs[targetBufferSizeMbKey]?.coerceAtLeast(0) ?: BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB,
+                    backBufferDurationMs = prefs[backBufferDurationMsKey] ?: BufferSettings.DEFAULT_BACK_BUFFER_DURATION_MS,
                     retainBackBufferFromKeyframe = prefs[retainBackBufferFromKeyframeKey] ?: false
                 )
             )
         }
 
-    /**
-     * Flow for just the libass toggle
-     */
     val useLibass: Flow<Boolean> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.onStart { migrateProfile(pid) }
     }.map { prefs ->
         prefs[useLibassKey] ?: false
     }
 
-    /**
-     * Flow for the libass render type
-     */
     val libassRenderType: Flow<LibassRenderType> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.onStart { migrateProfile(pid) }
     }.map { prefs ->
         prefs[libassRenderTypeKey]?.let {
             try { LibassRenderType.valueOf(it) } catch (e: Exception) { LibassRenderType.OVERLAY_OPEN_GL }
         } ?: LibassRenderType.OVERLAY_OPEN_GL
+    }
+    val lastPlaybackDiagnostics: Flow<LastPlaybackDiagnostics> = profileManager.activeProfileId.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map { prefs ->
+            val json = prefs[lastPlaybackDiagnosticsKey]
+            if (json.isNullOrBlank()) LastPlaybackDiagnostics.EMPTY
+            else LastPlaybackDiagnostics.fromJson(json)
+        }
     }
 
     // Player preference setter
@@ -831,23 +1041,14 @@ class PlayerSettingsDataStore @Inject constructor(
     }
 
     suspend fun setPreferredAudioLanguage(language: String) {
-        store().edit { prefs ->
-            prefs[preferredAudioLanguageKey] = normalizeSelectableLanguageCode(
-                language.ifBlank { AudioLanguageOption.DEVICE }
-            )
-        }
+        store().edit { it[preferredAudioLanguageKey] = normalizeSelectableLanguageCode(language.ifBlank { AudioLanguageOption.DEVICE }) }
     }
 
     suspend fun setSecondaryPreferredAudioLanguage(language: String?) {
         store().edit { prefs ->
-            val normalizedLanguage = language
-                ?.takeIf { it.isNotBlank() }
-                ?.let(::normalizeSecondaryAudioLanguageCode)
-            if (normalizedLanguage != null) {
-                prefs[secondaryPreferredAudioLanguageKey] = normalizedLanguage
-            } else {
-                prefs.remove(secondaryPreferredAudioLanguageKey)
-            }
+            val normalizedLanguage = language?.takeIf { it.isNotBlank() }?.let(::normalizeSecondaryAudioLanguageCode)
+            if (normalizedLanguage != null) prefs[secondaryPreferredAudioLanguageKey] = normalizedLanguage
+            else prefs.remove(secondaryPreferredAudioLanguageKey)
         }
     }
 
@@ -902,6 +1103,12 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             prefs[frameRateMatchingModeKey] = mode.name
             prefs[frameRateMatchingKey] = mode != FrameRateMatchingMode.OFF
+        }
+    }
+
+    suspend fun setEnableBufferLogs(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[enableBufferLogsKey] = enabled
         }
     }
 
@@ -1013,8 +1220,7 @@ class PlayerSettingsDataStore @Inject constructor(
     }
 
     private fun normalizeHalfStep(value: Float, min: Float, max: Float): Float {
-        val clamped = value.coerceIn(min, max)
-        return (clamped * 2f).roundToInt() / 2f
+        return (value.coerceIn(min, max) * 2f).roundToInt() / 2f
     }
 
     suspend fun setStreamReuseLastLinkEnabled(enabled: Boolean) {
@@ -1051,42 +1257,20 @@ class PlayerSettingsDataStore @Inject constructor(
 
 
     private fun parseSubtitleOrganizationMode(value: String?): SubtitleOrganizationMode {
-        return when (value) {
-            null, "NONE" -> SubtitleOrganizationMode.NONE
-            "BY_LANGUAGE" -> SubtitleOrganizationMode.BY_LANGUAGE
-            "BY_ADDON" -> SubtitleOrganizationMode.BY_ADDON
-            else -> SubtitleOrganizationMode.NONE
-        }
+        return when (value) { "BY_LANGUAGE" -> SubtitleOrganizationMode.BY_LANGUAGE; "BY_ADDON" -> SubtitleOrganizationMode.BY_ADDON; else -> SubtitleOrganizationMode.NONE }
     }
 
     private fun parseAddonSubtitleStartupMode(value: String?): AddonSubtitleStartupMode {
-        return when (value) {
-            null, "ALL_SUBTITLES" -> AddonSubtitleStartupMode.ALL_SUBTITLES
-            "PREFERRED_ONLY" -> AddonSubtitleStartupMode.PREFERRED_ONLY
-            "FAST_STARTUP" -> AddonSubtitleStartupMode.FAST_STARTUP
-            else -> AddonSubtitleStartupMode.ALL_SUBTITLES
-        }
+        return when (value) { "PREFERRED_ONLY" -> AddonSubtitleStartupMode.PREFERRED_ONLY; "FAST_STARTUP" -> AddonSubtitleStartupMode.FAST_STARTUP; else -> AddonSubtitleStartupMode.ALL_SUBTITLES }
     }
 
     private fun parseMpvHardwareDecodeMode(value: String?): MpvHardwareDecodeMode {
-        return when (value) {
-            null, "AUTO_SAFE" -> MpvHardwareDecodeMode.AUTO_SAFE
-            "HARDWARE_COPY" -> MpvHardwareDecodeMode.HARDWARE_COPY
-            "HARDWARE_DIRECT" -> MpvHardwareDecodeMode.HARDWARE_DIRECT
-            "DISABLED" -> MpvHardwareDecodeMode.DISABLED
-            "LEGACY_DIRECT_COPY" -> MpvHardwareDecodeMode.LEGACY_DIRECT_COPY
-            else -> MpvHardwareDecodeMode.AUTO_SAFE
-        }
+        return when (value) { "HARDWARE_COPY" -> MpvHardwareDecodeMode.HARDWARE_COPY; "HARDWARE_DIRECT" -> MpvHardwareDecodeMode.HARDWARE_DIRECT; "DISABLED" -> MpvHardwareDecodeMode.DISABLED; "LEGACY_DIRECT_COPY" -> MpvHardwareDecodeMode.LEGACY_DIRECT_COPY; else -> MpvHardwareDecodeMode.AUTO_SAFE }
     }
 
     private fun normalizeSelectableLanguageCode(language: String): String {
         val code = language.trim().lowercase()
-        return when (code) {
-            "pt-br", "pt_br", "br", "pob" -> "pt-br"
-            "pt-pt", "pt_pt", "por" -> "pt"
-            "forced", "force", "forc" -> SUBTITLE_LANGUAGE_FORCED
-            else -> code
-        }
+        return when (code) { "pt-br", "pt_br", "br", "pob" -> "pt-br"; "pt-pt", "pt_pt", "por" -> "pt"; "forced", "force", "forc" -> SUBTITLE_LANGUAGE_FORCED; else -> code }
     }
 
     private fun normalizeSecondaryAudioLanguageCode(language: String): String? {
@@ -1115,12 +1299,6 @@ class PlayerSettingsDataStore @Inject constructor(
             ?: "en"
     }
 
-    suspend fun setMapDV7ToHevc(enabled: Boolean) {
-        store().edit { prefs ->
-            prefs[mapDV7ToHevcKey] = enabled
-        }
-    }
-
     suspend fun setMpvHardwareDecodeMode(mode: MpvHardwareDecodeMode) {
         store().edit { prefs ->
             prefs[mpvHardwareDecodeModeKey] = mode.name
@@ -1145,28 +1323,29 @@ class PlayerSettingsDataStore @Inject constructor(
         }
     }
 
-    // Subtitle style settings functions
+    // Dolby Vision setters (libdovi conversion)
+    suspend fun setDv5ToDv81Enabled(enabled: Boolean) { store().edit { it[dv5ToDv81EnabledKey] = enabled } }
+    suspend fun setDv7ToDv81PreserveMappingEnabled(enabled: Boolean) { store().edit { it[dv7ToDv81PreserveMappingEnabledKey] = enabled } }
+    suspend fun setDv7HandlingMode(mode: Dv7HandlingMode) { store().edit { it[dv7HandlingModeKey] = mode.name } }
+    suspend fun setDv7LibdoviModeOverride(mode: Int) { store().edit { it[dv7LibdoviModeOverrideKey] = mode.coerceIn(-1, 4) } }
 
-    suspend fun setSubtitlePreferredLanguage(language: String) {
-        store().edit { prefs ->
-            prefs[subtitlePreferredLanguageKey] = normalizeSelectableLanguageCode(
-                language.ifBlank { "en" }
-            )
-        }
-    }
-
+    // Subtitle styles
+    suspend fun setSubtitlePreferredLanguage(language: String) { store().edit { it[subtitlePreferredLanguageKey] = normalizeSelectableLanguageCode(language.ifBlank { "en" }) } }
     suspend fun setSubtitleSecondaryLanguage(language: String?) {
         store().edit { prefs ->
-            val normalizedLanguage = language
-                ?.takeIf { it.isNotBlank() }
-                ?.let(::normalizeSelectableLanguageCode)
-            if (normalizedLanguage != null) {
-                prefs[subtitleSecondaryLanguageKey] = normalizedLanguage
-            } else {
-                prefs.remove(subtitleSecondaryLanguageKey)
-            }
+            val normalizedLanguage = language?.takeIf { it.isNotBlank() }?.let(::normalizeSelectableLanguageCode)
+            if (normalizedLanguage != null) prefs[subtitleSecondaryLanguageKey] = normalizedLanguage
+            else prefs.remove(subtitleSecondaryLanguageKey)
         }
     }
+    suspend fun setSubtitleSize(size: Int) { store().edit { it[subtitleSizeKey] = size.coerceIn(50, 200) } }
+    suspend fun setSubtitleVerticalOffset(offset: Int) { store().edit { it[subtitleVerticalOffsetKey] = offset.coerceIn(-20, 50) } }
+    suspend fun setSubtitleBold(bold: Boolean) { store().edit { it[subtitleBoldKey] = bold } }
+    suspend fun setSubtitleTextColor(color: Int) { store().edit { it[subtitleTextColorKey] = color } }
+    suspend fun setSubtitleBackgroundColor(color: Int) { store().edit { it[subtitleBackgroundColorKey] = color } }
+    suspend fun setSubtitleOutlineEnabled(enabled: Boolean) { store().edit { it[subtitleOutlineEnabledKey] = enabled } }
+    suspend fun setSubtitleOutlineColor(color: Int) { store().edit { it[subtitleOutlineColorKey] = color } }
+    suspend fun setSubtitleOutlineWidth(width: Int) { store().edit { it[subtitleOutlineWidthKey] = width.coerceIn(1, 5) } }
 
     suspend fun setUseForcedSubtitles(enabled: Boolean) {
         store().edit { prefs ->
@@ -1195,101 +1374,88 @@ class PlayerSettingsDataStore @Inject constructor(
         }
     }
 
-    suspend fun setSubtitleSize(size: Int) {
-        store().edit { prefs ->
-            prefs[subtitleSizeKey] = size.coerceIn(50, 200)
-        }
-    }
-
-    suspend fun setSubtitleVerticalOffset(offset: Int) {
-        store().edit { prefs ->
-            prefs[subtitleVerticalOffsetKey] = offset.coerceIn(-20, 50)
-        }
-    }
-
-    suspend fun setSubtitleBold(bold: Boolean) {
-        store().edit { prefs ->
-            prefs[subtitleBoldKey] = bold
-        }
-    }
-
-    suspend fun setSubtitleTextColor(color: Int) {
-        store().edit { prefs ->
-            prefs[subtitleTextColorKey] = color
-        }
-    }
-
-    suspend fun setSubtitleBackgroundColor(color: Int) {
-        store().edit { prefs ->
-            prefs[subtitleBackgroundColorKey] = color
-        }
-    }
-
-    suspend fun setSubtitleOutlineEnabled(enabled: Boolean) {
-        store().edit { prefs ->
-            prefs[subtitleOutlineEnabledKey] = enabled
-        }
-    }
-
-    suspend fun setSubtitleOutlineColor(color: Int) {
-        store().edit { prefs ->
-            prefs[subtitleOutlineColorKey] = color
-        }
-    }
-
-    suspend fun setSubtitleOutlineWidth(width: Int) {
-        store().edit { prefs ->
-            prefs[subtitleOutlineWidthKey] = width.coerceIn(1, 5)
-        }
-    }
-
     // Buffer settings functions
 
     suspend fun setBufferMinBufferMs(ms: Int) {
         store().edit { prefs ->
             val newMin = ms.coerceIn(5_000, 120_000)
             prefs[minBufferMsKey] = newMin
-            val currentMax = prefs[maxBufferMsKey] ?: 50_000
-            if (currentMax < newMin) {
-                prefs[maxBufferMsKey] = newMin
-            }
+            val currentMax = prefs[maxBufferMsKey] ?: BufferSettings.DEFAULT_MAX_BUFFER_MS
+            if (currentMax < newMin) prefs[maxBufferMsKey] = newMin
         }
     }
-
     suspend fun setBufferMaxBufferMs(ms: Int) {
         store().edit { prefs ->
-            val currentMin = prefs[minBufferMsKey] ?: 50_000
+            val currentMin = prefs[minBufferMsKey] ?: BufferSettings.DEFAULT_MIN_BUFFER_MS
             prefs[maxBufferMsKey] = ms.coerceIn(currentMin, 120_000)
         }
     }
+    suspend fun setBufferForPlaybackMs(ms: Int) { store().edit { it[bufferForPlaybackMsKey] = ms.coerceIn(1_000, 30_000) } }
+    suspend fun setBufferForPlaybackAfterRebufferMs(ms: Int) { store().edit { it[bufferForPlaybackAfterRebufferMsKey] = ms.coerceIn(1_000, 60_000) } }
+    suspend fun setBufferTargetSizeMb(mb: Int) { store().edit { it[targetBufferSizeMbKey] = mb.coerceAtLeast(0) } }
+    suspend fun setBufferBackBufferDurationMs(ms: Int) { store().edit { it[backBufferDurationMsKey] = ms.coerceIn(0, 120_000) } }
+    suspend fun setBufferRetainBackBufferFromKeyframe(retain: Boolean) { store().edit { it[retainBackBufferFromKeyframeKey] = retain } }
 
-    suspend fun setBufferForPlaybackMs(ms: Int) {
+    suspend fun resetBufferSettingsToDefaults() {
         store().edit { prefs ->
-            prefs[bufferForPlaybackMsKey] = ms.coerceIn(1_000, 30_000)
+            prefs[minBufferMsKey] = BufferSettings.DEFAULT_MIN_BUFFER_MS
+            prefs[maxBufferMsKey] = BufferSettings.DEFAULT_MAX_BUFFER_MS
+            prefs[bufferForPlaybackMsKey] = BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_MS
+            prefs[bufferForPlaybackAfterRebufferMsKey] = BufferSettings.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
+            prefs[targetBufferSizeMbKey] = BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB
+            prefs[backBufferDurationMsKey] = BufferSettings.DEFAULT_BACK_BUFFER_DURATION_MS
+            prefs[retainBackBufferFromKeyframeKey] = false
+            // VOD cache is grouped with the playback buffer section in the UI
+            // (both extend seek-back smoothness), so reset its values here too.
+            prefs[vodCacheEnabledKey] = PlayerSettings.DEFAULT_VOD_CACHE_ENABLED
+            prefs[vodCacheSizeModeKey] = PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MODE.name
+            prefs[vodCacheSizeMbKey] = PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MB
         }
     }
 
-    suspend fun setBufferForPlaybackAfterRebufferMs(ms: Int) {
+    suspend fun resetNetworkSettingsToDefaults() {
         store().edit { prefs ->
-            prefs[bufferForPlaybackAfterRebufferMsKey] = ms.coerceIn(1_000, 60_000)
+            prefs[useParallelConnectionsKey] = PlayerSettings.DEFAULT_USE_PARALLEL_CONNECTIONS
+            prefs[parallelConnectionCountKey] = PlayerSettings.DEFAULT_PARALLEL_CONNECTION_COUNT
+            prefs[parallelChunkSizeMbKey] = PlayerSettings.DEFAULT_PARALLEL_CHUNK_SIZE_MB
         }
     }
 
-    suspend fun setBufferTargetSizeMb(mb: Int) {
-        store().edit { prefs ->
-            prefs[targetBufferSizeMbKey] = mb.coerceAtLeast(0)
-        }
+    suspend fun setVodCacheEnabled(enabled: Boolean) { store().edit { it[vodCacheEnabledKey] = enabled } }
+    suspend fun setVodCacheSizeMode(mode: VodCacheSizeMode) { store().edit { it[vodCacheSizeModeKey] = mode.name } }
+    suspend fun setVodCacheSizeMb(mb: Int) { store().edit { it[vodCacheSizeMbKey] = mb.coerceIn(PlayerSettings.MIN_VOD_CACHE_SIZE_MB, PlayerSettings.MAX_VOD_CACHE_SIZE_MB) } }
+    suspend fun setUseParallelConnections(enabled: Boolean) { store().edit { it[useParallelConnectionsKey] = enabled } }
+    suspend fun setBufferEngineEnabled(enabled: Boolean) {
+        store().edit { it[bufferEngineEnabledKey] = enabled }
     }
 
-    suspend fun setBufferBackBufferDurationMs(ms: Int) {
-        store().edit { prefs ->
-            prefs[backBufferDurationMsKey] = ms.coerceIn(0, 120_000)
-        }
+    suspend fun setParallelNetworkEnabled(enabled: Boolean) {
+        store().edit { it[parallelNetworkEnabledKey] = enabled }
     }
 
-    suspend fun setBufferRetainBackBufferFromKeyframe(retain: Boolean) {
+    suspend fun setAllowLargeTargetBuffer(enabled: Boolean) {
+        store().edit { it[allowLargeTargetBufferKey] = enabled }
+    }
+    suspend fun setBufferBudgetManaged(enabled: Boolean) {
+        store().edit { it[bufferBudgetManagedKey] = enabled }
+    }
+    suspend fun setLastPlaybackDiagnostics(diagnostics: LastPlaybackDiagnostics) {
+        store().edit { it[lastPlaybackDiagnosticsKey] = diagnostics.toJson() }
+    }
+    suspend fun setParallelConnectionCount(count: Int) { store().edit { it[parallelConnectionCountKey] = count.coerceIn(PlayerSettings.MIN_PARALLEL_CONNECTION_COUNT, PlayerSettings.MAX_PARALLEL_CONNECTION_COUNT) } }
+    suspend fun setParallelChunkSizeMb(mb: Int) { store().edit { it[parallelChunkSizeMbKey] = mb.coerceIn(PlayerSettings.MIN_PARALLEL_CHUNK_SIZE_MB, PlayerSettings.MAX_PARALLEL_CHUNK_SIZE_MB) } }
+
+    suspend fun updateMemorySettings(
+        targetBufferSizeMb: Int? = null,
+        useParallelConnections: Boolean? = null,
+        parallelConnectionCount: Int? = null,
+        parallelChunkSizeMb: Int? = null
+    ) {
         store().edit { prefs ->
-            prefs[retainBackBufferFromKeyframeKey] = retain
+            targetBufferSizeMb?.let { prefs[targetBufferSizeMbKey] = it.coerceAtLeast(0) }
+            useParallelConnections?.let { prefs[useParallelConnectionsKey] = it }
+            parallelConnectionCount?.let { prefs[parallelConnectionCountKey] = it.coerceIn(PlayerSettings.MIN_PARALLEL_CONNECTION_COUNT, PlayerSettings.MAX_PARALLEL_CONNECTION_COUNT) }
+            parallelChunkSizeMb?.let { prefs[parallelChunkSizeMbKey] = it.coerceIn(PlayerSettings.MIN_PARALLEL_CHUNK_SIZE_MB, PlayerSettings.MAX_PARALLEL_CHUNK_SIZE_MB) }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/DolbyVisionBaseLayerPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/DolbyVisionBaseLayerPolicy.kt
@@ -1,0 +1,270 @@
+package com.nuvio.tv.core.player
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.media.MediaCodecInfo
+import android.media.MediaCodecInfo.CodecProfileLevel
+import android.media.MediaCodecList
+import android.os.Build
+import android.view.Display
+
+/**
+ * Decides what to do with a Dolby Vision stream at the codec selector. It only intervenes
+ * where there's a concrete fix; everything else falls through to default ExoPlayer behavior.
+ *
+ * Convert DV7 to DV8.1 when:
+ *  - the display is DV-capable and a Profile-8 decoder is present (Fire TV, Chromecast
+ *    with Google TV, etc.);
+ *  - the display is DV-capable but the DV decoder is hidden and doesn't advertise Profile 8
+ *    (some Amlogic boxes) — convert and let DolbyVisionCodecFallback find the decoder;
+ *  - the display is HDR10-only but a DV8.1 decoder exists — convert and let it emit HDR10.
+ *
+ * A true DV7 decoder (e.g. Shield) stays NATIVE_DV7; HDR10-only displays elsewhere strip
+ * to the HEVC base layer.
+ */
+object DolbyVisionBaseLayerPolicy {
+
+    enum class Decision {
+        /** Display supports DV. Either a native DV7 decoder is present, or we have no
+         *  useful intervention - pass the stream through and let the device handle it. */
+        NATIVE_DV7,
+        /** Convert DV7 RPU to DV8.1 with libdovi, then feed to a DV-aware decoder.
+         *  Used on Fire TV (profile-8-only Mediatek decoder), Xiaomi boxes (hidden
+         *  Amlogic DV decoder), and Samsung HDR10 (no DV display but DV81 decoder). */
+        CONVERT_TO_DV81,
+        /** Display supports HDR10/HDR10+. Strip DV, play HEVC base layer. */
+        STRIP_TO_HDR10,
+        /** Display capabilities unknown (pre-N or null caps). Strip defensively. */
+        STRIP_BEST_EFFORT,
+        /** Display known to be SDR-only or HLG-only. Strip and let renderer tonemap. */
+        STRIP_AND_TONEMAP
+    }
+
+    data class Result(
+        val decision: Decision,
+        val hdrCapsKnown: Boolean,
+        val displayDv: Boolean,
+        val displayHdr10: Boolean,
+        val displayHdr10Plus: Boolean,
+        val displayHlg: Boolean,
+        val codecSupportsDvheDtb: Boolean,
+        val codecSupportsDvheStn: Boolean,
+        val codecSupportsDvheSt: Boolean,
+        val isAmazonFireTv: Boolean,
+        val isSamsung: Boolean,
+        val isXiaomi: Boolean,
+        val bridgeReady: Boolean,
+        val apiLevel: Int
+    ) {
+        /** True when DV7 streams should be diverted away from the native DV7 decoder path. */
+        val divertsFromNativeDv7: Boolean
+            get() = decision != Decision.NATIVE_DV7
+
+        /** True when DV7 should be mapped to its HEVC base layer at the codec selector. */
+        val mapToHevc: Boolean
+            get() = when (decision) {
+                Decision.STRIP_TO_HDR10,
+                Decision.STRIP_BEST_EFFORT,
+                Decision.STRIP_AND_TONEMAP -> true
+                else -> false
+            }
+    }
+
+    fun resolveFromCapabilities(
+        hdrCapsKnown: Boolean,
+        displayDv: Boolean,
+        displayHdr10: Boolean,
+        displayHdr10Plus: Boolean,
+        displayHlg: Boolean,
+        codecSupportsDvheDtb: Boolean,
+        codecSupportsDvheStn: Boolean,
+        codecSupportsDvheSt: Boolean,
+        isAmazonFireTv: Boolean,
+        isSamsung: Boolean,
+        isXiaomi: Boolean,
+        bridgeReady: Boolean,
+        apiLevel: Int
+    ): Result {
+        val displayHdr10Family = displayHdr10 || displayHdr10Plus
+
+        val decision = when {
+            !hdrCapsKnown -> Decision.STRIP_BEST_EFFORT
+
+            // Display does DV, device has native DV7 decoder: best case, do nothing.
+            // Shield TV and similar with real DvheDtb decoder.
+            displayDv && codecSupportsDvheDtb -> Decision.NATIVE_DV7
+
+            // General DV-display convert path: any DV-capable display whose device has a
+            // Profile-8 decoder (DVHE.ST/STH) and a ready bridge. libdovi rewrites the DV7
+            // RPU to DV8.1 (mode 1 / ToMel by default) and the chip decodes 8.1 and emits
+            // DV. This was previously gated to Amazon Fire TV only, on May-2026 data that
+            // showed conversion degraded to HDR10 on Amlogic (Chromecast). Later testing
+            // showed the mode-1 app-level conversion produces real DV on Chromecast, LG
+            // panels, etc., so the manufacturer gate is removed. Devices with a true DV7
+            // decoder (DvheDtb, e.g. Shield) are handled by the NATIVE_DV7 branch above and
+            // never reach here; DV displays without a P8 decoder fall through to NATIVE_DV7
+            // below.
+            displayDv && bridgeReady && codecSupportsDvheSt ->
+                Decision.CONVERT_TO_DV81
+
+            // Xiaomi box path: Amlogic DV decoder exists but does NOT advertise Profile 8
+            // via MediaCodecList API (codecSupportsDvheSt is false). The hardware can
+            // decode DV8.1 when fed directly. DolbyVisionCodecFallback handles finding
+            // the hidden decoder in the codec selector.
+            // No codecSupportsDvheSt requirement — that's the whole point of this branch.
+            displayDv && isXiaomi && bridgeReady -> Decision.CONVERT_TO_DV81
+
+            // DV-capable display, non-intervened device. Pass through and let the device's
+            // media stack handle it. Chromecast with Google TV (older Amlogic) decodes
+            // DV7 natively. Google TV Streamer / Onn / MeCool etc. fall back to HEVC
+            // base layer via ExoPlayer's decoder fallback path, producing HDR10. Either
+            // way, no intervention from us improves things.
+            displayDv -> Decision.NATIVE_DV7
+
+            // Samsung HDR10 fallback (User 3): no DV display but a DV81 decoder is
+            // available. Convert DV7 to DV81 so the decoder emits HDR10. Without this
+            // branch the HEVC base layer fallback fails on some MTK SoCs.
+            // Also fires for Amazon devices on HDR10-only TVs (Karat + HDR10 TV).
+            displayHdr10Family && bridgeReady && codecSupportsDvheSt && (isSamsung || isAmazonFireTv) ->
+                Decision.CONVERT_TO_DV81
+
+            // Xiaomi box on HDR10-only TV: convert so the hidden decoder can emit HDR10.
+            // Without this, STRIP_TO_HDR10 fires and the HEVC fallback may fail on some
+            // Amlogic firmware (same class of issue as Samsung HDR10 path).
+            displayHdr10Family && isXiaomi && bridgeReady -> Decision.CONVERT_TO_DV81
+
+            // HDR10/HDR10+ display on a non-Amazon, non-Samsung, non-Xiaomi device.
+            // Includes Google TV Streamer on HDR10 TV. Strip DV, play HEVC base layer.
+            displayHdr10Family -> Decision.STRIP_TO_HDR10
+
+            else -> Decision.STRIP_AND_TONEMAP
+        }
+
+        return Result(
+            decision = decision,
+            hdrCapsKnown = hdrCapsKnown,
+            displayDv = displayDv,
+            displayHdr10 = displayHdr10,
+            displayHdr10Plus = displayHdr10Plus,
+            displayHlg = displayHlg,
+            codecSupportsDvheDtb = codecSupportsDvheDtb,
+            codecSupportsDvheStn = codecSupportsDvheStn,
+            codecSupportsDvheSt = codecSupportsDvheSt,
+            isAmazonFireTv = isAmazonFireTv,
+            isSamsung = isSamsung,
+            isXiaomi = isXiaomi,
+            bridgeReady = bridgeReady,
+            apiLevel = apiLevel
+        )
+    }
+
+    fun resolve(context: Context, bridgeReady: Boolean): Result {
+        val apiLevel = Build.VERSION.SDK_INT
+        val manufacturer = Build.MANUFACTURER
+        val isAmazonFireTv = manufacturer.equals("Amazon", ignoreCase = true)
+        val isSamsung = manufacturer.equals("Samsung", ignoreCase = true)
+        val isXiaomi = manufacturer.equals("Xiaomi", ignoreCase = true)
+
+        if (apiLevel < Build.VERSION_CODES.N) {
+            return resolveFromCapabilities(
+                hdrCapsKnown = false,
+                displayDv = false,
+                displayHdr10 = false,
+                displayHdr10Plus = false,
+                displayHlg = false,
+                codecSupportsDvheDtb = false,
+                codecSupportsDvheStn = false,
+                codecSupportsDvheSt = false,
+                isAmazonFireTv = isAmazonFireTv,
+                isSamsung = isSamsung,
+                isXiaomi = isXiaomi,
+                bridgeReady = bridgeReady,
+                apiLevel = apiLevel
+            )
+        }
+
+        @Suppress("DEPRECATION")
+        val hdrTypes: IntArray? = runCatching {
+            val dm = context.getSystemService(DisplayManager::class.java)
+            val display = dm?.getDisplay(Display.DEFAULT_DISPLAY)
+            display?.hdrCapabilities?.supportedHdrTypes
+        }.getOrNull()
+
+        val hdrCapsKnown = hdrTypes != null
+        val displayDv = hdrTypes?.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION) == true
+        val displayHdr10 = hdrTypes?.contains(Display.HdrCapabilities.HDR_TYPE_HDR10) == true
+        val displayHdr10Plus =
+            hdrTypes?.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS) == true
+        val displayHlg = hdrTypes?.contains(Display.HdrCapabilities.HDR_TYPE_HLG) == true
+
+        val decoderProfiles = queryDvDecoderProfileSupport()
+
+        return resolveFromCapabilities(
+            hdrCapsKnown = hdrCapsKnown,
+            displayDv = displayDv,
+            displayHdr10 = displayHdr10,
+            displayHdr10Plus = displayHdr10Plus,
+            displayHlg = displayHlg,
+            codecSupportsDvheDtb = decoderProfiles.dvheDtb,
+            codecSupportsDvheStn = decoderProfiles.dvheStn,
+            codecSupportsDvheSt = decoderProfiles.dvheSt,
+            isAmazonFireTv = isAmazonFireTv,
+            isSamsung = isSamsung,
+            isXiaomi = isXiaomi,
+            bridgeReady = bridgeReady,
+            apiLevel = apiLevel
+        )
+    }
+
+    private data class DvDecoderProfileSupport(
+        val dvheDtb: Boolean,   // P7
+        val dvheStn: Boolean,   // P5
+        val dvheSt: Boolean     // P8
+    )
+
+    /**
+     * Enumerates the platform's decoders and reports which DV profiles they advertise.
+     * Returns all-false on any error or pre-N devices.
+     */
+    private fun queryDvDecoderProfileSupport(): DvDecoderProfileSupport {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return DvDecoderProfileSupport(false, false, false)
+        }
+        return runCatching {
+            var dvheDtb = false
+            var dvheStn = false
+            var dvheSt = false
+            val list = MediaCodecList(MediaCodecList.REGULAR_CODECS)
+            for (info in list.codecInfos) {
+                if (info.isEncoder) continue
+                val supportsDvMime = info.supportedTypes.any { type ->
+                    type.equals(DOLBY_VISION_MIME, ignoreCase = true)
+                }
+                if (!supportsDvMime) continue
+                val caps: MediaCodecInfo.CodecCapabilities = runCatching {
+                    info.getCapabilitiesForType(DOLBY_VISION_MIME)
+                }.getOrNull() ?: continue
+                val profileLevels = caps.profileLevels ?: continue
+                for (profileLevel in profileLevels) {
+                    when (profileLevel.profile) {
+                        DvheDtbProfile -> dvheDtb = true
+                        DvheStnProfile -> dvheStn = true
+                        DvheStProfile -> dvheSt = true
+                    }
+                }
+            }
+            DvDecoderProfileSupport(dvheDtb, dvheStn, dvheSt)
+        }.getOrDefault(DvDecoderProfileSupport(false, false, false))
+    }
+
+    private const val DOLBY_VISION_MIME = "video/dolby-vision"
+
+    /** Android constant for DV Profile 7 (dual-layer FEL/MEL). Added in API 24. */
+    private const val DvheDtbProfile = CodecProfileLevel.DolbyVisionProfileDvheDtb
+
+    /** Android constant for DV Profile 5 (single-layer DV-only HEVC). Added in API 24. */
+    private const val DvheStnProfile = CodecProfileLevel.DolbyVisionProfileDvheStn
+
+    /** Android constant for DV Profile 8 (single-layer HDR10-compatible HEVC). Added in API 24. */
+    private const val DvheStProfile = CodecProfileLevel.DolbyVisionProfileDvheSt
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/DolbyVisionCodecFallback.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/DolbyVisionCodecFallback.kt
@@ -1,0 +1,145 @@
+package com.nuvio.tv.core.player
+
+import android.media.MediaCodec
+import android.media.MediaCodecList
+import android.os.Build
+import android.util.Log
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+
+/**
+ * Finds Dolby Vision hardware decoders that exist on the device but don't
+ * advertise Profile 8 in their profileLevels array.
+ *
+ * Problem: devices like the Xiaomi Mi Box S have a working DV decoder
+ * (c2.amlogic.dolby-vision.dvhe.decoder) that handles video/dolby-vision
+ * but only advertises Profile 7 support. When libdovi rewrites DV7 RPUs
+ * to DV8.1, ExoPlayer's standard codec selector rejects this decoder
+ * because Profile 8 isn't in its advertised profile list. Result: fallback
+ * to the generic HEVC decoder, giving HDR10 instead of DV.
+ *
+ * Solution: when CONVERT_TO_DV81 is active and the standard selector
+ * returns no decoders for video/dolby-vision, query MediaCodecList
+ * directly (ignoring profile) and return any DV-capable decoder with
+ * its real capabilities. The hardware accepts the DV8.1 stream even
+ * though it doesn't advertise Profile 8.
+ *
+ * Safety: we use the decoder's actual [android.media.MediaCodecInfo.CodecCapabilities]
+ * from the platform (never null), and optionally verify the decoder can be
+ * instantiated via [MediaCodec.createByCodecName] before returning it.
+ *
+ * Integration point: call [findDvDecodersIgnoringProfile] from your custom
+ * [androidx.media3.exoplayer.mediacodec.MediaCodecSelector] when the
+ * standard selector returns empty for video/dolby-vision AND the DV7
+ * handling mode is CONVERT_TO_DV81.
+ */
+@UnstableApi
+object DolbyVisionCodecFallback {
+
+    private const val TAG = "DvCodecFallback"
+
+    /**
+     * Returns Media3 [MediaCodecInfo] entries for every hardware decoder that
+     * handles `video/dolby-vision`, regardless of which DV profiles it advertises.
+     *
+     * Each returned entry uses the decoder's **real** [android.media.MediaCodecInfo.CodecCapabilities]
+     * from the platform — not null, not fabricated. This is safe: the decoder
+     * genuinely exists and supports the MIME type; we're only bypassing
+     * ExoPlayer's profile-level check because the hardware can handle DV8.1
+     * even though it doesn't say so in its advertisement.
+     *
+     * Returns an empty list if no DV decoder exists or on any error.
+     */
+    fun findDvDecodersIgnoringProfile(): List<MediaCodecInfo> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return emptyList()
+
+        return runCatching {
+            val codecList = MediaCodecList(MediaCodecList.REGULAR_CODECS)
+            val results = mutableListOf<MediaCodecInfo>()
+
+            for (info in codecList.codecInfos) {
+                if (info.isEncoder) continue
+
+                val supportsDv = info.supportedTypes.any { type ->
+                    type.equals(DV_MIME, ignoreCase = true)
+                }
+                if (!supportsDv) continue
+
+                val caps = runCatching {
+                    info.getCapabilitiesForType(DV_MIME)
+                }.getOrNull()
+                if (caps == null) {
+                    Log.w(TAG, "Skipping ${info.name}: getCapabilitiesForType returned null")
+                    continue
+                }
+
+                if (!probeCodecInstantiation(info.name)) {
+                    Log.w(TAG, "Skipping ${info.name}: probe instantiation failed")
+                    continue
+                }
+
+                val isHardwareAccelerated = if (Build.VERSION.SDK_INT >= 29) {
+                    info.isHardwareAccelerated
+                } else {
+                    !info.name.startsWith("OMX.google.", ignoreCase = true)
+                }
+
+                val isSoftwareOnly = if (Build.VERSION.SDK_INT >= 29) {
+                    info.isSoftwareOnly
+                } else {
+                    info.name.startsWith("OMX.google.", ignoreCase = true)
+                }
+
+                val isVendor = if (Build.VERSION.SDK_INT >= 29) {
+                    info.isVendor
+                } else {
+                    !info.name.startsWith("OMX.google.", ignoreCase = true)
+                }
+
+                // Media3 1.9+ uses a 9-parameter newInstance. If your version
+                // uses 7 parameters, remove the last two (forceDisableAdaptive,
+                // forceSecure) arguments.
+                val media3Info = MediaCodecInfo.newInstance(
+                    /* name= */ info.name,
+                    /* mimeType= */ DV_MIME,
+                    /* codecMimeType= */ DV_MIME,
+                    /* capabilities= */ caps,
+                    /* hardwareAccelerated= */ isHardwareAccelerated,
+                    /* softwareOnly= */ isSoftwareOnly,
+                    /* vendor= */ isVendor,
+                    /* forceDisableAdaptive= */ false,
+                    /* forceSecure= */ false
+                )
+
+                Log.i(TAG, "Found hidden DV decoder: ${info.name} (hw=$isHardwareAccelerated)")
+                results.add(media3Info)
+            }
+            results
+        }.getOrElse { e ->
+            Log.e(TAG, "Error probing DV decoders", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * Verifies that a codec can actually be instantiated by the platform.
+     * Creates and immediately releases. Returns true if the codec is usable.
+     *
+     * This catches cases where a decoder is listed in MediaCodecList but the
+     * firmware refuses to create it (seen on some Chinese Amlogic ROMs with
+     * incomplete DV licensing).
+     */
+    private fun probeCodecInstantiation(componentName: String): Boolean {
+        return runCatching {
+            val codec = MediaCodec.createByCodecName(componentName)
+            codec.release()
+            true
+        }.getOrElse { e ->
+            Log.w(TAG, "Codec probe failed for $componentName: ${e.message}")
+            false
+        }
+    }
+
+    private const val DV_MIME = MimeTypes.VIDEO_DOLBY_VISION
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/LastPlaybackDiagnostics.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/LastPlaybackDiagnostics.kt
@@ -1,0 +1,138 @@
+package com.nuvio.tv.core.player
+
+import org.json.JSONObject
+
+/**
+ * Snapshot of the most recent playback's diagnostic data.
+ *
+ * Populated during initializePlayer and onRenderedFirstFrame / onPlayerError.
+ * Persisted to DataStore so users can take a photo of Settings without ADB
+ * to report which DV decision branch was taken on their device.
+ *
+ * All fields are nullable / have safe defaults so partial data is okay
+ * (e.g. if playback errored before first frame, conversion counts will be 0).
+ */
+data class LastPlaybackDiagnostics(
+    val timestampMs: Long = 0L,
+    val host: String = "",
+
+    // Display capabilities (from DolbyVisionBaseLayerPolicy.Result)
+    val hdrCapsKnown: Boolean = false,
+    val displayDv: Boolean = false,
+    val displayHdr10: Boolean = false,
+    val displayHdr10Plus: Boolean = false,
+
+    // Codec capabilities
+    val codecDv7Supported: Boolean = false,
+    val dv81DecoderName: String? = null,  // e.g. "OMX.MTK.VIDEO.DECODER.DVHE.STH"
+
+    // libdovi bridge
+    val bridgeReady: Boolean = false,
+    val bridgeVersion: String? = null,
+    val bridgeReason: String? = null,  // "ready", "hdr10-base-layer-mode", etc.
+
+    // DV decision
+    val dv7ModeRequested: String = "",   // AUTO, HDR10_BASE_LAYER, DV81_LIBDOVI, OFF
+    val dv7ModeEffective: String = "",
+    val dv7AutoDecision: String? = null, // CONVERT_TO_DV81, STRIP_TO_HDR10, etc. (null when not AUTO)
+
+    // Buffer/Network toggles
+    val bufferEngineEnabled: Boolean = false,
+    val parallelNetworkEnabled: Boolean = false,
+
+    // Outcome
+    val firstFrameMs: Long = -1L,        // -1 = never rendered
+    val dv7DoviCalls: Int = 0,
+    val dv7DoviSuccess: Int = 0,
+    val dv7DoviSignalRewrites: Int = 0,
+    val dvSourceProfile: String? = null,
+
+    // Video output (captured at first frame from the played video Format)
+    val videoResolution: String? = null, // e.g. "3840x2160"
+    val videoCodec: String? = null,       // e.g. "Dolby Vision", "HEVC", "AV1"
+    val videoHdrType: String? = null,     // e.g. "Dolby Vision", "HDR10", "HLG", "SDR"
+
+    // Buffer telemetry (rebuffers counted after first frame; re-persisted at playback end)
+    val rebufferCount: Int = 0,
+    val rebufferTotalMs: Long = 0L,
+
+    val result: String = "Pending"       // "Played", "Error: ..."
+) {
+    /**
+     * Serialize to a JSON string for DataStore persistence.
+     * Uses org.json (built into Android) to avoid pulling in kotlinx-serialization
+     * or moshi for one data class.
+     */
+    fun toJson(): String = JSONObject().apply {
+        put("timestampMs", timestampMs)
+        put("host", host)
+        put("hdrCapsKnown", hdrCapsKnown)
+        put("displayDv", displayDv)
+        put("displayHdr10", displayHdr10)
+        put("displayHdr10Plus", displayHdr10Plus)
+        put("codecDv7Supported", codecDv7Supported)
+        put("dv81DecoderName", dv81DecoderName ?: JSONObject.NULL)
+        put("bridgeReady", bridgeReady)
+        put("bridgeVersion", bridgeVersion ?: JSONObject.NULL)
+        put("bridgeReason", bridgeReason ?: JSONObject.NULL)
+        put("dv7ModeRequested", dv7ModeRequested)
+        put("dv7ModeEffective", dv7ModeEffective)
+        put("dv7AutoDecision", dv7AutoDecision ?: JSONObject.NULL)
+        put("bufferEngineEnabled", bufferEngineEnabled)
+        put("parallelNetworkEnabled", parallelNetworkEnabled)
+        put("firstFrameMs", firstFrameMs)
+        put("dv7DoviCalls", dv7DoviCalls)
+        put("dv7DoviSuccess", dv7DoviSuccess)
+        put("dv7DoviSignalRewrites", dv7DoviSignalRewrites)
+        put("dvSourceProfile", dvSourceProfile ?: JSONObject.NULL)
+        put("videoResolution", videoResolution ?: JSONObject.NULL)
+        put("videoCodec", videoCodec ?: JSONObject.NULL)
+        put("videoHdrType", videoHdrType ?: JSONObject.NULL)
+        put("rebufferCount", rebufferCount)
+        put("rebufferTotalMs", rebufferTotalMs)
+        put("result", result)
+    }.toString()
+
+    companion object {
+        val EMPTY = LastPlaybackDiagnostics()
+
+        /**
+         * Parse from a JSON string previously produced by [toJson].
+         * Returns [EMPTY] on any parse failure or invalid input.
+         */
+        fun fromJson(json: String): LastPlaybackDiagnostics = try {
+            val o = JSONObject(json)
+            LastPlaybackDiagnostics(
+                timestampMs = o.optLong("timestampMs", 0L),
+                host = o.optString("host", ""),
+                hdrCapsKnown = o.optBoolean("hdrCapsKnown", false),
+                displayDv = o.optBoolean("displayDv", false),
+                displayHdr10 = o.optBoolean("displayHdr10", false),
+                displayHdr10Plus = o.optBoolean("displayHdr10Plus", false),
+                codecDv7Supported = o.optBoolean("codecDv7Supported", false),
+                dv81DecoderName = o.optString("dv81DecoderName", "").let { if (it.isBlank() || it == "null") null else it },
+                bridgeReady = o.optBoolean("bridgeReady", false),
+                bridgeVersion = o.optString("bridgeVersion", "").let { if (it.isBlank() || it == "null") null else it },
+                bridgeReason = o.optString("bridgeReason", "").let { if (it.isBlank() || it == "null") null else it },
+                dv7ModeRequested = o.optString("dv7ModeRequested", ""),
+                dv7ModeEffective = o.optString("dv7ModeEffective", ""),
+                dv7AutoDecision = o.optString("dv7AutoDecision", "").let { if (it.isBlank() || it == "null") null else it },
+                bufferEngineEnabled = o.optBoolean("bufferEngineEnabled", false),
+                parallelNetworkEnabled = o.optBoolean("parallelNetworkEnabled", false),
+                firstFrameMs = o.optLong("firstFrameMs", -1L),
+                dv7DoviCalls = o.optInt("dv7DoviCalls", 0),
+                dv7DoviSuccess = o.optInt("dv7DoviSuccess", 0),
+                dv7DoviSignalRewrites = o.optInt("dv7DoviSignalRewrites", 0),
+                dvSourceProfile = o.optString("dvSourceProfile", "").let { if (it.isBlank() || it == "null") null else it },
+                videoResolution = o.optString("videoResolution", "").let { if (it.isBlank() || it == "null") null else it },
+                videoCodec = o.optString("videoCodec", "").let { if (it.isBlank() || it == "null") null else it },
+                videoHdrType = o.optString("videoHdrType", "").let { if (it.isBlank() || it == "null") null else it },
+                rebufferCount = o.optInt("rebufferCount", 0),
+                rebufferTotalMs = o.optLong("rebufferTotalMs", 0L),
+                result = o.optString("result", "Pending")
+            )
+        } catch (e: Exception) {
+            EMPTY
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -1,0 +1,528 @@
+package com.nuvio.tv.ui.screens.player
+
+import android.net.Uri
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import java.io.InterruptedIOException
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import com.nuvio.tv.data.local.PlayerSettings
+import java.util.concurrent.atomic.AtomicBoolean
+import android.os.SystemClock
+
+/**
+ * A DataSource that downloads progressive files using multiple parallel HTTP range requests.
+ *
+ * Each individual TCP connection may be limited to ~100 Mbps (due to CDN per-connection limits
+ * or Java/Okio networking overhead). By downloading different byte ranges in parallel across
+ * multiple connections, we can multiply the effective throughput (e.g., 3 connections ≈ 300 Mbps).
+ *
+ * Uses a buffer pool to reuse ByteArrays and avoid GC churn from large object allocations.
+ *
+ * Only used for progressive downloads (MKV, MP4). HLS/DASH already handle chunked parallel downloads.
+ */
+@UnstableApi
+internal class ParallelRangeDataSource(
+    private val upstreamFactory: OkHttpDataSource.Factory,
+    private val parallelConnections: Int = PlayerSettings.DEFAULT_PARALLEL_CONNECTION_COUNT,
+    private val chunkSize: Long = PlayerSettings.DEFAULT_PARALLEL_CHUNK_SIZE_MB.toLong() * 1024 * 1024,
+    private val shouldAllowBackgroundPrefetch: () -> Boolean = { true },
+    private val onResolvedUri: (Uri?) -> Unit = {},
+    private val consumeBootstrapCache: (DataSpec) -> BootstrapCacheEntry? = { null },
+    private val updateBootstrapCache: (BootstrapCacheEntry?) -> Unit = {}
+) : DataSource {
+
+    companion object {
+        private const val TAG = "ParallelRangeDS"
+        private const val READ_BUFFER_SIZE = 512 * 1024 // 512KB read buffer for chunk downloads
+        private const val BOOTSTRAP_READ_BYTES = 1L * 1024L * 1024L
+    }
+
+    /**
+     * A downloaded chunk: a pooled byte array plus the actual number of bytes written.
+     * The array may be larger than [size] (it's from the pool).
+     */
+    private class DownloadedChunk(val data: ByteArray, val size: Int)
+
+    internal data class BootstrapCacheEntry(
+        val requestUri: Uri,
+        val startPosition: Long,
+        val resolvedUri: Uri?,
+        val openLength: Long,
+        val totalFileLength: Long,
+        val bootstrapData: ByteArray,
+        val bootstrapSize: Int,
+        val createdAtUptimeMs: Long
+    )
+
+    private var resolvedUri: Uri? = null
+    private var originalDataSpec: DataSpec? = null
+    private var totalFileLength: Long = C.LENGTH_UNSET.toLong()
+    private var position: Long = 0
+    private var bytesRemaining: Long = C.LENGTH_UNSET.toLong()
+    private val closed = AtomicBoolean(false)
+
+    // Chunk download state
+    private val chunks = ConcurrentHashMap<Long, CompletableFuture<DownloadedChunk>>()
+    private var executor = Executors.newFixedThreadPool(parallelConnections)
+
+    // Buffer pool: lock-free deque to reuse byte arrays and avoid GC churn
+    private val bufferPool = ConcurrentLinkedDeque<ByteArray>()
+    private val maxPoolSize = parallelConnections + 2
+
+    // Current chunk being served to ExoPlayer
+    private var currentChunk: DownloadedChunk? = null
+    private var currentChunkIndex: Long = -1
+    private var currentChunkReadOffset: Int = 0
+    private var bootstrapPrefetchDeferred: Boolean = false
+    private var bootstrapChunk: DownloadedChunk? = null
+    private var bootstrapStartPosition: Long = C.TIME_UNSET
+    private var continuationSource: OkHttpDataSource? = null
+    private var continuationEndPositionExclusive: Long = C.TIME_UNSET
+
+    private val transferListeners = mutableListOf<TransferListener>()
+
+    // Fallback: if parallel mode fails, use a single upstream DataSource
+    private var fallbackSource: OkHttpDataSource? = null
+
+    override fun open(dataSpec: DataSpec): Long {
+        closed.set(false)
+        originalDataSpec = dataSpec
+        position = dataSpec.position
+        bootstrapPrefetchDeferred = false
+        bootstrapChunk = null
+        bootstrapStartPosition = C.TIME_UNSET
+        continuationSource?.close()
+        continuationSource = null
+        continuationEndPositionExclusive = C.TIME_UNSET
+
+        // Cancel any in-flight chunks from a previous open (e.g., after seek)
+        cancelAllChunks()
+
+        // Recreate executor if it was shut down by a previous close()
+        if (executor.isShutdown) {
+            executor = Executors.newFixedThreadPool(parallelConnections)
+        }
+
+        consumeBootstrapCache(dataSpec)?.let { cached ->
+            resolvedUri = cached.resolvedUri
+            onResolvedUri(resolvedUri)
+            totalFileLength = cached.totalFileLength
+            bytesRemaining = cached.openLength
+            bootstrapChunk = DownloadedChunk(cached.bootstrapData, cached.bootstrapSize)
+            bootstrapStartPosition = cached.startPosition
+            bootstrapPrefetchDeferred = true
+            Log.d(
+                TAG,
+                "Reusing bootstrap window for immediate reopen at ${cached.startPosition}, " +
+                    "file=${totalFileLength / 1024 / 1024}MB, resolved=${resolvedUri?.host}"
+            )
+            return cached.openLength
+        }
+
+        // Open first connection to determine total length and capture the resolved (redirected) URL
+        val probeSource: OkHttpDataSource = upstreamFactory.createDataSource()
+        transferListeners.forEach { probeSource.addTransferListener(it) }
+
+        val openLength: Long
+        try {
+            openLength = probeSource.open(dataSpec)
+            resolvedUri = probeSource.uri // Final URL after redirects (CDN URL)
+            onResolvedUri(resolvedUri)
+        } catch (e: Exception) {
+            probeSource.close()
+            throw e
+        }
+
+        // Check if we can do parallel range requests
+        val responseHeaders = probeSource.responseHeaders
+        val acceptsRanges = responseHeaders["Accept-Ranges"]?.any { it.contains("bytes") } == true ||
+                responseHeaders["Content-Range"]?.isNotEmpty() == true
+
+        if (openLength == C.LENGTH_UNSET.toLong() || !acceptsRanges) {
+            // Can't determine length or server doesn't support ranges — reuse probe as single connection
+            Log.w(TAG, "Falling back to single connection (length=${openLength}, acceptsRanges=$acceptsRanges)")
+            fallbackSource = probeSource
+            return openLength
+        }
+
+        totalFileLength = position + openLength
+        bytesRemaining = openLength
+
+        Log.d(TAG, "Parallel mode: ${parallelConnections} connections, ${chunkSize / 1024 / 1024}MB chunks, " +
+                "file=${totalFileLength / 1024 / 1024}MB, resolved=${resolvedUri?.host}")
+
+        // Reuse a small probe window immediately for both startup and large seek reopens.
+        val firstChunkIndex = position / chunkSize
+        if (openLength > 0L) {
+            val bootstrapBytes = minOf(minOf(chunkSize, BOOTSTRAP_READ_BYTES), openLength).toInt()
+            val chunk = readBootstrapChunk(probeSource, bootstrapBytes)
+            bootstrapChunk = chunk
+            bootstrapStartPosition = position
+            // Avoid startup churn from immediate background fetches during repeated startup opens,
+            // but do not redownload the active seek chunk from its start.
+            bootstrapPrefetchDeferred = true
+            if (position == 0L) {
+                updateBootstrapCache(
+                    BootstrapCacheEntry(
+                        requestUri = dataSpec.uri,
+                        startPosition = dataSpec.position,
+                        resolvedUri = resolvedUri,
+                        openLength = openLength,
+                        totalFileLength = totalFileLength,
+                        bootstrapData = chunk.data,
+                        bootstrapSize = chunk.size,
+                        createdAtUptimeMs = SystemClock.uptimeMillis()
+                    )
+                )
+                probeSource.close()
+            } else {
+                continuationSource = probeSource
+                continuationEndPositionExclusive = minOf((firstChunkIndex + 1L) * chunkSize, totalFileLength)
+            }
+        } else {
+            probeSource.close()
+        }
+
+        return openLength
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        // Fallback mode: delegate to single upstream
+        fallbackSource?.let { return it.read(buffer, offset, length) }
+
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+
+        val toRead = minOf(length.toLong(), bytesRemaining).toInt()
+
+        val chunkIndex = position / chunkSize
+        val bootstrap = bootstrapChunk
+        if (currentChunk == null &&
+            bootstrap != null &&
+            position >= bootstrapStartPosition &&
+            position < bootstrapStartPosition + bootstrap.size
+        ) {
+            currentChunk = bootstrap
+            currentChunkIndex = chunkIndex
+            currentChunkReadOffset = (position - bootstrapStartPosition).toInt()
+        }
+
+        if (bootstrapPrefetchDeferred && shouldAllowBackgroundPrefetch() && currentChunk == null) {
+            bootstrapPrefetchDeferred = false
+            scheduleChunks()
+        }
+
+        continuationSource?.let { source ->
+            if (position < continuationEndPositionExclusive &&
+                bytesRemaining > 0L &&
+                (bootstrap == null || position >= bootstrapStartPosition + bootstrap.size)
+            ) {
+                val read = source.read(buffer, offset, toRead)
+                if (read > 0) {
+                    position += read
+                    bytesRemaining -= read
+                    if (position >= continuationEndPositionExclusive) {
+                        source.close()
+                        continuationSource = null
+                        continuationEndPositionExclusive = C.TIME_UNSET
+                        scheduleChunks()
+                    }
+                    return read
+                }
+                if (read == C.RESULT_END_OF_INPUT || position >= continuationEndPositionExclusive) {
+                    source.close()
+                    continuationSource = null
+                    continuationEndPositionExclusive = C.TIME_UNSET
+                    scheduleChunks()
+                }
+            } else if (position >= continuationEndPositionExclusive || bytesRemaining <= 0L) {
+                source.close()
+                continuationSource = null
+                continuationEndPositionExclusive = C.TIME_UNSET
+            }
+        }
+
+        // Load the chunk for the current position
+        if (currentChunkIndex != chunkIndex || currentChunk == null) {
+            ensureChunkScheduled(chunkIndex)
+            val future = chunks[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            try {
+                currentChunk = future.get(60, TimeUnit.SECONDS)
+            } catch (e: Exception) {
+                if (closed.get()) return C.RESULT_END_OF_INPUT
+                throw IOException("Failed to download chunk $chunkIndex", e)
+            }
+            currentChunkIndex = chunkIndex
+            currentChunkReadOffset = (position % chunkSize).toInt()
+
+            // Clean up old chunks (returns buffers to pool) and schedule new ones
+            cleanupOldChunks(chunkIndex)
+            scheduleChunks()
+        }
+
+        val chunk = currentChunk ?: return C.RESULT_END_OF_INPUT
+        val available = chunk.size - currentChunkReadOffset
+        if (available <= 0) {
+            // Current chunk exhausted, move to next
+            if (chunk === bootstrapChunk) {
+                bootstrapChunk = null
+                bootstrapStartPosition = C.TIME_UNSET
+            }
+            currentChunk = null
+            return read(buffer, offset, length)
+        }
+
+        val readSize = minOf(toRead, available)
+        System.arraycopy(chunk.data, currentChunkReadOffset, buffer, offset, readSize)
+        currentChunkReadOffset += readSize
+        position += readSize
+        bytesRemaining -= readSize
+
+        return readSize
+    }
+
+    private fun scheduleChunks() {
+        if (!shouldAllowBackgroundPrefetch()) return
+        val currentChunkIdx =
+            if (continuationSource != null && continuationEndPositionExclusive != C.TIME_UNSET && position < continuationEndPositionExclusive) {
+                continuationEndPositionExclusive / chunkSize
+            } else {
+                position / chunkSize
+            }
+        val maxAhead = parallelConnections + 1
+
+        for (i in 0 until maxAhead) {
+            val ci = currentChunkIdx + i
+            if (totalFileLength != C.LENGTH_UNSET.toLong() && ci * chunkSize >= totalFileLength) break
+            ensureChunkScheduled(ci)
+        }
+    }
+
+    private fun ensureChunkScheduled(chunkIndex: Long) {
+        chunks.computeIfAbsent(chunkIndex) {
+            CompletableFuture.supplyAsync({ downloadChunk(chunkIndex) }, executor)
+        }
+    }
+
+    private fun downloadChunk(chunkIndex: Long): DownloadedChunk {
+        var lastException: Exception? = null
+        for (attempt in 0..1) {
+            try {
+                return downloadChunkOnce(chunkIndex)
+            } catch (e: Exception) {
+                if (closed.get()) throw IOException("DataSource closed")
+                lastException = e
+                if (attempt == 0) {
+                    if (e.isTransientInterruption()) {
+                        Log.d(TAG, "Chunk $chunkIndex interrupted during prefetch (attempt 1), retrying")
+                        try {
+                            Thread.sleep(50)
+                        } catch (_: InterruptedException) {
+                        }
+                    } else {
+                        Log.w(TAG, "Chunk $chunkIndex download failed (attempt 1), retrying: ${e.message}")
+                    }
+                }
+            }
+        }
+        throw IOException("Failed to download chunk $chunkIndex after 2 attempts", lastException)
+    }
+
+    private fun downloadChunkOnce(chunkIndex: Long): DownloadedChunk {
+        val start = chunkIndex * chunkSize
+        val end = if (totalFileLength != C.LENGTH_UNSET.toLong()) {
+            minOf(start + chunkSize, totalFileLength)
+        } else {
+            start + chunkSize
+        }
+
+        val ds = upstreamFactory.createDataSource()
+        val uri = resolvedUri ?: originalDataSpec?.uri ?: throw IOException("No URI available")
+        val spec = DataSpec.Builder()
+            .setUri(uri)
+            .setPosition(start)
+            .setLength(end - start)
+            .build()
+
+        ds.open(spec)
+        val chunk = readIntoChunk(ds)
+        ds.close()
+        return chunk
+    }
+
+    private fun Exception.isTransientInterruption(): Boolean {
+        if (this is InterruptedIOException || this is InterruptedException) return true
+        val cause = cause
+        return cause is InterruptedIOException || cause is InterruptedException
+    }
+
+    /** Read from an already-opened DataSource into a pooled chunk buffer. */
+    private fun readIntoChunk(ds: DataSource): DownloadedChunk {
+        val buffer = acquireBuffer()
+        var totalRead = 0
+        try {
+            while (!closed.get()) {
+                val maxRead = minOf(buffer.size - totalRead, READ_BUFFER_SIZE)
+                if (maxRead <= 0) break
+                val read = ds.read(buffer, totalRead, maxRead)
+                if (read == C.RESULT_END_OF_INPUT) break
+                totalRead += read
+            }
+        } catch (e: Exception) {
+            releaseBuffer(buffer)
+            if (closed.get()) throw IOException("DataSource closed")
+            throw e
+        }
+        if (closed.get()) {
+            releaseBuffer(buffer)
+            throw IOException("DataSource closed")
+        }
+        return DownloadedChunk(buffer, totalRead)
+    }
+
+    /** Read only a small startup window from an already-opened DataSource. */
+    private fun readBootstrapChunk(ds: DataSource, maxBytes: Int): DownloadedChunk {
+        val buffer = ByteArray(maxBytes)
+        var totalRead = 0
+        try {
+            while (!closed.get() && totalRead < buffer.size) {
+                val maxRead = minOf(buffer.size - totalRead, READ_BUFFER_SIZE)
+                if (maxRead <= 0) break
+                val read = ds.read(buffer, totalRead, maxRead)
+                if (read == C.RESULT_END_OF_INPUT) break
+                totalRead += read
+            }
+        } catch (e: Exception) {
+            if (closed.get()) throw IOException("DataSource closed")
+            throw e
+        }
+        if (closed.get()) {
+            throw IOException("DataSource closed")
+        }
+        return DownloadedChunk(buffer, totalRead)
+    }
+
+    private fun acquireBuffer(): ByteArray {
+        return bufferPool.pollLast() ?: ByteArray(chunkSize.toInt())
+    }
+
+    /**
+     *   maxPoolSize in releaseBuffer only caps how many idle/recycled buffers are kept in the pool.
+     *   If the pool is full, the released buffer is GC'd instead of recycled. It does NOT
+     *   determine how many buffers exist simultaneously. The actual peak concurrent buffers
+     *   is driven by maxAhead.
+     */
+    private fun releaseBuffer(buffer: ByteArray) {
+        if (bufferPool.size < maxPoolSize) {
+            bufferPool.offerLast(buffer)
+        }
+        // else: let it be GC'd (pool is full)
+    }
+
+    private fun cleanupOldChunks(currentChunkIndex: Long) {
+        val iter = chunks.entries.iterator()
+        while (iter.hasNext()) {
+            val entry = iter.next()
+            if (entry.key < currentChunkIndex) {
+                val future = entry.value
+                if (future.isDone && !future.isCancelled) {
+                    try { releaseBuffer(future.get().data) } catch (_: Exception) {}
+                }
+                future.cancel(true)
+                iter.remove()
+            }
+        }
+    }
+
+    /** Cancel and clean up all in-flight chunks, returning buffers to the pool. */
+    private fun cancelAllChunks() {
+        currentChunk?.let {
+            if (it !== bootstrapChunk) {
+                releaseBuffer(it.data)
+            }
+        }
+        currentChunk = null
+        currentChunkIndex = -1
+        bootstrapChunk = null
+        bootstrapStartPosition = C.TIME_UNSET
+
+        chunks.values.forEach { future ->
+            if (future.isDone && !future.isCancelled) {
+                try { releaseBuffer(future.get().data) } catch (_: Exception) {}
+            }
+            future.cancel(true)
+        }
+        chunks.clear()
+    }
+
+    override fun close() {
+        closed.set(true)
+        fallbackSource?.close()
+        fallbackSource = null
+        continuationSource?.close()
+        continuationSource = null
+        continuationEndPositionExclusive = C.TIME_UNSET
+
+        cancelAllChunks()
+        executor.shutdownNow()
+
+        bufferPool.clear()
+    }
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        transferListeners.add(transferListener)
+    }
+
+    override fun getUri(): Uri? = resolvedUri ?: fallbackSource?.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> =
+        fallbackSource?.responseHeaders ?: emptyMap()
+
+    /**
+     * Factory for creating ParallelRangeDataSource instances.
+     */
+    class Factory(
+        private val upstreamFactory: OkHttpDataSource.Factory,
+        private val parallelConnections: Int = PlayerSettings.DEFAULT_PARALLEL_CONNECTION_COUNT,
+        private val chunkSize: Long = PlayerSettings.DEFAULT_PARALLEL_CHUNK_SIZE_MB.toLong() * 1024 * 1024,
+        private val shouldAllowBackgroundPrefetch: () -> Boolean = { true },
+        private val onResolvedUri: (Uri?) -> Unit = {}
+    ) : DataSource.Factory {
+        @Volatile
+        private var startupBootstrapCache: BootstrapCacheEntry? = null
+
+        override fun createDataSource(): DataSource {
+            return ParallelRangeDataSource(
+                upstreamFactory = upstreamFactory,
+                parallelConnections = parallelConnections,
+                chunkSize = chunkSize,
+                shouldAllowBackgroundPrefetch = shouldAllowBackgroundPrefetch,
+                onResolvedUri = onResolvedUri,
+                consumeBootstrapCache = { dataSpec ->
+                    val cached = startupBootstrapCache ?: return@ParallelRangeDataSource null
+                    val isFresh = SystemClock.uptimeMillis() - cached.createdAtUptimeMs <= 15_000L
+                    if (!isFresh) {
+                        startupBootstrapCache = null
+                        return@ParallelRangeDataSource null
+                    }
+                    if (cached.startPosition != 0L || dataSpec.position != 0L) return@ParallelRangeDataSource null
+                    if (dataSpec.position != cached.startPosition) return@ParallelRangeDataSource null
+                    if (dataSpec.uri != cached.requestUri) return@ParallelRangeDataSource null
+                    cached
+                },
+                updateBootstrapCache = { entry ->
+                    startupBootstrapCache = entry
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioRenderer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioRenderer.kt
@@ -17,7 +17,7 @@ import androidx.media3.exoplayer.mediacodec.MediaCodecUtil
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil.DecoderQueryException
 
 internal class PlaybackSpeedAwareAudioRenderer(
-    context: Context,
+    private val rendererContext: Context,
     codecAdapterFactory: MediaCodecAdapter.Factory,
     mediaCodecSelector: MediaCodecSelector,
     enableDecoderFallback: Boolean,
@@ -25,7 +25,7 @@ internal class PlaybackSpeedAwareAudioRenderer(
     eventListener: AudioRendererEventListener?,
     private val playbackSpeedAwareAudioSink: PlaybackSpeedAwareAudioSink
 ) : MediaCodecAudioRenderer(
-    context,
+    rendererContext,
     codecAdapterFactory,
     mediaCodecSelector,
     enableDecoderFallback,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
@@ -101,9 +101,11 @@ private fun ExtractorsFactory.withAssMkvSupportCompat(
     return ExtractorsFactory {
         val extractors = createExtractors()
         extractors.forEachIndexed { index, extractor ->
-            // The DV7 factory swaps in a vendored MatroskaExtractor; libass needs the ASS-aware
-            // one for MKV, so replace either. DV7-MKV conversion yields to ASS while libass is on.
-            if (extractor is MatroskaExtractor || extractor is DvMatroskaExtractor) {
+            // The DV7 factory swaps in a vendored MatroskaExtractor for DV conversion.
+            // When DV conversion is active (DvMatroskaExtractor), keep it — DV color
+            // correctness takes priority over libass ASS/SSA rendering for MKV.
+            // ASS subtitles will still render via the fallback text renderer.
+            if (extractor is MatroskaExtractor) {
                 extractors[index] = AssMatroskaExtractor(subtitleParserFactory, assHandler)
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
@@ -14,6 +14,7 @@ import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.text.SubtitleParser
+import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor as DvMatroskaExtractor
 import io.github.peerless2012.ass.media.AssHandler
 import io.github.peerless2012.ass.media.extractor.AssMatroskaExtractor
 import io.github.peerless2012.ass.media.kt.withAssSupport
@@ -100,7 +101,9 @@ private fun ExtractorsFactory.withAssMkvSupportCompat(
     return ExtractorsFactory {
         val extractors = createExtractors()
         extractors.forEachIndexed { index, extractor ->
-            if (extractor is MatroskaExtractor) {
+            // The DV7 factory swaps in a vendored MatroskaExtractor; libass needs the ASS-aware
+            // one for MKV, so replace either. DV7-MKV conversion yields to ASS while libass is on.
+            if (extractor is MatroskaExtractor || extractor is DvMatroskaExtractor) {
                 extractors[index] = AssMatroskaExtractor(subtitleParserFactory, assHandler)
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -1,34 +1,63 @@
 package com.nuvio.tv.ui.screens.player
 
 import android.content.Context
+import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
-import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.cache.CacheDataSink
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.SimpleCache
+import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.text.SubtitleParser
 import com.nuvio.tv.NuvioApplication
 import com.nuvio.tv.core.network.IPv4FirstDns
+import com.nuvio.tv.data.local.PlayerSettings
+import com.nuvio.tv.data.local.VodCacheSizeMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
 import java.io.InputStream
 import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
 import java.net.URLDecoder
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Locale
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
-import okhttp3.OkHttpClient
-import java.util.concurrent.TimeUnit
 
-internal class PlayerMediaSourceFactory {
+internal class PlayerMediaSourceFactory(private val context: Context) {
     private var customExtractorsFactory: ExtractorsFactory? = null
     private var customSubtitleParserFactory: SubtitleParser.Factory? = null
+    private val loadErrorHandlingPolicy = PlayerLoadErrorHandlingPolicy()
+
+    @Volatile private var currentVodCacheUrl: String? = null
+    @Volatile private var currentVodCacheResolvedUrl: String? = null
+    @Volatile private var currentVodCacheActive: Boolean = false
+    private val parallelStartupPrefetchUnlocked = AtomicBoolean(true)
+
+    var useParallelConnections: Boolean = PlayerSettings.DEFAULT_USE_PARALLEL_CONNECTIONS
+    var parallelConnectionCount: Int = PlayerSettings.DEFAULT_PARALLEL_CONNECTION_COUNT
+    var parallelChunkSizeMb: Int = PlayerSettings.DEFAULT_PARALLEL_CHUNK_SIZE_MB
+    var vodCacheEnabled: Boolean = PlayerSettings.DEFAULT_VOD_CACHE_ENABLED
+    var vodCacheSizeMode: VodCacheSizeMode = PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MODE
+    var vodCacheSizeMb: Int = PlayerSettings.DEFAULT_VOD_CACHE_SIZE_MB
+
+    // OkHttp client used only by the opt-in parallel-connections path.
     private val playbackHttpClient by lazy {
         val trustAllManager = object : X509TrustManager {
             override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
@@ -38,17 +67,23 @@ internal class PlayerMediaSourceFactory {
         val sslContext = SSLContext.getInstance("TLS").apply {
             init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
         }
+        val dispatcher = Dispatcher().apply {
+            maxRequests = 64
+            maxRequestsPerHost = 12
+        }
         OkHttpClient.Builder()
             .cookieJar(NuvioApplication.extensionCookieJar)
             .dns(IPv4FirstDns())
+            .dispatcher(dispatcher)
             .sslSocketFactory(sslContext.socketFactory, trustAllManager)
             .hostnameVerifier { _, _ -> true }
-            .connectTimeout(15, TimeUnit.SECONDS)
-            .readTimeout(15, TimeUnit.SECONDS)
-            .writeTimeout(15, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .writeTimeout(45, TimeUnit.SECONDS)
+            .connectionPool(ConnectionPool(5, 5, TimeUnit.MINUTES))
+            .retryOnConnectionFailure(true)
             .followRedirects(true)
             .followSslRedirects(true)
-            .retryOnConnectionFailure(true)
             .build()
     }
 
@@ -92,8 +127,56 @@ internal class PlayerMediaSourceFactory {
         }
 
         val mediaItem = mediaItemBuilder.build()
+
+        // 1. Parallel connections (opt-in). ParallelRangeDataSource needs a concrete
+        // OkHttpDataSource.Factory, so build one only on this path.
+        parallelStartupPrefetchUnlocked.set(!(useParallelConnections && !isHls && !isDash))
+        val progressiveUpstreamFactory: DataSource.Factory = if (useParallelConnections && !isHls && !isDash) {
+            val okHttpFactory = OkHttpDataSource.Factory(playbackHttpClient).apply {
+                setDefaultRequestProperties(sanitizedHeaders)
+                setUserAgent(DEFAULT_USER_AGENT)
+            }
+            ParallelRangeDataSource.Factory(
+                okHttpFactory,
+                parallelConnectionCount,
+                parallelChunkSizeMb.toLong() * 1024L * 1024L,
+                shouldAllowBackgroundPrefetch = { parallelStartupPrefetchUnlocked.get() },
+                onResolvedUri = { resolved -> currentVodCacheResolvedUrl = resolved?.toString() }
+            )
+        } else {
+            httpDataSourceFactory
+        }
+
+        // 2. VOD disk cache (opt-in).
+        val useVodCache = ENABLE_VOD_CACHE && vodCacheEnabled && !isHls && !isDash && shouldUseVodCache(url)
+        val previousVodCacheActive = currentVodCacheActive
+        currentVodCacheUrl = url
+        currentVodCacheResolvedUrl = null
+        // Size the cache only when used; 0 means off or not enough free space (skip, stream direct).
+        val vodCacheMaxBytes = if (useVodCache && !isVodCacheDisabled) resolveVodCacheMaxBytes() else 0L
+        val vodCacheActive = vodCacheMaxBytes > 0L
+
+        if (vodCacheActive) {
+            maybeApplyLiveVodCacheCapIncrease(context, vodCacheMaxBytes, !previousVodCacheActive)
+        }
+
+        val progressiveFactory: DataSource.Factory = if (vodCacheActive) {
+            val cache = getReadySimpleCache(vodCacheMaxBytes) ?: getAnySimpleCache()
+            if (cache != null) {
+                currentVodCacheActive = true
+                buildVodCacheDataSourceFactory(progressiveUpstreamFactory, cache)
+            } else {
+                currentVodCacheActive = false
+                progressiveUpstreamFactory
+            }
+        } else {
+            currentVodCacheActive = false
+            progressiveUpstreamFactory
+        }
+
         val extractorsFactory = customExtractorsFactory ?: DefaultExtractorsFactory()
-        val defaultFactory = DefaultMediaSourceFactory(httpDataSourceFactory, extractorsFactory).apply {
+        val defaultFactory = DefaultMediaSourceFactory(progressiveFactory, extractorsFactory).apply {
+            setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
             customSubtitleParserFactory?.let { parserFactory ->
                 setSubtitleParserFactory(parserFactory)
             }
@@ -111,8 +194,10 @@ internal class PlayerMediaSourceFactory {
         val mediaSource = when {
             isHls && !forceDefaultFactory -> HlsMediaSource.Factory(httpDataSourceFactory)
                 .setAllowChunklessPreparation(true)
+                .setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
                 .createMediaSource(mediaItem)
             isDash && !forceDefaultFactory -> DashMediaSource.Factory(httpDataSourceFactory)
+                .setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
                 .createMediaSource(mediaItem)
             else -> defaultFactory.createMediaSource(mediaItem)
         }
@@ -121,11 +206,56 @@ internal class PlayerMediaSourceFactory {
 
     fun shutdown() = Unit
 
+    private fun buildVodCacheDataSourceFactory(upstreamFactory: DataSource.Factory, cache: SimpleCache): DataSource.Factory {
+        val dataSinkFactory = CacheDataSink.Factory().setCache(cache).setFragmentSize(2L * 1024L * 1024L)
+        return CacheDataSource.Factory()
+            .setCache(cache)
+            .setCacheWriteDataSinkFactory(dataSinkFactory)
+            .setUpstreamDataSourceFactory(upstreamFactory)
+            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+    }
+
+    private fun shouldUseVodCache(url: String): Boolean {
+        val scheme = Uri.parse(url).scheme?.lowercase()
+        return scheme == "https" || scheme == "http"
+    }
+
+    private fun resolveVodCacheMaxBytes(): Long {
+        val minBytes = PlayerSettings.MIN_VOD_CACHE_SIZE_MB.toLong() * 1024L * 1024L
+        val maxBytes = PlayerSettings.MAX_VOD_CACHE_SIZE_MB.toLong() * 1024L * 1024L
+        val runtimeMaxBytes = resolveRuntimeVodCacheUpperBoundBytes(maxBytes)
+        // Not enough free space to host a useful cache: skip it (0 = caller streams direct).
+        if (runtimeMaxBytes < minBytes) return 0L
+        val manualBytes = vodCacheSizeMb
+            .coerceIn(PlayerSettings.MIN_VOD_CACHE_SIZE_MB, PlayerSettings.MAX_VOD_CACHE_SIZE_MB)
+            .toLong() * 1024L * 1024L
+        val resolvedManualBytes = manualBytes.coerceAtMost(runtimeMaxBytes)
+
+        if (vodCacheSizeMode == VodCacheSizeMode.MANUAL) return resolvedManualBytes
+
+        val freeSpaceBytes = context.cacheDir.usableSpace
+        if (freeSpaceBytes <= 0L) return resolvedManualBytes
+        val autoBytes = freeSpaceBytes / 5L // 20% for a healthy buffer
+        return autoBytes.coerceIn(minBytes, runtimeMaxBytes)
+    }
+
+    private fun resolveRuntimeVodCacheUpperBoundBytes(hardMaxBytes: Long): Long {
+        val freeSpaceBytes = context.cacheDir.usableSpace
+        val headroomAdjusted = if (freeSpaceBytes > VOD_CACHE_FREE_SPACE_RESERVE_BYTES) {
+            freeSpaceBytes - VOD_CACHE_FREE_SPACE_RESERVE_BYTES
+        } else {
+            (freeSpaceBytes * 8L) / 10L
+        }
+        return headroomAdjusted.coerceAtLeast(1L * 1024L * 1024L).coerceAtMost(hardMaxBytes)
+    }
+
     companion object {
         private const val PROBE_TIMEOUT_MS = 4000
         private const val PROBE_BYTES = 1024
         private const val MIME_PROBE_CACHE_SIZE = 64
         private const val MIME_VIDEO_QUICK_TIME = "video/quicktime"
+        private const val ENABLE_VOD_CACHE = true
+        private const val VOD_CACHE_FREE_SPACE_RESERVE_BYTES = 1024L * 1024L * 1024L
         internal const val DEFAULT_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -134,6 +264,10 @@ internal class PlayerMediaSourceFactory {
                 return size > MIME_PROBE_CACHE_SIZE
             }
         }
+
+        @Volatile private var sharedSimpleCache: SimpleCache? = null
+        @Volatile private var configuredVodCacheMaxBytes: Long = -1L
+        @Volatile private var isVodCacheDisabled: Boolean = false
 
         fun sanitizeHeaders(headers: Map<String, String>?): Map<String, String> {
             val raw: Map<*, *> = headers ?: return emptyMap()
@@ -180,6 +314,22 @@ internal class PlayerMediaSourceFactory {
             } catch (_: Exception) {
                 emptyMap()
             }
+        }
+
+        private fun getReadySimpleCache(expectedMaxBytes: Long): SimpleCache? {
+            val cache = sharedSimpleCache ?: return null
+            return if (configuredVodCacheMaxBytes == expectedMaxBytes) cache else null
+        }
+
+        private fun getAnySimpleCache(): SimpleCache? = sharedSimpleCache
+
+        private fun maybeApplyLiveVodCacheCapIncrease(
+            context: Context,
+            requestedMaxBytes: Long,
+            allowLiveReconfigure: Boolean
+        ) {
+            // Live cache reconfiguration is not yet implemented; the shared cache is
+            // created lazily elsewhere. Kept as the integration point for the VOD cache.
         }
 
         internal fun inferMimeType(
@@ -495,7 +645,6 @@ internal class PlayerMediaSourceFactory {
             }
         }
 
-
         private val DELIMITED_M3U8_PATTERN = Regex("(^|[=/_.?&-])m3u8($|[=/_.?&-])")
         private val DELIMITED_MPD_PATTERN = Regex("(^|[=/_.?&-])mpd($|[=/_.?&-])")
         private val DELIMITED_SS_PATTERN = Regex("(^|[=/_.?&-])(ism|isml)($|[=/_.?&-])")
@@ -537,4 +686,26 @@ internal class PlayerMediaSourceFactory {
             return cleanUri.toString() to mergedHeaders
         }
     }
+}
+
+private class PlayerLoadErrorHandlingPolicy : DefaultLoadErrorHandlingPolicy(6) {
+    override fun getRetryDelayMsFor(loadErrorInfo: LoadErrorHandlingPolicy.LoadErrorInfo): Long {
+        val timeout = loadErrorInfo.exception.findCause<SocketTimeoutException>() != null
+        return if (timeout) {
+            when (loadErrorInfo.errorCount) {
+                1 -> 750L
+                2 -> 1500L
+                else -> 3000L
+            }
+        } else super.getRetryDelayMsFor(loadErrorInfo)
+    }
+}
+
+private inline fun <reified T : Throwable> Throwable.findCause(): T? {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is T) return current
+        current = current.cause
+    }
+    return null
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
@@ -31,7 +31,9 @@ internal data class PlayerNavigationArgs(
     val infoHash: String?,
     val fileIdx: Int?,
     val sourcesJson: String?,
-    val contentLanguage: String?
+    val contentLanguage: String?,
+    val rememberedAudioLanguage: String?,
+    val rememberedAudioName: String?
 ) {
     val torrentTrackers: List<String>
         get() {
@@ -86,7 +88,9 @@ internal data class PlayerNavigationArgs(
                 infoHash = savedStateHandle.get<String>("infoHash")?.takeIf { it.isNotEmpty() },
                 fileIdx = savedStateHandle.get<String>("fileIdx")?.toIntOrNull(),
                 sourcesJson = decodedOrNull("sources"),
-                contentLanguage = decodedOrNull("contentLanguage")
+                contentLanguage = decodedOrNull("contentLanguage"),
+                rememberedAudioLanguage = decodedOrNull("rememberedAudioLanguage"),
+                rememberedAudioName = decodedOrNull("rememberedAudioName")
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -3,11 +3,14 @@ package com.nuvio.tv.ui.screens.player
 import android.app.Activity
 import android.content.Context
 import android.media.AudioDeviceCallback
+import android.media.audiofx.LoudnessEnhancer
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
+import androidx.media3.common.C
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.decoder.ffmpeg.FfmpegAudioRenderer
+import com.nuvio.tv.core.player.BitrateAwareLoadControl
 import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.debrid.DirectDebridStreamPreparer
 import com.nuvio.tv.core.plugin.PluginManager
@@ -36,6 +39,9 @@ import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.StreamRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
+import com.nuvio.tv.data.repository.extractYear
+import com.nuvio.tv.data.repository.parseContentIds
+import com.nuvio.tv.data.repository.toTraktIds
 import androidx.media3.session.MediaSession
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -84,6 +90,12 @@ class PlayerRuntimeController(
         internal const val SWITCH_TRACE_TAG = "SwitchTrace"
         internal const val SWITCH_TRACE_ENABLED = false
         internal const val TRACK_FRAME_RATE_GRACE_MS = 1500L
+        internal const val FIRST_FRAME_TIMEOUT_MS = 12_000L
+        // Stall watchdog: re-seeks past the buffered edge if bufferedPosition stops
+        // advancing during STATE_BUFFERING. Fires before OkHttp's readTimeout.
+        internal const val STALL_WATCHDOG_THRESHOLD_MS = 15_000L
+        internal const val STALL_WATCHDOG_POLL_INTERVAL_MS = 1_000L
+        internal const val MAX_TIMEOUT_RECOVERY_ATTEMPTS = 2
         internal const val ADDON_SUBTITLE_TRACK_ID_PREFIX = "nuvio-addon-sub:"
     }
 
@@ -147,7 +159,9 @@ class PlayerRuntimeController(
     internal val initialSeason: Int? = navigationArgs.initialSeason
     internal val initialEpisode: Int? = navigationArgs.initialEpisode
     internal val initialEpisodeTitle: String? = navigationArgs.initialEpisodeTitle
-    internal val mediaSourceFactory = PlayerMediaSourceFactory()
+    internal val rememberedAudioLanguage: String? = navigationArgs.rememberedAudioLanguage
+    internal val rememberedAudioName: String? = navigationArgs.rememberedAudioName
+    internal val mediaSourceFactory = PlayerMediaSourceFactory(context.applicationContext)
 
     internal var currentVideoHash: String? = navigationArgs.videoHash
     internal var currentVideoSize: Long? = navigationArgs.videoSize
@@ -221,12 +235,14 @@ class PlayerRuntimeController(
 
     internal fun updatePlaybackTimeline(
         currentPosition: Long = _playbackTimeline.value.currentPosition,
-        duration: Long = _playbackTimeline.value.duration
+        duration: Long = _playbackTimeline.value.duration,
+        bufferedPosition: Long = _playbackTimeline.value.bufferedPosition
     ) {
         _playbackTimeline.update {
             it.copy(
                 currentPosition = currentPosition.coerceAtLeast(0L),
-                duration = duration.coerceAtLeast(0L)
+                duration = duration.coerceAtLeast(0L),
+                bufferedPosition = bufferedPosition.coerceAtLeast(0L)
             )
         }
     }
@@ -241,6 +257,9 @@ class PlayerRuntimeController(
     internal var playbackSpeedAwareAudioSink: PlaybackSpeedAwareAudioSink? = null
 
     internal var progressJob: Job? = null
+    internal var vodTelemetryJob: Job? = null
+    internal var firstFrameWatchdogJob: Job? = null
+    internal var stallWatchdogJob: Job? = null
     internal var hideControlsJob: Job? = null
     internal var hideSeekOverlayJob: Job? = null
     internal var watchProgressSaveJob: Job? = null
@@ -260,16 +279,28 @@ class PlayerRuntimeController(
     internal var sourceStreamsCacheRequestKey: String? = null
     internal var hostActivityRef: WeakReference<Activity>? = null
     internal var initialPlaybackStarted: Boolean = false
-    
-    
+
     internal var lastSavedPosition: Long = 0L
-    internal val saveThresholdMs = 5000L 
+    internal val saveThresholdMs = 5000L
     internal var lastKnownDuration: Long = 0L
 
-    
     internal var playbackStartedForParentalGuide = false
     internal var hasRenderedFirstFrame = false
     internal var shouldEnforceAutoplayOnFirstReady = true
+
+    // ── Buffer/rebuffer telemetry (per playback; reset in initializePlayer) ──
+    /** Count of rebuffers (STATE_BUFFERING entered after the first frame). */
+    internal var rebufferCount: Int = 0
+    /** Total time (ms) spent rebuffering after the first frame. */
+    internal var rebufferTotalMs: Long = 0L
+    /** Wall-clock ms when the current post-first-frame rebuffer started, 0 if not rebuffering. */
+    internal var rebufferStartedAtMs: Long = 0L
+    /** Back buffer (ms) currently in force, after the first-frame DV7/low-RAM resolution. */
+    internal var effectiveBackBufferDurationMs: Int = 0
+    /** Custom LoadControl for this playback (null when using stock); used to resolve the back buffer at first frame. */
+    internal var currentBitrateAwareLoadControl: BitrateAwareLoadControl? = null
+    /** Back buffer (ms) the user configured, captured at build to restore once DV7 status is known. */
+    internal var configuredBackBufferMs: Int = 0
     internal var metaVideos: List<Video> = emptyList()
     internal var metaGenres: List<String> = emptyList()
     internal var metaCountry: String? = null
@@ -280,7 +311,6 @@ class PlayerRuntimeController(
     internal var pendingBackgroundCrashRecovery: Boolean = false
     internal var backgroundCrashSavedPositionMs: Long = 0L
 
-    
     internal var skipIntervals: List<SkipInterval> = emptyList()
     internal var skipIntroEnabled: Boolean = true
     internal var parentalGuideEnabled: Boolean = false
@@ -326,6 +356,7 @@ class PlayerRuntimeController(
     internal var mpvHardwareDecodeModeSetting: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE
     internal var mpvPreferredAudioLanguages: List<String> = emptyList()
     internal var currentStreamBingeGroup: String? = navigationArgs.bingeGroup
+    internal var hasAppliedRememberedAudioSelection: Boolean = false
     internal var hasInitializedAudioAmplificationForSession: Boolean = false
     internal var hasInitializedCenterMixForSession: Boolean = false
     internal var rememberAudioDelayPerDeviceEnabled: Boolean = false
@@ -333,8 +364,16 @@ class PlayerRuntimeController(
     internal var audioOutputRouteCallback: AudioDeviceCallback? = null
 
     internal var lastBufferLogTimeMs: Long = 0L
-    
+    internal var lastVodTelemetryRefreshTimeMs: Long = 0L
+    internal var cachedVodCacheLogState: String = "vod=warming"
+    internal var bufferLogsEnabled: Boolean = false
+    internal var lastProgressUiUpdateUptimeMs: Long = 0L
+    internal var lastSkipIntervalEvaluationUptimeMs: Long = 0L
+    internal var lastNextEpisodeEvaluationUptimeMs: Long = 0L
+    internal var bufferLogJob: Job? = null
+
     internal val gainAudioProcessor = GainAudioProcessor()
+    internal var loudnessEnhancer: LoudnessEnhancer? = null
     internal var trackSelector: DefaultTrackSelector? = null
     internal var currentMediaSession: MediaSession? = null
     internal var ffmpegAudioRenderer: FfmpegAudioRenderer? = null
@@ -359,10 +398,41 @@ class PlayerRuntimeController(
     internal var hasTriedDv7HevcFallback: Boolean = false
     internal var forceDv7ToHevc: Boolean = false
     internal var startupRetryCount: Int = 0
+    internal var hasRetriedCurrentStreamAfterUnexpectedNpe: Boolean = false
+    internal var hasRetriedCurrentStreamAfterMediaPeriodHolderCrash: Boolean = false
+    internal var timeoutRecoveryAttempts: Int = 0
     internal var errorRetryCount: Int = 0
     internal var consecutiveAutoPlayCount: Int = 0
     internal var errorRetryJob: Job? = null
     internal var stableProgressResetJob: Job? = null
+
+    internal val dv7ToHevcForcedStreamUrls: MutableSet<String> = mutableSetOf()
+    // Streams where manual Convert-to-DV8.1 mode 2 failed to play, so the next
+    // attempt is forced to libdovi mode 1 before falling back to HDR10 base layer.
+    internal val dv7Mode1ForcedStreamUrls: MutableSet<String> = mutableSetOf()
+    internal val vc1SoftwarePreferredStreamUrls: MutableSet<String> = mutableSetOf()
+    internal val vc1TrackSelectionBypassStreamUrls: MutableSet<String> = mutableSetOf()
+    internal val safeAudioForcedStreamUrls: MutableSet<String> = mutableSetOf()
+    internal val audioDisabledForcedStreamUrls: MutableSet<String> = mutableSetOf()
+    internal var isMapDv7ToHevcActiveForCurrentPlayback: Boolean = false
+    internal var isManualDv81Mode2ActiveForCurrentPlayback: Boolean = false
+    internal var isExperimentalDv7ToDv81ActiveForCurrentPlayback: Boolean = false
+    internal var isVc1SoftwareFallbackActiveForCurrentPlayback: Boolean = false
+    internal var isVc1TrackSelectionBypassActiveForCurrentPlayback: Boolean = false
+    internal var isSafeAudioModeActiveForCurrentPlayback: Boolean = false
+    internal var isAudioDisabledForCurrentPlayback: Boolean = false
+    internal var hasAttemptedDv7ToDv81ForCurrentPlayback: Boolean = false
+    internal var dv7ToDv81BridgeVersionForCurrentPlayback: String? = null
+    internal var dv7ToDv81LastProbeReasonForCurrentPlayback: String? = null
+
+    internal var playerInitializationStartedAtMs: Long = 0L
+    internal var pendingSeekTelemetryRequestedAtMs: Long = 0L
+    internal var pendingSeekTelemetryTargetMs: Long = -1L
+    internal var pendingSeekTelemetryReadyAtMs: Long = 0L
+    internal var pendingSeekTelemetryReadyLatencyMs: Long = -1L
+    internal var pendingSeekTelemetryAwaitingFirstFrame: Boolean = false
+    internal var pendingSeekTelemetryReadyAssumed: Boolean = false
+
     internal var currentScrobbleItem: TraktScrobbleItem? = null
     internal var currentTraktEpisodeMapping: EpisodeMappingEntry? = null
     internal var currentTraktEpisodeMappingKey: String? = null
@@ -372,6 +442,7 @@ class PlayerRuntimeController(
     internal var playbackPreparationJob: Job? = null
     internal var traktMappingJob: Job? = null
     internal var hasSentCompletionScrobbleForCurrentItem: Boolean = false
+
     internal var requestedUseLibassByUser: Boolean = false
     internal var libassPipelineOverrideForCurrentStream: Boolean? = null
     internal var activePlayerUsesLibass: Boolean = false
@@ -392,6 +463,17 @@ class PlayerRuntimeController(
                 }
             }.getOrNull()?.takeIf { it.isNotEmpty() }
         }
+
+    internal var currentStreamHasVideoTrack: Boolean = false
+    internal var currentVideoTrackIsLikelyVc1: Boolean = false
+    internal var currentVideoTrackMimeType: String? = null
+    internal var currentVideoTrackCodecs: String? = null
+    internal var currentVideoTrackWidth: Int = 0
+    internal var currentVideoTrackHeight: Int = 0
+    internal var currentVideoTrackColorTransfer: Int? = null
+    internal var currentVideoTrackSelected: Boolean = false
+    internal var currentVideoTrackBestSupport: Int = C.FORMAT_UNSUPPORTED_TYPE
+    internal var lastLoggedVideoTrackSignature: String? = null
 
     internal var episodeStreamsJob: Job? = null
     internal var episodeStreamsCacheRequestKey: String? = null
@@ -423,13 +505,47 @@ class PlayerRuntimeController(
             }
         }
     }
-    
 
     fun onCleared() {
         releasePlayer()
         stopTorrentStream()
+        vodTelemetryJob?.cancel()
         mediaSourceFactory.shutdown()
         sourceChipErrorDismissJob?.cancel()
+    }
+
+    // --- HELPER METHODS MOVED INSIDE THE CLASS ---
+
+
+
+    internal fun refreshScrobbleItem() {
+        val rawContentId = contentId ?: return
+        val parsedIds = parseContentIds(rawContentId)
+        val ids = toTraktIds(parsedIds)
+        val parsedYear = extractYear(year)
+        val normalizedType = contentType?.lowercase()
+
+        val isEpisode = normalizedType in listOf("series", "tv") &&
+                currentSeason != null && currentEpisode != null
+
+        currentScrobbleItem = if (isEpisode) {
+            TraktScrobbleItem.Episode(
+                showTitle = contentName ?: title,
+                showYear = parsedYear,
+                showIds = ids,
+                season = currentSeason ?: return,
+                number = currentEpisode ?: return,
+                episodeTitle = currentEpisodeTitle
+            )
+        } else {
+            TraktScrobbleItem.Movie(
+                title = contentName ?: title,
+                year = parsedYear,
+                ids = ids
+            )
+        }
+        hasSentScrobbleStartForCurrentItem = false
+        hasSentCompletionScrobbleForCurrentItem = false
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -2,17 +2,20 @@ package com.nuvio.tv.ui.screens.player
 
 import android.content.Context
 import android.content.res.Resources
+import android.media.audiofx.LoudnessEnhancer
+import android.net.Uri
 import android.os.Build
 import android.util.Log
-import com.nuvio.tv.R
 import android.view.accessibility.CaptioningManager
+import android.media.MediaFormat
+import android.os.Handler
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
-import androidx.media3.common.Tracks
 import androidx.media3.common.text.Cue
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
@@ -23,32 +26,52 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.ForwardingRenderer
 import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.AudioCapabilities
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
+import androidx.media3.exoplayer.video.VideoRendererEventListener
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.text.TextOutput
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
 import androidx.media3.extractor.ts.TsExtractor
 import androidx.media3.session.MediaSession
+import com.nuvio.tv.R
+import com.nuvio.tv.core.player.DolbyVisionCodecFallback
+import com.nuvio.tv.core.player.DolbyVisionBaseLayerPolicy
+import com.nuvio.tv.core.player.BitrateAwareLoadControl
+import com.nuvio.tv.core.player.DolbyVisionConversionConfig
+import com.nuvio.tv.core.player.DolbyVisionConversionStats
+import com.nuvio.tv.core.player.DolbyVisionExtractorsFactory
+import com.nuvio.tv.core.player.DoviBridge
+import com.nuvio.tv.core.player.LastPlaybackDiagnostics
+import com.nuvio.tv.ui.screens.settings.MemoryBudget
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioLanguageOption
-import com.nuvio.tv.data.local.SUBTITLE_LANGUAGE_FORCED
+import com.nuvio.tv.data.local.Dv7HandlingMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.SUBTITLE_LANGUAGE_FORCED
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.domain.model.Subtitle
+import io.github.peerless2012.ass.media.kt.buildWithAssSupport
 import io.github.peerless2012.ass.media.type.AssRenderType
-import android.os.Handler
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.net.SocketTimeoutException
+import kotlin.math.min
+import androidx.media3.common.Tracks
 
 private const val STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS = 20_000L
 private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
@@ -122,6 +145,8 @@ internal fun PlayerRuntimeController.initializePlayer(
             if (allowEngineFailover) {
                 startupEngineFailoverTriggered = false
             }
+            autoSubtitleSelected = false
+            hasScannedTextTracksOnce = false
             resetLoadingOverlayForNewStream()
             if (startPaused) {
                 userPausedManually = true
@@ -135,6 +160,12 @@ internal fun PlayerRuntimeController.initializePlayer(
             hasTriedDv7HevcFallback = false
             forceDv7ToHevc = false
             mpvDelayStartAfterAfrSwitch = false
+            playerInitializationStartedAtMs = System.currentTimeMillis()
+            // Reset per playback; only the ExoPlayer custom-buffer path sets a real value.
+            effectiveBackBufferDurationMs = 0
+            currentBitrateAwareLoadControl = null
+            configuredBackBufferMs = 0
+
             val playerSettings = playerSettingsDataStore.playerSettings.first()
             rememberAudioDelayPerDeviceEnabled = playerSettings.rememberAudioDelayPerDevice
             if (rememberAudioDelayPerDeviceEnabled) {
@@ -173,6 +204,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_detecting_format) else null
                 )
             }
+
             val afrJob = async {
                 runAfrPreflightIfEnabled(
                     url = url,
@@ -186,19 +218,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                 try {
                     afrJob.await()
                     if (mpvDelayStartAfterAfrSwitch) {
-                        Log.d(
-                            PlayerRuntimeController.TAG,
-                            "AFR display mode switched; delaying MPV start by ${MPV_AFR_SETTLE_DELAY_MS}ms"
-                        )
+                        Log.d(PlayerRuntimeController.TAG, "AFR display mode switched; delaying MPV start by ${MPV_AFR_SETTLE_DELAY_MS}ms")
                         delay(MPV_AFR_SETTLE_DELAY_MS)
                     }
-                    initializeMpvPlayer(
-                        url = url,
-                        headers = headers,
-                        allowEngineFailover = allowEngineFailover
-                    )
-                    // Keep addon subtitle discovery available on the mpv path too.
-                    // Exo does this later in this method, but this branch returns early.
+                    initializeMpvPlayer(url = url, headers = headers, allowEngineFailover = allowEngineFailover)
                     fetchAddonSubtitles()
                 } finally {
                     mpvInitializationInProgress = false
@@ -210,8 +233,254 @@ internal fun PlayerRuntimeController.initializePlayer(
                 headers = headers
             )
             mpvInitializationInProgress = false
+
+            // ── ExoPlayer Dolby Vision Logic (mode-driven via Dv7HandlingMode) ──
+            DoviBridge.resetRuntimeCounters()
+            DolbyVisionConversionStats.reset()
+            rebufferCount = 0
+            rebufferTotalMs = 0L
+            rebufferStartedAtMs = 0L
+
+            // Resolve effective DV7 mode — AUTO consults the display-capability policy.
+            // The persisted enum stays as-is; only the runtime behavior is derived per playback.
+            var effectiveDv7Mode: Dv7HandlingMode
+            val dv7AutoResult: DolbyVisionBaseLayerPolicy.Result?
+            when (playerSettings.dv7HandlingMode) {
+                Dv7HandlingMode.AUTO -> {
+                    val result = DolbyVisionBaseLayerPolicy.resolve(
+                        context = context,
+                        bridgeReady = DoviBridge.isLibraryLoaded
+                    )
+                    dv7AutoResult = result
+                    effectiveDv7Mode = when (result.decision) {
+                        DolbyVisionBaseLayerPolicy.Decision.NATIVE_DV7 -> Dv7HandlingMode.OFF
+                        DolbyVisionBaseLayerPolicy.Decision.CONVERT_TO_DV81 -> Dv7HandlingMode.DV81_LIBDOVI
+                        else -> Dv7HandlingMode.HDR10_BASE_LAYER
+                    }
+                    Log.i(
+                        PlayerRuntimeController.TAG,
+                        "DV7_AUTO: decision=${result.decision} " +
+                                "effectiveMode=$effectiveDv7Mode " +
+                                "hdrCapsKnown=${result.hdrCapsKnown} " +
+                                "displayDv=${result.displayDv} " +
+                                "displayHdr10=${result.displayHdr10} " +
+                                "displayHdr10Plus=${result.displayHdr10Plus} " +
+                                "codecDvheDtb=${result.codecSupportsDvheDtb} " +
+                                "bridgeReady=${result.bridgeReady} " +
+                                "api=${result.apiLevel} " +
+                                "host=${url.safeHost()}"
+                    )
+                }
+                else -> {
+                    dv7AutoResult = null
+                    effectiveDv7Mode = playerSettings.dv7HandlingMode
+                }
+            }
+
+            // Experimental: explicit libdovi conversion-mode override. Only applies
+            // when DV7 handling is Convert to DV8.1 (the modes are libdovi conversion
+            // modes, so they're only meaningful while conversion is active). Picks
+            // which conversion mode runs; -1 (None) uses the auto-selected mode.
+            val libdoviModeOverride = playerSettings.dv7LibdoviModeOverride
+            val libdoviModeOverrideActive = libdoviModeOverride in 0..4 &&
+                    playerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI &&
+                    effectiveDv7Mode == Dv7HandlingMode.DV81_LIBDOVI
+            if (libdoviModeOverrideActive) {
+                Log.i(
+                    PlayerRuntimeController.TAG,
+                    "DV7_LIBDOVI_OVERRIDE: forcing conversion mode=$libdoviModeOverride"
+                )
+            }
+
+            // DV7 to DV8.1 libdovi probe — only runs when the effective mode requests it.
+            val dv7ToDv81SettingActive = effectiveDv7Mode == Dv7HandlingMode.DV81_LIBDOVI
+            val dv7ToDv81Probe = if (dv7ToDv81SettingActive) {
+                DoviBridge.probeRealtimeConversionSupport(url)
+            } else {
+                val reason = when (effectiveDv7Mode) {
+                    Dv7HandlingMode.HDR10_BASE_LAYER -> "hdr10-base-layer-mode"
+                    Dv7HandlingMode.OFF -> "dv7-mode-off"
+                    Dv7HandlingMode.AUTO -> "auto-mode-no-dv81"  // unreachable; AUTO is collapsed above
+                    Dv7HandlingMode.DV81_LIBDOVI -> "setting-disabled"  // unreachable
+                }
+                DoviBridge.RealtimeConversionProbe(
+                    supported = false,
+                    reason = reason,
+                    bridgeVersion = DoviBridge.getBridgeVersionOrNull(),
+                    extractorHookReady = DoviBridge.isExtractorHookReadyInBuild,
+                    selfTest = DoviBridge.SelfTestResult(false, "not-run", 0, 0)
+                )
+            }
+            isExperimentalDv7ToDv81ActiveForCurrentPlayback = dv7ToDv81SettingActive && dv7ToDv81Probe.supported
+            // AUTO fallback: if AUTO chose DV81 but the probe failed for this stream,
+            // downgrade to HDR10_BASE_LAYER so the user still gets a picture.
+            if (playerSettings.dv7HandlingMode == Dv7HandlingMode.AUTO &&
+                effectiveDv7Mode == Dv7HandlingMode.DV81_LIBDOVI &&
+                !dv7ToDv81Probe.supported
+            ) {
+                effectiveDv7Mode = Dv7HandlingMode.HDR10_BASE_LAYER
+                Log.i(
+                    PlayerRuntimeController.TAG,
+                    "DV7_AUTO_FALLBACK: dv81-probe-failed reason=${dv7ToDv81Probe.reason} " +
+                            "fallback=HDR10_BASE_LAYER host=${url.safeHost()}"
+                )
+            }
+            hasAttemptedDv7ToDv81ForCurrentPlayback = false
+            dv7ToDv81BridgeVersionForCurrentPlayback = dv7ToDv81Probe.bridgeVersion
+            dv7ToDv81LastProbeReasonForCurrentPlayback = dv7ToDv81Probe.reason
+            Log.i(
+                PlayerRuntimeController.TAG,
+                "DV7_DOVI: mode=${playerSettings.dv7HandlingMode} " +
+                        "effectiveMode=$effectiveDv7Mode " +
+                        "dv81Active=$dv7ToDv81SettingActive " +
+                        "dv5Compat=${playerSettings.dv5ToDv81Enabled} " +
+                        "preserveMapping=${playerSettings.dv7ToDv81PreserveMappingEnabled} " +
+                        "buildNative=${DoviBridge.isNativeEnabledInBuild} " +
+                        "libraryLoaded=${DoviBridge.isLibraryLoaded} " +
+                        "extractorHookReady=${dv7ToDv81Probe.extractorHookReady} " +
+                        "active=${isExperimentalDv7ToDv81ActiveForCurrentPlayback} " +
+                        "reason=${dv7ToDv81Probe.reason} " +
+                        "selfTest=${dv7ToDv81Probe.selfTest.reason} " +
+                        "bridge=${dv7ToDv81Probe.bridgeVersion ?: "n/a"} " +
+                        "host=${url.safeHost()}"
+            )
+
+            // ── Diagnostics builder ──
+            // Built incrementally during init; written to DataStore on terminal events
+            // (first frame rendered = "Played", or final error display = "Error: ...").
+            var currentDiagnostics = LastPlaybackDiagnostics(
+                timestampMs = System.currentTimeMillis(),
+                host = url.safeHost(),
+                hdrCapsKnown = dv7AutoResult?.hdrCapsKnown ?: false,
+                displayDv = dv7AutoResult?.displayDv ?: false,
+                displayHdr10 = dv7AutoResult?.displayHdr10 ?: false,
+                displayHdr10Plus = dv7AutoResult?.displayHdr10Plus ?: false,
+                codecDv7Supported = dv7AutoResult?.codecSupportsDvheDtb ?: false,
+                dv81DecoderName = null,
+                bridgeReady = DoviBridge.isLibraryLoaded,
+                bridgeVersion = dv7ToDv81Probe.bridgeVersion,
+                bridgeReason = dv7ToDv81Probe.reason,
+                dv7ModeRequested = playerSettings.dv7HandlingMode.name,
+                dv7ModeEffective = effectiveDv7Mode.name,
+                dv7AutoDecision = dv7AutoResult?.decision?.name,
+                dvSourceProfile = null,
+                dv7DoviCalls = 0,
+                dv7DoviSuccess = 0,
+                dv7DoviSignalRewrites = 0,
+                bufferEngineEnabled = false,
+                parallelNetworkEnabled = false,
+                firstFrameMs = -1L,
+                result = "Pending"
+            )
+
+            // ── Buffer & Network ──
+            // Master toggles off => stock Media3 (DefaultLoadControl, single connection,
+            // no cache). DV7 to DV8.1 conversion runs libdovi off-heap, outside the heap
+            // budget; a large heap buffer on top of that is what pushed the Fire TV into the
+            // lowmemorykiller spiral, so for confirmed DV7 on low-RAM we drop the back buffer
+            // and shrink the budget at first frame (below).
+            val libdoviConversionActive = effectiveDv7Mode == Dv7HandlingMode.DV81_LIBDOVI
+            val loadControl = if (playerSettings.bufferEngineEnabled) {
+                val bufferSettings = playerSettings.bufferSettings
+                // Managed (default) caps the buffer at the device budget; off uses Target Buffer Size.
+                // Stay full here even on a DV display; first frame tightens only for confirmed DV7.
+                val budgetManaged = playerSettings.bufferBudgetManaged
+                val budgetMbEffective = if (budgetManaged) {
+                    MemoryBudget.budgetMb
+                } else {
+                    MemoryBudget.effectiveBufferMb(bufferSettings.targetBufferSizeMb)
+                        .coerceAtLeast(MemoryBudget.MIN_BUFFER_MB)
+                }
+                val budgetBytes = budgetMbEffective.toLong() * 1024L * 1024L
+                // Build with the user's back buffer so seek-back works immediately (it can't
+                // depend on the player re-polling the LoadControl). First frame only lowers it
+                // to 0 for confirmed DV7 on low-RAM; everything else keeps it.
+                configuredBackBufferMs = bufferSettings.backBufferDurationMs
+                val backBufferMsAtBuild = configuredBackBufferMs
+                Log.i(
+                    PlayerRuntimeController.TAG,
+                    "BUFFER_GATE: engine=exo-custom master=on " +
+                            "lowRam=${MemoryBudget.isLowRamTier} " +
+                            "allowLarge=${playerSettings.allowLargeTargetBuffer} " +
+                            "dv7conv=$libdoviConversionActive " +
+                            "managed=$budgetManaged " +
+                            "backBufferMsAtBuild=$backBufferMsAtBuild (set=$configuredBackBufferMs, lowered to 0 only for real DV7) " +
+                            "budgetMb=$budgetMbEffective host=${url.safeHost()}"
+                )
+                effectiveBackBufferDurationMs = backBufferMsAtBuild
+                BitrateAwareLoadControl(
+                    minBufferMs = bufferSettings.minBufferMs,
+                    maxBufferMs = bufferSettings.maxBufferMs,
+                    bufferForPlaybackMs = bufferSettings.bufferForPlaybackMs,
+                    bufferForPlaybackAfterRebufferMs = bufferSettings.bufferForPlaybackAfterRebufferMs,
+                    prioritizeTimeOverSizeThresholds = false,
+                    backBufferDurationMs = backBufferMsAtBuild,
+                    // Retain back to the keyframe before the boundary, else a backward seek
+                    // into the buffer has no keyframe to decode from and re-fetches. The
+                    // persisted setting defaults false and isn't exposed, so force it on.
+                    retainBackBufferFromKeyframe = true,
+                    budgetBytes = budgetBytes
+                ).also { currentBitrateAwareLoadControl = it }
+            } else {
+                // Stock LoadControl: DefaultLoadControl's back buffer is 0 by default.
+                effectiveBackBufferDurationMs = 0
+                currentBitrateAwareLoadControl = null
+                Log.i(
+                    PlayerRuntimeController.TAG,
+                    "BUFFER_GATE: engine=exo-stock master=off; DefaultLoadControl " +
+                            "(no back buffer, no VOD cache) host=${url.safeHost()}"
+                )
+                DefaultLoadControl.Builder().build()
+            }
+
+            // VOD cache sits under the buffer master in the UI, so gate it the same way at
+            // runtime (and off during conversion). Set explicitly every time so a stale
+            // value can't leave it running once the master is off.
+            val bufferEngineEffective = playerSettings.bufferEngineEnabled && !libdoviConversionActive
+            if (bufferEngineEffective) {
+                mediaSourceFactory.vodCacheEnabled = playerSettings.vodCacheEnabled
+                mediaSourceFactory.vodCacheSizeMode = playerSettings.vodCacheSizeMode
+                mediaSourceFactory.vodCacheSizeMb = playerSettings.vodCacheSizeMb
+            } else {
+                mediaSourceFactory.vodCacheEnabled = false
+            }
+
+            if (playerSettings.parallelNetworkEnabled && !libdoviConversionActive) {
+                mediaSourceFactory.useParallelConnections = playerSettings.useParallelConnections
+                mediaSourceFactory.parallelConnectionCount = playerSettings.parallelConnectionCount
+                mediaSourceFactory.parallelChunkSizeMb = playerSettings.parallelChunkSizeMb
+            } else {
+                // Reset each playback so the factory doesn't keep last stream's state; also
+                // off during conversion to avoid piling network buffers on the native cost.
+                mediaSourceFactory.useParallelConnections = false
+            }
+
+            // Log the effective state (post-gating), not the raw settings.
+            Log.i(
+                PlayerRuntimeController.TAG,
+                "BUFFER_NETWORK: bufferEngine=${playerSettings.bufferEngineEnabled} " +
+                        "parallelNetwork=${playerSettings.parallelNetworkEnabled} " +
+                        "useParallel=${mediaSourceFactory.useParallelConnections} " +
+                        "vodCache=${mediaSourceFactory.vodCacheEnabled} " +
+                        "host=${url.safeHost()}"
+            )
+
+            currentDiagnostics = currentDiagnostics.copy(
+                bufferEngineEnabled = playerSettings.bufferEngineEnabled && !libdoviConversionActive,
+                parallelNetworkEnabled = playerSettings.parallelNetworkEnabled && !libdoviConversionActive
+            )
+
+            val safeAudioModeEnabled = safeAudioForcedStreamUrls.contains(url)
+            val audioDisabledForStream = audioDisabledForcedStreamUrls.contains(url)
+            val vc1TrackSelectionBypassActive = vc1TrackSelectionBypassStreamUrls.contains(url)
+            isSafeAudioModeActiveForCurrentPlayback = safeAudioModeEnabled
+            isAudioDisabledForCurrentPlayback = audioDisabledForStream
+            isVc1TrackSelectionBypassActiveForCurrentPlayback = vc1TrackSelectionBypassActive
+
             val startupSubtitlePreparation = prepareStreamStartSubtitles(playerSettings, showLoadingStatus)
             afrJob.await()
+
+            // ── Libass Setup (From 0.5.7-beta/Left) ──
             requestedUseLibassByUser = playerSettings.useLibass
             val useLibass = when {
                 !requestedUseLibassByUser -> false
@@ -226,49 +495,39 @@ internal fun PlayerRuntimeController.initializePlayer(
                     libassRenderType = playerSettings.libassRenderType
                 )
             }
-            val loadControl = run {
-                DefaultLoadControl.Builder()
-                    .setTargetBufferBytes(100 * 1024 * 1024)
-                    .setBufferDurationsMs(
-                        DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-                        70_000,
-                        DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-                        5_000
-                    )
-                    .build()
-            }
 
-            
+            // ── Track Selector Setup ──
             trackSelector = DefaultTrackSelector(context).apply {
-                setParameters(
-                    buildUponParameters()
-                        .setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true)
-                )
-                if (playerSettings.tunnelingEnabled) {
+                setParameters(buildUponParameters().setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true))
+                if (playerSettings.tunnelingEnabled && !safeAudioModeEnabled) {
+                    setParameters(buildUponParameters().setTunnelingEnabled(true))
+                } else if (safeAudioModeEnabled) {
+                    setParameters(buildUponParameters().setTunnelingEnabled(false).setConstrainAudioChannelCountToDeviceCapabilities(true))
+                }
+                if (audioDisabledForStream) {
+                    setParameters(buildUponParameters().setDisabledTrackTypes(setOf(C.TRACK_TYPE_AUDIO)))
+                }
+                if (vc1TrackSelectionBypassActive) {
                     setParameters(
-                        buildUponParameters().setTunnelingEnabled(true)
+                        buildUponParameters()
+                            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, false)
+                            .setExceedVideoConstraintsIfNecessary(true)
+                            .setExceedRendererCapabilitiesIfNecessary(true)
+                            .setForceHighestSupportedBitrate(true)
                     )
                 }
 
                 if (preferredAudioLanguages.isNotEmpty()) {
-                    setParameters(
-                        buildUponParameters().setPreferredAudioLanguages(*preferredAudioLanguages.toTypedArray())
-                    )
+                    setParameters(buildUponParameters().setPreferredAudioLanguages(*preferredAudioLanguages.toTypedArray()))
                 }
 
-                
-                val appContext = this@initializePlayer.context
-                val captioningManager = appContext.getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+                val captioningManager = context?.getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
                 if (captioningManager != null) {
                     if (!captioningManager.isEnabled) {
-                        setParameters(
-                            buildUponParameters().setIgnoredTextSelectionFlags(C.SELECTION_FLAG_DEFAULT)
-                        )
+                        setParameters(buildUponParameters().setIgnoredTextSelectionFlags(C.SELECTION_FLAG_DEFAULT))
                     }
                     captioningManager.locale?.let { locale ->
-                        setParameters(
-                            buildUponParameters().setPreferredTextLanguage(locale.isO3Language)
-                        )
+                        setParameters(buildUponParameters().setPreferredTextLanguage(locale.isO3Language))
                     }
                 }
                 // When forced subtitles are disabled, tell ExoPlayer to ignore
@@ -283,22 +542,58 @@ internal fun PlayerRuntimeController.initializePlayer(
                 }
             }
 
-            
+            // ── Extractors & DV Hook ──
             val extractorsFactory = DefaultExtractorsFactory()
                 .setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
                 .setTsExtractorTimestampSearchBytes(1500 * TsExtractor.TS_PACKET_SIZE)
 
-            
+            // Manual Convert-to-DV8.1 uses mode 2; if a prior attempt at this stream
+            // failed to play, force mode 1 this time (before the HDR10 fallback).
+            val dv7Mode1Forced = dv7Mode1ForcedStreamUrls.contains(url)
+            val manualDv81Selected = playerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI
+            isManualDv81Mode2ActiveForCurrentPlayback =
+                manualDv81Selected &&
+                effectiveDv7Mode == Dv7HandlingMode.DV81_LIBDOVI &&
+                !libdoviModeOverrideActive &&
+                !dv7Mode1Forced
+            // DV7 conversion is handled app-side by DolbyVisionExtractorsFactory and the
+            // vendored Matroska extractor (wired into effectiveExtractorsFactory below).
+            if (isExperimentalDv7ToDv81ActiveForCurrentPlayback &&
+                dv7ToDv81LastProbeReasonForCurrentPlayback != "ready") {
+                dv7ToDv81LastProbeReasonForCurrentPlayback = "app-extractor-factory"
+            }
+
             audioDelayUs.set(_uiState.value.audioDelayMs.toLong() * 1000L)
             subtitleDelayUs.set(_uiState.value.subtitleDelayMs.toLong() * 1000L)
+
+            // ── Fallback Codec Setup ──
+            // mapDv7ToHevc is now driven by effective mode (HDR10_BASE_LAYER strips DV7),
+            // OR the error handler's per-stream override (preserved for retry-after-failure).
+            val mapDv7ToHevcEnabled = effectiveDv7Mode == Dv7HandlingMode.HDR10_BASE_LAYER ||
+                    dv7ToHevcForcedStreamUrls.contains(url)
+            //   DolbyVisionCompatibility.setMapDv7ToHevcEnabled(mapDv7ToHevcEnabled)
+            isMapDv7ToHevcActiveForCurrentPlayback = mapDv7ToHevcEnabled
+            val convertToDv81Active = !mapDv7ToHevcEnabled &&
+                    dv7AutoResult?.decision == DolbyVisionBaseLayerPolicy.Decision.CONVERT_TO_DV81
+            val codecSelector = createDolbyVisionFallbackCodecSelector(
+                convertToDv81Active = convertToDv81Active
+            )
+            val vc1SoftwareFallbackActive = vc1SoftwarePreferredStreamUrls.contains(url)
+            isVc1SoftwareFallbackActiveForCurrentPlayback = vc1SoftwareFallbackActive
+            val effectiveDecoderPriority = if (vc1SoftwareFallbackActive) {
+                DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER
+            } else {
+                playerSettings.decoderPriority
+            }
+
+            // ── Renderers Factory (Combining Libass offsets + Audio Gain + Video Fallback) ──
             val renderersFactory = SubtitleOffsetRenderersFactory(
                 context = context,
                 subtitleDelayUsProvider = subtitleDelayUs::get,
                 audioDelayUsProvider = audioDelayUs::get,
                 shouldNormalizeCuePositionProvider = {
                     val selectedAddonSubtitle = _uiState.value.selectedAddonSubtitle
-                    selectedAddonSubtitle != null &&
-                        PlayerSubtitleUtils.mimeTypeFromUrl(selectedAddonSubtitle.url) == MimeTypes.TEXT_VTT
+                    selectedAddonSubtitle != null && PlayerSubtitleUtils.mimeTypeFromUrl(selectedAddonSubtitle.url) == MimeTypes.TEXT_VTT
                 },
                 gainAudioProcessor = gainAudioProcessor,
                 downmixEnabled = playerSettings.downmixEnabled,
@@ -316,19 +611,53 @@ internal fun PlayerRuntimeController.initializePlayer(
                     applyCenterMixLevel(_uiState.value.centerMixLevelDb)
                     updateAudioControlAvailability()
                 }
-            ).setExtensionRendererMode(playerSettings.decoderPriority)
-                .setMapDV7ToHevc(playerSettings.mapDV7ToHevc || applyDv7FallbackOnStartup)
+            ).setExtensionRendererMode(effectiveDecoderPriority)
+                .setEnableDecoderFallback(true)
+                .setMediaCodecSelector(codecSelector)
+                .applyMapDv7ToHevcIfSupported(mapDv7ToHevcEnabled)
+
+            // The app-level factory performs DV7 conversion for the in-band-RPU containers
+            // (MP4/fMP4/TS); MKV goes through the vendored extractor. Pass-through for non-DV.
+            val effectiveExtractorsFactory: ExtractorsFactory =
+                if (isExperimentalDv7ToDv81ActiveForCurrentPlayback) {
+                    DolbyVisionExtractorsFactory(
+                        delegate = extractorsFactory,
+                        config = DolbyVisionConversionConfig(
+                            active = true,
+                            forcedMode = when {
+                                libdoviModeOverrideActive -> libdoviModeOverride
+                                dv7Mode1Forced -> 1
+                                else -> -1
+                            },
+                            // Manual-only; in AUTO the mode is auto-picked, so a stored value
+                            // must not override it.
+                            preserveMapping = playerSettings.dv7ToDv81PreserveMappingEnabled &&
+                                    manualDv81Selected,
+                            dv5Enabled = playerSettings.dv5ToDv81Enabled,
+                            manualDv81 = manualDv81Selected && !dv7Mode1Forced
+                        )
+                    )
+                } else {
+                    extractorsFactory
+                }
 
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
+            // ── Build ExoPlayer ──
             val buildDefaultPlayer = {
+                // The actual MediaSource is built by mediaSourceFactory.createMediaSource()
+                // (setMediaSource below), NOT the DefaultMediaSourceFactory on the builder.
+                // So the DV7 app-level factory must be wired in here, otherwise
+                // createMediaSource falls back to a plain DefaultExtractorsFactory and the
+                // conversion never runs. (The libass path wires it via buildWithAssSupportCompat.)
                 mediaSourceFactory.configureSubtitleParsing(
-                    extractorsFactory = null,
+                    extractorsFactory =
+                        if (isExperimentalDv7ToDv81ActiveForCurrentPlayback) effectiveExtractorsFactory else null,
                     subtitleParserFactory = null
                 )
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)
                     .setTrackSelector(trackSelector!!)
-                    .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
+                    .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, effectiveExtractorsFactory))
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
                     .setReleaseTimeoutMs(PLAYER_RELEASE_TIMEOUT_MS)
@@ -344,7 +673,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 ExoPlayer.Builder(context)
                     .setLoadControl(loadControl)
                     .setTrackSelector(trackSelector!!)
-                    .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, extractorsFactory))
+                    .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, effectiveExtractorsFactory))
                     .setReleaseTimeoutMs(PLAYER_RELEASE_TIMEOUT_MS)
                     .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
                     .buildWithAssSupportCompat(
@@ -352,7 +681,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         renderType = libassRenderType,
                         playerMediaSourceFactory = mediaSourceFactory,
                         dataSourceFactory = playerDataSourceFactory,
-                        extractorsFactory = extractorsFactory,
+                        extractorsFactory = effectiveExtractorsFactory,
                         renderersFactory = renderersFactory
                     )
             } else {
@@ -362,7 +691,6 @@ internal fun PlayerRuntimeController.initializePlayer(
             libassPipelineSwitchInFlight = false
 
             _exoPlayer?.apply {
-                
                 val audioAttributes = AudioAttributes.Builder()
                     .setUsage(C.USAGE_MEDIA)
                     .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
@@ -379,15 +707,9 @@ internal fun PlayerRuntimeController.initializePlayer(
                     hasTriedAudioPcmFallback = true
                 }
 
-                
-                if (playerSettings.skipSilence) {
-                    skipSilenceEnabled = true
-                }
-
-                
+                if (playerSettings.skipSilence) skipSilenceEnabled = true
                 setHandleAudioBecomingNoisy(true)
 
-                
                 try {
                     currentMediaSession?.release()
                     if (canAdvertiseSession()) {
@@ -401,7 +723,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                 applyAudioAmplification(_uiState.value.audioAmplificationDb)
                 applyCenterMixLevel(_uiState.value.centerMixLevelDb)
 
-                
                 notifyAudioSessionUpdate(true)
 
                 val preferred = playerSettings.subtitleStyle.preferredLanguage
@@ -409,6 +730,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 applySubtitlePreferences(preferred, secondary)
                 applyStartupSubtitlePreparation(startupSubtitlePreparation)
                 val startupSubtitleConfigurations = buildStartupSubtitleConfigurations(startupSubtitlePreparation)
+
                 setMediaSource(
                     mediaSourceFactory.createMediaSource(
                         context = context,
@@ -422,6 +744,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         mediaMetadata = buildMediaSessionMetadata()
                     )
                 )
+
                 if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }
                 val isTunneledPlayback = playerSettings.tunnelingEnabled
                 // Always start paused — playback begins in onRenderedFirstFrame()
@@ -439,18 +762,36 @@ internal fun PlayerRuntimeController.initializePlayer(
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         if (isReleasingPlayer) return
                         val playerDuration = duration
-                        if (playerDuration > lastKnownDuration) {
-                            lastKnownDuration = playerDuration
-                        }
+                        if (playerDuration > lastKnownDuration) { lastKnownDuration = playerDuration }
                         val isBuffering = playbackState == Player.STATE_BUFFERING
                         updatePlaybackTimeline(duration = playerDuration.coerceAtLeast(0L))
-                        _uiState.update { 
+                        _uiState.update {
                             it.copy(
                                 isBuffering = isBuffering,
                                 playbackEnded = playbackState == Player.STATE_ENDED
                             )
                         }
                         updateAudioControlAvailability()
+
+                        // Rebuffer telemetry: a rebuffer is STATE_BUFFERING entered
+                        // AFTER the first frame (initial startup buffering is excluded).
+                        // Accumulate time spent rebuffering; closed out on any non-buffering state.
+                        if (playbackState == Player.STATE_BUFFERING) {
+                            if (hasRenderedFirstFrame && rebufferStartedAtMs == 0L) {
+                                rebufferCount += 1
+                                rebufferStartedAtMs = System.currentTimeMillis()
+                                Log.i(
+                                    PlayerRuntimeController.TAG,
+                                    "REBUFFER: count=$rebufferCount totalRebufferMs=$rebufferTotalMs " +
+                                        "bufferEngine=${currentDiagnostics.bufferEngineEnabled} " +
+                                        "dv7dovi=${isExperimentalDv7ToDv81ActiveForCurrentPlayback} " +
+                                        "host=${currentStreamUrl.safeHost()}"
+                                )
+                            }
+                        } else if (rebufferStartedAtMs != 0L) {
+                            rebufferTotalMs += (System.currentTimeMillis() - rebufferStartedAtMs).coerceAtLeast(0L)
+                            rebufferStartedAtMs = 0L
+                        }
 
                         if (playbackState == Player.STATE_BUFFERING && !hasRenderedFirstFrame) {
                             _uiState.update { state ->
@@ -461,16 +802,28 @@ internal fun PlayerRuntimeController.initializePlayer(
                                 }
                             }
                         }
-                    
-                        
-                        if (playbackState == Player.STATE_READY) {
 
-                            
+                        // Arm stall watchdog while buffering.
+                        if (playbackState == Player.STATE_BUFFERING) {
+                            maybeScheduleStallWatchdog()
+                        } else {
+                            cancelStallWatchdog()
+                        }
+
+                        if (playbackState == Player.STATE_BUFFERING && pendingSeekTelemetryAwaitingFirstFrame && pendingSeekTelemetryReadyAssumed) {
+                            pendingSeekTelemetryReadyAtMs = 0L
+                            pendingSeekTelemetryReadyLatencyMs = -1L
+                            pendingSeekTelemetryReadyAssumed = false
+                        }
+
+                        if (playbackState == Player.STATE_READY) {
+                            if (pendingSeekTelemetryRequestedAtMs > 0L && pendingSeekTelemetryReadyAtMs <= 0L) {
+                                val latencyMs = (System.currentTimeMillis() - pendingSeekTelemetryRequestedAtMs).coerceAtLeast(0L)
+                                pendingSeekTelemetryReadyAtMs = System.currentTimeMillis()
+                                pendingSeekTelemetryReadyLatencyMs = latencyMs
+                            }
                             // Don't auto-play on the initial STATE_READY — wait
                             // for onRenderedFirstFrame() to ensure A/V sync.
-                            // After the first frame is visible, rebuffer events
-                            // can resume playback normally.
-                            //
                             // Exception: tunneled playback never fires
                             // onRenderedFirstFrame(), so we must start here.
                             if (shouldEnforceAutoplayOnFirstReady) {
@@ -501,15 +854,32 @@ internal fun PlayerRuntimeController.initializePlayer(
                                 seekTo(position)
                                 _uiState.update { it.copy(pendingSeekPosition = null) }
                             }
-                            // Re-evaluate subtitle auto-selection once player is ready.
                             tryAutoSelectPreferredSubtitleFromAvailableTracks()
-
                             trackSelectionParameters = trackSelectionParameters.buildUpon().build()
+                            maybeScheduleFirstFrameWatchdog()
+                        } else if (playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE) {
+                            cancelFirstFrameWatchdog()
                         }
-                    
-                        
+
                         if (playbackState == Player.STATE_ENDED) {
-                            emitCompletionScrobbleStop(progressPercent = 99.5f)
+                            // emitCompletionScrobbleStop(progressPercent = 99.5f)
+                            // Re-persist diagnostics with the final rebuffer totals (the
+                            // first-frame snapshot captured 0, since rebuffers accrue after).
+                            Log.i(
+                                PlayerRuntimeController.TAG,
+                                "BUFFER_SUMMARY: rebuffers=$rebufferCount rebufferTotalMs=$rebufferTotalMs " +
+                                    "bufferEngine=${currentDiagnostics.bufferEngineEnabled} host=${currentStreamUrl.safeHost()}"
+                            )
+                            if (currentDiagnostics.result == "Played") {
+                                currentDiagnostics = currentDiagnostics.copy(
+                                    rebufferCount = rebufferCount,
+                                    rebufferTotalMs = rebufferTotalMs
+                                )
+                                val endDiagnostics = currentDiagnostics
+                                scope.launch {
+                                    runCatching { playerSettingsDataStore.setLastPlaybackDiagnostics(endDiagnostics) }
+                                }
+                            }
                             saveWatchProgress()
                             resetPostPlayStateAfterPlaybackEnded()
                         }
@@ -526,13 +896,9 @@ internal fun PlayerRuntimeController.initializePlayer(
                             startWatchProgressSaving()
                             scheduleHideControls()
                             tryShowParentalGuide()
-                            emitScrobbleStart()
+                            //  emitScrobbleStart()
                         } else {
-                            if (userPausedManually) {
-                                schedulePauseOverlay()
-                            } else {
-                                cancelPauseOverlay()
-                            }
+                            if (userPausedManually) schedulePauseOverlay() else cancelPauseOverlay()
                             stopProgressUpdates()
                             stopWatchProgressSaving()
                             if (playbackState != Player.STATE_BUFFERING) {
@@ -549,6 +915,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     }
 
                     override fun onRenderedFirstFrame() {
+                        val isFirstFrame = !hasRenderedFirstFrame  // capture BEFORE flipping
                         hasRenderedFirstFrame = true
                         updateAudioControlAvailability()
                         // Start playback now that the first video frame is
@@ -563,73 +930,233 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (hasTriedAudioPcmFallback) {
                             _exoPlayer?.playbackParameters = PlaybackParameters(1f)
                         }
+                        cancelFirstFrameWatchdog()
                         _uiState.update {
                             it.copy(
                                 showLoadingOverlay = false,
                                 loadingMessage = null,
-                                // Snap the loading-logo fill to 100% so the logo
-                                // appears fully filled as the overlay fades out
-                                // (rather than freezing at the partial buffer %).
                                 loadingProgress = if (it.loadingProgress != null) 1f else null,
                                 showPlayerEngineSwitchInfo = false
                             )
                         }
+
+                        val startupMs = (System.currentTimeMillis() - playerInitializationStartedAtMs).coerceAtLeast(0L)
+                        val conversionCalls = DoviBridge.getConversionCallCount()
+                        val conversionSucceeded = DoviBridge.getConversionSuccessCount()
+                        val signalingRewrites = DolbyVisionConversionStats.getCodecStringRewriteCount()
+                        val sourceProfile = DolbyVisionConversionStats.getLastSourceProfile()
+                            ?: parseDvProfileFromCodecString(currentVideoTrackCodecs)
+                        val conversionMode = DolbyVisionConversionStats.getLastSelectedConversionMode()
+                        val conversionAttempted = hasAttemptedDv7ToDv81ForCurrentPlayback || conversionCalls > 0 || signalingRewrites > 0
+                        if (pendingSeekTelemetryAwaitingFirstFrame && pendingSeekTelemetryRequestedAtMs > 0L) {
+                            pendingSeekTelemetryRequestedAtMs = 0L
+                            pendingSeekTelemetryTargetMs = -1L
+                            pendingSeekTelemetryReadyAtMs = 0L
+                            pendingSeekTelemetryReadyLatencyMs = -1L
+                            pendingSeekTelemetryAwaitingFirstFrame = false
+                        }
+                        if (isFirstFrame) {
+                            Log.i(PlayerRuntimeController.TAG, "PLAYBACK_STARTUP: firstFrameMs=$startupMs dv7doviActive=$isExperimentalDv7ToDv81ActiveForCurrentPlayback dv7doviAttempted=$conversionAttempted dvSourceProfile=${sourceProfile ?: "n/a"} dvConvertMode=${conversionMode ?: "n/a"} dv7doviSignalRewrites=$signalingRewrites dv7doviCalls=$conversionCalls dv7doviSuccess=$conversionSucceeded dv7doviReason=${dv7ToDv81LastProbeReasonForCurrentPlayback ?: "n/a"} dv7doviBridge=${dv7ToDv81BridgeVersionForCurrentPlayback ?: "n/a"} dv7hevcActive=$isMapDv7ToHevcActiveForCurrentPlayback host=${currentStreamUrl.safeHost()}")
+
+                            // Real DV7 only if a conversion actually succeeded (or a DV profile
+                            // / codec rewrite was seen). Don't use conversionCalls: the startup
+                            // self-test fires one failing call on every playback, so calls is
+                            // always >= 1. Drives the "Dolby Vision" label and the DV7 memory cap.
+                            val dvConversionOccurred = conversionSucceeded > 0 ||
+                                signalingRewrites > 0 ||
+                                sourceProfile != null
+
+                            // Now that we know if it's really DV7: keep the back buffer at 0 for
+                            // DV7 on low-RAM (off-heap conversion memory), otherwise hand back the
+                            // user's value (covers non-DV content that merely armed conversion).
+                            currentBitrateAwareLoadControl?.let { lc ->
+                                // Signal-only DV5 runs no libdovi conversion (sourceProfile 5 with
+                                // no successful calls), so it needs no off-heap headroom. Only real
+                                // RPU conversion (DV7, or forced-mode DV5) warrants the cap.
+                                // Cap only when libdovi actually converted (off-heap memory); stripped
+                                // DV7 / native DV / signal-only DV5 leave success at 0. Off trusts the user.
+                                val budgetManaged = playerSettings.bufferBudgetManaged
+                                val keepZeroForDv7 = budgetManaged && conversionSucceeded > 0L &&
+                                        MemoryBudget.isLowRamTier
+                                val resolvedBackBufferMs = if (keepZeroForDv7) 0 else configuredBackBufferMs
+                                if (resolvedBackBufferMs != effectiveBackBufferDurationMs) {
+                                    lc.setBackBufferDurationOverrideMs(resolvedBackBufferMs)
+                                    effectiveBackBufferDurationMs = resolvedBackBufferMs
+                                }
+                                // DV7 on low-RAM: also drop to the conversion budget (takes
+                                // effect on the next track reselection) for off-heap headroom.
+                                if (keepZeroForDv7) {
+                                    lc.setBudgetBytesOverride(
+                                        MemoryBudget.conversionBudgetMb.toLong() * 1024L * 1024L
+                                    )
+                                }
+                                Log.i(
+                                    PlayerRuntimeController.TAG,
+                                    "BACK_BUFFER_RESOLVED: dvConversion=$dvConversionOccurred " +
+                                            "lowRam=${MemoryBudget.isLowRamTier} " +
+                                            "resolvedBackBufferMs=$resolvedBackBufferMs " +
+                                            "managed=$budgetManaged " +
+                                            "budgetMb=${when {
+                                                keepZeroForDv7 -> MemoryBudget.conversionBudgetMb
+                                                budgetManaged -> MemoryBudget.budgetMb
+                                                else -> MemoryBudget.effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
+                                            }} " +
+                                            "host=${currentStreamUrl.safeHost()}"
+                                )
+                            }
+                            val finalDiagnostics = currentDiagnostics.copy(
+                                firstFrameMs = startupMs,
+                                dv7DoviCalls = conversionCalls.toInt(),
+                                dv7DoviSuccess = conversionSucceeded.toInt(),
+                                dv7DoviSignalRewrites = signalingRewrites.toInt(),
+                                dvSourceProfile = sourceProfile?.toString(),
+                                videoResolution = if (currentVideoTrackWidth > 0 && currentVideoTrackHeight > 0)
+                                    "${currentVideoTrackWidth}x${currentVideoTrackHeight}" else null,
+                                videoCodec = friendlyVideoCodecName(currentVideoTrackMimeType, currentVideoTrackCodecs),
+                                videoHdrType = friendlyVideoHdrType(
+                                    currentVideoTrackMimeType,
+                                    currentVideoTrackColorTransfer,
+                                    currentDiagnostics.dv7ModeEffective,
+                                    dvConversionOccurred
+                                ),
+                                rebufferCount = rebufferCount,
+                                rebufferTotalMs = rebufferTotalMs,
+                                result = "Played"
+                            )
+                            // Keep currentDiagnostics in sync so the playback-end
+                            // re-persist (below) captures the final rebuffer totals.
+                            currentDiagnostics = finalDiagnostics
+                            scope.launch {
+                                runCatching {
+                                    playerSettingsDataStore.setLastPlaybackDiagnostics(finalDiagnostics)
+                                }
+                            }
+                        }
                     }
 
                     override fun onPlayerError(error: PlaybackException) {
-                        if (isReleasingPlayer && error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) {
-                            return
+                        if (isReleasingPlayer && error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) return
+                        cancelFirstFrameWatchdog()
+                        val detailedError = buildString {
+                            append(error.message ?: "Playback error")
+                            val cause = error.cause
+                            if (cause is androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException) {
+                                append(" (HTTP ${cause.responseCode})")
+                            } else if (cause != null) append(": ${cause.message}")
+                            append(" [${error.errorCode}]")
                         }
                         cancelStableProgressReset()
-                        val detailedError = error.toDisplayMessage(context)
 
-                        // If the codec crashed while the app is in the background (e.g. another
-                        // app reclaimed the hardware decoder), don't run the retry chain — each
-                        // retry can further corrupt vendor codec state and may resume playback
-                        // in background. Save position, free resources, and rebuild on resume.
-                        if (isInBackground && isRetryablePlaybackError(error)) {
-                            val savedPosition = currentPosition.takeIf { it > 0L } ?: 0L
-                            backgroundCrashSavedPositionMs = savedPosition
-                            pendingBackgroundCrashRecovery = true
-                            errorRetryJob?.cancel()
-                            errorRetryJob = scope.launch {
-                                releasePlayer(flushPlaybackState = false)
+                        // Error handlers: DV codec failures, audio decoder issues, codec state errors.
+                        if (error.isDolbyVisionDecoderFailure() && !isMapDv7ToHevcActiveForCurrentPlayback) {
+                            // Manual Convert-to-DV8.1 mode 2 failed to decode: try
+                            // libdovi mode 1 once before falling back to HDR10.
+                            if (isManualDv81Mode2ActiveForCurrentPlayback &&
+                                !dv7Mode1ForcedStreamUrls.contains(currentStreamUrl)
+                            ) {
+                                dv7Mode1ForcedStreamUrls.add(currentStreamUrl)
+                                Log.i(
+                                    PlayerRuntimeController.TAG,
+                                    "DV7_MODE2_PLAYBACK_FALLBACK: mode 2 decode failed; " +
+                                            "retrying stream at mode 1 host=${currentStreamUrl.safeHost()}"
+                                )
+                                retryCurrentStreamWithDv7Mode1Fallback(currentPosition)
+                                return
                             }
+                            if (isExperimentalDv7ToDv81ActiveForCurrentPlayback && !hasAttemptedDv7ToDv81ForCurrentPlayback) {
+                                hasAttemptedDv7ToDv81ForCurrentPlayback = true
+                                val probe = DoviBridge.probeRealtimeConversionSupport(currentStreamUrl)
+                                dv7ToDv81LastProbeReasonForCurrentPlayback = probe.reason
+                                dv7ToDv81BridgeVersionForCurrentPlayback = probe.bridgeVersion
+                            }
+                            dv7ToHevcForcedStreamUrls.add(currentStreamUrl)
+                            retryCurrentStreamWithDolbyVisionFallback(currentPosition)
                             return
                         }
 
-                        val responseCode = error.findInvalidResponseCodeException()?.responseCode
+                        if (error.isAudioTrackInitializationFailure()) {
+                            if (!isSafeAudioModeActiveForCurrentPlayback) {
+                                safeAudioForcedStreamUrls.add(currentStreamUrl)
+                                retryCurrentStreamWithSafeAudioFallback(currentPosition)
+                                return
+                            }
+                            if (!isAudioDisabledForCurrentPlayback) {
+                                audioDisabledForcedStreamUrls.add(currentStreamUrl)
+                                retryCurrentStreamWithAudioDisabled(currentPosition)
+                                return
+                            }
+                        }
+
+                        if (error.isStuckPlayingNoProgress()) {
+                            if (!isSafeAudioModeActiveForCurrentPlayback) {
+                                safeAudioForcedStreamUrls.add(currentStreamUrl)
+                                retryCurrentStreamWithSafeAudioFallback(currentPosition)
+                                return
+                            }
+                            if (!isAudioDisabledForCurrentPlayback) {
+                                audioDisabledForcedStreamUrls.add(currentStreamUrl)
+                                retryCurrentStreamWithAudioDisabled(currentPosition)
+                                return
+                            }
+                        }
+
+                        val timeoutError = error.findCause<SocketTimeoutException>()
+                        if (timeoutError != null && timeoutRecoveryAttempts < PlayerRuntimeController.MAX_TIMEOUT_RECOVERY_ATTEMPTS) {
+                            retryCurrentStreamAfterTimeout(currentPosition)
+                            return
+                        }
+
+                        if (error.isUnexpectedLoaderNullPointer() && !hasRetriedCurrentStreamAfterUnexpectedNpe) {
+                            hasRetriedCurrentStreamAfterUnexpectedNpe = true
+                            retryCurrentStreamAfterUnexpectedNpe(currentPosition)
+                            return
+                        }
+
+                        if (error.isMediaPeriodHolderStateCrash() && !hasRetriedCurrentStreamAfterMediaPeriodHolderCrash) {
+                            hasRetriedCurrentStreamAfterMediaPeriodHolderCrash = true
+                            retryCurrentStreamAfterMediaPeriodHolderCrash(currentPosition)
+                            return
+                        }
+
+                        val responseCode = (error.cause as? androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException)?.responseCode
                         if (responseCode == 416 && !hasRetriedCurrentStreamAfter416) {
                             retryCurrentStreamFromStartAfter416()
                             return
                         }
-                        if (maybeAutoSwitchInternalPlayerOnStartupError(
-                                detailedError = detailedError,
-                                allowEngineFailover = allowEngineFailover
-                            )
-                        ) {
+
+                        // ── Main Engine Failover ──
+                        if (maybeAutoSwitchInternalPlayerOnStartupError(detailedError = detailedError, allowEngineFailover = allowEngineFailover)) {
                             return
                         }
-                        // Attempt automatic recovery for transient errors.
-                        if (tryAudioTrackPcmFallback(error)) {
+                        if (attemptAutoRetry(error, detailedError)) {
                             return
                         }
-                        if (tryDv7HevcFallback(error)) {
-                            return
+
+                        val errorDiagnostics = currentDiagnostics.copy(
+                            result = "Error: $detailedError"
+                        )
+                        scope.launch {
+                            runCatching {
+                                playerSettingsDataStore.setLastPlaybackDiagnostics(errorDiagnostics)
+                            }
                         }
-                        if (attemptStartupRecovery(error, detailedError)) {
-                            return
-                        }
-                        if (hasRenderedFirstFrame && attemptAutoRetry(error, detailedError)) {
-                            return
-                        }
-                        _uiState.update {
-                            it.copy(
-                                error = detailedError,
-                                showLoadingOverlay = false,
-                                showPauseOverlay = false
-                            )
-                        }
+
+                        _uiState.update { it.copy(error = detailedError, showLoadingOverlay = false, showPauseOverlay = false) }
+                    }
+                })
+
+                addAnalyticsListener(object : androidx.media3.exoplayer.analytics.AnalyticsListener {
+                    override fun onVideoDecoderInitialized(
+                        eventTime: androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime,
+                        decoderName: String,
+                        initializedTimestampMs: Long,
+                        initializationDurationMs: Long
+                    ) {
+                        currentDiagnostics = currentDiagnostics.copy(dv81DecoderName = decoderName)
+                        Log.i(
+                            PlayerRuntimeController.TAG,
+                            "VIDEO_DECODER: name=$decoderName initMs=$initializationDurationMs host=${currentStreamUrl.safeHost()}"
+                        )
                     }
                 })
             }
@@ -687,11 +1214,7 @@ internal fun resolvePreferredAudioLanguages(
     contentOriginalLanguage: String? = null
 ): List<String> {
     fun normalize(language: String?): String? {
-        val normalized = language
-            ?.trim()
-            ?.lowercase()
-            ?.takeIf { it.isNotBlank() }
-            ?: return null
+        val normalized = language?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return null
         return when (normalized) {
             AudioLanguageOption.DEFAULT,
             AudioLanguageOption.DEVICE,
@@ -771,16 +1294,9 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
     }
 
     val preferredTargets = when (PlayerSubtitleUtils.normalizeLanguageCode(preferredLanguage)) {
-        "none" -> listOfNotNull(
-            secondaryLanguage
-                ?.takeIf { it.isNotBlank() }
-        )
-        else -> listOfNotNull(
-            preferredLanguage,
-            secondaryLanguage?.takeIf { it.isNotBlank() }
-        )
-    }.map { PlayerSubtitleUtils.normalizeLanguageCode(it) }
-        .distinct()
+        "none" -> listOfNotNull(secondaryLanguage?.takeIf { it.isNotBlank() })
+        else -> listOfNotNull(preferredLanguage, secondaryLanguage?.takeIf { it.isNotBlank() })
+    }.map { PlayerSubtitleUtils.normalizeLanguageCode(it) }.distinct()
 
     if (effectiveMode == AddonSubtitleStartupMode.PREFERRED_ONLY && preferredTargets.isEmpty()) {
         return StartupSubtitlePreparation(
@@ -805,19 +1321,11 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
                 _uiState.update { it.copy(loadingMessage = msg) }
             } else null
         )
-    } ?: return StartupSubtitlePreparation(
-        fetchedSubtitles = emptyList(),
-        attachedSubtitles = emptyList(),
-        fetchCompleted = false
-    )
+    } ?: return StartupSubtitlePreparation(emptyList(), emptyList(), false)
 
     val attachedSubtitles = when (effectiveMode) {
         AddonSubtitleStartupMode.ALL_SUBTITLES -> fetchedSubtitles
-        AddonSubtitleStartupMode.PREFERRED_ONLY -> fetchedSubtitles.filter { subtitle ->
-            preferredTargets.any { target ->
-                PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, target)
-            }
-        }
+        AddonSubtitleStartupMode.PREFERRED_ONLY -> fetchedSubtitles.filter { subtitle -> preferredTargets.any { target -> PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, target) } }
         AddonSubtitleStartupMode.FAST_STARTUP -> emptyList()
     }
 
@@ -831,14 +1339,6 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
 }
 
 internal fun PlayerRuntimeController.resetAddonSubtitleStateForNewStream() {
-    logSwitchTrace(
-        stage = "reset-addon-state-new-stream",
-        message = "autoSubtitleSelectedBefore=$autoSubtitleSelected " +
-            "subtitleDisabledByPersistedPreference=$subtitleDisabledByPersistedPreference " +
-            "subtitleAddonRestoredByPersistedPreference=$subtitleAddonRestoredByPersistedPreference " +
-            "explicitSelectionBefore=${explicitSubtitleSelectionForEngineSwitch?.selection?.javaClass?.simpleName ?: "none"} " +
-            "effectiveSelectionBefore=${effectiveSubtitleSelectionForEngineSwitch?.selection?.javaClass?.simpleName ?: "none"}"
-    )
     autoSubtitleSelected = subtitleDisabledByPersistedPreference || subtitleAddonRestoredByPersistedPreference
     hasScannedTextTracksOnce = false
     pendingAddonSubtitleLanguage = null
@@ -847,10 +1347,6 @@ internal fun PlayerRuntimeController.resetAddonSubtitleStateForNewStream() {
     explicitSubtitleSelectionForEngineSwitch = null
     effectiveSubtitleSelectionForEngineSwitch = null
     attachedAddonSubtitleKeys = emptySet()
-    logSwitchTrace(
-        stage = "reset-addon-state-new-stream",
-        message = "autoSubtitleSelectedAfter=$autoSubtitleSelected explicitSelectionAfter=none effectiveSelectionAfter=none"
-    )
     _uiState.update {
         it.copy(
             addonSubtitles = emptyList(),
@@ -883,37 +1379,52 @@ internal suspend fun PlayerRuntimeController.prepareStreamStartSubtitles(
     )
 }
 
-internal fun PlayerRuntimeController.applyStartupSubtitlePreparation(
-    startupSubtitlePreparation: StartupSubtitlePreparation
-) {
-    attachedAddonSubtitleKeys = startupSubtitlePreparation.attachedSubtitles
-        .distinctBy { addonSubtitleKey(it) }
-        .map(::addonSubtitleKey)
-        .toSet()
+internal fun PlayerRuntimeController.applyStartupSubtitlePreparation(startupSubtitlePreparation: StartupSubtitlePreparation) {
+    attachedAddonSubtitleKeys = startupSubtitlePreparation.attachedSubtitles.distinctBy { addonSubtitleKey(it) }.map(::addonSubtitleKey).toSet()
     if (!startupSubtitlePreparation.fetchCompleted) return
-
-    _uiState.update {
-        it.copy(
-            addonSubtitles = startupSubtitlePreparation.fetchedSubtitles,
-            isLoadingAddonSubtitles = false,
-            addonSubtitlesError = null
-        )
-    }
+    _uiState.update { it.copy(addonSubtitles = startupSubtitlePreparation.fetchedSubtitles, isLoadingAddonSubtitles = false, addonSubtitlesError = null) }
 }
 
-internal fun PlayerRuntimeController.buildStartupSubtitleConfigurations(
-    startupSubtitlePreparation: StartupSubtitlePreparation
-): List<androidx.media3.common.MediaItem.SubtitleConfiguration> {
-    return startupSubtitlePreparation.attachedSubtitles
-        .distinctBy { "${it.id}|${it.url}" }
-        .map(::toSubtitleConfiguration)
+internal fun PlayerRuntimeController.buildStartupSubtitleConfigurations(startupSubtitlePreparation: StartupSubtitlePreparation): List<androidx.media3.common.MediaItem.SubtitleConfiguration> {
+    return startupSubtitlePreparation.attachedSubtitles.distinctBy { "${it.id}|${it.url}" }.map(::toSubtitleConfiguration)
 }
 
 internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
+    cancelFirstFrameWatchdog()
+    cancelStallWatchdog()
     hasRenderedFirstFrame = false
     shouldEnforceAutoplayOnFirstReady = true
     userPausedManually = false
+    timeoutRecoveryAttempts = 0
+    hasRetriedCurrentStreamAfterUnexpectedNpe = false
+    hasRetriedCurrentStreamAfterMediaPeriodHolderCrash = false
+    hasRetriedCurrentStreamAfter416 = false
+    hasAttemptedDv7ToDv81ForCurrentPlayback = false
+    isExperimentalDv7ToDv81ActiveForCurrentPlayback = false
+    isVc1SoftwareFallbackActiveForCurrentPlayback = false
+    isVc1TrackSelectionBypassActiveForCurrentPlayback = false
+    isSafeAudioModeActiveForCurrentPlayback = false
+    isAudioDisabledForCurrentPlayback = false
+    dv7ToDv81BridgeVersionForCurrentPlayback = null
+    dv7ToDv81LastProbeReasonForCurrentPlayback = null
+    playerInitializationStartedAtMs = 0L
+    pendingSeekTelemetryRequestedAtMs = 0L
+    pendingSeekTelemetryTargetMs = -1L
+    pendingSeekTelemetryReadyAtMs = 0L
+    pendingSeekTelemetryReadyLatencyMs = -1L
+    pendingSeekTelemetryAwaitingFirstFrame = false
+    pendingSeekTelemetryReadyAssumed = false
     lastKnownDuration = 0L
+    currentStreamHasVideoTrack = false
+    currentVideoTrackIsLikelyVc1 = false
+    currentVideoTrackMimeType = null
+    currentVideoTrackCodecs = null
+    currentVideoTrackWidth = 0
+    currentVideoTrackHeight = 0
+    currentVideoTrackColorTransfer = null
+    currentVideoTrackSelected = false
+    currentVideoTrackBestSupport = C.FORMAT_UNSUPPORTED_TYPE
+    lastLoggedVideoTrackSignature = null
     _uiState.update { state ->
         state.copy(
             showLoadingOverlay = state.loadingOverlayEnabled,
@@ -922,6 +1433,8 @@ internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
         )
     }
 }
+
+// ── CUSTOM RENDERERS FOR AUDIO/SUBTITLES ──
 
 private class SubtitleOffsetRenderersFactory(
     context: Context,
@@ -981,7 +1494,7 @@ private class SubtitleOffsetRenderersFactory(
                 ?: startIndex
             out[mediaCodecAudioRendererIndex] =
                 PlaybackSpeedAwareAudioRenderer(
-                    context = context,
+                    rendererContext = context,
                     codecAdapterFactory = getCodecAdapterFactory(),
                     mediaCodecSelector = mediaCodecSelector,
                     enableDecoderFallback = enableDecoderFallback,
@@ -1129,4 +1642,192 @@ private class SubtitleOffsetRenderer(
         
         super.render(adjustedPositionUs, elapsedRealtimeUs)
     }
+}
+
+private inline fun <reified T : Throwable> Throwable.findCause(): T? {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is T) return current
+        current = current.cause
+    }
+    return null
+}
+
+private fun PlaybackException.isDolbyVisionDecoderFailure(): Boolean {
+    if (errorCode != PlaybackException.ERROR_CODE_DECODING_FAILED) return false
+    val details = buildString {
+        append(message ?: "")
+        append(' ')
+        append(cause?.message ?: "")
+        append(' ')
+        append(cause?.cause?.message ?: "")
+    }
+    return details.contains("dolby-vision", ignoreCase = true) && details.contains("decoder failed", ignoreCase = true)
+}
+
+private fun PlaybackException.isUnexpectedLoaderNullPointer(): Boolean {
+    if (errorCode != PlaybackException.ERROR_CODE_IO_UNSPECIFIED) return false
+    val details = buildString {
+        append(message ?: "")
+        append(' ')
+        append(cause?.message ?: "")
+        append(' ')
+        append(cause?.cause?.message ?: "")
+    }
+    return details.contains("unexpected nullpointerexception", ignoreCase = true) ||
+            (details.contains("nullpointerexception", ignoreCase = true) && details.contains("matroskaextractor", ignoreCase = true))
+}
+
+private fun PlaybackException.isAudioTrackInitializationFailure(): Boolean {
+    if (errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED) return true
+    val details = buildString {
+        append(message ?: "")
+        append(' ')
+        append(cause?.message ?: "")
+        append(' ')
+        append(cause?.cause?.message ?: "")
+    }
+    return details.contains("audiotrack init failed", ignoreCase = true)
+}
+
+private fun PlaybackException.isStuckPlayingNoProgress(): Boolean {
+    if (errorCode != PlaybackException.ERROR_CODE_TIMEOUT) return false
+    val details = buildString {
+        append(message ?: "")
+        append(' ')
+        append(cause?.message ?: "")
+        append(' ')
+        append(cause?.cause?.message ?: "")
+    }
+    return details.contains("stuck playing with no progress", ignoreCase = true)
+}
+
+private fun PlaybackException.isMediaPeriodHolderStateCrash(): Boolean {
+    if (errorCode != PlaybackException.ERROR_CODE_UNSPECIFIED) return false
+    val details = buildString {
+        append(message ?: "")
+        append(' ')
+        append(cause?.message ?: "")
+        append(' ')
+        append(cause?.cause?.message ?: "")
+    }
+    return details.contains("mediaperiodholder", ignoreCase = true) && details.contains(".info", ignoreCase = true) && details.contains("null", ignoreCase = true)
+}
+
+private fun String.safeHost(): String {
+    return runCatching { Uri.parse(this).host ?: "unknown" }.getOrDefault("unknown")
+}
+
+/**
+ * Parses the DV profile number from a codec string, e.g. "dvhe.07.06" gives 7.
+ * Used as a fallback when libdovi bridge hasn't loaded (e.g. HDR10_BASE_LAYER
+ * mode strips DV before the bridge runs, so its source-profile detector
+ * never sees the stream).
+ */
+private fun parseDvProfileFromCodecString(codecs: String?): Int? {
+    if (codecs.isNullOrBlank()) return null
+    val match = Regex("^(?:dvhe|dvav|dvh1|dva1)\\.(\\d+)\\.").find(codecs.trim().lowercase()) ?: return null
+    return match.groupValues[1].toIntOrNull()
+}
+
+/** Human-friendly codec name for the diagnostics card. */
+private fun friendlyVideoCodecName(mimeType: String?, codecs: String?): String? {
+    val mime = mimeType?.lowercase()
+    return when {
+        mime == null -> null
+        mime == MimeTypes.VIDEO_DOLBY_VISION -> "Dolby Vision"
+        mime == MimeTypes.VIDEO_H265 -> "HEVC"
+        mime == MimeTypes.VIDEO_H264 -> "H.264"
+        mime == MimeTypes.VIDEO_AV1 -> "AV1"
+        mime == MimeTypes.VIDEO_VP9 -> "VP9"
+        mime.startsWith("video/") -> mime.removePrefix("video/").uppercase()
+        else -> codecs ?: mime
+    }
+}
+
+/**
+ * Human-friendly HDR/output type for the diagnostics card — reflects what is
+ * actually output, not just the source track mime. When DV7 is stripped to the
+ * HDR10 base layer the output is HDR10/SDR even though the track mime is DV.
+ */
+private fun friendlyVideoHdrType(
+    mimeType: String?,
+    colorTransfer: Int?,
+    effectiveModeName: String?,
+    dvConversionOccurred: Boolean
+): String? {
+    val isDolbyVisionMime = mimeType?.lowercase() == MimeTypes.VIDEO_DOLBY_VISION
+    fun fromTransfer(): String? = when (colorTransfer) {
+        C.COLOR_TRANSFER_ST2084 -> "HDR10"
+        C.COLOR_TRANSFER_HLG -> "HLG"
+        C.COLOR_TRANSFER_SDR -> "SDR"
+        else -> null
+    }
+    return when {
+        // Stripped to the HDR10 base layer: output is HDR10/SDR, never Dolby Vision.
+        effectiveModeName == "HDR10_BASE_LAYER" -> fromTransfer() ?: "HDR10"
+        // DV8.1 conversion, but only label it DV if a conversion actually ran. AUTO arms
+        // this mode for every file on a DV display, so plain SDR/HDR10 lands here too.
+        effectiveModeName == "DV81_LIBDOVI" && dvConversionOccurred -> "Dolby Vision"
+        effectiveModeName == "DV81_LIBDOVI" -> fromTransfer()
+        // Native DV passthrough.
+        isDolbyVisionMime -> "Dolby Vision"
+        else -> fromTransfer()
+    }
+}
+
+private fun createDolbyVisionFallbackCodecSelector(
+    convertToDv81Active: Boolean = false
+): MediaCodecSelector {
+    // Stripping DV7 to its HEVC base layer is handled by the renderer (setMapDV7ToHevc),
+    // which only touches profile 7. We must NOT force video/dolby-vision to the HEVC
+    // decoder here: that also catches DV5, which has no HDR10 base layer and ends up
+    // decoded without its reshaping (wrong colors). DV5 keeps the DV decoder.
+    if (convertToDv81Active) {
+        return MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
+            val defaults = MediaCodecSelector.DEFAULT.getDecoderInfos(
+                mimeType, requiresSecureDecoder, requiresTunnelingDecoder
+            )
+            if (mimeType != MimeTypes.VIDEO_DOLBY_VISION || defaults.isNotEmpty()) {
+                return@MediaCodecSelector defaults
+            }
+            DolbyVisionCodecFallback.findDvDecodersIgnoringProfile()
+        }
+    }
+    return MediaCodecSelector.DEFAULT
+}
+
+private fun describeExtensionRendererMode(mode: Int): String {
+    return when (mode) {
+        DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF -> "off"
+        DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON -> "on"
+        DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER -> "prefer"
+        else -> mode.toString()
+    }
+}
+
+private fun DefaultRenderersFactory.applyMapDv7ToHevcIfSupported(enabled: Boolean): DefaultRenderersFactory {
+    return runCatching {
+        val method = javaClass.getMethod("setMapDV7ToHevc", Boolean::class.javaPrimitiveType)
+        method.invoke(this, enabled)
+        this
+    }.getOrElse { this }
+}
+
+private fun buildStableAudioCapabilities(context: Context): AudioCapabilities {
+    val detected = AudioCapabilities.getCapabilities(context, AudioAttributes.DEFAULT, null)
+    val supportedEncodings = mutableListOf<Int>()
+    val knownEncodings = intArrayOf(
+        C.ENCODING_PCM_16BIT, C.ENCODING_AC3, C.ENCODING_AC4, C.ENCODING_DTS,
+        C.ENCODING_E_AC3_JOC, C.ENCODING_E_AC3, C.ENCODING_DOLBY_TRUEHD
+    )
+    for (encoding in knownEncodings) {
+        if (detected.supportsEncoding(encoding)) {
+            supportedEncodings += encoding
+        }
+    }
+    if ((detected.supportsEncoding(C.ENCODING_DTS_HD) || detected.supportsEncoding(C.ENCODING_DTS_UHD_P2)) && C.ENCODING_DTS !in supportedEncodings) {
+        supportedEncodings += C.ENCODING_DTS
+    }
+    return AudioCapabilities(supportedEncodings.toIntArray(), detected.maxChannelCount)
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -200,7 +200,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
                     resizeMode = playerSettings.resizeMode,
                     aspectMode = deviceAspectMode,
-                    tunnelingEnabled = playerSettings.tunnelingEnabled,
+                    tunnelingEnabled = playerSettings.tunnelingEnabled &&
+                            effectiveInternalPlayerEngine != InternalPlayerEngine.MVP_PLAYER,
                     loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_detecting_format) else null
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -7,12 +7,16 @@ import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.domain.model.Subtitle
 import com.nuvio.tv.domain.model.enabledAddons
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.yield
 
 internal data class SubtitleFetchRequest(
     val type: String,
@@ -23,10 +27,21 @@ internal data class SubtitleFetchRequest(
 internal fun PlayerRuntimeController.buildSubtitleFetchRequest(): SubtitleFetchRequest? {
     val id = contentId ?: return null
     val type = contentType ?: return null
+    val baseId = id.split(":").firstOrNull() ?: id
+    val normalizedType = type.lowercase()
+    val videoId = if (
+        (normalizedType == "series" || normalizedType == "tv") &&
+        currentSeason != null &&
+        currentEpisode != null
+    ) {
+        "$baseId:$currentSeason:$currentEpisode"
+    } else {
+        null
+    }
     return SubtitleFetchRequest(
         type = type.lowercase(),
-        id = id,
-        videoId = currentVideoId
+        id = baseId,
+        videoId = videoId
     )
 }
 
@@ -98,26 +113,25 @@ internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
 
 internal fun PlayerRuntimeController.fetchAddonSubtitles() {
     if (buildSubtitleFetchRequest() == null) return
-    
+
     scope.launch {
         _uiState.update { it.copy(isLoadingAddonSubtitles = true, addonSubtitlesError = null) }
-        
+
         try {
             val subtitles = fetchAddonSubtitlesNow()
             val visibleSubtitles = filterToVisibleAddonSubtitles(subtitles)
             Log.d(PlayerRuntimeController.TAG, "fetchAddonSubtitles done: ${subtitles.size} subs, visible=${visibleSubtitles.size}, persistedPref=${persistedTrackPreference?.subtitle?.javaClass?.simpleName}")
-            _uiState.update { 
+            _uiState.update {
                 it.copy(
                     addonSubtitles = visibleSubtitles,
                     isLoadingAddonSubtitles = false
-                ) 
+                )
             }
             val pendingAddon = pendingRestoredAddonSubtitle
             if (pendingAddon != null) {
                 val match = visibleSubtitles.firstOrNull { it.id == pendingAddon.id }
                     ?: visibleSubtitles.firstOrNull { PlayerSubtitleUtils.matchesLanguageCode(it.lang, pendingAddon.lang) }
                 if (match != null) {
-                    Log.d(PlayerRuntimeController.TAG, "fetchAddonSubtitles: re-applying restored addon id=${match.id}")
                     autoSubtitleSelected = true
                     selectAddonSubtitle(match)
                     _uiState.update { it.copy(selectedAddonSubtitle = match, selectedSubtitleTrackIndex = -1) }
@@ -130,11 +144,11 @@ internal fun PlayerRuntimeController.fetchAddonSubtitles() {
             )
             tryAutoSelectPreferredSubtitleFromAvailableTracks()
         } catch (e: Exception) {
-            _uiState.update { 
+            _uiState.update {
                 it.copy(
                     isLoadingAddonSubtitles = false,
                     addonSubtitlesError = e.message
-                ) 
+                )
             }
         }
     }
@@ -267,12 +281,10 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             }
 
             _uiState.update { state ->
-                val shouldShowOverlay = if (settings.loadingOverlayEnabled && !hasRenderedFirstFrame) {
-                    true
-                } else if (!settings.loadingOverlayEnabled) {
-                    false
-                } else {
-                    state.showLoadingOverlay
+                val shouldShowOverlay = when {
+                    !settings.loadingOverlayEnabled -> false
+                    !hasRenderedFirstFrame && state.isBuffering -> true
+                    else -> state.showLoadingOverlay
                 }
 
                 state.copy(
@@ -304,6 +316,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                 unregisterAudioDelayRouteCallback()
             }
 
+            bufferLogsEnabled = settings.enableBufferLogs
             if (settings.frameRateMatchingMode == FrameRateMatchingMode.OFF) {
                 frameRateProbeJob?.cancel()
                 _uiState.update {
@@ -342,6 +355,16 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             nextEpisodeThresholdMinutesBeforeEndSetting = settings.nextEpisodeThresholdMinutesBeforeEnd
             stillWatchingEnabledSetting = settings.stillWatchingEnabled
             stillWatchingEpisodeThresholdSetting = settings.stillWatchingEpisodeThreshold
+
+            // VOD cache config is gated by the "Custom Playback Buffers" master.
+            // When the master is off the cache is disabled at player build time, so
+            // don't push live size updates to it here either (keeps the factory from
+            // carrying cache config the master has turned off).
+            if (settings.bufferEngineEnabled) {
+                mediaSourceFactory.vodCacheSizeMode = settings.vodCacheSizeMode
+                mediaSourceFactory.vodCacheSizeMb = settings.vodCacheSizeMb
+            }
+
             val previousMpvHardwareDecodeMode = mpvHardwareDecodeModeSetting
             mpvHardwareDecodeModeSetting = settings.mpvHardwareDecodeMode
             if (isUsingMpvEngine() && previousMpvHardwareDecodeMode != mpvHardwareDecodeModeSetting) {
@@ -425,7 +448,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
 
 internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode: Int?) {
     if (contentId == null) return
-    
+
     scope.launch {
         pendingResumeProgress = null
         val progress = if (season != null && episode != null) {
@@ -433,9 +456,9 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
         } else {
             watchProgressRepository.getProgress(contentId).firstOrNull()
         }
-        
+
         progress?.let { saved ->
-            
+
             if (saved.isInProgress()) {
                 pendingResumeProgress = saved
                 if (isUsingMpvEngine()) {
@@ -567,26 +590,172 @@ internal fun PlayerRuntimeController.retryCurrentStreamFromStartAfter416() {
     if (hasRetriedCurrentStreamAfter416) return
     hasRetriedCurrentStreamAfter416 = true
     pendingResumeProgress = null
-    showRecoveryOverlay()
-    _uiState.update { it.copy(pendingSeekPosition = null) }
-    _exoPlayer?.let { player ->
-        runCatching {
-            player.stop()
-            player.clearMediaItems()
-            player.setMediaSource(
-                mediaSourceFactory.createMediaSource(
-                    context = context,
-                    url = currentStreamUrl,
-                    headers = currentHeaders,
-                    filename = currentFilename,
-                    responseHeaders = currentStreamResponseHeaders,
-                    mimeTypeOverride = currentStreamMimeType,
-                    audioDelayUsProvider = audioDelayUs::get
+    scheduleDeferredPlayerReinitialize(fromPositionMs = 0L, clearResumeProgress = true)
+}
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@OptIn(UnstableApi::class)
+internal fun PlayerRuntimeController.retryCurrentStreamAfterTimeout(fromPositionMs: Long) {
+    if (timeoutRecoveryAttempts >= PlayerRuntimeController.MAX_TIMEOUT_RECOVERY_ATTEMPTS) return
+    timeoutRecoveryAttempts += 1
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@OptIn(UnstableApi::class)
+internal fun PlayerRuntimeController.retryCurrentStreamAfterUnexpectedNpe(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamAfterMediaPeriodHolderCrash(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamWithSafeAudioFallback(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamWithAudioDisabled(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamWithDolbyVisionFallback(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs, clearResumeProgress = true)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamWithDv7Mode1Fallback(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs, clearResumeProgress = true)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamWithVc1SoftwareFallback(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+internal fun PlayerRuntimeController.retryCurrentStreamWithVc1TrackSelectionBypass(fromPositionMs: Long) {
+    scheduleDeferredPlayerReinitialize(fromPositionMs = fromPositionMs)
+}
+
+internal fun PlayerRuntimeController.cancelFirstFrameWatchdog() {
+    firstFrameWatchdogJob?.cancel()
+    firstFrameWatchdogJob = null
+}
+
+internal fun PlayerRuntimeController.cancelStallWatchdog() {
+    stallWatchdogJob?.cancel()
+    stallWatchdogJob = null
+}
+
+/** Tiny skip past the buffered edge to force Media3 to cancel the in-flight Range request. */
+private const val STALL_WATCHDOG_SKIP_PAST_BUFFERED_MS = 250L
+
+/** Re-seeks past the buffered edge when bufferedPosition stops advancing during buffering. */
+internal fun PlayerRuntimeController.maybeScheduleStallWatchdog() {
+    if (stallWatchdogJob?.isActive == true) return
+    val player = _exoPlayer ?: return
+    if (player.playbackState != Player.STATE_BUFFERING) return
+
+    stallWatchdogJob = scope.launch {
+        var lastBufferedPosition = player.bufferedPosition
+        var lastAdvanceAtMs = System.currentTimeMillis()
+
+        while (isActive) {
+            delay(PlayerRuntimeController.STALL_WATCHDOG_POLL_INTERVAL_MS)
+            val livePlayer = _exoPlayer ?: return@launch
+            if (livePlayer.playbackState != Player.STATE_BUFFERING) {
+                // Buffering resolved on its own.
+                return@launch
+            }
+
+            val nowMs = System.currentTimeMillis()
+            val bufferedNow = livePlayer.bufferedPosition
+            if (bufferedNow > lastBufferedPosition) {
+                // Real progress — reset the stall timer.
+                lastBufferedPosition = bufferedNow
+                lastAdvanceAtMs = nowMs
+                continue
+            }
+
+            val stalledForMs = nowMs - lastAdvanceAtMs
+            if (stalledForMs >= PlayerRuntimeController.STALL_WATCHDOG_THRESHOLD_MS) {
+                val playheadMs = livePlayer.currentPosition.coerceAtLeast(0L)
+                // Seek past buffered edge to force Media3 to cancel the stuck Range request.
+                val durationMs = livePlayer.duration.coerceAtLeast(0L)
+                val seekTargetMs = (bufferedNow + STALL_WATCHDOG_SKIP_PAST_BUFFERED_MS)
+                    .coerceAtMost(durationMs)
+                Log.w(
+                    PlayerRuntimeController.TAG,
+                    "STALL_WATCHDOG: bufferedPosition stuck at $bufferedNow for ${stalledForMs}ms " +
+                        "during STATE_BUFFERING (playhead=$playheadMs); seeking past buffered " +
+                        "edge to $seekTargetMs to break stuck request"
                 )
-            )
-            player.seekTo(0L)
-            player.playWhenReady = true
-            player.prepare()
+                livePlayer.seekTo(seekTargetMs)
+                return@launch
+            }
+        }
+    }
+}
+
+internal fun PlayerRuntimeController.maybeScheduleFirstFrameWatchdog() {
+    if (hasRenderedFirstFrame || !currentStreamHasVideoTrack) return
+    val player = _exoPlayer ?: return
+    if (player.playbackState != Player.STATE_READY || !player.playWhenReady) return
+    if (firstFrameWatchdogJob?.isActive == true) return
+
+    firstFrameWatchdogJob = scope.launch {
+        delay(PlayerRuntimeController.FIRST_FRAME_TIMEOUT_MS)
+
+        val livePlayer = _exoPlayer ?: return@launch
+        if (hasRenderedFirstFrame) return@launch
+        if (livePlayer.playbackState != Player.STATE_READY || !livePlayer.playWhenReady) return@launch
+
+        val currentPosition = livePlayer.currentPosition
+        // Manual Convert-to-DV8.1 mode 2 produced no first frame (e.g. black
+        // screen): retry the stream at libdovi mode 1 before other fallbacks.
+        if (isManualDv81Mode2ActiveForCurrentPlayback &&
+            !dv7Mode1ForcedStreamUrls.contains(currentStreamUrl)
+        ) {
+            dv7Mode1ForcedStreamUrls.add(currentStreamUrl)
+            retryCurrentStreamWithDv7Mode1Fallback(currentPosition)
+            return@launch
+        }
+        if (currentVideoTrackIsLikelyVc1 && !isVc1SoftwareFallbackActiveForCurrentPlayback) {
+            vc1SoftwarePreferredStreamUrls.add(currentStreamUrl)
+            retryCurrentStreamWithVc1SoftwareFallback(currentPosition)
+            return@launch
+        }
+
+        if (currentVideoTrackIsLikelyVc1 &&
+            !currentVideoTrackSelected &&
+            isVc1SoftwareFallbackActiveForCurrentPlayback &&
+            !isVc1TrackSelectionBypassActiveForCurrentPlayback
+        ) {
+            vc1TrackSelectionBypassStreamUrls.add(currentStreamUrl)
+            retryCurrentStreamWithVc1TrackSelectionBypass(currentPosition)
+        }
+    }
+}
+
+private fun PlayerRuntimeController.scheduleDeferredPlayerReinitialize(
+    fromPositionMs: Long,
+    clearResumeProgress: Boolean = false
+) {
+    cancelFirstFrameWatchdog()
+    cancelStallWatchdog()
+    if (clearResumeProgress) {
+        pendingResumeProgress = null
+    }
+    _uiState.update {
+        it.copy(
+            pendingSeekPosition = if (fromPositionMs > 0L) fromPositionMs else null,
+            error = null,
+            showLoadingOverlay = it.loadingOverlayEnabled
+        )
+    }
+    scope.launch {
+        yield()
+        runCatching {
+            releasePlayer()
+            initializePlayer(currentStreamUrl, currentHeaders)
         }.onFailure { e ->
             _uiState.update {
                 it.copy(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -196,7 +196,8 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                 val displayPosition = pendingPreviewSeekPosition ?: pos
                 updatePlaybackTimeline(
                     currentPosition = displayPosition,
-                    duration = playerDuration.coerceAtLeast(0L)
+                    duration = playerDuration.coerceAtLeast(0L),
+                    bufferedPosition = player.bufferedPosition.coerceAtLeast(displayPosition)
                 )
                 // Update torrent rebuffer progress from ExoPlayer's buffer state
                 if (isTorrentStream && _uiState.value.isBuffering && hasRenderedFirstFrame) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -20,6 +20,7 @@ import com.nuvio.tv.ui.components.SourceChipStatus
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -592,12 +593,18 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
         headers = newHeaders
     )
     persistSelectedStreamForReuse(stream = stream, url = url, headers = newHeaders)
+
+    // Reset stream-state error flags for the new stream.
     hasRetriedCurrentStreamAfter416 = false
     resetErrorRetryState()
+    hasRetriedCurrentStreamAfterUnexpectedNpe = false
+    hasRetriedCurrentStreamAfterMediaPeriodHolderCrash = false
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
     lastSavedPosition = 0L
+    _exoPlayer?.stop()
+    resetLoadingOverlayForNewStream()
 
     _uiState.update {
         it.copy(
@@ -618,11 +625,38 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
     showStreamSourceIndicator(stream)
     resetPostPlayOverlayState(clearEpisode = false)
 
-    preparePlaybackBeforeStart(
-        url = url,
-        headers = newHeaders,
-        loadSavedProgress = true
-    )
+    _exoPlayer?.let { player ->
+        scope.launch {
+            try {
+                val playerSettings = playerSettingsDataStore.playerSettings.first()
+                runAfrPreflightIfEnabled(
+                    url = url,
+                    headers = newHeaders,
+                    frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                    resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                )
+                player.setMediaSource(
+                    mediaSourceFactory.createMediaSource(
+                        context = context,
+                        url = url,
+                        headers = newHeaders,
+                        filename = currentFilename,
+                        responseHeaders = currentStreamResponseHeaders,
+                        mimeTypeOverride = currentStreamMimeType,
+                        audioDelayUsProvider = audioDelayUs::get
+                    )
+                )
+                player.playWhenReady = true
+                player.prepare()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message ?: "Failed to play selected stream") }
+            }
+        }
+    } ?: run {
+        initializePlayer(url, newHeaders)
+    }
+
+    loadSavedProgressFor(currentSeason, currentEpisode)
 }
 
 internal fun PlayerRuntimeController.dismissEpisodesPanel() {
@@ -1058,8 +1092,18 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     val targetVideo = forcedTargetVideo
         ?: _uiState.value.episodes.firstOrNull { it.id == _uiState.value.episodeStreamsForVideoId }
 
-    resetLoadingOverlayForNewStream()
-    releasePlayer(flushPlaybackState = false)
+    currentStreamUrl = url
+    currentHeaders = newHeaders
+    currentStreamBingeGroup = stream.behaviorHints?.bingeGroup
+    currentVideoHash = stream.behaviorHints?.videoHash
+    currentVideoSize = stream.behaviorHints?.videoSize
+    currentFilename = stream.behaviorHints?.filename
+        ?: url.substringBefore('?').substringAfterLast('/', "")
+            .takeIf { it.isNotBlank() && it.contains('.') }
+    pendingAddonSubtitleLanguage = null
+    pendingAddonSubtitleTrackId = null
+    pendingAudioSelectionAfterSubtitleRefresh = null
+    attachedAddonSubtitleKeys = emptySet()
 
     applySelectedStreamState(
         stream = stream,
@@ -1158,15 +1202,20 @@ private fun PlayerRuntimeController.switchToEpisodeStreamCommon(
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
+    // Reset stream-state error flags for the new stream.
     hasRetriedCurrentStreamAfter416 = false
-    errorRetryCount = 0
+    hasRetriedCurrentStreamAfterUnexpectedNpe = false
+    hasRetriedCurrentStreamAfterMediaPeriodHolderCrash = false
+
     currentVideoId = targetVideo?.id ?: _uiState.value.episodeStreamsForVideoId ?: currentVideoId
     currentSeason = targetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
     currentEpisode = targetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode
     currentEpisodeTitle = targetVideo?.title ?: _uiState.value.episodeStreamsTitle ?: currentEpisodeTitle
-    currentTraktEpisodeMapping = null
-    currentTraktEpisodeMappingKey = null
+    refreshScrobbleItem()
+
     lastSavedPosition = 0L
+    _exoPlayer?.stop()
+    resetLoadingOverlayForNewStream()
 
     _uiState.update {
         it.copy(
@@ -1201,6 +1250,7 @@ private fun PlayerRuntimeController.switchToEpisodeStreamCommon(
     showStreamSourceIndicator(stream)
     recomputeNextEpisode(resetVisibility = true)
     updateEpisodeDescription()
+    refreshSubtitlesForCurrentEpisode()
 
     playbackStartedForParentalGuide = false
     skipIntervals = emptyList()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1,10 +1,13 @@
 package com.nuvio.tv.ui.screens.player
 
+import android.net.Uri
 import android.util.Log
 import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import androidx.media3.common.util.Util
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.core.player.FrameRateUtils
 import com.nuvio.tv.data.local.AVAILABLE_SUBTITLE_LANGUAGES
@@ -20,26 +23,45 @@ import kotlinx.coroutines.withContext
 import java.util.Locale
 import com.nuvio.tv.ui.util.languageCodeToName
 
+@UnstableApi
 internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
     logSwitchTrace(
         stage = "exo-tracks-update-start",
         message = "groupCount=${tracks.groups.size} uiAudioIndex=${_uiState.value.selectedAudioTrackIndex} " +
-            "uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex}"
+                "uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex}"
     )
     val audioTracks = mutableListOf<TrackInfo>()
     val subtitleTracks = mutableListOf<TrackInfo>()
     var selectedAudioIndex = -1
     var selectedSubtitleIndex = -1
 
+    var hasVideoTrack = false
+    var firstVideoFormat: Format? = null
+    var selectedVideoFormat: Format? = null
+    var bestVideoTrackSupport = C.FORMAT_UNSUPPORTED_TYPE
+    var selectedVideoTrackSupport = C.FORMAT_UNSUPPORTED_TYPE
+
     tracks.groups.forEachIndexed { groupIndex, trackGroup ->
         val trackType = trackGroup.type
-        
+
         when (trackType) {
             C.TRACK_TYPE_VIDEO -> {
+                if (trackGroup.length > 0) {
+                    hasVideoTrack = true
+                    if (firstVideoFormat == null) {
+                        firstVideoFormat = trackGroup.getTrackFormat(0)
+                    }
+                }
 
                 for (i in 0 until trackGroup.length) {
+                    val support = trackGroup.getTrackSupport(i)
+                    if (formatSupportRank(support) > formatSupportRank(bestVideoTrackSupport)) {
+                        bestVideoTrackSupport = support
+                    }
                     if (trackGroup.isTrackSelected(i)) {
                         val format = trackGroup.getTrackFormat(i)
+                        selectedVideoFormat = format
+                        selectedVideoTrackSupport = support
                         if (format.frameRate > 0f) {
                             val raw = format.frameRate
                             val snapped = FrameRateUtils.snapToStandardRate(raw)
@@ -71,7 +93,6 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                     val isSelected = trackGroup.isTrackSelected(i)
                     if (isSelected) selectedAudioIndex = audioTracks.size
 
-                    
                     val codecName = CustomDefaultTrackNameProvider.formatNameFromMime(format.sampleMimeType)
                     val channelLayout = CustomDefaultTrackNameProvider.getChannelLayoutName(
                         format.channelCount
@@ -104,7 +125,7 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                     if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) continue
                     val isSelected = trackGroup.isTrackSelected(i)
                     if (isSelected) selectedSubtitleIndex = subtitleTracks.size
-                    
+
                     val hasForcedFlag = (format.selectionFlags and C.SELECTION_FLAG_FORCED) != 0
                     val trackTexts = listOfNotNull(format.label, format.language, format.id)
                     val nameHintForced = trackTexts.any { it.contains("forced", ignoreCase = true) }
@@ -128,12 +149,92 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
         }
     }
 
+    currentStreamHasVideoTrack = hasVideoTrack
+    val effectiveVideoFormat = selectedVideoFormat ?: firstVideoFormat
+    if (effectiveVideoFormat != null) {
+        currentVideoTrackMimeType = effectiveVideoFormat.sampleMimeType
+        currentVideoTrackCodecs = effectiveVideoFormat.codecs
+        currentVideoTrackWidth = effectiveVideoFormat.width.coerceAtLeast(0)
+        currentVideoTrackHeight = effectiveVideoFormat.height.coerceAtLeast(0)
+        currentVideoTrackColorTransfer = effectiveVideoFormat.colorInfo?.colorTransfer
+        currentVideoTrackSelected = selectedVideoFormat != null
+        currentVideoTrackBestSupport = if (selectedVideoFormat != null) {
+            selectedVideoTrackSupport
+        } else {
+            bestVideoTrackSupport
+        }
+        currentVideoTrackIsLikelyVc1 = isLikelyVc1VideoFormat(
+            sampleMimeType = effectiveVideoFormat.sampleMimeType,
+            codecs = effectiveVideoFormat.codecs,
+            label = effectiveVideoFormat.label
+        )
+        val videoTrackSignature = buildString {
+            append(currentVideoTrackMimeType ?: "unknown")
+            append('|')
+            append(currentVideoTrackCodecs ?: "unknown")
+            append('|')
+            append(currentVideoTrackWidth)
+            append('x')
+            append(currentVideoTrackHeight)
+            append("|vc1=")
+            append(currentVideoTrackIsLikelyVc1)
+            append("|selected=")
+            append(currentVideoTrackSelected)
+            append("|support=")
+            append(Util.getFormatSupportString(currentVideoTrackBestSupport))
+            append("|vc1Fallback=")
+            append(isVc1SoftwareFallbackActiveForCurrentPlayback)
+            append("|vc1TrackBypass=")
+            append(isVc1TrackSelectionBypassActiveForCurrentPlayback)
+        }
+        if (videoTrackSignature != lastLoggedVideoTrackSignature) {
+            lastLoggedVideoTrackSignature = videoTrackSignature
+            Log.i(
+                PlayerRuntimeController.TAG,
+                "VIDEO_TRACK: mime=${currentVideoTrackMimeType ?: "unknown"} " +
+                        "codecs=${currentVideoTrackCodecs ?: "unknown"} " +
+                        "size=${currentVideoTrackWidth}x${currentVideoTrackHeight} " +
+                        "vc1=$currentVideoTrackIsLikelyVc1 " +
+                        "selected=$currentVideoTrackSelected " +
+                        "support=${Util.getFormatSupportString(currentVideoTrackBestSupport)} " +
+                        "vc1FallbackActive=$isVc1SoftwareFallbackActiveForCurrentPlayback " +
+                        "vc1TrackBypassActive=$isVc1TrackSelectionBypassActiveForCurrentPlayback"
+            )
+        }
+        if (currentVideoTrackIsLikelyVc1 &&
+            !currentVideoTrackSelected &&
+            isVc1SoftwareFallbackActiveForCurrentPlayback &&
+            !isVc1TrackSelectionBypassActiveForCurrentPlayback
+        ) {
+            val currentPosition = _exoPlayer?.currentPosition ?: 0L
+            vc1TrackSelectionBypassStreamUrls.add(currentStreamUrl)
+            Log.w(
+                PlayerRuntimeController.TAG,
+                "VIDEO_TRACK: VC-1 track present but unselected after software-preferred retry, " +
+                        "forcing track-selection bypass support=${Util.getFormatSupportString(currentVideoTrackBestSupport)} " +
+                        "host=${Uri.parse(currentStreamUrl).host ?: "unknown"} positionMs=$currentPosition"
+            )
+            retryCurrentStreamWithVc1TrackSelectionBypass(currentPosition)
+            return
+        }
+    } else {
+        currentVideoTrackMimeType = null
+        currentVideoTrackCodecs = null
+        currentVideoTrackWidth = 0
+        currentVideoTrackHeight = 0
+        currentVideoTrackColorTransfer = null
+        currentVideoTrackSelected = false
+        currentVideoTrackBestSupport = C.FORMAT_UNSUPPORTED_TYPE
+        currentVideoTrackIsLikelyVc1 = false
+        lastLoggedVideoTrackSignature = null
+    }
+
     hasScannedTextTracksOnce = true
     Log.d(
         PlayerRuntimeController.TAG,
         "TRACKS updated: internalSubs=${subtitleTracks.size}, selectedInternalIndex=$selectedSubtitleIndex, " +
-            "selectedAddon=${_uiState.value.selectedAddonSubtitle?.lang}, " +
-            "pendingAddonLang=$pendingAddonSubtitleLanguage, pendingAddonTrackId=$pendingAddonSubtitleTrackId"
+                "selectedAddon=${_uiState.value.selectedAddonSubtitle?.lang}, " +
+                "pendingAddonLang=$pendingAddonSubtitleLanguage, pendingAddonTrackId=$pendingAddonSubtitleTrackId"
     )
 
     val pendingAddonTrackId = pendingAddonSubtitleTrackId
@@ -184,7 +285,7 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
     logSwitchTrace(
         stage = "exo-tracks-update-end",
         message = "audioCount=${audioTracks.size} subtitleCount=${subtitleTracks.size} " +
-            "selectedAudioIndex=$selectedAudioIndex selectedSubtitleIndex=$selectedSubtitleIndex"
+                "selectedAudioIndex=$selectedAudioIndex selectedSubtitleIndex=$selectedSubtitleIndex"
     )
     rememberEffectiveExoSubtitleSelectionForEngineSwitch(
         subtitleTracks = subtitleTracks,
@@ -194,8 +295,46 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
         audioTracks = audioTracks,
         subtitleTracks = subtitleTracks
     )
+    if (currentStreamHasVideoTrack) {
+        maybeScheduleFirstFrameWatchdog()
+    } else {
+        cancelFirstFrameWatchdog()
+    }
     tryAutoSelectPreferredSubtitleFromAvailableTracks()
     maybeAdjustLibassPipelineForTracks(tracks)
+}
+
+private fun isLikelyVc1VideoFormat(
+    sampleMimeType: String?,
+    codecs: String?,
+    label: String?
+): Boolean {
+    // MIME type check — this is the authoritative signal
+    if (sampleMimeType?.equals(MimeTypes.VIDEO_VC1, ignoreCase = true) == true) {
+        return true
+    }
+
+    val haystack = listOfNotNull(codecs, label)
+        .joinToString(" ")
+        .lowercase(Locale.ROOT)
+
+    // Explicit VC1 codec identifiers only — no bare "vc1" substring match
+    // to avoid matching "avc1" (H.264) or "hvc1" (HEVC)
+    return haystack.contains("wvc1") ||
+            haystack.contains("vc-1") ||
+            haystack.contains("wmv3") ||
+            // Match "vc1" only as a whole token (bounded by non-alphanumeric or start/end)
+            Regex("(?<![a-z0-9])vc1(?![a-z0-9])").containsMatchIn(haystack)
+}
+
+private fun formatSupportRank(@C.FormatSupport formatSupport: Int): Int {
+    return when (formatSupport) {
+        C.FORMAT_HANDLED -> 4
+        C.FORMAT_EXCEEDS_CAPABILITIES -> 3
+        C.FORMAT_UNSUPPORTED_DRM -> 2
+        C.FORMAT_UNSUPPORTED_SUBTYPE -> 1
+        else -> 0
+    }
 }
 
 private fun PlayerRuntimeController.rememberEffectiveExoSubtitleSelectionForEngineSwitch(
@@ -255,13 +394,16 @@ internal fun PlayerRuntimeController.maybeAdjustLibassPipelineForTracks(tracks: 
     if (hasAssSsaTrack) {
         hasDetectedAssSsaTrackForCurrentStream = true
     }
-    // Only rebuild to ENABLE libass when ASS/SSA tracks are detected but libass
-    // is not active. Never rebuild to disable libass - keeping the libass pipeline
-    // active when no ASS tracks are should be harmless (standard subtitles still
-    // render normally - but this may change colors - need confimration)
+    // Don't rebuild just to drop libass, except when it's holding the MKV extractor on a DV7
+    // file with no ASS track and blocking conversion; then drop it so the DV extractor runs.
     val desiredUseLibass = requestedUseLibassByUser && hasDetectedAssSsaTrackForCurrentStream
     if (desiredUseLibass == activePlayerUsesLibass) return
-    if (!desiredUseLibass) return // don't rebuild just to remove libass
+    if (!desiredUseLibass) {
+        val libassBlockingDvConvert = activePlayerUsesLibass &&
+                isExperimentalDv7ToDv81ActiveForCurrentPlayback &&
+                tracks.hasDolbyVisionProfile7VideoTrack()
+        if (!libassBlockingDvConvert) return
+    }
 
     val player = _exoPlayer ?: return
     val resumePosition = player.currentPosition.takeIf { it > 0L }
@@ -294,11 +436,26 @@ private fun Tracks.hasAssSsaTextTrack(): Boolean {
                 ?.map { it.trim().lowercase(Locale.US) }
                 ?.any { codec ->
                     codec == MimeTypes.TEXT_SSA ||
-                        codec == "s_text/ass" ||
-                        codec == "s_text/ssa" ||
-                        codec.endsWith("/x-ssa")
+                            codec == "s_text/ass" ||
+                            codec == "s_text/ssa" ||
+                            codec.endsWith("/x-ssa")
                 } == true
             if (hasAssCodec) return true
+        }
+    }
+    return false
+}
+
+// Profile 7 only: it's the profile AUTO conversion rewrites. DV5/DV8 don't convert, so they
+// shouldn't trigger a libass-drop reload.
+private val DV_PROFILE_7_CODEC = Regex("^(dvhe|dvh1|dvav|dva1)\\.0?7\\.")
+
+private fun Tracks.hasDolbyVisionProfile7VideoTrack(): Boolean {
+    groups.forEach { trackGroup ->
+        if (trackGroup.type != C.TRACK_TYPE_VIDEO) return@forEach
+        for (index in 0 until trackGroup.length) {
+            val codec = trackGroup.getTrackFormat(index).codecs?.lowercase(Locale.US).orEmpty()
+            if (DV_PROFILE_7_CODEC.containsMatchIn(codec)) return true
         }
     }
     return false
@@ -330,10 +487,10 @@ internal fun PlayerRuntimeController.maybeRestorePendingAudioSelectionAfterSubti
     fun languageMatches(trackLanguage: String?): Boolean {
         val trackLang = normalizeTrackMatchValue(trackLanguage)
         return !targetLang.isNullOrBlank() &&
-            !trackLang.isNullOrBlank() &&
-            (trackLang == targetLang ||
-                trackLang.startsWith("$targetLang-") ||
-                trackLang.startsWith("${targetLang}_"))
+                !trackLang.isNullOrBlank() &&
+                (trackLang == targetLang ||
+                        trackLang.startsWith("$targetLang-") ||
+                        trackLang.startsWith("${targetLang}_"))
     }
 
     val exactNameIndex = if (!targetName.isNullOrBlank()) {
@@ -455,14 +612,14 @@ internal fun PlayerRuntimeController.findMatchingTrackIndexForEngineSwitchToMpv(
     logSwitchTrace(
         stage = "track-match-switch",
         message = "result=language-fallback index=$fallbackIndex sourceEngine=$sourceEngine " +
-            "target=${describeRememberedTrackForSwitchTrace(target)}"
+                "target=${describeRememberedTrackForSwitchTrace(target)}"
     )
     return fallbackIndex
 }
 
 private fun PlayerRuntimeController.describeTrackInfoForRestoreLog(track: TrackInfo): String {
     return "index=${track.index} lang=${track.language} name=${track.name} id=${track.trackId} " +
-        "forced=${track.isForced} selected=${track.isSelected}"
+            "forced=${track.isForced} selected=${track.isSelected}"
 }
 
 private fun PlayerRuntimeController.describeTrackCandidatesForRestoreLog(
@@ -478,8 +635,8 @@ private fun PlayerRuntimeController.describeRememberedTrackForSwitchTrace(
 ): String {
     if (selection == null) return "none"
     return "lang=${selection.language} name=${selection.name} trackId=${selection.trackId} " +
-        "indexHint=${selection.indexHint} languageIndexHint=${selection.languageIndexHint} " +
-        "forcedHint=${selection.isForcedHint}"
+            "indexHint=${selection.indexHint} languageIndexHint=${selection.languageIndexHint} " +
+            "forcedHint=${selection.isForcedHint}"
 }
 
 private fun PlayerRuntimeController.describeRememberedSubtitleForSwitchTrace(
@@ -506,9 +663,9 @@ private fun PlayerRuntimeController.findStrictMatchingTrackIndex(
     val exactTrackIdIndex = if (!targetTrackId.isNullOrBlank()) {
         tracks.indexOfFirst { track ->
             normalizeTrackMatchValue(track.trackId) == targetTrackId &&
-                (targetLang.isNullOrBlank() || normalizeTrackMatchValue(track.language) == targetLang) &&
-                (targetName.isNullOrBlank() || normalizeTrackMatchValue(track.name) == targetName ||
-                    normalizeTrackMatchValue(track.name)?.contains(targetName) == true)
+                    (targetLang.isNullOrBlank() || normalizeTrackMatchValue(track.language) == targetLang) &&
+                    (targetName.isNullOrBlank() || normalizeTrackMatchValue(track.name) == targetName ||
+                            normalizeTrackMatchValue(track.name)?.contains(targetName) == true)
         }
     } else {
         -1
@@ -518,7 +675,7 @@ private fun PlayerRuntimeController.findStrictMatchingTrackIndex(
     val exactNameIndex = if (!targetName.isNullOrBlank()) {
         tracks.indexOfFirst { track ->
             normalizeTrackMatchValue(track.name) == targetName &&
-                (targetLang.isNullOrBlank() || normalizeTrackMatchValue(track.language) == targetLang)
+                    (targetLang.isNullOrBlank() || normalizeTrackMatchValue(track.language) == targetLang)
         }
     } else {
         -1
@@ -528,7 +685,7 @@ private fun PlayerRuntimeController.findStrictMatchingTrackIndex(
     val nameContainsIndex = if (!targetName.isNullOrBlank()) {
         tracks.indexOfFirst { track ->
             normalizeTrackMatchValue(track.name)?.contains(targetName) == true &&
-                (targetLang.isNullOrBlank() || normalizeTrackMatchValue(track.language) == targetLang)
+                    (targetLang.isNullOrBlank() || normalizeTrackMatchValue(track.language) == targetLang)
         }
     } else {
         -1
@@ -553,15 +710,13 @@ private fun PlayerRuntimeController.findLanguageFallbackTrackIndex(
         val langCandidates = tracks.indices.filter { index ->
             val trackLang = normalizeTrackMatchValue(tracks[index].language)
             !trackLang.isNullOrBlank() &&
-                (trackLang == targetLang ||
-                    trackLang.startsWith("$targetLang-") ||
-                    trackLang.startsWith("${targetLang}_"))
+                    (trackLang == targetLang ||
+                            trackLang.startsWith("$targetLang-") ||
+                            trackLang.startsWith("${targetLang}_"))
         }
         if (langCandidates.size <= 1) {
             langCandidates.firstOrNull() ?: -1
         } else {
-            // Multiple tracks with the same base language — prefer the one
-            // whose detected variant matches the remembered selection.
             langCandidates.firstOrNull { index ->
                 val trackVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
                     language = tracks[index].language,
@@ -598,12 +753,12 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
     val baseCandidates = tracks.indices.filter { index ->
         val track = tracks[index]
         target.language.isNullOrBlank() ||
-            PlayerSubtitleUtils.matchesLanguageCode(track.language, target.language) ||
-            PlayerSubtitleUtils.detectTrackLanguageVariant(
-                language = track.language,
-                name = track.name,
-                trackId = track.trackId
-            ) == targetVariant
+                PlayerSubtitleUtils.matchesLanguageCode(track.language, target.language) ||
+                PlayerSubtitleUtils.detectTrackLanguageVariant(
+                    language = track.language,
+                    name = track.name,
+                    trackId = track.trackId
+                ) == targetVariant
     }
     val sparseCandidates = if (sparseMetadata) {
         if (targetForced == null) {
@@ -621,7 +776,7 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
             logSwitchTrace(
                 stage = "track-match-hint",
                 message = "result=indexHint-from-sparse index=$indexHint " +
-                    "indexHint=$indexHint languageIndexHint=$languageIndexHint targetForced=$targetForced"
+                        "indexHint=$indexHint languageIndexHint=$languageIndexHint targetForced=$targetForced"
             )
             return indexHint
         }
@@ -630,14 +785,14 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
             logSwitchTrace(
                 stage = "track-match-hint",
                 message = "result=languageIndexHint-from-sparse index=$resolved " +
-                    "indexHint=$indexHint languageIndexHint=$languageIndexHint targetForced=$targetForced"
+                        "indexHint=$indexHint languageIndexHint=$languageIndexHint targetForced=$targetForced"
             )
             return resolved
         }
         logSwitchTrace(
             stage = "track-match-hint",
             message = "result=-1 reason=empty-base-and-no-sparse-match indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-                "targetForced=$targetForced sparseMetadata=$sparseMetadata"
+                    "targetForced=$targetForced sparseMetadata=$sparseMetadata"
         )
         return -1
     }
@@ -653,7 +808,7 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
         logSwitchTrace(
             stage = "track-match-hint",
             message = "result=indexHint-preferred index=$indexHint indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+                    "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
         )
         return indexHint
     }
@@ -662,7 +817,7 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
         logSwitchTrace(
             stage = "track-match-hint",
             message = "result=languageIndexHint-preferred index=$resolved indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+                    "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
         )
         return resolved
     }
@@ -670,7 +825,7 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
         logSwitchTrace(
             stage = "track-match-hint",
             message = "result=indexHint-base index=$indexHint indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+                    "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
         )
         return indexHint
     }
@@ -678,7 +833,7 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
         logSwitchTrace(
             stage = "track-match-hint",
             message = "result=indexHint-sparse index=$indexHint indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+                    "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
         )
         return indexHint
     }
@@ -687,7 +842,7 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
         logSwitchTrace(
             stage = "track-match-hint",
             message = "result=languageIndexHint-sparse index=$resolved indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
+                    "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates sparseMetadata=$sparseMetadata"
         )
         return resolved
     }
@@ -695,8 +850,8 @@ private fun PlayerRuntimeController.findEngineSwitchHintTrackIndex(
     logSwitchTrace(
         stage = "track-match-hint",
         message = "result=-1 reason=no-hint-match indexHint=$indexHint languageIndexHint=$languageIndexHint " +
-            "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates " +
-            "sparseCandidates=$sparseCandidates sparseMetadata=$sparseMetadata"
+                "targetForced=$targetForced baseCandidates=$baseCandidates preferredCandidates=$preferredCandidates " +
+                "sparseCandidates=$sparseCandidates sparseMetadata=$sparseMetadata"
     )
     return -1
 }
@@ -708,11 +863,11 @@ private fun PlayerRuntimeController.hasSparseMpvSubtitleMetadataForEngineSwitch(
     val sparseCount = tracks.count { track ->
         val normalizedName = normalizeTrackMatchValue(track.name)
         track.language.isNullOrBlank() &&
-            (
-                normalizedName.isNullOrBlank() ||
-                    normalizedName == "subtitle" ||
-                    normalizedName.startsWith("subtitle ")
-                )
+                (
+                        normalizedName.isNullOrBlank() ||
+                                normalizedName == "subtitle" ||
+                                normalizedName.startsWith("subtitle ")
+                        )
     }
     return sparseCount > 0 && sparseCount * 2 >= tracks.size
 }
@@ -735,10 +890,10 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
     logSwitchTrace(
         stage = "restore-enter",
         message = "usingSwitchPending=$usingSwitchPending switchPending=${switchPending != null} persisted=${persistedTrackPreference != null} " +
-            "audioTracks=${audioTracks.size} subtitleTracks=${subtitleTracks.size} " +
-            "uiAudioIndex=${_uiState.value.selectedAudioTrackIndex} uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex} " +
-            "pendingAudio=${describeRememberedTrackForSwitchTrace(pendingCandidate?.audio)} " +
-            "pendingSubtitle=${describeRememberedSubtitleForSwitchTrace(pendingCandidate?.subtitle)}"
+                "audioTracks=${audioTracks.size} subtitleTracks=${subtitleTracks.size} " +
+                "uiAudioIndex=${_uiState.value.selectedAudioTrackIndex} uiSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex} " +
+                "pendingAudio=${describeRememberedTrackForSwitchTrace(pendingCandidate?.audio)} " +
+                "pendingSubtitle=${describeRememberedSubtitleForSwitchTrace(pendingCandidate?.subtitle)}"
     )
     val pending: PlayerRuntimeController.TrackPreference = pendingCandidate ?: run {
         logSwitchTrace(
@@ -766,8 +921,8 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 logSwitchTrace(
                     stage = "restore-audio",
                     message = "result=match index=$index alreadySelected=$alreadySelected " +
-                        "target=${describeRememberedTrackForSwitchTrace(audioSelection)} " +
-                        "matched=${audioTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
+                            "target=${describeRememberedTrackForSwitchTrace(audioSelection)} " +
+                            "matched=${audioTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
                 )
                 if (!alreadySelected) {
                     Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: audio index=$index lang=${audioTracks[index].language} name=${audioTracks[index].name}")
@@ -781,7 +936,7 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 logSwitchTrace(
                     stage = "restore-audio",
                     message = "result=no-match target=${describeRememberedTrackForSwitchTrace(audioSelection)} " +
-                        "candidates=${describeTrackCandidatesForRestoreLog(audioTracks)}"
+                            "candidates=${describeTrackCandidatesForRestoreLog(audioTracks)}"
                 )
                 Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: audio no match for lang=${audioSelection.language} name=${audioSelection.name}, clearing")
                 updatedPending = updatedPending.copy(audio = null)
@@ -831,14 +986,14 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                 logSwitchTrace(
                     stage = "restore-subtitle-internal",
                     message = "mode=${if (usingSwitchPending && switchSourceEngine != null) "switch-hint-aware" else "regular"} " +
-                        "sourceEngine=$switchSourceEngine resultIndex=$index target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)}"
+                            "sourceEngine=$switchSourceEngine resultIndex=$index target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)}"
                 )
                 if (index >= 0) {
                     val alreadySelected = subtitleTracks.getOrNull(index)?.isSelected == true
                     logSwitchTrace(
                         stage = "restore-subtitle-internal-match",
                         message = "index=$index alreadySelected=$alreadySelected " +
-                            "matched=${subtitleTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
+                                "matched=${subtitleTracks.getOrNull(index)?.let { describeTrackInfoForRestoreLog(it) }}"
                     )
                     if (!alreadySelected) {
                         Log.d(PlayerRuntimeController.TAG, "TRACK_PREF restore: internal subtitle index=$index (re-applying)")
@@ -852,16 +1007,15 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                     }
                 } else {
                     val shouldDeferSwitchRestore = usingSwitchPending &&
-                        switchSourceEngine == InternalPlayerEngine.EXOPLAYER &&
-                        isUsingMpvEngine() &&
-                        hasSparseMpvSubtitleMetadataForEngineSwitch(subtitleTracks)
+                            switchSourceEngine == InternalPlayerEngine.EXOPLAYER &&
+                            isUsingMpvEngine() &&
+                            hasSparseMpvSubtitleMetadataForEngineSwitch(subtitleTracks)
                     logSwitchTrace(
                         stage = "restore-subtitle-internal-no-match",
                         message = "shouldDeferSwitchRestore=$shouldDeferSwitchRestore " +
-                            "target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)} " +
-                            "candidates=${describeTrackCandidatesForRestoreLog(subtitleTracks)}"
+                                "target=${describeRememberedTrackForSwitchTrace(subtitleSelection.track)} " +
+                                "candidates=${describeTrackCandidatesForRestoreLog(subtitleTracks)}"
                     )
-                    // No internal track matches — try addon fallback with the same language variant.
                     val resolvedVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
                         language = subtitleSelection.track.language,
                         name = subtitleSelection.track.name,
@@ -878,20 +1032,20 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                             PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, resolvedVariant)
                         }
                         if (addonFallback != null) {
-                        logSwitchTrace(
-                            stage = "restore-subtitle-internal-fallback-addon",
-                            message = "addonId=${addonFallback.id} addonLang=${addonFallback.lang} variant=$resolvedVariant"
-                        )
-                        Log.d(
-                            PlayerRuntimeController.TAG,
-                            "TRACK_PREF restore: internal no match, falling back to addon lang=${addonFallback.lang} variant=$resolvedVariant"
-                        )
-                        autoSubtitleSelected = true
-                        subtitleAddonRestoredByPersistedPreference = true
-                        pendingRestoredAddonSubtitle = addonFallback
-                        selectAddonSubtitle(addonFallback)
-                        updatedAddonSubtitle = addonFallback
-                        updatedPending = updatedPending.copy(subtitle = null)
+                            logSwitchTrace(
+                                stage = "restore-subtitle-internal-fallback-addon",
+                                message = "addonId=${addonFallback.id} addonLang=${addonFallback.lang} variant=$resolvedVariant"
+                            )
+                            Log.d(
+                                PlayerRuntimeController.TAG,
+                                "TRACK_PREF restore: internal no match, falling back to addon lang=${addonFallback.lang} variant=$resolvedVariant"
+                            )
+                            autoSubtitleSelected = true
+                            subtitleAddonRestoredByPersistedPreference = true
+                            pendingRestoredAddonSubtitle = addonFallback
+                            selectAddonSubtitle(addonFallback)
+                            updatedAddonSubtitle = addonFallback
+                            updatedPending = updatedPending.copy(subtitle = null)
                         } else {
                             logSwitchTrace(
                                 stage = "restore-subtitle-internal-no-match",
@@ -931,14 +1085,14 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
                     usingSwitchPending && isUsingMpvEngine()
                 val addonSelectedInMpv =
                     !shouldKeepPendingUntilMpvConfirmsSelection ||
-                        isMpvAddonSubtitleTrackActive(addonMatch)
+                            isMpvAddonSubtitleTrackActive(addonMatch)
                 if (addonSelectedInMpv) {
                     updatedPending = updatedPending.copy(subtitle = null)
                 } else {
                     logSwitchTrace(
                         stage = "restore-subtitle-addon",
                         message = "result=defer-clear reason=mpv-addon-not-active-yet " +
-                            "addonId=${addonMatch.id} addonLang=${addonMatch.lang}"
+                                "addonId=${addonMatch.id} addonLang=${addonMatch.lang}"
                     )
                 }
             } else {
@@ -983,7 +1137,7 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         logSwitchTrace(
             stage = "restore-exit-switch",
             message = "remainingAudio=${describeRememberedTrackForSwitchTrace(normalizedPending?.audio)} " +
-                "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
+                    "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
         )
         pendingEngineSwitchTrackPreference = normalizedPending?.let { preference ->
             PlayerRuntimeController.PendingEngineSwitchTrackPreference(
@@ -996,7 +1150,7 @@ internal fun PlayerRuntimeController.applyPersistedTrackPreference(
         logSwitchTrace(
             stage = "restore-exit-persisted",
             message = "remainingAudio=${describeRememberedTrackForSwitchTrace(normalizedPending?.audio)} " +
-                "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
+                    "remainingSubtitle=${describeRememberedSubtitleForSwitchTrace(normalizedPending?.subtitle)}"
         )
         persistedTrackPreference = normalizedPending
     }
@@ -1288,14 +1442,14 @@ internal fun PlayerRuntimeController.findBrazilianPortugueseInGenericPtTracks(
 
     val brazilianNonForced = genericPtIndexes.filter { index ->
         !subtitleTracks[index].isForced &&
-            subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
-            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
+                subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
+                !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
     }
     if (brazilianNonForced.isNotEmpty()) return brazilianNonForced.first()
 
     return genericPtIndexes.firstOrNull { index ->
         subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS) &&
-            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
+                !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.EUROPEAN_PT_TAGS)
     } ?: genericPtIndexes.firstOrNull { index ->
         subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.BRAZILIAN_TAGS)
     } ?: -1
@@ -1339,14 +1493,14 @@ internal fun PlayerRuntimeController.findLatinoSpanishInGenericEsTracks(
 
     val latinoNonForced = genericEsIndexes.filter { index ->
         !subtitleTracks[index].isForced &&
-            subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
-            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
+                subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
+                !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
     }
     if (latinoNonForced.isNotEmpty()) return latinoNonForced.first()
 
     return genericEsIndexes.firstOrNull { index ->
         subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS) &&
-            !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
+                !subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.CASTILIAN_TAGS)
     } ?: genericEsIndexes.firstOrNull { index ->
         subtitleHasAnyTag(subtitleTracks[index], PlayerSubtitleUtils.LATINO_TAGS)
     } ?: -1
@@ -1469,10 +1623,8 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
         val matchedTargetPosition = targets.indexOfFirst { target ->
             val normalizedTarget = PlayerSubtitleUtils.normalizeLanguageCode(target)
             trackVariant == normalizedTarget ||
-                PlayerSubtitleUtils.matchesLanguageCode(trackVariant, target)
+                    PlayerSubtitleUtils.matchesLanguageCode(trackVariant, target)
         }
-        // If the match is only for a secondary (non-primary) target and addon subtitles haven't
-        // loaded yet, defer - a primary addon subtitle may still arrive.
         val addonSubtitlesLoaded = !state.isLoadingAddonSubtitles
         if (matchedTargetPosition > 0 && !addonSubtitlesLoaded) {
             Log.d(
@@ -1585,7 +1737,7 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
                 Log.d(
                     PlayerRuntimeController.TAG,
                     "AUTO_SUB addon fallback: target=$target matched addon lang=${match.lang} id=${match.id} " +
-                        "(addons=${state.addonSubtitles.size}, targets=$targets)"
+                            "(addons=${state.addonSubtitles.size}, targets=$targets)"
                 )
                 return@run match
             }
@@ -1630,7 +1782,7 @@ internal fun PlayerRuntimeController.startFrameRateProbe(
             if (!isActive) return@launch
             val stateSnapshot = withContext(Dispatchers.Main) { _uiState.value }
             val trackAlreadySet = stateSnapshot.detectedFrameRateSource == FrameRateSource.TRACK &&
-                stateSnapshot.detectedFrameRate > 0f
+                    stateSnapshot.detectedFrameRate > 0f
             if (trackAlreadySet) {
                 if (!allowAmbiguousTrackOverride) return@launch
 
@@ -1656,7 +1808,7 @@ internal fun PlayerRuntimeController.startFrameRateProbe(
                     val state = _uiState.value
                     val shouldApplyInitial = state.detectedFrameRate <= 0f
                     val shouldOverrideAmbiguousTrack = allowAmbiguousTrackOverride &&
-                        PlayerFrameRateHeuristics.shouldProbeOverrideTrack(state, detection)
+                            PlayerFrameRateHeuristics.shouldProbeOverrideTrack(state, detection)
 
                     if (shouldApplyInitial || shouldOverrideAmbiguousTrack) {
                         _uiState.update {
@@ -1702,8 +1854,8 @@ internal fun PlayerRuntimeController.applySubtitlePreferences(preferred: String,
             builder.setPreferredTextLanguage(null)
         } else {
             val userDisabledSubtitles = autoSubtitleSelected &&
-                _uiState.value.selectedSubtitleTrackIndex == -1 &&
-                _uiState.value.selectedAddonSubtitle == null
+                    _uiState.value.selectedSubtitleTrackIndex == -1 &&
+                    _uiState.value.selectedAddonSubtitle == null
             if (!userDisabledSubtitles) {
                 builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -318,6 +318,23 @@ fun PlayerScreen(
         }
     }
 
+    // Bump UI thread priority to THREAD_PRIORITY_DISPLAY (-4) while the player is active.
+    // The Linux scheduler favors the thread under CPU pressure (background addon prefetch,
+    // Trakt sync, image decode), reducing dropped frames at scene cuts and during decoder
+    // spin-up. Restored on dispose so non-player screens stay at default priority.
+    DisposableEffect(Unit) {
+        val tid = android.os.Process.myTid()
+        val previousPriority = runCatching { android.os.Process.getThreadPriority(tid) }.getOrDefault(0)
+        runCatching {
+            android.os.Process.setThreadPriority(tid, android.os.Process.THREAD_PRIORITY_DISPLAY)
+        }
+        onDispose {
+            runCatching {
+                android.os.Process.setThreadPriority(tid, previousPriority)
+            }
+        }
+    }
+
     // Frame rate matching lifecycle.
     val activity = LocalContext.current as? android.app.Activity
     LaunchedEffect(activity) {
@@ -1879,7 +1896,8 @@ private fun PlayerControlsProgressBarHost(
         upFocusRequester = upFocusRequester,
         downFocusRequester = downFocusRequester,
         onUpKey = onUpKey,
-        onFocused = onFocused
+        onFocused = onFocused,
+        bufferedPosition = playbackTimeline.bufferedPosition
     )
 }
 
@@ -1981,10 +1999,16 @@ private fun ProgressBar(
     upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
     onUpKey: (() -> Unit)? = null,
-    onFocused: (() -> Unit)? = null
+    onFocused: (() -> Unit)? = null,
+    /** Position (ms) up to which content is buffered. Pass 0 to skip the overlay. */
+    bufferedPosition: Long = 0L
 ) {
     val progress = if (duration > 0) {
         (currentPosition.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    val bufferedProgress = if (duration > 0 && bufferedPosition > currentPosition) {
+        (bufferedPosition.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
     } else 0f
 
     val animatedProgress by animateFloatAsState(
@@ -1992,12 +2016,17 @@ private fun ProgressBar(
         animationSpec = tween(100),
         label = "progress"
     )
+    val animatedBufferedProgress by animateFloatAsState(
+        targetValue = bufferedProgress,
+        animationSpec = tween(200),
+        label = "bufferedProgress"
+    )
     var isFocused by remember { mutableStateOf(false) }
 
-    Box(
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
-            .height(if (isFocused) 10.dp else 6.dp)
+            .height(if (isFocused) 12.dp else 8.dp)
             .then(
                 if (focusRequester != null) Modifier.focusRequester(focusRequester)
                 else Modifier
@@ -2077,10 +2106,24 @@ private fun ProgressBar(
                 else Color.White.copy(alpha = 0.3f)
             )
     ) {
+        val trackWidth = maxWidth
+
+        // Buffered-ahead overlay: the theme accent, faded so it reads under the played
+        // fill and on light themes.
+        if (animatedBufferedProgress > 0f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .width(trackWidth * animatedBufferedProgress)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(NuvioColors.Secondary.copy(alpha = 0.35f))
+            )
+        }
+        // Played fill.
         Box(
             modifier = Modifier
                 .fillMaxHeight()
-                .fillMaxWidth(animatedProgress)
+                .width(trackWidth * animatedProgress)
                 .clip(RoundedCornerShape(3.dp))
                 .background(NuvioColors.Secondary)
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -201,7 +201,9 @@ data class PlayerUiState(
 
 data class PlaybackTimelineState(
     val currentPosition: Long = 0L,
-    val duration: Long = 0L
+    val duration: Long = 0L,
+    /** Position (ms) up to which the player has buffered ahead of the playhead. */
+    val bufferedPosition: Long = 0L
 )
 
 data class TrackInfo(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebugSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebugSettingsScreen.kt
@@ -131,6 +131,15 @@ fun DebugSettingsContent(
                 )
             }
 
+            item(key = "debug_toggle_buffer_logs") {
+                DebugToggleCard(
+                    title = stringResource(R.string.debug_buffer_logs_title),
+                    subtitle = stringResource(R.string.debug_buffer_logs_subtitle),
+                    checked = uiState.bufferLogsEnabled,
+                    onToggle = { viewModel.onEvent(DebugSettingsEvent.ToggleBufferLogs(it)) }
+                )
+            }
+
             // ── Library Testing ──
             item(key = "debug_library_header") {
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebugSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebugSettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.data.local.DebugSettingsDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.LibraryPreferences
+import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.model.SavedLibraryItem
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,6 +26,7 @@ import kotlin.random.Random
 class DebugSettingsViewModel @Inject constructor(
     private val dataStore: DebugSettingsDataStore,
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    private val playerSettingsDataStore: PlayerSettingsDataStore,
     private val authManager: AuthManager,
     private val libraryPreferences: LibraryPreferences,
     @ApplicationContext private val context: Context
@@ -49,6 +51,12 @@ class DebugSettingsViewModel @Inject constructor(
                 _uiState.update { it.copy(composeHighlighterEnabled = enabled) }
             }
         }
+        // Buffer logs state
+        viewModelScope.launch {
+            playerSettingsDataStore.playerSettings.collectLatest { settings ->
+                _uiState.update { it.copy(bufferLogsEnabled = settings.enableBufferLogs) }
+            }
+        }
     }
 
     fun onEvent(event: DebugSettingsEvent) {
@@ -61,6 +69,9 @@ class DebugSettingsViewModel @Inject constructor(
             }
             is DebugSettingsEvent.ToggleComposeHighlighter -> {
                 viewModelScope.launch { layoutPreferenceDataStore.setComposeHighlighterEnabled(event.enabled) }
+            }
+            is DebugSettingsEvent.ToggleBufferLogs -> {
+                viewModelScope.launch { playerSettingsDataStore.setEnableBufferLogs(event.enabled) }
             }
             is DebugSettingsEvent.GenerateLibraryItems -> {
                 viewModelScope.launch {
@@ -149,6 +160,7 @@ data class DebugSettingsUiState(
     val accountTabEnabled: Boolean = false,
     val syncCodeFeaturesEnabled: Boolean = false,
     val composeHighlighterEnabled: Boolean = false,
+    val bufferLogsEnabled: Boolean = false,
     val generateLibraryLoading: Boolean = false,
     val generateLibraryResult: String? = null,
     val signInLoading: Boolean = false,
@@ -159,6 +171,7 @@ sealed class DebugSettingsEvent {
     data class ToggleAccountTab(val enabled: Boolean) : DebugSettingsEvent()
     data class ToggleSyncCodeFeatures(val enabled: Boolean) : DebugSettingsEvent()
     data class ToggleComposeHighlighter(val enabled: Boolean) : DebugSettingsEvent()
+    data class ToggleBufferLogs(val enabled: Boolean) : DebugSettingsEvent()
     data class GenerateLibraryItems(val count: Int) : DebugSettingsEvent()
     data class SignIn(val email: String, val password: String) : DebugSettingsEvent()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DiagnosticsCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DiagnosticsCard.kt
@@ -1,0 +1,287 @@
+@file:OptIn(ExperimentalTvMaterial3Api::class)
+
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Border
+import androidx.tv.material3.Card
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.core.player.DolbyVisionCodecFallback
+import com.nuvio.tv.core.player.LastPlaybackDiagnostics
+import com.nuvio.tv.ui.theme.NuvioColors
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Emits the diagnostics card content as 3 dense focusable Cards.
+ *
+ * Goal: minimize scrolling by packing related fields tightly per Card.
+ * Each Card is one D-pad stop containing 6-10 rows of related info.
+ */
+internal fun LazyListScope.diagnosticsCardItems(
+    diagnostics: LastPlaybackDiagnostics,
+    dvCurrentlyEnabled: Boolean = true
+) {
+    if (diagnostics.timestampMs == 0L || diagnostics.host.isBlank()) {
+        item(key = "diagnostics_empty_intro") {
+            DiagnosticsSectionCard {
+                Text(
+                    text = "Last Playback Diagnostics",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = NuvioColors.Primary
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "No playback data yet. Play a stream and return here to see DV decision details for that playback.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioColors.TextSecondary
+                )
+            }
+        }
+        return
+    }
+
+    // Only show DV rows when the last playback actually involved DV. Requested mode isn't
+    // enough: AUTO is the default, so "requested != OFF" holds even for SDR/HDR10. Use real
+    // evidence: a detected profile, a successful conversion, a codec rewrite, or DV output.
+    // Not dv7DoviCalls: the startup self-test makes it >= 1 on every playback.
+    val dvContentPlayed = diagnostics.dvSourceProfile != null ||
+        diagnostics.dv7DoviSuccess > 0 ||
+        diagnostics.dv7DoviSignalRewrites > 0 ||
+        (diagnostics.videoHdrType?.contains("Dolby Vision", ignoreCase = true) == true)
+    val dvEngaged = dvCurrentlyEnabled &&
+        diagnostics.dv7ModeRequested.isNotBlank() &&
+        diagnostics.dv7ModeRequested != "OFF" &&
+        dvContentPlayed
+    fun dv(value: String?): String =
+        if (dvEngaged) (value?.takeIf { it.isNotBlank() } ?: "-") else "-"
+
+    // Card 1: Source + Display + Decoder + Bridge (the input side)
+    item(key = "diag_card_input") {
+        DiagnosticsSectionCard {
+            SectionHeader("Source & Hardware", "Take a photo of this card if reporting an issue.")
+            DiagnosticRow("Host", diagnostics.host)
+            DiagnosticRow("When", formatTimestamp(diagnostics.timestampMs))
+            DiagnosticRow("Device", deviceName())
+            DiagnosticRow(
+                "Display",
+                dv(
+                    if (diagnostics.hdrCapsKnown) {
+                        buildString {
+                            if (diagnostics.displayDv) append("DV ")
+                            if (diagnostics.displayHdr10Plus) append("HDR10+ ")
+                            else if (diagnostics.displayHdr10) append("HDR10 ")
+                            if (!diagnostics.displayDv && !diagnostics.displayHdr10) append("SDR")
+                        }.trim().ifBlank { "Unknown" }
+                    } else {
+                        "Unknown"
+                    }
+                )
+            )
+            DiagnosticRow(
+                "DV7 Decoder",
+                dv(if (diagnostics.codecDv7Supported) "Available" else "Not available")
+            )
+            DiagnosticRow(
+                "DV Decoder",
+                dv(
+                    diagnostics.dv81DecoderName
+                        ?: findAnyDvDecoderName()?.let { "$it (hidden)" }
+                        ?: "None"
+                )
+            )
+            DiagnosticRow(
+                "DV Bridge",
+                dv(if (diagnostics.bridgeReady) "Ready" else "Not ready")
+            )
+            if (dvEngaged) {
+                diagnostics.bridgeVersion?.let { DiagnosticRow("Bridge Version", it) }
+                diagnostics.bridgeReason?.let { DiagnosticRow("Bridge Reason", it) }
+            }
+        }
+    }
+
+    // Card 2: Decision + Settings (the configured/effective behaviour)
+    item(key = "diag_card_decision") {
+        DiagnosticsSectionCard {
+            SectionHeader("Decision & Settings")
+            DiagnosticRow("DV Mode (requested)", dv(diagnostics.dv7ModeRequested))
+            if (dvEngaged && diagnostics.dv7ModeRequested != diagnostics.dv7ModeEffective) {
+                DiagnosticRow("DV Mode (effective)", dv(diagnostics.dv7ModeEffective))
+            }
+            DiagnosticRow("AUTO Decision", dv(diagnostics.dv7AutoDecision))
+            if (dvEngaged) {
+                diagnostics.dvSourceProfile?.let { DiagnosticRow("Source Profile", it) }
+                if (diagnostics.dv7DoviCalls > 0) {
+                    DiagnosticRow(
+                        "Conversions",
+                        "${diagnostics.dv7DoviSuccess} of ${diagnostics.dv7DoviCalls} successful"
+                    )
+                }
+                if (diagnostics.dv7DoviSignalRewrites > 0) {
+                    DiagnosticRow("Signal Rewrites", diagnostics.dv7DoviSignalRewrites.toString())
+                }
+            }
+            DiagnosticRow(
+                "Custom Buffers",
+                if (diagnostics.bufferEngineEnabled) "On" else "Off"
+            )
+            DiagnosticRow(
+                "Custom Network/Cache",
+                if (diagnostics.parallelNetworkEnabled) "On" else "Off"
+            )
+        }
+    }
+
+    // Card 3: Outcome
+    item(key = "diag_card_outcome") {
+        DiagnosticsSectionCard {
+            SectionHeader("Outcome")
+            DiagnosticRow("HDR Format (intended)", diagnostics.videoHdrType?.takeIf { it.isNotBlank() } ?: "-")
+            DiagnosticRow(
+                "First Frame",
+                if (diagnostics.firstFrameMs >= 0) "${diagnostics.firstFrameMs} ms" else "Never rendered"
+            )
+            DiagnosticRow(
+                "Rebuffers",
+                if (diagnostics.rebufferCount > 0)
+                    "${diagnostics.rebufferCount} (${diagnostics.rebufferTotalMs} ms)"
+                else "0"
+            )
+            DiagnosticRow(
+                "Result",
+                diagnostics.result,
+                valueColor = when {
+                    diagnostics.result.startsWith("Error", ignoreCase = true) -> Color(0xFFF44336)
+                    diagnostics.result == "Played" -> Color(0xFF4CAF50)
+                    else -> NuvioColors.TextPrimary
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun DiagnosticsSectionCard(
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        onClick = { /* read-only */ },
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            focusedContainerColor = NuvioColors.FocusBackground
+        ),
+        border = CardDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing.copy(alpha = 0.5f)),
+                shape = RoundedCornerShape(10.dp)
+            )
+        ),
+        shape = CardDefaults.shape(shape = RoundedCornerShape(10.dp)),
+        scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(label: String, subtitle: String? = null) {
+    Text(
+        text = label.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        color = NuvioColors.Primary
+    )
+    if (subtitle != null) {
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = NuvioColors.TextSecondary,
+            fontSize = 11.sp
+        )
+    }
+    Spacer(modifier = Modifier.height(4.dp))
+}
+
+@Composable
+private fun DiagnosticRow(
+    label: String,
+    value: String,
+    valueColor: Color = NuvioColors.TextPrimary
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = NuvioColors.TextSecondary,
+            modifier = Modifier.width(170.dp)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = valueColor,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+private fun formatTimestamp(ms: Long): String {
+    if (ms == 0L) return "—"
+    return SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date(ms))
+}
+
+/** "Manufacturer Model", de-duplicated (e.g. avoids "Xiaomi Xiaomi ..."). */
+private fun deviceName(): String {
+    val manufacturer = android.os.Build.MANUFACTURER?.trim().orEmpty()
+    val model = android.os.Build.MODEL?.trim().orEmpty()
+    return when {
+        model.isBlank() -> manufacturer.ifBlank { "Unknown" }
+        manufacturer.isBlank() -> model
+        model.startsWith(manufacturer, ignoreCase = true) -> model
+        else -> "$manufacturer $model"
+    }.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString() }
+}
+
+private fun findAnyDvDecoderName(): String? {
+    return runCatching {
+        val list = android.media.MediaCodecList(android.media.MediaCodecList.REGULAR_CODECS)
+        list.codecInfos
+            .filter { !it.isEncoder }
+            .firstOrNull { info ->
+                info.supportedTypes.any { it.equals("video/dolby-vision", ignoreCase = true) }
+            }
+            ?.name
+    }.getOrNull()
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
@@ -1,0 +1,111 @@
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.media3.common.util.UnstableApi
+import com.nuvio.tv.data.local.BufferSettings
+import com.nuvio.tv.data.local.PlayerSettings
+
+/**
+ * Shared memory budget constants and helpers for buffer + parallel connection settings.
+ * Used by both PlaybackSettingsViewModel and PlaybackBufferNetworkSettings UI.
+ */
+@UnstableApi
+object MemoryBudget {
+    const val TAG = "MemoryBudget"
+
+    // Heap-tiered budget ratios. Low-RAM devices (Fire TV class) need more
+    // headroom for codec/surface/UI; high-RAM devices can dedicate more to buffering.
+    private const val LOW_HEAP_RATIO = 0.65
+    private const val HIGH_HEAP_RATIO = 0.85
+    private const val HIGH_HEAP_THRESHOLD_MB = 512L
+    // The buffer allocator is on the Java heap; on low-RAM reserve a slice for the UI/decoder/caches
+    // and give the rest to the buffer (a flat % of max heap overcommits and starves them).
+    private const val LOW_HEAP_RESERVE_MB = 210L
+
+    /** ParallelRangeDataSource schedules maxAhead = parallelConnections + 1 chunks concurrently */
+    private const val BUFFER_OVERHEAD = 1
+
+    const val MIN_CONNECTIONS = 2
+    const val MAX_CONNECTIONS = 4
+    const val MIN_CHUNK_MB = 8
+    const val MAX_CHUNK_MB = 128
+    const val BUFFER_STEP_MB = 25
+    const val MIN_BUFFER_MB = 25
+    const val MAX_BUFFER_MB = 1024 * 4
+    private const val DEFAULT_EFFECTIVE_BUFFER_MB = 50
+
+    val defaultBufferSizeMb: Int = if (BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB > 0) {
+        BufferSettings.DEFAULT_TARGET_BUFFER_SIZE_MB
+    } else {
+        DEFAULT_EFFECTIVE_BUFFER_MB
+    }
+
+    private val maxHeapMb: Long = Runtime.getRuntime().maxMemory() / (1024L * 1024L)
+
+    /** True when the app heap is below the high-RAM threshold (Fire TV / TV-stick class). */
+    val isLowRamTier: Boolean = maxHeapMb < HIGH_HEAP_THRESHOLD_MB
+
+    // Pre-cap ratio budget; conversionBudgetMb derives from this so DV7 headroom isn't cut by the cap.
+    private val rawBudgetMb: Int =
+        (maxHeapMb * (if (isLowRamTier) LOW_HEAP_RATIO else HIGH_HEAP_RATIO)).toInt()
+
+    val budgetMb: Int =
+        if (isLowRamTier)
+            rawBudgetMb.coerceAtMost((maxHeapMb - LOW_HEAP_RESERVE_MB).toInt()).coerceAtLeast(MIN_BUFFER_MB)
+        else rawBudgetMb
+
+    // DV7 conversion headroom: a third of the raw budget on low-RAM, half on high-RAM; never above budget.
+    val conversionBudgetMb: Int =
+        (if (isLowRamTier) rawBudgetMb / 3 else rawBudgetMb / 2)
+            .coerceAtMost(budgetMb).coerceAtLeast(MIN_BUFFER_MB)
+
+    fun effectiveBufferMb(stored: Int): Int =
+        if (stored > 0) stored else defaultBufferSizeMb
+
+    /** Number of chunk-sized buffers alive concurrently */
+    fun bufferCount(connectionCount: Int): Int =
+        connectionCount + BUFFER_OVERHEAD
+
+    fun parallelOverheadMb(connectionCount: Int, chunkSizeMb: Int): Int =
+        bufferCount(connectionCount) * chunkSizeMb
+
+    fun totalUsageMb(bufferMb: Int, connectionCount: Int, chunkSizeMb: Int, parallelEnabled: Boolean): Int =
+        bufferMb + if (parallelEnabled) parallelOverheadMb(connectionCount, chunkSizeMb) else 0
+
+    /** Max chunk size that fits budget given current buffer size */
+    fun maxChunkMb(bufferMb: Int, connectionCount: Int): Int =
+        ((budgetMb - bufferMb) / bufferCount(connectionCount)).coerceIn(MIN_CHUNK_MB, MAX_CHUNK_MB)
+
+    /** Max buffer size that fits budget given current parallel overhead */
+    fun maxBufferMb(parallelOverheadMb: Int): Int =
+        ((budgetMb - parallelOverheadMb) / BUFFER_STEP_MB * BUFFER_STEP_MB)
+            .coerceIn(MIN_BUFFER_MB, MAX_BUFFER_MB)
+
+    /** Slider max for target buffer, optionally raised to 2GB when override is on. */
+    fun maxBufferMbWithOverride(parallelOverheadMb: Int, allowLargeTargetBuffer: Boolean): Int {
+        val safeMax = maxBufferMb(parallelOverheadMb)
+        return if (allowLargeTargetBuffer) {
+            PlayerSettings.LARGE_TARGET_BUFFER_MAX_MB
+                .coerceAtMost(MAX_BUFFER_MB)
+                .coerceAtLeast(safeMax)
+        } else {
+            safeMax
+        }
+    }
+
+    /**
+     * Enforce budget: reduce chunk first, then buffer as last resort.
+     * Returns (adjustedBufferMb, adjustedChunkMb).
+     */
+    fun enforce(bufferMb: Int, chunkMb: Int, connectionCount: Int): Pair<Int, Int> {
+        val buffers = bufferCount(connectionCount)
+        if (bufferMb + buffers * chunkMb <= budgetMb) return bufferMb to chunkMb
+
+        val newChunkMb = maxChunkMb(bufferMb, connectionCount)
+        if (bufferMb + buffers * newChunkMb <= budgetMb) return bufferMb to newChunkMb
+
+        // Even min chunk doesn't fit, also reduce buffer
+        val newBufferMb = ((budgetMb - buffers * MIN_CHUNK_MB) / BUFFER_STEP_MB * BUFFER_STEP_MB)
+            .coerceAtLeast(MIN_BUFFER_MB)
+        return newBufferMb to MIN_CHUNK_MB
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -61,6 +61,8 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.R
+import com.nuvio.tv.data.local.Dv7HandlingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.domain.model.ExperienceMode
 import com.nuvio.tv.ui.theme.NuvioColors
 import kotlinx.coroutines.Dispatchers
@@ -179,6 +181,16 @@ fun AdvancedSettingsContent(
 
     val scope = rememberCoroutineScope()
     val unknownError = stringResource(R.string.error_unknown)
+
+    // DV Diagnostics: reuse the playback settings store for the conversion-mode
+    // override and the last-playback diagnostics card.
+    val playbackVm: PlaybackSettingsViewModel = hiltViewModel()
+    val dvPlayerSettings by playbackVm.playerSettings.collectAsStateWithLifecycle(
+        initialValue = com.nuvio.tv.data.local.PlayerSettings()
+    )
+    val dvDiagnostics by playbackVm.lastPlaybackDiagnostics.collectAsStateWithLifecycle(
+        initialValue = com.nuvio.tv.core.player.LastPlaybackDiagnostics.EMPTY
+    )
 
     fun runSpeedTest() {
         scope.launch {
@@ -473,6 +485,69 @@ fun AdvancedSettingsContent(
                     }
                 )
             }
+        }
+
+        if (dvPlayerSettings.internalPlayerEngine == InternalPlayerEngine.EXOPLAYER ||
+            dvPlayerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO) {
+            item(key = "dv_diagnostics_header") {
+                Text(
+                    text = stringResource(R.string.advanced_section_dv_diagnostics),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = NuvioColors.TextTertiary,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
+            item(key = "dv_conversion_mode") {
+                val overrideEnabled = dvPlayerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI
+                var showModeDialog by remember { mutableStateOf(false) }
+                val modeOptions = listOf(
+                    SettingsPickerOption(
+                        -1,
+                        stringResource(R.string.dv7_libdovi_mode_none_title),
+                        stringResource(R.string.dv7_libdovi_mode_none_sub)
+                    ),
+                    SettingsPickerOption(0, stringResource(R.string.dv7_libdovi_mode_0_title), stringResource(R.string.dv7_libdovi_mode_0_sub)),
+                    SettingsPickerOption(1, stringResource(R.string.dv7_libdovi_mode_1_title), stringResource(R.string.dv7_libdovi_mode_1_sub)),
+                    SettingsPickerOption(2, stringResource(R.string.dv7_libdovi_mode_2_title), stringResource(R.string.dv7_libdovi_mode_2_sub)),
+                    SettingsPickerOption(3, stringResource(R.string.dv7_libdovi_mode_3_title), stringResource(R.string.dv7_libdovi_mode_3_sub)),
+                    SettingsPickerOption(4, stringResource(R.string.dv7_libdovi_mode_4_title), stringResource(R.string.dv7_libdovi_mode_4_sub))
+                )
+                // Show None whenever the row is disabled so a stale stored override
+                // never displays as a selected mode.
+                val effectiveOverride = if (overrideEnabled) dvPlayerSettings.dv7LibdoviModeOverride else -1
+                val currentLabel = modeOptions.firstOrNull { it.value == effectiveOverride }?.title
+                    ?: modeOptions.first().title
+                SettingsGroupCard(modifier = Modifier.fillMaxWidth()) {
+                    SettingsActionRow(
+                        title = stringResource(R.string.dv7_libdovi_mode_row_title),
+                        subtitle = stringResource(R.string.dv7_libdovi_mode_caption),
+                        value = currentLabel,
+                        onClick = { showModeDialog = true },
+                        enabled = overrideEnabled
+                    )
+                }
+                if (showModeDialog) {
+                    SettingsSingleChoiceDialog(
+                        title = stringResource(R.string.dv7_libdovi_mode_row_title),
+                        subtitle = stringResource(R.string.dv7_libdovi_mode_caption),
+                        options = modeOptions,
+                        selectedValue = effectiveOverride,
+                        onOptionSelected = { value ->
+                            scope.launch { playbackVm.setDv7LibdoviModeOverride(value) }
+                            showModeDialog = false
+                        },
+                        onDismiss = { showModeDialog = false },
+                        width = 460.dp,
+                        maxHeight = 360.dp
+                    )
+                }
+            }
+
+            diagnosticsCardItems(
+                diagnostics = dvDiagnostics,
+                dvCurrentlyEnabled = dvPlayerSettings.dv7HandlingMode != Dv7HandlingMode.OFF
+            )
         }
     }
         SettingsVerticalScrollIndicators(state = networkListState)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -54,6 +54,8 @@ import com.nuvio.tv.core.build.AppFeaturePolicy
 import com.nuvio.tv.data.local.AVAILABLE_SUBTITLE_LANGUAGES
 import com.nuvio.tv.data.local.AudioLanguageOption
 import com.nuvio.tv.data.local.AudioOutputChannels
+import com.nuvio.tv.data.local.Dv7HandlingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.MpvHardwareDecodeMode
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.TrailerSettings
@@ -69,6 +71,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onShowAudioOutputChannelsDialog: () -> Unit,
     onShowDecoderPriorityDialog: () -> Unit,
     onShowMpvHardwareDecodeModeDialog: () -> Unit,
+    onShowDv7HandlingModeDialog: () -> Unit,
     onSetTrailerEnabled: (Boolean) -> Unit,
     onSetTrailerDelaySeconds: (Int) -> Unit,
     onSetDownmixEnabled: (Boolean) -> Unit,
@@ -76,10 +79,17 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onSetSkipSilence: (Boolean) -> Unit,
     onSetRememberAudioDelayPerDevice: (Boolean) -> Unit,
     onSetTunnelingEnabled: (Boolean) -> Unit,
-    onSetMapDV7ToHevc: (Boolean) -> Unit,
+    onSetDv5ToDv81Enabled: (Boolean) -> Unit,
+    onSetDv7ToDv81PreserveMappingEnabled: (Boolean) -> Unit,
     onItemFocused: () -> Unit = {},
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    videoExtraItems: (LazyListScope.() -> Unit)? = null
 ) {
+    val isExoEngine = playerSettings.internalPlayerEngine == InternalPlayerEngine.EXOPLAYER ||
+            playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO
+    val isMpvEngine = playerSettings.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER ||
+            playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO
+
     if (AppFeaturePolicy.inAppTrailerPlaybackEnabled) {
         item(key = "audio_trailer_section_header") {
             Text(
@@ -120,6 +130,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         }
     }
 
+    // ── Audio Section ──
     item(key = "audio_header") {
         Spacer(modifier = Modifier.height(16.dp))
         Text(
@@ -174,129 +185,180 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         )
     }
 
-    item(key = "audio_skip_silence") {
-        ToggleSettingsItem(
-            icon = Icons.Default.Speed,
-            title = stringResource(R.string.audio_skip_silence),
-            subtitle = stringResource(R.string.audio_skip_silence_sub),
-            isChecked = playerSettings.skipSilence,
-            onCheckedChange = onSetSkipSilence,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
+    if (isExoEngine) {
+        item(key = "audio_skip_silence") {
+            ToggleSettingsItem(
+                icon = Icons.Default.Speed,
+                title = stringResource(R.string.audio_skip_silence),
+                subtitle = stringResource(R.string.audio_skip_silence_sub),
+                isChecked = playerSettings.skipSilence,
+                onCheckedChange = onSetSkipSilence,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
+        }
+
+        item(key = "audio_remember_delay_per_device") {
+            ToggleSettingsItem(
+                icon = Icons.Default.Timer,
+                title = stringResource(R.string.audio_remember_delay_per_device),
+                subtitle = stringResource(R.string.audio_remember_delay_per_device_sub),
+                isChecked = playerSettings.rememberAudioDelayPerDevice,
+                onCheckedChange = onSetRememberAudioDelayPerDevice,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
+        }
     }
 
-    item(key = "audio_remember_delay_per_device") {
-        ToggleSettingsItem(
-            icon = Icons.Default.Timer,
-            title = stringResource(R.string.audio_remember_delay_per_device),
-            subtitle = stringResource(R.string.audio_remember_delay_per_device_sub),
-            isChecked = playerSettings.rememberAudioDelayPerDevice,
-            onCheckedChange = onSetRememberAudioDelayPerDevice,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
+    if (isExoEngine) {
+        item(key = "audio_advanced_header") {
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.audio_advanced_section),
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioColors.TextSecondary,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+
+        item(key = "audio_advanced_warning") {
+            Text(
+                text = stringResource(R.string.audio_advanced_warning),
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFFFF9800),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        item(key = "audio_decoder_priority") {
+            val decoderName = when (playerSettings.decoderPriority) {
+                0 -> stringResource(R.string.audio_decoder_device_only)
+                1 -> stringResource(R.string.audio_decoder_prefer_device)
+                2 -> stringResource(R.string.audio_decoder_prefer_app)
+                else -> stringResource(R.string.audio_decoder_prefer_device)
+            }
+
+            NavigationSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_decoder_priority),
+                subtitle = decoderName,
+                onClick = onShowDecoderPriorityDialog,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
+        }
+
+        item(key = "audio_enable_downmix") {
+            ToggleSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_enable_downmix_title),
+                subtitle = stringResource(R.string.audio_enable_downmix_subtitle),
+                isChecked = playerSettings.downmixEnabled,
+                onCheckedChange = onSetDownmixEnabled,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
+        }
+
+        if (playerSettings.downmixEnabled) {
+            item(key = "audio_number_of_channels") {
+                NavigationSettingsItem(
+                    icon = Icons.Default.VolumeUp,
+                    title = stringResource(R.string.audio_number_of_channels),
+                    subtitle = playerSettings.audioOutputChannels.displayLabel,
+                    onClick = onShowAudioOutputChannelsDialog,
+                    onFocused = onItemFocused,
+                    enabled = enabled
+                )
+            }
+
+            item(key = "audio_downmix_normalization") {
+                ToggleSettingsItem(
+                    icon = Icons.Default.Tune,
+                    title = stringResource(R.string.audio_maintain_original_audio_on_downmix_title),
+                    subtitle = stringResource(R.string.audio_maintain_original_audio_on_downmix_subtitle),
+                    isChecked = playerSettings.maintainOriginalAudioOnDownmix,
+                    onCheckedChange = onSetMaintainOriginalAudioOnDownmix,
+                    onFocused = onItemFocused,
+                    enabled = enabled
+                )
+            }
+        }
+
+        item(key = "audio_tunneled_playback") {
+            ToggleSettingsItem(
+                icon = Icons.Default.VolumeUp,
+                title = stringResource(R.string.audio_tunneled),
+                subtitle = stringResource(R.string.audio_tunneled_sub),
+                isChecked = playerSettings.tunnelingEnabled,
+                onCheckedChange = onSetTunnelingEnabled,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
+        }
     }
 
-    item(key = "audio_advanced_header") {
-        Spacer(modifier = Modifier.height(16.dp))
+    // ── Video & DV Settings ──
+    item(key = "video_header") {
         Text(
-            text = stringResource(R.string.audio_advanced_section),
+            text = stringResource(R.string.video_section),
             style = MaterialTheme.typography.titleMedium,
             color = NuvioColors.TextSecondary,
             modifier = Modifier.padding(vertical = 8.dp)
         )
     }
 
-    item(key = "audio_advanced_warning") {
-        Text(
-            text = stringResource(R.string.audio_advanced_warning),
-            style = MaterialTheme.typography.bodySmall,
-            color = Color(0xFFFF9800),
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-    }
+    videoExtraItems?.invoke(this)
 
-    item(key = "audio_decoder_priority") {
-        val decoderName = when (playerSettings.decoderPriority) {
-            0 -> stringResource(R.string.audio_decoder_device_only)
-            1 -> stringResource(R.string.audio_decoder_prefer_device)
-            2 -> stringResource(R.string.audio_decoder_prefer_app)
-            else -> stringResource(R.string.audio_decoder_prefer_device)
-        }
-
-        NavigationSettingsItem(
-            icon = Icons.Default.Tune,
-            title = stringResource(R.string.audio_decoder_priority),
-            subtitle = decoderName,
-            onClick = onShowDecoderPriorityDialog,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
-
-    item(key = "audio_enable_downmix") {
-        ToggleSettingsItem(
-            icon = Icons.Default.Tune,
-            title = stringResource(R.string.audio_enable_downmix_title),
-            subtitle = stringResource(R.string.audio_enable_downmix_subtitle),
-            isChecked = playerSettings.downmixEnabled,
-            onCheckedChange = onSetDownmixEnabled,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
-
-    if (playerSettings.downmixEnabled) {
-        item(key = "audio_number_of_channels") {
+    if (isExoEngine) {
+        item(key = "audio_dv7_handling_mode") {
+            val modeName = when (playerSettings.dv7HandlingMode) {
+                Dv7HandlingMode.AUTO -> stringResource(R.string.dv7_mode_auto)
+                Dv7HandlingMode.HDR10_BASE_LAYER -> stringResource(R.string.dv7_mode_hdr10_base_layer)
+                Dv7HandlingMode.DV81_LIBDOVI -> stringResource(R.string.dv7_mode_dv81_libdovi)
+                Dv7HandlingMode.OFF -> stringResource(R.string.dv7_mode_off)
+            }
             NavigationSettingsItem(
-                icon = Icons.Default.VolumeUp,
-                title = stringResource(R.string.audio_number_of_channels),
-                subtitle = playerSettings.audioOutputChannels.displayLabel,
-                onClick = onShowAudioOutputChannelsDialog,
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.dv7_handling_title),
+                subtitle = modeName,
+                onClick = onShowDv7HandlingModeDialog,
                 onFocused = onItemFocused,
                 enabled = enabled
             )
         }
-
-        item(key = "audio_downmix_normalization") {
+        item(key = "audio_dv7_preserve_mapping") {
             ToggleSettingsItem(
                 icon = Icons.Default.Tune,
-                title = stringResource(R.string.audio_maintain_original_audio_on_downmix_title),
-                subtitle = stringResource(R.string.audio_maintain_original_audio_on_downmix_subtitle),
-                isChecked = playerSettings.maintainOriginalAudioOnDownmix,
-                onCheckedChange = onSetMaintainOriginalAudioOnDownmix,
+                title = stringResource(R.string.audio_dv7_preserve_mapping_title),
+                subtitle = stringResource(R.string.audio_dv7_preserve_mapping_sub),
+                // Show off outside Convert to DV8.1 so a persisted value doesn't read as active.
+                isChecked = playerSettings.dv7ToDv81PreserveMappingEnabled &&
+                        playerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI,
+                onCheckedChange = onSetDv7ToDv81PreserveMappingEnabled,
                 onFocused = onItemFocused,
-                enabled = enabled
+                enabled = enabled && playerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI
+            )
+        }
+
+        item(key = "audio_dv5_to_dv81") {
+            ToggleSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_dv5_to_dv81_title),
+                subtitle = stringResource(R.string.audio_dv5_to_dv81_sub),
+                // Show off outside Convert to DV8.1 so a persisted value doesn't read as active.
+                isChecked = playerSettings.dv5ToDv81Enabled &&
+                        playerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI,
+                onCheckedChange = onSetDv5ToDv81Enabled,
+                onFocused = onItemFocused,
+                enabled = enabled && playerSettings.dv7HandlingMode == Dv7HandlingMode.DV81_LIBDOVI
             )
         }
     }
 
-    item(key = "audio_tunneled_playback") {
-        ToggleSettingsItem(
-            icon = Icons.Default.VolumeUp,
-            title = stringResource(R.string.audio_tunneled),
-            subtitle = stringResource(R.string.audio_tunneled_sub),
-            isChecked = playerSettings.tunnelingEnabled,
-            onCheckedChange = onSetTunnelingEnabled,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
-
-    item(key = "audio_dv7_hevc_fallback") {
-        ToggleSettingsItem(
-            icon = Icons.Default.Tune,
-            title = stringResource(R.string.audio_dv_title),
-            subtitle = stringResource(R.string.audio_dv_sub),
-            isChecked = playerSettings.mapDV7ToHevc,
-            onCheckedChange = onSetMapDV7ToHevc,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
-    }
-
-    item(key = "audio_mpv_hardware_decode_mode") {
+    if (isMpvEngine) {
+        item(key = "audio_mpv_hardware_decode_mode") {
         val hwDecodeModeName = when (playerSettings.mpvHardwareDecodeMode) {
             MpvHardwareDecodeMode.LEGACY_DIRECT_COPY -> stringResource(R.string.audio_mpv_hwdec_legacy_direct_copy)
             MpvHardwareDecodeMode.AUTO_SAFE -> stringResource(R.string.audio_mpv_hwdec_auto_safe)
@@ -313,6 +375,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
             onFocused = onItemFocused,
             enabled = enabled
         )
+        }
     }
 }
 
@@ -323,21 +386,25 @@ internal fun AudioSettingsDialogs(
     showAudioOutputChannelsDialog: Boolean,
     showDecoderPriorityDialog: Boolean,
     showMpvHardwareDecodeModeDialog: Boolean,
+    showDv7HandlingModeDialog: Boolean,
     selectedLanguage: String,
     selectedSecondaryLanguage: String?,
     selectedAudioOutputChannels: AudioOutputChannels,
     selectedPriority: Int,
     selectedMpvHardwareDecodeMode: MpvHardwareDecodeMode,
+    selectedDv7HandlingMode: Dv7HandlingMode,
     onSetPreferredAudioLanguage: (String) -> Unit,
     onSetSecondaryPreferredAudioLanguage: (String?) -> Unit,
     onSetAudioOutputChannels: (AudioOutputChannels) -> Unit,
     onSetDecoderPriority: (Int) -> Unit,
     onSetMpvHardwareDecodeMode: (MpvHardwareDecodeMode) -> Unit,
+    onSetDv7HandlingMode: (Dv7HandlingMode) -> Unit,
     onDismissAudioLanguageDialog: () -> Unit,
     onDismissSecondaryAudioLanguageDialog: () -> Unit,
     onDismissAudioOutputChannelsDialog: () -> Unit,
     onDismissDecoderPriorityDialog: () -> Unit,
-    onDismissMpvHardwareDecodeModeDialog: () -> Unit
+    onDismissMpvHardwareDecodeModeDialog: () -> Unit,
+    onDismissDv7HandlingModeDialog: () -> Unit
 ) {
     if (showAudioLanguageDialog) {
         AudioLanguageSelectionDialog(
@@ -393,6 +460,17 @@ internal fun AudioSettingsDialogs(
                 onDismissMpvHardwareDecodeModeDialog()
             },
             onDismiss = onDismissMpvHardwareDecodeModeDialog
+        )
+    }
+
+    if (showDv7HandlingModeDialog) {
+        Dv7HandlingModeDialog(
+            selectedMode = selectedDv7HandlingMode,
+            onModeSelected = {
+                onSetDv7HandlingMode(it)
+                onDismissDv7HandlingModeDialog()
+            },
+            onDismiss = onDismissDv7HandlingModeDialog
         )
     }
 }
@@ -556,7 +634,110 @@ private fun MpvHardwareDecodeModeDialog(
         maxHeight = 360.dp
     )
 }
+@Composable
+private fun Dv7HandlingModeDialog(
+    selectedMode: Dv7HandlingMode,
+    onModeSelected: (Dv7HandlingMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    val options = listOf(
+        Triple(
+            Dv7HandlingMode.AUTO,
+            stringResource(R.string.dv7_mode_auto),
+            stringResource(R.string.dv7_mode_auto_desc)
+        ),
+        Triple(
+            Dv7HandlingMode.HDR10_BASE_LAYER,
+            stringResource(R.string.dv7_mode_hdr10_base_layer),
+            stringResource(R.string.dv7_mode_hdr10_base_layer_desc)
+        ),
+        Triple(
+            Dv7HandlingMode.DV81_LIBDOVI,
+            stringResource(R.string.dv7_mode_dv81_libdovi),
+            stringResource(R.string.dv7_mode_dv81_libdovi_desc)
+        ),
+        Triple(
+            Dv7HandlingMode.OFF,
+            stringResource(R.string.dv7_mode_off),
+            stringResource(R.string.dv7_mode_off_desc)
+        )
+    )
 
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    NuvioDialog(
+        onDismiss = onDismiss,
+        title = stringResource(R.string.dv7_handling_title),
+        subtitle = stringResource(R.string.dv7_handling_dialog_subtitle),
+        width = 460.dp,
+        suppressFirstKeyUp = false
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 360.dp)
+        ) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 4.dp)
+            ) {
+                items(
+                    count = options.size,
+                    key = { index -> options[index].first.name }
+                ) { index ->
+                    val (mode, title, description) = options[index]
+                    val isSelected = mode == selectedMode
+
+                    Card(
+                        onClick = { onModeSelected(mode) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(if (index == 0) Modifier.focusRequester(focusRequester) else Modifier),
+                        colors = CardDefaults.colors(
+                            containerColor = if (isSelected) NuvioColors.FocusBackground else NuvioColors.BackgroundCard,
+                            focusedContainerColor = NuvioColors.FocusBackground
+                        ),
+                        shape = CardDefaults.shape(shape = RoundedCornerShape(10.dp)),
+                        scale = CardDefaults.scale(focusedScale = 1f)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = title,
+                                    color = if (isSelected) NuvioColors.Primary else NuvioColors.TextPrimary,
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = description,
+                                    color = NuvioColors.TextSecondary,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                            if (isSelected) {
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = stringResource(R.string.cd_selected),
+                                    tint = NuvioColors.Primary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 @Composable
 internal fun DecoderPriorityDialog(
     selectedPriority: Int,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
@@ -1,0 +1,451 @@
+@file:OptIn(ExperimentalTvMaterial3Api::class)
+
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Hub
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.util.UnstableApi
+import androidx.tv.material3.Border
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.data.local.PlayerSettings
+import com.nuvio.tv.data.local.VodCacheSizeMode
+import com.nuvio.tv.ui.theme.NuvioColors
+import kotlin.math.min
+
+@androidx.annotation.OptIn(UnstableApi::class)
+internal fun LazyListScope.bufferAndNetworkSettingsItems(
+    playerSettings: PlayerSettings,
+    onSetBufferEngineEnabled: (Boolean) -> Unit,
+    onSetParallelNetworkEnabled: (Boolean) -> Unit,
+    onSetBufferMinBufferMs: (Int) -> Unit,
+    onSetBufferMaxBufferMs: (Int) -> Unit,
+    onSetBufferForPlaybackMs: (Int) -> Unit,
+    onSetBufferForPlaybackAfterRebufferMs: (Int) -> Unit,
+    onSetBufferTargetSizeMb: (Int) -> Unit,
+    onSetBufferBackBufferDurationMs: (Int) -> Unit,
+    onSetAllowLargeTargetBuffer: (Boolean) -> Unit,
+    onSetBufferBudgetManaged: (Boolean) -> Unit,
+    onResetToDefaults: () -> Unit,
+    onSetVodCacheEnabled: (Boolean) -> Unit,
+    onSetVodCacheSizeMode: (VodCacheSizeMode) -> Unit,
+    onSetVodCacheSizeMb: (Int) -> Unit,
+    onSetUseParallelConnections: (Boolean) -> Unit,
+    onSetParallelConnectionCount: (Int) -> Unit,
+    onSetParallelChunkSizeMb: (Int) -> Unit,
+    onResetNetworkToDefaults: () -> Unit
+) {
+    // ── Master toggle: custom buffer engine ──
+    item {
+        ToggleSettingsItem(
+            icon = Icons.Default.Tune,
+            title = "Custom Playback Buffers",
+            subtitle = "Override Media3's default buffering with the values below. When off, the player uses Media3's stock buffer durations and target size.",
+            isChecked = playerSettings.bufferEngineEnabled,
+            onCheckedChange = onSetBufferEngineEnabled
+        )
+    }
+
+    if (playerSettings.bufferEngineEnabled) {
+        item {
+            Text(
+                text = "Buffer",
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioColors.TextSecondary,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+
+        item {
+            Text(
+                text = "These settings affect buffering behavior. Incorrect values may cause playback issues.",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFFFF9800),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        item {
+            SliderSettingsItem(
+                icon = Icons.Default.Speed,
+                title = "Min Buffer Duration",
+                subtitle = "Minimum amount of media to buffer. The player will try to ensure at least this much content is always buffered ahead of the current playback position.",
+                value = playerSettings.bufferSettings.minBufferMs / 1000,
+                valueText = "${playerSettings.bufferSettings.minBufferMs / 1000}s",
+                minValue = 5,
+                maxValue = 120,
+                step = 5,
+                onValueChange = { onSetBufferMinBufferMs(it * 1000) }
+            )
+        }
+
+        item {
+            val minBufferSeconds = playerSettings.bufferSettings.minBufferMs / 1000
+            val maxBufferSeconds = playerSettings.bufferSettings.maxBufferMs / 1000
+            SliderSettingsItem(
+                icon = Icons.Default.Speed,
+                title = "Max Buffer Duration",
+                subtitle = "Maximum amount of media to buffer. Must be at least the minimum buffer duration. Higher values use more memory but provide smoother playback on unstable connections.",
+                value = maxBufferSeconds,
+                valueText = if (maxBufferSeconds == minBufferSeconds) {
+                    "${maxBufferSeconds}s (same as min)"
+                } else {
+                    "${maxBufferSeconds}s"
+                },
+                minValue = 5,
+                maxValue = 120,
+                step = 5,
+                onValueChange = { onSetBufferMaxBufferMs(maxOf(it, minBufferSeconds) * 1000) }
+            )
+        }
+
+        item {
+            SliderSettingsItem(
+                icon = Icons.Default.PlayArrow,
+                title = "Initial Buffer",
+                subtitle = "How much content must be buffered before playback starts. Lower values start faster but may cause initial stuttering on slow connections.",
+                value = playerSettings.bufferSettings.bufferForPlaybackMs / 1000,
+                valueText = "${playerSettings.bufferSettings.bufferForPlaybackMs / 1000}s",
+                minValue = 1,
+                maxValue = 60,
+                step = 1,
+                onValueChange = { onSetBufferForPlaybackMs(it * 1000) }
+            )
+        }
+
+        item {
+            SliderSettingsItem(
+                icon = Icons.Default.Refresh,
+                title = "Buffer After Rebuffer",
+                subtitle = "How much content to buffer after playback stalls due to buffering. Higher values reduce repeated buffering interruptions.",
+                value = playerSettings.bufferSettings.bufferForPlaybackAfterRebufferMs / 1000,
+                valueText = "${playerSettings.bufferSettings.bufferForPlaybackAfterRebufferMs / 1000}s",
+                minValue = 1,
+                maxValue = 120,
+                step = 1,
+                onValueChange = { onSetBufferForPlaybackAfterRebufferMs(it * 1000) }
+            )
+        }
+
+        item {
+            SliderSettingsItem(
+                icon = Icons.Default.History,
+                title = "Back Buffer Duration",
+                subtitle = "How much already-played content to keep in memory. Enables fast backward seeking without re-downloading. Set to 0 to disable and save memory.",
+                value = playerSettings.bufferSettings.backBufferDurationMs / 1000,
+                valueText = "${playerSettings.bufferSettings.backBufferDurationMs / 1000}s",
+                minValue = 0,
+                maxValue = 120,
+                step = 5,
+                onValueChange = { onSetBufferBackBufferDurationMs(it * 1000) }
+            )
+            // Live estimate of the back-buffer byte reserve Media3 holds on top of the
+            // target buffer. Reserve = targetBuffer * backBufferMs / maxBufferMs.
+            val backBufferMs = playerSettings.bufferSettings.backBufferDurationMs
+            val maxBufferMs = playerSettings.bufferSettings.maxBufferMs
+            if (backBufferMs > 0 && maxBufferMs > 0) {
+                val targetMb = MemoryBudget.effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
+                val reserveMb = (targetMb.toLong() * backBufferMs / maxBufferMs).toInt()
+                Text(
+                    text = "Reserves ~${reserveMb}MB on top of Target Buffer. " +
+                        "Raising Max Buffer Duration shrinks this without losing back-buffer time.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(start = 52.dp, end = 16.dp, top = 4.dp, bottom = 8.dp)
+                )
+            }
+        }
+
+        item {
+            ToggleSettingsItem(
+                icon = Icons.Default.Tune,
+                title = "Managed Memory Budget",
+                subtitle = "Caps the buffer to a safe share of this device's memory. Turn off to set the Target Buffer Size yourself (advanced — large values can crash low-memory devices).",
+                isChecked = playerSettings.bufferBudgetManaged,
+                onCheckedChange = onSetBufferBudgetManaged
+            )
+        }
+
+        item {
+            val budgetManaged = playerSettings.bufferBudgetManaged
+            val parallelOverheadMb = if (playerSettings.parallelNetworkEnabled && playerSettings.useParallelConnections)
+                MemoryBudget.parallelOverheadMb(playerSettings.parallelConnectionCount, playerSettings.parallelChunkSizeMb) else 0
+            val safeMaxMb = MemoryBudget.maxBufferMb(parallelOverheadMb)
+            val maxBufferSizeMb = MemoryBudget.maxBufferMbWithOverride(parallelOverheadMb, playerSettings.allowLargeTargetBuffer)
+            val minBufferSizeMb = ((MemoryBudget.defaultBufferSizeMb / 2) / MemoryBudget.BUFFER_STEP_MB * MemoryBudget.BUFFER_STEP_MB)
+                .coerceIn(MemoryBudget.MIN_BUFFER_MB, maxBufferSizeMb)
+            val bufferSizeMb = MemoryBudget
+                .effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
+                .coerceIn(minBufferSizeMb, maxBufferSizeMb)
+            SliderSettingsItem(
+                icon = Icons.Default.Storage,
+                title = "Target Buffer Size",
+                subtitle = "Maximum RAM used for ahead-buffering. The maximum is calculated from your device's available memory (Android's per-app heap limit), so higher-RAM devices unlock larger caps automatically.",
+                value = bufferSizeMb,
+                valueText = "$bufferSizeMb MB",
+                minValue = minBufferSizeMb,
+                maxValue = maxBufferSizeMb,
+                step = MemoryBudget.BUFFER_STEP_MB,
+                onValueChange = onSetBufferTargetSizeMb,
+                enabled = !budgetManaged
+            )
+            if (budgetManaged) {
+                Text(
+                    text = "Managed by the device memory budget. Turn off Managed Memory Budget to set this.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(start = 52.dp, end = 16.dp, top = 4.dp, bottom = 8.dp)
+                )
+            }
+            if (!budgetManaged && playerSettings.allowLargeTargetBuffer && bufferSizeMb > safeMaxMb) {
+                Text(
+                    text = "Warning: above device safe limit (${safeMaxMb} MB). App may crash during playback.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFFF44336),
+                    modifier = Modifier.padding(start = 52.dp, end = 16.dp, top = 4.dp, bottom = 8.dp)
+                )
+            }
+        }
+
+        item {
+            ToggleSettingsItem(
+                icon = Icons.Default.Tune,
+                title = "Allow Larger Target Buffer",
+                subtitle = "Removes the device-memory cap on the Target Buffer Size slider, allowing values up to 2GB. May crash on devices with less than 2GB of RAM.",
+                isChecked = playerSettings.allowLargeTargetBuffer,
+                onCheckedChange = onSetAllowLargeTargetBuffer,
+                enabled = !playerSettings.bufferBudgetManaged
+            )
+        }
+
+        // ── Disk cache (extends the in-memory back buffer) ──
+        item {
+            Text(
+                text = "Disk Cache",
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioColors.TextSecondary,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+
+        item {
+            ToggleSettingsItem(
+                icon = Icons.Default.Storage,
+                title = "VOD Disk Cache",
+                subtitle = "Persist downloaded bytes to disk for the current stream. Extends instant seek-back beyond the in-memory back buffer and survives brief network drops. Only applies to progressive streams (no HLS/DASH).",
+                isChecked = playerSettings.vodCacheEnabled,
+                onCheckedChange = onSetVodCacheEnabled
+            )
+        }
+
+        if (playerSettings.vodCacheEnabled) {
+            // Sub-option of the master VOD Disk Cache toggle. Indented to make
+            // the parent/child relationship visually clear so this doesn't read
+            // as a second redundant on/off switch.
+            item {
+                val autoMode = playerSettings.vodCacheSizeMode == VodCacheSizeMode.AUTO
+                Box(modifier = Modifier.padding(start = 32.dp)) {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.Tune,
+                        title = "Auto Size",
+                        subtitle = "When on, the cache is sized from free disk space. Turn off to pick a size manually.",
+                        isChecked = autoMode,
+                        onCheckedChange = { enabled ->
+                            onSetVodCacheSizeMode(if (enabled) VodCacheSizeMode.AUTO else VodCacheSizeMode.MANUAL)
+                        }
+                    )
+                }
+            }
+
+            if (playerSettings.vodCacheSizeMode == VodCacheSizeMode.MANUAL) {
+                item {
+                    val context = LocalContext.current
+                    val freeDiskBytes = context.cacheDir.usableSpace.coerceAtLeast(0L)
+                    val maxManualCacheMb = resolveManualVodCacheMaxMb(freeDiskBytes)
+                    val manualCacheMb = playerSettings.vodCacheSizeMb.coerceIn(
+                        PlayerSettings.MIN_VOD_CACHE_SIZE_MB,
+                        maxManualCacheMb
+                    )
+                    SliderSettingsItem(
+                        icon = Icons.Default.Storage,
+                        title = "VOD Cache Size",
+                        subtitle = "Maximum disk usage for progressive VOD cache (LRU-evicted).",
+                        value = manualCacheMb,
+                        valueText = "${manualCacheMb} MB",
+                        minValue = PlayerSettings.MIN_VOD_CACHE_SIZE_MB,
+                        maxValue = maxManualCacheMb,
+                        step = 50,
+                        onValueChange = onSetVodCacheSizeMb
+                    )
+                }
+            }
+
+            item {
+                val context = LocalContext.current
+                val freeDiskBytes = context.cacheDir.usableSpace.coerceAtLeast(0L)
+                val freeDiskLabel = formatStorageSize(freeDiskBytes)
+                val maxManualCacheMb = resolveManualVodCacheMaxMb(freeDiskBytes)
+                val manualMode = playerSettings.vodCacheSizeMode == VodCacheSizeMode.MANUAL
+                val infoText = buildString {
+                    append("Range: ${PlayerSettings.MIN_VOD_CACHE_SIZE_MB}-${maxManualCacheMb} MB. ")
+                    append("Auto mode targets about 10% of free space.")
+                    append(" Manual mode keeps about ${VOD_CACHE_FREE_SPACE_RESERVE_MB}MB headroom.")
+                    if (manualMode) {
+                        append(" Free disk available: $freeDiskLabel.")
+                        append(" New cache cap applies after app restart when changing between modes/sizes.")
+                    }
+                }
+                Text(
+                    text = infoText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioColors.TextSecondary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+        }
+
+        item {
+            Button(
+                onClick = onResetToDefaults,
+                shape = ButtonDefaults.shape(shape = RoundedCornerShape(10.dp)),
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioColors.Background,
+                    focusedContainerColor = NuvioColors.Background
+                ),
+                border = ButtonDefaults.border(
+                    focusedBorder = Border(
+                        border = BorderStroke(1.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                )
+            ) {
+                Text(
+                    text = "Reset to Default",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = NuvioColors.TextPrimary
+                )
+            }
+        }
+    }
+
+    // ── Master toggle: parallel connections ──
+    item {
+        ToggleSettingsItem(
+            icon = Icons.Default.Hub,
+            title = "Custom Network",
+            subtitle = "Use multiple parallel connections to fetch progressive streams. When off, a single connection is used.",
+            isChecked = playerSettings.parallelNetworkEnabled,
+            onCheckedChange = onSetParallelNetworkEnabled
+        )
+    }
+
+    if (playerSettings.parallelNetworkEnabled) {
+        item {
+            ToggleSettingsItem(
+                icon = Icons.Default.Wifi,
+                title = "Parallel Connections",
+                subtitle = "Use multiple connections in parallel for fetching streams. Activate when you experience buffering although your download speed is definitely more than sufficient.",
+                isChecked = playerSettings.useParallelConnections,
+                onCheckedChange = onSetUseParallelConnections
+            )
+        }
+
+        if (playerSettings.useParallelConnections) {
+            item {
+                SliderSettingsItem(
+                    icon = Icons.Default.Hub,
+                    title = "Connection Count",
+                    subtitle = "Number of parallel TCP connections. Higher values increase memory usage and throughput but with diminishing returns.",
+                    value = playerSettings.parallelConnectionCount,
+                    valueText = playerSettings.parallelConnectionCount.toString(),
+                    minValue = MemoryBudget.MIN_CONNECTIONS,
+                    maxValue = MemoryBudget.MAX_CONNECTIONS,
+                    step = 1,
+                    onValueChange = onSetParallelConnectionCount
+                )
+            }
+
+            item {
+                val effectiveBufferMb = MemoryBudget.effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
+                val maxChunkSizeMb = MemoryBudget.maxChunkMb(effectiveBufferMb, playerSettings.parallelConnectionCount)
+                val chunkSizeMb = playerSettings.parallelChunkSizeMb.coerceAtMost(maxChunkSizeMb)
+                SliderSettingsItem(
+                    icon = Icons.Default.Storage,
+                    title = "Chunk Size",
+                    subtitle = "Size of each download chunk per connection. Larger chunks reduce overhead but use more memory.",
+                    value = chunkSizeMb,
+                    valueText = "$chunkSizeMb MB",
+                    minValue = MemoryBudget.MIN_CHUNK_MB,
+                    maxValue = maxChunkSizeMb,
+                    step = 8,
+                    onValueChange = onSetParallelChunkSizeMb
+                )
+            }
+        }
+
+        item {
+            Button(
+                onClick = onResetNetworkToDefaults,
+                shape = ButtonDefaults.shape(shape = RoundedCornerShape(10.dp)),
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioColors.Background,
+                    focusedContainerColor = NuvioColors.Background
+                ),
+                border = ButtonDefaults.border(
+                    focusedBorder = Border(
+                        border = BorderStroke(1.dp, NuvioColors.FocusRing),
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                )
+            ) {
+                Text(
+                    text = "Reset to Default",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = NuvioColors.TextPrimary
+                )
+            }
+        }
+    }
+}
+
+private fun formatStorageSize(bytes: Long): String {
+    val gb = bytes / (1024.0 * 1024.0 * 1024.0)
+    if (gb >= 10.0) return String.format("%.0f GB", gb)
+    if (gb >= 1.0) return String.format("%.1f GB", gb)
+    val mb = bytes / (1024.0 * 1024.0)
+    return String.format("%.0f MB", mb)
+}
+
+private fun resolveManualVodCacheMaxMb(freeDiskBytes: Long): Int {
+    val freeDiskMb = freeDiskBytes.coerceAtLeast(0L) / (1024L * 1024L)
+    val dynamicMaxMb = when {
+        freeDiskMb > VOD_CACHE_FREE_SPACE_RESERVE_MB -> freeDiskMb - VOD_CACHE_FREE_SPACE_RESERVE_MB
+        else -> (freeDiskMb * 8L) / 10L
+    }
+    val boundedMb = min(
+        PlayerSettings.MAX_VOD_CACHE_SIZE_MB.toLong(),
+        dynamicMaxMb.coerceAtLeast(PlayerSettings.MIN_VOD_CACHE_SIZE_MB.toLong())
+    )
+    return boundedMb.toInt()
+}
+
+private const val VOD_CACHE_FREE_SPACE_RESERVE_MB = 1024L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -4,6 +4,7 @@ package com.nuvio.tv.ui.screens.settings
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,29 +21,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.ClosedCaption
-import androidx.compose.material.icons.filled.FormatBold
-import androidx.compose.material.icons.filled.FormatSize
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Key
-import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Storage
-import androidx.compose.material.icons.filled.Subtitles
-import androidx.compose.material.icons.filled.VerticalAlignBottom
-import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -52,6 +35,9 @@ import androidx.compose.runtime.remember
 import kotlin.math.roundToInt
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,16 +45,12 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
-import androidx.compose.ui.text.input.KeyboardType
 import android.view.KeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.unit.dp
@@ -80,27 +62,23 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.tv.material3.Border
-import androidx.tv.material3.Button
-import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
-import androidx.tv.material3.IconButton
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Switch
 import androidx.tv.material3.SwitchDefaults
 import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.AVAILABLE_SUBTITLE_LANGUAGES
 import com.nuvio.tv.data.local.AVAILABLE_TMDB_LANGUAGES
-import com.nuvio.tv.data.local.displayName
 import com.nuvio.tv.data.local.AudioLanguageOption
 import com.nuvio.tv.data.local.LibassRenderType
 import com.nuvio.tv.data.local.PlayerPreference
+import com.nuvio.tv.data.local.Dv7HandlingMode
 import com.nuvio.tv.data.local.PlayerSettings
-import com.nuvio.tv.data.local.StreamAutoPlayMode
-import com.nuvio.tv.data.local.StreamAutoPlaySource
 import com.nuvio.tv.data.local.TrailerSettings
+import com.nuvio.tv.data.local.displayName
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.components.P2pConsentDialog
 import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
@@ -142,6 +120,8 @@ fun PlaybackSettingsContent(
     val installedAddonNames by viewModel.installedAddonNames.collectAsStateWithLifecycle(initialValue = emptyList())
     val enabledPluginNames by viewModel.enabledPluginNames.collectAsStateWithLifecycle(initialValue = emptyList())
     val coroutineScope = rememberCoroutineScope()
+    var memoryUsageTrigger by remember { mutableStateOf(0) }
+    var showMemoryUsage by remember { mutableStateOf(false) }
 
     // Dialog states
     var showLanguageDialog by remember { mutableStateOf(false) }
@@ -151,6 +131,7 @@ fun PlaybackSettingsContent(
     var showBackgroundColorDialog by remember { mutableStateOf(false) }
     var showOutlineColorDialog by remember { mutableStateOf(false) }
     var showAudioLanguageDialog by remember { mutableStateOf(false) }
+    var showDv7HandlingModeDialog by remember { mutableStateOf(false) }
     var showSecondaryAudioLanguageDialog by remember { mutableStateOf(false) }
     var showAudioOutputChannelsDialog by remember { mutableStateOf(false) }
     var showDecoderPriorityDialog by remember { mutableStateOf(false) }
@@ -178,6 +159,7 @@ fun PlaybackSettingsContent(
         showAudioOutputChannelsDialog = false
         showDecoderPriorityDialog = false
         showMpvHardwareDecodeModeDialog = false
+        showDv7HandlingModeDialog = false
         showStreamAutoPlayModeDialog = false
         showStreamAutoPlaySourceDialog = false
         showStreamAutoPlayAddonSelectionDialog = false
@@ -193,6 +175,13 @@ fun PlaybackSettingsContent(
     fun openDialog(setter: () -> Unit) {
         dismissAllDialogs()
         setter()
+    }
+
+    LaunchedEffect(memoryUsageTrigger) {
+        if (memoryUsageTrigger == 0) return@LaunchedEffect
+        showMemoryUsage = true
+        kotlinx.coroutines.delay(2200)
+        showMemoryUsage = false
     }
 
     Column(
@@ -300,7 +289,22 @@ fun PlaybackSettingsContent(
                     coroutineScope.launch { viewModel.setRememberAudioDelayPerDevice(enabled) }
                 },
                 onSetTunnelingEnabled = { enabled -> coroutineScope.launch { viewModel.setTunnelingEnabled(enabled) } },
-                onSetMapDV7ToHevc = { enabled -> coroutineScope.launch { viewModel.setMapDV7ToHevc(enabled) } },
+                onShowDv7HandlingModeDialog = { openDialog { showDv7HandlingModeDialog = true } },
+                onSetDv5ToDv81Enabled = { enabled ->
+                    coroutineScope.launch { viewModel.setDv5ToDv81Enabled(enabled) }
+                },
+                onSetDv7ToDv81PreserveMappingEnabled = { enabled ->
+                    coroutineScope.launch {
+                        viewModel.setDv7ToDv81PreserveMappingEnabled(enabled)
+                    }
+                },
+                onSetBufferEngineEnabled = { enabled ->
+                    coroutineScope.launch { viewModel.setBufferEngineEnabled(enabled) }
+                    if (enabled) memoryUsageTrigger++
+                },
+                onSetParallelNetworkEnabled = { enabled ->
+                    coroutineScope.launch { viewModel.setParallelNetworkEnabled(enabled) }
+                },
                 onSetSubtitleSize = { newSize -> coroutineScope.launch { viewModel.setSubtitleSize(newSize) } },
                 onSetSubtitleVerticalOffset = { newOffset -> coroutineScope.launch { viewModel.setSubtitleVerticalOffset(newOffset) } },
                 onSetSubtitleBold = { bold -> coroutineScope.launch { viewModel.setSubtitleBold(bold) } },
@@ -320,8 +324,107 @@ fun PlaybackSettingsContent(
                     }
                 },
                 hideTorrentStats = torrentSettings.hideTorrentStats,
-                onSetHideTorrentStats = { enabled -> viewModel.setHideTorrentStats(enabled) }
+                onSetHideTorrentStats = { enabled -> viewModel.setHideTorrentStats(enabled) },
+                onSetUseParallelConnections = { enabled ->
+                    coroutineScope.launch { viewModel.setUseParallelConnections(enabled) }
+                    memoryUsageTrigger++
+                },
+                onSetParallelConnectionCount = { count ->
+                    coroutineScope.launch { viewModel.setParallelConnectionCount(count) }
+                    memoryUsageTrigger++
+                },
+                onSetParallelChunkSizeMb = { mb ->
+                    coroutineScope.launch { viewModel.setParallelChunkSizeMb(mb) }
+                    memoryUsageTrigger++
+                },
+                onSetBufferMinBufferMs = { ms ->
+                    coroutineScope.launch { viewModel.setBufferMinBufferMs(ms) }
+                },
+                onSetBufferMaxBufferMs = { ms ->
+                    coroutineScope.launch { viewModel.setBufferMaxBufferMs(ms) }
+                },
+                onSetBufferForPlaybackMs = { ms ->
+                    coroutineScope.launch { viewModel.setBufferForPlaybackMs(ms) }
+                },
+                onSetBufferForPlaybackAfterRebufferMs = { ms ->
+                    coroutineScope.launch { viewModel.setBufferForPlaybackAfterRebufferMs(ms) }
+                },
+                onSetBufferTargetSizeMb = { mb ->
+                    coroutineScope.launch { viewModel.setBufferTargetSizeMb(mb) }
+                    memoryUsageTrigger++
+                },
+                onSetBufferBackBufferDurationMs = { ms ->
+                    coroutineScope.launch { viewModel.setBufferBackBufferDurationMs(ms) }
+                },
+                onSetAllowLargeTargetBuffer = { enabled ->
+                    coroutineScope.launch { viewModel.setAllowLargeTargetBuffer(enabled) }
+                    memoryUsageTrigger++
+                },
+                onSetBufferBudgetManaged = { enabled ->
+                    coroutineScope.launch { viewModel.setBufferBudgetManaged(enabled) }
+                    memoryUsageTrigger++
+                },
+                onSetVodCacheEnabled = { enabled ->
+                    coroutineScope.launch { viewModel.setVodCacheEnabled(enabled) }
+                },
+                onSetVodCacheSizeMode = { mode ->
+                    coroutineScope.launch { viewModel.setVodCacheSizeMode(mode) }
+                },
+                onSetVodCacheSizeMb = { mb ->
+                    coroutineScope.launch { viewModel.setVodCacheSizeMb(mb) }
+                },
+                onResetBufferSettingsToDefaults = {
+                    coroutineScope.launch { viewModel.resetBufferSettingsToDefaults() }
+                    memoryUsageTrigger++
+                },
+                onResetNetworkSettingsToDefaults = {
+                    coroutineScope.launch { viewModel.resetNetworkSettingsToDefaults() }
+                    memoryUsageTrigger++
+                }
             )
+        }
+
+        AnimatedVisibility(
+            visible = showMemoryUsage &&
+                    (playerSettings.bufferEngineEnabled || playerSettings.parallelNetworkEnabled),
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            // Buffer engine off: only parallel overhead counts. On: managed uses the device cap,
+            // otherwise the user's target size.
+            val effectiveBufferMb = when {
+                !playerSettings.bufferEngineEnabled -> 0
+                playerSettings.bufferBudgetManaged -> MemoryBudget.budgetMb
+                else -> MemoryBudget.effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
+            }
+            val totalUsageMb = MemoryBudget.totalUsageMb(
+                effectiveBufferMb,
+                playerSettings.parallelConnectionCount,
+                playerSettings.parallelChunkSizeMb,
+                playerSettings.useParallelConnections
+            )
+            val usageRatio = totalUsageMb.toFloat() / MemoryBudget.budgetMb.coerceAtLeast(1)
+            val usageColor = when {
+                usageRatio > 0.9f -> Color(0xFFF44336)
+                usageRatio > 0.7f -> Color(0xFFFF9800)
+                else -> Color(0xFF4CAF50)
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = NuvioColors.BackgroundCard,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .border(1.dp, usageColor.copy(alpha = 0.35f), RoundedCornerShape(10.dp))
+                    .padding(horizontal = 14.dp, vertical = 10.dp)
+            ) {
+                Text(
+                    text = "Estimated memory usage: $totalUsageMb / ${MemoryBudget.budgetMb} MB",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = usageColor
+                )
+            }
         }
     }
 
@@ -342,6 +445,7 @@ fun PlaybackSettingsContent(
         showAudioOutputChannelsDialog = showAudioOutputChannelsDialog,
         showDecoderPriorityDialog = showDecoderPriorityDialog,
         showMpvHardwareDecodeModeDialog = showMpvHardwareDecodeModeDialog,
+        showDv7HandlingModeDialog = showDv7HandlingModeDialog,
         showStreamAutoPlayModeDialog = showStreamAutoPlayModeDialog,
         showStreamAutoPlaySourceDialog = showStreamAutoPlaySourceDialog,
         showStreamAutoPlayAddonSelectionDialog = showStreamAutoPlayAddonSelectionDialog,
@@ -390,6 +494,9 @@ fun PlaybackSettingsContent(
         onSetMpvHardwareDecodeMode = { mode ->
             coroutineScope.launch { viewModel.setMpvHardwareDecodeMode(mode) }
         },
+        onSetDv7HandlingMode = { mode ->
+            coroutineScope.launch { viewModel.setDv7HandlingMode(mode) }
+        },
         onSetStreamAutoPlayMode = { mode ->
             coroutineScope.launch { viewModel.setStreamAutoPlayMode(mode) }
         },
@@ -422,6 +529,7 @@ fun PlaybackSettingsContent(
         onDismissAudioOutputChannelsDialog = ::dismissAllDialogs,
         onDismissDecoderPriorityDialog = ::dismissAllDialogs,
         onDismissMpvHardwareDecodeModeDialog = ::dismissAllDialogs,
+        onDismissDv7HandlingModeDialog = ::dismissAllDialogs,
         onDismissStreamAutoPlayModeDialog = ::dismissAllDialogs,
         onDismissStreamAutoPlaySourceDialog = ::dismissAllDialogs,
         onDismissStreamRegexDialog = ::dismissAllDialogs,
@@ -553,7 +661,7 @@ internal fun RenderTypeSettingsItem(
 ) {
     var isFocused by remember { mutableStateOf(false) }
     val contentAlpha = if (enabled) 1f else 0.4f
-    
+
     Card(
         onClick = { if (enabled) onClick() },
         modifier = Modifier
@@ -611,7 +719,7 @@ internal fun RenderTypeSettingsItem(
                     color = NuvioColors.TextSecondary.copy(alpha = contentAlpha)
                 )
             }
-            
+
             if (isSelected) {
                 Spacer(modifier = Modifier.width(16.dp))
                 Icon(
@@ -1329,7 +1437,7 @@ private fun ColorOption(
     modifier: Modifier = Modifier
 ) {
     var isFocused by remember { mutableStateOf(false) }
-    
+
     Card(
         onClick = onClick,
         modifier = Modifier
@@ -1374,7 +1482,7 @@ private fun ColorOption(
                         .border(1.dp, NuvioColors.Border, CircleShape)
                 )
             }
-            
+
             if (isSelected) {
                 Icon(
                     imageVector = Icons.Default.Check,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -34,9 +34,11 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PauseCircle
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -563,7 +565,8 @@ internal fun PlaybackSettingsSections(
                             focusRequester = afrHeaderFocus,
                             onFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                             enabled = !generalUi.isExternalPlayer,
-                            showWarningIcon = showAfrWarning
+                            showWarningIcon = showAfrWarning,
+                            icon = Icons.Default.Speed
                         )
                     }
 
@@ -742,7 +745,8 @@ private fun PlaybackSectionHeader(
     focusRequester: FocusRequester,
     onFocused: () -> Unit,
     enabled: Boolean = true,
-    showWarningIcon: Boolean = false
+    showWarningIcon: Boolean = false,
+    icon: ImageVector? = null
 ) {
     SettingsActionRow(
         title = title,
@@ -756,7 +760,8 @@ private fun PlaybackSectionHeader(
         enabled = enabled,
         trailingIcon = if (expanded) Icons.Default.ExpandMore else Icons.Default.ChevronRight,
         titleTrailingIcon = if (showWarningIcon) Icons.Default.Warning else null,
-        titleTrailingIconTint = Color(0xFFFFB74D)
+        titleTrailingIconTint = Color(0xFFFFB74D),
+        leadingIcon = icon
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -5,6 +5,8 @@ package com.nuvio.tv.ui.screens.settings
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,10 +46,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
@@ -65,11 +65,14 @@ import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioOutputChannels
 import com.nuvio.tv.data.local.AutoSkipSegmentType
+import com.nuvio.tv.data.local.Dv7HandlingMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
+import com.nuvio.tv.data.local.LibassRenderType
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.TrailerSettings
+import com.nuvio.tv.data.local.VodCacheSizeMode
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioColors
 
@@ -78,7 +81,9 @@ private enum class PlaybackSection {
     STREAM_SELECTION,
     AUDIO_TRAILER,
     SUBTITLES,
-    P2P
+    P2P,
+    BUFFER_NETWORK,
+    DIAGNOSTICS
 }
 
 private data class PlaybackGeneralUi(
@@ -153,7 +158,9 @@ internal fun PlaybackSettingsSections(
     onSetSkipSilence: (Boolean) -> Unit,
     onSetRememberAudioDelayPerDevice: (Boolean) -> Unit,
     onSetTunnelingEnabled: (Boolean) -> Unit,
-    onSetMapDV7ToHevc: (Boolean) -> Unit,
+    onShowDv7HandlingModeDialog: () -> Unit,
+    onSetDv5ToDv81Enabled: (Boolean) -> Unit,
+    onSetDv7ToDv81PreserveMappingEnabled: (Boolean) -> Unit,
     onSetSubtitleSize: (Int) -> Unit,
     onSetSubtitleVerticalOffset: (Int) -> Unit,
     onSetSubtitleBold: (Boolean) -> Unit,
@@ -161,11 +168,29 @@ internal fun PlaybackSettingsSections(
     onSetSubtitleShowOnlyPreferredLanguages: (Boolean) -> Unit,
     onSetSubtitleOutlineEnabled: (Boolean) -> Unit,
     onSetUseLibass: (Boolean) -> Unit,
-    onSetLibassRenderType: (com.nuvio.tv.data.local.LibassRenderType) -> Unit,
+    onSetLibassRenderType: (LibassRenderType) -> Unit,
     p2pEnabled: Boolean = false,
     onSetP2pEnabled: (Boolean) -> Unit = {},
     hideTorrentStats: Boolean = false,
-    onSetHideTorrentStats: (Boolean) -> Unit = {}
+    onSetHideTorrentStats: (Boolean) -> Unit = {},
+    onSetBufferEngineEnabled: (Boolean) -> Unit,
+    onSetParallelNetworkEnabled: (Boolean) -> Unit,
+    onSetUseParallelConnections: (Boolean) -> Unit,
+    onSetParallelConnectionCount: (Int) -> Unit,
+    onSetParallelChunkSizeMb: (Int) -> Unit,
+    onSetBufferMinBufferMs: (Int) -> Unit,
+    onSetBufferMaxBufferMs: (Int) -> Unit,
+    onSetBufferForPlaybackMs: (Int) -> Unit,
+    onSetBufferForPlaybackAfterRebufferMs: (Int) -> Unit,
+    onSetBufferTargetSizeMb: (Int) -> Unit,
+    onSetBufferBackBufferDurationMs: (Int) -> Unit,
+    onSetAllowLargeTargetBuffer: (Boolean) -> Unit,
+    onSetBufferBudgetManaged: (Boolean) -> Unit,
+    onSetVodCacheEnabled: (Boolean) -> Unit,
+    onSetVodCacheSizeMode: (VodCacheSizeMode) -> Unit,
+    onSetVodCacheSizeMb: (Int) -> Unit,
+    onResetBufferSettingsToDefaults: () -> Unit,
+    onResetNetworkSettingsToDefaults: () -> Unit
 ) {
     var generalExpanded by rememberSaveable { mutableStateOf(false) }
     var afrExpanded by rememberSaveable { mutableStateOf(false) }
@@ -174,6 +199,7 @@ internal fun PlaybackSettingsSections(
     var audioTrailerExpanded by rememberSaveable { mutableStateOf(false) }
     var subtitlesExpanded by rememberSaveable { mutableStateOf(false) }
     var p2pExpanded by rememberSaveable { mutableStateOf(false) }
+    var bufferAndNetworkExpanded by rememberSaveable { mutableStateOf(false) }
 
     val defaultGeneralHeaderFocus = remember { FocusRequester() }
     val afrHeaderFocus = remember { FocusRequester() }
@@ -182,6 +208,7 @@ internal fun PlaybackSettingsSections(
     val audioTrailerHeaderFocus = remember { FocusRequester() }
     val subtitlesHeaderFocus = remember { FocusRequester() }
     val p2pHeaderFocus = remember { FocusRequester() }
+    val bufferAndNetworkHeaderFocus = remember { FocusRequester() }
     val generalHeaderFocus = initialFocusRequester ?: defaultGeneralHeaderFocus
 
     var focusedSection by remember { mutableStateOf<PlaybackSection?>(null) }
@@ -279,6 +306,11 @@ internal fun PlaybackSettingsSections(
     LaunchedEffect(p2pExpanded, focusedSection) {
         if (!p2pExpanded && focusedSection == PlaybackSection.P2P) {
             p2pHeaderFocus.requestFocus()
+        }
+    }
+    LaunchedEffect(bufferAndNetworkExpanded, focusedSection) {
+        if (!bufferAndNetworkExpanded && focusedSection == PlaybackSection.BUFFER_NETWORK) {
+            bufferAndNetworkHeaderFocus.requestFocus()
         }
     }
 
@@ -415,45 +447,6 @@ internal fun PlaybackSettingsSections(
                 }
             }
 
-            item(key = "general_afr_header") {
-                PlaybackSectionHeader(
-                    title = stringResource(R.string.playback_auto_frame_rate),
-                    description = generalUi.frameRateMatchingLabel,
-                    expanded = afrExpanded,
-                    onToggle = { afrExpanded = !afrExpanded },
-                    focusRequester = afrHeaderFocus,
-                    onFocused = { focusedSection = PlaybackSection.GENERAL },
-                    enabled = !generalUi.isExternalPlayer,
-                    showWarningIcon = showAfrWarning
-                )
-            }
-
-            if (afrExpanded) {
-                item(key = "general_afr_capability_warning") {
-                    AfrCapabilityWarningCard(
-                        snapshot = displayCapabilities,
-                        afrModeOn = playerSettings.frameRateMatchingMode != FrameRateMatchingMode.OFF,
-                        resolutionMatchingOn = playerSettings.resolutionMatchingEnabled,
-                        headerFocusRequester = afrHeaderFocus,
-                        onDisableAll = onDisableAfrAndResolution,
-                        onDisableAfrOnly = onDisableAfrOnly,
-                        onDisableResolutionOnly = onDisableResolutionOnly,
-                        onFocused = { focusedSection = PlaybackSection.GENERAL }
-                    )
-                }
-                item(key = "general_afr_options") {
-                    FrameRateMatchingModeOptions(
-                        selectedMode = playerSettings.frameRateMatchingMode,
-                        resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled,
-                        resolutionSwitchingSupported = !displayCapabilities.apiSupported ||
-                            displayCapabilities.supportsResolutionSwitching,
-                        onSelect = onSetFrameRateMatchingMode,
-                        onSetResolutionMatchingEnabled = onSetResolutionMatchingEnabled,
-                        onFocused = { focusedSection = PlaybackSection.GENERAL },
-                        enabled = !generalUi.isExternalPlayer
-                    )
-                }
-            }
         }
 
         playbackCollapsibleSection(
@@ -548,6 +541,7 @@ internal fun PlaybackSettingsSections(
                 onShowAudioOutputChannelsDialog = onShowAudioOutputChannelsDialog,
                 onShowDecoderPriorityDialog = onShowDecoderPriorityDialog,
                 onShowMpvHardwareDecodeModeDialog = onShowMpvHardwareDecodeModeDialog,
+                onShowDv7HandlingModeDialog = onShowDv7HandlingModeDialog,
                 onSetTrailerEnabled = onSetTrailerEnabled,
                 onSetTrailerDelaySeconds = onSetTrailerDelaySeconds,
                 onSetDownmixEnabled = onSetDownmixEnabled,
@@ -555,9 +549,51 @@ internal fun PlaybackSettingsSections(
                 onSetSkipSilence = onSetSkipSilence,
                 onSetRememberAudioDelayPerDevice = onSetRememberAudioDelayPerDevice,
                 onSetTunnelingEnabled = onSetTunnelingEnabled,
-                onSetMapDV7ToHevc = onSetMapDV7ToHevc,
+                onSetDv5ToDv81Enabled = onSetDv5ToDv81Enabled,
+                onSetDv7ToDv81PreserveMappingEnabled = onSetDv7ToDv81PreserveMappingEnabled,
                 onItemFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
-                enabled = !generalUi.isExternalPlayer
+                enabled = !generalUi.isExternalPlayer,
+                videoExtraItems = {
+                    item(key = "general_afr_header") {
+                        PlaybackSectionHeader(
+                            title = stringResource(R.string.playback_auto_frame_rate),
+                            description = generalUi.frameRateMatchingLabel,
+                            expanded = afrExpanded,
+                            onToggle = { afrExpanded = !afrExpanded },
+                            focusRequester = afrHeaderFocus,
+                            onFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
+                            enabled = !generalUi.isExternalPlayer,
+                            showWarningIcon = showAfrWarning
+                        )
+                    }
+
+                    if (afrExpanded) {
+                        item(key = "general_afr_capability_warning") {
+                            AfrCapabilityWarningCard(
+                                snapshot = displayCapabilities,
+                                afrModeOn = playerSettings.frameRateMatchingMode != FrameRateMatchingMode.OFF,
+                                resolutionMatchingOn = playerSettings.resolutionMatchingEnabled,
+                                headerFocusRequester = afrHeaderFocus,
+                                onDisableAll = onDisableAfrAndResolution,
+                                onDisableAfrOnly = onDisableAfrOnly,
+                                onDisableResolutionOnly = onDisableResolutionOnly,
+                                onFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER }
+                            )
+                        }
+                        item(key = "general_afr_options") {
+                            FrameRateMatchingModeOptions(
+                                selectedMode = playerSettings.frameRateMatchingMode,
+                                resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled,
+                                resolutionSwitchingSupported = !displayCapabilities.apiSupported ||
+                                    displayCapabilities.supportsResolutionSwitching,
+                                onSelect = onSetFrameRateMatchingMode,
+                                onSetResolutionMatchingEnabled = onSetResolutionMatchingEnabled,
+                                onFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
+                                enabled = !generalUi.isExternalPlayer
+                            )
+                        }
+                    }
+                }
             )
         }
 
@@ -621,6 +657,42 @@ internal fun PlaybackSettingsSections(
                 )
             }
         }
+
+        if (playerSettings.internalPlayerEngine == InternalPlayerEngine.EXOPLAYER ||
+            playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO) {
+            playbackCollapsibleSection(
+                keyPrefix = "buffer_network",
+                title = "Buffer & Network",
+                description = "How much content to keep in memory and how to fetch streams.",
+                expanded = bufferAndNetworkExpanded,
+                onToggle = { bufferAndNetworkExpanded = !bufferAndNetworkExpanded },
+                focusRequester = bufferAndNetworkHeaderFocus,
+                onHeaderFocused = { focusedSection = PlaybackSection.BUFFER_NETWORK }
+            ) {
+                bufferAndNetworkSettingsItems(
+                    playerSettings = playerSettings,
+                    onSetBufferEngineEnabled = onSetBufferEngineEnabled,
+                    onSetParallelNetworkEnabled = onSetParallelNetworkEnabled,
+                    onSetBufferMinBufferMs = onSetBufferMinBufferMs,
+                    onSetBufferMaxBufferMs = onSetBufferMaxBufferMs,
+                    onSetBufferForPlaybackMs = onSetBufferForPlaybackMs,
+                    onSetBufferForPlaybackAfterRebufferMs = onSetBufferForPlaybackAfterRebufferMs,
+                    onSetBufferTargetSizeMb = onSetBufferTargetSizeMb,
+                    onSetBufferBackBufferDurationMs = onSetBufferBackBufferDurationMs,
+                    onSetAllowLargeTargetBuffer = onSetAllowLargeTargetBuffer,
+                    onSetBufferBudgetManaged = onSetBufferBudgetManaged,
+                    onSetVodCacheEnabled = onSetVodCacheEnabled,
+                    onSetVodCacheSizeMode = onSetVodCacheSizeMode,
+                    onSetVodCacheSizeMb = onSetVodCacheSizeMb,
+                    onResetToDefaults = onResetBufferSettingsToDefaults,
+                    onSetUseParallelConnections = onSetUseParallelConnections,
+                    onSetParallelConnectionCount = onSetParallelConnectionCount,
+                    onSetParallelChunkSizeMb = onSetParallelChunkSizeMb,
+                    onResetNetworkToDefaults = onResetNetworkSettingsToDefaults
+                )
+            }
+        }
+
     }
         SettingsVerticalScrollIndicators(state = playbackListState)
     }
@@ -894,6 +966,7 @@ internal fun PlaybackSettingsDialogsHost(
     showAudioOutputChannelsDialog: Boolean,
     showDecoderPriorityDialog: Boolean,
     showMpvHardwareDecodeModeDialog: Boolean,
+    showDv7HandlingModeDialog: Boolean,
     showStreamAutoPlayModeDialog: Boolean,
     showStreamAutoPlaySourceDialog: Boolean,
     showStreamAutoPlayAddonSelectionDialog: Boolean,
@@ -916,6 +989,7 @@ internal fun PlaybackSettingsDialogsHost(
     onSetAudioOutputChannels: (AudioOutputChannels) -> Unit,
     onSetDecoderPriority: (Int) -> Unit,
     onSetMpvHardwareDecodeMode: (com.nuvio.tv.data.local.MpvHardwareDecodeMode) -> Unit,
+    onSetDv7HandlingMode: (Dv7HandlingMode) -> Unit,
     onSetStreamAutoPlayMode: (com.nuvio.tv.data.local.StreamAutoPlayMode) -> Unit,
     onSetStreamAutoPlaySource: (com.nuvio.tv.data.local.StreamAutoPlaySource) -> Unit,
     onSetNextEpisodeThresholdMode: (com.nuvio.tv.data.local.NextEpisodeThresholdMode) -> Unit,
@@ -934,6 +1008,7 @@ internal fun PlaybackSettingsDialogsHost(
     onDismissAudioOutputChannelsDialog: () -> Unit,
     onDismissDecoderPriorityDialog: () -> Unit,
     onDismissMpvHardwareDecodeModeDialog: () -> Unit,
+    onDismissDv7HandlingModeDialog: () -> Unit,
     onDismissStreamAutoPlayModeDialog: () -> Unit,
     onDismissStreamAutoPlaySourceDialog: () -> Unit,
     onDismissStreamRegexDialog: () -> Unit,
@@ -992,21 +1067,25 @@ internal fun PlaybackSettingsDialogsHost(
         showAudioOutputChannelsDialog = showAudioOutputChannelsDialog,
         showDecoderPriorityDialog = showDecoderPriorityDialog,
         showMpvHardwareDecodeModeDialog = showMpvHardwareDecodeModeDialog,
+        showDv7HandlingModeDialog = showDv7HandlingModeDialog,
         selectedLanguage = playerSettings.preferredAudioLanguage,
         selectedSecondaryLanguage = playerSettings.secondaryPreferredAudioLanguage,
         selectedAudioOutputChannels = playerSettings.audioOutputChannels,
         selectedPriority = playerSettings.decoderPriority,
         selectedMpvHardwareDecodeMode = playerSettings.mpvHardwareDecodeMode,
+        selectedDv7HandlingMode = playerSettings.dv7HandlingMode,
         onSetPreferredAudioLanguage = onSetPreferredAudioLanguage,
         onSetSecondaryPreferredAudioLanguage = onSetSecondaryPreferredAudioLanguage,
         onSetAudioOutputChannels = onSetAudioOutputChannels,
         onSetDecoderPriority = onSetDecoderPriority,
         onSetMpvHardwareDecodeMode = onSetMpvHardwareDecodeMode,
+        onSetDv7HandlingMode = onSetDv7HandlingMode,
         onDismissAudioLanguageDialog = onDismissAudioLanguageDialog,
         onDismissSecondaryAudioLanguageDialog = onDismissSecondaryAudioLanguageDialog,
         onDismissAudioOutputChannelsDialog = onDismissAudioOutputChannelsDialog,
         onDismissDecoderPriorityDialog = onDismissDecoderPriorityDialog,
-        onDismissMpvHardwareDecodeModeDialog = onDismissMpvHardwareDecodeModeDialog
+        onDismissMpvHardwareDecodeModeDialog = onDismissMpvHardwareDecodeModeDialog,
+        onDismissDv7HandlingModeDialog = onDismissDv7HandlingModeDialog
     )
 
     AutoPlaySettingsDialogs(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -1,12 +1,15 @@
 package com.nuvio.tv.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
+import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.data.local.LibassRenderType
 import com.nuvio.tv.data.local.InternalPlayerEngine
+import com.nuvio.tv.data.local.Dv7HandlingMode
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.PlayerPreference
+import com.nuvio.tv.core.player.LastPlaybackDiagnostics
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.StreamAutoPlayMode
@@ -20,11 +23,13 @@ import com.nuvio.tv.data.local.TrailerSettings
 import com.nuvio.tv.data.local.TrailerSettingsDataStore
 import com.nuvio.tv.core.torrent.TorrentSettings
 import com.nuvio.tv.core.torrent.TorrentSettingsData
+import com.nuvio.tv.data.local.VodCacheSizeMode
 import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.domain.repository.AddonRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -43,6 +48,8 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     fun setP2pEnabled(enabled: Boolean) = torrentSettings.setP2pEnabled(enabled)
     fun setHideTorrentStats(enabled: Boolean) = torrentSettings.setHideTorrentStats(enabled)
+
+    val lastPlaybackDiagnostics: Flow<LastPlaybackDiagnostics> = playerSettingsDataStore.lastPlaybackDiagnostics
     val installedAddonNames: Flow<List<String>> = addonRepository.getInstalledAddons().map { addons ->
         addons
             .enabledAddons()
@@ -165,29 +172,40 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setResolutionMatchingEnabled(false)
     }
 
-    suspend fun setMapDV7ToHevc(enabled: Boolean) {
-        playerSettingsDataStore.setMapDV7ToHevc(enabled)
-    }
-
     suspend fun setMpvHardwareDecodeMode(mode: MpvHardwareDecodeMode) {
         playerSettingsDataStore.setMpvHardwareDecodeMode(mode)
     }
 
-    /**
-     * Set whether to use libass for ASS/SSA subtitle rendering
-     */
+
+    suspend fun setDv5ToDv81Enabled(enabled: Boolean) {
+        playerSettingsDataStore.setDv5ToDv81Enabled(enabled)
+    }
+
+    suspend fun setDv7ToDv81PreserveMappingEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setDv7ToDv81PreserveMappingEnabled(enabled)
+    }
+
+    suspend fun setDv7HandlingMode(mode: Dv7HandlingMode) {
+        playerSettingsDataStore.setDv7HandlingMode(mode)
+        // The conversion-mode override only applies when handling is Convert to
+        // DV8.1. Any other mode clears the override back to None so a stale forced
+        // mode can't linger (disabled in UI but still stored).
+        if (mode != Dv7HandlingMode.DV81_LIBDOVI) {
+            playerSettingsDataStore.setDv7LibdoviModeOverride(-1)
+        }
+    }
+
+    suspend fun setDv7LibdoviModeOverride(mode: Int) {
+        playerSettingsDataStore.setDv7LibdoviModeOverride(mode)
+    }
+
     suspend fun setUseLibass(enabled: Boolean) {
         playerSettingsDataStore.setUseLibass(enabled)
     }
 
-    /**
-     * Set the libass render type
-     */
     suspend fun setLibassRenderType(renderType: LibassRenderType) {
         playerSettingsDataStore.setLibassRenderType(renderType)
     }
-
-    // Subtitle style settings functions
 
     suspend fun setSubtitlePreferredLanguage(language: String) {
         playerSettingsDataStore.setSubtitlePreferredLanguage(language)
@@ -263,8 +281,26 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setBufferForPlaybackAfterRebufferMs(ms)
     }
 
+    @androidx.annotation.OptIn(UnstableApi::class)
     suspend fun setBufferTargetSizeMb(mb: Int) {
-        playerSettingsDataStore.setBufferTargetSizeMb(mb)
+        val current = playerSettings.first()
+        if (!current.useParallelConnections) {
+            playerSettingsDataStore.setBufferTargetSizeMb(mb)
+            return
+        }
+        val (adjBuffer, adjChunk) = MemoryBudget.enforce(
+            mb,
+            current.parallelChunkSizeMb,
+            current.parallelConnectionCount
+        )
+        if (adjBuffer == mb && adjChunk == current.parallelChunkSizeMb) {
+            playerSettingsDataStore.setBufferTargetSizeMb(mb)
+        } else {
+            playerSettingsDataStore.updateMemorySettings(
+                targetBufferSizeMb = adjBuffer,
+                parallelChunkSizeMb = adjChunk
+            )
+        }
     }
 
     suspend fun setBufferBackBufferDurationMs(ms: Int) {
@@ -273,6 +309,100 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setBufferRetainBackBufferFromKeyframe(retain: Boolean) {
         playerSettingsDataStore.setBufferRetainBackBufferFromKeyframe(retain)
+    }
+
+    @androidx.annotation.OptIn(UnstableApi::class)
+    suspend fun resetBufferSettingsToDefaults() {
+        playerSettingsDataStore.resetBufferSettingsToDefaults()
+        val current = playerSettings.first()
+        if (!current.useParallelConnections) return
+
+        val (adjBuffer, adjChunk) = MemoryBudget.enforce(
+            MemoryBudget.defaultBufferSizeMb,
+            current.parallelChunkSizeMb,
+            current.parallelConnectionCount
+        )
+        if (adjChunk != current.parallelChunkSizeMb ||
+            adjBuffer != MemoryBudget.defaultBufferSizeMb
+        ) {
+            playerSettingsDataStore.updateMemorySettings(
+                targetBufferSizeMb = adjBuffer,
+                parallelChunkSizeMb = adjChunk
+            )
+        }
+    }
+
+    suspend fun resetNetworkSettingsToDefaults() {
+        playerSettingsDataStore.resetNetworkSettingsToDefaults()
+    }
+
+    suspend fun setVodCacheEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setVodCacheEnabled(enabled)
+    }
+    suspend fun setBufferEngineEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setBufferEngineEnabled(enabled)
+    }
+
+    suspend fun setParallelNetworkEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setParallelNetworkEnabled(enabled)
+    }
+
+    suspend fun setAllowLargeTargetBuffer(enabled: Boolean) {
+        playerSettingsDataStore.setAllowLargeTargetBuffer(enabled)
+    }
+    suspend fun setBufferBudgetManaged(enabled: Boolean) {
+        playerSettingsDataStore.setBufferBudgetManaged(enabled)
+    }
+    suspend fun setUseParallelConnections(enabled: Boolean) {
+        if (!enabled) {
+            playerSettingsDataStore.setUseParallelConnections(false)
+            return
+        }
+        val current = playerSettings.first()
+        val bufferMb = MemoryBudget.effectiveBufferMb(current.bufferSettings.targetBufferSizeMb)
+        val (adjBuffer, adjChunk) = MemoryBudget.enforce(
+            bufferMb,
+            current.parallelChunkSizeMb,
+            current.parallelConnectionCount
+        )
+        if (adjBuffer == bufferMb && adjChunk == current.parallelChunkSizeMb) {
+            playerSettingsDataStore.setUseParallelConnections(true)
+        } else {
+            playerSettingsDataStore.updateMemorySettings(
+                useParallelConnections = true,
+                targetBufferSizeMb = if (adjBuffer != bufferMb) adjBuffer else null,
+                parallelChunkSizeMb = adjChunk
+            )
+        }
+    }
+
+    @androidx.annotation.OptIn(UnstableApi::class)
+    suspend fun setParallelConnectionCount(count: Int) {
+        val current = playerSettings.first()
+        if (count <= current.parallelConnectionCount) {
+            playerSettingsDataStore.setParallelConnectionCount(count)
+        } else {
+            val bufferMb = MemoryBudget.effectiveBufferMb(current.bufferSettings.targetBufferSizeMb)
+            val maxChunk = MemoryBudget.maxChunkMb(bufferMb, count)
+            val newChunkMb = current.parallelChunkSizeMb.coerceAtMost(maxChunk)
+            if (newChunkMb == current.parallelChunkSizeMb) {
+                playerSettingsDataStore.setParallelConnectionCount(count)
+            } else {
+                playerSettingsDataStore.updateMemorySettings(
+                    parallelConnectionCount = count,
+                    parallelChunkSizeMb = newChunkMb
+                )
+            }
+        }
+    }
+
+    @androidx.annotation.OptIn(UnstableApi::class)
+    suspend fun setParallelChunkSizeMb(mb: Int) {
+        val current = playerSettings.first()
+        val bufferMb = MemoryBudget.effectiveBufferMb(current.bufferSettings.targetBufferSizeMb)
+        val maxChunk = MemoryBudget.maxChunkMb(bufferMb, current.parallelConnectionCount)
+        val clampedChunk = mb.coerceAtMost(maxChunk)
+        playerSettingsDataStore.setParallelChunkSizeMb(clampedChunk)
     }
 
     suspend fun setStreamAutoPlayMode(mode: StreamAutoPlayMode) {
@@ -337,5 +467,13 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setStreamReuseLastLinkCacheHours(hours: Int) {
         playerSettingsDataStore.setStreamReuseLastLinkCacheHours(hours)
+    }
+
+    suspend fun setVodCacheSizeMode(mode: VodCacheSizeMode) {
+        playerSettingsDataStore.setVodCacheSizeMode(mode)
+    }
+
+    suspend fun setVodCacheSizeMb(mb: Int) {
+        playerSettingsDataStore.setVodCacheSizeMb(mb)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
@@ -475,7 +475,8 @@ internal fun SettingsActionRow(
     enabled: Boolean = true,
     trailingIcon: ImageVector = Icons.Default.ChevronRight,
     titleTrailingIcon: ImageVector? = null,
-    titleTrailingIconTint: Color = NuvioColors.TextPrimary
+    titleTrailingIconTint: Color = NuvioColors.TextPrimary,
+    leadingIcon: ImageVector? = null
 ) {
     val contentAlpha = if (enabled) 1f else 0.4f
     var isFocused by remember { mutableStateOf(false) }
@@ -512,6 +513,15 @@ internal fun SettingsActionRow(
                 .padding(horizontal = 18.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            if (leadingIcon != null) {
+                Icon(
+                    imageVector = leadingIcon,
+                    contentDescription = null,
+                    tint = NuvioColors.TextPrimary.copy(alpha = contentAlpha),
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+            }
             Column(modifier = Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -415,7 +415,6 @@
     <string name="audio_decoder_priority">أولوية فك التشفير</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
-    <string name="audio_dv_sub">Map Dolby Vision Profile 7 to standard HEVC for devices without DV hardware support</string>
     <string name="audio_decoder_device_only_desc">Only use built-in hardware decoders. Most compatible but may not support all formats.</string>
     <string name="audio_decoder_prefer_device_desc">Use hardware decoders when available, fall back to FFmpeg. Recommended for most devices.</string>
     <string name="audio_decoder_prefer_app_desc">Use FFmpeg decoders when available. Better format support but higher CPU usage.</string>
@@ -1300,8 +1299,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">تمرير الصوت (TrueHD, DTS, AC-3، إلخ) تلقائي. عند التوصيل بمستقبل AV أو مكبر صوت متوافق عبر HDMI، يتم إرسال الصوت دون فك تشفيره.</string>
-    <string name="audio_dv_title">DV7 - تراجع لـ HEVC</string>
-
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">الرئيسية</string>
     <string name="nav_discover">استكشاف</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -409,7 +409,6 @@
     <string name="audio_decoder_priority">Prioritet Dekodera</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Sinhronizacija zvuka/videa na hardverskom nivou. Može poboljšati reprodukciju na nekim Android TV uređajima.</string>
-    <string name="audio_dv_sub">Mapiraj Dolby Vision Profile 7 na standardni HEVC za uređaje bez hardverske Dolby Vision podrške.</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (Samo MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Odaberite kako bi libmpv trebao koristiti hardware dekodere.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direct -&gt; copy)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -483,6 +483,28 @@
 <string name="contributors_show_kofi_qr">Zobrazit Ko-fi QR</string>
 <string name="contributors_hide_kofi_qr">Skrýt Ko-fi QR</string>
 <string name="contributors_profile_unavailable">Odkaz na GitHub profil nedostupný.</string>
+    <string name="audio_trailer_section">Trailer</string>
+    <string name="audio_autoplay_trailers">Automaticky přehrávat trailery</string>
+    <string name="audio_autoplay_trailers_sub">Automaticky přehrát trailery na detailní obrazovce po chvíli nečinnosti</string>
+    <string name="audio_trailer_delay">Zpoždění traileru</string>
+    <string name="audio_section">Audio</string>
+    <string name="audio_lang_default">Výchozí (podle souboru)</string>
+    <string name="audio_lang_device">Jazyk zařízení</string>
+    <string name="audio_preferred_lang">Preferovaný jazyk audia</string>
+    <string name="audio_skip_silence">Přeskočit ticho</string>
+    <string name="audio_skip_silence_sub">Přeskočit tiché části audia během přehrávání</string>
+    <string name="audio_advanced_section">Pokročilé audio</string>
+    <string name="audio_advanced_warning">Tato nastavení mohou způsobit problémy na některých zařízeních. Měníte na vlastní riziko.</string>
+    <string name="audio_decoder_device_only">Pouze hardwarové dekodéry</string>
+    <string name="audio_decoder_prefer_device">Preferovat hardwarové dekodéry</string>
+    <string name="audio_decoder_prefer_app">Preferovat dekodéry aplikace (FFmpeg)</string>
+    <string name="audio_decoder_priority">Priorita dekodéru</string>
+    <string name="audio_tunneled">Tunelované přehrávání</string>
+    <string name="audio_tunneled_sub">Hardwarová synchronizace audio/video. Může zlepšit přehrávání na některých Android TV zařízeních</string>
+    <string name="audio_decoder_device_only_desc">Použít pouze vestavěné hardwarové dekodéry. Nejkompatibilnější, ale nemusí podporovat všechny formáty.</string>
+    <string name="audio_decoder_prefer_device_desc">Použít hardwarové dekodéry, pokud jsou dostupné, jinak FFmpeg. Doporučeno pro většinu zařízení.</string>
+    <string name="audio_decoder_prefer_app_desc">Použít FFmpeg dekodéry, pokud jsou dostupné. Lepší podpora formátů, vyšší zatížení CPU.</string>
+    <string name="audio_decoder_controls">Ovládá, zda se použijí hardwarové nebo softwarové (FFmpeg) dekodéry pro audio a video</string>
 
 <!-- PlaybackSettingsSections -->
 <string name="playback_section_general">Obecné</string>
@@ -545,29 +567,10 @@
 <string name="playback_engine_mvplayer_desc">Používá libmpv s OSD ovládacími prvky Nuvio. Experimentální.</string>
 
 <!-- PlaybackAudioSettings -->
-<string name="audio_trailer_section">Trailer</string>
-<string name="audio_autoplay_trailers">Automaticky přehrávat trailery</string>
-<string name="audio_autoplay_trailers_sub">Automaticky přehrávat trailery na obrazovce podrobností po určité době nečinnosti</string>
-<string name="audio_trailer_delay">Zpoždění traileru</string>
-<string name="audio_section">Zvuk</string>
-<string name="audio_lang_default">Výchozí (mediální soubor)</string>
-<string name="audio_lang_device">Jazyk zařízení</string>
 <string name="audio_lang_original">Původní jazyk</string>
 <string name="audio_lang_original_hint">Vyžaduje povolené obohacení TMDB</string>
-<string name="audio_preferred_lang">Preferovaný jazyk zvuku</string>
-<string name="audio_skip_silence">Přeskočit ticho</string>
-<string name="audio_skip_silence_sub">Během přehrávání přeskakovat tiché části zvuku</string>
 <string name="audio_remember_delay_per_device">Pamatovat si zpoždění zvuku podle zařízení</string>
 <string name="audio_remember_delay_per_device_sub">Uložit a obnovit zpoždění zvuku v přehrávači pro aktuální trasu zvukového výstupu</string>
-<string name="audio_advanced_section">Pokročilý zvuk</string>
-<string name="audio_advanced_warning">Tato nastavení mohou na některých zařízeních způsobit problémy. Měňte je, pouze pokud víte, co děláte.</string>
-<string name="audio_decoder_device_only">Pouze dekodéry zařízení</string>
-<string name="audio_decoder_prefer_device">Preferovat dekodéry zařízení</string>
-<string name="audio_decoder_prefer_app">Preferovat dekodéry aplikace (FFmpeg)</string>
-<string name="audio_decoder_priority">Priorita dekodéru</string>
-<string name="audio_tunneled">Tunelované přehrávání</string>
-<string name="audio_tunneled_sub">Hardwarová synchronizace zvuku a videa. Může zlepšit přehrávání na některých zařízeních Android TV</string>
-<string name="audio_dv_sub">Mapovat Dolby Vision Profile 7 na standardní HEVC pro zařízení bez hardwarové podpory DV</string>
 <string name="audio_mpv_hwdec_title">Hardwarové dekódování (pouze MPV)</string>
 <string name="audio_mpv_hwdec_dialog_subtitle">Vyberte, jak má libmpv používat hardwarové dekodéry.</string>
 <string name="audio_mpv_hwdec_legacy_direct_copy">Starší (přímé -> kopírování)</string>
@@ -580,10 +583,6 @@
 <string name="audio_mpv_hwdec_hardware_direct_desc">Používá přímé hardwarové dekódování. Nejrychlejší cesta na kompatibilních zařízeních.</string>
 <string name="audio_mpv_hwdec_disabled">Zakázáno (ne)</string>
 <string name="audio_mpv_hwdec_disabled_desc">Zakáže hardwarové dekódování a použije pouze softwarové dekódování.</string>
-<string name="audio_decoder_device_only_desc">Používat pouze vestavěné hardwarové dekodéry. Nejkompatibilnější, ale nemusí podporovat všechny formáty.</string>
-<string name="audio_decoder_prefer_device_desc">Používat hardwarové dekodéry, když jsou dostupné, jinak přejít na FFmpeg. Doporučeno pro většinu zařízení.</string>
-<string name="audio_decoder_prefer_app_desc">Používat dekodéry FFmpeg, když jsou dostupné. Lepší podpora formátů, ale vyšší využití CPU.</string>
-<string name="audio_decoder_controls">Řídí, zda se pro zvuk a video používají hardwarové nebo softwarové (FFmpeg) dekodéry</string>
 
 <!-- PlaybackSubtitleSettings -->
 <string name="sub_section">Titulky</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -628,7 +628,6 @@
     <string name="audio_decoder_priority">Decoder-Priorität</string>
     <string name="audio_tunneled">Getunnelte Wiedergabe</string>
     <string name="audio_tunneled_sub">Audio-Video-Sync auf Hardware (kann Android-TV Wiedergabe verbessern)</string>
-    <string name="audio_dv_sub">Dolby Vision Profile 7 für inkompatible Geräte auf HEVC umkodieren.</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (MPV-only)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Select how libmpv should use hardware decoders.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direct -&gt; copy)</string>
@@ -1633,7 +1632,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio-Passthrough (TrueHD, DTS, AC-3 usw.) erfolgt automatisch. Bei Anschluss an einen kompatiblen AV-Receiver oder eine Soundbar über HDMI wird verlustfreies Audio ohne Dekodierung und unverändert übertragen.</string>
-    <string name="audio_dv_title">DV7 – HEVC-Fallback</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Startseite</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -633,7 +633,6 @@
     <string name="audio_enable_downmix_subtitle">Χρησιμοποιεί τη διαδρομή downmix FFmpeg. Όταν είναι απενεργοποιημένο, ο ήχος ακολουθεί την προηγούμενη διαδρομή Android/συσκευής.</string>
     <string name="audio_tunneled">Αναπαραγωγή tunneled</string>
     <string name="audio_tunneled_sub">Συγχρονισμός ήχου/βίντεο σε επίπεδο υλικού. Μπορεί να βελτιώσει την αναπαραγωγή σε ορισμένες συσκευές Android TV</string>
-    <string name="audio_dv_sub">Αντιστοίχιση Dolby Vision Profile 7 σε standard HEVC για συσκευές χωρίς υποστήριξη υλικού DV</string>
     <string name="audio_mpv_hwdec_title">Αποκωδικοποίηση υλικού (μόνο MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Επιλέξτε πώς θα χρησιμοποιεί το libmpv τους αποκωδικοποιητές υλικού.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Παλαιό (direct -&gt; copy)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -255,7 +255,6 @@
     <string name="audio_decoder_priority">Prioridad del decodificador</string>
     <string name="audio_tunneled">Reproducción tunelizada</string>
     <string name="audio_tunneled_sub">Sincronización de audio/vídeo a nivel de hardware. Puede mejorar la reproducción en algunos dispositivos Android TV</string>
-    <string name="audio_dv_sub">Mapear Dolby Vision Perfil 7 a HEVC estándar para dispositivos sin soporte de hardware DV</string>
     <string name="audio_decoder_device_only_desc">Usa solo decodificadores de hardware incorporados. Más compatible pero puede que no admita todos los formatos.</string>
     <string name="audio_decoder_prefer_device_desc">Usa decodificadores de hardware cuando estén disponibles, fallback a FFmpeg. Recomendado para la mayoría de dispositivos.</string>
     <string name="audio_decoder_prefer_app_desc">Usa decodificadores FFmpeg cuando estén disponibles. Mejor soporte de formatos pero mayor uso de CPU.</string>
@@ -884,7 +883,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">El audio pasthrough (TrueHD, DTS, AC-3, etc.) es automático. Cuando está conectado a un receptor AV o barra de sonido compatible vía HDMI, el audio sin pérdida se envía tal cual sin decodificación.</string>
-    <string name="audio_dv_title">DV7 - Fallback HEVC</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Inicio</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -518,7 +518,6 @@
     <string name="audio_decoder_priority">Priorité du décodeur</string>
     <string name="audio_tunneled">Lecture tunnelisée</string>
     <string name="audio_tunneled_sub">Synchronisation audio/vidéo au niveau matériel. Peut améliorer la lecture sur certains appareils Android TV</string>
-    <string name="audio_dv_sub">Convertir le Dolby Vision profil 7 en HEVC standard pour les appareils sans prise en charge matérielle du DV</string>
     <string name="audio_mpv_hwdec_title">Décodage matériel (MPV uniquement)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Choisis comment libmpv doit utiliser les décodeurs matériels.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Ancien mode (direct -&gt; copy)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -295,7 +295,6 @@
     <string name="audio_decoder_priority">डिकोडर प्राथमिकता</string>
     <string name="audio_tunneled">टनल्ड प्लेबैक</string>
     <string name="audio_tunneled_sub">हार्डवेयर स्तर का ऑडियो/वीडियो सिंक। कुछ Android TV डिवाइस पर प्लेबैक बेहतर हो सकता है</string>
-    <string name="audio_dv_sub">Dolby Vision Profile 7 को मानक HEVC में मैप करें उन डिवाइस के लिए जिनमें DV हार्डवेयर सपोर्ट नहीं है</string>
     <string name="audio_decoder_device_only_desc">केवल बिल्ट-इन हार्डवेयर डिकोडर का उपयोग करें। सबसे अधिक संगत लेकिन सभी फॉर्मेट सपोर्ट नहीं हो सकते।</string>
     <string name="audio_decoder_prefer_device_desc">जहाँ उपलब्ध हो हार्डवेयर डिकोडर उपयोग करें, अन्यथा FFmpeg पर जाएँ। अधिकांश डिवाइस के लिए अनुशंसित।</string>
     <string name="audio_decoder_prefer_app_desc">जहाँ उपलब्ध हो FFmpeg डिकोडर उपयोग करें। बेहतर फॉर्मेट सपोर्ट लेकिन अधिक CPU उपयोग।</string>
@@ -1001,7 +1000,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">ऑडियो पासथ्रू (TrueHD, DTS, AC-3 आदि) स्वचालित है। HDMI के माध्यम से संगत AV रिसीवर या साउंडबार से जुड़ने पर लॉसलेस ऑडियो बिना डिकोड किए सीधे भेजा जाता है।</string>
-    <string name="audio_dv_title">DV7 - HEVC फ़ॉलबैक</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">होम</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -633,7 +633,6 @@
     <string name="audio_enable_downmix_subtitle">Az FFmpeg lekeverési utat használja. Ha le van tiltva, a hang a korábbi Android/eszköz utat követi.</string>
     <string name="audio_tunneled">Alagutazott (tunneled) lejátszás</string>
     <string name="audio_tunneled_sub">Hang/videó szinkronizálása hardveres szinten. Javíthatja a lejátszást egyes Android TV eszközökön.</string>
-    <string name="audio_dv_sub">Dolby Vision Profile 7 leképzése szabványos HEVC-re a DV-t nem támogató eszközökön</string>
     <string name="audio_mpv_hwdec_title">Hardveres dekódolás (Csak MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Válaszd ki, hogyan használja a libmpv a hardveres dekódereket.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Hagyományos (közvetlen -&gt; másolás)</string>
@@ -1720,8 +1719,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">A hangátvitel (passthrough – TrueHD, DTS, AC-3 stb.) automatikus. Kompatibilis erősítőhöz vagy soundbarhoz HDMI-n csatlakozva a veszteségmentes hang dekódolás nélkül továbbítódik.</string>
-    <string name="audio_dv_title">DV7 – HEVC tartalék (Fallback)</string>
-
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Kezdőlap</string>
     <string name="nav_discover">Felfedezés</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -633,7 +633,6 @@
     <string name="audio_enable_downmix_subtitle">Menggunakan jalur downmix FFmpeg. Jika dinonaktifkan, audio akan mengikuti jalur Android/perangkat sebelumnya.</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Sinkronisasi audio/video tingkat hardware. Mungkin meningkatkan pemutaran di beberapa perangkat Android TV</string>
-    <string name="audio_dv_sub">Petakan Dolby Vision Profil 7 ke HEVC standar untuk perangkat tanpa dukungan hardware DV</string>
     <string name="audio_mpv_hwdec_title">Dekoding Hardware (Hanya MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Pilih cara libmpv menggunakan dekoder hardware.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Lama (direct → copy)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -442,7 +442,6 @@
 <string name="audio_decoder_priority">Priorità decoder</string>
 <string name="audio_tunneled">Riproduzione Tunneled</string>
 <string name="audio_tunneled_sub">Sincronizzazione audio/video a livello hardware. Può migliorare la riproduzione su alcuni dispositivi Android TV</string>
-<string name="audio_dv_sub">Mappa il profilo Dolby Vision 7 in HEVC standard per i dispositivi senza supporto hardware DV</string>
 <string name="audio_mpv_hwdec_title">Decodifica Hardware (Solo MPV)</string>
 <string name="audio_mpv_hwdec_dialog_subtitle">Seleziona come libmpv deve utilizzare i decoder hardware.</string>
 <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (diretto -> copia)</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1006,8 +1006,6 @@
     <string name="audio_advanced_section">שמע מתקדם</string>
     <string name="audio_advanced_warning">הגדרות אלה עלולות לגרום לבעיות בחלק מהמכשירים. שנה רק אם אתה יודע מה אתה עושה.</string>
     <string name="audio_passthrough_info">מעבר שמע (TrueHD, DTS, AC-3 וכו׳) הוא אוטומטי. כשמחובר למקלט AV תואם או soundbar דרך HDMI, שמע ללא אובדן נשלח כמות שהוא ללא פענוח.</string>
-    <string name="audio_dv_title">DV7 - נפילה ל-HEVC</string>
-    <string name="audio_dv_sub">ממפה Dolby Vision Profile 7 ל-HEVC סטנדרטי למכשירים ללא תמיכת DV חומרתית</string>
 
     <!-- Subtitles (advanced) -->
     <string name="sub_section">כתוביות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -340,7 +340,6 @@
     <string name="audio_decoder_priority">デコーダー優先度</string>
     <string name="audio_tunneled">トンネル再生</string>
     <string name="audio_tunneled_sub">ハードウェアレベルの音声/映像同期。一部のAndroid TVデバイスで再生を改善する可能性があります</string>
-    <string name="audio_dv_sub">DV非対応デバイス向けにDolby Vision Profile 7を標準HEVCにマッピング</string>
     <string name="audio_decoder_device_only_desc">内蔵ハードウェアデコーダーのみ使用。最も互換性が高いですが、すべての形式に対応していない場合があります</string>
     <string name="audio_decoder_prefer_device_desc">利用可能な場合はハードウェアデコーダーを使用し、FFmpegにフォールバック。ほとんどのデバイスで推奨</string>
     <string name="audio_decoder_prefer_app_desc">利用可能な場合はFFmpegデコーダーを使用。対応形式は増えますがCPU使用率が上がります</string>
@@ -1179,7 +1178,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">音声パススルー（TrueHD・DTS・AC-3など）は自動で有効になります。対応AVレシーバーやサウンドバーにHDMI接続している場合、ロスレスオーディオはデコードなしでそのまま出力されます</string>
-    <string name="audio_dv_title">DV7 - HEVCフォールバック</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">ホーム</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -297,7 +297,6 @@
     <string name="audio_decoder_priority">Dekoderio prioritetas</string>
     <string name="audio_tunneled">Tunelinis atkūrimas (Tunneled Playback)</string>
     <string name="audio_tunneled_sub">Aparatūros lygio garso / vaizdo sinchronizavimas. Gali pagerinti atkūrimą kai kuriuose „Android TV“ įrenginiuose.</string>
-    <string name="audio_dv_sub">Susieti „Dolby Vision 7“ profilį su standartiniu HEVC įrenginiams be DV aparatūros palaikymo</string>
     <string name="audio_decoder_device_only_desc">Naudoti tik integruotus aparatūros dekoderius. Labiausiai suderinama, bet gali palaikyti ne visus formatus.</string>
     <string name="audio_decoder_prefer_device_desc">Naudoti aparatūros dekoderius, kai jie prieinami, kitu atveju — FFmpeg. Rekomenduojama daugumai įrenginių.</string>
     <string name="audio_decoder_prefer_app_desc">Naudoti FFmpeg dekoderius, kai jie prieinami. Geresnis formatų palaikymas, bet didesnis CPU naudojimas.</string>
@@ -1014,7 +1013,6 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Garso pralaidumas tiesiogiai į jūsų garso sistemą</string>
-    <string name="audio_dv_title">„Dolby Vision“ apdorojimas</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Pagrindinis</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -217,7 +217,6 @@
 <string name="audio_decoder_priority">Decoderprioriteit</string>
 <string name="audio_tunneled">Tunneled playback</string>
 <string name="audio_tunneled_sub">Hardwarematige audio/video-synchronisatie. Kan de weergave verbeteren op sommige Android TV-apparaten</string>
-<string name="audio_dv_sub">Map Dolby Vision-profiel 7 naar standaard HEVC voor apparaten zonder DV-hardwareondersteuning</string>
 <string name="audio_decoder_device_only_desc">Gebruik alleen ingebouwde hardwaredecoders. Meest compatibel, maar ondersteunt mogelijk niet alle formaten.</string>
 <string name="audio_decoder_prefer_device_desc">Gebruik hardwaredecoders indien beschikbaar, anders FFmpeg. Aanbevolen voor de meeste apparaten.</string>
 <string name="audio_decoder_prefer_app_desc">Gebruik FFmpeg-decoders indien beschikbaar. Betere formaatondersteuning, maar hoger CPU-gebruik.</string>
@@ -864,7 +863,6 @@
 
 <!-- PlaybackAudioSettings -->
 <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, enz.) is automatisch. Wanneer aangesloten op een compatibele AV-receiver of soundbar via HDMI, wordt lossless audio direct doorgestuurd zonder decodering.</string>
-<string name="audio_dv_title">DV7 - HEVC fallback</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Beginpagina</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -339,7 +339,6 @@
     <string name="audio_decoder_priority">Dekoder prioritering</string>
     <string name="audio_tunneled">Tunnelert avspilling</string>
     <string name="audio_tunneled_sub">Lyd-/videosynkronisering på maskinvarenivå. Kan forbedre avspilling på noen Android TV-enheter</string>
-    <string name="audio_dv_sub">Kartlegg Dolby Vision-profil 7 til standard HEVC for enheter uten DV-maskinvarestøtte</string>
     <string name="audio_decoder_device_only_desc">Bruk bare innebygde maskinvaredekodere. Mest kompatibel, men kan ikke støtte alle formater.</string>
     <string name="audio_decoder_prefer_device_desc">Bruk maskinvaredekodere når tilgjengelig, fall tilbake til FFmpeg. Anbefalt for de fleste enheter.</string>
     <string name="audio_decoder_prefer_app_desc">Bruk FFmpeg-dekodere når tilgjengelig. Bedre formatstøtte, men høyere CPU-bruk.</string>
@@ -1122,7 +1121,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Lydgjennomgang (TrueHD, DTS, AC-3, osv.) er automatisk. Når den er koblet til en kompatibel AV-mottaker eller høyttaler via HDMI, sendes lyd som-er uten dekoding.</string>
-    <string name="audio_dv_title">DV7 – HEVC fallback</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Hjem</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -239,7 +239,6 @@
     <string name="audio_decoder_priority">Priorytet dekodera</string>
     <string name="audio_tunneled">Tunelowane odtwarzanie</string>
     <string name="audio_tunneled_sub">Synchronizacja audio/wideo na poziomie sprzętu. Może poprawić odtwarzanie na niektórych urządzeniach Android TV</string>
-    <string name="audio_dv_sub">Mapuj Dolby Vision Profil 7 na standardowy HEVC dla urządzeń bez obsługi DV</string>
     <string name="audio_mpv_hwdec_title">Dekodowanie sprzętowe (tylko MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Wybierz jak libmpv powinien używać dekoderów sprzętowych.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Starszy (direct -&gt; copy)</string>
@@ -1043,7 +1042,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Przepuszczanie audio (TrueHD, DTS, AC-3 itp.) jest automatyczne. Po podlaczeniu do kompatybilnego amplitunera lub soundbara przez HDMI, bezstratne audio jest przesylane bez dekodowania.</string>
-    <string name="audio_dv_title">DV7 - Fallback HEVC</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Główna</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -633,7 +633,6 @@
     <string name="audio_enable_downmix_subtitle">Utiliza a mixagem do FFmpeg. Se desativado, o áudio segue o caminho padrão do dispositivo/Android.</string>
     <string name="audio_tunneled">Reprodução tunneled</string>
     <string name="audio_tunneled_sub">Melhora a sincronização de áudio e vídeo usando o hardware.</string>
-    <string name="audio_dv_sub">Mapear Dolby Vision 7 para HEVC</string>
     <string name="audio_mpv_hwdec_title">Decodificação por hardware (MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Definir uso de decodificadores</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direto → cópia)</string>
@@ -1718,7 +1717,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">A passagem direta de áudio (passthrough) para TrueHD, DTS e AC-3 é automática. Se a sua Soundbar/Receiver for compatível, o áudio será enviado sem perdas e sem decodificação prévia.</string>
-    <string name="audio_dv_title">DV7 - Modo HEVC Alternativo</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Início</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -209,7 +209,6 @@
     <string name="audio_decoder_priority">Prioritate decodor</string>
     <string name="audio_tunneled">Redare prin tunel</string>
     <string name="audio_tunneled_sub">Sincronizare audio/video la nivel hardware. Poate îmbunătăți redarea pe unele dispozitive Android TV</string>
-    <string name="audio_dv_sub">Mapează Dolby Vision Profil 7 la HEVC standard pentru dispozitivele fără suport hardware DV</string>
     <string name="audio_decoder_device_only_desc">Folosește doar decodoarele hardware încorporate. Cele mai compatibile, dar s-ar putea să nu suporte toate formatele.</string>
     <string name="audio_decoder_prefer_device_desc">Folosește decodoarele hardware când sunt disponibile, revine la FFmpeg dacă nu. Recomandat pentru majoritatea dispozitivelor.</string>
     <string name="audio_decoder_prefer_app_desc">Folosește decodoarele FFmpeg când sunt disponibile. Compatibilitate mai bună a formatelor, dar consumă mai mult CPU.</string>
@@ -838,7 +837,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Passthrough audio (TrueHD, DTS, AC-3, etc.) este automat. Când este conectat la un receptor AV compatibil sau soundbar prin HDMI, audio lossless este trimis așa cum este, fără decodare.</string>
-    <string name="audio_dv_title">DV7 - HEVC rezervă</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Acasă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -409,7 +409,6 @@
     <string name="audio_decoder_priority">Приоритет декодеров</string>
     <string name="audio_tunneled">Туннельное воспроизведение</string>
     <string name="audio_tunneled_sub">Аппаратная синхронизация аудио/видео. Может улучшить воспроизведение на некоторых устройствах Android TV</string>
-    <string name="audio_dv_sub">Преобразование профиля Dolby Vision 7 в стандартный HEVC для устройств без аппаратной поддержки DV</string>
     <string name="audio_mpv_hwdec_title">Аппаратное декодирование (только MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Выберите, как libmpv должен использовать аппаратные декодеры.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Устаревшее (прямое -&gt; копирование)</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -604,7 +604,6 @@
     <string name="audio_decoder_priority">Prioriteta dekoderja</string>
     <string name="audio_tunneled">Tunelirano predvajanje</string>
     <string name="audio_tunneled_sub">Strojna sinhronizacija zvoka/videa. Lahko izboljša predvajanje na nekaterih napravah Android TV</string>
-    <string name="audio_dv_sub">Preslikaj Dolby Vision Profile 7 v standardni HEVC za naprave brez strojne podpore DV</string>
     <string name="audio_mpv_hwdec_title">Strojno dekodiranje (samo MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Izberite, kako naj libmpv uporablja strojne dekoderje.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Podedovano (direct -&gt; copy)</string>
@@ -1559,6 +1558,7 @@
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Prehod zvoka (TrueHD, DTS, AC-3 itd.) je samodejen. Ob povezavi z združljivim AV sprejemnikom ali zvočno vrstico prek HDMI se zvok brez izgub pošlje nespremenjen, brez dekodiranja.</string>
     <string name="audio_dv_title">DV7 - HEVC Rezerva</string>
+
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Domov</string>
     <string name="nav_discover">Odkrij</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -298,7 +298,6 @@
     <string name="audio_decoder_priority">Avkodarprioritet</string>
     <string name="audio_tunneled">Tunneluppspelning</string>
     <string name="audio_tunneled_sub">Ljud/video-synk på hårdvarunivå. Kan förbättra uppspelning på vissa Android TV-enheter</string>
-    <string name="audio_dv_sub">Mappa Dolby Vision Profil 7 till standard-HEVC för enheter utan DV-hårdvarustöd</string>
     <string name="audio_decoder_device_only_desc">Använd bara inbyggda hårdvaruavkodare. Mest kompatibelt men stödjer inte alla format.</string>
     <string name="audio_decoder_prefer_device_desc">Använd hårdvaruavkodare när tillgängliga, använd FFmpeg som reserv. Rekommenderas för de flesta enheter.</string>
     <string name="audio_decoder_prefer_app_desc">Använd FFmpeg-avkodare när tillgängliga. Bättre formatstöd men högre CPU-användning.</string>
@@ -1056,7 +1055,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Ljudgenomströmning (TrueHD, DTS, AC-3, etc.) är automatisk. När enheten är ansluten till en kompatibel AV-receiver eller soundbar via HDMI skickas förlustfritt ljud som det är utan avkodning.</string>
-    <string name="audio_dv_title">DV7 - HEVC-reserv</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Hem</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -622,7 +622,6 @@
     <string name="audio_decoder_priority">டிகோடர் முன்னுரிமை</string>
     <string name="audio_tunneled">டனல்டு இயக்கம்</string>
     <string name="audio_tunneled_sub">வன்பொருள் நிலை ஒலி/காணொளி ஒத்திசைவு. சில ஆண்ட்ராய்டு டிவி சாதனங்களில் இயக்கத்தை மேம்படுத்தலாம்</string>
-    <string name="audio_dv_sub">டால்பி விஷன் ப்ரொஃபைல் ௭-ஐ டிவி ஆதரவு இல்லாத சாதனங்களுக்கு சாதாரண ஹெவிசியாக மாற்று</string>
     <string name="audio_mpv_hwdec_title">வன்பொருள் டிகோடிங் (எம்பிவி மட்டும்)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">லிப்எம்பிவி வன்பொருள் டிகோடர்களை எவ்வாறு பயன்படுத்த வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும்.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">பழைய முறை (நேரடி -&gt; நகல்)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -628,7 +628,6 @@
     <string name="audio_enable_downmix_subtitle">FFmpeg downmix yolunu kullanır. Devre dışı bırakıldığında ses önceki Android/cihaz yolunu takip eder.</string>
     <string name="audio_tunneled">Tünelli Oynatma</string>
     <string name="audio_tunneled_sub">Donanım seviyesinde ses/video senkronizasyonu. Bazı Android TV cihazlarında performansı artırabilir</string>
-    <string name="audio_dv_sub">DV donanım desteği olmayan cihazlar için Dolby Vision Profil 7\'yi standart HEVC\'ye dönüştür</string>
     <string name="audio_mpv_hwdec_title">Donanım Kod Çözme (yalnızca MPV)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">libmpv\'nin donanım kod çözücülerini nasıl kullanacağını seçin.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Eski mod (direct -&gt; copy)</string>
@@ -1761,7 +1760,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Yüksek kaliteli ses geçidi (TrueHD, DTS, AC-3) desteklenen HDMI veya uyumlu ses alıcı / arayüz bar donanımlarına bağlanıldığında yazılımın çözümüne bırakılmadan direkt doğrudan iletilir.</string>
-    <string name="audio_dv_title">DV7 - HEVC Geri Yansıması</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Ana Menü</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -216,7 +216,6 @@
     <string name="audio_decoder_priority">Ưu tiên bộ giải mã</string>
     <string name="audio_tunneled">Phát tunneled</string>
     <string name="audio_tunneled_sub">Đồng bộ âm thanh/video ở mức phần cứng. Có thể cải thiện phát trên một số thiết bị Android TV</string>
-    <string name="audio_dv_sub">Chuyển Dolby Vision Profile 7 sang HEVC tiêu chuẩn cho thiết bị không hỗ trợ phần cứng DV</string>
     <string name="audio_decoder_device_only_desc">Chỉ dùng bộ giải mã phần cứng tích hợp. Tương thích nhất nhưng có thể không hỗ trợ tất cả định dạng.</string>
     <string name="audio_decoder_prefer_device_desc">Dùng bộ giải mã phần cứng khi có, dự phòng bằng FFmpeg. Khuyến nghị cho hầu hết thiết bị.</string>
     <string name="audio_decoder_prefer_app_desc">Dùng bộ giải mã FFmpeg khi có. Hỗ trợ nhiều định dạng hơn nhưng tốn CPU hơn.</string>
@@ -884,7 +883,6 @@
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3...) là tự động. Khi kết nối với bộ khuếch đại AV hoặc soundbar tương thích qua HDMI, âm thanh lossless được truyền nguyên vẹn mà không giải mã.</string>
-    <string name="audio_dv_title">DV7 - Dự phòng HEVC</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Trang chủ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <string name="type_series_plural">Series</string>
     <string name="type_unknown">Unknown</string>
 
-    <!-- WebConfigServers -->
     <string name="web_manage_addons_title">Manage Addons</string>
     <string name="web_manage_addons_subtitle">Manage addons, catalogs, and collections</string>
     <string name="web_manage_addons_only_subtitle">Install or remove add-ons</string>
@@ -97,14 +96,12 @@
     <string name="web_import_success">Imported {count} collection(s). Review and hit Save Changes to apply.</string>
     <string name="web_import_invalid_json">Invalid JSON</string>
 
-    <!-- HomeScreen -->
     <string name="home_no_addons">No addons installed. Add one to get started.</string>
     <string name="home_no_catalog_addons">No catalog addons installed. Install a catalog addon to see content.</string>
     <string name="auth_notice_nuvio_logged_out">You have been signed out of Nuvio. Please sign in again.</string>
     <string name="auth_notice_trakt_logged_out">You have been signed out of Trakt. Please reconnect.</string>
     <string name="error_generic">An error occurred</string>
 
-    <!-- ErrorState -->
     <string name="action_retry">Retry</string>
     <string name="error_state_generic_issue">Something went wrong.</string>
     <string name="error_state_possible_fix">Possible fix: %1$s</string>
@@ -139,7 +136,6 @@
     <string name="error_stream_tried_generic">Tried stream addons: %1$s. Streams could not be loaded for id=%2$s (type=%3$s).</string>
     <string name="error_stream_tried_issues">Tried stream addons: %1$s. Streams could not be loaded for id=%2$s (type=%3$s). Issues: %4$s.</string>
 
-    <!-- ContinueWatchingSection -->
     <string name="continue_watching">Continue Watching</string>
     <string name="cw_upcoming">Upcoming</string>
     <string name="cw_next_up">Next Up</string>
@@ -163,12 +159,10 @@
     <string name="cw_dialog_subtitle">Choose what you want to do with this item.</string>
     <string name="home_poster_dialog_subtitle">Title actions</string>
 
-    <!-- CatalogRowSection -->
     <string name="catalog_from_addon">from %1$s</string>
     <string name="action_see_all">See All</string>
     <string name="action_load_more">Load More</string>
 
-    <!-- HeroSection -->
     <string name="hero_creator">Creator: %1$s</string>
     <string name="hero_director">Director: %1$s</string>
     <string name="hero_writer">Writer: %1$s</string>
@@ -182,7 +176,6 @@
     <string name="hero_press_back_trailer">Press back to exit trailer</string>
     <string name="cd_rating">Rating</string>
 
-    <!-- EpisodesSection -->
     <string name="episodes_season">Season %1$d</string>
     <string name="episodes_specials">Specials</string>
     <string name="episodes_episode">Episode</string>
@@ -199,7 +192,6 @@
     <string name="play_manually">Play manually</string>
     <string name="episodes_season_actions">Season actions</string>
 
-    <!-- MetaDetailsViewModel -->
     <string name="detail_added_to_library">Added to library</string>
     <string name="detail_removed_from_library">Removed from library</string>
     <string name="detail_episode_marked_watched">Episode marked as watched</string>
@@ -215,7 +207,6 @@
     <string name="detail_marked_episodes_unwatched">Episodes marked as unwatched: %1$d</string>
     <string name="detail_marked_previous_watched">Previous episodes marked as watched: %1$d</string>
 
-    <!-- MetaDetailsScreen -->
     <string name="detail_btn_play">Play</string>
     <string name="detail_btn_resume">Resume</string>
     <string name="detail_btn_play_episode">Play S%1$d E%2$d</string>
@@ -304,19 +295,16 @@
     <string name="action_save">Save</string>
     <string name="action_saving">Saving…</string>
 
-    <!-- AppLanguage -->
     <string name="appearance_language">App Language</string>
     <string name="appearance_language_subtitle">Override system language</string>
     <string name="appearance_language_system">System default</string>
     <string name="appearance_language_dialog_title">Choose Language</string>
     <string name="appearance_language_restart_hint">Restart the app to apply the language change.</string>
 
-    <!-- Font -->
     <string name="appearance_font">App Font</string>
     <string name="appearance_font_subtitle">Choose your preferred font</string>
     <string name="appearance_font_dialog_title">Choose Font</string>
 
-    <!-- ThemeSettingsScreen -->
     <string name="appearance_title">Appearance</string>
     <string name="appearance_subtitle">Choose your color theme, font and language</string>
     <string name="appearance_color_theme">Color Theme</string>
@@ -336,7 +324,6 @@
     <string name="appearance_font_and_language_subtitle">Choose the typeface and locale used throughout the app</string>
     <string name="cd_selected">Selected</string>
 
-    <!-- AboutScreen -->
     <string name="about_title">About</string>
     <string name="about_subtitle">App information, updates, and legal links</string>
     <string name="about_made_with_love">Made with ❤️ by Tapframe and friends</string>
@@ -471,6 +458,7 @@
     <string name="advanced_section_performance">Performance &amp; navigation</string>
     <string name="advanced_section_diagnostics">Diagnostics</string>
     <string name="advanced_section_cache">Cache</string>
+    <string name="advanced_section_dv_diagnostics" translatable="false">DV Diagnostics</string>
     <string name="advanced_fast_horizontal_navigation">Fast Horizontal Navigation</string>
     <string name="advanced_fast_horizontal_navigation_subtitle">Increase D-pad repeat speed in rows while keeping repeat throttling enabled.</string>
     <string name="advanced_nuvio_focus_scroll">Nuvio Focus Scrolling</string>
@@ -500,7 +488,6 @@
     <string name="settings_animeskip_subtitle">Anime intro/outro skip timestamps</string>
     <string name="settings_debrid_subtitle">Experimental cloud account sources</string>
 
-    <!-- PlaybackSettingsScreen -->
     <string name="playback_title">Playback Settings</string>
     <string name="playback_subtitle">Configure video playback and subtitle options</string>
     <string name="cd_decrease">Decrease</string>
@@ -511,7 +498,6 @@
     <string name="action_none">None</string>
     <string name="action_close">Close</string>
 
-    <!-- SupportersContributorsScreen -->
     <string name="supporters_contributors_title">Supporters &amp; Contributors</string>
     <string name="supporters_contributors_subtitle">The people backing Nuvio and the contributors building it across TV and mobile.</string>
     <string name="supporters_contributors_supporters_copy">Supporters and donators help keep the project moving, fund infrastructure, and make room for ambitious features.</string>
@@ -544,7 +530,6 @@
     <string name="contributors_hide_kofi_qr">Hide Ko-fi QR</string>
     <string name="contributors_profile_unavailable">GitHub profile link unavailable.</string>
 
-    <!-- PlaybackSettingsSections -->
     <string name="playback_section_general">General</string>
     <string name="playback_section_general_desc">Core playback behavior.</string>
     <string name="playback_loading_overlay">Loading Overlay</string>
@@ -577,8 +562,8 @@
     <string name="playback_engine_mvplayer">Libmpv (Beta)</string>
     <string name="playback_auto_switch_internal_player_on_error">Auto-switch engine on startup error</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">If stream startup fails, switch between ExoPlayer and libmpv automatically.</string>
-    <string name="playback_section_audio">Audio &amp; Trailer</string>
-    <string name="playback_section_audio_desc">Trailer behavior and audio controls.</string>
+    <string name="playback_section_audio">Video &amp; Audio</string>
+    <string name="playback_section_audio_desc">Video compatibility, trailer behavior, and audio controls.</string>
     <string name="playback_section_subtitles">Subtitles</string>
     <string name="playback_section_subtitles_desc">Language, style, and render mode.</string>
     <string name="playback_afr_open">Open</string>
@@ -606,7 +591,7 @@
     <string name="playback_engine_exoplayer_desc">Best compatibility with current Nuvio features.</string>
     <string name="playback_engine_mvplayer_desc">Uses libmpv with Nuvio OSD controls. Experimental.</string>
 
-    <!-- PlaybackAudioSettings -->
+    <string name="video_section">Video</string>
     <string name="audio_trailer_section">Trailer</string>
     <string name="audio_autoplay_trailers">Auto-play Trailers</string>
     <string name="audio_autoplay_trailers_sub">Automatically play trailers on the detail screen after a period of inactivity</string>
@@ -633,7 +618,35 @@
     <string name="audio_enable_downmix_subtitle">Uses the FFmpeg downmix path. When disabled, audio follows the previous Android/device path.</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
-    <string name="audio_dv_sub">Map Dolby Vision Profile 7 to standard HEVC for devices without DV hardware support</string>
+    <!-- DV7 Handling Mode -->
+    <string name="dv7_handling_title">Dolby Vision Profile 7 Handling</string>
+    <string name="dv7_handling_dialog_subtitle">Choose how DV Profile 7 streams are processed at playback time.</string>
+    <string name="dv7_mode_auto">Auto (recommended)</string>
+    <string name="dv7_mode_auto_desc">Detects your display and picks the best mode. If playback issues occur, try HDR10 base layer.</string>
+    <string name="dv7_mode_hdr10_base_layer">HDR10 base layer</string>
+    <string name="dv7_mode_hdr10_base_layer_desc">Always strip Dolby Vision and play the HEVC HDR10 base layer.</string>
+    <string name="dv7_mode_dv81_libdovi">Convert to DV8.1</string>
+    <string name="dv7_mode_dv81_libdovi_desc">Convert DV7 to single-layer DV8.1. Requires Dolby Vision display.</string>
+    <string name="dv7_mode_off">Off (native)</string>
+    <string name="dv7_mode_off_desc">Pass DV7 through unmodified. May glitch on hardware that does not support DV Profile 7.</string>
+    <string name="audio_dv5_to_dv81_title">Convert DV5 to DV8.1</string>
+    <string name="audio_dv5_to_dv81_sub">Signal Profile 5 streams as Profile 8.1 for HDR10-compatible output. Helps on devices that do not have a native DV5 decoder.</string>
+    <string name="audio_dv7_preserve_mapping_title">Preserve DV mapping (DV7 to DV8.1)</string>
+    <string name="audio_dv7_preserve_mapping_sub">Keeps original creator-intended tone-mapping at the cost of slightly more processing per frame.</string>
+    <string name="dv7_libdovi_mode_caption" translatable="false">Conversion mode (auto-selected, do not change unless instructed). Pick one to force it; None uses auto. Active only when DV7 Handling is Convert to DV8.1.</string>
+    <string name="dv7_libdovi_mode_row_title" translatable="false">Conversion mode</string>
+    <string name="dv7_libdovi_mode_none_title" translatable="false">None</string>
+    <string name="dv7_libdovi_mode_none_sub" translatable="false">No override. Uses the automatically selected conversion mode.</string>
+    <string name="dv7_libdovi_mode_0_title" translatable="false">Mode 0 — Copy (no convert)</string>
+    <string name="dv7_libdovi_mode_0_sub" translatable="false">Parse the RPU and write it back untouched. No profile conversion.</string>
+    <string name="dv7_libdovi_mode_1_title" translatable="false">Mode 1 — MEL</string>
+    <string name="dv7_libdovi_mode_1_sub" translatable="false">Convert the RPU to be MEL (Minimum Enhancement Layer) compatible.</string>
+    <string name="dv7_libdovi_mode_2_title" translatable="false">Mode 2 — 8.1 (no-op mapping)</string>
+    <string name="dv7_libdovi_mode_2_sub" translatable="false">Convert to profile 8.1 with luma and chroma mapping set to no-op. The standard conversion.</string>
+    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — Profile 5 to 8.1</string>
+    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert Profile 5 (DV5) streams to Profile 8.1. Same conversion the Convert DV5 to DV8.1 toggle uses.</string>
+    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.4 (static)</string>
+    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to static profile 8.4.</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (MPV-only)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Select how libmpv should use hardware decoders.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direct -&gt; copy)</string>
@@ -651,7 +664,6 @@
     <string name="audio_decoder_prefer_app_desc">Use FFmpeg decoders when available. Better format support but higher CPU usage.</string>
     <string name="audio_decoder_controls">Controls whether hardware or software (FFmpeg) decoders are used for audio and video</string>
 
-    <!-- PlaybackSubtitleSettings -->
     <string name="sub_section">Subtitles</string>
     <string name="sub_not_set">Not set</string>
     <string name="sub_forced_lang">Forced</string>
@@ -698,7 +710,6 @@
     <string name="sub_startup_mode_preferred_desc">Prefetch addon subtitles before playback and attach preferred/secondary language tracks.</string>
     <string name="sub_startup_mode_all_desc">Prefetch and attach all addon subtitles before playback. Slowest startup.</string>
 
-    <!-- PlaybackAutoPlaySettings -->
     <string name="autoplay_reuse_last_link">Reuse Last Link</string>
     <string name="autoplay_reuse_last_link_sub">Auto-play your last working stream for this same movie/episode when cache is still valid</string>
     <string name="autoplay_last_link_cache">Last Link Cache Duration</string>
@@ -751,7 +762,6 @@
     <string name="autoplay_regex_presets">Presets</string>
     <string name="autoplay_invalid_regex">Invalid regex pattern</string>
 
-    <!-- LayoutSettingsScreen -->
     <string name="layout_title">Layout Settings</string>
     <string name="layout_subtitle">Adjust home layout, content visibility, and poster behavior</string>
     <string name="layout_classic">Classic View</string>
@@ -864,7 +874,6 @@
     <string name="layout_custom">Custom</string>
 
 
-    <!-- MDBListSettingsScreen -->
     <string name="mdblist_title">MDBList Ratings</string>
     <string name="mdblist_subtitle">Configure external ratings shown in the detail hero</string>
     <string name="mdblist_enable_title">Enable MDBList Ratings</string>
@@ -1028,7 +1037,6 @@
     <string name="animeskip_invalid_client_id">Invalid Client ID</string>
     <string name="action_clear">Clear</string>
 
-    <!-- TmdbSettingsScreen -->
     <string name="tmdb_title">TMDB Enrichment</string>
     <string name="tmdb_subtitle">Choose which metadata fields should come from TMDB</string>
     <string name="tmdb_enable_title">Enable TMDB Enrichment</string>
@@ -1064,7 +1072,6 @@
 
     <string name="tmdb_language_dialog_title">TMDB Language</string>
 
-    <!-- TraktScreen -->
     <string name="trakt_description">Sync your watchlist, watch progress, continue watching, scrobbles, and personal lists with Trakt.</string>
     <string name="trakt_connected_as">Connected as %1$s</string>
     <string name="trakt_account_login">Account Login</string>
@@ -1142,7 +1149,6 @@
     <string name="trakt_all_history">All history</string>
     <string name="trakt_days_format">%1$d days</string>
 
-    <!-- DebugSettingsScreen -->
     <string name="debug_title">Debug</string>
     <string name="debug_subtitle">Developer tools and feature flags (debug builds only)</string>
     <string name="debug_section_popup">Popup / Dialog Testing</string>
@@ -1153,6 +1159,8 @@
     <string name="debug_account_tab_subtitle">Show the Account tab in Settings navigation</string>
     <string name="debug_sync_code_title">Sync Code Features</string>
     <string name="debug_sync_code_subtitle">Show Generate/Enter Sync Code buttons in Account settings</string>
+    <string name="debug_buffer_logs_title">Enable BUFFER Logs</string>
+    <string name="debug_buffer_logs_subtitle">Emit periodic player buffer diagnostics to logcat (disabled by default)</string>
     <string name="debug_section_account">Account</string>
     <string name="debug_manual_signin_title">Manual Sign In</string>
     <string name="debug_manual_signin_subtitle">Sign in with email and password (Supabase auth)</string>
@@ -1170,7 +1178,6 @@
     <string name="debug_generate_library_button">Generate</string>
     <string name="debug_generating_library">Generating\u2026</string>
 
-    <!-- ProfileSettingsContent -->
     <string name="profile_title">Profiles</string>
     <string name="profile_subtitle">Manage user profiles for this account</string>
     <string name="profile_manage_button">Manage Profiles</string>
@@ -1289,8 +1296,10 @@
     <string name="addon_refresh_done_subtitle">Addons refreshed just now</string>
     <string name="addon_pending_collections_updated">Collections updated</string>
     <string name="addon_pending_collections_replace">%1$d collection(s) will replace current collections</string>
+    <string name="addon_confirm_total_addons">Total addons: %1$d</string>
+    <string name="addon_confirm_total_catalogs">Total catalogs: %1$d</string>
+    <string name="addon_catalogs_types">Catalogs: %1$d - Types: %2$s</string>
 
-    <!-- CatalogOrderScreen -->
     <string name="catalog_order_title">Reorder Home Catalogs</string>
     <string name="catalog_order_subtitle">This controls catalog row order on Home (Classic + Modern + Grid).</string>
     <string name="catalog_order_follow_addons">Follow addons order</string>
@@ -1301,7 +1310,6 @@
     <string name="catalog_order_disable">Disable</string>
 
 
-    <!-- StreamScreen -->
     <string name="stream_retry">Retry</string>
     <string name="stream_no_streams">No streams found</string>
     <string name="stream_no_streams_hint">Try installing more addons to find streams</string>
@@ -1328,8 +1336,8 @@
     <string name="stream_player_internal">Internal</string>
     <string name="stream_player_external">External</string>
     <string name="stream_filter_all">All</string>
+    <string name="stream_episode_label">S%1$d E%2$d</string>
 
-    <!-- PlayerScreen -->
     <string name="player_no_external_player">No external player found</string>
     <string name="player_loading_preparing">Preparing stream…</string>
     <string name="player_loading_detecting_format">Detecting stream format…</string>
@@ -1380,8 +1388,9 @@
     <string name="player_more_speed">Playback Speed</string>
     <string name="player_more_aspect_ratio">Aspect Ratio</string>
     <string name="player_more_open_external">Open in External Player</string>
+    <string name="player_error_no_stream_url">No stream URL provided</string>
 
-    <!-- StreamInfoOverlay -->
+
     <string name="stream_info_section_source">SOURCE</string>
     <string name="stream_info_section_file">FILE</string>
     <string name="stream_info_section_video">VIDEO</string>
@@ -1402,14 +1411,12 @@
     <string name="stream_info_subtitle_source_embedded">Embedded</string>
     <string name="stream_info_player_engine">Player Engine</string>
 
-    <!-- StreamSourcesSidePanel -->
     <string name="sources_title">Sources</string>
     <string name="sources_reload">Reload</string>
     <string name="sources_close">Close</string>
     <string name="sources_playing">Playing</string>
     <string name="sources_no_streams">No streams found</string>
 
-    <!-- EpisodesSidePanel -->
     <string name="episodes_panel_close">Close</string>
     <string name="episodes_panel_back">Back</string>
     <string name="episodes_panel_reload">Reload</string>
@@ -1427,7 +1434,6 @@
     <string name="player_aspect_mode_slight_zoom">Slight Zoom</string>
     <string name="player_aspect_mode_cinema_zoom">Cinema Zoom</string>
 
-    <!-- AudioDialog -->
     <string name="audio_dialog_title">Audio</string>
     <string name="audio_dialog_tab_tracks">Audio</string>
     <string name="audio_dialog_tab_mix">Mix</string>
@@ -1447,7 +1453,6 @@
     <string name="audio_maintain_original_audio_on_downmix_title">Maintain original audio on downmix</string>
     <string name="audio_maintain_original_audio_on_downmix_subtitle">When disabled, downmix normalization can reduce overall volume.</string>
 
-    <!-- SubtitleDialog / SubtitleStyleSidePanel -->
     <string name="subtitle_dialog_title">Subtitles</string>
     <string name="subtitle_no_builtin">No built-in subtitles available</string>
     <string name="subtitle_loading_addon">Loading subtitles from addons\u2026</string>
@@ -1484,10 +1489,10 @@
     <string name="subtitle_style_defaults">Defaults</string>
     <string name="subtitle_style_on">On</string>
     <string name="subtitle_style_off">Off</string>
+    <string name="subtitle_style_weight">Weight</string>
     <string name="panel_failed_load_streams">Failed to load streams</string>
     <string name="panel_failed_load_episodes">Failed to load episodes</string>
 
-    <!-- PauseOverlay -->
     <string name="pause_you_are_watching">You\'re watching</string>
     <string name="pause_cast_label">Cast</string>
     <string name="pause_back_to_details">Back to details</string>
@@ -1520,7 +1525,6 @@
     <string name="display_mode_resolution">Resolution</string>
 
 
-    <!-- SearchScreen -->
     <string name="search_keyboard_hint">Press Done on the keyboard to search</string>
     <string name="search_placeholder">Search movies &amp; series</string>
     <string name="search_start_title">Start Searching</string>
@@ -1532,8 +1536,10 @@
     <string name="search_voice_mic_permission">Microphone permission is required for voice search.</string>
     <string name="search_voice_failed">Voice recognition failed. Try again.</string>
     <string name="search_voice_unavailable">Voice search is unavailable on this device.</string>
+    <string name="search_no_results_title">No Results</string>
+    <string name="search_no_results_subtitle">Try searching with different keywords</string>
+    <string name="search_error_no_catalogs">No searchable catalogs found in installed addons</string>
 
-    <!-- LibraryScreen -->
     <string name="library_syncing">Syncing Trakt library\u2026</string>
     <string name="library_title">Library</string>
     <string name="library_filter_list">List</string>
@@ -1541,7 +1547,6 @@
     <string name="library_filter_sort">Sort</string>
     <string name="library_filter_genre">Genre</string>
     <string name="library_filter_year">Year</string>
-    <!-- Genre names (from TMDB movie + TV) -->
     <string name="genre_action">Action</string>
     <string name="genre_adventure">Adventure</string>
     <string name="genre_animation">Animation</string>
@@ -1561,7 +1566,6 @@
     <string name="genre_thriller">Thriller</string>
     <string name="genre_war">War</string>
     <string name="genre_western">Western</string>
-    <!-- TV-specific genres -->
     <string name="genre_action_adventure">Action &amp; Adventure</string>
     <string name="genre_kids">Kids</string>
     <string name="genre_news">News</string>
@@ -1606,6 +1610,10 @@
     <string name="library_empty_trakt_subtitle">Use + in details to add items to watchlist or lists</string>
     <string name="library_empty_trakt_not_auth_title">Trakt not connected</string>
     <string name="library_empty_trakt_not_auth_subtitle">Connect your Trakt account in Settings to view your Trakt library</string>
+    <string name="library_list_create_dialog_title">Create List</string>
+    <string name="library_list_edit_dialog_title">Edit List</string>
+    <string name="library_sync_btn">Sync</string>
+    <string name="library_syncing_btn">Syncing\u2026</string>
     <string name="cloud_library_connect_action">Connect account</string>
     <string name="cloud_library_connect_message">Connect an account in Connected Services settings to browse playable files from your cloud library.</string>
     <string name="cloud_library_connect_title">No cloud account connected</string>
@@ -1649,13 +1657,19 @@
     <string name="account_total_label">Total</string>
     <string name="account_loading_sync">Loading sync data\u2026</string>
     <string name="account_sign_out">Sign Out</string>
+    <string name="account_error_signin_required">Sign in with an account first.</string>
+    <string name="account_signin_create_title">Sign In / Create Account</string>
+    <string name="account_signin_create_desc">Use email and password to create or sign into your account.</string>
+    <string name="account_generate_sync_desc">Create a code on this device so other devices can link to it.</string>
+    <string name="account_enter_sync_desc">Link this device to another device using a sync code.</string>
+    <string name="account_signed_in_as">Signed in as</string>
+    <string name="account_generate_sync_signed_in_desc">Create a code so other devices can sync with this account.</string>
+    <string name="account_unknown_device">Unknown Device</string>
 
-    <!-- AuthSignInScreen -->
     <string name="auth_signin_title">Sign In</string>
     <string name="auth_signin_tv_disabled">Email/password entry on TV is disabled. Continue with QR sign in.</string>
     <string name="auth_signin_qr_btn">Continue with QR</string>
 
-    <!-- AuthQrSignInScreen -->
     <string name="auth_qr_title">Sign In With QR</string>
     <string name="auth_qr_account_login">Account Login</string>
     <string name="auth_qr_finishing">Finishing sign in\u2026</string>
@@ -1674,7 +1688,6 @@
     <string name="auth_qr_continue">Continue</string>
     <string name="auth_qr_back">Back</string>
 
-    <!-- SyncCodeGenerateScreen -->
     <string name="sync_generate_title">Generate Sync Code</string>
     <string name="sync_generate_subtitle">Create a PIN to protect your sync code. Share the code with your other devices.</string>
     <string name="sync_generate_code_label">Your Sync Code</string>
@@ -1682,8 +1695,9 @@
     <string name="sync_generate_done">Done</string>
     <string name="sync_generate_pin_label">Choose a PIN (4-8 characters)</string>
     <string name="sync_generate_pin_placeholder">Enter PIN</string>
+    <string name="sync_generate_generating">Generating\u2026</string>
+    <string name="sync_generate_code_btn">Generate Code</string>
 
-    <!-- SyncCodeClaimScreen -->
     <string name="sync_claim_title">Link Device</string>
     <string name="sync_claim_subtitle">Enter the sync code and PIN from your other device to link this device.</string>
     <string name="sync_claim_success">Device linked successfully! Your addons and plugins will now sync.</string>
@@ -1692,8 +1706,8 @@
     <string name="sync_claim_code_placeholder">XXXX-XXXX-XXXX-XXXX-XXXX</string>
     <string name="sync_claim_pin_label">PIN</string>
     <string name="sync_claim_pin_placeholder">Enter PIN</string>
+    <string name="sync_claim_linking">Linking\u2026</string>
 
-    <!-- PluginScreen -->
     <string name="plugin_readonly_notice">Using primary profile\'s plugins and can\'t be changed</string>
     <string name="plugin_repositories_section">Repositories (%1$d)</string>
     <string name="plugin_providers_section">Providers (%1$d)</string>
@@ -1727,8 +1741,19 @@
     <string name="plugin_updated_format">Updated: %1$s</string>
     <string name="plugin_test_btn">Test</string>
     <string name="plugin_test_results">Test Results (%1$d streams)</string>
+    <string name="plugin_and_more">... and %1$d more</string>
+    <string name="plugin_providers_count">%1$d providers</string>
+    <string name="plugin_enabled">Enabled</string>
+    <string name="plugin_disabled">Disabled</string>
+    <string name="plugin_no_repos">No repositories added yet.\nAdd a repository to get started.</string>
+    <string name="plugin_error_invalid_url">Please enter a valid URL</string>
+    <string name="plugin_error_add_repo">Failed to add repository: %1$s</string>
+    <string name="plugin_error_refresh">Failed to refresh: %1$s</string>
+    <string name="plugin_error_test">Test failed: %1$s</string>
+    <string name="plugin_test_no_results">No results found</string>
+    <string name="plugin_test_found_streams">Found %1$d streams</string>
+    <string name="plugin_version">Version %1$s</string>
 
-    <!-- ProfileSelectionScreen -->
     <string name="profile_selection_title">Who\'s watching?</string>
     <string name="profile_selection_subtitle">Select a profile to continue</string>
     <string name="profile_selection_hint">Hold to manage profile</string>
@@ -1740,7 +1765,6 @@
     <string name="profile_delete_btn">Delete Profile</string>
     <string name="profile_saving">Saving\u2026</string>
 
-    <!-- CastDetailScreen -->
     <string name="cast_detail_error">Something went wrong</string>
     <string name="cast_detail_retry">Retry</string>
     <string name="cast_detail_filmography">Filmography</string>
@@ -1748,17 +1772,14 @@
     <string name="cast_detail_born_died">Born: %1$s — †%2$s</string>
     <string name="cast_detail_age">age %1$d</string>
 
-    <!-- CatalogSeeAllScreen -->
     <string name="catalog_see_all_from">from %1$s</string>
     <string name="catalog_see_all_empty_title">No items available</string>
     <string name="catalog_see_all_empty_subtitle">Try a different catalog or check back later</string>
 
-    <!-- LayoutSelectionScreen -->
     <string name="layout_selection_welcome">Welcome to Nuvio</string>
     <string name="layout_selection_subtitle">Choose your home screen layout</string>
     <string name="layout_selection_continue">Continue</string>
 
-    <!-- UpdatePromptDialog -->
     <string name="update_title">App Update</string>
     <string name="update_downloading">Downloading update</string>
     <string name="update_download">Download</string>
@@ -1794,16 +1815,8 @@
     <string name="discover_empty_no_content_subtitle">Try a different genre or catalog</string>
 
     <!-- AddonManagerScreen -->
-    <string name="addon_confirm_total_addons">Total addons: %1$d</string>
-    <string name="addon_confirm_total_catalogs">Total catalogs: %1$d</string>
-    <string name="addon_catalogs_types">Catalogs: %1$d - Types: %2$s</string>
 
     <!-- PluginScreen -->
-    <string name="plugin_and_more">... and %1$d more</string>
-    <string name="plugin_providers_count">%1$d providers</string>
-    <string name="plugin_enabled">Enabled</string>
-    <string name="plugin_disabled">Disabled</string>
-    <string name="plugin_no_repos">No repositories added yet.\nAdd a repository to get started.</string>
 
     <!-- ProfileSettingsContent -->
     <string name="profile_edit_title_id">Edit Profile %1$d</string>
@@ -1811,6 +1824,7 @@
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Audio passthrough (TrueHD, DTS, AC-3, etc.) is automatic. When connected to a compatible AV receiver or soundbar via HDMI, lossless audio is sent as-is without decoding.</string>
     <string name="audio_dv_title">DV7 - HEVC Fallback</string>
+    <string name="audio_dv_sub">Map Dolby Vision Profile 7 to standard HEVC for devices without hardware DV support</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Home</string>
@@ -1838,9 +1852,6 @@
     <string name="update_error_download_failed">Download failed</string>
     <string name="update_error_apk_missing">Downloaded file is missing</string>
 
-    <string name="watchlist_added">Added to watchlist</string>
-    <string name="watchlist_removed">Removed from watchlist</string>
-
     <!-- Profile PIN errors -->
     <string name="profile_pin_save_error">Could not save PIN. Try again.</string>
     <string name="profile_pin_locked">Profile is locked. Try again in %1$ds.</string>
@@ -1850,47 +1861,26 @@
     <string name="profile_pin_current_required">This profile already has a PIN. Enter the current PIN to change it.</string>
 
     <!-- Account Screen -->
-    <string name="account_signin_create_title">Sign In / Create Account</string>
-    <string name="account_signin_create_desc">Use email and password to create or sign into your account.</string>
-    <string name="account_generate_sync_desc">Create a code on this device so other devices can link to it.</string>
-    <string name="account_enter_sync_desc">Link this device to another device using a sync code.</string>
-    <string name="account_signed_in_as">Signed in as</string>
-    <string name="account_generate_sync_signed_in_desc">Create a code so other devices can sync with this account.</string>
-    <string name="account_unknown_device">Unknown Device</string>
 
     <!-- Sync screens -->
-    <string name="sync_claim_linking">Linking\u2026</string>
-    <string name="sync_generate_generating">Generating\u2026</string>
-    <string name="sync_generate_code_btn">Generate Code</string>
 
     <!-- Search -->
-    <string name="search_no_results_title">No Results</string>
-    <string name="search_no_results_subtitle">Try searching with different keywords</string>
     <string name="discover_disabled_title">Discover is disabled</string>
     <string name="discover_disabled_subtitle">Enable Discover in Layout settings</string>
 
     <!-- Library -->
-    <string name="library_list_create_dialog_title">Create List</string>
-    <string name="library_list_edit_dialog_title">Edit List</string>
-    <string name="library_sync_btn">Sync</string>
-    <string name="library_syncing_btn">Syncing\u2026</string>
 
     <!-- Error messages (shared) -->
     <string name="error_network_required">Connect to Wi-Fi or Ethernet to use this feature</string>
     <string name="error_server_ports_unavailable">Could not start server. All ports in use.</string>
 
     <!-- Plugin errors -->
-    <string name="plugin_error_invalid_url">Please enter a valid URL</string>
-    <string name="plugin_error_add_repo">Failed to add repository: %1$s</string>
-    <string name="plugin_error_refresh">Failed to refresh: %1$s</string>
-    <string name="plugin_error_test">Test failed: %1$s</string>
-    <string name="plugin_test_no_results">No results found</string>
-    <string name="plugin_test_found_streams">Found %1$d streams</string>
     <string name="plugin_repo_added_with_providers">Added %1$s with %2$d providers</string>
     <string name="plugin_repo_removed">Repository removed</string>
     <string name="plugin_repo_refreshed">Repository refreshed</string>
 
     <!-- Trakt errors -->
+
     <string name="trakt_error_code_expired">Device code expired. Start again.</string>
     <string name="trakt_error_code_used">Device code already used. Start again.</string>
     <string name="trakt_error_denied">Authorization denied on Trakt.</string>
@@ -1919,34 +1909,22 @@
     <string name="addon_error_not_found">Addon not found</string>
 
     <!-- Account errors -->
-    <string name="account_error_signin_required">Sign in with an account first.</string>
 
     <!-- Search errors -->
-    <string name="search_error_no_catalogs">No searchable catalogs found in installed addons</string>
 
     <!-- Home errors -->
     <string name="home_error_no_addons">No addons installed</string>
     <string name="home_error_no_catalog_addons">No catalog addons installed</string>
 
     <!-- Player errors -->
-    <string name="player_error_no_stream_url">No stream URL provided</string>
     <string name="player_error_failed_start_torrent">Failed to start torrent: %1$s</string>
 
     <!-- Playback subtitle settings -->
     <string name="sub_mode_overlay_canvas_sub">HDR support with canvas rendering. May block UI thread.</string>
-    <string name="subtitle_style_weight">Weight</string>
 
-    <!-- Plugin screen -->
-    <string name="plugin_version">Version %1$s</string>
-
-    <!-- Stream screen -->
-    <string name="stream_episode_label">S%1$d E%2$d</string>
-
-    <!-- Episode ratings -->
     <string name="ratings_season_label">S%1$d</string>
     <string name="ratings_episode_label">E%1$d</string>
 
-    <!-- Content descriptions -->
     <string name="cd_play">Play</string>
     <string name="cd_pause">Pause</string>
     <string name="cd_subtitles">Subtitles</string>
@@ -1989,7 +1967,6 @@
     <string name="cd_qr_login">QR login code</string>
     <string name="cd_nuvio">Nuvio</string>
 
-    <!-- Debug -->
     <string name="debug_signin_success">Signed in successfully</string>
     <string name="debug_generate_description">Debug-generated %1$s item #%2$d</string>
     <string name="debug_generate_result_failed">Failed: %1$s</string>
@@ -2486,5 +2463,12 @@
     <string name="trakt_related_error_request_failed">Trakt related request failed</string>
     <string name="trakt_comments_error_request_failed">Trakt comments request failed</string>
     <string name="trakt_library_error_fetch_list_items">Failed to fetch list items</string>
+
+
+
+    <string name="watchlist_removed">Removed from watchlist</string>
+    <string name="watchlist_added">Added to watchlist</string>
+
+
 
 </resources>

--- a/app/src/test/java/com/nuvio/tv/core/player/DolbyVisionBaseLayerPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/DolbyVisionBaseLayerPolicyTest.kt
@@ -1,0 +1,379 @@
+package com.nuvio.tv.core.player
+
+import com.nuvio.tv.core.player.DolbyVisionBaseLayerPolicy.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DolbyVisionBaseLayerPolicyTest {
+
+    private fun resolve(
+        hdrCapsKnown: Boolean = true,
+        displayDv: Boolean = false,
+        displayHdr10: Boolean = false,
+        displayHdr10Plus: Boolean = false,
+        displayHlg: Boolean = false,
+        codecSupportsDvheDtb: Boolean = false,
+        codecSupportsDvheStn: Boolean = false,
+        codecSupportsDvheSt: Boolean = false,
+        isAmazonFireTv: Boolean = false,
+        isSamsung: Boolean = false,
+        isXiaomi: Boolean = false,
+        bridgeReady: Boolean = false,
+        apiLevel: Int = 30
+    ) = DolbyVisionBaseLayerPolicy.resolveFromCapabilities(
+        hdrCapsKnown = hdrCapsKnown,
+        displayDv = displayDv,
+        displayHdr10 = displayHdr10,
+        displayHdr10Plus = displayHdr10Plus,
+        displayHlg = displayHlg,
+        codecSupportsDvheDtb = codecSupportsDvheDtb,
+        codecSupportsDvheStn = codecSupportsDvheStn,
+        codecSupportsDvheSt = codecSupportsDvheSt,
+        isAmazonFireTv = isAmazonFireTv,
+        isSamsung = isSamsung,
+        isXiaomi = isXiaomi,
+        bridgeReady = bridgeReady,
+        apiLevel = apiLevel
+    )
+
+    // ── Unknown caps ──
+
+    @Test
+    fun `unknown caps returns STRIP_BEST_EFFORT regardless of other flags`() {
+        val r = resolve(
+            hdrCapsKnown = false,
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheDtb = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.STRIP_BEST_EFFORT, r.decision)
+        assertTrue(r.divertsFromNativeDv7)
+        assertTrue(r.mapToHevc)
+    }
+
+    // ── NATIVE_DV7: native DV7 decoder (Shield) ──
+
+    @Test
+    fun `DV display with native DvheDtb decoder returns NATIVE_DV7`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheDtb = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+        assertFalse(r.divertsFromNativeDv7)
+        assertFalse(r.mapToHevc)
+    }
+
+    @Test
+    fun `Amazon device with native DvheDtb prefers NATIVE_DV7 over conversion`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheDtb = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+    }
+
+    @Test
+    fun `Xiaomi device with native DvheDtb prefers NATIVE_DV7 over conversion`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheDtb = true,
+            isXiaomi = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+    }
+
+    // ── CONVERT_TO_DV81: Fire TV Karat (Amazon-gated) ──
+
+    @Test
+    fun `Fire TV on DV display with DV81 decoder and bridge converts`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            displayHdr10Plus = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+        assertTrue(r.divertsFromNativeDv7)
+        assertFalse(r.mapToHevc)
+    }
+
+    @Test
+    fun `Fire TV on DV display without bridge falls through to NATIVE_DV7`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = true,
+            bridgeReady = false
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+    }
+
+    @Test
+    fun `Fire TV on DV display without DV81 decoder falls through to NATIVE_DV7`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheSt = false,
+            isAmazonFireTv = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+    }
+
+    // ── CONVERT_TO_DV81: Xiaomi Mi Box (relaxed, no codec check) ──
+
+    @Test
+    fun `Xiaomi on DV display with bridge converts even without DvheSt`() {
+        // Mi Box S: displayDv comes from LG/Samsung TV, codecSupportsDvheSt is false
+        // because the Amlogic decoder doesn't advertise Profile 8. Relaxed branch
+        // fires on manufacturer + bridge alone.
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheSt = false,
+            isXiaomi = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+        assertTrue(r.divertsFromNativeDv7)
+        assertFalse(r.mapToHevc)
+    }
+
+    @Test
+    fun `Xiaomi on DV display with DvheSt also converts`() {
+        // Future Xiaomi device that DOES advertise Profile 8. The Amazon-gated
+        // branch won't fire (not Amazon), but the Xiaomi branch catches it.
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isXiaomi = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+    }
+
+    @Test
+    fun `Xiaomi on DV display without bridge falls through to NATIVE_DV7`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            isXiaomi = true,
+            bridgeReady = false
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+    }
+
+    @Test
+    fun `Xiaomi on HDR10 display with bridge converts`() {
+        // Mi Box connected to HDR10-only TV: bridge converts so the hidden
+        // DV decoder can emit HDR10. Better than STRIP which may fail on
+        // some Amlogic firmware.
+        val r = resolve(
+            displayDv = false,
+            displayHdr10 = true,
+            isXiaomi = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+    }
+
+    @Test
+    fun `Xiaomi on HDR10 display without bridge strips to HDR10`() {
+        val r = resolve(
+            displayDv = false,
+            displayHdr10 = true,
+            isXiaomi = true,
+            bridgeReady = false
+        )
+        assertEquals(Decision.STRIP_TO_HDR10, r.decision)
+    }
+
+    // ── NATIVE_DV7 catch-all: non-Amazon non-Xiaomi devices on DV display ──
+
+    @Test
+    fun `non-Amazon device on DV display with DV81 decoder falls through to NATIVE_DV7`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = false,
+            isSamsung = false,
+            isXiaomi = false,
+            bridgeReady = true
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+        assertFalse(r.divertsFromNativeDv7)
+        assertFalse(r.mapToHevc)
+    }
+
+    @Test
+    fun `Samsung device on DV display still falls through to NATIVE_DV7`() {
+        val r = resolve(
+            displayDv = true,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isSamsung = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.NATIVE_DV7, r.decision)
+    }
+
+    // ── CONVERT_TO_DV81: HDR10 fallback (Samsung + Amazon) ──
+
+    @Test
+    fun `Samsung HDR10 panel with DV81 decoder and bridge converts`() {
+        val r = resolve(
+            displayDv = false,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isSamsung = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+        assertTrue(r.divertsFromNativeDv7)
+        assertFalse(r.mapToHevc)
+    }
+
+    @Test
+    fun `Samsung HDR10Plus panel with DV81 decoder and bridge converts`() {
+        val r = resolve(
+            displayDv = false,
+            displayHdr10Plus = true,
+            codecSupportsDvheSt = true,
+            isSamsung = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+    }
+
+    @Test
+    fun `Fire TV on HDR10 panel with DV81 decoder and bridge converts`() {
+        val r = resolve(
+            displayDv = false,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.CONVERT_TO_DV81, r.decision)
+    }
+
+    // ── STRIP_TO_HDR10: Google TV Streamer + Samsung TV (non-intervened) ──
+
+    @Test
+    fun `Generic HDR10 panel with DV81 decoder strips when non-Samsung non-Amazon non-Xiaomi`() {
+        val r = resolve(
+            displayDv = false,
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = false,
+            isSamsung = false,
+            isXiaomi = false,
+            bridgeReady = true
+        )
+        assertEquals(Decision.STRIP_TO_HDR10, r.decision)
+        assertTrue(r.mapToHevc)
+    }
+
+    @Test
+    fun `Samsung HDR10 panel without bridge strips to HDR10`() {
+        val r = resolve(
+            displayHdr10 = true,
+            codecSupportsDvheSt = true,
+            isSamsung = true,
+            bridgeReady = false
+        )
+        assertEquals(Decision.STRIP_TO_HDR10, r.decision)
+    }
+
+    @Test
+    fun `Samsung HDR10 panel with bridge but no DV81 decoder strips to HDR10`() {
+        val r = resolve(
+            displayHdr10 = true,
+            codecSupportsDvheSt = false,
+            isSamsung = true,
+            bridgeReady = true
+        )
+        assertEquals(Decision.STRIP_TO_HDR10, r.decision)
+    }
+
+    @Test
+    fun `HDR10 panel with nothing useful strips to HDR10`() {
+        val r = resolve(displayHdr10 = true)
+        assertEquals(Decision.STRIP_TO_HDR10, r.decision)
+        assertTrue(r.mapToHevc)
+    }
+
+    @Test
+    fun `HDR10Plus panel with nothing useful strips to HDR10`() {
+        val r = resolve(displayHdr10Plus = true)
+        assertEquals(Decision.STRIP_TO_HDR10, r.decision)
+    }
+
+    // ── STRIP_AND_TONEMAP ──
+
+    @Test
+    fun `SDR-only display returns STRIP_AND_TONEMAP`() {
+        val r = resolve(codecSupportsDvheSt = true, bridgeReady = true)
+        assertEquals(Decision.STRIP_AND_TONEMAP, r.decision)
+        assertTrue(r.mapToHevc)
+    }
+
+    @Test
+    fun `HLG-only display returns STRIP_AND_TONEMAP`() {
+        val r = resolve(displayHlg = true, bridgeReady = true)
+        assertEquals(Decision.STRIP_AND_TONEMAP, r.decision)
+    }
+
+    // ── Result field propagation ──
+
+    @Test
+    fun `result preserves all input fields`() {
+        val r = resolve(
+            hdrCapsKnown = true,
+            displayDv = true,
+            displayHdr10 = true,
+            displayHdr10Plus = true,
+            displayHlg = false,
+            codecSupportsDvheDtb = false,
+            codecSupportsDvheStn = true,
+            codecSupportsDvheSt = true,
+            isAmazonFireTv = true,
+            isSamsung = false,
+            isXiaomi = false,
+            bridgeReady = true,
+            apiLevel = 33
+        )
+        assertTrue(r.hdrCapsKnown)
+        assertTrue(r.displayDv)
+        assertTrue(r.displayHdr10)
+        assertTrue(r.displayHdr10Plus)
+        assertFalse(r.displayHlg)
+        assertFalse(r.codecSupportsDvheDtb)
+        assertTrue(r.codecSupportsDvheStn)
+        assertTrue(r.codecSupportsDvheSt)
+        assertTrue(r.isAmazonFireTv)
+        assertFalse(r.isSamsung)
+        assertFalse(r.isXiaomi)
+        assertTrue(r.bridgeReady)
+        assertEquals(33, r.apiLevel)
+    }
+}

--- a/local.example.properties
+++ b/local.example.properties
@@ -9,3 +9,18 @@ FFMPEG_SOURCE_DIR=path_to_ffmpeg_source_tree
 FFMPEG_BUILD_DIR=path_to_ffmpeg_build_root
 UNIQUE_CONTRIBUTIONS_BASE_URL=
 PREMIUMIZE_CLIENT_ID=
+
+# --- DV7 / libdovi (Dolby Vision Profile 7 to 8.1) ---
+
+# Build the dovi_bridge native lib + load the runtime bridge.
+DOVI_NATIVE_ENABLED=true
+
+# Marks extractor hook integration as available in the current build.
+DOVI_EXTRACTOR_HOOK_READY=true
+
+# Link the prebuilt libdovi static archive into dovi_bridge.
+DOVI_ENABLE_REAL_LINK=true
+# Optional explicit overrides (otherwise resolved from the prebuilt root below):
+# DOVI_LIBDOVI_STATIC_LIB=/path/to/libdovi.a
+# DOVI_LIBDOVI_INCLUDE_DIR=/path/to/libdovi/include
+DOVI_LIBDOVI_PREBUILT_ROOT=DV7/libdovi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary
Adds real-time Dolby Vision Profile 7 to 8.1 conversion, buffer track, and a custom playback buffer engine. Replaces the existing "DV7 - HEVC" option with a DV7 Handling setting.
- **DV7 Handling mode**: AUTO, Convert to DV8.1, Strip to HDR10, or Off (Native). Strip to HDR10 is the old "DV7 - HEVC" behavior, now one of the modes. Migration path also added, so no user regression. Device specific pre determined modes also included in auto logic per feedback. 
- Convert DV5 to DV8.1: signals DV5 as 8.1 for HDR10-only displays.
- **Advanced** conversion-mode override: manually pick the libdovi mode.
- DV7 MKV needs a modified extractor — the stock MatroskaExtractor discards the DV7 enhancement-layer/RPU BlockAdditional before it reaches a TrackOutput. Rather than fork all of media3, this switches the DV path to AAR-mode media3 and vendors a single app-level MatroskaExtractor that surfaces the RPU; the media3-source submodule is removed. 
- Rewrote to not need its own fork of media3 or exo like the original PR from another contributor needed.
- **Code optimizations** for playback and buffering during converting
- New defaults: DV7 Handling on (AUTO); custom network and buffer settings off.
- Custom buffer engine: device-aware memory budget (with manual override,) back buffer, optional parallel connections and VOD disk cache.
- Buffered-ahead track on the seek bar, follows the theme color.
- **Stall watchdog**: detects rebuffers/stalls and feeds a playback diagnostics card. For stalls, it assists in recovery of the stream from a stuck buffered state.
- DV diagnostics card to help users report DV-related issues.
- **Subtitle handling preserved** through the DV7 extractor swap (ASS/SSA + embedded fonts still render; pipeline rebuilds when libass is needed).
- libdovi: prebuilt static archives for arm64-v8a / armeabi-v7a / x86 / x86_64 under DV7/libdovi, built from dovi_tool C API. CMake links them directly; stub mode when absent.

## PR type
<!-- Neither type fits; this is a feature change. See Why. -->
- [ ] Translation/localization only
- [ ] Critical bug fix

## Why
**Adds DV7 playback** on devices that can't decode it natively, and folds the existing "DV7 - HEVC" fallback into the DV7 Handling setting (Strip to HDR10 covers the old behavior.) Also adds buffering controls for low-RAM streaming sticks. Fixes some issues and address some requests along the way (buffer track.)

## Issue or approval
Discussed and approved with maintainers on Discord.

## Reproduction steps
N/A, not a bug fix.

## UI / behavior impact
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

- Changed to Video & Audio from Audio & Trailer
- Added Buffer & Network under Playback
- Advanced now has an additional diagnostic card for DV info.
## Policy check
<!-- Feature change; the feature-exclusion items below do not apply and are left unchecked intentionally. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] linked issue + repro + testing (bug fixes)
- [x] I listed the testing performed below.

## Scope boundaries
Localization touched only to remove dead strings for the replaced "DV7 - HEVC". No unrelated refactors. libdovi under DV7/libdovi is a vendored prebuilt.

## Testing
Tested extensively across multiple devices and testers in two Discord threads:
- DV7: https://discord.com/channels/1379902184207941732/1484038326087323648
- Buffer: https://discord.com/channels/1379902184207941732/1482446693982015598

Covered DV7 convert, DV7 strip to HDR10, DV5 native and signal, SDR, and buffering on Fire TV Stick 4K Max, onn 4K Streaming Device, and Google TV Streamer.

## Screenshots / Video
UI added (DV7 Handling, buffer controls, buffered-ahead track, diagnostics). Screenshots: 
<img width="5712" height="4284" alt="IMG_4880" src="https://github.com/user-attachments/assets/ac2acbf3-b713-4c04-86d6-e03077ad8eb8" />
<img width="5712" height="4284" alt="IMG_4881" src="https://github.com/user-attachments/assets/dcd20d33-6535-4c60-b927-404b05dc5855" />
<img width="5712" height="4284" alt="IMG_4882" src="https://github.com/user-attachments/assets/bef9c9d3-4571-437f-9a32-f3416641aa9c" />
<img width="5712" height="4284" alt="IMG_4883" src="https://github.com/user-attachments/assets/c91fb876-ba7f-4f98-8b2a-34c757d49e79" />

## Breaking changes
None.

## Linked issues
- #204
- #76
- #594
- #877


APK if needed: 

Download: 
https://app.box.com/s/544wqqjad830s53tnss1hpw6lo1srhda

Downloader code: 568 8 762
