### PR TITLE
feat(settings): add 'Released / Upcoming (Last released)' sorting mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -272,8 +272,11 @@ class LayoutPreferenceDataStore @Inject constructor(
 
     val continueWatchingSortMode: Flow<ContinueWatchingSortMode> = profileFlow { prefs ->
         val stored = prefs[continueWatchingSortModeKey] ?: ContinueWatchingSortMode.DEFAULT.name
-        runCatching { ContinueWatchingSortMode.valueOf(stored) }
-            .getOrDefault(ContinueWatchingSortMode.DEFAULT)
+        when (stored) {
+            "STREAMING_STYLE" -> ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED
+            else -> runCatching { ContinueWatchingSortMode.valueOf(stored) }
+                .getOrDefault(ContinueWatchingSortMode.DEFAULT)
+        }
     }
 
     val detailPageTrailerButtonEnabled: Flow<Boolean> = profileFlow { prefs ->

--- a/app/src/main/java/com/nuvio/tv/domain/model/ContinueWatchingSortMode.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/ContinueWatchingSortMode.kt
@@ -2,5 +2,6 @@ package com.nuvio.tv.domain.model
 
 enum class ContinueWatchingSortMode {
     DEFAULT,
-    STREAMING_STYLE
+    STREAMING_STYLE,
+    STREAMING_PRIORITIZE_NEW
 }

--- a/app/src/main/java/com/nuvio/tv/domain/model/ContinueWatchingSortMode.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/ContinueWatchingSortMode.kt
@@ -2,6 +2,6 @@ package com.nuvio.tv.domain.model
 
 enum class ContinueWatchingSortMode {
     DEFAULT,
-    STREAMING_STYLE,
-    STREAMING_PRIORITIZE_NEW
+    RELEASED_UPCOMING_LAST_RELEASED,
+    RELEASED_UPCOMING_LAST_WATCHED
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1552,11 +1552,11 @@ internal fun sortContinueWatchingItems(
         }
 
         ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> {
-            sortStreamingStyleItems(items) { it.info.releaseTimestamp }
+            sortStreamingStyleItems(items) { it.info.sortTimestamp }
         }
 
         ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> {
-            sortStreamingStyleItems(items) { it.info.sortTimestamp }
+            sortStreamingStyleItems(items) { it.info.lastWatched }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1551,11 +1551,11 @@ internal fun sortContinueWatchingItems(
             }
         }
 
-        ContinueWatchingSortMode.STREAMING_STYLE -> {
+        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> {
             sortStreamingStyleItems(items) { it.info.releaseTimestamp }
         }
 
-        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> {
+        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> {
             sortStreamingStyleItems(items) { it.info.sortTimestamp }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1598,19 +1598,12 @@ internal fun sortContinueWatchingItems(
                 }
             }
 
-            val sortedReleased = released.sortedWith(
-                compareByDescending<ContinueWatchingItem> { item ->
-                    when (item) {
-                        is ContinueWatchingItem.InProgress -> false
-                        is ContinueWatchingItem.NextUp -> item.info.isReleaseAlert
-                    }
-                }.thenByDescending { item ->
-                    when (item) {
-                        is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                        is ContinueWatchingItem.NextUp -> item.info.lastWatched
-                    }
+            val sortedReleased = released.sortedByDescending { item ->
+                when (item) {
+                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                    is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
                 }
-            )
+            }
 
             val sortedUnreleased = unreleased.sortedWith { a, b ->
                 val dateA = parseEpisodeReleaseDate(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1552,83 +1552,55 @@ internal fun sortContinueWatchingItems(
         }
 
         ContinueWatchingSortMode.STREAMING_STYLE -> {
-            val (released, unreleased) = items.partition { item ->
-                when (item) {
-                    is ContinueWatchingItem.InProgress -> true // in-progress is always released
-                    is ContinueWatchingItem.NextUp -> item.info.hasAired
-                }
-            }
-
-            val sortedReleased = released.sortedByDescending { item ->
-                when (item) {
-                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                    is ContinueWatchingItem.NextUp -> item.info.lastWatched
-                }
-            }
-
-            val sortedUnreleased = unreleased.sortedWith { a, b ->
-                val dateA = parseEpisodeReleaseDate(
-                    when (a) {
-                        is ContinueWatchingItem.InProgress -> null
-                        is ContinueWatchingItem.NextUp -> a.info.released
-                    }
-                )
-                val dateB = parseEpisodeReleaseDate(
-                    when (b) {
-                        is ContinueWatchingItem.InProgress -> null
-                        is ContinueWatchingItem.NextUp -> b.info.released
-                    }
-                )
-                when {
-                    dateA == null && dateB == null -> 0
-                    dateA == null -> 1 // unknown dates go to the end
-                    dateB == null -> -1
-                    else -> dateA.compareTo(dateB) // ascending: soonest first
-                }
-            }
-
-            sortedReleased + sortedUnreleased
+            sortStreamingStyleItems(items) { it.info.releaseTimestamp }
         }
 
         ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> {
-            val (released, unreleased) = items.partition { item ->
-                when (item) {
-                    is ContinueWatchingItem.InProgress -> true // in-progress is always released
-                    is ContinueWatchingItem.NextUp -> item.info.hasAired
-                }
-            }
-
-            val sortedReleased = released.sortedByDescending { item ->
-                when (item) {
-                    is ContinueWatchingItem.InProgress -> item.progress.lastWatched
-                    is ContinueWatchingItem.NextUp -> item.info.sortTimestamp
-                }
-            }
-
-            val sortedUnreleased = unreleased.sortedWith { a, b ->
-                val dateA = parseEpisodeReleaseDate(
-                    when (a) {
-                        is ContinueWatchingItem.InProgress -> null
-                        is ContinueWatchingItem.NextUp -> a.info.released
-                    }
-                )
-                val dateB = parseEpisodeReleaseDate(
-                    when (b) {
-                        is ContinueWatchingItem.InProgress -> null
-                        is ContinueWatchingItem.NextUp -> b.info.released
-                    }
-                )
-                when {
-                    dateA == null && dateB == null -> 0
-                    dateA == null -> 1 // unknown dates go to the end
-                    dateB == null -> -1
-                    else -> dateA.compareTo(dateB) // ascending: soonest first
-                }
-            }
-
-            sortedReleased + sortedUnreleased
+            sortStreamingStyleItems(items) { it.info.sortTimestamp }
         }
     }
+}
+
+private fun sortStreamingStyleItems(
+    items: List<ContinueWatchingItem>,
+    releasedNextUpSelector: (ContinueWatchingItem.NextUp) -> Long?
+): List<ContinueWatchingItem> {
+    val (released, unreleased) = items.partition { item ->
+        when (item) {
+            is ContinueWatchingItem.InProgress -> true // in-progress is always released
+            is ContinueWatchingItem.NextUp -> item.info.hasAired
+        }
+    }
+
+    val sortedReleased = released.sortedByDescending { item ->
+        when (item) {
+            is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+            is ContinueWatchingItem.NextUp -> releasedNextUpSelector(item)
+        }
+    }
+
+    val sortedUnreleased = unreleased.sortedWith { a, b ->
+        val dateA = parseEpisodeReleaseDate(
+            when (a) {
+                is ContinueWatchingItem.InProgress -> null
+                is ContinueWatchingItem.NextUp -> a.info.released
+            }
+        )
+        val dateB = parseEpisodeReleaseDate(
+            when (b) {
+                is ContinueWatchingItem.InProgress -> null
+                is ContinueWatchingItem.NextUp -> b.info.released
+            }
+        )
+        when {
+            dateA == null && dateB == null -> 0
+            dateA == null -> 1 // unknown dates go to the end
+            dateB == null -> -1
+            else -> dateA.compareTo(dateB) // ascending: soonest first
+        }
+    }
+
+    return sortedReleased + sortedUnreleased
 }
 
 internal fun mergeContinueWatchingItems(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1589,6 +1589,52 @@ internal fun sortContinueWatchingItems(
 
             sortedReleased + sortedUnreleased
         }
+
+        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> {
+            val (released, unreleased) = items.partition { item ->
+                when (item) {
+                    is ContinueWatchingItem.InProgress -> true // in-progress is always released
+                    is ContinueWatchingItem.NextUp -> item.info.hasAired
+                }
+            }
+
+            val sortedReleased = released.sortedWith(
+                compareByDescending<ContinueWatchingItem> { item ->
+                    when (item) {
+                        is ContinueWatchingItem.InProgress -> false
+                        is ContinueWatchingItem.NextUp -> item.info.isReleaseAlert
+                    }
+                }.thenByDescending { item ->
+                    when (item) {
+                        is ContinueWatchingItem.InProgress -> item.progress.lastWatched
+                        is ContinueWatchingItem.NextUp -> item.info.lastWatched
+                    }
+                }
+            )
+
+            val sortedUnreleased = unreleased.sortedWith { a, b ->
+                val dateA = parseEpisodeReleaseDate(
+                    when (a) {
+                        is ContinueWatchingItem.InProgress -> null
+                        is ContinueWatchingItem.NextUp -> a.info.released
+                    }
+                )
+                val dateB = parseEpisodeReleaseDate(
+                    when (b) {
+                        is ContinueWatchingItem.InProgress -> null
+                        is ContinueWatchingItem.NextUp -> b.info.released
+                    }
+                )
+                when {
+                    dateA == null && dateB == null -> 0
+                    dateA == null -> 1 // unknown dates go to the end
+                    dateB == null -> -1
+                    else -> dateA.compareTo(dateB) // ascending: soonest first
+                }
+            }
+
+            sortedReleased + sortedUnreleased
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -636,8 +636,8 @@ fun LayoutSettingsContent(
                         subtitle = stringResource(R.string.layout_cw_sort_mode_sub),
                         value = when (uiState.continueWatchingSortMode) {
                             ContinueWatchingSortMode.DEFAULT -> stringResource(R.string.layout_cw_sort_default)
-                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
-                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_streaming)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_released_upcoming_last_watched)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_released_upcoming_last_released)
                         },
                         onClick = { showCwSortModeDialog = true },
                         onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
@@ -841,13 +841,13 @@ private fun ContinueWatchingSortModeDialog(
         ),
         SettingsPickerOption(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
-            stringResource(R.string.layout_cw_sort_streaming_prioritize_new),
-            stringResource(R.string.layout_cw_sort_streaming_prioritize_new_desc)
+            stringResource(R.string.layout_cw_sort_released_upcoming_last_watched),
+            stringResource(R.string.layout_cw_sort_released_upcoming_last_watched_desc)
         ),
         SettingsPickerOption(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
-            stringResource(R.string.layout_cw_sort_streaming),
-            stringResource(R.string.layout_cw_sort_streaming_desc)
+            stringResource(R.string.layout_cw_sort_released_upcoming_last_released),
+            stringResource(R.string.layout_cw_sort_released_upcoming_last_released_desc)
         )
     )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -636,8 +636,8 @@ fun LayoutSettingsContent(
                         subtitle = stringResource(R.string.layout_cw_sort_mode_sub),
                         value = when (uiState.continueWatchingSortMode) {
                             ContinueWatchingSortMode.DEFAULT -> stringResource(R.string.layout_cw_sort_default)
-                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_streaming)
-                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_streaming)
                         },
                         onClick = { showCwSortModeDialog = true },
                         onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
@@ -841,13 +841,13 @@ private fun ContinueWatchingSortModeDialog(
         ),
         SettingsPickerOption(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
-            stringResource(R.string.layout_cw_sort_streaming),
-            stringResource(R.string.layout_cw_sort_streaming_desc)
+            stringResource(R.string.layout_cw_sort_streaming_prioritize_new),
+            stringResource(R.string.layout_cw_sort_streaming_prioritize_new_desc)
         ),
         SettingsPickerOption(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
-            stringResource(R.string.layout_cw_sort_streaming_prioritize_new),
-            stringResource(R.string.layout_cw_sort_streaming_prioritize_new_desc)
+            stringResource(R.string.layout_cw_sort_streaming),
+            stringResource(R.string.layout_cw_sort_streaming_desc)
         )
     )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -636,8 +636,8 @@ fun LayoutSettingsContent(
                         subtitle = stringResource(R.string.layout_cw_sort_mode_sub),
                         value = when (uiState.continueWatchingSortMode) {
                             ContinueWatchingSortMode.DEFAULT -> stringResource(R.string.layout_cw_sort_default)
-                            ContinueWatchingSortMode.STREAMING_STYLE -> stringResource(R.string.layout_cw_sort_streaming)
-                            ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_streaming)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
                         },
                         onClick = { showCwSortModeDialog = true },
                         onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
@@ -840,12 +840,12 @@ private fun ContinueWatchingSortModeDialog(
             stringResource(R.string.layout_cw_sort_default_desc)
         ),
         SettingsPickerOption(
-            ContinueWatchingSortMode.STREAMING_STYLE,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
             stringResource(R.string.layout_cw_sort_streaming),
             stringResource(R.string.layout_cw_sort_streaming_desc)
         ),
         SettingsPickerOption(
-            ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
             stringResource(R.string.layout_cw_sort_streaming_prioritize_new),
             stringResource(R.string.layout_cw_sort_streaming_prioritize_new_desc)
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -637,6 +637,7 @@ fun LayoutSettingsContent(
                         value = when (uiState.continueWatchingSortMode) {
                             ContinueWatchingSortMode.DEFAULT -> stringResource(R.string.layout_cw_sort_default)
                             ContinueWatchingSortMode.STREAMING_STYLE -> stringResource(R.string.layout_cw_sort_streaming)
+                            ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
                         },
                         onClick = { showCwSortModeDialog = true },
                         onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
@@ -842,6 +843,11 @@ private fun ContinueWatchingSortModeDialog(
             ContinueWatchingSortMode.STREAMING_STYLE,
             stringResource(R.string.layout_cw_sort_streaming),
             stringResource(R.string.layout_cw_sort_streaming_desc)
+        ),
+        SettingsPickerOption(
+            ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW,
+            stringResource(R.string.layout_cw_sort_streaming_prioritize_new),
+            stringResource(R.string.layout_cw_sort_streaming_prioritize_new_desc)
         )
     )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -636,8 +636,8 @@ fun LayoutSettingsContent(
                         subtitle = stringResource(R.string.layout_cw_sort_mode_sub),
                         value = when (uiState.continueWatchingSortMode) {
                             ContinueWatchingSortMode.DEFAULT -> stringResource(R.string.layout_cw_sort_default)
-                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_streaming)
-                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> stringResource(R.string.layout_cw_sort_streaming)
+                            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> stringResource(R.string.layout_cw_sort_streaming_prioritize_new)
                         },
                         onClick = { showCwSortModeDialog = true },
                         onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
@@ -840,12 +840,12 @@ private fun ContinueWatchingSortModeDialog(
             stringResource(R.string.layout_cw_sort_default_desc)
         ),
         SettingsPickerOption(
-            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
             stringResource(R.string.layout_cw_sort_streaming),
             stringResource(R.string.layout_cw_sort_streaming_desc)
         ),
         SettingsPickerOption(
-            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
             stringResource(R.string.layout_cw_sort_streaming_prioritize_new),
             stringResource(R.string.layout_cw_sort_streaming_prioritize_new_desc)
         )

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -845,8 +845,8 @@
     <string name="layout_cw_sort_mode_sub">آلية ترتيب عناصر متابعة المشاهدة</string>
     <string name="layout_cw_sort_default">الافتراضي</string>
     <string name="layout_cw_sort_default_desc">فرز جميع العناصر حسب الأحدث</string>
-    <string name="layout_cw_sort_streaming">نمط منصات المشاهدة</string>
-    <string name="layout_cw_sort_streaming_desc">الحلقات المتوفرة أولاً، والحلقات القادمة في الأخير</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">نمط منصات المشاهدة</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">الحلقات المتوفرة أولاً، والحلقات القادمة في الأخير</string>
     <string name="layout_trailer_button">إظهار زر الإعلان</string>
     <string name="layout_trailer_button_sub">إظهار زر الإعلان في صفحة التفاصيل (عند توفره فقط).</string>
     <string name="layout_prefer_external_meta">تفضيل جلب بيانات الإضافات الخارجية</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -830,10 +830,10 @@
     <string name="layout_cw_sort_mode_sub">Cómo se organizan los elementos de Continuar viendo</string>
     <string name="layout_cw_sort_default">Predeterminado</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos los elementos por fecha reciente</string>
-    <string name="layout_cw_sort_streaming">Estrenados / Próximos (Últimos estrenados)</string>
-    <string name="layout_cw_sort_streaming_desc">Elementos estrenados ordenados por fecha de estreno, próximos estrenos por fecha de emisión</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Estrenados / Próximos (Últimos vistos)</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto, próximos estrenos por fecha de emisión</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Estrenados / Próximos (Últimos estrenados)</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Elementos estrenados ordenados por fecha de estreno, próximos estrenos por fecha de emisión</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched">Estrenados / Próximos (Últimos vistos)</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched_desc">Elementos estrenados ordenados por último visto, próximos estrenos por fecha de emisión</string>
     <string name="layout_trailer_button">Mostrar botón de tráiler</string>
     <string name="layout_trailer_button_sub">Mostrar el botón de tráiler en la página de detalles (solo si está disponible).</string>
     <string name="layout_prefer_external_meta">Preferir metadatos de addon externo</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -830,10 +830,10 @@
     <string name="layout_cw_sort_mode_sub">Cómo se organizan los elementos de Continuar viendo</string>
     <string name="layout_cw_sort_default">Predeterminado</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos los elementos por fecha reciente</string>
-    <string name="layout_cw_sort_streaming">Estrenados / Próximos</string>
-    <string name="layout_cw_sort_streaming_desc">Elementos estrenados ordenados por último visto, elementos no estrenados por fecha de estreno</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Priorizar nuevos episodios</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto (priorizando nuevos episodios), próximos estrenos por fecha de emisión</string>
+    <string name="layout_cw_sort_streaming">Estrenados / Próximos (Últimos estrenados)</string>
+    <string name="layout_cw_sort_streaming_desc">Elementos estrenados ordenados por fecha de estreno, próximos estrenos por fecha de emisión</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Estrenados / Próximos (Últimos vistos)</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto, próximos estrenos por fecha de emisión</string>
     <string name="layout_trailer_button">Mostrar botón de tráiler</string>
     <string name="layout_trailer_button_sub">Mostrar el botón de tráiler en la página de detalles (solo si está disponible).</string>
     <string name="layout_prefer_external_meta">Preferir metadatos de addon externo</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -830,8 +830,10 @@
     <string name="layout_cw_sort_mode_sub">Cómo se organizan los elementos de Continuar viendo</string>
     <string name="layout_cw_sort_default">Predeterminado</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos los elementos por fecha reciente</string>
-    <string name="layout_cw_sort_streaming">Estilo streaming</string>
-    <string name="layout_cw_sort_streaming_desc">Elementos estrenados primero, próximos estrenos al final</string>
+    <string name="layout_cw_sort_streaming">Estrenados / Próximos</string>
+    <string name="layout_cw_sort_streaming_desc">Elementos estrenados ordenados por último visto, elementos no estrenados por fecha de estreno</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Priorizar nuevos episodios</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto (priorizando nuevos episodios), próximos estrenos por fecha de emisión</string>
     <string name="layout_trailer_button">Mostrar botón de tráiler</string>
     <string name="layout_trailer_button_sub">Mostrar el botón de tráiler en la página de detalles (solo si está disponible).</string>
     <string name="layout_prefer_external_meta">Preferir metadatos de addon externo</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -741,8 +741,8 @@
 <string name="layout_cw_sort_mode_sub">Jak jsou položky Pokračovat ve sledování uspořádány</string>
 <string name="layout_cw_sort_default">Výchozí</string>
 <string name="layout_cw_sort_default_desc">Seřadit všechny položky podle aktuálnosti</string>
-<string name="layout_cw_sort_streaming">Styl streamování</string>
-<string name="layout_cw_sort_streaming_desc">Nejprve vydané položky, nadcházející na konci</string>
+<string name="layout_cw_sort_released_upcoming_last_released">Styl streamování</string>
+<string name="layout_cw_sort_released_upcoming_last_released_desc">Nejprve vydané položky, nadcházející na konci</string>
 <string name="layout_trailer_button">Zobrazit tlačítko traileru</string>
 <string name="layout_trailer_button_sub">Zobrazit tlačítko traileru na stránce podrobností (pouze pokud je trailer k dispozici).</string>
 <string name="layout_prefer_external_meta">Preferovat metadata z externího doplňku</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -808,8 +808,8 @@
     <string name="layout_cw_sort_mode_sub">How Continue Watching items are arranged</string>
     <string name="layout_cw_sort_default">Default</string>
     <string name="layout_cw_sort_default_desc">Sort all items by recency</string>
-    <string name="layout_cw_sort_streaming">Streaming Style</string>
-    <string name="layout_cw_sort_streaming_desc">Released items first, upcoming at the end</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Streaming Style</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Released items first, upcoming at the end</string>
     <string name="layout_trailer_button">Trailer-Schaltfläche anzeigen</string>
     <string name="layout_trailer_button_sub">Trailer-Schaltfläche auf der Detailseite anzeigen. (wenn verfügbar)</string>
     <string name="layout_prefer_external_meta">Metainformationen aus externem Add-on bevorzugen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -815,8 +815,8 @@
     <string name="layout_cw_sort_mode_sub">Πώς ταξινομούνται τα στοιχεία Συνέχεια παρακολούθησης</string>
     <string name="layout_cw_sort_default">Προεπιλογή</string>
     <string name="layout_cw_sort_default_desc">Ταξινόμηση όλων των στοιχείων κατά πρόσφατα</string>
-    <string name="layout_cw_sort_streaming">Στυλ streaming</string>
-    <string name="layout_cw_sort_streaming_desc">Κυκλοφορημένα πρώτα, επερχόμενα στο τέλος</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Στυλ streaming</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Κυκλοφορημένα πρώτα, επερχόμενα στο τέλος</string>
     <string name="layout_trailer_button">Εμφάνιση κουμπιού τρέιλερ</string>
     <string name="layout_trailer_button_sub">Εμφάνιση κουμπιού τρέιλερ στην οθόνη λεπτομερειών (μόνο όταν υπάρχει τρέιλερ).</string>
     <string name="layout_prefer_external_meta">Προτίμηση μεταδεδομένων από εξωτερικό πρόσθετο</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2321,8 +2321,8 @@
     <string name="layout_cw_sort_mode_sub">Comment les éléments Continuer à regarder sont organisés</string>
     <string name="layout_cw_sort_default">Par défaut</string>
     <string name="layout_cw_sort_default_desc">Trier les éléments du plus récent au plus ancien</string>
-    <string name="layout_cw_sort_streaming">Style streaming</string>
-    <string name="layout_cw_sort_streaming_desc">Les éléments sortis d’abord, ceux à venir à la fin</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Style streaming</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Les éléments sortis d’abord, ceux à venir à la fin</string>
 
     <!-- Trakt&#160;: source des recommandations Similaires -->
     <string name="trakt_more_like_this_source_title">Source de la section Similaires</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -830,8 +830,8 @@
     <string name="layout_cw_sort_mode_sub">A Megtekintés folytatása elemek elrendezése</string>
     <string name="layout_cw_sort_default">Alapértelmezett</string>
     <string name="layout_cw_sort_default_desc">Az összes elem rendezése frissesség szerint</string>
-    <string name="layout_cw_sort_streaming">Streaming stílus</string>
-    <string name="layout_cw_sort_streaming_desc">Megjelent elemek elöl, hamarosan megjelenők a végén</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Streaming stílus</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Megjelent elemek elöl, hamarosan megjelenők a végén</string>
     <string name="layout_trailer_button">Előzetes gomb megjelenítése</string>
     <string name="layout_trailer_button_sub">Előzetes gomb a részletek oldalon (csak ha van elérhető előzetes).</string>
     <string name="layout_prefer_external_meta">Külső bővítmény metaadatainak előnyben részesítése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -815,8 +815,8 @@
     <string name="layout_cw_sort_mode_sub">Cara item Lanjutkan Menonton disusun</string>
     <string name="layout_cw_sort_default">Bawaan</string>
     <string name="layout_cw_sort_default_desc">Urutkan semua item berdasarkan terbaru</string>
-    <string name="layout_cw_sort_streaming">Gaya Streaming</string>
-    <string name="layout_cw_sort_streaming_desc">Item yang sudah dirilis lebih dulu, yang akan datang di akhir</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Gaya Streaming</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Item yang sudah dirilis lebih dulu, yang akan datang di akhir</string>
     <string name="layout_trailer_button">Tampilkan Tombol Trailer</string>
     <string name="layout_trailer_button_sub">Tampilkan tombol trailer di halaman detail (hanya saat trailer tersedia).</string>
     <string name="layout_prefer_external_meta">Utamakan meta dari addon eksternal</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2024,8 +2024,8 @@
   <string name="layout_cw_sort_mode_sub">Come vengono ordinati gli elementi in \"Continua a guardare\"</string>
   <string name="layout_cw_sort_default">Predefinito</string>
   <string name="layout_cw_sort_default_desc">Ordina tutti gli elementi per data recente</string>
-  <string name="layout_cw_sort_streaming">Stile streaming</string>
-  <string name="layout_cw_sort_streaming_desc">Elementi usciti per primi, in arrivo alla fine</string>
+  <string name="layout_cw_sort_released_upcoming_last_released">Stile streaming</string>
+  <string name="layout_cw_sort_released_upcoming_last_released_desc">Elementi usciti per primi, in arrivo alla fine</string>
   <string name="essential_addon_setup_title">Configura gli add-on</string>
   <string name="essential_addon_setup_subtitle">Installa un add-on per iniziare lo streaming. Puoi aggiungerne altri in seguito dalla sezione Add-on.</string>
   <string name="essential_addon_show_qr">Mostra QR</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2112,8 +2112,8 @@
     <string name="layout_cw_sort_default_desc">Sortuj wszystkie elementy według aktualności</string>
     <string name="layout_cw_sort_mode">Kolejność sortowania</string>
     <string name="layout_cw_sort_mode_sub">Jak elementy Kontynuuj oglądanie są ułożone</string>
-    <string name="layout_cw_sort_streaming">Styl streamingowy</string>
-    <string name="layout_cw_sort_streaming_desc">Wydane elementy najpierw, nadchodzące na końcu</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Styl streamingowy</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Wydane elementy najpierw, nadchodzące na końcu</string>
     <string name="layout_discover_location_action">Lokalizacja Odkrywaj</string>
     <string name="layout_discover_location_dialog_title">Lokalizacja Odkrywaj</string>
     <string name="layout_discover_location_in_search">Pokaż w Szukaj</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -828,10 +828,10 @@
     <string name="layout_cw_sort_mode_sub">Como organizar Continuar Assistindo</string>
     <string name="layout_cw_sort_default">Padrão</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos por mais recentes</string>
-    <string name="layout_cw_sort_streaming">Lançados / Próximos</string>
-    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados pelo último assistido, itens não lançados por data de lançamento</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Priorizar novos episódios</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido (priorizando novos episódios), próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_streaming">Lançados / Próximos (Últimos lançados)</string>
+    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Lançados / Próximos (Últimos assistidos)</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido, próximos itens por data de exibição</string>
     <string name="layout_trailer_button">Botão de Trailer</string>
     <string name="layout_trailer_button_sub">Exiba o botão nos detalhes, se disponível.</string>
     <string name="layout_prefer_external_meta">Priorizar metadados externos</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -828,10 +828,10 @@
     <string name="layout_cw_sort_mode_sub">Como organizar Continuar Assistindo</string>
     <string name="layout_cw_sort_default">Padrão</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos por mais recentes</string>
-    <string name="layout_cw_sort_streaming">Lançados / Próximos (Últimos lançados)</string>
-    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Lançados / Próximos (Últimos assistidos)</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido, próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Lançados / Próximos (Últimos lançados)</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched">Lançados / Próximos (Últimos assistidos)</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched_desc">Itens lançados ordenados pelo último assistido, próximos itens por data de exibição</string>
     <string name="layout_trailer_button">Botão de Trailer</string>
     <string name="layout_trailer_button_sub">Exiba o botão nos detalhes, se disponível.</string>
     <string name="layout_prefer_external_meta">Priorizar metadados externos</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -828,8 +828,10 @@
     <string name="layout_cw_sort_mode_sub">Como organizar Continuar Assistindo</string>
     <string name="layout_cw_sort_default">Padrão</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos por mais recentes</string>
-    <string name="layout_cw_sort_streaming">Estilo streaming</string>
-    <string name="layout_cw_sort_streaming_desc">Lançados primeiro, futuros no fim</string>
+    <string name="layout_cw_sort_streaming">Lançados / Próximos</string>
+    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados pelo último assistido, itens não lançados por data de lançamento</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Priorizar novos episódios</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido (priorizando novos episódios), próximos itens por data de exibição</string>
     <string name="layout_trailer_button">Botão de Trailer</string>
     <string name="layout_trailer_button_sub">Exiba o botão nos detalhes, se disponível.</string>
     <string name="layout_prefer_external_meta">Priorizar metadados externos</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -814,8 +814,10 @@
     <string name="layout_cw_sort_mode_sub">Como os itens do Continuar a Ver são organizados</string>
     <string name="layout_cw_sort_default">Predefinido</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos os itens por recência</string>
-    <string name="layout_cw_sort_streaming">Estilo Streaming</string>
-    <string name="layout_cw_sort_streaming_desc">Itens já lançados primeiro, os próximos no fim</string>
+    <string name="layout_cw_sort_streaming">Lançados / Próximos</string>
+    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados pelo último visto, itens não lançados por data de lançamento</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Priorizar novos episódios</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último visto (priorizando novos episódios), próximos itens por data de exibição</string>
     <string name="layout_trailer_button">Mostrar botão de trailer</string>
     <string name="layout_trailer_button_sub">Mostrar o botão de trailer na página de detalhes (apenas quando o trailer estiver disponível).</string>
     <string name="layout_prefer_external_meta">Preferir metadados de addon externo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -814,10 +814,10 @@
     <string name="layout_cw_sort_mode_sub">Como os itens do Continuar a Ver são organizados</string>
     <string name="layout_cw_sort_default">Predefinido</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos os itens por recência</string>
-    <string name="layout_cw_sort_streaming">Lançados / Próximos</string>
-    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados pelo último visto, itens não lançados por data de lançamento</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Priorizar novos episódios</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último visto (priorizando novos episódios), próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_streaming">Lançados / Próximos (Últimos lançados)</string>
+    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Lançados / Próximos (Últimos vistos)</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último visto, próximos itens por data de exibição</string>
     <string name="layout_trailer_button">Mostrar botão de trailer</string>
     <string name="layout_trailer_button_sub">Mostrar o botão de trailer na página de detalhes (apenas quando o trailer estiver disponível).</string>
     <string name="layout_prefer_external_meta">Preferir metadados de addon externo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -814,10 +814,10 @@
     <string name="layout_cw_sort_mode_sub">Como os itens do Continuar a Ver são organizados</string>
     <string name="layout_cw_sort_default">Predefinido</string>
     <string name="layout_cw_sort_default_desc">Ordenar todos os itens por recência</string>
-    <string name="layout_cw_sort_streaming">Lançados / Próximos (Últimos lançados)</string>
-    <string name="layout_cw_sort_streaming_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Lançados / Próximos (Últimos vistos)</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Itens lançados ordenados pelo último visto, próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Lançados / Próximos (Últimos lançados)</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched">Lançados / Próximos (Últimos vistos)</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched_desc">Itens lançados ordenados pelo último visto, próximos itens por data de exibição</string>
     <string name="layout_trailer_button">Mostrar botão de trailer</string>
     <string name="layout_trailer_button_sub">Mostrar o botão de trailer na página de detalhes (apenas quando o trailer estiver disponível).</string>
     <string name="layout_prefer_external_meta">Preferir metadados de addon externo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1780,8 +1780,8 @@
     <string name="layout_cw_sort_mode_sub">Порядок элементов «Продолжить просмотр»</string>
     <string name="layout_cw_sort_default">По умолчанию</string>
     <string name="layout_cw_sort_default_desc">Сортировать все элементы по дате</string>
-    <string name="layout_cw_sort_streaming">Стиль стриминга</string>
-    <string name="layout_cw_sort_streaming_desc">Вышедшие вначале, предстоящие в конце</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Стиль стриминга</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Вышедшие вначале, предстоящие в конце</string>
     <string name="layout_memory_only_scroll">Вертикальная прокрутка только из памяти</string>
     <string name="layout_memory_only_scroll_sub">Не загружать новые изображения при вертикальной прокрутке.</string>
     <!-- Batch 5: debrid settings -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -816,8 +816,8 @@
     <string name="layout_cw_sort_mode_sub">Ako sú usporiadané položky Pokračovať v sledovaní</string>
     <string name="layout_cw_sort_default">Predvolené</string>
     <string name="layout_cw_sort_default_desc">Zoradiť všetky položky podľa aktuálnosti</string>
-    <string name="layout_cw_sort_streaming">Štýl streamovania</string>
-    <string name="layout_cw_sort_streaming_desc">Vydané položky ako prvé, nadchádzajúce na konci</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Štýl streamovania</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Vydané položky ako prvé, nadchádzajúce na konci</string>
     <string name="layout_trailer_button">Zobraziť tlačidlo traileru</string>
     <string name="layout_trailer_button_sub">Zobraziť tlačidlo traileru na detailnej stránke (iba ak je dostupný).</string>
     <string name="layout_prefer_external_meta">Preferovať externé meta</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -782,8 +782,8 @@
     <string name="layout_cw_sort_mode_sub">Kako so razporejeni elementi v Nadaljuj z ogledom</string>
     <string name="layout_cw_sort_default">Privzeto</string>
     <string name="layout_cw_sort_default_desc">Razvrsti vse elemente po nedavnosti</string>
-    <string name="layout_cw_sort_streaming">Slog pretočnega predvajanja</string>
-    <string name="layout_cw_sort_streaming_desc">Najprej izdani elementi, prihajajoči na koncu</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Slog pretočnega predvajanja</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Najprej izdani elementi, prihajajoči na koncu</string>
     <string name="layout_trailer_button">Prikaži gumb za napovednik</string>
     <string name="layout_trailer_button_sub">Prikaži gumb za napovednik na strani s podrobnostmi (samo, ko je napovednik na voljo).</string>															  
     <string name="layout_prefer_external_meta">Prednost metapodatkom iz zunanjega dodatka</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -802,8 +802,8 @@
     <string name="layout_cw_sort_mode_sub">தொடர்ந்து பார்ப்பது உருப்படிகள் எவ்வாறு ஒழுங்குபடுத்தப்படுகின்றன</string>
     <string name="layout_cw_sort_default">இயல்புநிலை</string>
     <string name="layout_cw_sort_default_desc">அனைத்து உருப்படிகளையும் சமீபத்தியதன் அடிப்படையில் வரிசைப்படுத்து</string>
-    <string name="layout_cw_sort_streaming">ஒளிபரப்பு நடை</string>
-    <string name="layout_cw_sort_streaming_desc">வெளியானவை முதலில், வரவிருப்பவை இறுதியில்</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">ஒளிபரப்பு நடை</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">வெளியானவை முதலில், வரவிருப்பவை இறுதியில்</string>
     <string name="layout_trailer_button">டிரெய்லர் பொத்தானை காட்டு</string>
     <string name="layout_trailer_button_sub">விவரப் பக்கத்தில் டிரெய்லர் பொத்தானை காட்டு (டிரெய்லர் கிடைத்தால் மட்டும்).</string>
     <string name="layout_prefer_external_meta">வெளிப்புற அடானிலிருந்து மேட்டா தரவை விரும்பு</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -831,8 +831,8 @@
     <string name="layout_cw_sort_mode_sub">İzlemeye Devam Et öğelerinin nasıl dizileceği</string>
     <string name="layout_cw_sort_default">Varsayılan</string>
     <string name="layout_cw_sort_default_desc">Tüm öğeleri yeniliğe göre sırala</string>
-    <string name="layout_cw_sort_streaming">Yayın Stili</string>
-    <string name="layout_cw_sort_streaming_desc">Yayındakiler önce, yaklaşanlar sonda</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Yayın Stili</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Yayındakiler önce, yaklaşanlar sonda</string>
     <string name="layout_trailer_button">Fragman Düğmesini Göster</string>
     <string name="layout_trailer_button_sub">Ayrıntı sayfasında fragman düğmesi göster (sadece fragman mevcutsa).</string>
     <string name="layout_prefer_external_meta">Harici eklentinin meta verisini tercih et</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -816,8 +816,8 @@
     <string name="layout_cw_sort_mode_sub">继续观看项目的排列方式</string>
     <string name="layout_cw_sort_default">默认</string>
     <string name="layout_cw_sort_default_desc">按最近度排序所有项目</string>
-    <string name="layout_cw_sort_streaming">流媒体风格</string>
-    <string name="layout_cw_sort_streaming_desc">已发布项目在前，即将上线在后</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">流媒体风格</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">已发布项目在前，即将上线在后</string>
     <string name="layout_trailer_button">显示预告片按钮</string>
     <string name="layout_trailer_button_sub">详情页显示预告片按钮（仅预告片可用时）。</string>
     <string name="layout_prefer_external_meta">优先使用外部插件元数据</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -831,10 +831,10 @@
     <string name="layout_cw_sort_mode_sub">How Continue Watching items are arranged</string>
     <string name="layout_cw_sort_default">Default</string>
     <string name="layout_cw_sort_default_desc">Sort all items by recency</string>
-    <string name="layout_cw_sort_streaming">Streaming Style</string>
-    <string name="layout_cw_sort_streaming_desc">Released items first, upcoming at the end</string>
+    <string name="layout_cw_sort_streaming">Released / Upcoming</string>
+    <string name="layout_cw_sort_streaming_desc">Released items sorted by last watched, unreleased items by release date</string>
     <string name="layout_cw_sort_streaming_prioritize_new">Prioritize new episodes</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Streaming Style, but new episodes come first</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Released items sorted by last watched (prioritizing new episodes), upcoming items by air date</string>
     <string name="layout_trailer_button">Show Trailer Button</string>
     <string name="layout_trailer_button_sub">Show trailer button on detail page (only when trailer is available).</string>
     <string name="layout_prefer_external_meta">Prefer meta from external addon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -831,10 +831,10 @@
     <string name="layout_cw_sort_mode_sub">How Continue Watching items are arranged</string>
     <string name="layout_cw_sort_default">Default</string>
     <string name="layout_cw_sort_default_desc">Sort all items by recency</string>
-    <string name="layout_cw_sort_streaming">Released / Upcoming</string>
-    <string name="layout_cw_sort_streaming_desc">Released items sorted by last watched, unreleased items by release date</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Prioritize new episodes</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Released items sorted by last watched (prioritizing new episodes), upcoming items by air date</string>
+    <string name="layout_cw_sort_streaming">Released / Upcoming (Last released)</string>
+    <string name="layout_cw_sort_streaming_desc">Released items sorted by release date, upcoming items by air date</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Released / Upcoming (Last watched)</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Released items sorted by last watched, upcoming items by air date</string>
     <string name="layout_trailer_button">Show Trailer Button</string>
     <string name="layout_trailer_button_sub">Show trailer button on detail page (only when trailer is available).</string>
     <string name="layout_prefer_external_meta">Prefer meta from external addon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -831,10 +831,10 @@
     <string name="layout_cw_sort_mode_sub">How Continue Watching items are arranged</string>
     <string name="layout_cw_sort_default">Default</string>
     <string name="layout_cw_sort_default_desc">Sort all items by recency</string>
-    <string name="layout_cw_sort_streaming">Released / Upcoming (Last released)</string>
-    <string name="layout_cw_sort_streaming_desc">Released items sorted by release date, upcoming items by air date</string>
-    <string name="layout_cw_sort_streaming_prioritize_new">Released / Upcoming (Last watched)</string>
-    <string name="layout_cw_sort_streaming_prioritize_new_desc">Released items sorted by last watched, upcoming items by air date</string>
+    <string name="layout_cw_sort_released_upcoming_last_released">Released / Upcoming (Last released)</string>
+    <string name="layout_cw_sort_released_upcoming_last_released_desc">Released items sorted by release date, upcoming items by air date</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched">Released / Upcoming (Last watched)</string>
+    <string name="layout_cw_sort_released_upcoming_last_watched_desc">Released items sorted by last watched, upcoming items by air date</string>
     <string name="layout_trailer_button">Show Trailer Button</string>
     <string name="layout_trailer_button_sub">Show trailer button on detail page (only when trailer is available).</string>
     <string name="layout_prefer_external_meta">Prefer meta from external addon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -833,6 +833,8 @@
     <string name="layout_cw_sort_default_desc">Sort all items by recency</string>
     <string name="layout_cw_sort_streaming">Streaming Style</string>
     <string name="layout_cw_sort_streaming_desc">Released items first, upcoming at the end</string>
+    <string name="layout_cw_sort_streaming_prioritize_new">Prioritize new episodes</string>
+    <string name="layout_cw_sort_streaming_prioritize_new_desc">Streaming Style, but new episodes come first</string>
     <string name="layout_trailer_button">Show Trailer Button</string>
     <string name="layout_trailer_button_sub">Show trailer button on detail page (only when trailer is available).</string>
     <string name="layout_prefer_external_meta">Prefer meta from external addon</string>


### PR DESCRIPTION
## Summary

Introduces a new "Released / Upcoming (Last watched)" sort order option for the Continue Watching carousel.
Additionally, renames the "Streaming style" sorting mode option to "Released / Upcoming (Last released)" for clarity, updates the descriptions for both options to clearly explain how items are partitioned and sorted, and adds Portuguese (pt-BR, pt-PT) and Spanish (es-419) translations.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The user requested a new sorting order where 'New episodes' release alerts are not strictly pinned to the absolute front of the released items list. Instead, they are sorted by their release/update recency integrated with when other ongoing/in-progress items were last watched. This means the released group is sorted by a unified timestamp: `lastWatched` for in-progress and standard next-up items, and `releaseTimestamp` for next-up release alerts. This integrates new episodes by release recency alongside recently watched shows. The naming of the sorting options was also polished to make the partitioning rules ("Released / Upcoming (Last watched)" and "Released / Upcoming (Last released)") clearer to the user.

### Sorting Comparison Scenarios

To help understand the difference, here is a breakdown of how the two modes sort the Continue Watching carousel under different states.

#### Sample Data Setup:
*   **Show G:** In-progress with a new episode alert (Watched 3h ago; new episode aired 1d ago).
*   **Show A:** Standard In-progress (Watched 6h ago; next episode not yet aired).
*   **Show B:** Next-up with a new episode alert (Watched 10d ago; new episode aired 2d ago).
*   **Show C:** Standard Next-up (Watched 5d ago; next episode aired 30d ago).
*   **Show F:** Next-up/Abandoned (Watched 70d ago; next episode aired 10d ago — no badge due to the 60-day limit).
*   **Show D:** Upcoming/Unreleased (Next episode airs in 5 days).
*   **Show E:** Upcoming/Unreleased (Next episode airs in 15 days).

### Visual Carousel Scenarios:

#### Option 1: `Released / Upcoming (Last watched)`
*Released items sorted by the user's watch recency. New episode alerts for shows watched ≤ 60 days ago use their air date as the sort key; all others use `lastWatched`.*

**Scenario A — Heavy watcher with mixed new episodes:**
*You watch daily. Show A and G are in-progress; Show B has a new episode alert but was last watched 10 days ago.*
```mermaid
flowchart LR
    subgraph Released
        G1["Show G (in-progress, watched 3h ago)"] --> A1["Show A (in-progress, watched 6h ago)"]
        A1 --> B1["Show B (alert: aired 2d ago, watched 10d ago)"]
        B1 --> C1["Show C (next-up, watched 5d ago)"]
    end
    subgraph Upcoming
        D1["Show D (airs in 5 days)"] --> E1["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario B — Casual watcher; long gap since last session:**
*You haven't watched in weeks. An abandoned show (F) has a new episode but exceeds the 60-day limit — stays buried.*
```mermaid
flowchart LR
    subgraph Released
        B2["Show B (alert: aired 2d ago, key = 2d)"] --> C2["Show C (next-up, key = last watched 5d ago)"]
        C2 --> F2["Show F (abandoned 70d ago, alert ignored → key = 70d)"]
    end
    subgraph Upcoming
        D2["Show D (airs in 5 days)"] --> E2["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario C — All shows have new episode alerts:**
*Every show has a new episode. Alerts within 60 days use air date as key; abandoned (>60d) fall back to lastWatched.*
```mermaid
flowchart LR
    subgraph Released
        G3["Show G (alert: aired 1d ago → key = 1d)"] --> B3["Show B (alert: aired 2d ago → key = 2d)"]
        B3 --> F3["Show F (alert: aired 10d ago, watched 70d ago → key = 70d)"]
    end
    subgraph Upcoming
        D3["Show D (airs in 5 days)"] --> E3["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

#### Option 2: `Released / Upcoming (Last released)`
*Released items sorted by the next episode's air/release date, most recent first. `lastWatched` is used only for in-progress items with no release date.*

**Scenario A — Heavy watcher with mixed new episodes:**
*Same library as Scenario A above. In-progress items use `lastWatched`; next-up items use their air date.*
```mermaid
flowchart LR
    subgraph Released
        G4["Show G (in-progress, key = last watched 3h ago)"] --> A4["Show A (in-progress, key = last watched 6h ago)"]
        A4 --> B4["Show B (alert: aired 2d ago → key = 2d)"]
        B4 --> C4["Show C (next-up, aired 30d ago → key = 30d)"]
    end
    subgraph Upcoming
        D4["Show D (airs in 5 days)"] --> E4["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario B — Casual watcher; long gap since last session:**
*The abandoned show (F) jumps forward — its air date (10d ago) is more recent than Show C's (30d ago).*
```mermaid
flowchart LR
    subgraph Released
        B5["Show B (alert: aired 2d ago → key = 2d)"] --> F5["Show F (abandoned, aired 10d ago → key = 10d)"]
        F5 --> C5["Show C (next-up, aired 30d ago → key = 30d)"]
    end
    subgraph Upcoming
        D5["Show D (airs in 5 days)"] --> E5["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario C — All shows have new episode alerts:**
*Sorted strictly by air date — the 60-day badge limit does not affect position here.*
```mermaid
flowchart LR
    subgraph Released
        G6["Show G (alert: aired 1d ago → key = 1d)"] --> B6["Show B (alert: aired 2d ago → key = 2d)"]
        B6 --> F6["Show F (alert: aired 10d ago → key = 10d)"]
    end
    subgraph Upcoming
        D6["Show D (airs in 5 days)"] --> E6["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```



## Issue or approval

Approved by user/maintainer request (#2210).

## Reproduction steps

No reproduction steps - feature addition.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to adding the sorting enum, implementation of the comparator, updated and translated string resources, and layout settings dialog options.

## Testing

Verified by local Gradle compilation (`:app:compileFullDebugKotlin` task).

## Screenshots / Video

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/2d73137f-d824-4eec-bb71-23f2c931d2b6" />


| Streaming Style | Prioritize New Episodes |
|-----------------|-------------------------|
| <img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/14095875-c062-4345-b4f0-ea0ea9bc62c6" /> | <img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/42bd657b-f548-4c66-929e-c015eddaf7a7" /> |


## Breaking changes

None.

## Linked issues

Fixes #2210.
