### PR TITLE
Fix persist contentLanguage and year in stream link cache for CW reuse

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/StreamLinkCacheDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/StreamLinkCacheDataStore.kt
@@ -23,7 +23,8 @@ data class CachedStreamLink(
     val fileIdx: Int? = null,
     val sources: List<String>? = null,
     val bingeGroup: String? = null,
-    val contentLanguage: String? = null
+    val contentLanguage: String? = null,
+    val year: String? = null
 )
 
 @Singleton
@@ -50,7 +51,8 @@ class StreamLinkCacheDataStore @Inject constructor(
         fileIdx: Int? = null,
         sources: List<String>? = null,
         bingeGroup: String? = null,
-        contentLanguage: String? = null
+        contentLanguage: String? = null,
+        year: String? = null
     ) {
         val payload = JSONObject().apply {
             put("url", url)
@@ -65,6 +67,7 @@ class StreamLinkCacheDataStore @Inject constructor(
             sources?.let { put("sources", JSONArray(it)) }
             bingeGroup?.let { put("bingeGroup", it) }
             contentLanguage?.let { put("contentLanguage", it) }
+            year?.let { put("year", it) }
         }.toString()
 
         store().edit { prefs ->
@@ -117,7 +120,8 @@ class StreamLinkCacheDataStore @Inject constructor(
                 fileIdx = if (json.has("fileIdx")) json.optInt("fileIdx", -1).takeIf { it >= 0 } else null,
                 sources = sources,
                 bingeGroup = json.optString("bingeGroup", "").ifBlank { null },
-                contentLanguage = json.optString("contentLanguage", "").ifBlank { null }
+                contentLanguage = json.optString("contentLanguage", "").ifBlank { null },
+                year = json.optString("year", "").ifBlank { null }
             )
         }.getOrNull()
 

--- a/app/src/main/java/com/nuvio/tv/data/local/StreamLinkCacheDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/StreamLinkCacheDataStore.kt
@@ -22,7 +22,8 @@ data class CachedStreamLink(
     val infoHash: String? = null,
     val fileIdx: Int? = null,
     val sources: List<String>? = null,
-    val bingeGroup: String? = null
+    val bingeGroup: String? = null,
+    val contentLanguage: String? = null
 )
 
 @Singleton
@@ -48,7 +49,8 @@ class StreamLinkCacheDataStore @Inject constructor(
         infoHash: String? = null,
         fileIdx: Int? = null,
         sources: List<String>? = null,
-        bingeGroup: String? = null
+        bingeGroup: String? = null,
+        contentLanguage: String? = null
     ) {
         val payload = JSONObject().apply {
             put("url", url)
@@ -62,6 +64,7 @@ class StreamLinkCacheDataStore @Inject constructor(
             fileIdx?.let { put("fileIdx", it) }
             sources?.let { put("sources", JSONArray(it)) }
             bingeGroup?.let { put("bingeGroup", it) }
+            contentLanguage?.let { put("contentLanguage", it) }
         }.toString()
 
         store().edit { prefs ->
@@ -113,7 +116,8 @@ class StreamLinkCacheDataStore @Inject constructor(
                 infoHash = infoHash,
                 fileIdx = if (json.has("fileIdx")) json.optInt("fileIdx", -1).takeIf { it >= 0 } else null,
                 sources = sources,
-                bingeGroup = json.optString("bingeGroup", "").ifBlank { null }
+                bingeGroup = json.optString("bingeGroup", "").ifBlank { null },
+                contentLanguage = json.optString("contentLanguage", "").ifBlank { null }
             )
         }.getOrNull()
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -72,7 +72,8 @@ internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
                         fileIdx = currentFileIdx,
                         sources = currentTorrentSources,
                         bingeGroup = currentStreamBingeGroup,
-                        contentLanguage = contentLanguage
+                        contentLanguage = contentLanguage,
+                        year = year
                     )
                 } else if (currentStreamUrl.isNotBlank()) {
                     streamLinkCacheDataStore.save(
@@ -84,7 +85,8 @@ internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
                         videoHash = currentVideoHash,
                         videoSize = currentVideoSize,
                         bingeGroup = currentStreamBingeGroup,
-                        contentLanguage = contentLanguage
+                        contentLanguage = contentLanguage,
+                        year = year
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -71,7 +71,8 @@ internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
                         infoHash = torrentInfoHash,
                         fileIdx = currentFileIdx,
                         sources = currentTorrentSources,
-                        bingeGroup = currentStreamBingeGroup
+                        bingeGroup = currentStreamBingeGroup,
+                        contentLanguage = contentLanguage
                     )
                 } else if (currentStreamUrl.isNotBlank()) {
                     streamLinkCacheDataStore.save(
@@ -82,7 +83,8 @@ internal suspend fun PlayerRuntimeController.fetchAddonSubtitlesNow(
                         filename = currentFilename,
                         videoHash = currentVideoHash,
                         videoSize = currentVideoSize,
-                        bingeGroup = currentStreamBingeGroup
+                        bingeGroup = currentStreamBingeGroup,
+                        contentLanguage = contentLanguage
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -476,7 +476,8 @@ private fun PlayerRuntimeController.persistSelectedStreamForReuse(
             filename = currentFilename,
             videoHash = currentVideoHash,
             videoSize = currentVideoSize,
-            bingeGroup = stream.behaviorHints?.bingeGroup
+            bingeGroup = stream.behaviorHints?.bingeGroup,
+            contentLanguage = contentLanguage
         )
     }
 }
@@ -501,7 +502,8 @@ private fun PlayerRuntimeController.persistTorrentStreamForReuse(stream: Stream)
             infoHash = infoHash,
             fileIdx = stream.fileIdx,
             sources = stream.sources,
-            bingeGroup = stream.behaviorHints?.bingeGroup
+            bingeGroup = stream.behaviorHints?.bingeGroup,
+            contentLanguage = contentLanguage
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -477,7 +477,8 @@ private fun PlayerRuntimeController.persistSelectedStreamForReuse(
             videoHash = currentVideoHash,
             videoSize = currentVideoSize,
             bingeGroup = stream.behaviorHints?.bingeGroup,
-            contentLanguage = contentLanguage
+            contentLanguage = contentLanguage,
+            year = year
         )
     }
 }
@@ -503,7 +504,8 @@ private fun PlayerRuntimeController.persistTorrentStreamForReuse(stream: Stream)
             fileIdx = stream.fileIdx,
             sources = stream.sources,
             bingeGroup = stream.behaviorHints?.bingeGroup,
-            contentLanguage = contentLanguage
+            contentLanguage = contentLanguage,
+            year = year
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -345,7 +345,7 @@ class StreamScreenViewModel @Inject constructor(
                                 videoSize = cached.videoSize,
                                 fileIdx = cached.fileIdx,
                                 sources = cached.sources,
-                                contentLanguage = contentLanguage
+                                contentLanguage = cached.contentLanguage ?: contentLanguage
                             ),
                             showDirectAutoPlayOverlay = showOverlay || it.showDirectAutoPlayOverlay,
                             isDirectAutoPlayFlow = showOverlay || it.isDirectAutoPlayFlow
@@ -1049,7 +1049,8 @@ class StreamScreenViewModel @Inject constructor(
                             filename = resolved.filename,
                             videoHash = resolved.videoHash,
                             videoSize = resolved.videoSize,
-                            bingeGroup = resolved.bingeGroup
+                            bingeGroup = resolved.bingeGroup,
+                            contentLanguage = contentLanguage
                         )
                     }
                 }
@@ -1183,7 +1184,8 @@ class StreamScreenViewModel @Inject constructor(
                     filename = playbackInfo.filename,
                     videoHash = playbackInfo.videoHash,
                     videoSize = playbackInfo.videoSize,
-                    bingeGroup = playbackInfo.bingeGroup
+                    bingeGroup = playbackInfo.bingeGroup,
+                    contentLanguage = contentLanguage
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -323,7 +323,7 @@ class StreamScreenViewModel @Inject constructor(
                                 url = cached.url.takeIf { u -> u.isNotBlank() },
                                 title = title,
                                 streamName = cached.streamName,
-                                year = year,
+                                year = cached.year ?: year,
                                 isExternal = false,
                                 isTorrent = isCachedTorrent,
                                 infoHash = cached.infoHash,
@@ -1050,7 +1050,8 @@ class StreamScreenViewModel @Inject constructor(
                             videoHash = resolved.videoHash,
                             videoSize = resolved.videoSize,
                             bingeGroup = resolved.bingeGroup,
-                            contentLanguage = contentLanguage
+                            contentLanguage = contentLanguage,
+                            year = year
                         )
                     }
                 }
@@ -1185,7 +1186,8 @@ class StreamScreenViewModel @Inject constructor(
                     videoHash = playbackInfo.videoHash,
                     videoSize = playbackInfo.videoSize,
                     bingeGroup = playbackInfo.bingeGroup,
-                    contentLanguage = contentLanguage
+                    contentLanguage = contentLanguage,
+                    year = year
                 )
             }
         }


### PR DESCRIPTION
## Summary

Persist `contentLanguage` and `year` in the stream link cache so they survive reuse-last-link playback from Continue Watching.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. When playing from Continue Watching via reuse-last-link, the original audio language is lost because `contentLanguage` was never saved to the stream link cache. This causes wrong subtitle/audio language selection on resume.
2. Similarly, `year` is not persisted, so the OSD omits the release year when replaying from Continue Watching.

Both fields are passed via navigation params which are `null` when coming from CW (CW items don't carry year/genres). The stream link cache is the only place that can preserve them across sessions.

## Issue or approval

Fixes user report: "Play a new movie, back out to Continue Watching and play again. Year will now be omitted from OSD."
Fixes user report: wrong audio language selected when resuming via reuse-last-link.

## Reproduction steps

**Year missing:**
1. Play a movie from details screen (year visible in OSD)
2. Back out to home -> Continue Watching
3. Play again from CW -> year missing from OSD

**Wrong language:**
1. Play foreign-language content (e.g. Japanese anime)
2. Correct audio track auto-selected based on contentLanguage
3. Back out, play again from CW via reuse-last-link
4. Default language selected instead of original

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only StreamLinkCacheDataStore, PlayerRuntimeControllerStreams, PlayerRuntimeControllerObservers, and StreamScreenViewModel are changed.
- No changes to CW pipeline, navigation, or player track selection logic.
- Existing cached entries without these fields gracefully return null (backward compatible).

## Testing

- Verified contentLanguage and year are persisted to JSON in stream link cache.
- Verified getValid() parses both new fields (returns null for old entries without them).
- Verified StreamScreenViewModel uses cached.contentLanguage/cached.year with fallback to nav param.
- Verified player persist functions pass both fields on HTTP and torrent paths.
- Build: compileFullBenchmarkKotlin -> BUILD SUCCESSFUL.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. Old cached entries without contentLanguage/year fields are handled gracefully (null fallback).

## Linked issues

- User report: year omitted from OSD on CW replay
- User report: wrong language on reuse-last-link resume
