### PR TITLE
Fix post-credits next episode timing and auto-play after dismissed countdown

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -43,11 +43,32 @@ object PlayerNextEpisodeRules {
             val latestOutroEndMs = (outroSegments.maxOf { it.endTime } * 1_000.0).toLong()
             val postOutroGapMs = durationMs - latestOutroEndMs
 
-            return if (postOutroGapMs > POST_OUTRO_AUTOPLAY_GAP_MS) {
-                // Post-credits scene: hold prompt until video truly ends.
-                positionMs >= durationMs - END_OF_VIDEO_EPSILON_MS
+            // Calculate the user's configured threshold as milliseconds from end.
+            val userThresholdMs = when (thresholdMode) {
+                NextEpisodeThresholdMode.PERCENTAGE -> {
+                    val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
+                    ((1.0 - clampedPercent / 100.0) * durationMs).toLong()
+                }
+                NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                    val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
+                    (clampedMinutes * 60_000f).toLong()
+                }
+            }
+
+            return if (postOutroGapMs > userThresholdMs) {
+                when (thresholdMode) {
+                    NextEpisodeThresholdMode.PERCENTAGE -> {
+                        val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
+                        (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
+                    }
+                    NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                        val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
+                        val remainingMs = durationMs - positionMs
+                        remainingMs <= (clampedMinutes * 60_000f).toLong()
+                    }
+                }
             } else {
-                // Fire at earliest outro start if outro ends near file end.
+                // Outro ends close to the file end — fire at earliest outro start.
                 positionMs / 1_000.0 >= outroSegments.minOf { it.startTime }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -115,6 +115,19 @@ internal fun PlayerRuntimeController.resetPostPlayStateAfterPlaybackEnded() {
     ) {
         return
     }
+
+    // If auto-play is enabled and the user dismissed the card earlier,
+    // still auto-play the next episode when playback ends naturally.
+    val state = _uiState.value
+    if (state.postPlayDismissedForCurrentEpisode &&
+        streamAutoPlayNextEpisodeEnabledSetting &&
+        state.nextEpisode?.hasAired == true &&
+        nextEpisodeVideo != null
+    ) {
+        playNextEpisode()
+        return
+    }
+
     resetPostPlayOverlayState(clearEpisode = false)
 }
 


### PR DESCRIPTION
## Summary

Fix next episode card timing when post-credits scenes are detected, and auto-play next episode when playback ends after user dismissed the countdown card. Improvement over #2245.

Two changes:
1. When the gap between outro end and file end exceeds the user's configured next episode threshold, fall back to that threshold instead of waiting until the last second.
2. When auto-play is enabled and user dismissed the countdown card, still auto-play the next episode when playback ends naturally (instead of closing the player).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

1. The logic from #2245 used a hardcoded 5s gap (`POST_OUTRO_AUTOPLAY_GAP_MS`) to detect post-credits scenes and then waited until 1s before file end (`END_OF_VIDEO_EPSILON_MS`) to show the next episode card.

2. When a user has auto-play enabled and dismisses the countdown card mid-episode (because they want to keep watching), the player would simply close when playback ended - losing the auto-play behavior entirely. Now it respects the auto-play setting and transitions to the next episode.

## Issue or approval

Improvement over #2245.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change behavior when outro ends near file end (< threshold) - still fires at outro start
- Does not change the "still watching" prompt logic
- Does not affect manual mode users
- `POST_OUTRO_AUTOPLAY_GAP_MS` and `END_OF_VIDEO_EPSILON_MS` constants kept for reference but no longer used in the threshold logic

## Testing

- Episode with ending at 22:00, file end at 24:00, threshold 0.5min: card appears at 23:30 (not 23:59)
- Episode with ending at 23:50, file end at 24:00, threshold 0.5min: card appears at outro start 23:50 (gap < threshold, normal behavior)
- Auto-play ON, dismiss countdown card, playback ends: next episode starts automatically
- Auto-play OFF: no change in behavior (confirm prompt still shows on end)
- No regressions with "still watching" prompt after consecutive episodes

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Improvement over #2245.
