### PR TITLE
fix(player): revert WebView subtitles and restore Canvas rendering

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1613,8 +1613,7 @@ private class CueNormalizingTextOutput(
 
     override fun onCues(cueGroup: CueGroup) {
         val processed = cueGroup.cues.map { cue ->
-            var c = fixCuePositionAnchor(cue)
-            c = fixRtlCueText(c)
+            var c = fixRtlCueText(cue)
             if (shouldNormalizeCuePositionProvider()) c = normalizeCuePosition(c)
             c
         }
@@ -1624,25 +1623,11 @@ private class CueNormalizingTextOutput(
     @Deprecated("Uses the deprecated Media3 callback for text outputs.")
     override fun onCues(cues: List<Cue>) {
         val processed = cues.map { cue ->
-            var c = fixCuePositionAnchor(cue)
-            c = fixRtlCueText(c)
+            var c = fixRtlCueText(cue)
             if (shouldNormalizeCuePositionProvider()) c = normalizeCuePosition(c)
             c
         }
         delegate.onCues(processed)
-    }
-
-    // WebViewSubtitleOutput bug: position==DIMEN_UNSET → left:50%, but
-    // positionAnchor==TYPE_UNSET → translate(0%) instead of translate(-50%).
-    // Fix by setting ANCHOR_TYPE_MIDDLE so the cue is properly centered.
-    private fun fixCuePositionAnchor(cue: Cue): Cue {
-        if (cue.bitmap != null) return cue
-        if (cue.position != Cue.DIMEN_UNSET) return cue
-        if (cue.positionAnchor != Cue.TYPE_UNSET) return cue
-        return cue.buildUpon()
-            .setPosition(Cue.DIMEN_UNSET)
-            .setPositionAnchor(Cue.ANCHOR_TYPE_MIDDLE)
-            .build()
     }
 
     private fun normalizeCuePosition(cue: Cue): Cue {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1433,7 +1433,6 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
     }
     setTag(R.id.player_view_subtitle_style_tag, subtitleStyle)
     subtitleView?.apply {
-        setViewType(androidx.media3.ui.SubtitleView.VIEW_TYPE_WEB)
         val baseFontSize = 24f
         val scaledFontSize = baseFontSize * (subtitleStyle.size / 100f)
         setFixedTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, scaledFontSize)
@@ -1470,11 +1469,7 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
 
         post {
             val extraPadding = (height * (subtitleStyle.verticalOffset / 400f)).toInt().coerceAtLeast(0)
-            setPadding(0, 0, 0, extraPadding)
-            findWebView()?.let { wv ->
-                wv.setLayerType(android.view.View.LAYER_TYPE_NONE, null)
-                wv.layoutDirection = android.view.View.LAYOUT_DIRECTION_LTR
-            }
+            setPadding(paddingLeft, paddingTop, paddingRight, extraPadding)
         }
     }
 }
@@ -2837,19 +2832,4 @@ private fun PlayerBufferingIndicator(
             LoadingIndicator()
         }
     }
-}
-
-private fun View.findWebView(): android.webkit.WebView? {
-    if (this is android.webkit.WebView) {
-        return this
-    }
-    if (this is android.view.ViewGroup) {
-        for (i in 0 until childCount) {
-            val webView = getChildAt(i).findWebView()
-            if (webView != null) {
-                return webView
-            }
-        }
-    }
-    return null
 }


### PR DESCRIPTION
## Summary
Reverts WebView subtitle rendering changes and returns the player subtitle output view type to Canvas rendering (`VIEW_TYPE_CANVAS`), restoring standard, reliable subtitle styling (size, bolding, outlines).
## PR type
- [ ] Translation/localization only
- [x] Critical bug fix
## Why
The transition to WebView-based subtitle rendering in PR #2179 completely broke the subtitle styling settings (bolding and custom outline width) for users because Media3's `WebViewSubtitleOutput` ignores the `style.typeface` (bolding) field and hardcodes outline text-shadows to exactly `1px`. Reverting this transition restores the fully functional Canvas-based rendering (`SubtitlePainter`), which natively supports proper typeface rendering and readable outline styling.
## Issue or approval
No linked issue: critical regression fix following the merge of PR #2179 and PR #2212.
## Reproduction steps
1. Build NuvioTV on current `dev` branch.
2. Open the player and play any media with subtitles.
3. Change subtitle style settings in the menu (e.g. set font size to 90%, check "Bold").
4. Observe that subtitles remain regular weight and do not apply bolding or outline width changes.
## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.
## Scope boundaries
This PR only reverts changes in `PlayerScreen.kt` and `PlayerRuntimeControllerInitialization.kt` that were introduced for WebView rendering. It does not introduce any new layout or UI components.
## Testing
Clean build compilation using:
`.\gradlew.bat :app:compileFullDebugSources`
## Screenshots / Video
Not a UI change
## Breaking changes
None.
## Linked issues
Reverts the changes from:
- PR #2179 (perf/webview-subtitles-v2)
- PR #2212 (fix/webview-subtitle-layer-none)
- Related history: PR #2154 and PR #2160
