### PR TITLE
Fix/hls adaptive hud

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -553,7 +553,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                                                 rendererFormatSupports[rendererIndex][groupIndex][trackIndex] =
                                                     RendererCapabilities.create(
                                                         C.FORMAT_HANDLED,
-                                                        RendererCapabilities.getAdaptiveSupport(support),
+                                                        RendererCapabilities.ADAPTIVE_SEAMLESS,
                                                         RendererCapabilities.getTunnelingSupport(support),
                                                         RendererCapabilities.getHardwareAccelerationSupport(support),
                                                         RendererCapabilities.getDecoderSupport(support)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1249,6 +1249,23 @@ internal fun PlayerRuntimeController.buildStreamInfoData(): StreamInfoData {
     val selectedSubtitle = state.subtitleTracks.firstOrNull { it.isSelected }
     val addonSub = state.selectedAddonSubtitle
 
+    val activeVideoFormat = _exoPlayer?.videoFormat
+    val matchedFormat = _exoPlayer?.currentTracks?.groups
+        ?.firstOrNull { it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO && it.isSelected }
+        ?.let { group ->
+            (0 until group.length)
+                .map { group.getTrackFormat(it) }
+                .firstOrNull { it.id == activeVideoFormat?.id || (it.bitrate > 0 && it.bitrate == activeVideoFormat?.bitrate) }
+        }
+
+    val videoWidth = matchedFormat?.width?.takeIf { it > 0 } ?: activeVideoFormat?.width?.takeIf { it > 0 } ?: currentVideoWidth
+    val videoHeight = matchedFormat?.height?.takeIf { it > 0 } ?: activeVideoFormat?.height?.takeIf { it > 0 } ?: currentVideoHeight
+    val videoBitrate = activeVideoFormat?.bitrate?.takeIf { it > 0 } ?: currentVideoBitrate
+    val videoCodec = activeVideoFormat?.let { format ->
+        CustomDefaultTrackNameProvider.formatNameFromMime(format.sampleMimeType)
+            ?: CustomDefaultTrackNameProvider.formatNameFromMime(format.codecs)
+    } ?: currentVideoCodec
+
     return StreamInfoData(
         addonName = currentAddonName,
         addonLogo = currentAddonLogo,
@@ -1256,11 +1273,11 @@ internal fun PlayerRuntimeController.buildStreamInfoData(): StreamInfoData {
         streamDescription = currentStreamDescription,
         filename = currentFilename,
         fileSize = currentVideoSize,
-        videoCodec = currentVideoCodec,
-        videoWidth = currentVideoWidth,
-        videoHeight = currentVideoHeight,
+        videoCodec = videoCodec,
+        videoWidth = videoWidth,
+        videoHeight = videoHeight,
         videoFrameRate = state.detectedFrameRate.takeIf { it > 0f },
-        videoBitrate = currentVideoBitrate,
+        videoBitrate = videoBitrate,
         audioCodec = selectedAudio?.codec,
         audioChannels = selectedAudio?.channelCount?.let {
             CustomDefaultTrackNameProvider.getChannelLayoutName(it)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
@@ -237,14 +237,15 @@ private fun formatBitrate(bps: Int): String {
     }
 }
 
-private fun formatResolution(width: Int, height: Int): String {
+internal fun formatResolution(width: Int, height: Int): String {
+    val maxDim = maxOf(width, height)
     val label = when {
-        height >= 2160 || width >= 3840 -> "4K"
-        height >= 1440 || width >= 2560 -> "1440p"
-        height >= 1080 || width >= 1920 -> "1080p"
-        height >= 720 || width >= 1280 -> "720p"
-        height >= 480 || width >= 854 -> "480p"
-        else -> "${height}p"
+        maxDim >= 3600 -> "4K"
+        maxDim >= 2400 -> "1440p"
+        maxDim >= 1800 -> "1080p"
+        maxDim >= 1200 -> "720p"
+        maxDim >= 800 -> "480p"
+        else -> "${minOf(width, height)}p"
     }
     return "$width × $height ($label)"
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/TrackSelectionInvestigationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/TrackSelectionInvestigationTest.kt
@@ -491,15 +491,10 @@ class TrackSelectionInvestigationTest {
             .setCodecs("avc1.640028")
             .build()
 
-        // Mock currentTracks structure
-        val mockGroup = mockk<Tracks.Group>(relaxed = true)
-        every { mockGroup.type } returns C.TRACK_TYPE_VIDEO
-        every { mockGroup.isSelected } returns true
-        every { mockGroup.length } returns 1
-        every { mockGroup.getTrackFormat(0) } returns manifestFormat
-
-        val mockTracks = mockk<Tracks>(relaxed = true)
-        every { mockTracks.groups } returns listOf(mockGroup)
+        // Construct real currentTracks structure using media3 class constructors
+        val mediaTrackGroup = TrackGroup(manifestFormat)
+        val realGroup = Tracks.Group(mediaTrackGroup, false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(true))
+        val mockTracks = Tracks(com.google.common.collect.ImmutableList.of(realGroup))
         
         every { mockExoPlayer.videoFormat } returns activeFormat
         every { mockExoPlayer.currentTracks } returns mockTracks
@@ -533,5 +528,28 @@ class TrackSelectionInvestigationTest {
         assertEquals(1080, streamInfo.videoHeight)
         assertEquals(1800000, streamInfo.videoBitrate)
         assertEquals("AVC", streamInfo.videoCodec)
+    }
+
+    @Test
+    fun testFormatResolution() {
+        // Cropped widescreen / letterboxed resolutions
+        assertEquals("1918 × 802 (1080p)", formatResolution(1918, 802))
+        assertEquals("854 × 357 (480p)", formatResolution(854, 357))
+        assertEquals("1278 × 530 (720p)", formatResolution(1278, 530))
+        assertEquals("3836 × 1600 (4K)", formatResolution(3836, 1600))
+
+        // Standard resolutions
+        assertEquals("1920 × 1080 (1080p)", formatResolution(1920, 1080))
+        assertEquals("1280 × 720 (720p)", formatResolution(1280, 720))
+        assertEquals("854 × 480 (480p)", formatResolution(854, 480))
+        assertEquals("3840 × 2160 (4K)", formatResolution(3840, 2160))
+
+        // Portrait / vertical resolutions
+        assertEquals("1080 × 1920 (1080p)", formatResolution(1080, 1920))
+        assertEquals("720 × 1280 (720p)", formatResolution(720, 1280))
+
+        // Custom / fallback resolutions
+        assertEquals("640 × 360 (360p)", formatResolution(640, 360))
+        assertEquals("720 × 576 (576p)", formatResolution(720, 576))
     }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/TrackSelectionInvestigationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/TrackSelectionInvestigationTest.kt
@@ -29,6 +29,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.net.URL
 import java.net.HttpURLConnection
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.Tracks
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class TrackSelectionInvestigationTest {
 
@@ -461,5 +464,74 @@ class TrackSelectionInvestigationTest {
 
         val finalSupportHevc10 = RendererCapabilities.getFormatSupport(rendererFormatSupports[0][1][0])
         assertEquals(C.FORMAT_EXCEEDS_CAPABILITIES, finalSupportHevc10)
+    }
+
+    @Test
+    fun testBuildStreamInfoDataWithActiveVideoFormat() {
+        val controller = mockk<PlayerRuntimeController>(relaxed = true)
+        val mockExoPlayer = mockk<ExoPlayer>(relaxed = true)
+        
+        // Active format is the cropped format returned by the decoder/player (1918x802)
+        val activeFormat = Format.Builder()
+            .setId("1")
+            .setWidth(1918)
+            .setHeight(802)
+            .setPeakBitrate(1800000)
+            .setSampleMimeType("video/avc")
+            .setCodecs("avc1.640028")
+            .build()
+
+        // Manifest format contains the original uncropped resolution (1920x1080)
+        val manifestFormat = Format.Builder()
+            .setId("1")
+            .setWidth(1920)
+            .setHeight(1080)
+            .setPeakBitrate(1800000)
+            .setSampleMimeType("video/avc")
+            .setCodecs("avc1.640028")
+            .build()
+
+        // Mock currentTracks structure
+        val mockGroup = mockk<Tracks.Group>(relaxed = true)
+        every { mockGroup.type } returns C.TRACK_TYPE_VIDEO
+        every { mockGroup.isSelected } returns true
+        every { mockGroup.length } returns 1
+        every { mockGroup.getTrackFormat(0) } returns manifestFormat
+
+        val mockTracks = mockk<Tracks>(relaxed = true)
+        every { mockTracks.groups } returns listOf(mockGroup)
+        
+        every { mockExoPlayer.videoFormat } returns activeFormat
+        every { mockExoPlayer.currentTracks } returns mockTracks
+        every { controller._exoPlayer } returns mockExoPlayer
+
+        // Mock other controller properties
+        every { controller._uiState } returns MutableStateFlow(PlayerUiState(
+            currentStreamName = "Test Stream",
+            detectedFrameRate = 23.976f
+        ))
+        every { controller.currentAddonName } returns "Test Addon"
+        every { controller.currentAddonLogo } returns "logo.png"
+        every { controller.currentStreamDescription } returns "Description"
+        every { controller.currentFilename } returns "file.mkv"
+        every { controller.currentVideoSize } returns 1024L
+        every { controller.currentVideoWidth } returns 1920
+        every { controller.currentVideoHeight } returns 1080
+        every { controller.currentVideoBitrate } returns 4500000
+        every { controller.currentVideoCodec } returns "HEVC"
+        every { controller.currentInternalPlayerEngine } returns com.nuvio.tv.data.local.InternalPlayerEngine.EXOPLAYER
+
+        val mockContext = mockk<Context>(relaxed = true)
+        every { mockContext.getString(any()) } returns "mocked_string"
+        every { mockContext.resources } returns mockk(relaxed = true)
+        every { controller.context } returns mockContext
+
+        val streamInfo = controller.buildStreamInfoData()
+
+        // Verify that the uncropped manifest/header resolution is matched and resolved
+        assertEquals(1920, streamInfo.videoWidth)
+        assertEquals(1080, streamInfo.videoHeight)
+        assertEquals(1800000, streamInfo.videoBitrate)
+        assertEquals("AVC", streamInfo.videoCodec)
     }
 }


### PR DESCRIPTION
## Summary

This is a follow-up fix to https://github.com/NuvioMedia/NuvioTV/pull/2237. 

It fixes a regression where HLS adaptive track selection gets stuck at lower resolutions (e.g., 720p/480p) and never reaches 1080p. We resolve this by forcing `RendererCapabilities.ADAPTIVE_SEAMLESS` instead of `RendererCapabilities.getAdaptiveSupport(support)` when overriding track format capabilities in `DefaultTrackSelector.selectAllTracks`.

Additionally, it resolves HLS active resolution metadata dynamically inside `PlayerRuntimeControllerPlaybackEvents.kt` by matching the active format against the HLS manifest's declared formats in `currentTracks`. This ensures cropped widescreen streams (e.g., 1918x802) correctly display their original container quality (e.g., 1920x1080 / 1080p) in the HUD overlay, rather than incorrectly displaying cropped values or requiring changes to the strict resolution label thresholds.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

This PR addresses two issues related to HLS playback:

### 1. HLS stuck at 720p (Adaptive Track Selection Regression)
In https://github.com/NuvioMedia/NuvioTV/pull/2237, the capability override was moved to a custom `DefaultTrackSelector.selectAllTracks` implementation. However, since underreported 1080p tracks originally exceed the device's capabilities, their original adaptive support value is evaluated as `ADAPTIVE_NOT_SUPPORTED`. 

Retaining this flag via `RendererCapabilities.getAdaptiveSupport(support)` meant ExoPlayer's `AdaptiveTrackSelection` excluded the upgraded 1080p track from its adaptive selection queue, locking playback to lower resolutions (like 720p/480p). Forcing `RendererCapabilities.ADAPTIVE_SEAMLESS` during the override allows ExoPlayer to dynamically scale playback to 1080p seamlessly.

### 2. HUD showing 1080p as 720p (Widescreen Cropping / Letterbox)
For cinematic widescreen streams (e.g., 2.39:1 aspect ratio), video encoders often crop out the top and bottom black bars (letterboxing) to save encoding bandwidth. This results in the active stream having cropped dimensions (e.g., `1918x802` or `1920x802`) instead of standard `1920x1080` (16:9).

During playback, the hardware decoder decodes at `1918x802` and reports this via `onVideoSizeChanged`. Furthermore, some HLS manifests declare the cropped widescreen dimensions directly. Because the height (`802 < 1080`) and width (`1918 < 1920`) fell below the strict 1080p limits in `StreamInfoOverlay.kt`, the HUD classified the widescreen 1080p video as `720p`.

We fix this on two fronts:
1. We dynamically match the active playback format against the HLS manifest's declared formats in `currentTracks` to retrieve uncropped container dimensions when available.
2. In cases where the HLS manifest itself contains the cropped dimensions (e.g. `1918x802` or `854x357` directly), we refactored the resolution label thresholds in `StreamInfoOverlay.kt` to use the maximum dimension (`maxOf(width, height)`) with tolerance bands (e.g. `maxDim >= 1800` for `1080p` and `maxDim >= 800` for `480p`). This robustly resolves standard, widescreen-cropped, and portrait streams to their correct resolution label.

## Issue or approval

References / resolves regression introduced in PR: #2237

## Reproduction steps

1. Play an HLS stream (e.g. "Pluribus" stream with `avc1.640028` codec as first stream) on a Fire Stick 4K device.
2. Note that playback starts at 720p/480p and never transitions up to 1080p, despite high-speed fiber internet.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change updates the adaptive support evaluation in `PlayerRuntimeControllerInitialization.kt`, adds dynamic manifest format matching in `PlayerRuntimeControllerPlaybackEvents.kt`, and updates resolution formatting in `StreamInfoOverlay.kt` to fix HUD resolution labels. It does not touch UI layout files or other player event logic.

## Testing

Ran the local track selection unit test suite successfully:
```powershell
.\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.TrackSelectionInvestigationTest"
```

### Verification Logs

Investigation logs from local debug run exposing the underreported HLS track evaluation (`support=4` / `FORMAT_HANDLED`) and the `MediaCodec` decoder configuration confirming cropped active dimensions (`1918x802`):

```log
2026-06-11 03:30:20.238 31678-1213  NuvioTrackSelector      com.nuvio.tv.debug                   D  selectAllTracks run: streamMime=application/x-mpegURL, isHls=true
2026-06-11 03:30:20.239 31678-1213  NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:0, res=1920x1080, mime=video/avc, codecs=avc1.640028, support=4
2026-06-11 03:30:20.239 31678-1213  NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:1, res=1280x720, mime=video/avc, codecs=avc1.64001f, support=4
2026-06-11 03:30:20.239 31678-1213  NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:2, res=854x480, mime=video/avc, codecs=avc1.64001f, support=4
...
2026-06-11 03:30:20.540 31678-1213  MediaCodec              com.nuvio.tv.debug                   I  [0xb0d38d10]===V MediaCodec::configure===
2026-06-11 03:30:20.540 31678-1213  MediaCodec              com.nuvio.tv.debug                   I  AMessage(what = 0x00000000) = {
  int32_t max-height = 1080
  int32_t max-width = 1920
  int32_t width = 1918
  int32_t height = 802
  ...
}
2026-06-11 03:30:20.711 31678-31678 PlayerViewModel         com.nuvio.tv.debug                   D  onVideoSizeChanged: updated resolution to 1918x802
```

Investigation logs showing HLS manifests declaring cropped widescreen dimensions directly (`1918x802`, `854x357`):

```log
2026-06-11 20:48:26.355 12551-13608 NuvioTrackSelector      com.nuvio.tv.debug                   D  selectAllTracks run: streamMime=application/x-mpegURL, isHls=true
2026-06-11 20:48:26.356 12551-13608 NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:0, res=1918x802, mime=video/avc, codecs=avc1.4d4028, support=4
2026-06-11 20:48:26.356 12551-13608 NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:1, res=854x357, mime=video/avc, codecs=avc1.4d401e, support=4
2026-06-11 20:48:26.356 12551-13608 NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:2, res=1918x802, mime=video/avc, codecs=avc1.4d4028, support=4
2026-06-11 20:48:26.356 12551-13608 NuvioTrackSelector      com.nuvio.tv.debug                   D  Evaluating track: id=0:3, res=854x357, mime=video/avc, codecs=avc1.4d401e, support=4
```

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Ref: #2237
