### PR TITLE
Fix grid home stealing focus/scroll back to top on launch

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -189,14 +190,25 @@ fun GridHomeContent(
         gridItems.any { it is GridItem.Content || it is GridItem.SeeAll }
     }
 
+    // Once the user scrolls, initial focus must not pull back to the hero.
+    var userScrolledGrid by remember { mutableStateOf(false) }
+    LaunchedEffect(gridState) {
+        snapshotFlow {
+            gridState.firstVisibleItemIndex > 0 || gridState.firstVisibleItemScrollOffset > 0
+        }.collect { scrolledAway ->
+            if (scrolledAway) userScrolledGrid = true
+        }
+    }
+
+    // Keyed on the "is there something focusable" booleans (not gridItems.size, which
+    // churns per catalog and stole focus back to the top); retries until the target attaches.
     LaunchedEffect(
         shouldRequestInitialFocus,
         hasHero,
         hasContinueWatching,
-        hasStandaloneFocusableGridItem,
-            gridItems.size
+        hasStandaloneFocusableGridItem
     ) {
-        if (!shouldRequestInitialFocus) return@LaunchedEffect
+        if (!shouldRequestInitialFocus || userScrolledGrid) return@LaunchedEffect
         if (hasContinueWatching && !hasHero) return@LaunchedEffect
         val targetRequester = when {
             hasHero -> heroFocusRequester
@@ -204,10 +216,12 @@ fun GridHomeContent(
             else -> null
         } ?: return@LaunchedEffect
 
-        repeat(2) { withFrameNanos { } }
-        try {
-            targetRequester.requestFocus()
-        } catch (_: IllegalStateException) {
+        repeat(8) {
+            withFrameNanos { }
+            if (userScrolledGrid) return@LaunchedEffect
+            if (runCatching { targetRequester.requestFocus(); true }.getOrDefault(false)) {
+                return@LaunchedEffect
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the grid Home screen stealing focus and scroll position back to the top for the first few seconds after launch. While catalogs stream in, the user can't scroll down, each newly loaded row yanks focus/scroll back to the top until loading settles.

This brings the **grid layout in line with the modern and classic layouts**, which already behave correctly on launch, so all three home layouts are now consistent.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

In `GridHomeContent.kt`, the initial-focus `LaunchedEffect` is keyed on `gridItems.size`, which changes on every catalog that streams in during launch. Each change re-requests focus on the hero (the top item), and `shouldRequestInitialFocus` stays true for the whole session, so focus (and the scroll position) is pulled back to the top repeatedly until all catalogs finish loading.

The classic and modern layouts don't have this bug because they already guard against it. Classic keys initial focus on stable boolean signals, and modern guards it behind an "active row established" flag. This change applies the same protection to grid, matching their behavior.

## Issue or approval

Fixes #2207

## Reproduction steps

1. Set the home layout to **Grid**.
2. Cold-launch the app (force stop first), land on Home.
3. While catalogs are still loading, try to scroll down.
4. Before fix: focus/scroll snaps back to the top each time a row loads, for several seconds. After fix: scrolling down works and holds (same as modern/classic).

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only the grid layout's initial-focus logic is changed.
- Classic and modern layouts are untouched (they already guard against this); this aligns grid with them.
- No new UI, no new settings, no change to where initial focus lands (still the hero on boot).

## Testing

- Device: NVIDIA Shield TV (2019), Android 11. Debug-signed release APK, sideloaded.
- Grid layout, cold launch: confirmed scrolling down immediately now holds instead of snapping back to the top, matching modern/classic.
- Confirmed initial focus still lands on the hero on boot.
- Verified the "scroll to top" sidebar Home action and saved-focus restoration still work.

## Screenshots / Video

Not a UI change (no visual element changed). _Before/after screen recording of the scroll behavior to be attached._

## Breaking changes

None.

## Linked issues

Fixes #2207