### PR TITLE
Fix: Prevent terminal 3001 ParserExceptions on custom Matroska headersProblem

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DefaultEbmlReader.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DefaultEbmlReader.java
@@ -148,6 +148,8 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
         case EbmlProcessor.ELEMENT_TYPE_UNKNOWN:
           input.skipFully((int) elementContentSize);
           elementState = ELEMENT_STATE_READ_ID;
+          elementContentSize = 0;
+          elementId = 0;
           break;
         default:
           throw ParserException.createForMalformedContainer(


### PR DESCRIPTION
Problem: Certain remuxing utilities inject non-standard EBML elements that trigger a 3001 Malformed Container error. While DefaultEbmlReader attempts to skip unknown element types, the internal parser state engine fails to re-synchronize properly after the skip boundary, causing downstream reads to evaluate prematurely and crash playback.

Solution: Updated the ELEMENT_TYPE_UNKNOWN handling logic in DefaultEbmlReader.java to explicitly reset structural tracking fields (elementContentSize, elementId) immediately following the skip execution.

Result: Adds support for built-in ExoPlayer playback of non-standard or tagged MKV containers with zero additional streaming initialization delays.