### PR TITLE
i18n(fr): extract Debrid stream filters + subtitle unknown (batch7)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -109,6 +109,7 @@ internal fun SubtitleSelectionOverlay(
     modifier: Modifier = Modifier
 ) {
     val noneLabel = stringResource(R.string.subtitle_none)
+    val unknownLabel = stringResource(R.string.subtitle_language_unknown)
     val builtInLabel = stringResource(R.string.subtitle_built_in)
     val forcedLabel = stringResource(R.string.sub_forced_lang)
     var persistedStyleFocusKey by rememberSaveable { mutableStateOf<String?>(null) }
@@ -136,7 +137,8 @@ internal fun SubtitleSelectionOverlay(
             secondaryPreferredLanguage = sessionSecondaryPreferredLanguage,
             showOnlyPreferredLanguages = sessionShowOnlyPreferredLanguages,
             currentLanguageKey = sessionSelectedSubtitleLanguageKey,
-            noneLabel = noneLabel
+            noneLabel = noneLabel,
+            unknownLabel = unknownLabel
         )
     }
     val sessionInitialLanguageKey = remember(visible, languageItems, sessionSelectedSubtitleLanguageKey) {
@@ -1675,7 +1677,8 @@ private fun buildSubtitleLanguageRailItems(
     secondaryPreferredLanguage: String?,
     showOnlyPreferredLanguages: Boolean,
     currentLanguageKey: String,
-    noneLabel: String
+    noneLabel: String,
+    unknownLabel: String
 ): List<SubtitleLanguageRailItem> {
     val counts = linkedMapOf<String, Int>()
     internalTracks.forEach { track ->
@@ -1714,7 +1717,7 @@ private fun buildSubtitleLanguageRailItems(
         .map { (key, count) ->
             SubtitleLanguageRailItem(
                 key = key,
-                label = subtitleLanguageLabel(key),
+                label = subtitleLanguageLabel(key, unknownLabel),
                 count = count
             )
         }
@@ -1879,17 +1882,18 @@ private fun normalizeOverlayLanguageKeyForTrack(track: TrackInfo): String {
     }
 }
 
-private fun subtitleLanguageLabel(key: String): String {
+private fun subtitleLanguageLabel(key: String, unknownLabel: String): String {
     return when (key) {
         SubtitleOffLanguageKey -> Subtitle.languageCodeToName("none")
-        SubtitleUnknownLanguageKey -> "Unknown"
+        SubtitleUnknownLanguageKey -> unknownLabel
         else -> Subtitle.languageCodeToName(key)
     }
 }
 
 private fun subtitleLanguageSortLabel(key: String): String = when (key) {
     SubtitleUnknownLanguageKey -> "\uFFFF"
-    else -> subtitleLanguageLabel(key).lowercase()
+    SubtitleOffLanguageKey -> Subtitle.languageCodeToName("none").lowercase()
+    else -> Subtitle.languageCodeToName(key).lowercase()
 }
 
 private fun formatSubtitleDelay(delayMs: Int): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
@@ -2,6 +2,7 @@
 
 package com.nuvio.tv.ui.screens.settings
 
+import android.content.Context
 import android.view.KeyEvent
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
@@ -305,13 +306,13 @@ fun DebridSettingsContent(
                             SettingsActionRow(
                                 title = stringResource(R.string.debrid_stream_size_range_title),
                                 subtitle = stringResource(R.string.debrid_stream_size_range_subtitle),
-                                value = sizeRangeLabel(uiState.streamPreferences),
+                                value = sizeRangeLabel(uiState.streamPreferences, context),
                                 onClick = { activeStreamPicker = DebridStreamPicker.SIZE_RANGE },
                                 enabled = true
                             )
                         }
 
-                        debridRuleRows(uiState.streamPreferences) { picker, title, subtitle, value ->
+                        debridRuleRows(uiState.streamPreferences, context) { picker, title, subtitle, value ->
                             item(key = "debrid_rule_${picker.name}") {
                                 SettingsActionRow(
                                     title = title,
@@ -818,6 +819,7 @@ private fun DebridSizeRangeDialog(
     onSelected: (Pair<Int, Int>) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val context = LocalContext.current
     val options = listOf(
         0 to 0,
         0 to 5,
@@ -830,7 +832,7 @@ private fun DebridSizeRangeDialog(
     SettingsSingleChoiceDialog(
         title = stringResource(R.string.debrid_stream_size_range_title),
         options = options.map { value ->
-            SettingsPickerOption(value, sizeRangeLabel(value.first, value.second))
+            SettingsPickerOption(value, sizeRangeLabel(value.first, value.second, context))
         },
         selectedValue = selectedValue,
         onOptionSelected = onSelected,
@@ -962,47 +964,171 @@ private fun sortProfileLabel(value: DebridSortProfile): String {
 
 private fun LazyListScope.debridRuleRows(
     preferences: DebridStreamPreferences,
+    context: Context,
     row: LazyListScope.(DebridStreamPicker, String, String?, String) -> Unit
 ) {
-    row(DebridStreamPicker.PREFERRED_RESOLUTIONS, "Preferred resolutions", "Sort selected resolutions first, in default order.", selectionCountLabel(preferences.preferredResolutions))
-    row(DebridStreamPicker.REQUIRED_RESOLUTIONS, "Required resolutions", "Only show selected resolutions.", selectionCountLabel(preferences.requiredResolutions))
-    row(DebridStreamPicker.EXCLUDED_RESOLUTIONS, "Excluded resolutions", "Hide selected resolutions.", selectionCountLabel(preferences.excludedResolutions))
-    row(DebridStreamPicker.PREFERRED_QUALITIES, "Preferred qualities", "Sort selected qualities first, in default order.", selectionCountLabel(preferences.preferredQualities))
-    row(DebridStreamPicker.REQUIRED_QUALITIES, "Required qualities", "Only show selected source qualities.", selectionCountLabel(preferences.requiredQualities))
-    row(DebridStreamPicker.EXCLUDED_QUALITIES, "Excluded qualities", "Hide selected source qualities.", selectionCountLabel(preferences.excludedQualities))
-    row(DebridStreamPicker.PREFERRED_VISUAL_TAGS, "Preferred visual tags", "Sort DV, HDR, 10bit, IMAX and similar tags.", selectionCountLabel(preferences.preferredVisualTags))
-    row(DebridStreamPicker.REQUIRED_VISUAL_TAGS, "Required visual tags", "Require DV, HDR, 10bit, IMAX, SDR and similar tags.", selectionCountLabel(preferences.requiredVisualTags))
-    row(DebridStreamPicker.EXCLUDED_VISUAL_TAGS, "Excluded visual tags", "Hide DV, HDR, 10bit, 3D and similar tags.", selectionCountLabel(preferences.excludedVisualTags))
-    row(DebridStreamPicker.PREFERRED_AUDIO_TAGS, "Preferred audio tags", "Sort Atmos, TrueHD, DTS, AAC and similar tags.", selectionCountLabel(preferences.preferredAudioTags))
-    row(DebridStreamPicker.REQUIRED_AUDIO_TAGS, "Required audio tags", "Require Atmos, TrueHD, DTS, AAC and similar tags.", selectionCountLabel(preferences.requiredAudioTags))
-    row(DebridStreamPicker.EXCLUDED_AUDIO_TAGS, "Excluded audio tags", "Hide selected audio tags.", selectionCountLabel(preferences.excludedAudioTags))
-    row(DebridStreamPicker.PREFERRED_AUDIO_CHANNELS, "Preferred channels", "Sort preferred channel layouts first.", selectionCountLabel(preferences.preferredAudioChannels))
-    row(DebridStreamPicker.REQUIRED_AUDIO_CHANNELS, "Required channels", "Only show selected channel layouts.", selectionCountLabel(preferences.requiredAudioChannels))
-    row(DebridStreamPicker.EXCLUDED_AUDIO_CHANNELS, "Excluded channels", "Hide selected channel layouts.", selectionCountLabel(preferences.excludedAudioChannels))
-    row(DebridStreamPicker.PREFERRED_ENCODES, "Preferred encodes", "Sort AV1, HEVC, AVC and similar encodes.", selectionCountLabel(preferences.preferredEncodes))
-    row(DebridStreamPicker.REQUIRED_ENCODES, "Required encodes", "Require AV1, HEVC, AVC and similar encodes.", selectionCountLabel(preferences.requiredEncodes))
-    row(DebridStreamPicker.EXCLUDED_ENCODES, "Excluded encodes", "Hide selected encodes.", selectionCountLabel(preferences.excludedEncodes))
-    row(DebridStreamPicker.PREFERRED_LANGUAGES, "Preferred languages", "Sort preferred audio languages first.", selectionCountLabel(preferences.preferredLanguages))
-    row(DebridStreamPicker.REQUIRED_LANGUAGES, "Required languages", "Only show streams with selected languages.", selectionCountLabel(preferences.requiredLanguages))
-    row(DebridStreamPicker.EXCLUDED_LANGUAGES, "Excluded languages", "Hide streams where every language is excluded.", selectionCountLabel(preferences.excludedLanguages))
-    row(DebridStreamPicker.REQUIRED_RELEASE_GROUPS, "Required release groups", "Only show selected release groups.", selectionCountLabel(preferences.requiredReleaseGroups))
-    row(DebridStreamPicker.EXCLUDED_RELEASE_GROUPS, "Excluded release groups", "Hide selected release groups.", selectionCountLabel(preferences.excludedReleaseGroups))
+    row(
+        DebridStreamPicker.PREFERRED_RESOLUTIONS,
+        context.getString(R.string.debrid_picker_preferred_resolutions_title),
+        context.getString(R.string.debrid_picker_preferred_resolutions_subtitle),
+        selectionCountLabel(preferences.preferredResolutions, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_RESOLUTIONS,
+        context.getString(R.string.debrid_picker_required_resolutions_title),
+        context.getString(R.string.debrid_picker_required_resolutions_subtitle),
+        selectionCountLabel(preferences.requiredResolutions, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_RESOLUTIONS,
+        context.getString(R.string.debrid_picker_excluded_resolutions_title),
+        context.getString(R.string.debrid_picker_excluded_resolutions_subtitle),
+        selectionCountLabel(preferences.excludedResolutions, context)
+    )
+    row(
+        DebridStreamPicker.PREFERRED_QUALITIES,
+        context.getString(R.string.debrid_picker_preferred_qualities_title),
+        context.getString(R.string.debrid_picker_preferred_qualities_subtitle),
+        selectionCountLabel(preferences.preferredQualities, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_QUALITIES,
+        context.getString(R.string.debrid_picker_required_qualities_title),
+        context.getString(R.string.debrid_picker_required_qualities_subtitle),
+        selectionCountLabel(preferences.requiredQualities, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_QUALITIES,
+        context.getString(R.string.debrid_picker_excluded_qualities_title),
+        context.getString(R.string.debrid_picker_excluded_qualities_subtitle),
+        selectionCountLabel(preferences.excludedQualities, context)
+    )
+    row(
+        DebridStreamPicker.PREFERRED_VISUAL_TAGS,
+        context.getString(R.string.debrid_picker_preferred_visual_tags_title),
+        context.getString(R.string.debrid_picker_preferred_visual_tags_subtitle),
+        selectionCountLabel(preferences.preferredVisualTags, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_VISUAL_TAGS,
+        context.getString(R.string.debrid_picker_required_visual_tags_title),
+        context.getString(R.string.debrid_picker_required_visual_tags_subtitle),
+        selectionCountLabel(preferences.requiredVisualTags, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_VISUAL_TAGS,
+        context.getString(R.string.debrid_picker_excluded_visual_tags_title),
+        context.getString(R.string.debrid_picker_excluded_visual_tags_subtitle),
+        selectionCountLabel(preferences.excludedVisualTags, context)
+    )
+    row(
+        DebridStreamPicker.PREFERRED_AUDIO_TAGS,
+        context.getString(R.string.debrid_picker_preferred_audio_tags_title),
+        context.getString(R.string.debrid_picker_preferred_audio_tags_subtitle),
+        selectionCountLabel(preferences.preferredAudioTags, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_AUDIO_TAGS,
+        context.getString(R.string.debrid_picker_required_audio_tags_title),
+        context.getString(R.string.debrid_picker_required_audio_tags_subtitle),
+        selectionCountLabel(preferences.requiredAudioTags, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_AUDIO_TAGS,
+        context.getString(R.string.debrid_picker_excluded_audio_tags_title),
+        context.getString(R.string.debrid_picker_excluded_audio_tags_subtitle),
+        selectionCountLabel(preferences.excludedAudioTags, context)
+    )
+    row(
+        DebridStreamPicker.PREFERRED_AUDIO_CHANNELS,
+        context.getString(R.string.debrid_picker_preferred_audio_channels_title),
+        context.getString(R.string.debrid_picker_preferred_audio_channels_subtitle),
+        selectionCountLabel(preferences.preferredAudioChannels, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_AUDIO_CHANNELS,
+        context.getString(R.string.debrid_picker_required_audio_channels_title),
+        context.getString(R.string.debrid_picker_required_audio_channels_subtitle),
+        selectionCountLabel(preferences.requiredAudioChannels, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_AUDIO_CHANNELS,
+        context.getString(R.string.debrid_picker_excluded_audio_channels_title),
+        context.getString(R.string.debrid_picker_excluded_audio_channels_subtitle),
+        selectionCountLabel(preferences.excludedAudioChannels, context)
+    )
+    row(
+        DebridStreamPicker.PREFERRED_ENCODES,
+        context.getString(R.string.debrid_picker_preferred_encodes_title),
+        context.getString(R.string.debrid_picker_preferred_encodes_subtitle),
+        selectionCountLabel(preferences.preferredEncodes, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_ENCODES,
+        context.getString(R.string.debrid_picker_required_encodes_title),
+        context.getString(R.string.debrid_picker_required_encodes_subtitle),
+        selectionCountLabel(preferences.requiredEncodes, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_ENCODES,
+        context.getString(R.string.debrid_picker_excluded_encodes_title),
+        context.getString(R.string.debrid_picker_excluded_encodes_subtitle),
+        selectionCountLabel(preferences.excludedEncodes, context)
+    )
+    row(
+        DebridStreamPicker.PREFERRED_LANGUAGES,
+        context.getString(R.string.debrid_picker_preferred_languages_title),
+        context.getString(R.string.debrid_picker_preferred_languages_subtitle),
+        selectionCountLabel(preferences.preferredLanguages, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_LANGUAGES,
+        context.getString(R.string.debrid_picker_required_languages_title),
+        context.getString(R.string.debrid_picker_required_languages_subtitle),
+        selectionCountLabel(preferences.requiredLanguages, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_LANGUAGES,
+        context.getString(R.string.debrid_picker_excluded_languages_title),
+        context.getString(R.string.debrid_picker_excluded_languages_subtitle),
+        selectionCountLabel(preferences.excludedLanguages, context)
+    )
+    row(
+        DebridStreamPicker.REQUIRED_RELEASE_GROUPS,
+        context.getString(R.string.debrid_picker_required_release_groups_title),
+        context.getString(R.string.debrid_picker_required_release_groups_subtitle),
+        selectionCountLabel(preferences.requiredReleaseGroups, context)
+    )
+    row(
+        DebridStreamPicker.EXCLUDED_RELEASE_GROUPS,
+        context.getString(R.string.debrid_picker_excluded_release_groups_title),
+        context.getString(R.string.debrid_picker_excluded_release_groups_subtitle),
+        selectionCountLabel(preferences.excludedReleaseGroups, context)
+    )
 }
 
-private fun selectionCountLabel(values: List<*>): String {
-    return if (values.isEmpty()) "Any" else "${values.size} selected"
+private fun selectionCountLabel(values: List<*>, context: Context): String {
+    return if (values.isEmpty()) {
+        context.getString(R.string.debrid_selection_count_any)
+    } else {
+        context.resources.getQuantityString(
+            R.plurals.debrid_selection_count_value,
+            values.size,
+            values.size
+        )
+    }
 }
 
-private fun sizeRangeLabel(preferences: DebridStreamPreferences): String {
-    return sizeRangeLabel(preferences.sizeMinGb, preferences.sizeMaxGb)
+private fun sizeRangeLabel(preferences: DebridStreamPreferences, context: Context): String {
+    return sizeRangeLabel(preferences.sizeMinGb, preferences.sizeMaxGb, context)
 }
 
-private fun sizeRangeLabel(minGb: Int, maxGb: Int): String {
+private fun sizeRangeLabel(minGb: Int, maxGb: Int, context: Context): String {
     return when {
-        minGb <= 0 && maxGb <= 0 -> "Any"
-        minGb <= 0 -> "Up to ${maxGb}GB"
-        maxGb <= 0 -> "${minGb}GB+"
-        else -> "${minGb}-${maxGb}GB"
+        minGb <= 0 && maxGb <= 0 -> context.getString(R.string.debrid_size_range_any)
+        minGb <= 0 -> context.getString(R.string.debrid_size_range_up_to, maxGb)
+        maxGb <= 0 -> context.getString(R.string.debrid_size_range_min_plus, minGb)
+        else -> context.getString(R.string.debrid_size_range_min_max, minGb, maxGb)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -55,8 +55,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val TAG = "StreamScreenViewModel"
-private const val EMBEDDED_STREAM_GROUP_NAME = "Embedded Streams"
-private const val EMBEDDED_STREAM_FALLBACK_NAME = "Embed Stream"
 private const val DIRECT_AUTOPLAY_HARD_TIMEOUT_MS = 60_000L
 
 @HiltViewModel
@@ -86,6 +84,13 @@ class StreamScreenViewModel @Inject constructor(
     private var streamLoadJob: Job? = null
     private var sourceChipErrorDismissJob: Job? = null
     private var pendingCacheSaveJob: Job? = null
+
+    private val embeddedStreamGroupName: String by lazy {
+        context.getString(R.string.stream_embedded_group)
+    }
+    private val embeddedStreamFallbackName: String by lazy {
+        context.getString(R.string.stream_embedded_fallback_name)
+    }
 
     private val videoId: String = savedStateHandle["videoId"] ?: ""
     private val contentType: String = savedStateHandle["contentType"] ?: ""
@@ -815,14 +820,14 @@ class StreamScreenViewModel @Inject constructor(
 
         val streams = video.streams.map { stream ->
             stream.copy(
-                name = stream.name ?: stream.title ?: stream.description ?: EMBEDDED_STREAM_FALLBACK_NAME,
-                addonName = EMBEDDED_STREAM_GROUP_NAME,
+                name = stream.name ?: stream.title ?: stream.description ?: embeddedStreamFallbackName,
+                addonName = embeddedStreamGroupName,
                 addonLogo = null
             )
         }
 
         return AddonStreams(
-            addonName = EMBEDDED_STREAM_GROUP_NAME,
+            addonName = embeddedStreamGroupName,
             addonLogo = null,
             streams = streams
         )

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -419,7 +419,7 @@
     <string name="supporters_contributors_qr_title">Scanner pour faire un don</string>
     <string name="supporters_contributors_qr_subtitle">Ouvre le lien sur ton téléphone et soutiens Nuvio via Ko-fi.</string>
     <string name="supporters_contributors_qr_hint">Pointe ta caméra vers le code QR ou utilise le bouton ci-dessous.</string>
-    <string name="supporters_contributors_back_button">Revenir aux détails</string>
+    <string name="supporters_contributors_back_button">Retour aux détails</string>
     <string name="supporters_tab">Soutiens</string>
     <string name="sponsors_tab">Sponsors</string>
     <string name="contributors_tab">Contributeurs</string>
@@ -466,6 +466,8 @@
     <string name="playback_engine_mvplayer">Libmpv (bêta)</string>
     <string name="playback_auto_switch_internal_player_on_error">Changement auto du moteur en cas d’erreur au démarrage</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Si le démarrage du flux échoue, bascule automatiquement entre ExoPlayer et libmpv.</string>
+    <string name="playback_external_forward_subtitles">Transférer les sous-titres au lecteur externe</string>
+    <string name="playback_external_forward_subtitles_sub">Récupère les sous-titres dans ta langue préférée depuis les addons et les transmet au lecteur externe.</string>
     <string name="playback_section_audio">Audio et vidéo</string>
     <string name="playback_section_audio_desc">Contrôles audio et compatibilité vidéo.</string>
     <string name="playback_section_subtitles">Sous-titres</string>
@@ -496,6 +498,7 @@
     <string name="playback_engine_mvplayer_desc">Utilise libmpv avec les contrôles OSD de Nuvio. Expérimental.</string>
 
     <!-- PlaybackAudioSettings -->
+    <string name="video_section">Vidéo</string>
     <string name="audio_trailer_section">Bande-annonce</string>
     <string name="audio_autoplay_trailers">Lecture automatique des bandes-annonces</string>
     <string name="audio_autoplay_trailers_sub">Lire automatiquement les bandes-annonces sur l’écran de détail après une période d’inactivité</string>
@@ -895,6 +898,8 @@
     <string name="debug_account_tab_subtitle">Afficher l’onglet compte dans la navigation des paramètres</string>
     <string name="debug_sync_code_title">Fonctionnalités de code de synchronisation</string>
     <string name="debug_sync_code_subtitle">Afficher les boutons pour générer et saisir un code de synchronisation dans les paramètres du compte</string>
+    <string name="debug_buffer_logs_title">Activer les logs BUFFER</string>
+    <string name="debug_buffer_logs_subtitle">Émettre périodiquement les diagnostics du buffer du lecteur dans logcat (désactivé par défaut)</string>
     <string name="debug_section_account">Compte</string>
     <string name="debug_manual_signin_title">Connexion manuelle</string>
     <string name="debug_manual_signin_subtitle">Se connecter avec un e-mail et un mot de passe (auth Supabase)</string>
@@ -1488,6 +1493,23 @@
     <!-- PlaybackAudioSettings -->
     <string name="audio_passthrough_info">Le passthrough audio (TrueHD, DTS, AC-3, etc.) est automatique. Lorsqu’il est connecté à un récepteur AV ou une barre de son compatible via HDMI, l’audio sans perte est envoyé tel quel sans décodage.</string>
     <string name="audio_dv_title">DV7 – repli HEVC</string>
+    <string name="audio_dv_sub">Convertit Dolby Vision Profile 7 en HEVC standard pour les appareils sans prise en charge matérielle DV</string>
+
+    <!-- DV7 Handling Mode -->
+    <string name="dv7_handling_title">Gestion de Dolby Vision Profile 7</string>
+    <string name="dv7_handling_dialog_subtitle">Choisis comment les flux DV Profile 7 sont traités à la lecture.</string>
+    <string name="dv7_mode_auto">Auto (recommandé)</string>
+    <string name="dv7_mode_auto_desc">Détecte ton écran et choisit le meilleur mode. En cas de problème de lecture, essaie «&#160;Couche HDR10 de base&#160;».</string>
+    <string name="dv7_mode_hdr10_base_layer">Couche HDR10 de base</string>
+    <string name="dv7_mode_hdr10_base_layer_desc">Supprime systématiquement Dolby Vision et lit la couche HEVC HDR10 de base.</string>
+    <string name="dv7_mode_dv81_libdovi">Convertir en DV8.1</string>
+    <string name="dv7_mode_dv81_libdovi_desc">Convertit DV7 en DV8.1 mono-couche. Nécessite un écran Dolby Vision.</string>
+    <string name="dv7_mode_off">Désactivé (natif)</string>
+    <string name="dv7_mode_off_desc">Passe DV7 sans modification. Peut causer des artefacts sur le matériel qui ne prend pas en charge DV Profile 7.</string>
+    <string name="audio_dv5_to_dv81_title">Convertir DV5 en DV8.1</string>
+    <string name="audio_dv5_to_dv81_sub">Signale les flux Profile 5 comme Profile 8.1 pour une sortie compatible HDR10. Utile sur les appareils sans décodeur DV5 natif.</string>
+    <string name="audio_dv7_preserve_mapping_title">Préserver le mapping DV (DV7 vers DV8.1)</string>
+    <string name="audio_dv7_preserve_mapping_sub">Conserve le tone-mapping voulu par le créateur, au prix d’un traitement légèrement plus lourd par image.</string>
 
     <!-- SidebarNavigation / MainActivity -->
     <string name="nav_home">Accueil</string>
@@ -2396,6 +2418,12 @@
     <string name="debrid_stream_sort_quality">Qualité, la plus élevée d’abord</string>
     <string name="debrid_stream_sort_size_desc">Taille, la plus grande d’abord</string>
     <string name="debrid_stream_sort_size_asc">Taille, la plus petite d’abord</string>
+    <string name="debrid_stream_sort_original">Ordre d’origine</string>
+    <string name="debrid_stream_sort_best_quality">Meilleure qualité en premier</string>
+    <string name="debrid_stream_sort_largest">Plus gros en premier</string>
+    <string name="debrid_stream_sort_smallest">Plus petit en premier</string>
+    <string name="debrid_stream_sort_best_audio">Meilleur audio en premier</string>
+    <string name="debrid_stream_sort_language">Langue en premier</string>
     <string name="debrid_stream_min_quality_title">Qualité minimale</string>
     <string name="debrid_stream_min_quality_subtitle">Masquer les sources sous la résolution sélectionnée.</string>
     <string name="debrid_stream_min_quality_any">Toutes qualités</string>
@@ -2524,4 +2552,66 @@
     <!-- Erreurs du dépôt Bibliothèque cloud -->
     <string name="cloud_library_error_provider_unavailable">Bibliothèque cloud indisponible pour %1$s.</string>
     <string name="cloud_library_error_disabled">La bibliothèque cloud est désactivée.</string>
+
+    <!-- Debrid: filter rule rows (title + subtitle pairs) -->
+    <string name="debrid_picker_preferred_resolutions_title">Résolutions préférées</string>
+    <string name="debrid_picker_preferred_resolutions_subtitle">Trie d’abord les résolutions sélectionnées, dans l’ordre par défaut.</string>
+    <string name="debrid_picker_required_resolutions_title">Résolutions requises</string>
+    <string name="debrid_picker_required_resolutions_subtitle">N’affiche que les résolutions sélectionnées.</string>
+    <string name="debrid_picker_excluded_resolutions_title">Résolutions exclues</string>
+    <string name="debrid_picker_excluded_resolutions_subtitle">Masque les résolutions sélectionnées.</string>
+    <string name="debrid_picker_preferred_qualities_title">Qualités préférées</string>
+    <string name="debrid_picker_preferred_qualities_subtitle">Trie d’abord les qualités sélectionnées, dans l’ordre par défaut.</string>
+    <string name="debrid_picker_required_qualities_title">Qualités requises</string>
+    <string name="debrid_picker_required_qualities_subtitle">N’affiche que les qualités de source sélectionnées.</string>
+    <string name="debrid_picker_excluded_qualities_title">Qualités exclues</string>
+    <string name="debrid_picker_excluded_qualities_subtitle">Masque les qualités de source sélectionnées.</string>
+    <string name="debrid_picker_preferred_visual_tags_title">Tags visuels préférés</string>
+    <string name="debrid_picker_preferred_visual_tags_subtitle">Trie les tags DV, HDR, 10bit, IMAX et similaires.</string>
+    <string name="debrid_picker_required_visual_tags_title">Tags visuels requis</string>
+    <string name="debrid_picker_required_visual_tags_subtitle">Exige les tags DV, HDR, 10bit, IMAX, SDR et similaires.</string>
+    <string name="debrid_picker_excluded_visual_tags_title">Tags visuels exclus</string>
+    <string name="debrid_picker_excluded_visual_tags_subtitle">Masque les tags DV, HDR, 10bit, 3D et similaires.</string>
+    <string name="debrid_picker_preferred_audio_tags_title">Tags audio préférés</string>
+    <string name="debrid_picker_preferred_audio_tags_subtitle">Trie les tags Atmos, TrueHD, DTS, AAC et similaires.</string>
+    <string name="debrid_picker_required_audio_tags_title">Tags audio requis</string>
+    <string name="debrid_picker_required_audio_tags_subtitle">Exige les tags Atmos, TrueHD, DTS, AAC et similaires.</string>
+    <string name="debrid_picker_excluded_audio_tags_title">Tags audio exclus</string>
+    <string name="debrid_picker_excluded_audio_tags_subtitle">Masque les tags audio sélectionnés.</string>
+    <string name="debrid_picker_preferred_audio_channels_title">Canaux préférés</string>
+    <string name="debrid_picker_preferred_audio_channels_subtitle">Trie d’abord les configurations de canaux préférées.</string>
+    <string name="debrid_picker_required_audio_channels_title">Canaux requis</string>
+    <string name="debrid_picker_required_audio_channels_subtitle">N’affiche que les configurations de canaux sélectionnées.</string>
+    <string name="debrid_picker_excluded_audio_channels_title">Canaux exclus</string>
+    <string name="debrid_picker_excluded_audio_channels_subtitle">Masque les configurations de canaux sélectionnées.</string>
+    <string name="debrid_picker_preferred_encodes_title">Encodages préférés</string>
+    <string name="debrid_picker_preferred_encodes_subtitle">Trie les encodages AV1, HEVC, AVC et similaires.</string>
+    <string name="debrid_picker_required_encodes_title">Encodages requis</string>
+    <string name="debrid_picker_required_encodes_subtitle">Exige les encodages AV1, HEVC, AVC et similaires.</string>
+    <string name="debrid_picker_excluded_encodes_title">Encodages exclus</string>
+    <string name="debrid_picker_excluded_encodes_subtitle">Masque les encodages sélectionnés.</string>
+    <string name="debrid_picker_preferred_languages_title">Langues préférées</string>
+    <string name="debrid_picker_preferred_languages_subtitle">Trie d’abord les langues audio préférées.</string>
+    <string name="debrid_picker_required_languages_title">Langues requises</string>
+    <string name="debrid_picker_required_languages_subtitle">N’affiche que les flux avec les langues sélectionnées.</string>
+    <string name="debrid_picker_excluded_languages_title">Langues exclues</string>
+    <string name="debrid_picker_excluded_languages_subtitle">Masque les flux dont toutes les langues sont exclues.</string>
+    <string name="debrid_picker_required_release_groups_title">Groupes de release requis</string>
+    <string name="debrid_picker_required_release_groups_subtitle">N’affiche que les groupes de release sélectionnés.</string>
+    <string name="debrid_picker_excluded_release_groups_title">Groupes de release exclus</string>
+    <string name="debrid_picker_excluded_release_groups_subtitle">Masque les groupes de release sélectionnés.</string>
+
+    <!-- Debrid: selection count + size range labels -->
+    <string name="debrid_selection_count_any">Toutes</string>
+    <plurals name="debrid_selection_count_value">
+        <item quantity="one">%d sélectionné</item>
+        <item quantity="other">%d sélectionnés</item>
+    </plurals>
+    <string name="debrid_size_range_any">Indifférente</string>
+    <string name="debrid_size_range_up_to">Jusqu’à %1$d Go</string>
+    <string name="debrid_size_range_min_plus">%1$d Go et plus</string>
+    <string name="debrid_size_range_min_max">%1$d-%2$d Go</string>
+
+    <!-- Subtitle selection: unknown language fallback -->
+    <string name="subtitle_language_unknown">Inconnue</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2472,11 +2472,69 @@
     <string name="trakt_comments_error_request_failed">Trakt comments request failed</string>
     <string name="trakt_library_error_fetch_list_items">Failed to fetch list items</string>
 
-
-
     <string name="watchlist_removed">Removed from watchlist</string>
     <string name="watchlist_added">Added to watchlist</string>
 
+    <!-- Debrid: filter rule rows (title + subtitle pairs) -->
+    <string name="debrid_picker_preferred_resolutions_title">Preferred resolutions</string>
+    <string name="debrid_picker_preferred_resolutions_subtitle">Sort selected resolutions first, in default order.</string>
+    <string name="debrid_picker_required_resolutions_title">Required resolutions</string>
+    <string name="debrid_picker_required_resolutions_subtitle">Only show selected resolutions.</string>
+    <string name="debrid_picker_excluded_resolutions_title">Excluded resolutions</string>
+    <string name="debrid_picker_excluded_resolutions_subtitle">Hide selected resolutions.</string>
+    <string name="debrid_picker_preferred_qualities_title">Preferred qualities</string>
+    <string name="debrid_picker_preferred_qualities_subtitle">Sort selected qualities first, in default order.</string>
+    <string name="debrid_picker_required_qualities_title">Required qualities</string>
+    <string name="debrid_picker_required_qualities_subtitle">Only show selected source qualities.</string>
+    <string name="debrid_picker_excluded_qualities_title">Excluded qualities</string>
+    <string name="debrid_picker_excluded_qualities_subtitle">Hide selected source qualities.</string>
+    <string name="debrid_picker_preferred_visual_tags_title">Preferred visual tags</string>
+    <string name="debrid_picker_preferred_visual_tags_subtitle">Sort DV, HDR, 10bit, IMAX and similar tags.</string>
+    <string name="debrid_picker_required_visual_tags_title">Required visual tags</string>
+    <string name="debrid_picker_required_visual_tags_subtitle">Require DV, HDR, 10bit, IMAX, SDR and similar tags.</string>
+    <string name="debrid_picker_excluded_visual_tags_title">Excluded visual tags</string>
+    <string name="debrid_picker_excluded_visual_tags_subtitle">Hide DV, HDR, 10bit, 3D and similar tags.</string>
+    <string name="debrid_picker_preferred_audio_tags_title">Preferred audio tags</string>
+    <string name="debrid_picker_preferred_audio_tags_subtitle">Sort Atmos, TrueHD, DTS, AAC and similar tags.</string>
+    <string name="debrid_picker_required_audio_tags_title">Required audio tags</string>
+    <string name="debrid_picker_required_audio_tags_subtitle">Require Atmos, TrueHD, DTS, AAC and similar tags.</string>
+    <string name="debrid_picker_excluded_audio_tags_title">Excluded audio tags</string>
+    <string name="debrid_picker_excluded_audio_tags_subtitle">Hide selected audio tags.</string>
+    <string name="debrid_picker_preferred_audio_channels_title">Preferred channels</string>
+    <string name="debrid_picker_preferred_audio_channels_subtitle">Sort preferred channel layouts first.</string>
+    <string name="debrid_picker_required_audio_channels_title">Required channels</string>
+    <string name="debrid_picker_required_audio_channels_subtitle">Only show selected channel layouts.</string>
+    <string name="debrid_picker_excluded_audio_channels_title">Excluded channels</string>
+    <string name="debrid_picker_excluded_audio_channels_subtitle">Hide selected channel layouts.</string>
+    <string name="debrid_picker_preferred_encodes_title">Preferred encodes</string>
+    <string name="debrid_picker_preferred_encodes_subtitle">Sort AV1, HEVC, AVC and similar encodes.</string>
+    <string name="debrid_picker_required_encodes_title">Required encodes</string>
+    <string name="debrid_picker_required_encodes_subtitle">Require AV1, HEVC, AVC and similar encodes.</string>
+    <string name="debrid_picker_excluded_encodes_title">Excluded encodes</string>
+    <string name="debrid_picker_excluded_encodes_subtitle">Hide selected encodes.</string>
+    <string name="debrid_picker_preferred_languages_title">Preferred languages</string>
+    <string name="debrid_picker_preferred_languages_subtitle">Sort preferred audio languages first.</string>
+    <string name="debrid_picker_required_languages_title">Required languages</string>
+    <string name="debrid_picker_required_languages_subtitle">Only show streams with selected languages.</string>
+    <string name="debrid_picker_excluded_languages_title">Excluded languages</string>
+    <string name="debrid_picker_excluded_languages_subtitle">Hide streams where every language is excluded.</string>
+    <string name="debrid_picker_required_release_groups_title">Required release groups</string>
+    <string name="debrid_picker_required_release_groups_subtitle">Only show selected release groups.</string>
+    <string name="debrid_picker_excluded_release_groups_title">Excluded release groups</string>
+    <string name="debrid_picker_excluded_release_groups_subtitle">Hide selected release groups.</string>
 
+    <!-- Debrid: selection count + size range labels -->
+    <string name="debrid_selection_count_any">Any</string>
+    <plurals name="debrid_selection_count_value">
+        <item quantity="one">%d selected</item>
+        <item quantity="other">%d selected</item>
+    </plurals>
+    <string name="debrid_size_range_any">Any</string>
+    <string name="debrid_size_range_up_to">Up to %1$dGB</string>
+    <string name="debrid_size_range_min_plus">%1$dGB+</string>
+    <string name="debrid_size_range_min_max">%1$d-%2$dGB</string>
+
+    <!-- Subtitle selection: unknown language fallback -->
+    <string name="subtitle_language_unknown">Unknown</string>
 
 </resources>


### PR DESCRIPTION
## Summary

Seventh i18n extraction pass: extract 57 hardcoded English strings from `DebridSettingsScreen.kt` (Debrid stream filters & sorting block), `SubtitleSelectionOverlay.kt` (unknown language fallback) and `StreamScreenViewModel.kt` (embedded streams labels), with full French translations added to `values-fr/strings.xml`. Plus one FR harmonization (`Revenir aux détails` → `Retour aux détails` to match the existing `pause_back_to_details`).

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

The Debrid filter rows, sort profile labels, selection/size labels, the subtitle "Unknown" fallback, and the embedded streams labels were still hardcoded in Kotlin, so they were never translated regardless of the user's locale. This batch externalizes them to `strings.xml` and provides French translations in tutoiement consistent with the existing FR file (87 tutoiement occurrences already in place, 0 vouvoiement).

The helper functions in `DebridSettingsScreen.kt` (`sortProfileLabel`, `selectionCountLabel`, `sizeRangeLabel`, `debridRuleRows`) and `subtitleLanguageLabel` in `SubtitleSelectionOverlay.kt` are non-`@Composable` so they cannot call `stringResource` directly. The minimal change required to localize them is to accept a `Context` parameter and use `context.getString(R.string.x)` — this is mechanically required for the localization, not a feature refactor. Same pattern that was used and accepted in PR #2066 (batch6, `refactor safeApiCall with Context`).

The 2 `StreamScreenViewModel` constants (`EMBEDDED_STREAM_GROUP_NAME`, `EMBEDDED_STREAM_FALLBACK_NAME`) consolidate on the existing `stream_embedded_group` and `stream_embedded_fallback_name` resources that were already defined in `strings.xml` but unreferenced — no new keys created, no duplicates.

## Issue or approval

No linked issue: localization-only update.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No new features.
- No UI redesign, no layout changes, no spacing/typography changes.
- No behavior change: same rows, same dialogs, same labels — only the source of the label text changes (hardcoded → `stringResource`/`getString`).
- No drive-by cleanups or formatting changes outside the strings being extracted.
- `Context` parameter additions to private helpers are the minimal mechanical change required to call `getString` from non-`@Composable` code.
- The following hardcoded strings were intentionally **not** extracted in this pass (out of scope):
  - `LanguageUtils.languageCodeToName` `"None"` (7+ call-sites — deferred to a dedicated pass)
  - `ErrorState.defaultErrorStateStrings()` fallback strings (parallel source of truth — deferred)
  - `CustomDefaultTrackNameProvider` `"Mono"/"Stereo"` (universal audio terms — deferred for team discussion)

## Testing

- `./gradlew :app:compileFullDebugKotlin` ✓ BUILD SUCCESSFUL (1m 16s, no error)
- `xmllint --noout` ✓ on both `values/strings.xml` and `values-fr/strings.xml`
- EN ↔ FR parity: 2304 strings + 2 plurals = 2306 named entries each, 0 missing, 0 orphan, 0 duplicate
- Placeholders consistency: 100% across all keys (no divergent `%1$s`, `%d`, `\n`, `<xliff:g>`)
- Full FR file audit (2306 entries) passed: 0 mojibake, 321 typographic apostrophes (U+2019, 0 ASCII), 93 non-breaking spaces correctly used before `;:!?»`, 0 false friends, 0 anglicism calques, 100% tutoiement style
- Manual smoke test pending on Ugoos device: open Settings → Debrid → Filters & Sorting in French and verify each row label/subtitle renders correctly (FR strings ~20-30% longer than EN — confirm no overflow on TV cards)

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.