### PR TITLE
fix(cw): respect 'Up Next From Furthest' setting during rewatch

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1491,31 +1491,37 @@ class TraktProgressService @Inject constructor(
             traktEpisodeId = progress.traktEpisodeId
         )
 
-        watchedShowSeedsState.update { current ->
-            val updated = current.toMutableList()
-            val existingIndex = updated.indexOfFirst { canonicalLookupKey(it.contentId) == contentId }
-            if (existingIndex >= 0) {
-                val existing = updated[existingIndex]
-                val shouldReplace =
-                    (candidate.season ?: -1) > (existing.season ?: -1) ||
-                        (
-                            candidate.season == existing.season &&
-                                (
-                                    (candidate.episode ?: -1) > (existing.episode ?: -1) ||
-                                        (
-                                            candidate.episode == existing.episode &&
-                                                candidate.lastWatched >= existing.lastWatched
-                                            )
-                                    )
-                            )
-                if (!shouldReplace) {
-                    return@update current
+        scope.launch {
+            val useFurthest = layoutPreferenceDataStore.nextUpFromFurthestEpisode.first()
+            watchedShowSeedsState.update { current ->
+                val updated = current.toMutableList()
+                val existingIndex = updated.indexOfFirst { canonicalLookupKey(it.contentId) == contentId }
+                if (existingIndex >= 0) {
+                    val existing = updated[existingIndex]
+                    val shouldReplace = if (useFurthest) {
+                        (candidate.season ?: -1) > (existing.season ?: -1) ||
+                            (
+                                candidate.season == existing.season &&
+                                    (
+                                        (candidate.episode ?: -1) > (existing.episode ?: -1) ||
+                                            (
+                                                candidate.episode == existing.episode &&
+                                                    candidate.lastWatched >= existing.lastWatched
+                                                )
+                                        )
+                                )
+                    } else {
+                        candidate.lastWatched >= existing.lastWatched
+                    }
+                    if (!shouldReplace) {
+                        return@update current
+                    }
+                    updated[existingIndex] = candidate
+                } else {
+                    updated.add(candidate)
                 }
-                updated[existingIndex] = candidate
-            } else {
-                updated.add(candidate)
+                updated.sortedByDescending { it.lastWatched }
             }
-            updated.sortedByDescending { it.lastWatched }
         }
         watchedShowSeedsUpdatedAtMs = now
         hasLoadedWatchedShowSeeds = true

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -405,9 +405,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
                                         progress.source == WatchProgress.SOURCE_TRAKT_HISTORY
                                 }
                             }
-                            .onStart { emit(emptyList()) }
-                    ) { canonicalSeeds, optimisticSeeds ->
-                        mergeNextUpSeeds(canonicalSeeds, optimisticSeeds)
+                            .onStart { emit(emptyList()) },
+                        layoutPreferenceDataStore.nextUpFromFurthestEpisode
+                    ) { canonicalSeeds, optimisticSeeds, useFurthest ->
+                        mergeNextUpSeeds(canonicalSeeds, optimisticSeeds, useFurthest)
                     }
                 } else {
                     // Use watched items (fully synced with pagination) to build seeds
@@ -475,7 +476,8 @@ class WatchProgressRepositoryImpl @Inject constructor(
 
     private fun mergeNextUpSeeds(
         canonicalSeeds: List<WatchProgress>,
-        optimisticSeeds: List<WatchProgress>
+        optimisticSeeds: List<WatchProgress>,
+        useFurthest: Boolean
     ): List<WatchProgress> {
         val merged = linkedMapOf<String, WatchProgress>()
         canonicalSeeds.forEach { seed ->
@@ -484,7 +486,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
         optimisticSeeds.forEach { seed ->
             val key = nextUpSeedKey(seed)
             val existing = merged[key]
-            if (existing == null || shouldReplaceNextUpSeed(existing, seed)) {
+            if (existing == null || shouldReplaceNextUpSeed(existing, seed, useFurthest)) {
                 merged[key] = seed
             }
         }
@@ -510,8 +512,12 @@ class WatchProgressRepositoryImpl @Inject constructor(
 
     private fun shouldReplaceNextUpSeed(
         existing: WatchProgress,
-        candidate: WatchProgress
+        candidate: WatchProgress,
+        useFurthest: Boolean
     ): Boolean {
+        if (!useFurthest) {
+            return candidate.lastWatched >= existing.lastWatched
+        }
         val candidateSeason = candidate.season ?: -1
         val candidateEpisode = candidate.episode ?: -1
         val existingSeason = existing.season ?: -1


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->
Hello there! This PR fixes a bug in the "Continue Watching" logic where series would incorrectly prioritize the furthest watched episode even when the "Up Next From Furthest Episode" setting was disabled. I updated the seed merging logic in WatchProgressRepositoryImpl and the optimistic update logic in TraktProgressService to respect the user's preference, using the last-watched timestamp as the primary sorting criteria when the filter is OFF.
## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

<!-- Why this change is needed. Explain the critical bug or localization update. -->
When rewatching a series, users expect the "Continue Watching" row to suggest the episode following their most recent activity. Currently, the system hard-codes a "Furthest Season/Episode wins" rule, making it impossible to use the "Continue Watching" row for rewatches as it keeps jumping back to the most advanced episode in the history.
## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->
Fixes #2145
## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->
   1. Go to Settings > Layout and disable "Up Next From Furthest Episode".
   2. Watch an advanced episode of a series .
   3. Watch an earlier episode of the same series.
   4. Go back to the Home screen.
   5. Observed behavior: The app suggests the furthest episode (ignoring the setting).
   6. Expected behavior: The app should suggest the next episode to the most recent watched (respecting the setting and most recent activity).

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
This PR intentionally does not modify the Home screen UI or the logic for movies. It focuses solely on the episode selection criteria for series within the "Continue Watching" pipeline
## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->
  Manual testing performed on a Virtual Device (Android TV):
   - Verified that with the filter ON, the furthest episode is still prioritized.
   - Verified that with the filter OFF, watching an earlier episode correctly updates the "Continue Watching" seed to that episode's successor based on the lastWatched timestamp.
## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
Not a UI change.
## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.
## Linked issues
Fixes #2145
<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
