### PR TITLE
fix(player): improve adaptive stream quality selection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -37,7 +37,9 @@ import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
 import androidx.media3.exoplayer.video.VideoRendererEventListener
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.text.TextOutput
+import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
@@ -78,6 +80,8 @@ private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
 private const val AUDIO_DELAY_REFRESH_DEBOUNCE_MS = 120L
 private const val PLAYER_RELEASE_TIMEOUT_MS = 3000L
 private const val PLAYER_REBUILD_SETTLE_DELAY_MS = 120L
+private const val ADAPTIVE_QUALITY_INCREASE_MIN_DURATION_MS = 2_000
+private const val ADAPTIVE_INITIAL_BITRATE_ESTIMATE_BPS = 25_000_000L
 
 internal data class StartupSubtitlePreparation(
     val fetchedSubtitles: List<Subtitle>,
@@ -498,7 +502,13 @@ internal fun PlayerRuntimeController.initializePlayer(
             }
 
             // ── Track Selector Setup ──
-            trackSelector = DefaultTrackSelector(context).apply {
+            val adaptiveTrackSelectionFactory = AdaptiveTrackSelection.Factory(
+                ADAPTIVE_QUALITY_INCREASE_MIN_DURATION_MS,
+                AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
+                AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,
+                AdaptiveTrackSelection.DEFAULT_BANDWIDTH_FRACTION
+            )
+            trackSelector = DefaultTrackSelector(context, adaptiveTrackSelectionFactory).apply {
                 setParameters(buildUponParameters().setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true))
                 if (playerSettings.tunnelingEnabled && !safeAudioModeEnabled) {
                     setParameters(buildUponParameters().setTunnelingEnabled(true))
@@ -646,6 +656,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                     extractorsFactory
                 }
 
+            val bandwidthMeter = DefaultBandwidthMeter.Builder(context)
+                .setInitialBitrateEstimate(ADAPTIVE_INITIAL_BITRATE_ESTIMATE_BPS)
+                .build()
+
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             // ── Build ExoPlayer ──
             val buildDefaultPlayer = {
@@ -661,6 +675,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 )
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)
+                    .setBandwidthMeter(bandwidthMeter)
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, effectiveExtractorsFactory))
                     .setRenderersFactory(renderersFactory)
@@ -676,6 +691,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             _exoPlayer = if (useLibass) {
                 val playerDataSourceFactory = PlayerPlaybackNetworking.createDataSourceFactory(context, headers)
                 ExoPlayer.Builder(context)
+                    .setBandwidthMeter(bandwidthMeter)
                     .setLoadControl(loadControl)
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, effectiveExtractorsFactory))


### PR DESCRIPTION
## Summary

Improves adaptive video quality selection for internal ExoPlayer playback.

This PR configures ExoPlayer with a less conservative adaptive track selection startup policy and a higher initial bandwidth estimate, applied to both the normal player path and the libass player path.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some adaptive HLS/DASH streams can start on a lower video variant and remain there longer than expected, even when higher quality variants are available and the device/network can support them.

This change helps ExoPlayer select or switch up to the best available supported variant sooner without forcing the highest bitrate permanently.

## Issue or approval

Fixes #2170

## Reproduction steps

1. Open content with an adaptive HLS/DASH stream that exposes multiple video quality variants.
2. Start playback using the internal ExoPlayer mode.
3. Wait for playback startup and continue playback for at least 30-60 seconds.
4. Observe that the selected video resolution can remain below the best available supported variant.
5. Repeat with another adaptive stream/source to confirm it is not tied to a single stream URL.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes internal ExoPlayer adaptive stream startup selection.

It does not:
- add UI
- add settings
- change source selection
- force the highest bitrate permanently
- change MPV playback
- change direct file playback behavior for single-quality streams

## Testing

- Verified the code change is limited to `PlayerRuntimeControllerInitialization.kt`.
- Verified both ExoPlayer construction paths receive the same bandwidth meter:
  - normal ExoPlayer path
  - libass ExoPlayer path
- Ran `git diff --check`.

Could not run Android compilation in my local environment because Java Runtime is not available there.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2170