### PR TITLE
fix(player): change WebView subtitle layer type to LAYER_TYPE_NONE to…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1472,7 +1472,7 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
             val extraPadding = (height * (subtitleStyle.verticalOffset / 400f)).toInt().coerceAtLeast(0)
             setPadding(0, 0, 0, extraPadding)
             findWebView()?.let { wv ->
-                wv.setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null)
+                wv.setLayerType(android.view.View.LAYER_TYPE_NONE, null)
                 wv.layoutDirection = android.view.View.LAYOUT_DIRECTION_LTR
             }
         }


### PR DESCRIPTION
## Summary
Sets the WebView subtitle layer type to `LAYER_TYPE_NONE` instead of `LAYER_TYPE_HARDWARE` inside `PlayerScreen.kt`. Disabling the off-screen hardware layer on the subtitle `WebView` prevents buffer allocation exhaustion and conflicts with `MTK_GRALLOC` on MediaTek devices (such as the Google TV Streamer). This change was identified during validation and testing of **PR #2179** to resolve decoder lockups, codec timeout errors (1003), and main thread ANR crashes during autoplay or rapid playback switching.
## PR type
- [ ] Translation/localization only
- [x] Critical bug fix
## Why
During testing and validation of **PR #2179**, a critical crash and playback timeout regression was detected on MediaTek devices (specifically Google TV Streamer). WebView-based subtitle rendering (`VIEW_TYPE_WEB`) is chosen because it is significantly better than ExoPlayer's default Canvas-based rendering (`VIEW_TYPE_CANVAS`), which has caused CPU rendering spikes under heavy subtitle loads and fails to correctly render rich HTML/CSS styling, custom fonts, positioning, and subtitle overlaps.
However, initializing the subtitle WebView with `LAYER_TYPE_HARDWARE` allocated an off-screen GPU buffer layer that directly conflicted with the hardware video decoder's buffer manager (`MTK_GRALLOC`). During rapid playback changes (e.g., autoplaying the next episode), this exhausted the graphics memory, causing the video decoder to hang and the main thread to crash with an ANR.
By setting the layer type to `LAYER_TYPE_NONE`:
1. **No GPU Buffer Exhaustion**: It disables the dedicated off-screen GPU layer allocation that caused the `MTK_GRALLOC` driver starvation.
2. **High Fidelity Subtitles**: The player retains the superior rendering quality and efficiency of WebView subtitles compared to the default ExoPlayer Canvas renderer, without inducing GPU/CPU overhead.
This specific bug-fix is added to resolve the issues observed in PR #2179.
### Diagnostic Logs
```log
06-06 09:31:24.287   510   555 I MTK_GRALLOC: updateLayout not layout format 0x21
06-06 09:31:24.299 13688 14924 D CCodecBufferChannel: [c2.mtk.avc.decoder#163] Discard frames from previous generation.
...
06-06 09:31:32.510   698   926 W InputDispatcher: Window 92a3c0f com.nuviodebug.com/com.nuvio.tv.MainActivity (server) is unresponsive
06-06 09:31:32.614   698   926 I WindowManager: ANR in Window{92a3c0f u0 com.nuviodebug.com/com.nuvio.tv.MainActivity}. Reason:Input dispatching timed out
```
## Issue or approval
Fixes #2179
## Reproduction steps
1. Enable WebView-based subtitles in the player settings.
2. Run the application on a MediaTek Android TV device (e.g., Google TV Streamer).
3. Switch videos rapidly or trigger autoplay of multiple episodes in quick succession.
4. The player will hang on loading, outputting MTK_GRALLOC errors, and eventually freeze the app, producing an ANR dialog.
## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI changed only to fix a documented glitch/bug
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.
## Scope boundaries
This change is strictly limited to replacing `LAYER_TYPE_HARDWARE` with `LAYER_TYPE_NONE` for the subtitle WebView inside `PlayerScreen.kt`. It does not introduce any custom player timeouts or playback recovery retries.
## Testing
- Verified on Google TV Streamer (MediaTek platform) during validation of PR #2179.
- Tested switching subtitle settings and rapidly skipping through episodes; no gralloc failures, CPU spikes, or ANRs occurred.
## Screenshots / Video
Not a UI change
## Breaking changes
None.
## Linked issues
Fixes #2179