### PR TITLE
fix(ui): resolve focus jumping and focus loss in StreamScreen and Sid…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -27,6 +27,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,13 +62,20 @@ internal fun StreamSourcesSidePanel(
     onStreamSelected: (Stream) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var listHasFocus by remember { mutableStateOf(false) }
+    var listHadFocusBeforeLoading by remember { mutableStateOf(true) }
+
     // Request focus when loading finishes OR when the list content updates
     // (ensures higher-priority addons get focus if they load later)
     LaunchedEffect(uiState.isLoadingSourceStreams, uiState.sourceFilteredStreams.size) {
         if (!uiState.isLoadingSourceStreams && uiState.sourceFilteredStreams.isNotEmpty()) {
-            try {
-                streamsFocusRequester.requestFocus()
-            } catch (_: Exception) {}
+            if (listHadFocusBeforeLoading) {
+                repeat(2) { withFrameNanos { } }
+                try {
+                    streamsFocusRequester.requestFocus()
+                } catch (_: Exception) {}
+                listHadFocusBeforeLoading = false
+            }
         }
     }
 
@@ -198,6 +210,26 @@ internal fun StreamSourcesSidePanel(
                     val initialFocusStream = uiState.sourceFilteredStreams.getOrNull(currentStreamIndex)
                         ?: uiState.sourceFilteredStreams.firstOrNull()
 
+                    // Compute stable keys to prevent focus loss during filtering/recomposition
+                    val streamKeys = remember(uiState.sourceFilteredStreams) {
+                        val seen = mutableMapOf<String, Int>()
+                        uiState.sourceFilteredStreams.map { stream ->
+                            val base = stream.stableKey(0)
+                            val count = seen.getOrDefault(base, 0)
+                            seen[base] = count + 1
+                            stream.stableKey(count)
+                        }
+                    }
+
+                    LaunchedEffect(uiState.sourceSelectedAddonFilter) {
+                        if (listHasFocus && uiState.sourceFilteredStreams.isNotEmpty()) {
+                            repeat(2) { withFrameNanos { } }
+                            try {
+                                streamsFocusRequester.requestFocus()
+                            } catch (_: Exception) {}
+                        }
+                    }
+
                     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
 
                     LazyColumn(
@@ -210,6 +242,14 @@ internal fun StreamSourcesSidePanel(
                         ),
                         modifier = Modifier
                             .fillMaxHeight()
+                            .onFocusChanged { 
+                                listHasFocus = it.hasFocus
+                                if (it.hasFocus) {
+                                    listHadFocusBeforeLoading = true
+                                } else if (!uiState.isLoadingSourceStreams) {
+                                    listHadFocusBeforeLoading = false
+                                }
+                            }
                             .onKeyEvent { event ->
                                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
 
@@ -235,8 +275,8 @@ internal fun StreamSourcesSidePanel(
                                 }
                             }
                     ) {
-                        itemsIndexed(uiState.sourceFilteredStreams, key = { index, stream ->
-                            stream.stableKey(index)
+                        itemsIndexed(uiState.sourceFilteredStreams, key = { index, _ ->
+                            streamKeys.getOrElse(index) { index.toString() }
                         }) { index, stream ->
                             StreamItem(
                                 stream = stream,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -585,6 +585,7 @@ private fun RightStreamSection(
     var shouldFocusFirstStream by remember { mutableStateOf(false) }
     var wasLoading by remember { mutableStateOf(true) }
     var listHasFocus by remember { mutableStateOf(false) }
+    var listHadFocusBeforeLoading by remember { mutableStateOf(true) }
     val scope = rememberCoroutineScope()
     var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
     val orderedAddonNames = remember(availableAddons, sourceChips) {
@@ -613,7 +614,10 @@ private fun RightStreamSection(
     }
     LaunchedEffect(isLoading, streams.size) {
         if (wasLoading && !isLoading && streams.isNotEmpty()) {
-            shouldFocusFirstStream = true
+            if (listHadFocusBeforeLoading) {
+                shouldFocusFirstStream = true
+                listHadFocusBeforeLoading = false
+            }
         }
         wasLoading = isLoading
     }
@@ -688,7 +692,14 @@ private fun RightStreamSection(
                             onAddonFilterSelected = { onAddonFilterSelectedGuarded(it) },
                             chipFocusRequesters = chipFocusRequesters,
                             orderedAddonNames = orderedAddonNames,
-                            onFocusChanged = { listHasFocus = it }
+                            onFocusChanged = { 
+                                listHasFocus = it
+                                if (it) {
+                                    listHadFocusBeforeLoading = true
+                                } else if (!isLoading) {
+                                    listHadFocusBeforeLoading = false
+                                }
+                            }
                         )
                     }
                 }
@@ -902,6 +913,18 @@ private fun StreamsList(
     val firstCardFocusRequester = remember { FocusRequester() }
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     val restoreFocusRequester = remember { FocusRequester() }
+    var hasFocus by remember { mutableStateOf(false) }
+
+    // Compute stable keys to prevent focus loss during filtering/recomposition
+    val streamKeys = remember(streams) {
+        val seen = mutableMapOf<String, Int>()
+        streams.map { stream ->
+            val base = stream.stableKey(0)
+            val count = seen.getOrDefault(base, 0)
+            seen[base] = count + 1
+            stream.stableKey(count)
+        }
+    }
     val firstStreamKey = streams.firstOrNull()?.let { first ->
         "${first.addonName}_${first.url ?: first.infoHash ?: first.ytId ?: "unknown"}"
     }
@@ -930,11 +953,23 @@ private fun StreamsList(
         onRestoreFocusedStreamHandled()
     }
 
+    LaunchedEffect(selectedAddonFilter) {
+        if (hasFocus && streams.isNotEmpty()) {
+            repeat(2) { withFrameNanos { } }
+            try {
+                firstCardFocusRequester.requestFocus()
+            } catch (_: Exception) {}
+        }
+    }
+
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
-            .onFocusChanged { onFocusChanged(it.hasFocus) }
+            .onFocusChanged { 
+                hasFocus = it.hasFocus
+                onFocusChanged(it.hasFocus)
+            }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
 
@@ -968,8 +1003,8 @@ private fun StreamsList(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp)
     ) {
-        itemsIndexed(streams, key = { index, stream ->
-            stream.stableKey(index)
+        itemsIndexed(streams, key = { index, _ ->
+            streamKeys.getOrElse(index) { index.toString() }
         }) { index, stream ->
             StreamCard(
                 stream = stream,


### PR DESCRIPTION
## Summary

Fixes focus jumping and focus loss issues in `StreamScreen` and `StreamSourcesSidePanel` caused by state changes (e.g., transitioning from loading to completed states) or recompositions when filters/providers change.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When transitioning from a loading state to a completed stream source state, the application was forcefully taking focus back to the `StreamsList`. This "focus hijacking" caused the user to lose their current focus position if they had navigated elsewhere (e.g., sidebar or d-pad navigation) while loading. By tracking `listHadFocusBeforeLoading` and stabilizing stream keys, focus is now properly retained.

## Issue or approval

Fixes #2108. Fixing a critical focus disruption bug for TV interfaces.

## Reproduction steps

1. Navigate to `StreamScreen` and open `StreamSourcesSidePanel`.
2. Start loading a stream source.
3. While it is loading, move the focus to another element (e.g., sidebar).
4. Observe that when the stream source finishes loading, the focus does not abruptly jump back to the stream list unless it had focus before the loading started.
5. Navigate between sources and verify focus moves correctly and releases previous chips (fixes #2108).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The scope is strictly limited to focus handling logic in `StreamScreen.kt` and `StreamSourcesSidePanel.kt`. It adds a focus state machine (`listHasFocus`, `listHadFocusBeforeLoading`) and utilizes `stableKey` to ensure stable compositions. It does not introduce extra UI polish or unrelated behavior tweaks.

## Testing

Manually tested on TV (D-pad navigation) by switching between the stream list and the sidebar during the loading phase. Ensured that focus behaves predictably when filters change and when the loading state finishes. Verified focus moves between chips without jumping back.

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2108
