### PR TITLE
fix: improved focus handling in sources panel

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -68,7 +68,12 @@ internal fun StreamItem(
     requestInitialFocus: Boolean,
     isCurrentStream: Boolean = false,
     onClick: () -> Unit,
-    onUpKey: (() -> Unit)? = null
+    onUpKey: (() -> Unit)? = null,
+    onLeftKey: (() -> Unit)? = null,
+    onRightKey: (() -> Unit)? = null,
+    leftFocusRequester: FocusRequester? = null,
+    rightFocusRequester: FocusRequester? = null,
+    upFocusRequester: FocusRequester? = null
 ) {
     val context = LocalContext.current
     val streamName = remember(stream) { stream.getDisplayName() }
@@ -87,12 +92,36 @@ internal fun StreamItem(
         modifier = Modifier
             .fillMaxWidth()
             .then(if (requestInitialFocus) Modifier.focusRequester(focusRequester) else Modifier)
-            .then(if (onUpKey != null) Modifier.onKeyEvent { event ->
-                if (event.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN &&
-                    event.key == Key.DirectionUp) {
-                    onUpKey(); true
-                } else false
-            } else Modifier),
+            .focusProperties {
+                leftFocusRequester?.let { left = it }
+                rightFocusRequester?.let { right = it }
+                upFocusRequester?.let { up = it }
+            }
+            .onKeyEvent { event ->
+                if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
+
+                when (event.key) {
+                    Key.DirectionUp -> {
+                        if (onUpKey != null && upFocusRequester == null) {
+                            onUpKey()
+                            true
+                        } else false
+                    }
+                    Key.DirectionLeft -> {
+                        if (onLeftKey != null && leftFocusRequester == null) {
+                            onLeftKey()
+                            true
+                        } else false
+                    }
+                    Key.DirectionRight -> {
+                        if (onRightKey != null && rightFocusRequester == null) {
+                            onRightKey()
+                            true
+                        } else false
+                    }
+                    else -> false
+                }
+            },
         colors = CardDefaults.colors(
             containerColor = NuvioColors.BackgroundElevated,
             focusedContainerColor = NuvioColors.BackgroundElevated
@@ -219,50 +248,44 @@ internal fun AddonFilterChips(
         List(orderedNames.size + 1) { FocusRequester() }
     }
 
+    val selectedIndex = if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+    var focusedChipIndex by remember { mutableStateOf(selectedIndex) }
 
-    val selectedIndex = if (selectedAddon == null) 0 else orderedNames.indexOf(selectedAddon) + 1
-    // Track the focused chip index to handle duplicate addon names correctly.
-    var focusedChipIndex by remember { mutableStateOf(selectedIndex.coerceAtLeast(0)) }
+    // Sync focusedChipIndex if selectedAddon changes externally
     LaunchedEffect(selectedAddon, orderedNames) {
         val idx = if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
         focusedChipIndex = idx
     }
-    LaunchedEffect(selectedAddon) {
-        if (selectedIndex >= 0 && selectedIndex < focusRequesters.size) {
-            try { focusRequesters[selectedIndex].requestFocus() } catch (_: Exception) {}
-        }
-    }
 
-    var chipRowHasFocus by remember { mutableStateOf(false) }
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
+    val allOptions = remember(orderedNames) { listOf<String?>(null) + orderedNames }
 
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
         modifier = Modifier
-            .focusRestorer {
-                val idx = focusedChipIndex.coerceIn(0, focusRequesters.lastIndex)
-                focusRequesters[idx]
-            }
-            .onFocusChanged { chipRowHasFocus = it.hasFocus }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
 
-                // Throttle rapid key repeats (long-press)
                 if (event.nativeKeyEvent.repeatCount > 0) {
                     val now = android.os.SystemClock.uptimeMillis()
                     if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
                     lastKeyRepeatDispatchRef.set(now)
                 }
 
-                val allOptions = listOf<String?>(null) + orderedNames
                 val currentIdx = focusedChipIndex.coerceIn(0, allOptions.lastIndex)
                 when (event.key) {
-                    androidx.compose.ui.input.key.Key.DirectionLeft -> {
-                        if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                    Key.DirectionLeft -> {
+                        val nextIdx = if (currentIdx > 0) currentIdx - 1 else allOptions.lastIndex
+                        focusedChipIndex = nextIdx
+                        try { focusRequesters[nextIdx].requestFocus() } catch (_: Exception) {}
+                        true
                     }
-                    androidx.compose.ui.input.key.Key.DirectionRight -> {
-                        if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                    Key.DirectionRight -> {
+                        val nextIdx = if (currentIdx < allOptions.lastIndex) currentIdx + 1 else 0
+                        focusedChipIndex = nextIdx
+                        try { focusRequesters[nextIdx].requestFocus() } catch (_: Exception) {}
+                        true
                     }
                     else -> false
                 }
@@ -276,7 +299,12 @@ internal fun AddonFilterChips(
                 onClick = { onAddonSelected(null) },
                 modifier = Modifier
                     .focusRequester(focusRequesters[0])
-                    .focusProperties { canFocus = selectedAddon == null || chipRowHasFocus }
+                    .onFocusChanged { 
+                        if (it.isFocused) {
+                            focusedChipIndex = 0
+                            onAddonSelected(null)
+                        }
+                    }
             )
         }
 
@@ -290,7 +318,14 @@ internal fun AddonFilterChips(
                 status = chipStatus,
                 isSelectable = isSelectable,
                 onClick = { onAddonSelected(addon) },
-                modifier = Modifier.focusRequester(focusRequesters[i + 1])
+                modifier = Modifier
+                    .focusRequester(focusRequesters[i + 1])
+                    .onFocusChanged { 
+                        if (it.isFocused) {
+                            focusedChipIndex = i + 1
+                            onAddonSelected(addon)
+                        }
+                    }
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -36,10 +36,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import android.view.KeyEvent
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
 import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.theme.NuvioColors
@@ -75,6 +71,18 @@ internal fun StreamSourcesSidePanel(
     }
     val chipFocusRequesters = remember(orderedAddonNames.size) {
         List(orderedAddonNames.size + 1) { FocusRequester() }
+    }
+
+    LaunchedEffect(uiState.isLoadingSourceStreams, uiState.sourceFilteredStreams.size) {
+        if (!uiState.isLoadingSourceStreams) {
+            try {
+                val selectedIdx = if (uiState.sourceSelectedAddonFilter == null) 0
+                else (orderedAddonNames.indexOf(uiState.sourceSelectedAddonFilter) + 1).coerceAtLeast(0)
+                if (selectedIdx < chipFocusRequesters.size) {
+                    chipFocusRequesters[selectedIdx].requestFocus()
+                }
+            } catch (_: Exception) {}
+        }
     }
 
     Box(
@@ -143,7 +151,7 @@ internal fun StreamSourcesSidePanel(
 
             AnimatedVisibility(
                 visible = uiState.sourceChips.isNotEmpty() ||
-                    (!uiState.isLoadingSourceStreams && uiState.sourceAvailableAddons.isNotEmpty()),
+                        (!uiState.isLoadingSourceStreams && uiState.sourceAvailableAddons.isNotEmpty()),
                 enter = fadeIn(animationSpec = tween(200)),
                 exit = fadeOut(animationSpec = tween(120))
             ) {
@@ -198,7 +206,8 @@ internal fun StreamSourcesSidePanel(
                     val initialFocusStream = uiState.sourceFilteredStreams.getOrNull(currentStreamIndex)
                         ?: uiState.sourceFilteredStreams.firstOrNull()
 
-                    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
+                    val allOptions = listOf<String?>(null) + orderedAddonNames
+                    val currentIdx = allOptions.indexOf(uiState.sourceSelectedAddonFilter).coerceAtLeast(0)
 
                     LazyColumn(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -208,32 +217,7 @@ internal fun StreamSourcesSidePanel(
                             end = 8.dp,
                             bottom = 8.dp
                         ),
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .onKeyEvent { event ->
-                                if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
-
-                                // Throttle rapid key repeats (long-press)
-                                if (event.nativeKeyEvent.repeatCount > 0) {
-                                    val now = android.os.SystemClock.uptimeMillis()
-                                    if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
-                                    lastKeyRepeatDispatchRef.set(now)
-                                }
-
-                                val addons = uiState.sourceAvailableAddons
-                                if (addons.isEmpty()) return@onKeyEvent false
-                                val allOptions = listOf<String?>(null) + addons
-                                val currentIdx = allOptions.indexOf(uiState.sourceSelectedAddonFilter)
-                                when (event.key) {
-                                    Key.DirectionLeft -> {
-                                        if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
-                                    }
-                                    Key.DirectionRight -> {
-                                        if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
-                                    }
-                                    else -> false
-                                }
-                            }
+                        modifier = Modifier.fillMaxHeight()
                     ) {
                         itemsIndexed(uiState.sourceFilteredStreams, key = { index, stream ->
                             stream.stableKey(index)
@@ -244,13 +228,21 @@ internal fun StreamSourcesSidePanel(
                                 requestInitialFocus = stream == initialFocusStream,
                                 isCurrentStream = index == currentStreamIndex,
                                 onClick = { onStreamSelected(stream) },
-                                onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{
-                                    val selected = uiState.sourceSelectedAddonFilter
-                                    val idx = if (selected == null) 0 else orderedAddonNames.indexOf(selected) + 1
-                                    if (idx >= 0 && idx < chipFocusRequesters.size) {
-                                        try { chipFocusRequesters[idx].requestFocus() } catch (_: Exception) {}
+                                onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {
+                                    {
+                                        if (currentIdx >= 0 && currentIdx < chipFocusRequesters.size) {
+                                            try { chipFocusRequesters[currentIdx].requestFocus() } catch (_: Exception) {}
+                                        }
                                     }
-                                }} else null
+                                } else null,
+                                onLeftKey = {
+                                    val nextIdx = if (currentIdx > 0) currentIdx - 1 else allOptions.lastIndex
+                                    try { chipFocusRequesters[nextIdx].requestFocus() } catch (_: Exception) {}
+                                },
+                                onRightKey = {
+                                    val nextIdx = if (currentIdx < allOptions.lastIndex) currentIdx + 1 else 0
+                                    try { chipFocusRequesters[nextIdx].requestFocus() } catch (_: Exception) {}
+                                }
                             )
                         }
                     }
@@ -273,7 +265,7 @@ private fun findCurrentStreamIndex(
     if (hasUrl && hasName) {
         val bothMatch = streams.indexOfFirst { stream ->
             stream.getStreamUrl() == currentStreamUrl &&
-                stream.getDisplayName().equals(currentStreamName, ignoreCase = true)
+                    stream.getDisplayName().equals(currentStreamName, ignoreCase = true)
         }
         if (bothMatch >= 0) return bothMatch
     }


### PR DESCRIPTION
## Summary
Fixed an issue with addon chips in players source panel not releasing focus when navigating between addons.

## PR type
- [X] Critical bug fix

## Why
Was causing incorrect clicks or making it tedious to click the intended addon due to not being able to tell which was being focused.

## Issue or approval
Fixes #2108 

## Reproduction steps
1. Start a stream
2. Open the player UI
3. Open the sources side panel (Cloud button)
4. Wait for sources to finish loading
5. Navigate between addon chips (Row)

## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [X] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [X] I have read and understood `CONTRIBUTING.md`.
- [X] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [X] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [X] This PR is small, focused, and limited to one issue.
- [X] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [X] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [X] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries
Only touches `StreamSourcesSidePanel.kt` and `StreamComponents.kt`, specifically the focus handling logic for navigating between addons. It does not introduce extra UI polish or unrelated behavior tweaks.

## Testing
Tested navigating back and forth between the addon chips themselves and left/right navigation when the stream Card inside the addon is focused to ensure the new addon tab gets focused, new stream sources are shown, and previous addon chip focus is released. Tested on both virtual device and personal TV box.

## Screenshots / Video
Not a UI change

## Breaking changes
None.

## Linked issues
#2108
