### PR TITLE
Fix main-thread blocking in ensureExtractorsLoaded

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -661,7 +661,9 @@ class PluginManager @Inject constructor(
             val allDexIds = dataStore.scrapers.first()
                 .filter { it.type == RepositoryType.EXTERNAL_DEX }
                 .map { it.id }
-            externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
+            withContext(Dispatchers.IO) {
+                externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
+            }
         }
 
         val results = enabledScraperList.map { scraper ->
@@ -700,7 +702,9 @@ class PluginManager @Inject constructor(
             val allDexIds = dataStore.scrapers.first()
                 .filter { it.type == RepositoryType.EXTERNAL_DEX }
                 .map { it.id }
-            externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
+            withContext(Dispatchers.IO) {
+                externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
+            }
         }
 
         // Launch all scrapers concurrently within the channelFlow scope
@@ -890,7 +894,9 @@ class PluginManager @Inject constructor(
             val allDexIds = dataStore.scrapers.first()
                 .filter { it.type == RepositoryType.EXTERNAL_DEX }
                 .map { it.id }
-            externalExtensionLoader.ensureExtractorsLoaded(allDexIds, diagnostics)
+            withContext(Dispatchers.IO) {
+                externalExtensionLoader.ensureExtractorsLoaded(allDexIds, diagnostics)
+            }
         }
 
         val testSeason = if (testMediaType == "movie") null else 1


### PR DESCRIPTION
## Summary

Wraps all 3 calls to \ExternalExtensionLoader.ensureExtractorsLoaded()\ with \withContext(Dispatchers.IO)\ to prevent the UI thread from being blocked synchronously while loading DEX-based extractors.

## Root Cause

\nsureExtractorsLoaded()\ is a non-suspend function that performs synchronous work:
- \DexClassLoader\ instantiation
- \plugin.load()\ — registers all extractors (e.g. StreamPlay registers **115**)
- \Class.forName()\ scanning

But it was called from coroutine scopes that **inherit the caller's dispatcher** (typically \Dispatchers.Main\) with no dispatcher switch:

| Call Site | Line | Context |
|-----------|------|---------|
| \xecuteScrapers\ | 664 | \coroutineScope { }\ — inherits caller |
| \xecuteScrapersStreaming\ | 703 | \channelFlow { }\ — inherits collector |
| \	estScraper\ | 893 | \suspend fun\ — inherits caller |

The typical call chain from the UI layer:
`
ViewModel (collects on Main)
  -> flow { }  [StreamRepositoryImpl.kt:66]
      -> streamLocalPlugins()  [StreamRepositoryImpl.kt:300]
          -> executeScrapersStreaming()  [PluginManager.kt:682]
              -> channelFlow { }
                  -> ensureExtractorsLoaded()  <- ON MAIN THREAD
`

## Fix

All 3 call sites are now wrapped in \withContext(Dispatchers.IO)\:

\\\kotlin
// Before
externalExtensionLoader.ensureExtractorsLoaded(allDexIds)

// After
withContext(Dispatchers.IO) {
    externalExtensionLoader.ensureExtractorsLoaded(allDexIds)
}
\\\

## Verification

- Compiled successfully (\:app:compileFullDebugKotlin\ — BUILD SUCCESSFUL)
- Tested on Realtek RTD1319 TV with StreamPlay (115 extractors) — UI no longer hangs

Fixes #2263