### PR TITLE
Fix stale Trakt sync, mark-as-watched scope, and forced subtitle persistence

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -229,6 +229,9 @@ class MainActivity : ComponentActivity() {
 
     private lateinit var jankStats: JankStats
 
+    /** True until the first onResume after onCreate completes. */
+    private var isFirstResumeAfterCreate = false
+
     @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
     override fun attachBaseContext(newBase: Context) {
         val tag = LocaleCache.localeTag.takeIf { it != LocaleCache.UNSET }
@@ -251,6 +254,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
+        isFirstResumeAfterCreate = true
         window?.setBackgroundDrawable(null)
 
         PluginRuntimeHooks.onActivityCreate(this)
@@ -726,7 +730,12 @@ class MainActivity : ComponentActivity() {
         if (::jankStats.isInitialized) jankStats.isTrackingEnabled = true
         startupSyncService.requestSyncNow(includeProfileSettings = false)
         lifecycleScope.launch {
-            traktProgressService.refreshNow()
+            if (isFirstResumeAfterCreate) {
+                isFirstResumeAfterCreate = false
+                traktProgressService.invalidateAndRefresh()
+            } else {
+                traktProgressService.refreshNow()
+            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
@@ -19,6 +19,7 @@ class TrackPreferenceDataStore @Inject constructor(
         private const val SUB_LANG = "sub_lang"
         private const val SUB_NAME = "sub_name"
         private const val SUB_TRACK_ID = "sub_track_id"
+        private const val SUB_IS_FORCED = "sub_is_forced"
         private const val SUB_ADDON_ID = "sub_addon_id"
         private const val SUB_ADDON_URL = "sub_addon_url"
         private const val SUB_ADDON_NAME = "sub_addon_name"
@@ -49,6 +50,7 @@ class TrackPreferenceDataStore @Inject constructor(
             set(SUB_LANG, pref.subtitleLanguage)
             set(SUB_NAME, pref.subtitleName)
             set(SUB_TRACK_ID, pref.subtitleTrackId)
+            set(SUB_IS_FORCED, pref.subtitleIsForced?.toString())
             set(SUB_ADDON_ID, pref.addonSubtitleId)
             set(SUB_ADDON_URL, pref.addonSubtitleUrl)
             set(SUB_ADDON_NAME, pref.addonSubtitleAddonName)
@@ -75,6 +77,7 @@ class TrackPreferenceDataStore @Inject constructor(
             subtitleLanguage = prefs[key(SUB_LANG, contentId)],
             subtitleName = prefs[key(SUB_NAME, contentId)],
             subtitleTrackId = prefs[key(SUB_TRACK_ID, contentId)],
+            subtitleIsForced = prefs[key(SUB_IS_FORCED, contentId)]?.toBooleanStrictOrNull(),
             addonSubtitleId = prefs[key(SUB_ADDON_ID, contentId)],
             addonSubtitleUrl = prefs[key(SUB_ADDON_URL, contentId)],
             addonSubtitleAddonName = prefs[key(SUB_ADDON_NAME, contentId)],
@@ -108,6 +111,7 @@ data class PersistedTrackPreference(
     val subtitleLanguage: String?,
     val subtitleName: String?,
     val subtitleTrackId: String?,
+    val subtitleIsForced: Boolean? = null,
     val addonSubtitleId: String?,
     val addonSubtitleUrl: String?,
     val addonSubtitleAddonName: String?,
@@ -130,7 +134,8 @@ internal fun PersistedTrackPreference.toTrackPreference(): com.nuvio.tv.ui.scree
             track = com.nuvio.tv.ui.screens.player.PlayerRuntimeController.RememberedTrackSelection(
                 language = subtitleLanguage,
                 name = subtitleName,
-                trackId = subtitleTrackId
+                trackId = subtitleTrackId,
+                isForcedHint = subtitleIsForced
             )
         )
         "ADDON" -> com.nuvio.tv.ui.screens.player.PlayerRuntimeController.RememberedSubtitleSelection.Addon(

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktAuthDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktAuthDataStore.kt
@@ -9,6 +9,7 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktDeviceCodeResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktTokenResponseDto
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -89,6 +90,25 @@ class TraktAuthDataStore @Inject constructor(
     val isAuthenticated: Flow<Boolean> = state.map { it.isAuthenticated }
 
     val isEffectivelyAuthenticated: Flow<Boolean> = isAuthenticated
+
+    /** Direct read of auth state for the current active profile, bypassing flatMapLatest. */
+    suspend fun getCurrentState(): TraktAuthState {
+        val prefs = store().data.first()
+        return TraktAuthState(
+            accessToken = prefs[accessTokenKey],
+            refreshToken = prefs[refreshTokenKey],
+            tokenType = prefs[tokenTypeKey],
+            createdAt = prefs[createdAtKey],
+            expiresIn = prefs[expiresInKey]?.let(::normalizeTraktTokenLifetimeSeconds),
+            username = prefs[usernameKey],
+            userSlug = prefs[userSlugKey],
+            deviceCode = prefs[deviceCodeKey],
+            userCode = prefs[userCodeKey],
+            verificationUrl = prefs[verificationUrlKey],
+            expiresAt = prefs[expiresAtKey],
+            pollInterval = prefs[pollIntervalKey]
+        )
+    }
 
     suspend fun saveToken(token: TraktTokenResponseDto) {
         store().edit { preferences ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
@@ -121,7 +121,7 @@ class TraktAuthService @Inject constructor(
         return BuildConfig.TRAKT_CLIENT_ID.isNotBlank() && BuildConfig.TRAKT_CLIENT_SECRET.isNotBlank()
     }
 
-    suspend fun getCurrentAuthState(): TraktAuthState = traktAuthDataStore.state.first()
+    suspend fun getCurrentAuthState(): TraktAuthState = traktAuthDataStore.getCurrentState()
 
     suspend fun startDeviceAuth(): Result<TraktDeviceCodeResponseDto> {
         if (!hasRequiredCredentials()) {

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -339,6 +339,21 @@ class TraktProgressService @Inject constructor(
         refreshSignals.emit(Unit)
     }
 
+    /** Full cache invalidation + refresh. Called on Activity cold-start (warm process). */
+    suspend fun invalidateAndRefresh() {
+        trace("invalidateAndRefresh: resetting fingerprints and caches")
+        lastKnownActivityFingerprint = null
+        lastKnownMoviesWatchedAt = null
+        lastKnownEpisodeActivityFingerprint = null
+        watchedMoviesStale = true
+        watchedShowSeedsStale = true
+        cachedMoviesPlayback = null
+        cachedEpisodesPlayback = null
+        forceRefreshUntilMs = System.currentTimeMillis() + 30_000L
+        lastManualRefreshSignalMs = 0L
+        refreshSignals.emit(Unit)
+    }
+
     suspend fun getCachedStats(forceRefresh: Boolean = false): TraktCachedStats? {
         val now = System.currentTimeMillis()
         cacheMutex.withLock {
@@ -753,6 +768,13 @@ class TraktProgressService @Inject constructor(
                 invalidateEpisodeProgressCache(effectiveProgress.contentId)
             }
             updateWatchedShowSeedOptimistically(effectiveProgress)
+        }
+        // Invalidate playback cache and remove completed item from CW immediately.
+        cachedMoviesPlayback = null
+        cachedEpisodesPlayback = null
+        val completedKey = progressKey(effectiveProgress)
+        remoteProgress.update { current ->
+            current.filter { progressKey(it) != completedKey }
         }
         refreshNow()
     }

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -1,15 +1,19 @@
 package com.nuvio.tv.ui.components.posteroptions
 
 import android.util.Log
+import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.WatchedSeriesStateHolder
 import com.nuvio.tv.data.repository.parseContentIds
 import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.repository.LibraryRepository
+import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -38,6 +42,8 @@ class PosterOptionsController @Inject constructor(
     @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val libraryRepository: LibraryRepository,
     private val watchProgressRepository: WatchProgressRepository,
+    private val metaRepository: MetaRepository,
+    private val watchedSeriesStateHolder: WatchedSeriesStateHolder,
     private val tmdbService: TmdbService
 ) {
     private val _state = MutableStateFlow(PosterOptionsState())
@@ -96,10 +102,20 @@ class PosterOptionsController @Inject constructor(
                 if (item == null) {
                     flowOf(false to false)
                 } else {
-                    combine(
-                        libraryRepository.isInLibrary(item.id, item.apiType),
-                        watchProgressRepository.isWatched(item.id, videoId = item.imdbId)
-                    ) { lib, watched -> lib to watched }
+                    val isSeries = item.apiType.equals("series", ignoreCase = true) ||
+                        item.apiType.equals("tv", ignoreCase = true) ||
+                        item.apiType.equals("anime", ignoreCase = true)
+                    if (isSeries) {
+                        combine(
+                            libraryRepository.isInLibrary(item.id, item.apiType),
+                            watchedSeriesStateHolder.fullyWatchedSeriesIds
+                        ) { lib, watchedIds -> lib to (item.id in watchedIds) }
+                    } else {
+                        combine(
+                            libraryRepository.isInLibrary(item.id, item.apiType),
+                            watchProgressRepository.isWatched(item.id, videoId = item.imdbId)
+                        ) { lib, watched -> lib to watched }
+                    }
                 }
             }
             .onEach { (isInLibrary, isWatched) ->
@@ -118,12 +134,19 @@ class PosterOptionsController @Inject constructor(
         showJob?.cancel()
         showJob = launchScope.launch {
             val canonical = canonicalize(item)
+            val isSeries = canonical.apiType.equals("series", ignoreCase = true) ||
+                canonical.apiType.equals("tv", ignoreCase = true) ||
+                canonical.apiType.equals("anime", ignoreCase = true)
             val initialIsInLibrary = runCatching {
                 libraryRepository.isInLibrary(canonical.id, canonical.apiType).first()
             }.getOrDefault(false)
-            val initialIsWatched = runCatching {
-                watchProgressRepository.isWatched(canonical.id, videoId = canonical.imdbId).first()
-            }.getOrDefault(false)
+            val initialIsWatched = if (isSeries) {
+                canonical.id in watchedSeriesStateHolder.fullyWatchedSeriesIds.value
+            } else {
+                runCatching {
+                    watchProgressRepository.isWatched(canonical.id, videoId = canonical.imdbId).first()
+                }.getOrDefault(false)
+            }
 
             _state.update { current ->
                 current.copy(
@@ -143,7 +166,8 @@ class PosterOptionsController @Inject constructor(
         if (item.id.startsWith("tt", ignoreCase = false)) return item
         val tmdbNumber = parseContentIds(item.id).tmdb ?: item.id.toIntOrNull() ?: return item
         val mediaType = if (item.apiType.equals("series", ignoreCase = true) ||
-            item.apiType.equals("tv", ignoreCase = true)
+            item.apiType.equals("tv", ignoreCase = true) ||
+            item.apiType.equals("anime", ignoreCase = true)
         ) "tv" else "movie"
         val imdb = runCatching { tmdbService.tmdbToImdb(tmdbNumber, mediaType) }.getOrNull()
         return if (!imdb.isNullOrBlank()) item.copy(id = imdb) else item
@@ -324,6 +348,98 @@ class PosterOptionsController @Inject constructor(
             }
             _state.update { it.copy(isWatchedPending = false) }
         }
+    }
+
+    fun toggleSeriesWatched() {
+        val state = _state.value
+        val item = state.target ?: return
+        val isSeries = item.apiType.equals("series", ignoreCase = true) ||
+            item.apiType.equals("tv", ignoreCase = true) ||
+            item.apiType.equals("anime", ignoreCase = true)
+        if (!isSeries) return
+        if (state.isWatchedPending) return
+        val scope = this.scope ?: return
+
+        val currentlyWatched = state.isWatched
+
+        // Optimistic UI update — badge changes immediately
+        val currentIds = watchedSeriesStateHolder.fullyWatchedSeriesIds.value
+        val optimisticIds = if (currentlyWatched) currentIds - item.id else currentIds + item.id
+        watchedSeriesStateHolder.update(optimisticIds)
+
+        _state.update { it.copy(isWatchedPending = true) }
+        scope.launch {
+            val canonical = ensureCanonical() ?: return@launch
+            runCatching {
+                if (currentlyWatched) {
+                    unmarkSeriesWatched(canonical)
+                } else {
+                    markSeriesWatched(canonical)
+                }
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to toggle series watched for ${canonical.id}: ${error.message}")
+                // Revert optimistic update on failure
+                watchedSeriesStateHolder.update(currentIds)
+            }
+            _state.update { it.copy(isWatchedPending = false) }
+        }
+    }
+
+    private suspend fun markSeriesWatched(item: MetaPreview) {
+        val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
+        if (episodes.isEmpty()) {
+            watchProgressRepository.markAsCompleted(buildCompletedMovieProgress(item))
+            return
+        }
+
+        val progressList = episodes.map { video ->
+            WatchProgress(
+                contentId = item.id,
+                contentType = item.apiType,
+                name = item.name,
+                poster = item.poster,
+                backdrop = item.backdropUrl,
+                logo = item.logo,
+                videoId = video.id,
+                season = video.season,
+                episode = video.episode,
+                episodeTitle = video.title,
+                position = 1L,
+                duration = 1L,
+                lastWatched = System.currentTimeMillis(),
+                progressPercent = 100f
+            )
+        }
+        watchProgressRepository.markAsCompletedBatch(progressList)
+    }
+
+    private suspend fun unmarkSeriesWatched(item: MetaPreview) {
+        val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
+        if (episodes.isEmpty()) {
+            watchProgressRepository.removeFromHistory(item.id, videoId = item.imdbId)
+            return
+        }
+
+        val episodePairs = episodes.map { it.season!! to it.episode!! }
+        watchProgressRepository.removeFromHistoryBatch(
+            contentId = item.id,
+            videoId = item.imdbId,
+            episodes = episodePairs
+        )
+    }
+
+    private suspend fun fetchSeriesEpisodes(item: MetaPreview): List<Video> {
+        val type = if (item.apiType.equals("tv", ignoreCase = true) ||
+            item.apiType.equals("anime", ignoreCase = true)
+        ) "series" else item.apiType
+        var episodes: List<Video> = emptyList()
+        metaRepository.getMetaFromPrimaryAddon(type, item.id)
+            .collect { networkResult ->
+                if (networkResult is NetworkResult.Success) {
+                    episodes = networkResult.data.videos
+                }
+            }
+        return episodes
     }
 
     private var activeListPickerInput: LibraryEntryInput? = null

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsDialog.kt
@@ -37,6 +37,7 @@ fun PosterOptionsDialog(
     isLibraryPending: Boolean,
     showManageLists: Boolean,
     isMovie: Boolean,
+    isSeries: Boolean = false,
     isWatched: Boolean,
     isWatchedPending: Boolean,
     onDismiss: () -> Unit,
@@ -90,7 +91,7 @@ fun PosterOptionsDialog(
             )
         }
 
-        if (isMovie) {
+        if (isMovie || isSeries) {
             Button(
                 onClick = onToggleWatched,
                 enabled = !isWatchedPending,
@@ -202,12 +203,17 @@ fun PosterOptionsHost(
 ) {
     val target = state.target
     if (target != null) {
+        val isMovie = target.apiType.equals("movie", ignoreCase = true)
+        val isSeries = target.apiType.equals("series", ignoreCase = true) ||
+            target.apiType.equals("tv", ignoreCase = true) ||
+            target.apiType.equals("anime", ignoreCase = true)
         PosterOptionsDialog(
             title = target.name,
             isInLibrary = state.isInLibrary,
             isLibraryPending = state.isLibraryPending,
             showManageLists = state.librarySourceMode == LibrarySourceMode.TRAKT,
-            isMovie = target.apiType.equals("movie", ignoreCase = true),
+            isMovie = isMovie,
+            isSeries = isSeries,
             isWatched = state.isWatched,
             isWatchedPending = state.isWatchedPending,
             onDismiss = { controller.dismiss() },
@@ -224,7 +230,11 @@ fun PosterOptionsHost(
                 }
             },
             onToggleWatched = {
-                controller.toggleMovieWatched()
+                if (isMovie) {
+                    controller.toggleMovieWatched()
+                } else {
+                    controller.toggleSeriesWatched()
+                }
                 controller.dismiss()
             }
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -78,7 +78,7 @@ class HomeViewModel @Inject constructor(
     internal val watchedItemsPreferences: WatchedItemsPreferences,
     internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     internal val cwEnrichmentCache: ContinueWatchingEnrichmentCache,
-    private val profileManager: com.nuvio.tv.core.profile.ProfileManager,
+    internal val profileManager: com.nuvio.tv.core.profile.ProfileManager,
     internal val tvRecommendationManager: TvRecommendationManager
 ) : ViewModel() {
     companion object {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -295,6 +295,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
             )
         }.debounce(CW_PROGRESS_DEBOUNCE_MS).collectLatest { snapshot ->
             val debug = CwDebugSession()
+            val pipelineProfileId = profileManager.activeProfileId.value
             try {
                 debug.markPhase("filter-snapshot")
                 val cycleStartMs = SystemClock.elapsedRealtime()
@@ -560,7 +561,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                     contentLanguage = item.contentLanguage
                                 )
                             }
-                            runCatching { cwEnrichmentCache.saveInProgressSnapshot(ipSnap) }
+                            runCatching {
+                                if (profileManager.activeProfileId.value == pipelineProfileId) {
+                                    cwEnrichmentCache.saveInProgressSnapshot(ipSnap)
+                                }
+                            }
                         }
                     }
                 }
@@ -918,7 +923,11 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                                 seedEpisode = info.seedEpisode, contentLanguage = info.contentLanguage
                                             )
                                         }
-                                        runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap) }
+                                        runCatching {
+                                            if (profileManager.activeProfileId.value == pipelineProfileId) {
+                                                cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap)
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1083,8 +1092,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             contentLanguage = ip.contentLanguage
                         )
                     }
-                    runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap, force = true) }
-                    runCatching { cwEnrichmentCache.saveInProgressSnapshot(ipSnap, force = true) }
+                    if (profileManager.activeProfileId.value == pipelineProfileId) {
+                        runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnap, force = true) }
+                        runCatching { cwEnrichmentCache.saveInProgressSnapshot(ipSnap, force = true) }
+                    }
                 }
 
                 // Rich metadata only runs after the final lightweight CW list is visible.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1937,7 +1937,10 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         }
         return null
     }
-    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp)
+    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp,
+        watchedEpisodes = if (layoutPreferenceDataStore.nextUpFromFurthestEpisode.first())
+            watchProgressRepository.getWatchedShowEpisodes()[progress.contentId]
+        else null)
     if (nextVideo == null) {
         debug?.recordNextUpResult(
             progress = progress,
@@ -2002,7 +2005,8 @@ private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary,
-    showUnairedNextUp: Boolean
+    showUnairedNextUp: Boolean,
+    watchedEpisodes: Set<Pair<Int, Int>>? = null
 ): CwVideoSummary? {
     val episodes = meta.videos
         .filter { video ->
@@ -2052,6 +2056,10 @@ private fun resolveNextUpVideoFromMeta(
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
+        // Skip episodes already marked as watched.
+        if (watchedEpisodes != null && video.season != null && video.episode != null) {
+            if ((video.season to video.episode) in watchedEpisodes) return@firstOrNull false
+        }
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1937,10 +1937,7 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         }
         return null
     }
-    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp,
-        watchedEpisodes = if (layoutPreferenceDataStore.nextUpFromFurthestEpisode.first())
-            watchProgressRepository.getWatchedShowEpisodes()[progress.contentId]
-        else null)
+    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp)
     if (nextVideo == null) {
         debug?.recordNextUpResult(
             progress = progress,
@@ -2005,8 +2002,7 @@ private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary,
-    showUnairedNextUp: Boolean,
-    watchedEpisodes: Set<Pair<Int, Int>>? = null
+    showUnairedNextUp: Boolean
 ): CwVideoSummary? {
     val episodes = meta.videos
         .filter { video ->
@@ -2056,10 +2052,6 @@ private fun resolveNextUpVideoFromMeta(
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
-        // Skip episodes already marked as watched.
-        if (watchedEpisodes != null && video.season != null && video.episode != null) {
-            if ((video.season to video.episode) in watchedEpisodes) return@firstOrNull false
-        }
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
@@ -287,7 +287,10 @@ fun HomeViewModel.togglePosterSeriesWatched(item: MetaPreview) {
 
 private suspend fun HomeViewModel.markSeriesWatched(item: MetaPreview) {
     val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
-    if (episodes.isEmpty()) return
+    if (episodes.isEmpty()) {
+        watchProgressRepository.markAsCompleted(buildCompletedMovieProgress(item))
+        return
+    }
 
     val progressList = episodes.map { video ->
         WatchProgress(
@@ -312,7 +315,10 @@ private suspend fun HomeViewModel.markSeriesWatched(item: MetaPreview) {
 
 private suspend fun HomeViewModel.unmarkSeriesWatched(item: MetaPreview) {
     val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
-    if (episodes.isEmpty()) return
+    if (episodes.isEmpty()) {
+        watchProgressRepository.removeFromHistory(item.id, videoId = item.imdbId)
+        return
+    }
 
     val episodePairs = episodes.map { it.season!! to it.episode!! }
     watchProgressRepository.removeFromHistoryBatch(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -531,6 +531,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                         setParameters(buildUponParameters().setPreferredTextLanguage(locale.isO3Language))
                     }
                 }
+                // Forced mode: disable ExoPlayer auto text selection; our logic handles it.
+                if (playerSettings.subtitleStyle.useForcedSubtitles) {
+                    setParameters(buildUponParameters().setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true))
+                }
                 // When forced subtitles are disabled, tell ExoPlayer to ignore
                 // SELECTION_FLAG_FORCED so it won't auto-select forced tracks.
                 if (!playerSettings.subtitleStyle.useForcedSubtitles) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -565,6 +565,7 @@ internal fun PlayerRuntimeController.persistTrackPreference() {
         },
         subtitleName = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Internal)?.track?.name,
         subtitleTrackId = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Internal)?.track?.trackId,
+        subtitleIsForced = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Internal)?.track?.isForcedHint,
         addonSubtitleId = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Addon)?.id,
         addonSubtitleUrl = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Addon)?.url,
         addonSubtitleAddonName = (subtitle as? PlayerRuntimeController.RememberedSubtitleSelection.Addon)?.addonName,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -1679,6 +1679,14 @@ internal fun PlayerRuntimeController.tryAutoSelectPreferredSubtitleFromAvailable
             return
         }
         if (state.isLoadingAddonSubtitles) {
+            // Disable any non-forced subtitle ExoPlayer auto-selected while we wait.
+            val hasNonForcedSubtitleActive = state.selectedSubtitleTrackIndex >= 0 &&
+                state.subtitleTracks.getOrNull(state.selectedSubtitleTrackIndex)?.isForced != true
+            if (hasNonForcedSubtitleActive) {
+                Log.d(PlayerRuntimeController.TAG, "AUTO_SUB forced: disabling non-forced subtitle while addons load")
+                disableSubtitles()
+                _uiState.update { it.copy(selectedSubtitleTrackIndex = -1) }
+            }
             Log.d(PlayerRuntimeController.TAG, "AUTO_SUB defer forced: addon subtitles still loading")
             return
         }
@@ -1866,10 +1874,16 @@ internal fun PlayerRuntimeController.applySubtitlePreferences(preferred: String,
             val userDisabledSubtitles = autoSubtitleSelected &&
                     _uiState.value.selectedSubtitleTrackIndex == -1 &&
                     _uiState.value.selectedAddonSubtitle == null
-            if (!userDisabledSubtitles) {
+            // Suppress ExoPlayer auto-select when forced mode is active —
+            // our custom logic handles track selection.
+            val useForcedSubtitles = _uiState.value.subtitleStyle.useForcedSubtitles
+            val shouldSuppressExoAutoSelect = useForcedSubtitles && !autoSubtitleSelected
+            if (!userDisabledSubtitles && !shouldSuppressExoAutoSelect) {
                 builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
             }
-            builder.setPreferredTextLanguage(preferred)
+            if (!shouldSuppressExoAutoSelect) {
+                builder.setPreferredTextLanguage(preferred)
+            }
         }
 
         // Update forced flag handling: when forced subtitles are disabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -557,19 +557,29 @@ private fun PlayerRuntimeController.findLanguageFallbackTrackIndex(
                     trackLang.startsWith("$targetLang-") ||
                     trackLang.startsWith("${targetLang}_"))
         }
-        if (langCandidates.size <= 1) {
-            langCandidates.firstOrNull() ?: -1
+
+        // If the remembered track was forced, only consider forced candidates.
+        // This prevents restoring a non-forced subtitle when the user had a forced
+        // track selected (e.g. switching episodes where the new one lacks forced subs).
+        val filteredCandidates = if (target.isForcedHint == true) {
+            langCandidates.filter { index -> tracks[index].isForced }
+        } else {
+            langCandidates
+        }
+
+        if (filteredCandidates.size <= 1) {
+            filteredCandidates.firstOrNull() ?: -1
         } else {
             // Multiple tracks with the same base language — prefer the one
             // whose detected variant matches the remembered selection.
-            langCandidates.firstOrNull { index ->
+            filteredCandidates.firstOrNull { index ->
                 val trackVariant = PlayerSubtitleUtils.detectTrackLanguageVariant(
                     language = tracks[index].language,
                     name = tracks[index].name,
                     trackId = tracks[index].trackId
                 )
                 trackVariant == targetVariant
-            } ?: langCandidates.first()
+            } ?: filteredCandidates.first()
         }
     } else {
         -1

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -65,6 +65,7 @@ class TraktViewModel @Inject constructor(
     private val traktSettingsDataStore: TraktSettingsDataStore,
     private val startupSyncService: StartupSyncService,
     private val watchedItemsPreferences: WatchedItemsPreferences,
+    private val watchProgressPreferences: com.nuvio.tv.data.local.WatchProgressPreferences,
     private val watchedItemsSyncService: WatchedItemsSyncService,
     private val watchedSeriesStateHolder: WatchedSeriesStateHolder,
     private val cwEnrichmentCache: com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache,
@@ -127,6 +128,7 @@ class TraktViewModel @Inject constructor(
             // Clear CW cache so stale items from the previous source don't flash on screen.
             cwEnrichmentCache.saveInProgressSnapshot(emptyList(), force = true)
             cwEnrichmentCache.saveNextUpSnapshot(emptyList(), force = true)
+            watchProgressPreferences.clearAll()
             if (source == WatchProgressSource.TRAKT) {
                 watchedItemsPreferences.clearAll()
                 watchedSeriesStateHolder.update(emptySet())
@@ -229,10 +231,11 @@ class TraktViewModel @Inject constructor(
             // Clear CW cache so stale Trakt items don't flash on next launch.
             cwEnrichmentCache.saveInProgressSnapshot(emptyList(), force = true)
             cwEnrichmentCache.saveNextUpSnapshot(emptyList(), force = true)
-            // Repopulate watched items from Nuvio sync now that Trakt is no
-            // longer the source of truth.
+            watchProgressPreferences.clearAll()
             watchedSeriesStateHolder.update(emptySet())
+            // Repopulate from Nuvio sync.
             repopulateWatchedItemsFromNuvioSync()
+            startupSyncService.requestSyncNow()
             _uiState.update {
                 it.copy(
                     isLoading = false,

--- a/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsControllerShowTest.kt
@@ -3,17 +3,20 @@ package com.nuvio.tv.ui.components.posteroptions
 import android.content.Context
 import android.util.Log
 import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.WatchedSeriesStateHolder
 import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.repository.LibraryRepository
+import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -106,10 +109,16 @@ class PosterOptionsControllerShowTest {
             }
             coEvery { tmdbToImdb(222, "movie") } returns "tt0000002"
         }
+        val metaRepository = mockk<MetaRepository>(relaxed = true)
+        val watchedSeriesStateHolder = mockk<WatchedSeriesStateHolder>(relaxed = true) {
+            every { fullyWatchedSeriesIds } returns MutableStateFlow(emptySet())
+        }
         val controller = PosterOptionsController(
             appContext = context,
             libraryRepository = libraryRepository,
             watchProgressRepository = watchProgressRepository,
+            metaRepository = metaRepository,
+            watchedSeriesStateHolder = watchedSeriesStateHolder,
             tmdbService = tmdbService
         )
         controller.bind(this)
@@ -141,10 +150,16 @@ class PosterOptionsControllerShowTest {
         val tmdbService = mockk<TmdbService>(relaxed = true) {
             coEvery { tmdbToImdb(12345, "movie") } returns imdbId
         }
+        val metaRepository = mockk<MetaRepository>(relaxed = true)
+        val watchedSeriesStateHolder = mockk<WatchedSeriesStateHolder>(relaxed = true) {
+            every { fullyWatchedSeriesIds } returns MutableStateFlow(emptySet())
+        }
         val controller = PosterOptionsController(
             appContext = context,
             libraryRepository = libraryRepository,
             watchProgressRepository = watchProgressRepository,
+            metaRepository = metaRepository,
+            watchedSeriesStateHolder = watchedSeriesStateHolder,
             tmdbService = tmdbService
         )
         controller.bind(this)
@@ -168,10 +183,16 @@ class PosterOptionsControllerShowTest {
             every { isWatched(any(), any(), any(), any()) } returns flowOf(isWatched)
         }
         val tmdbService = mockk<TmdbService>(relaxed = true)
+        val metaRepository = mockk<MetaRepository>(relaxed = true)
+        val watchedSeriesStateHolder = mockk<WatchedSeriesStateHolder>(relaxed = true) {
+            every { fullyWatchedSeriesIds } returns MutableStateFlow(emptySet())
+        }
         return PosterOptionsController(
             appContext = context,
             libraryRepository = libraryRepository,
             watchProgressRepository = watchProgressRepository,
+            metaRepository = metaRepository,
+            watchedSeriesStateHolder = watchedSeriesStateHolder,
             tmdbService = tmdbService
         )
     }


### PR DESCRIPTION
## Summary

Three critical bug fixes:

1. **Mark as watched from all screens** - PosterOptionsController now supports marking content as watched from any screen (not just home), including proper show-level handling.

2. **Trakt watched status stale after app restart** - When user exits with Back button and returns, watched status and CW showed stale data because TraktProgressService kept cached activity fingerprints. Now on Activity recreation we invalidate fingerprints and force a full Trakt refresh. Also removes completed items from `remoteProgress` immediately in `markAsWatched` so CW updates without waiting for the next poll.

3. **Forced subtitle track preference not remembered** - When user manually selected a forced subtitle track, the `isForced` flag wasn't persisted, so on next playback the track wasn't restored.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. Mark as watched was only functional from home screen - users on details/search/library couldn't mark content.

2. Users report items watched in Nuvio showing as unwatched after restarting the app (without force-close). Process survives `finishAndRemoveTask()`, singleton keeps stale fingerprints -> `hasActivityChanged()` returns false -> no refresh -> UI shows old state.

3. Forced subtitle selection was lost between playback sessions because `isForced` wasn't stored alongside the track preference.

## Issue or approval

Reported by user N7_Tigger on community - Trakt watched status and CW not updating without force-close.

## Reproduction steps

**Bug 1 (Mark as watched):**
1. Navigate to search/library/details screen
2. Long-press a poster -> select "Mark as watched"
3. Observe: action was unavailable or didn't work on non-home screens

**Bug 2 (Trakt sync):**
1. Watch a movie/episode to completion in Nuvio (Trakt linked, CW source = Trakt)
2. Exit app with Back button (not force-close)
3. Reopen app from launcher
4. Observe: movie still shows as unwatched, completed episode still in CW

**Bug 3 (Forced subtitles):**
1. Play content with forced subtitle tracks available
2. Manually select a forced subtitle track
3. Stop playback, play same or similar content again
4. Observe: forced track preference not restored

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No changes to CW pipeline logic, next-up resolution, or UI rendering.
- No changes to Trakt API calls or auth flow.
- `invalidateAndRefresh` only fires once per Activity creation (warm process restart), not on every resume.
- Subtitle fix limited to persisting `isForced` flag - no changes to track selection UI or matching logic.
- Mark as watched reuses existing repository methods, just wires them into PosterOptionsController for all screens.

## Testing

- TCL Android TV
- Bug 1: Long-press poster on search/library/details -> mark as watched -> verify state updates
- Bug 1: PosterOptionsControllerShowTest added for show-level marking
- Bug 2: Watch movie -> exit with Back -> reopen -> verify watched status updates without force-close
- Bug 2: Watch episode -> verify CW removes completed entry immediately and shows next-up within seconds
- Bug 2: Verify normal resume (from player/settings) still uses lightweight `refreshNow`
- Bug 3: Select forced subtitle -> stop -> replay -> verify forced track restored

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Community report: Trakt watched status and Continue Watching not updating without force-close