### PR TITLE
fix(collections): Extend Most Voted sorting to builders sorted client-side

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolver.kt
@@ -326,7 +326,10 @@ class TmdbCollectionSourceResolver @Inject constructor(
                 compareByDescending<MetaPreview> { it.imdbRating ?: -1f }
                     .thenByDescending { it.releaseInfo ?: "" }
             )
-            TmdbCollectionSort.VOTE_COUNT_DESC.value -> this
+            TmdbCollectionSort.VOTE_COUNT_DESC.value -> sortedWith(
+                compareByDescending<MetaPreview> { it.voteCount ?: -1 }
+                    .thenByDescending { it.imdbRating ?: -1f }
+            )
             TmdbCollectionSort.RELEASE_DATE_DESC.value,
             TmdbCollectionSort.FIRST_AIR_DATE_DESC.value -> sortedByDescending { it.releaseInfo ?: "" }
             TmdbCollectionSort.POPULAR_DESC.value -> this
@@ -420,6 +423,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
                 TmdbCollectionMediaType.TV -> firstAirDate?.takeIf { it.isNotBlank() }
             },
             imdbRating = voteAverage?.toFloat(),
+            voteCount = voteCount,
             genres = emptyList()
         )
     }
@@ -450,6 +454,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
                 TmdbCollectionMediaType.TV -> firstAirDate?.takeIf { it.isNotBlank() }
             },
             imdbRating = voteAverage?.toFloat(),
+            voteCount = voteCount,
             genres = emptyList()
         )
     }

--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolver.kt
@@ -194,6 +194,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
                     releaseInfo = it.releaseDate?.take(4),
                     released = it.releaseDate?.takeIf { value -> value.isNotBlank() },
                     imdbRating = it.voteAverage?.toFloat(),
+                    voteCount = it.voteCount,
                     genres = emptyList()
                 )
             }
@@ -362,6 +363,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
             releaseInfo = (releaseDate ?: firstAirDate)?.take(4),
             released = (releaseDate ?: firstAirDate)?.takeIf { it.isNotBlank() },
             imdbRating = voteAverage?.toFloat(),
+            voteCount = voteCount,
             genres = emptyList()
         )
     }
@@ -393,6 +395,7 @@ class TmdbCollectionSourceResolver @Inject constructor(
                 TmdbCollectionMediaType.TV -> firstAirDate?.takeIf { it.isNotBlank() }
             },
             imdbRating = voteAverage?.toFloat(),
+            voteCount = voteCount,
             genres = emptyList()
         )
     }

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -653,6 +653,7 @@ data class TmdbPersonCreditCast(
     @Json(name = "first_air_date") val firstAirDate: String? = null,
     @Json(name = "character") val character: String? = null,
     @Json(name = "vote_average") val voteAverage: Double? = null,
+    @Json(name = "vote_count") val voteCount: Int? = null,
     @Json(name = "overview") val overview: String? = null,
     @Json(name = "genre_ids") val genreIds: List<Int>? = null
 )
@@ -669,6 +670,7 @@ data class TmdbPersonCreditCrew(
     @Json(name = "first_air_date") val firstAirDate: String? = null,
     @Json(name = "job") val job: String? = null,
     @Json(name = "vote_average") val voteAverage: Double? = null,
+    @Json(name = "vote_count") val voteCount: Int? = null,
     @Json(name = "overview") val overview: String? = null,
     @Json(name = "genre_ids") val genreIds: List<Int>? = null
 )

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -532,6 +532,7 @@ data class TmdbListItem(
     @Json(name = "release_date") val releaseDate: String? = null,
     @Json(name = "first_air_date") val firstAirDate: String? = null,
     @Json(name = "vote_average") val voteAverage: Double? = null,
+    @Json(name = "vote_count") val voteCount: Int? = null,
     @Json(name = "genre_ids") val genreIds: List<Int>? = null
 )
 
@@ -693,7 +694,8 @@ data class TmdbCollectionPart(
     @Json(name = "release_date") val releaseDate: String? = null,
     @Json(name = "poster_path") val posterPath: String? = null,
     @Json(name = "backdrop_path") val backdropPath: String? = null,
-    @Json(name = "vote_average") val voteAverage: Double? = null
+    @Json(name = "vote_average") val voteAverage: Double? = null,
+    @Json(name = "vote_count") val voteCount: Int? = null
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/nuvio/tv/domain/model/MetaPreview.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/MetaPreview.kt
@@ -32,7 +32,8 @@ data class MetaPreview(
     val behaviorHints: MetaBehaviorHints? = null,
     val trailers: List<MetaTrailer> = emptyList(),
     val trailerYtIds: List<String> = emptyList(),
-    val seasonCount: Int? = null
+    val seasonCount: Int? = null,
+    val voteCount: Int? = null
 ) {
     val apiType: String
         get() = type.toApiString(rawType)


### PR DESCRIPTION
## Summary

Extending Most Voted sorting logic to apply to client-side sorted collection builders (Director, Person, Production, etc.).

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When Most Voted sorting option was added, the logic was only applied to builders using the discover endpoint, and not builders that are sorted client-side (Director, Person, Production, etc.). This PR extends the logic to apply to client-side sorted builders as well.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioTV/issues/2156

## Reproduction steps

Create a collection catalog with a builder not using the discover endpoint (Director, Collection, List, etc.) and choose Most Voted sorting option.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Applies only to TMDB Collection builders that are sorted client-side.

## Testing

Manually created and observed sorting of catalogs created using a client-side sorted Builder with Most Voted sorting option selcted. Used Director with person ID 138 (Quentin Tarantino). Pre-fix, the first three titles were Four Rooms (2.8k), Grindhouse (1.8k), and Reservoir Dogs (0.2k), mirroring the original sorting order. Post-fix, the first three titles are Pulp Fiction (30.2k), Django Unchained (28k), and Inglorious Basterds (24.1k), aligning with the sorting of the most voted Tarantino titles on TMDB.

## Screenshots / Video

### Before:
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/86a185a9-eb10-4d93-8ff3-27181de062fa" />

### After:
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/12ff4c1b-6912-4d22-b8f0-719e285e5d6d" />


## Breaking changes

None

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/2156
