### PR TITLE
fix: prevent autoplay from skipping post-credits scenes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -36,23 +36,33 @@ object PlayerNextEpisodeRules {
         thresholdPercent: Float,
         thresholdMinutesBeforeEnd: Float
     ): Boolean {
-        val outroInterval = skipIntervals.firstOrNull {
-            it.type == "outro" || it.type == "ed" || it.type == "mixed-ed"
-        }
-        return if (outroInterval != null) {
-            positionMs / 1000.0 >= outroInterval.startTime
-        } else {
+        val outroSegments = skipIntervals.filter { it.type in OUTRO_SEGMENT_TYPES }
+
+        if (outroSegments.isNotEmpty()) {
             if (durationMs <= 0L) return false
-            when (thresholdMode) {
-                NextEpisodeThresholdMode.PERCENTAGE -> {
-                    val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
-                    (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
-                }
-                NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
-                    val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
-                    val remainingMs = durationMs - positionMs
-                    remainingMs <= (clampedMinutes * 60_000f).toLong()
-                }
+            val latestOutroEndMs = (outroSegments.maxOf { it.endTime } * 1_000.0).toLong()
+            val postOutroGapMs = durationMs - latestOutroEndMs
+
+            return if (postOutroGapMs > POST_OUTRO_AUTOPLAY_GAP_MS) {
+                // Post-credits scene: hold prompt until video truly ends.
+                positionMs >= durationMs - END_OF_VIDEO_EPSILON_MS
+            } else {
+                // Fire at earliest outro start if outro ends near file end.
+                positionMs / 1_000.0 >= outroSegments.minOf { it.startTime }
+            }
+        }
+
+        // Fallback to the settings threshold when no outro data exists.
+        if (durationMs <= 0L) return false
+        return when (thresholdMode) {
+            NextEpisodeThresholdMode.PERCENTAGE -> {
+                val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
+                (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
+            }
+            NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
+                val remainingMs = durationMs - positionMs
+                remainingMs <= (clampedMinutes * 60_000f).toLong()
             }
         }
     }
@@ -70,4 +80,10 @@ object PlayerNextEpisodeRules {
         val releasedDate = parseEpisodeReleaseDate(raw) ?: return true
         return !releasedDate.isAfter(LocalDate.now(clock))
     }
+
+    val OUTRO_SEGMENT_TYPES = setOf("outro", "ed", "mixed-ed")
+
+    const val POST_OUTRO_AUTOPLAY_GAP_MS = 5_000L
+
+    const val END_OF_VIDEO_EPSILON_MS = 1_000L
 }


### PR DESCRIPTION
## Summary

Fixes autoplay skipping post-credits scenes when outro timecodes are available. With outro data, the next-episode prompt used to fire the moment the outro started, jumping past anything after it. Now, when there's a gap between the outro ending and the actual end of the video, the prompt waits until it finishes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When a show has outro timecodes and a post-credits scene, autoplay triggered the moment the outro began and skipped right past the scene. This holds the next-episode prompt until the video actually ends whenever it detects a gap after the outro. Playback with no outro data is unchanged and still uses the normal threshold.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioTV/issues/2243

## Reproduction steps

1. Play an episode/title that has outro timecodes and a post-credits scene after the outro.
2. With autoplay enabled, let playback reach the outro.
3. Observe that the next-episode prompt fires at the outro start and autoplay advances, skipping the post-credits scene.

Expected: the prompt should hold until the video nearly ends so the post-credits scene is not skipped.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only changes when the next-episode prompt fires; nothing else in autoplay or playback is touched.
- When an outro is detected with a gap over 5s before the video ends, the prompt holds until the video nearly ends (within 1s), treating it as a post-credits scene.
- With no such gap, the prompt still fires when the earliest outro starts, as before.
- With no outro data, it falls back to the existing percentage or minutes-before-end threshold.

## Testing

<!-- What you tested and how. -->
- Episode with a post-credits scene -> next-episode prompt waits until the video ends.
- Episode with an outro and no gap -> prompt fires when the outro starts, as before.
- Episode with no outro data -> prompt falls back to the threshold setting.
- Tested on Chromecast with Google TV (4K) with a debug build.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes https://github.com/NuvioMedia/NuvioTV/issues/2243