### PR TITLE
Prevent clearing non trakt ids, when using Trakt as CW

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -329,7 +329,8 @@ class WatchProgressPreferences @Inject constructor(
         remoteEntries: Map<String, WatchProgress>,
         lastSuccessfulPushMs: Long = 0L,
         profileId: Int = profileManager.activeProfileId.value,
-        removeMissingRemoteEntries: Boolean = true
+        removeMissingRemoteEntries: Boolean = true,
+        isNonTraktId: ((String) -> Boolean)? = null
     ): Boolean {
         var preservedLocalItems = false
         Log.d("WatchProgressPrefs", "mergeRemoteEntries: ${remoteEntries.size} remote entries, lastPushMs=$lastSuccessfulPushMs, profile=$profileId, removeMissing=$removeMissingRemoteEntries")
@@ -341,11 +342,19 @@ class WatchProgressPreferences @Inject constructor(
             // Remove local entries that no longer exist on remote - but protect
             // entries created after the last successful push (they haven't reached
             // remote yet, so their absence doesn't mean deletion on another device).
+            // When isNonTraktId is provided, also protect entries with non-Trakt-
+            // compatible IDs — these can never appear in a Trakt remote response,
+            // so their absence does NOT indicate deletion on another device.
+            // (Nuvio Sync does support these IDs, so callers using Nuvio Sync
+            // should NOT pass isNonTraktId.)
             if (removeMissingRemoteEntries && remoteEntries.isNotEmpty()) {
                 val removedKeys = local.keys - remoteEntries.keys
                 removedKeys.forEach { key ->
                     val localEntry = local[key]
-                    if (localEntry != null && localEntry.lastWatched > lastSuccessfulPushMs) {
+                    if (localEntry != null && isNonTraktId != null && isNonTraktId(localEntry.contentId)) {
+                        Log.d("WatchProgressPrefs", "  preserved key=$key (non-Trakt ID: ${localEntry.contentId})")
+                        preservedLocalItems = true
+                    } else if (localEntry != null && localEntry.lastWatched > lastSuccessfulPushMs) {
                         Log.d("WatchProgressPrefs", "  preserved key=$key (lastWatched=${localEntry.lastWatched} > lastPush=$lastSuccessfulPushMs)")
                         preservedLocalItems = true
                     } else {
@@ -441,6 +450,27 @@ class WatchProgressPreferences @Inject constructor(
     suspend fun clearAll() {
         store().edit { preferences ->
             preferences.remove(watchProgressKey)
+            preferences.remove(deltaCursorKey)
+            preferences.remove(deltaInitializedKey)
+        }
+    }
+
+    /**
+     * Clear all watch progress entries EXCEPT those with non-Trakt-compatible IDs
+     */
+    suspend fun clearAllPreservingNonTraktIds(
+        isNonTraktId: (String) -> Boolean
+    ) {
+        store().edit { preferences ->
+            val json = preferences[watchProgressKey] ?: "{}"
+            val map = parseProgressMap(json)
+            val preserved = map.filter { (_, progress) -> isNonTraktId(progress.contentId) }
+            if (preserved.isEmpty()) {
+                preferences.remove(watchProgressKey)
+            } else {
+                preferences[watchProgressKey] = gson.toJson(preserved)
+                Log.d(TAG, "clearAllPreservingNonTraktIds: preserved ${preserved.size} non-Trakt entries")
+            }
             preferences.remove(deltaCursorKey)
             preferences.remove(deltaInitializedKey)
         }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -1034,7 +1034,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
     override suspend fun clearAll() {
         if (shouldUseTraktProgress()) {
             traktProgressService.clearOptimistic()
-            watchProgressPreferences.clearAll()
+            watchProgressPreferences.clearAllPreservingNonTraktIds { contentId ->
+                !isTraktCompatibleId(contentId)
+            }
             return
         }
         watchProgressPreferences.clearAll()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -128,7 +128,9 @@ class TraktViewModel @Inject constructor(
             // Clear CW cache so stale items from the previous source don't flash on screen.
             cwEnrichmentCache.saveInProgressSnapshot(emptyList(), force = true)
             cwEnrichmentCache.saveNextUpSnapshot(emptyList(), force = true)
-            watchProgressPreferences.clearAll()
+            watchProgressPreferences.clearAllPreservingNonTraktIds { contentId ->
+                !com.nuvio.tv.data.repository.isTraktCompatibleId(contentId)
+            }
             if (source == WatchProgressSource.TRAKT) {
                 watchedItemsPreferences.clearAll()
                 watchedSeriesStateHolder.update(emptySet())
@@ -231,7 +233,9 @@ class TraktViewModel @Inject constructor(
             // Clear CW cache so stale Trakt items don't flash on next launch.
             cwEnrichmentCache.saveInProgressSnapshot(emptyList(), force = true)
             cwEnrichmentCache.saveNextUpSnapshot(emptyList(), force = true)
-            watchProgressPreferences.clearAll()
+            watchProgressPreferences.clearAllPreservingNonTraktIds { contentId ->
+                !com.nuvio.tv.data.repository.isTraktCompatibleId(contentId)
+            }
             watchedSeriesStateHolder.update(emptySet())
             // Repopulate from Nuvio sync.
             repopulateWatchedItemsFromNuvioSync()


### PR DESCRIPTION
## Summary

Preserve non-Trakt-compatible watch progress entries (kitsu:, mal:, anilist:, anidb:, tvdb:) when switching CW source to/from Trakt or disconnecting Trakt. Previously, `clearAll()` was called unconditionally, permanently deleting anime/non-Trakt progress that cannot be recovered from Trakt API.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When users switch Continue Watching source to Trakt, disconnect Trakt, or trigger a "clear all" while Trakt is active, all local watch progress is wiped including entries with non-Trakt IDs. Since Trakt cannot resolve these IDs (kitsu:, mal:, anilist:, etc.), the progress is permanently lost with no way to recover it.

## Issue or approval

Found during internal testing

## Reproduction steps

1. Add anime content with a kitsu: or mal: ID to Continue Watching (play partially)
2. Go to Settings > Trakt > Watch Progress Source
3. Switch source to Trakt (or disconnect Trakt)
4. Non-Trakt items disappear from Continue Watching permanently
5. Switching back to Nuvio Sync does not restore them

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Nuvio Sync merge logic is unchanged (it correctly handles non-Trakt IDs already)
- No changes to how Trakt data is fetched or displayed
- No changes to the `allProgress` flow merging logic in WatchProgressRepositoryImpl
- The `mergeRemoteEntries` new parameter defaults to null, preserving existing behavior for all current call sites

## Testing

- Played content with kitsu: ID partially, confirmed it appears in CW
- Switched CW source from Nuvio Sync to Trakt, confirmed kitsu: item persisted
- Switched back to Nuvio Sync, confirmed kitsu: item still present
- Disconnected Trakt, confirmed kitsu: item still present
- Triggered "Clear All" while Trakt active, confirmed kitsu: item preserved while Trakt items cleared
- Confirmed Trakt-compatible items (IMDB, TMDB) are properly cleared on source switch
- Tested on Pixel 7 emulator API 34

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Found during internal testing
