### PR TITLE
Fallback to videoId for scrobble and progress when contentId is unresolvable for trakt

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktIdUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktIdUtils.kt
@@ -97,3 +97,32 @@ internal fun isTraktCompatibleId(contentId: String?): Boolean {
     if (beforeColon.toIntOrNull() != null) return true
     return false
 }
+
+/**
+ * If [contentId] is not Trakt-resolvable but [videoId] contains a valid
+ * IMDB or TMDB prefix, extract and return the resolved ID from videoId.
+ * This handles addons that wrap real IDs in non-standard content IDs
+ * (e.g. contentId = "tun_tt7821582", videoId = "tt7821582:3:7").
+ *
+ * Returns the original [contentId] if it's already valid or if no
+ * better ID can be extracted from [videoId].
+ */
+internal fun resolveEffectiveContentId(contentId: String, videoId: String?): String {
+    val parsedContent = parseContentIds(contentId)
+    val contentIds = toTraktIds(parsedContent)
+    if (contentIds.hasAnyId()) return contentId
+
+    if (videoId.isNullOrBlank() || videoId == contentId) return contentId
+
+    val parsedVideo = parseContentIds(videoId)
+    val videoIds = toTraktIds(parsedVideo)
+    if (!videoIds.hasAnyId()) return contentId
+
+    // Rebuild a canonical content ID from the resolved video IDs
+    return when {
+        !parsedVideo.imdb.isNullOrBlank() -> parsedVideo.imdb
+        parsedVideo.tmdb != null -> "tmdb:${parsedVideo.tmdb}"
+        parsedVideo.trakt != null -> parsedVideo.trakt.toString()
+        else -> contentId
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -208,6 +208,7 @@ class PlayerRuntimeController(
     internal var currentVideoId: String? = videoId
     internal var currentSeason: Int? = initialSeason
     internal var currentEpisode: Int? = initialEpisode
+    @Volatile internal var isTraktCwActive: Boolean = false
     internal var currentEpisodeTitle: String? = initialEpisodeTitle
 
     internal val _uiState = MutableStateFlow(
@@ -503,6 +504,7 @@ class PlayerRuntimeController(
         observeTorrentSettings()
         observeStreamBadgeSettings()
         observeDeviceLocalAspectMode()
+        scope.launch { isTraktCwActive = watchProgressRepository.isTraktProgressActive() }
     }
 
     private fun observeTorrentSettings() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.data.repository.SkipInterval
 import com.nuvio.tv.data.repository.TraktScrobbleItem
 import com.nuvio.tv.data.repository.extractYear
 import com.nuvio.tv.data.repository.parseContentIds
+import com.nuvio.tv.data.repository.resolveEffectiveContentId
 import com.nuvio.tv.data.repository.toTraktIds
 import com.nuvio.tv.domain.model.WatchProgress
 import kotlinx.coroutines.delay
@@ -319,8 +320,17 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, d
 
     val fallbackPercent = if (duration <= 0L) 5f else null
 
+    // If Trakt is the active CW source and contentId is not Trakt-resolvable
+    // but videoId contains a valid IMDB/TMDB, use the resolved ID to avoid
+    // duplicate CW entries (one local with garbage ID, one from Trakt with real ID).
+    val effectiveContentId = if (isTraktCwActive) {
+        resolveEffectiveContentId(contentId, currentVideoId)
+    } else {
+        contentId
+    }
+
     val progress = WatchProgress(
-        contentId = contentId,
+        contentId = effectiveContentId,
         contentType = contentType,
         name = contentName ?: title,
         poster = poster,
@@ -360,7 +370,16 @@ internal fun PlayerRuntimeController.refreshScrobbleItem() {
 internal fun PlayerRuntimeController.buildScrobbleItem(): TraktScrobbleItem? {
     val rawContentId = contentId ?: return null
     val parsedIds = parseContentIds(rawContentId)
-    val ids = toTraktIds(parsedIds)
+    var ids = toTraktIds(parsedIds)
+    // Fallback: if contentId doesn't resolve to valid Trakt IDs, try videoId.
+    // Some addons use non-standard contentId (e.g. "tun_tt7821582") but set a
+    // valid IMDB/TMDB videoId (e.g. "tt7821582:3:7").
+    if (ids.trakt == null && ids.imdb.isNullOrBlank() && ids.tmdb == null) {
+        val fallbackVideoId = currentVideoId
+        if (!fallbackVideoId.isNullOrBlank() && fallbackVideoId != rawContentId) {
+            ids = toTraktIds(parseContentIds(fallbackVideoId))
+        }
+    }
     if (ids.trakt == null && ids.imdb.isNullOrBlank() && ids.tmdb == null) return null
     val parsedYear = extractYear(year)
     val normalizedType = contentType?.lowercase()


### PR DESCRIPTION
## Summary

Fallback to videoId when contentId is not Trakt-resolvable for scrobble and local progress save. Fixes addons that use non-standard content IDs (e.g. `tun_tt7821582`) while providing valid IMDB/TMDB in videoId (e.g. `tt7821582:3:7`).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some addons set a non-standard contentId (e.g. `tun_tt7821582`) that cannot be resolved to any Trakt-compatible ID, but provide a valid IMDB in videoId (`tt7821582:3:7`). This causes scrobble to silently fail (no valid IDs to send)

## Issue or approval

Fixes #2221

## Reproduction steps

1. Use an addon that sets contentId = `tun_tt7821582` and videoId = `tt7821582:3:7`
2. Set Trakt as CW source
3. Play content partially
4. Observe: no scrobble sent to Trakt

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- contentId resolution only applies when Trakt is the active CW source (Nuvio Sync users unaffected)
- Scrobble videoId fallback fires whenever Trakt is connected, regardless of CW source
- No changes to Nuvio Sync, badge logic, UI, or stream selection

## Testing

- Addon with contentId `tun_tt7821582` / videoId `tt7821582:3:7`: scrobble now sends with IMDB `tt7821582`
- Local progress saved under `tt7821582` when Trakt is CW source, no duplicate after refresh
- Same addon with Nuvio Sync as CW: contentId stays `tun_tt7821582` unchanged
- Standard addons (contentId = `tt1234567` or `tmdb:12345`): behavior unchanged, no fallback triggered
- Build successful, no new warnings
- Tested on TCL Android TV

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2221
