### PR TITLE
fix(sync): reliable cross-device Continue Watching — prompt updates + authoritative resume

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -131,6 +131,7 @@ import com.nuvio.tv.domain.model.AuthState
 import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.ExperienceMode
 import com.nuvio.tv.domain.repository.AddonRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.ui.components.NuvioScrollDefaults
 import com.nuvio.tv.ui.components.ProfileAvatarCircle
 import com.nuvio.tv.ui.navigation.NuvioNavHost
@@ -202,6 +203,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var traktProgressService: TraktProgressService
+
+    @Inject
+    lateinit var watchProgressRepository: WatchProgressRepository
 
     @Inject
     lateinit var startupSyncService: StartupSyncService
@@ -743,6 +747,10 @@ class MainActivity : ComponentActivity() {
         super.onResume()
         if (::jankStats.isInitialized) jankStats.isTrackingEnabled = true
         startupSyncService.requestSyncNow(includeProfileSettings = false)
+        // Cheap, dedicated Nuvio Sync watch-progress pull (decoupled from the heavy startup
+        // pull's 30-min throttle) so cross-device Continue Watching refreshes on every resume.
+        // No-op when Trakt is the active source — that path is driven by the Trakt refresh below.
+        watchProgressRepository.requestForegroundSync()
         lifecycleScope.launch {
             if (isFirstResumeAfterCreate) {
                 isFirstResumeAfterCreate = false

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -599,6 +599,42 @@ class TraktProgressService @Inject constructor(
         )
     }
 
+    /**
+     * Force-fetches the freshest Trakt progress for a SINGLE title and returns it directly
+     * (not via a Flow). Used by the authoritative-resume path so a stale local snapshot can't
+     * drive playback and corrupt history on stop.
+     *
+     * Episode: forces the show's episode-progress snapshot and reads [season to episode].
+     * Movie: forces the in-progress playback list and maps the matching entry.
+     * Returns null if the title has no in-progress remote entry (caller falls back to local).
+     */
+    suspend fun refreshAndGetProgress(
+        contentId: String,
+        season: Int?,
+        episode: Int?
+    ): WatchProgress? {
+        return try {
+            if (season != null && episode != null) {
+                val snapshot = ensureEpisodeProgressSnapshot(contentId = contentId, forceRefresh = true)
+                snapshot[season to episode]
+            } else {
+                val canonical = canonicalLookupKey(contentId)
+                var match: WatchProgress? = null
+                for (item in getPlayback("movies", force = true)) {
+                    val mapped = mapPlaybackMovie(item) ?: continue
+                    if (canonicalLookupKey(mapped.contentId) == canonical) {
+                        match = mapped
+                        break
+                    }
+                }
+                match
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "refreshAndGetProgress failed for $contentId s=$season e=$episode", e)
+            null
+        }
+    }
+
     fun observeMovieWatched(contentId: String, videoId: String? = null): Flow<Boolean> {
         val rawKey = contentId.trim()
         val canonicalKey = canonicalLookupKey(rawKey)

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.sync.WatchProgressSyncService
 import com.nuvio.tv.core.sync.WatchedItemsSyncService
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
@@ -65,7 +66,17 @@ class WatchProgressRepositoryImpl @Inject constructor(
     companion object {
         private const val TAG = "WatchProgressRepo"
         private const val OPTIMISTIC_NEXT_UP_SEED_WINDOW_MS = 3 * 60_000L
-        private const val NUVIO_SYNC_PERIODIC_INTERVAL_MS = 30 * 60_000L
+        // Cheap delta-pull cadence while the app is foregrounded, so progress written on
+        // another device (phone → TV) appears without an app restart.
+        private const val NUVIO_SYNC_PERIODIC_INTERVAL_MS = 2 * 60_000L
+        // Every Nth periodic cycle, do a full reconcile pull that also clears entries deleted
+        // on another device (delta pulls can't observe deletions). ~10 min at the cadence above.
+        private const val FULL_RECONCILE_EVERY_N = 5
+        // Cap on exponential backoff when periodic pulls keep failing, so a degraded backend
+        // isn't hammered every couple of minutes.
+        private const val NUVIO_SYNC_MAX_BACKOFF_MS = 10 * 60_000L
+        // Min spacing between foreground (resume-triggered) pulls so rapid resumes don't spam.
+        private const val FOREGROUND_SYNC_MIN_INTERVAL_MS = 15_000L
     }
 
     private data class EpisodeMetadata(
@@ -92,6 +103,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
     var isSyncingFromRemote = false
     var hasCompletedInitialPull = false
     var hasCompletedInitialWatchedItemsPull = false
+    private var lastForegroundPullElapsedMs = 0L
 
     private val metadataState = MutableStateFlow<Map<String, ContentMetadata>>(emptyMap())
     private val optimisticContinueWatchingUpdates = MutableSharedFlow<WatchProgress>(
@@ -103,37 +115,80 @@ class WatchProgressRepositoryImpl @Inject constructor(
     private val metadataHydrationLimit = 30
 
     init {
-        // Nuvio Sync has no recurring remote pull after startup; add one so watch progress
-        // written on other devices (phone → TV) appears without requiring an app restart.
+        // Nuvio Sync has no push channel; while the app is open we poll so watch progress
+        // written on another device (phone → TV) appears without requiring an app restart.
+        // Most cycles are a cheap delta pull; every Nth cycle does a full reconcile so entries
+        // deleted on another device also clear locally. Backs off on consecutive failures.
         syncScope.launch {
+            var cycle = 0
+            var backoffMs = NUVIO_SYNC_PERIODIC_INTERVAL_MS
             while (true) {
-                delay(NUVIO_SYNC_PERIODIC_INTERVAL_MS)
-                if (useTraktProgressFlow().first()) continue
-                if (isSyncingFromRemote || !hasCompletedInitialPull || !authManager.isAuthenticated) continue
-                // Capture profile ID at the start of the sync cycle to prevent
-                // race conditions if the user switches profiles mid-operation.
-                val profileId = profileManager.activeProfileId.value
-                val sinceLastWatched = watchProgressPreferences.getAllRawEntries(profileId)
-                    .values
-                    .maxOfOrNull { progress -> progress.lastWatched }
-                watchProgressSyncService.pullFromRemote(
-                    profileId = profileId,
-                    sinceLastWatched = sinceLastWatched
-                )
-                    .onSuccess { entries ->
-                        val hadUnsynced = watchProgressPreferences.mergeRemoteEntries(
-                            entries.toMap(),
-                            lastSuccessfulPushMs = watchProgressSyncService.lastSuccessfulPushMs,
-                            profileId = profileId,
-                            removeMissingRemoteEntries = false
-                        )
-                        Log.d(TAG, "Periodic Nuvio Sync pull: merged ${entries.size} entries for profile $profileId sinceLastWatched=$sinceLastWatched")
-                        if (hadUnsynced) {
-                            watchProgressSyncService.pushToRemote(profileId)
-                        }
-                    }
-                    .onFailure { Log.w(TAG, "Periodic Nuvio Sync pull failed", it) }
+                delay(backoffMs)
+                val reconcileRemovals = (cycle % FULL_RECONCILE_EVERY_N) == 0
+                val ok = pullWatchProgressFromRemote(reconcileRemovals)
+                cycle++
+                backoffMs = if (ok) {
+                    NUVIO_SYNC_PERIODIC_INTERVAL_MS
+                } else {
+                    (backoffMs * 2).coerceAtMost(NUVIO_SYNC_MAX_BACKOFF_MS)
+                }
             }
+        }
+    }
+
+    /**
+     * Pulls Nuvio Sync watch progress into the local store and pushes back any unsynced local
+     * entries. Returns true on success (or a guarded no-op skip), false only on a real failure
+     * so callers can back off.
+     *
+     * INVARIANT: [reconcileRemovals] == true ⇔ a FULL pull (sinceLastWatched = null). A delta
+     * pull (false) must never set removeMissingRemoteEntries=true, or every local entry outside
+     * the delta window would be deleted.
+     */
+    private suspend fun pullWatchProgressFromRemote(reconcileRemovals: Boolean): Boolean {
+        // Trakt-as-source drives its own refresh; Nuvio data would not feed the CW UI anyway.
+        if (useTraktProgressFlow().first()) return true
+        if (isSyncingFromRemote || !hasCompletedInitialPull || !authManager.isAuthenticated) return true
+        // Capture profile ID at the start so a mid-operation profile switch can't cross-pollinate.
+        val profileId = profileManager.activeProfileId.value
+        val sinceLastWatched = if (reconcileRemovals) {
+            null
+        } else {
+            watchProgressPreferences.getAllRawEntries(profileId)
+                .values
+                .maxOfOrNull { progress -> progress.lastWatched }
+        }
+        return watchProgressSyncService.pullFromRemote(
+            profileId = profileId,
+            sinceLastWatched = sinceLastWatched
+        ).fold(
+            onSuccess = { entries ->
+                val hadUnsynced = watchProgressPreferences.mergeRemoteEntries(
+                    entries.toMap(),
+                    lastSuccessfulPushMs = watchProgressSyncService.lastSuccessfulPushMs,
+                    profileId = profileId,
+                    removeMissingRemoteEntries = reconcileRemovals
+                )
+                Log.d(TAG, "Nuvio Sync pull (reconcile=$reconcileRemovals): merged ${entries.size} entries for profile $profileId sinceLastWatched=$sinceLastWatched")
+                if (hadUnsynced) {
+                    watchProgressSyncService.pushToRemote(profileId)
+                }
+                true
+            },
+            onFailure = {
+                Log.w(TAG, "Nuvio Sync pull failed (reconcile=$reconcileRemovals)", it)
+                false
+            }
+        )
+    }
+
+    override fun requestForegroundSync() {
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastForegroundPullElapsedMs < FOREGROUND_SYNC_MIN_INTERVAL_MS) return
+        lastForegroundPullElapsedMs = now
+        syncScope.launch {
+            // Full reconcile so deletions on other devices clear immediately on app open.
+            pullWatchProgressFromRemote(reconcileRemovals = true)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -445,6 +445,34 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
     }
 
+    override suspend fun getFreshestProgress(
+        contentId: String,
+        season: Int?,
+        episode: Int?,
+        timeoutMs: Long
+    ): WatchProgress? {
+        // Bounded remote fetch. Falls through to the local read on timeout/failure/skip so it
+        // never blocks playback beyond timeoutMs.
+        val direct = withTimeoutOrNull(timeoutMs) {
+            if (shouldUseTraktProgress()) {
+                traktProgressService.refreshAndGetProgress(contentId, season, episode)
+            } else {
+                // Awaited delta pull merges remote into the local store; read it below.
+                // reconcileRemovals MUST stay false here (delta-pull invariant).
+                pullWatchProgressFromRemote(reconcileRemovals = false)
+                null
+            }
+        }
+        val local = if (season != null && episode != null) {
+            getEpisodeProgress(contentId, season, episode).firstOrNull()
+        } else {
+            getProgress(contentId).firstOrNull()
+        }
+        // Prefer the freshest by lastWatched. For Trakt, `direct` reflects the forced fetch
+        // (observeAllProgress can lag it); for Nuvio, `direct` is null and `local` is post-merge.
+        return listOfNotNull(direct, local).maxByOrNull { it.lastWatched }
+    }
+
     override fun getAllEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> {
         return useTraktProgressFlow()
             .flatMapLatest { useTraktProgress ->

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -135,4 +135,12 @@ interface WatchProgressRepository {
      * Returns true if Trakt is both configured AND authenticated as the active progress source.
      */
     suspend fun isTraktProgressActive(): Boolean
+
+    /**
+     * Triggers an immediate, throttled foreground pull of Nuvio Sync watch progress
+     * (a full reconcile, so entries deleted on other devices also clear locally). No-op
+     * when Trakt is the active source (Trakt drives its own refresh). Call on app resume
+     * so cross-device Continue Watching updates appear promptly without an app restart.
+     */
+    fun requestForegroundSync()
 }

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -27,7 +27,21 @@ interface WatchProgressRepository {
      * Get watch progress for a specific episode
      */
     fun getEpisodeProgress(contentId: String, season: Int, episode: Int): Flow<WatchProgress?>
-    
+
+    /**
+     * Returns the freshest watch progress for a single title, triggering a bounded remote
+     * fetch (Trakt force-fetch / Nuvio delta pull) within [timeoutMs] before reading. On
+     * timeout/offline/unauth it falls back to the current local value, so it never blocks
+     * playback beyond the timeout. Use at play-time so the resume position is authoritative
+     * and a stale resume cannot overwrite newer cross-device progress.
+     */
+    suspend fun getFreshestProgress(
+        contentId: String,
+        season: Int? = null,
+        episode: Int? = null,
+        timeoutMs: Long = 1_800L
+    ): WatchProgress?
+
     /**
      * Get all episode progress for a series as a map of (season, episode) to progress
      */

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
@@ -114,6 +116,13 @@ fun HomeScreen(
     // Notify ViewModel of locale changes after activity recreation
     LaunchedEffect(Unit) {
         viewModel.notifyLocaleChanged()
+    }
+
+    // Refresh Continue Watching from Nuvio Sync whenever Home is (re)entered/resumed, so
+    // cross-device progress shows without waiting for the periodic pull. Throttled + no-op
+    // under Trakt in the repository.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.refreshContinueWatchingFromRemote()
     }
 
     val movieWatchedStatus = uiState.movieWatchedStatus

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -136,6 +136,15 @@ class HomeViewModel @Inject constructor(
         _scrollToTopTrigger.value++
     }
 
+    /**
+     * Pulls the freshest watch progress from Nuvio Sync so Continue Watching reflects
+     * other devices when the Home screen is (re)entered, not only on a full app resume.
+     * Throttled in the repository (15s) and a no-op when Trakt is the active source.
+     */
+    fun refreshContinueWatchingFromRemote() {
+        watchProgressRepository.requestForegroundSync()
+    }
+
     internal val _loadingCatalogs = MutableStateFlow<Set<String>>(emptySet())
     val loadingCatalogs: StateFlow<Set<String>> = _loadingCatalogs.asStateFlow()
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -486,10 +486,10 @@ class PlayerRuntimeController(
 
     init {
         // NOTE: Saved watch progress is loaded inside preparePlaybackBeforeStart()
-        // via loadSavedProgressSuspend() — NOT here.  Loading it in the init block
-        // was a fire-and-forget coroutine that raced against initializePlayer(),
-        // causing the resume seek to be silently lost when ExoPlayer's STATE_READY
-        // fired before the DB read completed.
+        // via an authoritative getFreshestProgress() fetch + applyResumeCandidate() — NOT
+        // here.  Loading it in the init block was a fire-and-forget coroutine that raced
+        // against initializePlayer(), causing the resume seek to be silently lost when
+        // ExoPlayer's STATE_READY fired before the read completed.
         observeSubtitleSettings()
         fetchMetaDetails(contentId, contentType)
         observeBlurUnwatchedEpisodes()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.domain.model.Subtitle
+import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.model.enabledAddons
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -481,34 +482,23 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
 }
 
 /**
- * Suspend variant of [loadSavedProgressFor] that completes the DB read inline
- * instead of launching a fire-and-forget coroutine.
+ * Applies an authoritatively-fetched resume candidate (see
+ * [WatchProgressRepository.getFreshestProgress]) to [pendingResumeProgress].
  *
  * This MUST be called **before** [initializePlayer] inside [preparePlaybackBeforeStart]
  * so that [pendingResumeProgress] is guaranteed to be set by the time ExoPlayer's
- * `STATE_READY` callback fires.  The fire-and-forget version races against the
- * player lifecycle and can lose the resume position entirely.
+ * `STATE_READY` callback fires.  Only an in-progress entry becomes a resume point; a
+ * completed or null candidate leaves [pendingResumeProgress] null (playback starts at 0).
  */
-internal suspend fun PlayerRuntimeController.loadSavedProgressSuspend(season: Int?, episode: Int?) {
-    if (contentId == null) return
-
-    pendingResumeProgress = null
-    val progress = if (season != null && episode != null) {
-        watchProgressRepository.getEpisodeProgress(contentId, season, episode).firstOrNull()
-    } else {
-        watchProgressRepository.getProgress(contentId).firstOrNull()
-    }
-
-    progress?.let { saved ->
-        if (saved.isInProgress()) {
-            pendingResumeProgress = saved
-            Log.d(
-                PlayerRuntimeController.TAG,
-                "loadSavedProgressSuspend: set pendingResumeProgress " +
-                    "position=${saved.position} duration=${saved.duration} " +
-                    "percent=${saved.progressPercent} S${season}E${episode}"
-            )
-        }
+internal fun PlayerRuntimeController.applyResumeCandidate(saved: WatchProgress?) {
+    pendingResumeProgress = saved?.takeIf { it.isInProgress() }
+    pendingResumeProgress?.let {
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "applyResumeCandidate: set pendingResumeProgress " +
+                "position=${it.position} duration=${it.duration} " +
+                "percent=${it.progressPercent} S${it.season}E${it.episode}"
+        )
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -23,6 +24,19 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
     traktMappingJob?.cancel()
     traktMappingJob = scope.launch {
         warmTraktEpisodeMappingForCurrentPlayback()
+    }
+
+    // Authoritative resume: kick off a bounded remote fetch for THIS title now so it overlaps
+    // the scrobble/track-pref preparation below, then await it before initializePlayer().
+    // This prevents resuming from a stale local position (which, on stop, would overwrite
+    // newer cross-device progress). Falls back to the local value on timeout/offline.
+    val resumeContentId = contentId
+    val freshestProgressDeferred = if (loadSavedProgress && resumeContentId != null) {
+        scope.async {
+            watchProgressRepository.getFreshestProgress(resumeContentId, currentSeason, currentEpisode)
+        }
+    } else {
+        null
     }
 
     playbackPreparationJob = scope.launch {
@@ -71,13 +85,13 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
                     "subtitle=${persistedTrackPreference?.subtitle?.javaClass?.simpleName ?: "none"}"
             )
         }
-        // Load saved watch progress BEFORE player init.
+        // Apply the authoritative resume candidate BEFORE player init.
         // This eliminates the race condition where ExoPlayer's STATE_READY
-        // callback fired before the DB read completed, causing the resume
+        // callback fired before the read completed, causing the resume
         // seek to be silently skipped — the player would start from 0:00
         // or hang in buffering after a late seek.
         if (loadSavedProgress) {
-            loadSavedProgressSuspend(currentSeason, currentEpisode)
+            applyResumeCandidate(freshestProgressDeferred?.await())
         }
         initializePlayer(url, headers)
     }


### PR DESCRIPTION
## Summary

Makes cross-device Continue Watching reliable in **Nuvio Sync** mode, in two parts:

1. **Prompt cross-device updates (regression fix).** `e24a04ea` raised `FORCE_RESYNC_MIN_INTERVAL_MS` from 60s to 30 min, throttling the resume-triggered pull (`MainActivity.onResume` → `StartupSyncService.requestSyncNow`); the only other Nuvio pull was a 30-minute loop, so progress from another device took up to ~30 min to appear, and deletions never reconciled while the app stayed open. Fixed by decoupling a cheap watch-progress pull from the heavy startup pull (foreground pull on resume + 2-min delta / ~10-min full-reconcile periodic pull with backoff), plus an on-focus refresh of the Home screen.

2. **Authoritative resume (data-corruption fix).** The resume position was read from the local store, which lags the backend. Tapping a stale Continue Watching entry resumed from an old position; on stop it wrote `{old position, lastWatched=now}`, which wins the last-write-wins merge and **overwrote newer progress on every device**, corrupting watch history. Fixed by fetching the freshest progress for the tapped title at play-time (bounded ~1.8s; Trakt force-fetch / Nuvio delta pull; falls back to local on timeout — never blocks playback) and resuming from that.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Watch progress made on one device could take up to ~30 minutes to reach another, and—worse—resuming a stale entry silently overwrote newer progress everywhere. Both break the core cross-device Continue Watching contract.

## Issue or approval

Fixes #2129. Related: #1194 (cross-device resume).

## Reproduction steps

Sync mode = Nuvio Sync (not Trakt); same account on two devices (e.g. phone + Android TV).

- **Latency:** watch a title a few minutes on the phone; with the TV app open, the TV's Continue Watching does not update for up to ~30 min, and resuming the app doesn't refresh it.
- **Corruption:** the TV holds an older position for a title; watch it further on the phone; tap it on the TV before the list refreshes → it resumes from the stale TV position and, on stop, overwrites the phone's newer progress.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy (critical bug fixes).
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

Unchanged: the heavy startup pull's 30-min throttle, the Trakt refresh path (the new foreground/resume pulls are no-ops when Trakt is the active source), Trakt scrobble, and `mergeRemoteEntries` conflict-resolution semantics. One additive repository method (`getFreshestProgress`); no UI, dependency, or schema changes.

## Testing

- Built `:app:assembleFullDebug` (JDK 17); installed the universal debug APK on a Fire TV Stick 4K Max (Android 9), same Nuvio account as a phone.
- Latency fix: confirmed the TV's Continue Watching updates while the app stays open and on resume.
- Authoritative resume: with the TV holding a stale position, watched further on the phone, tapped on the TV immediately → it resumed from the phone's (fresh) position, not the stale one.
- `:app:compileFullDebugKotlin` passes (no new warnings).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2129.
