### PR TITLE
0.7.0 Post Release Fixes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -528,6 +528,12 @@ public class MatroskaExtractor implements Extractor {
   private final SubtitleParser.Factory subtitleParserFactory;
   @Nullable private final DolbyVisionSampleTransformer dolbyVisionSampleTransformer;
 
+  /** Returns the Dolby Vision sample transformer, if one was provided at construction time. */
+  @Nullable
+  public DolbyVisionSampleTransformer getDolbyVisionSampleTransformer() {
+    return dolbyVisionSampleTransformer;
+  }
+
   // Temporary arrays.
   private final ParsableByteArray nalStartCode;
   private final ParsableByteArray nalLength;

--- a/app/src/main/java/com/nuvio/tv/core/server/DebridFormatterConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/DebridFormatterConfigServer.kt
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class DebridFormatterConfigServer(
@@ -69,16 +70,31 @@ class DebridFormatterConfigServer(
     }
 
     private fun serveSettings(): Response {
-        val response = DebridFormatterSettingsResponse(
-            settings = currentSettingsProvider(),
-            defaults = DebridFormatterSettings(
-                nameTemplate = DebridStreamFormatterDefaults.NAME_TEMPLATE,
-                descriptionTemplate = DebridStreamFormatterDefaults.DESCRIPTION_TEMPLATE,
-                streamPreferences = DebridStreamPreferences(),
-                streamBadgeRules = StreamBadgeRules()
-            )
+        val settings = currentSettingsProvider()
+        val defaults = DebridFormatterSettings(
+            nameTemplate = DebridStreamFormatterDefaults.NAME_TEMPLATE,
+            descriptionTemplate = DebridStreamFormatterDefaults.DESCRIPTION_TEMPLATE,
+            streamPreferences = DebridStreamPreferences(),
+            streamBadgeRules = StreamBadgeRules()
         )
-        return newFixedLengthResponse(Response.Status.OK, "application/json; charset=utf-8", gson.toJson(response))
+        val settingsBadgeJson = badgeJson.encodeToString(StreamBadgeRules.serializer(), settings.streamBadgeRules)
+        val defaultsBadgeJson = badgeJson.encodeToString(StreamBadgeRules.serializer(), defaults.streamBadgeRules)
+        // Serialize settings/defaults without streamBadgeRules, then inject the properly
+        // serialized badge rules via kotlinx.serialization to avoid Gson mangling them.
+        val settingsMap = mapOf(
+            "nameTemplate" to settings.nameTemplate,
+            "descriptionTemplate" to settings.descriptionTemplate,
+            "streamPreferences" to settings.streamPreferences
+        )
+        val defaultsMap = mapOf(
+            "nameTemplate" to defaults.nameTemplate,
+            "descriptionTemplate" to defaults.descriptionTemplate,
+            "streamPreferences" to defaults.streamPreferences
+        )
+        val settingsJson = gson.toJson(settingsMap).dropLast(1) + ""","streamBadgeRules":$settingsBadgeJson}"""
+        val defaultsJson = gson.toJson(defaultsMap).dropLast(1) + ""","streamBadgeRules":$defaultsBadgeJson}"""
+        val responseJson = """{"settings":$settingsJson,"defaults":$defaultsJson}"""
+        return newFixedLengthResponse(Response.Status.OK, "application/json; charset=utf-8", responseJson)
     }
 
     private fun handleSettingsUpdate(session: IHTTPSession): Response {
@@ -140,10 +156,11 @@ class DebridFormatterConfigServer(
             )
             val rules = currentRules.upsert(parsedImport, activate = true)
             onSettingsChanged(currentSettings.copy(streamBadgeRules = rules))
+            val rulesJson = badgeJson.encodeToString(StreamBadgeRules.serializer(), rules)
             newFixedLengthResponse(
                 Response.Status.OK,
                 "application/json; charset=utf-8",
-                gson.toJson(mapOf("status" to "imported", "streamBadgeRules" to rules))
+                """{"status":"imported","streamBadgeRules":$rulesJson}"""
             )
         } catch (error: Exception) {
             errorResponse(error.message ?: "Badge import failed.")
@@ -155,10 +172,11 @@ class DebridFormatterConfigServer(
         val currentSettings = currentSettingsProvider()
         val rules = currentSettings.streamBadgeRules.normalized().setActiveSource(sourceUrl)
         onSettingsChanged(currentSettings.copy(streamBadgeRules = rules))
+        val rulesJson = badgeJson.encodeToString(StreamBadgeRules.serializer(), rules)
         return newFixedLengthResponse(
             Response.Status.OK,
             "application/json; charset=utf-8",
-            gson.toJson(mapOf("status" to "saved", "streamBadgeRules" to rules))
+            """{"status":"saved","streamBadgeRules":$rulesJson}"""
         )
     }
 
@@ -167,10 +185,11 @@ class DebridFormatterConfigServer(
         val currentSettings = currentSettingsProvider()
         val rules = currentSettings.streamBadgeRules.normalized().removeSource(sourceUrl)
         onSettingsChanged(currentSettings.copy(streamBadgeRules = rules))
+        val rulesJson = badgeJson.encodeToString(StreamBadgeRules.serializer(), rules)
         return newFixedLengthResponse(
             Response.Status.OK,
             "application/json; charset=utf-8",
-            gson.toJson(mapOf("status" to "deleted", "streamBadgeRules" to rules))
+            """{"status":"deleted","streamBadgeRules":$rulesJson}"""
         )
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
@@ -98,14 +98,21 @@ private fun ExtractorsFactory.withAssMkvSupportCompat(
     subtitleParserFactory: SubtitleParser.Factory,
     assHandler: AssHandler
 ): ExtractorsFactory {
+    val delegate = this
     return ExtractorsFactory {
-        val extractors = createExtractors()
+        val extractors = delegate.createExtractors()
         extractors.forEachIndexed { index, extractor ->
-            // The DV7 factory swaps in a vendored MatroskaExtractor for DV conversion.
-            // When DV conversion is active (DvMatroskaExtractor), keep it — DV color
-            // correctness takes priority over libass ASS/SSA rendering for MKV.
-            // ASS subtitles will still render via the fallback text renderer.
+            // Stock MatroskaExtractor: replace with ASS-aware variant for libass support.
             if (extractor is MatroskaExtractor) {
+                extractors[index] = AssMatroskaExtractor(subtitleParserFactory, assHandler)
+            }
+            // The DV7 factory swaps in a vendored DvMatroskaExtractor for DV conversion.
+            // AssMatroskaExtractor extends stock MatroskaExtractor and cannot handle DV7
+            // BlockAdditional RPU, but it IS required for libass ASS/SSA rendering.
+            // Replace DvMatroskaExtractor with AssMatroskaExtractor so that libass works.
+            // For actual DV content, maybeAdjustLibassPipelineForTracks will detect the DV
+            // video track and rebuild the player without libass, restoring DvMatroskaExtractor.
+            if (extractor is DvMatroskaExtractor) {
                 extractors[index] = AssMatroskaExtractor(subtitleParserFactory, assHandler)
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -901,7 +901,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                             startWatchProgressSaving()
                             scheduleHideControls()
                             tryShowParentalGuide()
-                            //  emitScrobbleStart()
+                            emitScrobbleStart()
                         } else {
                             if (userPausedManually) schedulePauseOverlay() else cancelPauseOverlay()
                             stopProgressUpdates()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -27,21 +27,10 @@ internal data class SubtitleFetchRequest(
 internal fun PlayerRuntimeController.buildSubtitleFetchRequest(): SubtitleFetchRequest? {
     val id = contentId ?: return null
     val type = contentType ?: return null
-    val baseId = id.split(":").firstOrNull() ?: id
-    val normalizedType = type.lowercase()
-    val videoId = if (
-        (normalizedType == "series" || normalizedType == "tv") &&
-        currentSeason != null &&
-        currentEpisode != null
-    ) {
-        "$baseId:$currentSeason:$currentEpisode"
-    } else {
-        null
-    }
     return SubtitleFetchRequest(
         type = type.lowercase(),
-        id = baseId,
-        videoId = videoId
+        id = id,
+        videoId = currentVideoId
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -394,14 +394,14 @@ internal fun PlayerRuntimeController.maybeAdjustLibassPipelineForTracks(tracks: 
     if (hasAssSsaTrack) {
         hasDetectedAssSsaTrackForCurrentStream = true
     }
-    // Don't rebuild just to drop libass, except when it's holding the MKV extractor on a DV7
-    // file with no ASS track and blocking conversion; then drop it so the DV extractor runs.
+    // Don't rebuild just to drop libass, except when it's holding the MKV extractor on a DV
+    // file and blocking conversion; then drop it so the DV extractor runs.
     val desiredUseLibass = requestedUseLibassByUser && hasDetectedAssSsaTrackForCurrentStream
     if (desiredUseLibass == activePlayerUsesLibass) return
     if (!desiredUseLibass) {
         val libassBlockingDvConvert = activePlayerUsesLibass &&
                 isExperimentalDv7ToDv81ActiveForCurrentPlayback &&
-                tracks.hasDolbyVisionProfile7VideoTrack()
+                tracks.hasDolbyVisionConvertibleVideoTrack()
         if (!libassBlockingDvConvert) return
     }
 
@@ -456,6 +456,20 @@ private fun Tracks.hasDolbyVisionProfile7VideoTrack(): Boolean {
         for (index in 0 until trackGroup.length) {
             val codec = trackGroup.getTrackFormat(index).codecs?.lowercase(Locale.US).orEmpty()
             if (DV_PROFILE_7_CODEC.containsMatchIn(codec)) return true
+        }
+    }
+    return false
+}
+
+// Profiles that the DolbyVisionExtractorsFactory actually converts (7 always, 5 when enabled).
+private val DV_CONVERTIBLE_CODEC = Regex("^(dvhe|dvh1|dvav|dva1)\\.0?[57]\\.")
+
+private fun Tracks.hasDolbyVisionConvertibleVideoTrack(): Boolean {
+    groups.forEach { trackGroup ->
+        if (trackGroup.type != C.TRACK_TYPE_VIDEO) return@forEach
+        for (index in 0 until trackGroup.length) {
+            val codec = trackGroup.getTrackFormat(index).codecs?.lowercase(Locale.US).orEmpty()
+            if (DV_CONVERTIBLE_CODEC.containsMatchIn(codec)) return true
         }
     }
     return false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -131,9 +131,7 @@ internal fun StreamItem(
                     Text(
                         text = streamName,
                         style = MaterialTheme.typography.titleMedium,
-                        color = NuvioColors.TextPrimary,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                        color = NuvioColors.TextPrimary
                     )
 
                     if (isCurrentStream) {
@@ -157,9 +155,7 @@ internal fun StreamItem(
                         Text(
                             text = description,
                             style = MaterialTheme.typography.bodySmall,
-                            color = NuvioTheme.extendedColors.textSecondary,
-                            maxLines = 3,
-                            overflow = TextOverflow.Ellipsis
+                            color = NuvioTheme.extendedColors.textSecondary
                         )
                     }
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsViewModel.kt
@@ -113,6 +113,12 @@ class DebridSettingsViewModel @Inject constructor(
                 )
             },
             onSettingsChanged = { settings ->
+                _uiState.update { it.copy(
+                    streamNameTemplate = settings.nameTemplate,
+                    streamDescriptionTemplate = settings.descriptionTemplate,
+                    streamPreferences = settings.streamPreferences,
+                    streamBadgeRules = settings.streamBadgeRules
+                ) }
                 viewModelScope.launch {
                     dataStore.setStreamTemplates(
                         nameTemplate = settings.nameTemplate,


### PR DESCRIPTION
## Summary

Fix multiple regressions introduced by #2106 (DV7 PR) and one debrid web editor bug:

1. Trakt scrobbling - emitScrobbleStart() was commented out in ExoPlayer's onIsPlayingChanged listener
2. Libass + DV7 conflict - DolbyVisionExtractorsFactory unconditionally replaced MatroskaExtractor, breaking libass for all MKV content
3. Subtitle fetch videoId - buildSubtitleFetchRequest() incorrectly split contentId and reconstructed videoId instead of passing currentVideoId directly
4. Stream description truncation - player source side panel still had maxLines/overflow (missed in eb8e8390b)
5. Debrid formatter badge URL import - Gson failed to serialize @Serializable StreamBadgeRules correctly, causing web UI to show empty imports and save to wipe data

## PR type

- [x] Critical bug fix

## Why

Users reported Trakt scrobbling stopped working on Android TV since 0.7.0. Libass ASS/SSA subtitle rendering broke for all MKV when DV conversion was active. Addon subtitle fetching sent wrong videoId (e.g. mal:1:1 instead of mal:60371:1). Badge URL import in debrid web editor appeared to succeed but data was lost on save.

## Issue or approval

Fixes regressions from #2106. User reports from Discord and Reddit confirm Trakt regression. Libass and subtitle fetch bugs confirmed by maintainer testing and Discord users. Badge URL bug reported on Discord.

## Reproduction steps

1. Trakt: Play any content on Android TV with Trakt connected -> "Now Playing" never appears on Trakt
2. Libass: Enable DV5->DV8 or DV7 conversion + libass -> play non-DV MKV with ASS subtitles -> no subtitles rendered
3. Subtitle fetch: Play anime with mal: prefix contentId (e.g. mal:60371) -> addon subtitle request goes to mal:1:1 instead of mal:60371:1
4. Badge URL: Open debrid formatter web editor -> import badge URL -> shows "No badge URLs imported" despite success message -> click Save -> import is wiped

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression
- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- DV7/DV5 conversion logic itself is not changed - only the interaction with libass pipeline
- No changes to Trakt API calls or auth - only re-enabling the scrobble start trigger
- Stream description fix is cosmetic only (removal of maxLines), matching the existing fix in StreamScreen.kt

## Testing

- Trakt: Verified emitScrobbleStart() fires on playback start via logcat (scrobble appears on Trakt website)
- Libass: Tested anime MKV with embedded ASS subs + DV5->DV8 enabled -> ASS renders via libass, DV5 content still converts correctly (pipeline switch confirmed in logs)
- Subtitle fetch: Confirmed correct videoId (mal:60371:1) in logcat after fix
- Badge URL: Import -> UI shows "1/3 URLs, X active badges" -> Save -> reload page -> data persists
- Stream description: Player source side panel shows full description without truncation

## Screenshots / Video

Not a UI change (except stream description truncation fix which matches existing behavior in StreamScreen.kt).

## Breaking changes

None.

## Linked issues

Fixes regressions from #2106.
