### PR TITLE
fix(tv): refresh Continue Watching launcher channel reliably

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -207,6 +207,9 @@ class MainActivity : ComponentActivity() {
     lateinit var startupSyncService: StartupSyncService
 
     @Inject
+    lateinit var androidTvChannelSyncService: com.nuvio.tv.core.sync.androidtv.AndroidTvChannelSyncService
+
+    @Inject
     lateinit var profileSettingsSyncService: ProfileSettingsSyncService
 
     @Inject
@@ -761,6 +764,14 @@ class MainActivity : ComponentActivity() {
     override fun onStart() {
         super.onStart()
         profileSettingsSyncService.requestForegroundPull()
+        androidTvChannelSyncService.onForegroundChanged(true)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // App going to background (e.g. user returning to the launcher): reconcile the
+        // Continue Watching channel once so Projectivy repaints it with fresh progress.
+        androidTvChannelSyncService.onForegroundChanged(false)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
@@ -125,17 +125,22 @@ class AndroidTvChannelManager @Inject constructor(
                 val values = buildProgramValues(progress, channelId, index, key)
                 val existingRow = existing[key]
                 if (existingRow != null) {
-                    // Delete + re-insert instead of UPDATE: launchers (e.g. Projectivy) only
-                    // re-render tiles when a new row ID appears; UPDATE to an existing row is
-                    // typically ignored by the launcher's display cache.
-                    context.contentResolver.delete(
-                        TvContractCompat.buildPreviewProgramUri(existingRow), null, null
+                    // UPDATE the existing program row in place — keeping its row ID stable.
+                    // This mirrors the canonical androidx PreviewChannelHelper.updatePreviewProgram
+                    // approach (which Stremio uses and which launchers like Projectivy repaint
+                    // on). The previous delete+re-insert of every program on every reconcile
+                    // churned the provider and left launchers showing a stale cached view until
+                    // the channel's visibility was toggled. buildProgramValues() explicitly nulls
+                    // absent columns, so updates don't leave stale artwork/position behind.
+                    context.contentResolver.update(
+                        TvContractCompat.buildPreviewProgramUri(existingRow), values, null, null
+                    )
+                } else {
+                    context.contentResolver.insert(
+                        TvContractCompat.PreviewPrograms.CONTENT_URI, values
                     )
                 }
-                context.contentResolver.insert(
-                    TvContractCompat.PreviewPrograms.CONTENT_URI, values
-                )
-                Log.d(TAG, "${if (existingRow != null) "Refreshed" else "Inserted"} program key=$key pos=${values.getAsInteger("last_playback_position_millis")} dur=${values.getAsInteger("duration_millis")} pct=${progress.progressPercent}")
+                Log.d(TAG, "${if (existingRow != null) "Updated" else "Inserted"} program key=$key pos=${values.getAsInteger("last_playback_position_millis")} dur=${values.getAsInteger("duration_millis")} pct=${progress.progressPercent}")
             }
         }.onFailure { Log.w(TAG, "reconcile failed", it) }
     }

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelSyncService.kt
@@ -49,6 +49,22 @@ class AndroidTvChannelSyncService @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    // The launcher channel is only visible while the app is in the background. Reconciling on
+    // every in-playback cache bump (~10s) thrashes the TvProvider and stops launchers like
+    // Projectivy from repainting. We instead reconcile once when the app goes to background
+    // (user returns to the launcher) — see [onForegroundChanged].
+    @Volatile private var appInForeground = false
+
+    /** Called from the host Activity's onStart/onStop. On background we reconcile once so the
+     *  channel reflects the latest watch progress exactly as the launcher regains foreground. */
+    fun onForegroundChanged(foreground: Boolean) {
+        val wasForeground = appInForeground
+        appInForeground = foreground
+        if (wasForeground && !foreground) {
+            scope.launch { reconcileFromCache() }
+        }
+    }
+
     @OptIn(FlowPreview::class)
     fun start() {
         if (!manager.isSupported()) {
@@ -56,6 +72,9 @@ class AndroidTvChannelSyncService @Inject constructor(
             return
         }
         TvChannelRefreshJobService.schedulePeriodic(context)
+
+        // Populate the channel once on startup from the current cache.
+        scope.launch { reconcileFromCache() }
 
         scope.launch {
             // Observe cache snapshot updates and settings changes to trigger reconciliation.
@@ -73,6 +92,11 @@ class AndroidTvChannelSyncService @Inject constructor(
             }
                 .debounce(DEBOUNCE_MS)
                 .collect { settings ->
+                    // Skip while the app is foregrounded — the launcher channel isn't visible
+                    // then, and reconciling on every ~10s in-playback cache bump thrashes the
+                    // provider (and stops launchers like Projectivy from repainting). The
+                    // background transition (onForegroundChanged) + periodic job cover it.
+                    if (appInForeground) return@collect
                     reconcileFromCache(settings)
                 }
         }


### PR DESCRIPTION
## Summary

Makes the Android TV "Continue Watching" preview channel refresh on its own. Previously it stayed stale in launchers (e.g. Projectivy) until the channel's visibility was manually toggled.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The launcher Continue Watching channel never updated after watching unless the user manually toggled its visibility — see #2133. Two causes:

1. `AndroidTvChannelManager.reconcile()` delete+re-inserted **every** preview program on **every** reconcile. That churn left launchers showing a stale cached view of the channel.
2. The channel reconciled on every in-playback enrichment-cache bump (~10s) while the app was foregrounded — pointless (the launcher channel isn't visible during playback) and a heavy ContentProvider thrash.

## Issue or approval

Fixes #2133.

## Reproduction steps

1. On a launcher that renders preview channels (Projectivy), enable Nuvio's Continue Watching channel.
2. Watch something in Nuvio, return to the launcher home.
3. The channel stays stale and only refreshes after toggling its visibility off/on.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy (critical bug fixes).
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

Only the launcher channel reconcile/trigger is changed. Watch-progress storage, the in-app Continue Watching UI, and the Watch Next ("Play Next") row are unchanged. No UI, dependency, or schema changes.

## Testing

- Built `:app:assembleFullDebug` (JDK 17); installed the universal debug APK on a Fire TV Stick 4K Max (Android 9) running the Projectivy launcher.
- Before: channel stale after watching, only updated on manual visibility toggle.
- After: the channel updates on its own once the app returns to the background — no toggle needed. (UPDATE-in-place mirrors what Stremio's working channel does.)
- `:app:compileFullDebugKotlin` passes.

## Screenshots / Video

Not an in-app UI change (launcher-side channel).

## Breaking changes

None.

## Linked issues

Fixes #2133.
