### PR TITLE
Complete Greek localization parity

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackKeepAliveService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackKeepAliveService.kt
@@ -95,7 +95,7 @@ class ExternalPlaybackKeepAliveService : Service() {
                 getString(R.string.app_name),
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = "Keeps app alive during external player playback"
+                description = getString(R.string.external_playback_channel_description)
                 setShowBadge(false)
                 setSound(null, null)
             }
@@ -107,7 +107,7 @@ class ExternalPlaybackKeepAliveService : Service() {
     private fun buildNotification(): Notification {
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.app_name))
-            .setContentText("Playing in external player")
+            .setContentText(getString(R.string.external_playback_notification_text))
             .setSmallIcon(R.drawable.ic_launcher)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -2451,4 +2451,217 @@
     <string name="trakt_comments_error_request_failed">Αποτυχία αιτήματος σχολίων Trakt</string>
     <string name="trakt_library_error_fetch_list_items">Αποτυχία ανάκτησης στοιχείων λίστας</string>
 
+    <!-- Missing Greek locale parity -->
+    <string name="advanced_section_dv_diagnostics" translatable="false">DV Diagnostics</string>
+    <string name="playback_external_forward_subtitles">Προώθηση υποτίτλων σε εξωτερικό player</string>
+    <string name="playback_external_forward_subtitles_sub">Ανάκτηση υποτίτλων στην προτιμώμενη γλώσσα σας από πρόσθετα και αποστολή τους στον εξωτερικό player.</string>
+    <string name="video_section">Βίντεο</string>
+    <string name="dv7_handling_title">Χειρισμός Dolby Vision Profile 7</string>
+    <string name="dv7_handling_dialog_subtitle">Επιλέξτε πώς θα γίνεται επεξεργασία των ροών DV Profile 7 κατά την αναπαραγωγή.</string>
+    <string name="dv7_mode_auto">Αυτόματο (προτείνεται)</string>
+    <string name="dv7_mode_auto_desc">Ανιχνεύει την οθόνη σας και επιλέγει την καλύτερη λειτουργία. Αν παρουσιαστούν προβλήματα, δοκιμάστε τη βασική στρώση HDR10.</string>
+    <string name="dv7_mode_hdr10_base_layer">Βασική στρώση HDR10</string>
+    <string name="dv7_mode_hdr10_base_layer_desc">Αφαιρεί πάντα το Dolby Vision και αναπαράγει τη βασική στρώση HEVC HDR10.</string>
+    <string name="dv7_mode_dv81_libdovi">Μετατροπή σε DV8.1</string>
+    <string name="dv7_mode_dv81_libdovi_desc">Μετατρέπει DV7 σε μονής στρώσης DV8.1. Απαιτεί οθόνη με Dolby Vision.</string>
+    <string name="dv7_mode_off">Απενεργοποιημένο (native)</string>
+    <string name="dv7_mode_off_desc">Περνά το DV7 χωρίς τροποποίηση. Μπορεί να εμφανίσει προβλήματα σε hardware που δεν υποστηρίζει DV Profile 7.</string>
+    <string name="audio_dv5_to_dv81_title">Μετατροπή DV5 σε DV8.1</string>
+    <string name="audio_dv5_to_dv81_sub">Σηματοδοτεί τις ροές Profile 5 ως Profile 8.1 για έξοδο συμβατή με HDR10. Βοηθά σε συσκευές χωρίς native αποκωδικοποιητή DV5.</string>
+    <string name="audio_dv7_preserve_mapping_title">Διατήρηση χαρτογράφησης DV (DV7 σε DV8.1)</string>
+    <string name="audio_dv7_preserve_mapping_sub">Διατηρεί το αρχικό tone-mapping του δημιουργού με κόστος ελαφρώς μεγαλύτερη επεξεργασία ανά καρέ.</string>
+    <string name="dv7_libdovi_mode_caption" translatable="false">Conversion mode (auto-selected, do not change unless instructed). Pick one to force it; None uses auto. Active only when DV7 Handling is Convert to DV8.1.</string>
+    <string name="dv7_libdovi_mode_row_title" translatable="false">Conversion mode</string>
+    <string name="dv7_libdovi_mode_none_title" translatable="false">None</string>
+    <string name="dv7_libdovi_mode_none_sub" translatable="false">No override. Uses the automatically selected conversion mode.</string>
+    <string name="dv7_libdovi_mode_0_title" translatable="false">Mode 0 — Copy (no convert)</string>
+    <string name="dv7_libdovi_mode_0_sub" translatable="false">Parse the RPU and write it back untouched. No profile conversion.</string>
+    <string name="dv7_libdovi_mode_1_title" translatable="false">Mode 1 — MEL</string>
+    <string name="dv7_libdovi_mode_1_sub" translatable="false">Convert the RPU to be MEL (Minimum Enhancement Layer) compatible.</string>
+    <string name="dv7_libdovi_mode_2_title" translatable="false">Mode 2 — 8.1 (no-op mapping)</string>
+    <string name="dv7_libdovi_mode_2_sub" translatable="false">Convert to profile 8.1 with luma and chroma mapping set to no-op. The standard conversion.</string>
+    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — Profile 5 to 8.1</string>
+    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert Profile 5 (DV5) streams to Profile 8.1. Same conversion the Convert DV5 to DV8.1 toggle uses.</string>
+    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.4 (static)</string>
+    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to static profile 8.4.</string>
+    <string name="layout_section_streams">Ροές</string>
+    <string name="layout_section_streams_desc">Ρυθμίσεις εμφάνισης για αποτελέσματα ροών και πάνελ πηγών του player.</string>
+    <string name="debrid_stream_sort_original">Αρχική σειρά</string>
+    <string name="debrid_stream_sort_best_quality">Καλύτερη ποιότητα πρώτα</string>
+    <string name="debrid_stream_sort_largest">Μεγαλύτερα πρώτα</string>
+    <string name="debrid_stream_sort_smallest">Μικρότερα πρώτα</string>
+    <string name="debrid_stream_sort_best_audio">Καλύτερος ήχος πρώτα</string>
+    <string name="debrid_stream_sort_language">Γλώσσα πρώτα</string>
+    <string name="debrid_stream_per_resolution_limit_title">Όριο ανά ανάλυση</string>
+    <string name="debrid_stream_per_resolution_limit_subtitle">Περιορισμός επαναλαμβανόμενων αποτελεσμάτων 2160p, 1080p, 720p μετά την ταξινόμηση.</string>
+    <string name="debrid_stream_per_quality_limit_title">Όριο ανά ποιότητα</string>
+    <string name="debrid_stream_per_quality_limit_subtitle">Περιορισμός επαναλαμβανόμενων αποτελεσμάτων BluRay, WEB-DL, REMUX μετά την ταξινόμηση.</string>
+    <string name="debrid_stream_size_range_title">Εύρος μεγέθους</string>
+    <string name="debrid_stream_size_range_subtitle">Φιλτράρισμα ροών βάσει μεγέθους αρχείου.</string>
+    <string name="debrid_stream_resolutions_preferred">Προτιμώμενες αναλύσεις</string>
+    <string name="debrid_stream_resolutions_required">Απαιτούμενες αναλύσεις</string>
+    <string name="debrid_stream_resolutions_excluded">Εξαιρούμενες αναλύσεις</string>
+    <string name="debrid_stream_qualities_preferred">Προτιμώμενες ποιότητες</string>
+    <string name="debrid_stream_qualities_required">Απαιτούμενες ποιότητες</string>
+    <string name="debrid_stream_qualities_excluded">Εξαιρούμενες ποιότητες</string>
+    <string name="debrid_stream_visual_tags_preferred">Προτιμώμενα visual tags</string>
+    <string name="debrid_stream_visual_tags_required">Απαιτούμενα visual tags</string>
+    <string name="debrid_stream_visual_tags_excluded">Εξαιρούμενα visual tags</string>
+    <string name="debrid_stream_audio_tags_preferred">Προτιμώμενα audio tags</string>
+    <string name="debrid_stream_audio_tags_required">Απαιτούμενα audio tags</string>
+    <string name="debrid_stream_audio_tags_excluded">Εξαιρούμενα audio tags</string>
+    <string name="debrid_stream_channels_preferred">Προτιμώμενα κανάλια</string>
+    <string name="debrid_stream_channels_required">Απαιτούμενα κανάλια</string>
+    <string name="debrid_stream_channels_excluded">Εξαιρούμενα κανάλια</string>
+    <string name="debrid_stream_encodes_preferred">Προτιμώμενες κωδικοποιήσεις</string>
+    <string name="debrid_stream_encodes_required">Απαιτούμενες κωδικοποιήσεις</string>
+    <string name="debrid_stream_encodes_excluded">Εξαιρούμενες κωδικοποιήσεις</string>
+    <string name="debrid_stream_languages_preferred">Προτιμώμενες γλώσσες</string>
+    <string name="debrid_stream_languages_required">Απαιτούμενες γλώσσες</string>
+    <string name="debrid_stream_languages_excluded">Εξαιρούμενες γλώσσες</string>
+    <string name="debrid_stream_release_groups_required">Απαιτούμενα release groups</string>
+    <string name="debrid_stream_release_groups_excluded">Εξαιρούμενα release groups</string>
+    <string name="debrid_stream_release_groups_input_subtitle">Εισαγάγετε ένα group ανά γραμμή.</string>
+    <string name="settings_stream_badges_section">Στυλ Fusion</string>
+    <string name="settings_stream_size_badges_title">Badges μεγέθους</string>
+    <string name="settings_stream_size_badges_description">Εμφάνιση badges μεγέθους αρχείου στα αποτελέσματα ροών και στα πάνελ πηγών του player.</string>
+    <string name="settings_stream_badge_urls_title">Fusion badge URLs</string>
+    <string name="settings_stream_badge_urls_description">Εισαγάγετε έως %1$d Fusion-style stream badge JSON URLs. Κάθε URL μπορεί να ενημερωθεί ή να διαγραφεί ξεχωριστά.</string>
+    <string name="settings_stream_badge_urls_search_description">Διαχείριση των εισαγμένων Fusion-style stream badge JSON URLs.</string>
+    <string name="settings_fusion_badges_summary">%1$d/%2$d URLs, %3$d ενεργά Fusion badges</string>
+    <string name="settings_fusion_badges_empty">Δεν έχουν εισαχθεί Fusion badge URLs.</string>
+    <string name="settings_fusion_badge_url_label">Fusion badge JSON URL</string>
+    <string name="settings_fusion_badge_urls_imported">Εισήχθησαν %1$d/%2$d Fusion URLs</string>
+    <string name="settings_fusion_badge_url_active">Ενεργό</string>
+    <string name="settings_fusion_badge_url_inactive">Ανενεργό</string>
+    <string name="settings_fusion_badge_url_status_summary">%1$s, %2$d ενεργά badges, %3$d ομάδες</string>
+    <string name="settings_fusion_badge_preview_action">Προεπισκόπηση</string>
+    <string name="settings_fusion_badge_preview_title">Προεπισκόπηση Fusion badge</string>
+    <string name="settings_fusion_badge_preview_count">%1$d Fusion-style badges από αυτό το URL</string>
+    <string name="settings_fusion_badge_preview_empty">Δεν υπάρχουν εικόνες Fusion-style badge σε αυτό το URL.</string>
+    <string name="settings_fusion_badge_group_title">Ομάδα %1$d</string>
+    <string name="settings_fusion_badge_other_group_title">Άλλα Fusion badges</string>
+    <string name="stream_badge_qr_instruction">Σαρώστε αυτό το QR code από το κινητό σας για διαχείριση Fusion badge URLs.</string>
+    <string name="streams_size">ΜΕΓΕΘΟΣ %1$s</string>
+    <string name="action_import">Εισαγωγή</string>
+    <string name="action_delete">Διαγραφή</string>
+    <string name="debug_buffer_logs_title">Ενεργοποίηση BUFFER Logs</string>
+    <string name="debug_buffer_logs_subtitle">Αποστολή περιοδικών διαγνωστικών buffer του player στο logcat (απενεργοποιημένο από προεπιλογή)</string>
+    <string name="cloud_library_error_provider_unavailable">Η cloud βιβλιοθήκη δεν είναι διαθέσιμη για %1$s.</string>
+    <string name="cloud_library_error_disabled">Η cloud βιβλιοθήκη είναι απενεργοποιημένη.</string>
+    <string name="audio_dv_sub">Χαρτογράφηση Dolby Vision Profile 7 σε standard HEVC για συσκευές χωρίς hardware υποστήριξη DV</string>
+    <string name="update_error_check_failed">Ο έλεγχος ενημέρωσης απέτυχε</string>
+    <string name="update_error_download_failed">Η λήψη απέτυχε</string>
+    <string name="update_error_apk_missing">Το ληφθέν αρχείο λείπει</string>
+    <string name="debrid_picker_preferred_resolutions_title">Προτιμώμενες αναλύσεις</string>
+    <string name="debrid_picker_preferred_resolutions_subtitle">Ταξινόμηση των επιλεγμένων αναλύσεων πρώτα, με την προεπιλεγμένη σειρά.</string>
+    <string name="debrid_picker_required_resolutions_title">Απαιτούμενες αναλύσεις</string>
+    <string name="debrid_picker_required_resolutions_subtitle">Εμφάνιση μόνο των επιλεγμένων αναλύσεων.</string>
+    <string name="debrid_picker_excluded_resolutions_title">Εξαιρούμενες αναλύσεις</string>
+    <string name="debrid_picker_excluded_resolutions_subtitle">Απόκρυψη των επιλεγμένων αναλύσεων.</string>
+    <string name="debrid_picker_preferred_qualities_title">Προτιμώμενες ποιότητες</string>
+    <string name="debrid_picker_preferred_qualities_subtitle">Ταξινόμηση των επιλεγμένων ποιοτήτων πρώτα, με την προεπιλεγμένη σειρά.</string>
+    <string name="debrid_picker_required_qualities_title">Απαιτούμενες ποιότητες</string>
+    <string name="debrid_picker_required_qualities_subtitle">Εμφάνιση μόνο των επιλεγμένων ποιοτήτων πηγής.</string>
+    <string name="debrid_picker_excluded_qualities_title">Εξαιρούμενες ποιότητες</string>
+    <string name="debrid_picker_excluded_qualities_subtitle">Απόκρυψη των επιλεγμένων ποιοτήτων πηγής.</string>
+    <string name="debrid_picker_preferred_visual_tags_title">Προτιμώμενα visual tags</string>
+    <string name="debrid_picker_preferred_visual_tags_subtitle">Ταξινόμηση tags όπως DV, HDR, 10bit, IMAX και παρόμοια.</string>
+    <string name="debrid_picker_required_visual_tags_title">Απαιτούμενα visual tags</string>
+    <string name="debrid_picker_required_visual_tags_subtitle">Απαίτηση tags όπως DV, HDR, 10bit, IMAX, SDR και παρόμοια.</string>
+    <string name="debrid_picker_excluded_visual_tags_title">Εξαιρούμενα visual tags</string>
+    <string name="debrid_picker_excluded_visual_tags_subtitle">Απόκρυψη tags όπως DV, HDR, 10bit, 3D και παρόμοια.</string>
+    <string name="debrid_picker_preferred_audio_tags_title">Προτιμώμενα audio tags</string>
+    <string name="debrid_picker_preferred_audio_tags_subtitle">Ταξινόμηση tags όπως Atmos, TrueHD, DTS, AAC και παρόμοια.</string>
+    <string name="debrid_picker_required_audio_tags_title">Απαιτούμενα audio tags</string>
+    <string name="debrid_picker_required_audio_tags_subtitle">Απαίτηση tags όπως Atmos, TrueHD, DTS, AAC και παρόμοια.</string>
+    <string name="debrid_picker_excluded_audio_tags_title">Εξαιρούμενα audio tags</string>
+    <string name="debrid_picker_excluded_audio_tags_subtitle">Απόκρυψη των επιλεγμένων audio tags.</string>
+    <string name="debrid_picker_preferred_audio_channels_title">Προτιμώμενα κανάλια</string>
+    <string name="debrid_picker_preferred_audio_channels_subtitle">Ταξινόμηση των προτιμώμενων διατάξεων καναλιών πρώτα.</string>
+    <string name="debrid_picker_required_audio_channels_title">Απαιτούμενα κανάλια</string>
+    <string name="debrid_picker_required_audio_channels_subtitle">Εμφάνιση μόνο των επιλεγμένων διατάξεων καναλιών.</string>
+    <string name="debrid_picker_excluded_audio_channels_title">Εξαιρούμενα κανάλια</string>
+    <string name="debrid_picker_excluded_audio_channels_subtitle">Απόκρυψη των επιλεγμένων διατάξεων καναλιών.</string>
+    <string name="debrid_picker_preferred_encodes_title">Προτιμώμενες κωδικοποιήσεις</string>
+    <string name="debrid_picker_preferred_encodes_subtitle">Ταξινόμηση κωδικοποιήσεων όπως AV1, HEVC, AVC και παρόμοιων.</string>
+    <string name="debrid_picker_required_encodes_title">Απαιτούμενες κωδικοποιήσεις</string>
+    <string name="debrid_picker_required_encodes_subtitle">Απαίτηση κωδικοποιήσεων όπως AV1, HEVC, AVC και παρόμοιων.</string>
+    <string name="debrid_picker_excluded_encodes_title">Εξαιρούμενες κωδικοποιήσεις</string>
+    <string name="debrid_picker_excluded_encodes_subtitle">Απόκρυψη των επιλεγμένων κωδικοποιήσεων.</string>
+    <string name="debrid_picker_preferred_languages_title">Προτιμώμενες γλώσσες</string>
+    <string name="debrid_picker_preferred_languages_subtitle">Ταξινόμηση των προτιμώμενων γλωσσών ήχου πρώτα.</string>
+    <string name="debrid_picker_required_languages_title">Απαιτούμενες γλώσσες</string>
+    <string name="debrid_picker_required_languages_subtitle">Εμφάνιση μόνο ροών με τις επιλεγμένες γλώσσες.</string>
+    <string name="debrid_picker_excluded_languages_title">Εξαιρούμενες γλώσσες</string>
+    <string name="debrid_picker_excluded_languages_subtitle">Απόκρυψη ροών όπου όλες οι γλώσσες είναι εξαιρούμενες.</string>
+    <string name="debrid_picker_required_release_groups_title">Απαιτούμενα release groups</string>
+    <string name="debrid_picker_required_release_groups_subtitle">Εμφάνιση μόνο των επιλεγμένων release groups.</string>
+    <string name="debrid_picker_excluded_release_groups_title">Εξαιρούμενα release groups</string>
+    <string name="debrid_picker_excluded_release_groups_subtitle">Απόκρυψη των επιλεγμένων release groups.</string>
+    <string name="debrid_selection_count_any">Οποιοδήποτε</string>
+    <string name="debrid_size_range_any">Οποιοδήποτε</string>
+    <string name="debrid_size_range_up_to">Έως %1$dGB</string>
+    <string name="debrid_size_range_min_plus">%1$dGB+</string>
+    <string name="debrid_size_range_min_max">%1$d-%2$dGB</string>
+    <string name="subtitle_language_unknown">Άγνωστη</string>
+    <plurals name="debrid_selection_count_value">
+        <item quantity="one">%d επιλεγμένο</item>
+        <item quantity="other">%d επιλεγμένα</item>
+    </plurals>
+
+    <!-- External playback keep-alive notification -->
+    <string name="external_playback_channel_description">Διατηρεί την εφαρμογή ενεργή κατά την αναπαραγωγή σε εξωτερικό player</string>
+    <string name="external_playback_notification_text">Αναπαραγωγή σε εξωτερικό player</string>
+
+    <!-- Playback — Buffer & Network settings -->
+    <string name="playback_section_buffer_network">Buffer &amp; Δίκτυο</string>
+    <string name="playback_section_buffer_network_desc">Πόσο περιεχόμενο να διατηρείται στη μνήμη και πώς να γίνεται η ανάκτηση ροών.</string>
+    <string name="playback_buffer_custom">Προσαρμοσμένα Playback Buffers</string>
+    <string name="playback_buffer_custom_sub">Παράκαμψη των προεπιλεγμένων ρυθμίσεων buffering του Media3 με τις παρακάτω τιμές. Όταν είναι απενεργοποιημένο, ο player χρησιμοποιεί τις προεπιλεγμένες διάρκειες και το προεπιλεγμένο μέγεθος buffer του Media3.</string>
+    <string name="playback_buffer_header">Προσωρινή μνήμη</string>
+    <string name="playback_buffer_warning">Αυτές οι ρυθμίσεις επηρεάζουν τη συμπεριφορά buffering. Λανθασμένες τιμές μπορεί να προκαλέσουν προβλήματα αναπαραγωγής.</string>
+    <string name="playback_buffer_min">Ελάχιστη διάρκεια buffer</string>
+    <string name="playback_buffer_min_sub">Ελάχιστο περιεχόμενο προς αποθήκευση στο buffer. Ο player προσπαθεί να διατηρεί τουλάχιστον αυτό το περιεχόμενο μπροστά από την τρέχουσα θέση αναπαραγωγής.</string>
+    <string name="playback_buffer_max">Μέγιστη διάρκεια buffer</string>
+    <string name="playback_buffer_max_sub">Μέγιστο περιεχόμενο προς αποθήκευση στο buffer. Πρέπει να είναι τουλάχιστον ίσο με την ελάχιστη διάρκεια. Μεγαλύτερες τιμές χρησιμοποιούν περισσότερη μνήμη αλλά προσφέρουν ομαλότερη αναπαραγωγή σε ασταθείς συνδέσεις.</string>
+    <string name="playback_buffer_value_same_as_min">%1$ds (ίδιο με το ελάχιστο)</string>
+    <string name="playback_buffer_initial">Αρχικό buffer</string>
+    <string name="playback_buffer_initial_sub">Πόσο περιεχόμενο πρέπει να αποθηκευτεί στο buffer πριν ξεκινήσει η αναπαραγωγή. Μικρότερες τιμές ξεκινούν γρηγορότερα αλλά μπορεί να προκαλέσουν αρχικά κολλήματα σε αργές συνδέσεις.</string>
+    <string name="playback_buffer_after_rebuffer">Buffer μετά από rebuffer</string>
+    <string name="playback_buffer_after_rebuffer_sub">Πόσο περιεχόμενο να αποθηκεύεται μετά από διακοπή αναπαραγωγής λόγω buffering. Μεγαλύτερες τιμές μειώνουν τις επαναλαμβανόμενες διακοπές.</string>
+    <string name="playback_buffer_back">Διάρκεια back buffer</string>
+    <string name="playback_buffer_back_sub">Πόσο ήδη αναπαραχθέν περιεχόμενο να παραμένει στη μνήμη. Επιτρέπει γρήγορη μετακίνηση προς τα πίσω χωρίς εκ νέου λήψη. Ορίστε 0 για απενεργοποίηση και εξοικονόμηση μνήμης.</string>
+    <string name="playback_buffer_back_reserve">Δεσμεύει ~%1$dMB πάνω από το Target Buffer. Η αύξηση της μέγιστης διάρκειας buffer μειώνει αυτό το αποθεματικό χωρίς απώλεια χρόνου back-buffer.</string>
+    <string name="playback_buffer_managed">Διαχειριζόμενο όριο μνήμης</string>
+    <string name="playback_buffer_managed_sub">Περιορίζει το buffer σε ασφαλές ποσοστό της μνήμης της συσκευής. Απενεργοποιήστε το για χειροκίνητη ρύθμιση του Target Buffer Size (προχωρημένο· μεγάλες τιμές μπορεί να προκαλέσουν κρασάρισμα σε συσκευές με λίγη μνήμη).</string>
+    <string name="playback_buffer_target">Μέγεθος Target Buffer</string>
+    <string name="playback_buffer_target_sub">Μέγιστη RAM που χρησιμοποιείται για buffer μπροστά από την αναπαραγωγή. Το μέγιστο υπολογίζεται από τη διαθέσιμη μνήμη της συσκευής (όριο heap ανά εφαρμογή Android), οπότε συσκευές με περισσότερη RAM επιτρέπουν μεγαλύτερα όρια.</string>
+    <string name="playback_buffer_target_managed_hint">Διαχειρίζεται από το όριο μνήμης της συσκευής. Απενεργοποιήστε το Διαχειριζόμενο όριο μνήμης για να το ρυθμίσετε.</string>
+    <string name="playback_buffer_target_warning">Προειδοποίηση: πάνω από το ασφαλές όριο συσκευής (%1$d MB). Η εφαρμογή μπορεί να κρασάρει κατά την αναπαραγωγή.</string>
+    <string name="playback_buffer_allow_large">Επιτρεπόμενο μεγαλύτερο Target Buffer</string>
+    <string name="playback_buffer_allow_large_sub">Αφαιρεί το όριο μνήμης συσκευής από το slider Target Buffer Size, επιτρέποντας τιμές έως 2GB. Μπορεί να κρασάρει σε συσκευές με λιγότερα από 2GB RAM.</string>
+    <string name="playback_cache_header">Cache δίσκου</string>
+    <string name="playback_cache_vod">VOD cache δίσκου</string>
+    <string name="playback_cache_vod_sub">Αποθηκεύει τα ληφθέντα δεδομένα στον δίσκο για την τρέχουσα ροή. Επεκτείνει την άμεση επιστροφή προς τα πίσω πέρα από το back buffer μνήμης και αντέχει σε σύντομες διακοπές δικτύου. Ισχύει μόνο για progressive streams (όχι HLS/DASH).</string>
+    <string name="playback_cache_auto_size">Αυτόματο μέγεθος</string>
+    <string name="playback_cache_auto_size_sub">Όταν είναι ενεργό, το μέγεθος cache προκύπτει από τον ελεύθερο χώρο δίσκου. Απενεργοποιήστε το για χειροκίνητη επιλογή μεγέθους.</string>
+    <string name="playback_cache_vod_size">Μέγεθος VOD Cache</string>
+    <string name="playback_cache_vod_size_sub">Μέγιστη χρήση δίσκου για progressive VOD cache (διαγραφή με LRU).</string>
+    <string name="playback_cache_info_range">Εύρος: %1$d-%2$d MB.</string>
+    <string name="playback_cache_info_auto">Η αυτόματη λειτουργία στοχεύει περίπου στο 10% του ελεύθερου χώρου.</string>
+    <string name="playback_cache_info_manual_headroom">Η χειροκίνητη λειτουργία κρατά περίπου %1$dMB ελεύθερο περιθώριο.</string>
+    <string name="playback_cache_info_free_disk">Διαθέσιμος ελεύθερος δίσκος: %1$s.</string>
+    <string name="playback_cache_info_restart">Το νέο όριο cache εφαρμόζεται μετά από επανεκκίνηση της εφαρμογής όταν αλλάζετε λειτουργία ή μέγεθος.</string>
+    <string name="playback_reset_to_default">Επαναφορά στις προεπιλογές</string>
+    <string name="playback_net_custom">Προσαρμοσμένο δίκτυο</string>
+    <string name="playback_net_custom_sub">Χρήση πολλαπλών παράλληλων συνδέσεων για ανάκτηση progressive streams. Όταν είναι απενεργοποιημένο, χρησιμοποιείται μία σύνδεση.</string>
+    <string name="playback_net_parallel">Παράλληλες συνδέσεις</string>
+    <string name="playback_net_parallel_sub">Χρήση πολλαπλών συνδέσεων παράλληλα για λήψη ροών. Ενεργοποιήστε το αν εμφανίζεται buffering παρότι η ταχύτητα λήψης είναι επαρκής.</string>
+    <string name="playback_net_connection_count">Αριθμός συνδέσεων</string>
+    <string name="playback_net_connection_count_sub">Αριθμός παράλληλων TCP συνδέσεων. Μεγαλύτερες τιμές αυξάνουν χρήση μνήμης και throughput, με φθίνουσες αποδόσεις.</string>
+    <string name="playback_net_chunk_size">Μέγεθος chunk</string>
+    <string name="playback_net_chunk_size_sub">Μέγεθος κάθε chunk λήψης ανά σύνδεση. Μεγαλύτερα chunks μειώνουν το overhead αλλά χρησιμοποιούν περισσότερη μνήμη.</string>
+
 </resources>
+

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -2452,7 +2452,6 @@
     <string name="trakt_library_error_fetch_list_items">Αποτυχία ανάκτησης στοιχείων λίστας</string>
 
     <!-- Missing Greek locale parity -->
-    <string name="advanced_section_dv_diagnostics" translatable="false">DV Diagnostics</string>
     <string name="playback_external_forward_subtitles">Προώθηση υποτίτλων σε εξωτερικό player</string>
     <string name="playback_external_forward_subtitles_sub">Ανάκτηση υποτίτλων στην προτιμώμενη γλώσσα σας από πρόσθετα και αποστολή τους στον εξωτερικό player.</string>
     <string name="video_section">Βίντεο</string>
@@ -2470,20 +2469,6 @@
     <string name="audio_dv5_to_dv81_sub">Σηματοδοτεί τις ροές Profile 5 ως Profile 8.1 για έξοδο συμβατή με HDR10. Βοηθά σε συσκευές χωρίς native αποκωδικοποιητή DV5.</string>
     <string name="audio_dv7_preserve_mapping_title">Διατήρηση χαρτογράφησης DV (DV7 σε DV8.1)</string>
     <string name="audio_dv7_preserve_mapping_sub">Διατηρεί το αρχικό tone-mapping του δημιουργού με κόστος ελαφρώς μεγαλύτερη επεξεργασία ανά καρέ.</string>
-    <string name="dv7_libdovi_mode_caption" translatable="false">Conversion mode (auto-selected, do not change unless instructed). Pick one to force it; None uses auto. Active only when DV7 Handling is Convert to DV8.1.</string>
-    <string name="dv7_libdovi_mode_row_title" translatable="false">Conversion mode</string>
-    <string name="dv7_libdovi_mode_none_title" translatable="false">None</string>
-    <string name="dv7_libdovi_mode_none_sub" translatable="false">No override. Uses the automatically selected conversion mode.</string>
-    <string name="dv7_libdovi_mode_0_title" translatable="false">Mode 0 — Copy (no convert)</string>
-    <string name="dv7_libdovi_mode_0_sub" translatable="false">Parse the RPU and write it back untouched. No profile conversion.</string>
-    <string name="dv7_libdovi_mode_1_title" translatable="false">Mode 1 — MEL</string>
-    <string name="dv7_libdovi_mode_1_sub" translatable="false">Convert the RPU to be MEL (Minimum Enhancement Layer) compatible.</string>
-    <string name="dv7_libdovi_mode_2_title" translatable="false">Mode 2 — 8.1 (no-op mapping)</string>
-    <string name="dv7_libdovi_mode_2_sub" translatable="false">Convert to profile 8.1 with luma and chroma mapping set to no-op. The standard conversion.</string>
-    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — Profile 5 to 8.1</string>
-    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert Profile 5 (DV5) streams to Profile 8.1. Same conversion the Convert DV5 to DV8.1 toggle uses.</string>
-    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.4 (static)</string>
-    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to static profile 8.4.</string>
     <string name="layout_section_streams">Ροές</string>
     <string name="layout_section_streams_desc">Ρυθμίσεις εμφάνισης για αποτελέσματα ροών και πάνελ πηγών του player.</string>
     <string name="debrid_stream_sort_original">Αρχική σειρά</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2562,6 +2562,10 @@
     <!-- Subtitle selection: unknown language fallback -->
     <string name="subtitle_language_unknown">Unknown</string>
 
+    <!-- External playback keep-alive notification -->
+    <string name="external_playback_channel_description">Keeps app alive during external player playback</string>
+    <string name="external_playback_notification_text">Playing in external player</string>
+
     <!-- Playback — Buffer & Network settings -->
     <string name="playback_section_buffer_network">Buffer &amp; Network</string>
     <string name="playback_section_buffer_network_desc">How much content to keep in memory and how to fetch streams.</string>


### PR DESCRIPTION
## Summary

Greek localization parity update: added all missing `values-el/strings.xml` entries to match base keys, translated newly uncovered UI strings, and moved remaining hardcoded playback/notification text into string resources so Greek is applied consistently.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Translation/localization only
- [ ] Critical bug fix

## Why

Greek still had many untranslated strings and a few hardcoded English UI texts. This update closes those gaps so the app is fully localized in Greek.

## Issue or approval

No linked issue: localization-only update.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Did not change product behavior, logic flows, features, or design. Only localization resources and replacement of hardcoded user-facing text with localized string resources.

## Testing

- XML/resource key parity check (`values` vs `values-el`) confirms no missing/extra Greek keys.
- Build/type-check not run in this environment (`JAVA_HOME` not available).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.