### PR TITLE
fix(player): restore background codec-crash recovery deferral

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1053,6 +1053,22 @@ internal fun PlayerRuntimeController.initializePlayer(
                         }
                         cancelStableProgressReset()
 
+                        // If the codec crashed while the app is in the background (e.g. another
+                        // app reclaimed the hardware decoder), don't run the retry chain. Each
+                        // retry just re-acquires a decoder the foreground app immediately reclaims
+                        // again, burning the retry budget and landing on an unrecoverable
+                        // ERROR_CODE_DECODING_FAILED by the time the user returns. Save the
+                        // position, free the decoder, and rebuild paused on resume instead.
+                        if (isInBackground && isRetryablePlaybackError(error)) {
+                            backgroundCrashSavedPositionMs = currentPosition.takeIf { it > 0L } ?: 0L
+                            pendingBackgroundCrashRecovery = true
+                            errorRetryJob?.cancel()
+                            errorRetryJob = scope.launch {
+                                releasePlayer(flushPlaybackState = false)
+                            }
+                            return
+                        }
+
                         // Error handlers: DV codec failures, audio decoder issues, codec state errors.
                         if (error.isDolbyVisionDecoderFailure() && !isMapDv7ToHevcActiveForCurrentPlayback) {
                             // Manual Convert-to-DV8.1 mode 2 failed to decode: try


### PR DESCRIPTION
## Summary

Restores the background codec-crash recovery deferral that PR #1563 added and the DV7 rewrite of `onPlayerError` accidentally dropped. When the hardware decoder is reclaimed by a foreground app while NuvioTV is paused in the background, the player now defers recovery to `onResume` instead of running the retry chain in the background.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

PR #1563 (Layer 2) added an early-return at the top of `onPlayerError` that, when the app is backgrounded and the error is a retryable codec error, saves the position, releases the decoder, and sets `pendingBackgroundCrashRecovery` instead of retrying. The DV7 PR (commit a24c38b4) fully rewrote `onPlayerError` and deleted that producer block. The state vars and the `resumeForLifecycle()` consumer survived but became dead code, so the retry chain runs in the background again, burns its budget re-acquiring a decoder the foreground app immediately reclaims, and lands on `ERROR_CODE_DECODING_FAILED` by the time the user returns.

## Issue or approval

Fixes #1560 (regression of the fix originally merged in #1563).

## Reproduction steps

1. Play a stream in NuvioTV (TCL C735, ExoPlayer engine, OMX hardware decoder).
2. Pause playback.
3. Switch to another app that needs a hardware decoder (e.g. Aerial Views) and leave it running ~20-30s so it keeps cycling clips.
4. Return to NuvioTV.
5. Before the fix: the player shows an `ERROR_CODE_DECODING_FAILED` screen and must be backed out and restarted manually.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Single file, +16 lines, in `onPlayerError` only. The foreground recovery chain (DV/audio fallbacks, engine failover, auto-retry) is unchanged and still runs for foreground errors. No UI, no refactor, no formatting changes. The `resumeForLifecycle()` consumer already exists and is not modified.

## Testing

Tested on-device: TCL C735 (Android 11, armeabi-v7a, OMX hardware decoder, ExoPlayer engine). Built `assembleFullDebug`, installed via `adb install -r`, reproduced the scenario above twice with Aerial Views reclaiming the decoder while backgrounded, and captured `adb logcat` (tag `PlayerViewModel`). Before: `Auto-retry 1/2` then `2/2` fire while Aerial is foreground, then the error screen on return. After: zero `Auto-retry` lines, decoder released cleanly, no error UI state, player rebuilds paused at the saved position on return across both background crashes.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1560.