### PR TITLE
i18n(fr): extract Buffer & Network playback settings (batch8)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
@@ -27,6 +28,7 @@ import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.nuvio.tv.R
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.VodCacheSizeMode
 import com.nuvio.tv.ui.theme.NuvioColors
@@ -58,8 +60,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     item {
         ToggleSettingsItem(
             icon = Icons.Default.Tune,
-            title = "Custom Playback Buffers",
-            subtitle = "Override Media3's default buffering with the values below. When off, the player uses Media3's stock buffer durations and target size.",
+            title = stringResource(R.string.playback_buffer_custom),
+            subtitle = stringResource(R.string.playback_buffer_custom_sub),
             isChecked = playerSettings.bufferEngineEnabled,
             onCheckedChange = onSetBufferEngineEnabled
         )
@@ -68,7 +70,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     if (playerSettings.bufferEngineEnabled) {
         item {
             Text(
-                text = "Buffer",
+                text = stringResource(R.string.playback_buffer_header),
                 style = MaterialTheme.typography.titleMedium,
                 color = NuvioColors.TextSecondary,
                 modifier = Modifier.padding(vertical = 8.dp)
@@ -77,7 +79,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item {
             Text(
-                text = "These settings affect buffering behavior. Incorrect values may cause playback issues.",
+                text = stringResource(R.string.playback_buffer_warning),
                 style = MaterialTheme.typography.bodySmall,
                 color = Color(0xFFFF9800),
                 modifier = Modifier.padding(bottom = 8.dp)
@@ -87,8 +89,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             SliderSettingsItem(
                 icon = Icons.Default.Speed,
-                title = "Min Buffer Duration",
-                subtitle = "Minimum amount of media to buffer. The player will try to ensure at least this much content is always buffered ahead of the current playback position.",
+                title = stringResource(R.string.playback_buffer_min),
+                subtitle = stringResource(R.string.playback_buffer_min_sub),
                 value = playerSettings.bufferSettings.minBufferMs / 1000,
                 valueText = "${playerSettings.bufferSettings.minBufferMs / 1000}s",
                 minValue = 5,
@@ -103,11 +105,11 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
             val maxBufferSeconds = playerSettings.bufferSettings.maxBufferMs / 1000
             SliderSettingsItem(
                 icon = Icons.Default.Speed,
-                title = "Max Buffer Duration",
-                subtitle = "Maximum amount of media to buffer. Must be at least the minimum buffer duration. Higher values use more memory but provide smoother playback on unstable connections.",
+                title = stringResource(R.string.playback_buffer_max),
+                subtitle = stringResource(R.string.playback_buffer_max_sub),
                 value = maxBufferSeconds,
                 valueText = if (maxBufferSeconds == minBufferSeconds) {
-                    "${maxBufferSeconds}s (same as min)"
+                    stringResource(R.string.playback_buffer_value_same_as_min, maxBufferSeconds)
                 } else {
                     "${maxBufferSeconds}s"
                 },
@@ -121,8 +123,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             SliderSettingsItem(
                 icon = Icons.Default.PlayArrow,
-                title = "Initial Buffer",
-                subtitle = "How much content must be buffered before playback starts. Lower values start faster but may cause initial stuttering on slow connections.",
+                title = stringResource(R.string.playback_buffer_initial),
+                subtitle = stringResource(R.string.playback_buffer_initial_sub),
                 value = playerSettings.bufferSettings.bufferForPlaybackMs / 1000,
                 valueText = "${playerSettings.bufferSettings.bufferForPlaybackMs / 1000}s",
                 minValue = 1,
@@ -135,8 +137,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             SliderSettingsItem(
                 icon = Icons.Default.Refresh,
-                title = "Buffer After Rebuffer",
-                subtitle = "How much content to buffer after playback stalls due to buffering. Higher values reduce repeated buffering interruptions.",
+                title = stringResource(R.string.playback_buffer_after_rebuffer),
+                subtitle = stringResource(R.string.playback_buffer_after_rebuffer_sub),
                 value = playerSettings.bufferSettings.bufferForPlaybackAfterRebufferMs / 1000,
                 valueText = "${playerSettings.bufferSettings.bufferForPlaybackAfterRebufferMs / 1000}s",
                 minValue = 1,
@@ -149,8 +151,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             SliderSettingsItem(
                 icon = Icons.Default.History,
-                title = "Back Buffer Duration",
-                subtitle = "How much already-played content to keep in memory. Enables fast backward seeking without re-downloading. Set to 0 to disable and save memory.",
+                title = stringResource(R.string.playback_buffer_back),
+                subtitle = stringResource(R.string.playback_buffer_back_sub),
                 value = playerSettings.bufferSettings.backBufferDurationMs / 1000,
                 valueText = "${playerSettings.bufferSettings.backBufferDurationMs / 1000}s",
                 minValue = 0,
@@ -166,8 +168,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 val targetMb = MemoryBudget.effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
                 val reserveMb = (targetMb.toLong() * backBufferMs / maxBufferMs).toInt()
                 Text(
-                    text = "Reserves ~${reserveMb}MB on top of Target Buffer. " +
-                        "Raising Max Buffer Duration shrinks this without losing back-buffer time.",
+                    text = stringResource(R.string.playback_buffer_back_reserve, reserveMb),
                     style = MaterialTheme.typography.bodySmall,
                     color = NuvioColors.TextSecondary,
                     modifier = Modifier.padding(start = 52.dp, end = 16.dp, top = 4.dp, bottom = 8.dp)
@@ -178,8 +179,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             ToggleSettingsItem(
                 icon = Icons.Default.Tune,
-                title = "Managed Memory Budget",
-                subtitle = "Caps the buffer to a safe share of this device's memory. Turn off to set the Target Buffer Size yourself (advanced — large values can crash low-memory devices).",
+                title = stringResource(R.string.playback_buffer_managed),
+                subtitle = stringResource(R.string.playback_buffer_managed_sub),
                 isChecked = playerSettings.bufferBudgetManaged,
                 onCheckedChange = onSetBufferBudgetManaged
             )
@@ -198,8 +199,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 .coerceIn(minBufferSizeMb, maxBufferSizeMb)
             SliderSettingsItem(
                 icon = Icons.Default.Storage,
-                title = "Target Buffer Size",
-                subtitle = "Maximum RAM used for ahead-buffering. The maximum is calculated from your device's available memory (Android's per-app heap limit), so higher-RAM devices unlock larger caps automatically.",
+                title = stringResource(R.string.playback_buffer_target),
+                subtitle = stringResource(R.string.playback_buffer_target_sub),
                 value = bufferSizeMb,
                 valueText = "$bufferSizeMb MB",
                 minValue = minBufferSizeMb,
@@ -210,7 +211,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
             )
             if (budgetManaged) {
                 Text(
-                    text = "Managed by the device memory budget. Turn off Managed Memory Budget to set this.",
+                    text = stringResource(R.string.playback_buffer_target_managed_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = NuvioColors.TextSecondary,
                     modifier = Modifier.padding(start = 52.dp, end = 16.dp, top = 4.dp, bottom = 8.dp)
@@ -218,7 +219,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
             }
             if (!budgetManaged && playerSettings.allowLargeTargetBuffer && bufferSizeMb > safeMaxMb) {
                 Text(
-                    text = "Warning: above device safe limit (${safeMaxMb} MB). App may crash during playback.",
+                    text = stringResource(R.string.playback_buffer_target_warning, safeMaxMb),
                     style = MaterialTheme.typography.bodySmall,
                     color = Color(0xFFF44336),
                     modifier = Modifier.padding(start = 52.dp, end = 16.dp, top = 4.dp, bottom = 8.dp)
@@ -229,8 +230,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             ToggleSettingsItem(
                 icon = Icons.Default.Tune,
-                title = "Allow Larger Target Buffer",
-                subtitle = "Removes the device-memory cap on the Target Buffer Size slider, allowing values up to 2GB. May crash on devices with less than 2GB of RAM.",
+                title = stringResource(R.string.playback_buffer_allow_large),
+                subtitle = stringResource(R.string.playback_buffer_allow_large_sub),
                 isChecked = playerSettings.allowLargeTargetBuffer,
                 onCheckedChange = onSetAllowLargeTargetBuffer,
                 enabled = !playerSettings.bufferBudgetManaged
@@ -240,7 +241,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         // ── Disk cache (extends the in-memory back buffer) ──
         item {
             Text(
-                text = "Disk Cache",
+                text = stringResource(R.string.playback_cache_header),
                 style = MaterialTheme.typography.titleMedium,
                 color = NuvioColors.TextSecondary,
                 modifier = Modifier.padding(vertical = 8.dp)
@@ -250,8 +251,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             ToggleSettingsItem(
                 icon = Icons.Default.Storage,
-                title = "VOD Disk Cache",
-                subtitle = "Persist downloaded bytes to disk for the current stream. Extends instant seek-back beyond the in-memory back buffer and survives brief network drops. Only applies to progressive streams (no HLS/DASH).",
+                title = stringResource(R.string.playback_cache_vod),
+                subtitle = stringResource(R.string.playback_cache_vod_sub),
                 isChecked = playerSettings.vodCacheEnabled,
                 onCheckedChange = onSetVodCacheEnabled
             )
@@ -266,8 +267,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 Box(modifier = Modifier.padding(start = 32.dp)) {
                     ToggleSettingsItem(
                         icon = Icons.Default.Tune,
-                        title = "Auto Size",
-                        subtitle = "When on, the cache is sized from free disk space. Turn off to pick a size manually.",
+                        title = stringResource(R.string.playback_cache_auto_size),
+                        subtitle = stringResource(R.string.playback_cache_auto_size_sub),
                         isChecked = autoMode,
                         onCheckedChange = { enabled ->
                             onSetVodCacheSizeMode(if (enabled) VodCacheSizeMode.AUTO else VodCacheSizeMode.MANUAL)
@@ -287,8 +288,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                     )
                     SliderSettingsItem(
                         icon = Icons.Default.Storage,
-                        title = "VOD Cache Size",
-                        subtitle = "Maximum disk usage for progressive VOD cache (LRU-evicted).",
+                        title = stringResource(R.string.playback_cache_vod_size),
+                        subtitle = stringResource(R.string.playback_cache_vod_size_sub),
                         value = manualCacheMb,
                         valueText = "${manualCacheMb} MB",
                         minValue = PlayerSettings.MIN_VOD_CACHE_SIZE_MB,
@@ -305,13 +306,29 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 val freeDiskLabel = formatStorageSize(freeDiskBytes)
                 val maxManualCacheMb = resolveManualVodCacheMaxMb(freeDiskBytes)
                 val manualMode = playerSettings.vodCacheSizeMode == VodCacheSizeMode.MANUAL
+                val rangeInfo = stringResource(
+                    R.string.playback_cache_info_range,
+                    PlayerSettings.MIN_VOD_CACHE_SIZE_MB,
+                    maxManualCacheMb
+                )
+                val autoInfo = stringResource(R.string.playback_cache_info_auto)
+                val headroomInfo = stringResource(
+                    R.string.playback_cache_info_manual_headroom,
+                    VOD_CACHE_FREE_SPACE_RESERVE_MB.toInt()
+                )
+                val freeDiskInfo = stringResource(R.string.playback_cache_info_free_disk, freeDiskLabel)
+                val restartInfo = stringResource(R.string.playback_cache_info_restart)
                 val infoText = buildString {
-                    append("Range: ${PlayerSettings.MIN_VOD_CACHE_SIZE_MB}-${maxManualCacheMb} MB. ")
-                    append("Auto mode targets about 10% of free space.")
-                    append(" Manual mode keeps about ${VOD_CACHE_FREE_SPACE_RESERVE_MB}MB headroom.")
+                    append(rangeInfo)
+                    append(" ")
+                    append(autoInfo)
+                    append(" ")
+                    append(headroomInfo)
                     if (manualMode) {
-                        append(" Free disk available: $freeDiskLabel.")
-                        append(" New cache cap applies after app restart when changing between modes/sizes.")
+                        append(" ")
+                        append(freeDiskInfo)
+                        append(" ")
+                        append(restartInfo)
                     }
                 }
                 Text(
@@ -339,7 +356,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 )
             ) {
                 Text(
-                    text = "Reset to Default",
+                    text = stringResource(R.string.playback_reset_to_default),
                     style = MaterialTheme.typography.labelLarge,
                     color = NuvioColors.TextPrimary
                 )
@@ -351,8 +368,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     item {
         ToggleSettingsItem(
             icon = Icons.Default.Hub,
-            title = "Custom Network",
-            subtitle = "Use multiple parallel connections to fetch progressive streams. When off, a single connection is used.",
+            title = stringResource(R.string.playback_net_custom),
+            subtitle = stringResource(R.string.playback_net_custom_sub),
             isChecked = playerSettings.parallelNetworkEnabled,
             onCheckedChange = onSetParallelNetworkEnabled
         )
@@ -362,8 +379,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
         item {
             ToggleSettingsItem(
                 icon = Icons.Default.Wifi,
-                title = "Parallel Connections",
-                subtitle = "Use multiple connections in parallel for fetching streams. Activate when you experience buffering although your download speed is definitely more than sufficient.",
+                title = stringResource(R.string.playback_net_parallel),
+                subtitle = stringResource(R.string.playback_net_parallel_sub),
                 isChecked = playerSettings.useParallelConnections,
                 onCheckedChange = onSetUseParallelConnections
             )
@@ -373,8 +390,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
             item {
                 SliderSettingsItem(
                     icon = Icons.Default.Hub,
-                    title = "Connection Count",
-                    subtitle = "Number of parallel TCP connections. Higher values increase memory usage and throughput but with diminishing returns.",
+                    title = stringResource(R.string.playback_net_connection_count),
+                    subtitle = stringResource(R.string.playback_net_connection_count_sub),
                     value = playerSettings.parallelConnectionCount,
                     valueText = playerSettings.parallelConnectionCount.toString(),
                     minValue = MemoryBudget.MIN_CONNECTIONS,
@@ -390,8 +407,8 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 val chunkSizeMb = playerSettings.parallelChunkSizeMb.coerceAtMost(maxChunkSizeMb)
                 SliderSettingsItem(
                     icon = Icons.Default.Storage,
-                    title = "Chunk Size",
-                    subtitle = "Size of each download chunk per connection. Larger chunks reduce overhead but use more memory.",
+                    title = stringResource(R.string.playback_net_chunk_size),
+                    subtitle = stringResource(R.string.playback_net_chunk_size_sub),
                     value = chunkSizeMb,
                     valueText = "$chunkSizeMb MB",
                     minValue = MemoryBudget.MIN_CHUNK_MB,
@@ -418,7 +435,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 )
             ) {
                 Text(
-                    text = "Reset to Default",
+                    text = stringResource(R.string.playback_reset_to_default),
                     style = MaterialTheme.typography.labelLarge,
                     color = NuvioColors.TextPrimary
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -251,6 +251,8 @@ internal fun PlaybackSettingsSections(
     val strSectionAudioDesc = stringResource(R.string.playback_section_audio_desc)
     val strSectionSubtitles = stringResource(R.string.playback_section_subtitles)
     val strSectionSubtitlesDesc = stringResource(R.string.playback_section_subtitles_desc)
+    val strSectionBufferNetwork = stringResource(R.string.playback_section_buffer_network)
+    val strSectionBufferNetworkDesc = stringResource(R.string.playback_section_buffer_network_desc)
     val strSectionP2p = stringResource(R.string.settings_p2p_title)
     val strSectionP2pDesc = stringResource(R.string.settings_p2p_subtitle)
     val strHideTorrentStats = stringResource(R.string.settings_p2p_hide_stats_title)
@@ -673,8 +675,8 @@ internal fun PlaybackSettingsSections(
             playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO) {
             playbackCollapsibleSection(
                 keyPrefix = "buffer_network",
-                title = "Buffer & Network",
-                description = "How much content to keep in memory and how to fetch streams.",
+                title = strSectionBufferNetwork,
+                description = strSectionBufferNetworkDesc,
                 expanded = bufferAndNetworkExpanded,
                 onToggle = { bufferAndNetworkExpanded = !bufferAndNetworkExpanded },
                 focusRequester = bufferAndNetworkHeaderFocus,

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -735,7 +735,7 @@
     <string name="layout_preset_pill">Pilule</string>
     <string name="layout_card_width">Largeur</string>
     <string name="layout_card_radius">Rayon des coins</string>
-    <string name="layout_reset_default">Réinitialiser par défaut</string>
+    <string name="layout_reset_default">Réinitialiser les valeurs par défaut</string>
     <string name="layout_custom">Personnalisé</string>
 
 
@@ -2414,10 +2414,10 @@
     <string name="debrid_stream_max_results_count">%1$d flux</string>
     <string name="debrid_stream_sort_title">Trier les flux</string>
     <string name="debrid_stream_sort_subtitle">Choisis l’ordre des sources Direct Debrid.</string>
-    <string name="debrid_stream_sort_default">Par défaut</string>
-    <string name="debrid_stream_sort_quality">Qualité, la plus élevée d’abord</string>
-    <string name="debrid_stream_sort_size_desc">Taille, la plus grande d’abord</string>
-    <string name="debrid_stream_sort_size_asc">Taille, la plus petite d’abord</string>
+    <string name="debrid_stream_sort_default">Ordre d’origine</string>
+    <string name="debrid_stream_sort_quality">Meilleure qualité en premier</string>
+    <string name="debrid_stream_sort_size_desc">Plus gros en premier</string>
+    <string name="debrid_stream_sort_size_asc">Plus petit en premier</string>
     <string name="debrid_stream_sort_original">Ordre d’origine</string>
     <string name="debrid_stream_sort_best_quality">Meilleure qualité en premier</string>
     <string name="debrid_stream_sort_largest">Plus gros en premier</string>
@@ -2614,4 +2614,53 @@
 
     <!-- Subtitle selection: unknown language fallback -->
     <string name="subtitle_language_unknown">Inconnue</string>
+
+    <!-- Playback — Buffer & Network settings -->
+    <string name="playback_section_buffer_network">Mémoire tampon et réseau</string>
+    <string name="playback_section_buffer_network_desc">Quelle quantité de contenu garder en mémoire et comment récupérer les flux.</string>
+    <string name="playback_buffer_custom">Tampons de lecture personnalisés</string>
+    <string name="playback_buffer_custom_sub">Remplace la mise en mémoire tampon par défaut de Media3 par les valeurs ci-dessous. Quand c’est désactivé, le lecteur utilise les durées de tampon et la taille cible d’origine de Media3.</string>
+    <string name="playback_buffer_header">Mémoire tampon</string>
+    <string name="playback_buffer_warning">Ces paramètres influent sur le comportement de mise en mémoire tampon. Des valeurs incorrectes peuvent causer des problèmes de lecture.</string>
+    <string name="playback_buffer_min">Durée min. de tampon</string>
+    <string name="playback_buffer_min_sub">Quantité minimale de média à mettre en mémoire tampon. Le lecteur essaie de toujours garder au moins cette quantité de contenu en tampon, en avance sur la position de lecture actuelle.</string>
+    <string name="playback_buffer_max">Durée max. de tampon</string>
+    <string name="playback_buffer_max_sub">Quantité maximale de média à mettre en mémoire tampon. Doit être au moins égale à la durée minimale de tampon. Des valeurs plus élevées utilisent plus de mémoire mais offrent une lecture plus fluide sur les connexions instables.</string>
+    <string name="playback_buffer_value_same_as_min">%1$ds (identique au min)</string>
+    <string name="playback_buffer_initial">Tampon initial</string>
+    <string name="playback_buffer_initial_sub">Quantité de contenu à mettre en mémoire tampon avant le démarrage de la lecture. Des valeurs plus faibles démarrent plus vite mais peuvent causer des saccades initiales sur les connexions lentes.</string>
+    <string name="playback_buffer_after_rebuffer">Tampon après interruption</string>
+    <string name="playback_buffer_after_rebuffer_sub">Quantité de contenu à mettre en mémoire tampon après une interruption de la lecture due à la mise en tampon. Des valeurs plus élevées réduisent les interruptions répétées.</string>
+    <string name="playback_buffer_back">Durée du tampon arrière</string>
+    <string name="playback_buffer_back_sub">Quantité de contenu déjà lu à garder en mémoire. Permet un retour arrière rapide sans retéléchargement. Mets 0 pour désactiver et économiser de la mémoire.</string>
+    <string name="playback_buffer_back_reserve">Réserve ~%1$d Mo en plus de la taille de tampon cible. Augmenter la durée max. de tampon réduit cette réserve sans perdre de temps de tampon arrière.</string>
+    <string name="playback_buffer_managed">Budget mémoire géré</string>
+    <string name="playback_buffer_managed_sub">Limite le tampon à une part sûre de la mémoire de cet appareil. Désactive pour définir toi-même la taille de tampon cible (avancé — de grandes valeurs peuvent faire planter les appareils à faible mémoire).</string>
+    <string name="playback_buffer_target">Taille de tampon cible</string>
+    <string name="playback_buffer_target_sub">RAM maximale utilisée pour la mise en mémoire tampon anticipée. Le maximum est calculé d’après la mémoire disponible de ton appareil (la limite de tas par application d’Android), donc les appareils dotés de plus de RAM débloquent automatiquement des plafonds plus élevés.</string>
+    <string name="playback_buffer_target_managed_hint">Géré par le budget mémoire de l’appareil. Désactive «&#160;Budget mémoire géré&#160;» pour définir cette valeur.</string>
+    <string name="playback_buffer_target_warning">Attention&#160;: au-dessus de la limite sûre de l’appareil (%1$d Mo). L’application peut planter pendant la lecture.</string>
+    <string name="playback_buffer_allow_large">Autoriser un tampon cible plus grand</string>
+    <string name="playback_buffer_allow_large_sub">Supprime le plafond de mémoire de l’appareil sur le curseur de taille de tampon cible, autorisant des valeurs jusqu’à 2 Go. Peut planter sur les appareils avec moins de 2 Go de RAM.</string>
+    <string name="playback_cache_header">Cache disque</string>
+    <string name="playback_cache_vod">Cache disque VOD</string>
+    <string name="playback_cache_vod_sub">Conserve sur le disque les octets téléchargés pour le flux en cours. Étend le retour arrière instantané au-delà du tampon arrière en mémoire et survit aux brèves coupures réseau. Ne s’applique qu’aux flux progressifs (pas HLS/DASH).</string>
+    <string name="playback_cache_auto_size">Taille automatique</string>
+    <string name="playback_cache_auto_size_sub">Quand c’est activé, la taille du cache est calculée d’après l’espace disque libre. Désactive pour choisir une taille manuellement.</string>
+    <string name="playback_cache_vod_size">Taille du cache VOD</string>
+    <string name="playback_cache_vod_size_sub">Utilisation disque maximale pour le cache VOD progressif (éviction LRU).</string>
+    <string name="playback_cache_info_range">Plage&#160;: %1$d-%2$d Mo.</string>
+    <string name="playback_cache_info_auto">Le mode automatique vise environ 10&#160;% de l’espace libre.</string>
+    <string name="playback_cache_info_manual_headroom">Le mode manuel garde environ %1$d Mo de marge.</string>
+    <string name="playback_cache_info_free_disk">Espace disque libre&#160;: %1$s.</string>
+    <string name="playback_cache_info_restart">Le nouveau plafond de cache s’applique après le redémarrage de l’application lors d’un changement de mode ou de taille.</string>
+    <string name="playback_reset_to_default">Réinitialiser les valeurs par défaut</string>
+    <string name="playback_net_custom">Réseau personnalisé</string>
+    <string name="playback_net_custom_sub">Utilise plusieurs connexions parallèles pour récupérer les flux progressifs. Quand c’est désactivé, une seule connexion est utilisée.</string>
+    <string name="playback_net_parallel">Connexions parallèles</string>
+    <string name="playback_net_parallel_sub">Utilise plusieurs connexions en parallèle pour récupérer les flux. Active cette option si tu rencontres des mises en mémoire tampon alors que ta vitesse de téléchargement est largement suffisante.</string>
+    <string name="playback_net_connection_count">Nombre de connexions</string>
+    <string name="playback_net_connection_count_sub">Nombre de connexions TCP parallèles. Des valeurs plus élevées augmentent l’utilisation de la mémoire et le débit, mais avec un rendement décroissant.</string>
+    <string name="playback_net_chunk_size">Taille des blocs</string>
+    <string name="playback_net_chunk_size_sub">Taille de chaque bloc de téléchargement par connexion. Des blocs plus grands réduisent la surcharge mais utilisent plus de mémoire.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2537,4 +2537,53 @@
     <!-- Subtitle selection: unknown language fallback -->
     <string name="subtitle_language_unknown">Unknown</string>
 
+    <!-- Playback — Buffer & Network settings -->
+    <string name="playback_section_buffer_network">Buffer &amp; Network</string>
+    <string name="playback_section_buffer_network_desc">How much content to keep in memory and how to fetch streams.</string>
+    <string name="playback_buffer_custom">Custom Playback Buffers</string>
+    <string name="playback_buffer_custom_sub">Override Media3\'s default buffering with the values below. When off, the player uses Media3\'s stock buffer durations and target size.</string>
+    <string name="playback_buffer_header">Buffer</string>
+    <string name="playback_buffer_warning">These settings affect buffering behavior. Incorrect values may cause playback issues.</string>
+    <string name="playback_buffer_min">Min Buffer Duration</string>
+    <string name="playback_buffer_min_sub">Minimum amount of media to buffer. The player will try to ensure at least this much content is always buffered ahead of the current playback position.</string>
+    <string name="playback_buffer_max">Max Buffer Duration</string>
+    <string name="playback_buffer_max_sub">Maximum amount of media to buffer. Must be at least the minimum buffer duration. Higher values use more memory but provide smoother playback on unstable connections.</string>
+    <string name="playback_buffer_value_same_as_min">%1$ds (same as min)</string>
+    <string name="playback_buffer_initial">Initial Buffer</string>
+    <string name="playback_buffer_initial_sub">How much content must be buffered before playback starts. Lower values start faster but may cause initial stuttering on slow connections.</string>
+    <string name="playback_buffer_after_rebuffer">Buffer After Rebuffer</string>
+    <string name="playback_buffer_after_rebuffer_sub">How much content to buffer after playback stalls due to buffering. Higher values reduce repeated buffering interruptions.</string>
+    <string name="playback_buffer_back">Back Buffer Duration</string>
+    <string name="playback_buffer_back_sub">How much already-played content to keep in memory. Enables fast backward seeking without re-downloading. Set to 0 to disable and save memory.</string>
+    <string name="playback_buffer_back_reserve">Reserves ~%1$dMB on top of Target Buffer. Raising Max Buffer Duration shrinks this without losing back-buffer time.</string>
+    <string name="playback_buffer_managed">Managed Memory Budget</string>
+    <string name="playback_buffer_managed_sub">Caps the buffer to a safe share of this device\'s memory. Turn off to set the Target Buffer Size yourself (advanced — large values can crash low-memory devices).</string>
+    <string name="playback_buffer_target">Target Buffer Size</string>
+    <string name="playback_buffer_target_sub">Maximum RAM used for ahead-buffering. The maximum is calculated from your device\'s available memory (Android\'s per-app heap limit), so higher-RAM devices unlock larger caps automatically.</string>
+    <string name="playback_buffer_target_managed_hint">Managed by the device memory budget. Turn off Managed Memory Budget to set this.</string>
+    <string name="playback_buffer_target_warning">Warning: above device safe limit (%1$d MB). App may crash during playback.</string>
+    <string name="playback_buffer_allow_large">Allow Larger Target Buffer</string>
+    <string name="playback_buffer_allow_large_sub">Removes the device-memory cap on the Target Buffer Size slider, allowing values up to 2GB. May crash on devices with less than 2GB of RAM.</string>
+    <string name="playback_cache_header">Disk Cache</string>
+    <string name="playback_cache_vod">VOD Disk Cache</string>
+    <string name="playback_cache_vod_sub">Persist downloaded bytes to disk for the current stream. Extends instant seek-back beyond the in-memory back buffer and survives brief network drops. Only applies to progressive streams (no HLS/DASH).</string>
+    <string name="playback_cache_auto_size">Auto Size</string>
+    <string name="playback_cache_auto_size_sub">When on, the cache is sized from free disk space. Turn off to pick a size manually.</string>
+    <string name="playback_cache_vod_size">VOD Cache Size</string>
+    <string name="playback_cache_vod_size_sub">Maximum disk usage for progressive VOD cache (LRU-evicted).</string>
+    <string name="playback_cache_info_range">Range: %1$d-%2$d MB.</string>
+    <string name="playback_cache_info_auto">Auto mode targets about 10% of free space.</string>
+    <string name="playback_cache_info_manual_headroom">Manual mode keeps about %1$dMB headroom.</string>
+    <string name="playback_cache_info_free_disk">Free disk available: %1$s.</string>
+    <string name="playback_cache_info_restart">New cache cap applies after app restart when changing between modes/sizes.</string>
+    <string name="playback_reset_to_default">Reset to Default</string>
+    <string name="playback_net_custom">Custom Network</string>
+    <string name="playback_net_custom_sub">Use multiple parallel connections to fetch progressive streams. When off, a single connection is used.</string>
+    <string name="playback_net_parallel">Parallel Connections</string>
+    <string name="playback_net_parallel_sub">Use multiple connections in parallel for fetching streams. Activate when you experience buffering although your download speed is definitely more than sufficient.</string>
+    <string name="playback_net_connection_count">Connection Count</string>
+    <string name="playback_net_connection_count_sub">Number of parallel TCP connections. Higher values increase memory usage and throughput but with diminishing returns.</string>
+    <string name="playback_net_chunk_size">Chunk Size</string>
+    <string name="playback_net_chunk_size_sub">Size of each download chunk per connection. Larger chunks reduce overhead but use more memory.</string>
+
 </resources>


### PR DESCRIPTION
## Summary

Externalizes the **Buffer & Network** playback settings screen (previously hardcoded in English) and adds French translations. 47 strings moved to `res/values/strings.xml` (EN) with French in `res/values-fr/strings.xml`, following the existing `playback_*` key convention. Also harmonizes a few existing French Debrid sort / reset labels for consistency. Batch 8 of the ongoing FR localization effort (same pattern as merged PR #2111).

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

The Buffer & Network playback settings were hardcoded English string literals, so they could not be localized at all. This batch externalizes them into string resources and provides the French translation, continuing the incremental FR i18n work.

## Issue or approval

No linked issue: localization-only update (continues the FR i18n batches, e.g. merged PR #2111).

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

English text is unchanged (strings were extracted verbatim into `values/strings.xml`); only French users now see localized text instead of hardcoded English. No layout or behavior change.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to the Buffer & Network playback settings localization plus consistency fixes to existing FR Debrid sort / reset labels. No other locale files, no app logic, no layout changes.

## Testing

Built `:app:compileFullDebugKotlin` - BUILD SUCCESSFUL. Verified EN<->FR string parity (2371/2371 translatable), `xmllint` valid on both files, format placeholders preserved, UTF-8 with no mojibake. Not manually run on device (localization-only).

## Screenshots / Video

Not a UI change (localization only).

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.
