### PR TITLE
fix(player): resolve Trakt resume position on external players (simpl…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -288,7 +288,11 @@ class ExternalPlaybackTracker @Inject constructor(
         }
         val wp = flow.firstOrNull() ?: return 0L
         if (wp.isCompleted()) return 0L
-        return wp.position
+        return if (wp.duration > 0L) {
+            wp.resolveResumePosition(wp.duration)
+        } else {
+            wp.position
+        }
     }
 
     private fun saveProgress(metadata: ExternalPlaybackMetadata, positionMs: Long, durationMs: Long?) {


### PR DESCRIPTION
# fix(player): resolve Trakt resume position on external players (simple fix)

## Summary

Modified `ExternalPlaybackTracker.kt` to calculate the resume position using `wp.resolveResumePosition(wp.duration)` if a duration is present, instead of directly passing `wp.position` (which was always evaluated to `0L` in this case).

"Note: I also have a branch that pre-calculates this position in the data layers (TraktProgressService / WatchProgressRepositoryImpl) to keep the DB models hydrated, but I submitted this player-level fix first to keep the PR minimal. Let me know if you would prefer the data-layer approach instead!"

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Items synced from Trakt do not have their absolute playback position (in milliseconds) saved initially because Trakt's API only provides progress as a percentage. When Nuvio launches an external player (like Vimu, MX Player, or VLC) via Intent, it fetches `wp.position` which is `0L`, causing the external player to start from the beginning.

By calling Nuvio's built-in `resolveResumePosition` with the hydrated metadata duration, we calculate the correct millisecond offset (e.g., `duration * percentage`) and pass it to the external player, restoring the resume feature.

## Issue or approval

No linked issue (bug reported on Discord, maintainer requested addition).

## Reproduction steps

1. Connect a Trakt account that has partially-watched items (e.g., 50% watched on another device).
2. Sync Nuvio's library with Trakt.
3. Open a stream and select an external player (e.g., Vimu Player).
4. Notice that the video starts playing from 0:00 instead of resuming at 50%.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This fix does not change any UI or local database writing logic. It is strictly limited to resolving the resume position intent parameter at the moment of launching external players.

## Testing

Manually verified the Kotlin code structure and logic flow in `ExternalPlaybackTracker.kt`. (Full Gradle build compilation was skipped locally due to missing local Android SDK environment, but the code relies on existing, standard Nuvio API helpers).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - bug reported and discussed on Discord.