### PR TITLE
Add addon logo toggle

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/streams/StreamBadgeSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/core/streams/StreamBadgeSettings.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.core.streams
 data class StreamBadgeSettings(
     val rules: StreamBadgeRules = StreamBadgeRules(),
     val showFileSizeBadges: Boolean = true,
+    val showAddonLogo: Boolean = true,
     val badgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM
 )
 

--- a/app/src/main/java/com/nuvio/tv/data/local/StreamBadgeSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/StreamBadgeSettingsDataStore.kt
@@ -48,6 +48,7 @@ class StreamBadgeSettingsDataStore @Inject constructor(
 
     private val streamBadgeRulesKey = stringPreferencesKey("stream_badge_rules")
     private val showFileSizeBadgesKey = booleanPreferencesKey("show_file_size_badges")
+    private val showAddonLogoKey = booleanPreferencesKey("show_addon_logo")
     private val streamBadgePlacementKey = stringPreferencesKey("stream_badge_placement")
     private val legacyDebridStreamBadgeRulesKey = stringPreferencesKey("debrid_stream_badge_rules")
 
@@ -57,6 +58,7 @@ class StreamBadgeSettingsDataStore @Inject constructor(
         StreamBadgeSettings(
             rules = parseStreamBadgeRules(prefs[streamBadgeRulesKey]) ?: StreamBadgeRules(),
             showFileSizeBadges = prefs[showFileSizeBadgesKey] ?: true,
+            showAddonLogo = prefs[showAddonLogoKey] ?: true,
             badgePlacement = prefs[streamBadgePlacementKey].toStreamBadgePlacement()
         )
     }
@@ -76,6 +78,10 @@ class StreamBadgeSettingsDataStore @Inject constructor(
         store().edit { it[showFileSizeBadgesKey] = enabled }
     }
 
+    suspend fun setShowAddonLogo(enabled: Boolean) {
+        store().edit { it[showAddonLogoKey] = enabled }
+    }
+
     suspend fun setStreamBadgePlacement(placement: StreamBadgePlacement) {
         store().edit { it[streamBadgePlacementKey] = placement.name }
     }
@@ -89,6 +95,7 @@ class StreamBadgeSettingsDataStore @Inject constructor(
                 it.remove(streamBadgeRulesKey)
             }
             it[showFileSizeBadgesKey] = settings.showFileSizeBadges
+            it[showAddonLogoKey] = settings.showAddonLogo
             it[streamBadgePlacementKey] = settings.badgePlacement.name
         }
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -502,16 +502,27 @@ class StreamRepositoryImpl @Inject constructor(
         // For inline streams the meta is fetched using the content-level ID
         // (everything before the video-specific suffix).  For "other" type
         // the videoId IS the content ID; for series it is contentId:S:E.
-        val contentId = videoId.substringBefore(":")
-            .takeIf { it.isNotBlank() }
-            ?: videoId
-        // Reconstruct a content-level ID that keeps the addon-specific prefix.
-        // e.g. "realdebrid:ABC:3" → "realdebrid:ABC"
+        // Video ID formats:
+        //   tt1234567:1:5      → metaId = tt1234567
+        //   mal:63375:1:5      → metaId = mal:63375
+        //   kitsu:12345:2      → metaId = kitsu:12345
+        // Strategy: drop up to 2 trailing numeric segments (season, episode)
+        // but never reduce below 2 segments for prefixed IDs (mal:X, kitsu:X).
         val metaId = run {
             val parts = videoId.split(":")
-            // Drop trailing numeric segment(s) that represent video index
-            val contentParts = parts.dropLastWhile { it.toIntOrNull() != null }
-            if (contentParts.isNotEmpty()) contentParts.joinToString(":") else videoId
+            if (parts.size <= 1) return@run videoId
+            // Count trailing numeric segments
+            val trailingNumericCount = parts.reversed().takeWhile { it.toIntOrNull() != null }.size
+            // Keep at least 2 segments for prefixed IDs (e.g. "mal:63375"),
+            // or 1 segment for IMDB-style IDs (e.g. "tt1234567")
+            val firstSegment = parts.first()
+            val minSegments = if (firstSegment.startsWith("tt") || firstSegment.toIntOrNull() != null) 1 else 2
+            val segmentsToDrop = trailingNumericCount.coerceAtMost((parts.size - minSegments).coerceAtLeast(0))
+            if (segmentsToDrop > 0) {
+                parts.dropLast(segmentsToDrop).joinToString(":")
+            } else {
+                videoId
+            }
         }
         val cleanBaseUrl = addon.baseUrl.trimEnd('/')
         val queryStart = cleanBaseUrl.indexOf('?')

--- a/app/src/main/java/com/nuvio/tv/ui/components/Skeletons.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/Skeletons.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.lazy.items
 @Composable
 fun StreamsSkeletonList(
     modifier: Modifier = Modifier,
+    showAddonLogo: Boolean = true,
     itemCount: Int = 6
 ) {
     LazyColumn(
@@ -49,7 +50,7 @@ fun StreamsSkeletonList(
         contentPadding = PaddingValues(vertical = NuvioTheme.spacing.sm)
     ) {
         items(itemCount) {
-            StreamCardSkeleton(shimmerBrush = rememberShimmerBrush())
+            StreamCardSkeleton(showAddonLogo = showAddonLogo, shimmerBrush = rememberShimmerBrush())
         }
     }
 }
@@ -57,6 +58,7 @@ fun StreamsSkeletonList(
 @Composable
 fun StreamCardSkeleton(
     modifier: Modifier = Modifier,
+    showAddonLogo: Boolean = true,
     shimmerBrush: Brush = rememberShimmerBrush()
 ) {
     Box(
@@ -83,17 +85,19 @@ fun StreamCardSkeleton(
                 }
             }
 
-            Column(
-                horizontalAlignment = Alignment.End
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(NuvioTheme.spacing.xxl)
-                        .clip(RoundedCornerShape(NuvioTheme.radii.sm))
-                        .background(shimmerBrush)
-                )
-                Spacer(modifier = Modifier.height(6.dp))
-                SkeletonBar(width = 64.dp, height = 10.dp, brush = shimmerBrush, cornerRadius = NuvioTheme.spacing.sm)
+            if (showAddonLogo) {
+                Column(
+                    horizontalAlignment = Alignment.End
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(NuvioTheme.spacing.xxl)
+                            .clip(RoundedCornerShape(NuvioTheme.radii.sm))
+                            .background(shimmerBrush)
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    SkeletonBar(width = 64.dp, height = 10.dp, brush = shimmerBrush, cornerRadius = NuvioTheme.spacing.sm)
+                }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/components/StreamBadgeChips.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/StreamBadgeChips.kt
@@ -64,11 +64,11 @@ fun StreamBadgeChips(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xs)
     ) {
-        if (sizeBytes != null) {
-            StreamFileSizeBadge(bytes = sizeBytes)
-        }
         imageBadges.forEach { badge ->
             StreamImportedBadgeChip(badge = badge)
+        }
+        if (sizeBytes != null) {
+            StreamFileSizeBadge(bytes = sizeBytes)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodesSidePanel.kt
@@ -263,6 +263,7 @@ private fun EpisodeStreamsView(
                         focusRequester = streamsFocusRequester,
                         requestInitialFocus = stream == uiState.episodeFilteredStreams.firstOrNull(),
                         showFileSizeBadges = uiState.showFileSizeBadges,
+                        showAddonLogo = uiState.showAddonLogo,
                         badgePlacement = uiState.streamBadgePlacement,
                         onClick = { onStreamSelected(stream) }
                     )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -526,6 +526,7 @@ class PlayerRuntimeController(
                 _uiState.update {
                     it.copy(
                         showFileSizeBadges = settings.showFileSizeBadges,
+                        showAddonLogo = settings.showAddonLogo,
                         streamBadgePlacement = settings.badgePlacement
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -145,6 +145,7 @@ data class PlayerUiState(
     val sourceAvailableAddons: List<String> = emptyList(),
     val sourceChips: List<SourceChipItem> = emptyList(),
     val showFileSizeBadges: Boolean = true,
+    val showAddonLogo: Boolean = true,
     val streamBadgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM,
     val error: String? = null,
     val pendingSeekPosition: Long? = null, // For resuming from saved progress

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -192,29 +192,31 @@ internal fun StreamItem(
                 }
             }
 
-            Column(
-                horizontalAlignment = Alignment.End
-            ) {
-                if (showAddonLogo && addonLogoModel != null) {
-                    AsyncImage(
-                        model = addonLogoModel,
-                        contentDescription = stream.addonName,
-                        modifier = Modifier
-                            .size(NuvioTheme.spacing.xxl)
-                            .clip(RoundedCornerShape(NuvioTheme.radii.xs)),
-                        contentScale = ContentScale.Fit
+            if (showAddonLogo) {
+                Column(
+                    horizontalAlignment = Alignment.End
+                ) {
+                    if (addonLogoModel != null) {
+                        AsyncImage(
+                            model = addonLogoModel,
+                            contentDescription = stream.addonName,
+                            modifier = Modifier
+                                .size(NuvioTheme.spacing.xxl)
+                                .clip(RoundedCornerShape(NuvioTheme.radii.xs)),
+                            contentScale = ContentScale.Fit
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(NuvioTheme.spacing.xs))
+
+                    Text(
+                        text = stream.addonName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = NuvioTheme.extendedColors.textTertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
-
-                Spacer(modifier = Modifier.height(NuvioTheme.spacing.xs))
-
-                Text(
-                    text = stream.addonName,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = NuvioTheme.extendedColors.textTertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -69,6 +69,7 @@ internal fun StreamItem(
     requestInitialFocus: Boolean,
     isCurrentStream: Boolean = false,
     showFileSizeBadges: Boolean = true,
+    showAddonLogo: Boolean = true,
     badgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM,
     onClick: () -> Unit,
     onUpKey: (() -> Unit)? = null
@@ -194,7 +195,7 @@ internal fun StreamItem(
             Column(
                 horizontalAlignment = Alignment.End
             ) {
-                if (addonLogoModel != null) {
+                if (showAddonLogo && addonLogoModel != null) {
                     AsyncImage(
                         model = addonLogoModel,
                         contentDescription = stream.addonName,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -243,6 +243,7 @@ internal fun StreamSourcesSidePanel(
                                 requestInitialFocus = stream == initialFocusStream,
                                 isCurrentStream = index == currentStreamIndex,
                                 showFileSizeBadges = uiState.showFileSizeBadges,
+                                showAddonLogo = uiState.showAddonLogo,
                                 badgePlacement = uiState.streamBadgePlacement,
                                 onClick = { onStreamSelected(stream) },
                                 onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -565,15 +565,6 @@ fun LayoutSettingsContent(
                         },
                         onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
                     )
-                    CompactToggleRow(
-                        title = stringResource(R.string.settings_stream_addon_logo_title),
-                        subtitle = stringResource(R.string.settings_stream_addon_logo_description),
-                        checked = streamBadgeUiState.showAddonLogo,
-                        onToggle = {
-                            viewModel.setShowAddonLogo(!streamBadgeUiState.showAddonLogo)
-                        },
-                        onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
-                    )
                     NavigationSettingsItem(
                         icon = Icons.Default.Image,
                         title = stringResource(R.string.settings_stream_badge_position_title),
@@ -586,6 +577,20 @@ fun LayoutSettingsContent(
                         title = stringResource(R.string.settings_stream_badge_urls_title),
                         subtitle = streamBadgeRulesPreview(streamBadgeUiState),
                         onClick = viewModel::startStreamBadgeQrMode,
+                        onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_stream_display_section),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = NuvioTheme.colors.TextSecondary
+                    )
+                    CompactToggleRow(
+                        title = stringResource(R.string.settings_stream_addon_logo_title),
+                        subtitle = stringResource(R.string.settings_stream_addon_logo_description),
+                        checked = streamBadgeUiState.showAddonLogo,
+                        onToggle = {
+                            viewModel.setShowAddonLogo(!streamBadgeUiState.showAddonLogo)
+                        },
                         onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -565,6 +565,15 @@ fun LayoutSettingsContent(
                         },
                         onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
                     )
+                    CompactToggleRow(
+                        title = stringResource(R.string.settings_stream_addon_logo_title),
+                        subtitle = stringResource(R.string.settings_stream_addon_logo_description),
+                        checked = streamBadgeUiState.showAddonLogo,
+                        onToggle = {
+                            viewModel.setShowAddonLogo(!streamBadgeUiState.showAddonLogo)
+                        },
+                        onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
+                    )
                     NavigationSettingsItem(
                         icon = Icons.Default.Image,
                         title = stringResource(R.string.settings_stream_badge_position_title),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -417,6 +417,10 @@ class LayoutSettingsViewModel @Inject constructor(
         viewModelScope.launch { streamBadgeSettingsDataStore.setShowFileSizeBadges(enabled) }
     }
 
+    fun setShowAddonLogo(enabled: Boolean) {
+        viewModelScope.launch { streamBadgeSettingsDataStore.setShowAddonLogo(enabled) }
+    }
+
     fun setStreamBadgePlacement(placement: StreamBadgePlacement) {
         viewModelScope.launch { streamBadgeSettingsDataStore.setStreamBadgePlacement(placement) }
     }
@@ -720,6 +724,9 @@ data class StreamBadgeSettingsUiState(
 
     val showFileSizeBadges: Boolean
         get() = settings.showFileSizeBadges
+
+    val showAddonLogo: Boolean
+        get() = settings.showAddonLogo
 
     val badgePlacement: StreamBadgePlacement
         get() = settings.badgePlacement

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -755,7 +755,7 @@ private fun RightStreamSection(
             ) {
                 when {
                     isLoading -> {
-                        LoadingState()
+                        LoadingState(showAddonLogo = showAddonLogo)
                     }
                     error != null -> {
                         ErrorState(
@@ -892,8 +892,8 @@ private fun AddonFilterChips(
 }
 
 @Composable
-private fun LoadingState() {
-    StreamsSkeletonList()
+private fun LoadingState(showAddonLogo: Boolean = true) {
+    StreamsSkeletonList(showAddonLogo = showAddonLogo)
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -1209,28 +1209,30 @@ private fun StreamCard(
                 }
             }
 
-            Column(
-                horizontalAlignment = Alignment.End
-            ) {
-                if (showAddonLogo && addonLogoModel != null) {
-                    AsyncImage(
-                        model = addonLogoModel,
-                        contentDescription = stream.addonName,
-                        modifier = Modifier
-                            .size(NuvioTheme.spacing.xxl)
-                            .clip(RoundedCornerShape(NuvioTheme.radii.xs)),
-                        contentScale = ContentScale.Fit
+            if (showAddonLogo) {
+                Column(
+                    horizontalAlignment = Alignment.End
+                ) {
+                    if (addonLogoModel != null) {
+                        AsyncImage(
+                            model = addonLogoModel,
+                            contentDescription = stream.addonName,
+                            modifier = Modifier
+                                .size(NuvioTheme.spacing.xxl)
+                                .clip(RoundedCornerShape(NuvioTheme.radii.xs)),
+                            contentScale = ContentScale.Fit
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(NuvioTheme.spacing.xs))
+
+                    Text(
+                        text = stream.addonName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = NuvioTheme.extendedColors.textTertiary,
+                        maxLines = 1
                     )
                 }
-
-                Spacer(modifier = Modifier.height(NuvioTheme.spacing.xs))
-
-                Text(
-                    text = stream.addonName,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = NuvioTheme.extendedColors.textTertiary,
-                    maxLines = 1
-                )
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -391,6 +391,7 @@ fun StreamScreen(
                     sourceChips = uiState.sourceChips,
                     selectedAddonFilter = uiState.selectedAddonFilter,
                     showFileSizeBadges = streamBadgeSettings.showFileSizeBadges,
+                    showAddonLogo = streamBadgeSettings.showAddonLogo,
                     badgePlacement = streamBadgeSettings.badgePlacement,
                     hasBadgeRules = streamBadgeSettings.rules.hasImport,
                     onAddonFilterSelected = { viewModel.onEvent(StreamScreenEvent.OnAddonFilterSelected(it)) },
@@ -660,6 +661,7 @@ private fun RightStreamSection(
     sourceChips: List<SourceChipItem>,
     selectedAddonFilter: String?,
     showFileSizeBadges: Boolean,
+    showAddonLogo: Boolean,
     badgePlacement: StreamBadgePlacement,
     hasBadgeRules: Boolean = false,
     onAddonFilterSelected: (String?) -> Unit,
@@ -776,6 +778,7 @@ private fun RightStreamSection(
                             availableAddons = availableAddons,
                             selectedAddonFilter = selectedAddonFilter,
                             showFileSizeBadges = showFileSizeBadges,
+                            showAddonLogo = showAddonLogo,
                             badgePlacement = badgePlacement,
                             hasBadgeRules = hasBadgeRules,
                             onAddonFilterSelected = { onAddonFilterSelectedGuarded(it) },
@@ -987,6 +990,7 @@ private fun StreamsList(
     availableAddons: List<String> = emptyList(),
     selectedAddonFilter: String? = null,
     showFileSizeBadges: Boolean = true,
+    showAddonLogo: Boolean = true,
     badgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM,
     hasBadgeRules: Boolean = false,
     onAddonFilterSelected: (String?) -> Unit = {},
@@ -1071,6 +1075,7 @@ private fun StreamsList(
                 StreamCard(
                     stream = stream,
                     showFileSizeBadges = showFileSizeBadges,
+                    showAddonLogo = showAddonLogo,
                     badgePlacement = badgePlacement,
                     reserveBadgeSpace = hasBadgeRules && stream.badges.isEmpty(),
                     onClick = { onStreamSelected(stream) },
@@ -1097,6 +1102,7 @@ private fun StreamsList(
 private fun StreamCard(
     stream: Stream,
     showFileSizeBadges: Boolean,
+    showAddonLogo: Boolean,
     badgePlacement: StreamBadgePlacement,
     reserveBadgeSpace: Boolean = false,
     onClick: () -> Unit,
@@ -1206,7 +1212,7 @@ private fun StreamCard(
             Column(
                 horizontalAlignment = Alignment.End
             ) {
-                if (addonLogoModel != null) {
+                if (showAddonLogo && addonLogoModel != null) {
                     AsyncImage(
                         model = addonLogoModel,
                         contentDescription = stream.addonName,

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2534,6 +2534,9 @@
     <string name="settings_stream_badges_section">Styl Fusion</string>
     <string name="settings_stream_size_badges_title">Znaczniki rozmiaru</string>
     <string name="settings_stream_size_badges_description">Pokazuj znaczniki rozmiaru pliku w wynikach źródeł i panelach odtwarzacza.</string>
+    <string name="settings_stream_addon_logo_title">Logo dodatku</string>
+    <string name="settings_stream_addon_logo_description">Pokazuj logo i nazwę dodatku obok źródeł.</string>
+    <string name="settings_stream_display_section">Wyświetlanie</string>
     <string name="settings_stream_badge_urls_title">Adresy URL znaczników Fusion</string>
     <string name="settings_stream_badge_urls_description">Importuj do %1$d adresów URL ze znacznikami Fusion w formacie JSON. Każdy URL można osobno edytować lub usunąć.</string>
     <string name="settings_stream_badge_urls_search_description">Zarządzaj zaimportowanymi adresami URL znaczników Fusion.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1045,6 +1045,7 @@
     <string name="settings_stream_size_badges_description">Show file size badges in stream results and player source panels.</string>
     <string name="settings_stream_addon_logo_title">Addon logo</string>
     <string name="settings_stream_addon_logo_description">Show addon logo and name next to stream sources.</string>
+    <string name="settings_stream_display_section">Display</string>
     <string name="settings_stream_badge_position_title">Badge position</string>
     <string name="settings_stream_badge_position_description">Choose whether Fusion and size badges appear above or below stream cards.</string>
     <string name="settings_stream_badge_position_dialog_title">Badge position</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1043,6 +1043,8 @@
     <string name="settings_stream_badges_section">Fusion Style</string>
     <string name="settings_stream_size_badges_title">Size badges</string>
     <string name="settings_stream_size_badges_description">Show file size badges in stream results and player source panels.</string>
+    <string name="settings_stream_addon_logo_title">Addon logo</string>
+    <string name="settings_stream_addon_logo_description">Show addon logo and name next to stream sources.</string>
     <string name="settings_stream_badge_position_title">Badge position</string>
     <string name="settings_stream_badge_position_description">Choose whether Fusion and size badges appear above or below stream cards.</string>
     <string name="settings_stream_badge_position_dialog_title">Badge position</string>


### PR DESCRIPTION
## Summary

Add a "Display" settings section in Streams layout settings with a toggle to show/hide addon logo and name on stream cards. Also fixes inline stream meta URL construction for prefixed IDs (mal:, kitsu:) and moves file size badge to the end of the badge row.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

1. Addon logo toggle: allows users to hide the addon logo/name column from stream cards for a cleaner look. Enabled by default to preserve current experience.
2. Inline meta URL fix: video IDs like `mal:63375:1` were incorrectly split — `dropLastWhile { it.toIntOrNull() != null }` stripped both `1` (episode) and `63375` (part of the ID), resulting in requests to `/meta/series/mal.json` instead of `/meta/series/mal:63375.json`.
3. Size badge moved to end of badge row for consistency with mobile version.

## Issue or approval

[No linked issue - feature addition with inline bug fix.](https://github.com/NuvioMedia/NuvioMobile/pull/1316)

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Addon logo toggle defaults to ON (preserves current UX for existing users)
- Toggle controls both the logo image AND the addon name text
- Skeleton loading state also respects the toggle
- Size badge reorder is cosmetic only - no logic change
- Inline meta fix only affects `fetchInlineStreamsFromMeta`, not regular meta loading

## Testing

- Toggle ON: addon logo + name visible on stream cards, player source panels, episode panels
- Toggle OFF: entire right column hidden (logo + name), skeleton hides right column too
- Inline meta fix: `mal:63375:1` correctly resolves to metaId `mal:63375`
- Verified: `tt1234567:1:5` -> `tt1234567`, `kitsu:12345:2` -> `kitsu:12345``
- Size badge now renders after Fusion badges (end of row)
- Polish translation included
- No new warnings

## Screenshots / Video (UI changes only)
<img width="4096" height="3072" alt="IMG20260610134629" src="https://github.com/user-attachments/assets/36fc1b81-9146-432c-8997-00f676b69370" />
<img width="4096" height="3072" alt="IMG20260610145253" src="https://github.com/user-attachments/assets/507ff728-3243-4d5b-878c-eb86a7c0ae75" />



## Breaking changes

None.

## Linked issues

[No linked issue.](https://github.com/NuvioMedia/NuvioMobile/pull/1316)
