### PR TITLE
i18n(fr): translate badge position, DV strip mode, license attributions (batch10)

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1506,6 +1506,8 @@
     <string name="dv7_mode_dv81_libdovi_desc">Convertit DV7 en DV8.1 mono-couche. Nécessite un écran Dolby Vision.</string>
     <string name="dv7_mode_off">Désactivé (natif)</string>
     <string name="dv7_mode_off_desc">Passe DV7 sans modification. Peut causer des artefacts sur le matériel qui ne prend pas en charge DV Profile 7.</string>
+    <string name="dv7_mode_strip_dv">Toujours supprimer la DV</string>
+    <string name="dv7_mode_strip_dv_desc">Supprime la couche RPU Dolby Vision de tous les flux.</string>
     <string name="audio_dv5_to_dv81_title">Convertir DV5 en DV8.1</string>
     <string name="audio_dv5_to_dv81_sub">Signale les flux Profile 5 comme Profile 8.1 pour une sortie compatible HDR10. Utile sur les appareils sans décodeur DV5 natif.</string>
     <string name="audio_dv7_preserve_mapping_title">Préserver le mapping DV (DV7 vers DV8.1)</string>
@@ -1991,6 +1993,7 @@
     <string name="essential_stream_selection_subtitle">Choisis manuellement ou lance automatiquement le premier flux disponible.</string>
     <string name="essential_autoplay_next_episode">Lecture automatique de l’épisode suivant</string>
     <string name="essential_autoplay_next_episode_subtitle">Enchaîne vers l’épisode suivant à la fin d’un flux.</string>
+    <string name="external_auto_next_loading">Chargement de l’épisode suivant…</string>
     <string name="essential_p2p_streams">Flux P2P</string>
     <string name="essential_p2p_streams_subtitle">Autoriser les sources de flux pair-à-pair.</string>
     <string name="essential_subtitle_language_subtitle">Langue préférée pour les sous-titres.</string>
@@ -2293,6 +2296,10 @@
     <string name="licenses_attributions_tmdb_body">Nuvio utilise l’API TMDB pour les métadonnées de films et de séries, les visuels, les bandes-annonces, la distribution, les détails de production, les collections et les recommandations. Ce produit utilise l’API TMDB mais n’est ni approuvé ni certifié par TMDB.</string>
     <string name="licenses_attributions_trakt_title">Trakt</string>
     <string name="licenses_attributions_trakt_body">Nuvio se connecte à Trakt pour l’authentification du compte, l’historique de visionnage, la synchronisation de la progression, les données de bibliothèque, les notes, les listes et les commentaires. Nuvio n’est ni affilié à Trakt ni approuvé par Trakt.</string>
+    <string name="licenses_attributions_premiumize_title">Premiumize</string>
+    <string name="licenses_attributions_premiumize_body">Nuvio se connecte à Premiumize pour l’authentification du compte, l’accès à la bibliothèque cloud, les vérifications de cache et les fonctions de lecture cloud. Nuvio n’est ni affilié à Premiumize ni approuvé par Premiumize.</string>
+    <string name="licenses_attributions_torbox_title">TorBox</string>
+    <string name="licenses_attributions_torbox_body">Nuvio se connecte à TorBox pour l’authentification du compte, l’accès à la bibliothèque cloud, les vérifications de cache et les fonctions de lecture cloud. Nuvio n’est ni affilié à TorBox ni approuvé par TorBox.</string>
     <string name="licenses_attributions_mdblist_title">MDBList</string>
     <string name="licenses_attributions_mdblist_body">Nuvio utilise MDBList pour les notes et les données de fournisseurs de scores externes. Nuvio n’est ni affilié à MDBList ni approuvé par MDBList.</string>
     <string name="licenses_attributions_introdb_title">IntroDB</string>
@@ -2647,6 +2654,12 @@
     <string name="settings_stream_badge_urls_title">URL de badges Fusion</string>
     <string name="settings_stream_size_badges_description">Affiche les badges de taille de fichier dans les résultats de flux et les panneaux de source du lecteur.</string>
     <string name="settings_stream_size_badges_title">Badges de taille</string>
+    <string name="settings_stream_badge_position_title">Position des badges</string>
+    <string name="settings_stream_badge_position_description">Choisis si les badges Fusion et de taille apparaissent au-dessus ou en dessous des cartes de flux.</string>
+    <string name="settings_stream_badge_position_dialog_title">Position des badges</string>
+    <string name="settings_stream_badge_position_dialog_description">Choisis où les badges de flux apparaissent sur les cartes de flux.</string>
+    <string name="settings_stream_badge_position_top">En haut</string>
+    <string name="settings_stream_badge_position_bottom">En bas</string>
     <string name="stream_badge_qr_instruction">Scanne ce code QR sur ton téléphone pour gérer les URL de badges Fusion.</string>
     <string name="streams_size">TAILLE %1$s</string>
 


### PR DESCRIPTION
## Summary

Closes the remaining French translation gaps in `values-fr/strings.xml` (**+13 FR keys**), bringing EN↔FR to full parity for all translatable strings:

- **Badge position settings** (6) — `settings_stream_badge_position_*` (title, description, dialog title/description, top/bottom). This is the surface that surfaced in English on the TV settings screen.
- **Dolby Vision "Always Strip DV" mode** (2) — `dv7_mode_strip_dv` + `_desc`. These were the only untranslated members of the otherwise-localized `dv7_mode_*` family.
- **External playback auto-next** (1) — `external_auto_next_loading`.
- **License attributions** (4) — Premiumize + TorBox (title + body each), following the existing Trakt/MDBList attribution wording already in the file.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

Several recently-added surfaces had English-only strings because the keys existed in `values/strings.xml` but were never backfilled into `values-fr/strings.xml`. With the device set to French, the badge-position settings, the DV "Always Strip DV" mode row, the external auto-next loading toast, and the Premiumize/TorBox license attributions all fell back to English. This PR adds the missing translations to reach full parity.

## Issue or approval

No linked issue: localization-only update (same maintenance pattern as #2056, #2066, #2111, #2166).

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `app/src/main/res/values-fr/strings.xml` is touched (+13 lines).
- The 15 `translatable="false"` Dolby Vision / libdovi technical strings (`dv7_libdovi_mode_*`, `advanced_section_dv_diagnostics`) are intentionally **left untranslated**, per their EN source flag.
- The pre-existing upstream brand-casing inconsistency in the EN source (`TorBox` ×3 in license attributions vs `Torbox` ×7 in `debrid_*` keys) is **not** changed here — the FR mirrors the EN casing key-by-key, so fixing it belongs in an EN-side PR, not a FR-only translation PR.
- `tu` editorial style, consistent with the rest of the project.

## Testing

- EN↔FR parity verified: 2435/2435 translatable keys, 0 missing, 0 orphan (the 15-key delta is exactly the `translatable="false"` set).
- XML validity checked with `xmllint --noout` and Python minidom — both pass.
- No duplicate `name="…"` keys; UTF-8 clean, no mojibake; typographic apostrophe `’` used throughout (no unescaped `'`).
- Terminology aligned with existing FR (`bibliothèque cloud`, `n’est ni affilié à X ni approuvé par X`, `RPU`/`Dolby Vision`/`cache`/`cloud`/`flux` conventions).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.