### PR TITLE
fix(tv): use event-driven state machine to suppress select key leakag…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/NuvioDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/NuvioDialog.kt
@@ -43,8 +43,7 @@ fun NuvioDialog(
     suppressFirstKeyUp: Boolean = true,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    var suppressNextKeyUp by remember { mutableStateOf(suppressFirstKeyUp) }
-    val openedAtMillis = remember { SystemClock.uptimeMillis() }
+    var isReady by remember { mutableStateOf(!suppressFirstKeyUp) }
     val maxDialogHeight = (LocalConfiguration.current.screenHeightDp.dp - 48.dp).coerceAtLeast(320.dp)
 
     Dialog(onDismissRequest = onDismiss) {
@@ -58,10 +57,12 @@ fun NuvioDialog(
                 .padding(24.dp)
                 .onPreviewKeyEvent { event ->
                     val native = event.nativeKeyEvent
-                    if (suppressNextKeyUp && native.action == AndroidKeyEvent.ACTION_UP) {
-                        if (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU) {
-                            suppressNextKeyUp = false
-                            return@onPreviewKeyEvent native.downTime <= openedAtMillis
+                    if (isSelectKey(native.keyCode) || native.keyCode == AndroidKeyEvent.KEYCODE_MENU) {
+                        if (native.action == AndroidKeyEvent.ACTION_DOWN && native.repeatCount == 0) {
+                            isReady = true
+                        }
+                        if (!isReady) {
+                            return@onPreviewKeyEvent true
                         }
                     }
                     false


### PR DESCRIPTION
## Summary

Fixes unintended remote control clicks (key leakage) occurring when opening dialogs via long-press on Android TV devices.
When a user long-pressed the Select/OK button on a CEC remote, the continuous stream of `ACTION_DOWN` repeats and the final `ACTION_UP` event were leaking into the newly opened dialog, causing an immediate, accidental click on the first focused button. This PR implements an event-driven `isReady` state machine in `NuvioDialog.kt` to suppress all stale events without arbitrary time delays.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

CEC remotes send continuous `ACTION_DOWN` (with `repeatCount > 0`) when held, followed by an `ACTION_UP`. When holding OK to open a dialog (e.g. for "Continue Watching" item options, or Episode selection), the remaining events hit the newly focused item in the dialog. This critical bug fix resolves the accidental triggering by making the dialog ignore inputs until a fresh `ACTION_DOWN` (`repeatCount == 0`) arrives.

## Issue or approval

Fixes https://discord.com/channels/1379902184207941732/1504236074157998314

## Reproduction steps

1. Use a CEC remote (or TV remote through CEC).
2. Long-press OK on an item that opens a dialog (e.g., a card in "Continue Watching").
3. The dialog opens, but the first focused item inside the dialog is immediately clicked/selected.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Reverted previous temporary focus-delays in `ContinueWatchingSection`, `EpisodesSection`, and `PosterOptionsDialog`. All fixes are now centralized strictly within `NuvioDialog.kt`. No UI polish or extra features added.

## Testing

Verified on Android TV using D-pad/CEC remote:
1. Long-pressing "Continue Watching" items no longer automatically clicks "Go to details".
2. Long-pressing episode selection options no longer automatically toggles "mark watched/unwatched".
Standard navigation and selection within the dialog function correctly after a fresh click.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

https://discord.com/channels/1379902184207941732/1504236074157998314
