### PR TITLE
i18n(fr): extract hardcoded strings + translate DV diagnostics, units, fallbacks (batch11)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/profile/ProfileManager.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.core.profile
 
 import android.content.Context
+import com.nuvio.tv.R
 import com.nuvio.tv.data.local.ProfileDataStore
 import com.nuvio.tv.data.local.ProfileDataStoreFactory
 import com.nuvio.tv.domain.model.UserProfile
@@ -44,7 +45,7 @@ class ProfileManager @Inject constructor(
 
     val profiles: StateFlow<List<UserProfile>> = profileDataStore.profilesList
         .stateIn(scope, SharingStarted.Eagerly, listOf(
-            UserProfile(id = 1, name = "Profile 1", avatarColorHex = "#1E88E5")
+            UserProfile(id = 1, name = context.getString(R.string.profile_default_name, 1), avatarColorHex = "#1E88E5")
         ))
 
     val activeProfile: UserProfile?
@@ -82,7 +83,7 @@ class ProfileManager @Inject constructor(
 
         val profile = UserProfile(
             id = nextId,
-            name = name.trim().ifEmpty { "Profile $nextId" },
+            name = name.trim().ifEmpty { context.getString(R.string.profile_default_name, nextId) },
             avatarColorHex = avatarColorHex,
             usesPrimaryAddons = usesPrimaryAddons,
             usesPrimaryPlugins = usesPrimaryPlugins,

--- a/app/src/main/java/com/nuvio/tv/core/server/StreamBadgeConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/StreamBadgeConfigServer.kt
@@ -132,7 +132,7 @@ class StreamBadgeConfigServer(
                 """{"status":"imported","streamBadgeRules":$rulesJson}"""
             )
         } catch (error: Exception) {
-            errorResponse(error.message ?: "Badge import failed.")
+            errorResponse(error.message ?: badgeImportFailedMessage())
         }
     }
 
@@ -193,13 +193,16 @@ class StreamBadgeConfigServer(
         return try {
             val code = connection.responseCode
             if (code !in 200..299) {
-                throw IllegalArgumentException("Badge import failed.")
+                throw IllegalArgumentException(badgeImportFailedMessage())
             }
             connection.inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
         } finally {
             connection.disconnect()
         }
     }
+
+    private fun badgeImportFailedMessage(): String =
+        context?.getString(com.nuvio.tv.R.string.web_stream_badge_import_error) ?: "Badge import failed."
 
     private fun errorResponse(message: String): Response =
         newFixedLengthResponse(

--- a/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ProfileDataStore.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.UserProfile
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -105,7 +106,7 @@ class ProfileDataStore @Inject constructor(
 
     private fun defaultPrimaryProfile() = UserProfile(
         id = 1,
-        name = "Profile 1",
+        name = context.getString(R.string.profile_default_name, 1),
         avatarColorHex = "#1E88E5"
     )
 

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -68,9 +68,15 @@ data class Stream(
     fun isExternal(): Boolean = externalUrl != null && url == null && !externalUrl.isMagnetLink()
 
     /**
+     * Returns a display name for the stream, or null when no field is usable.
+     * UI call sites should substitute a localized fallback (R.string.stream_unknown).
+     */
+    fun getDisplayNameOrNull(): String? = name ?: title ?: description
+
+    /**
      * Returns a display name for the stream
      */
-    fun getDisplayName(): String = name ?: title ?: description ?: "Unknown Stream"
+    fun getDisplayName(): String = getDisplayNameOrNull() ?: "Unknown Stream"
 
     /**
      * Returns a display description for the stream

--- a/app/src/main/java/com/nuvio/tv/ui/components/StreamBadgeChips.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/StreamBadgeChips.kt
@@ -75,14 +75,16 @@ fun StreamBadgeChips(
 
 @Composable
 private fun StreamFileSizeBadge(bytes: Long) {
-    val label = remember(bytes) {
+    val gbTemplate = stringResource(R.string.unit_size_gb)
+    val mbTemplate = stringResource(R.string.unit_size_mb)
+    val label = remember(bytes, gbTemplate, mbTemplate) {
         val gib = bytes.toDouble() / (1024.0 * 1024.0 * 1024.0)
         if (gib >= 1.0) {
             val roundedGiB = round(gib * 10.0) / 10.0
-            "$roundedGiB GB"
+            gbTemplate.format(roundedGiB.toString())
         } else {
             val mib = bytes.toDouble() / (1024.0 * 1024.0)
-            "${round(mib).toInt()} MB"
+            mbTemplate.format(round(mib).toInt().toString())
         }
     }
     val shape = RoundedCornerShape(6.dp)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -427,7 +427,8 @@ class AccountViewModel @Inject constructor(
                     val remote = response.profiles[pidStr]
                     ProfileSyncStats(
                         profileId = pid,
-                        profileName = local?.name ?: remote?.name ?: "Profile $pid",
+                        profileName = local?.name ?: remote?.name
+                            ?: context.getString(com.nuvio.tv.R.string.profile_default_name, pid),
                         avatarColorHex = local?.avatarColorHex ?: remote?.color ?: "#1E88E5",
                         addons = response.addons[pidStr] ?: 0,
                         plugins = response.plugins[pidStr] ?: 0,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorTmdbPicker.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/CollectionEditorTmdbPicker.kt
@@ -292,7 +292,8 @@ fun TmdbSourcePickerContent(
                         )
                     }
                     items(uiState.tmdbCollectionResults) { result ->
-                        val title = result.name ?: "TMDB Collection ${result.id}"
+                        val title = result.name
+                            ?: stringResource(R.string.collections_editor_tmdb_collection_fallback, result.id)
                         TmdbPickerCard(
                             title = title,
                             subtitle = stringResource(R.string.collections_editor_tmdb_collection),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -688,7 +688,8 @@ class MetaDetailsViewModel @Inject constructor(
             id = itemId,
             type = type,
             rawType = itemType,
-            name = enrichment.localizedTitle ?: enrichment.originalTitle ?: "TMDB $tmdbId",
+            name = enrichment.localizedTitle ?: enrichment.originalTitle
+                ?: context.getString(R.string.detail_tmdb_fallback_title, tmdbId),
             poster = enrichment.poster,
             posterShape = com.nuvio.tv.domain.model.PosterShape.POSTER,
             background = enrichment.backdrop,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1142,7 +1142,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (isReleasingPlayer && error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) return
                         cancelFirstFrameWatchdog()
                         val detailedError = buildString {
-                            append(error.message ?: "Playback error")
+                            append(error.message ?: context.getString(R.string.player_error_playback_fallback))
                             val cause = error.cause
                             if (cause is androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException) {
                                 append(" (HTTP ${cause.responseCode})")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -224,10 +224,19 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     val message = if (statsHidden) {
                         null
                     } else {
-                        val speed = formatTorrentSpeed(_uiState.value.torrentDownloadSpeed)
-                        val peerInfo = "${_uiState.value.torrentSeeds} seeds \u00B7 ${_uiState.value.torrentPeers} peers"
+                        val speed = formatTorrentSpeed(context, _uiState.value.torrentDownloadSpeed)
+                        val peerInfo = context.getString(
+                            R.string.player_torrent_peer_info,
+                            _uiState.value.torrentSeeds,
+                            _uiState.value.torrentPeers
+                        )
                         val bufLabel = String.format("%.0fs", bufferedSec)
-                        "$bufLabel buffered \u00B7 $peerInfo \u00B7 $speed"
+                        context.getString(
+                            R.string.player_torrent_buffered_status,
+                            bufLabel,
+                            peerInfo,
+                            speed
+                        )
                     }
                     val progress = (bufferedSec / 10f).coerceIn(0f, 1f)
                     _uiState.update {
@@ -1296,10 +1305,10 @@ internal fun PlayerRuntimeController.buildStreamInfoData(): StreamInfoData {
     )
 }
 
-private fun formatTorrentSpeed(bytesPerSec: Long): String {
+private fun formatTorrentSpeed(context: android.content.Context, bytesPerSec: Long): String {
     return when {
-        bytesPerSec >= 1_048_576 -> String.format("%.1f MB/s", bytesPerSec / 1_048_576.0)
-        bytesPerSec >= 1_024 -> String.format("%.0f KB/s", bytesPerSec / 1_024.0)
-        else -> "$bytesPerSec B/s"
+        bytesPerSec >= 1_048_576 -> context.getString(R.string.unit_speed_mb_s, String.format("%.1f", bytesPerSec / 1_048_576.0))
+        bytesPerSec >= 1_024 -> context.getString(R.string.unit_speed_kb_s, String.format("%.0f", bytesPerSec / 1_024.0))
+        else -> context.getString(R.string.unit_speed_b_s, bytesPerSec)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -777,7 +777,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(stream: Stream) {
                 player.playWhenReady = true
                 player.prepare()
             } catch (e: Exception) {
-                _uiState.update { it.copy(error = e.message ?: "Failed to play selected stream") }
+                _uiState.update { it.copy(error = e.message ?: context.getString(com.nuvio.tv.R.string.player_error_play_stream_failed)) }
             }
         }
     } ?: run {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTorrent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTorrent.kt
@@ -80,9 +80,9 @@ internal fun PlayerRuntimeController.observeTorrentState() {
                 }
 
                 is TorrentState.Streaming -> {
-                    val speed = formatSpeed(torrentState.downloadSpeed)
+                    val speed = formatSpeed(context, torrentState.downloadSpeed)
                     val peerInfo = context.getString(com.nuvio.tv.R.string.player_torrent_peer_info, torrentState.seeds, torrentState.peers)
-                    val mbLoaded = formatMB(torrentState.preloadedBytes)
+                    val mbLoaded = formatMB(context, torrentState.preloadedBytes)
                     val statsHidden = _uiState.value.hideTorrentStats
 
                     if (!hasRenderedFirstFrame) {
@@ -191,12 +191,13 @@ internal fun PlayerRuntimeController.launchTorrentSourceStream(
     }
 }
 
-private fun formatSpeed(bytesPerSec: Long): String {
+private fun formatSpeed(context: android.content.Context, bytesPerSec: Long): String {
     return when {
-        bytesPerSec >= 1_048_576 -> String.format("%.1f MB/s", bytesPerSec / 1_048_576.0)
-        bytesPerSec >= 1_024 -> String.format("%.0f KB/s", bytesPerSec / 1_024.0)
-        else -> "$bytesPerSec B/s"
+        bytesPerSec >= 1_048_576 -> context.getString(com.nuvio.tv.R.string.unit_speed_mb_s, String.format("%.1f", bytesPerSec / 1_048_576.0))
+        bytesPerSec >= 1_024 -> context.getString(com.nuvio.tv.R.string.unit_speed_kb_s, String.format("%.0f", bytesPerSec / 1_024.0))
+        else -> context.getString(com.nuvio.tv.R.string.unit_speed_b_s, bytesPerSec)
     }
 }
 
-private fun formatMB(bytes: Long): String = String.format("%.1f MB", bytes / 1_048_576.0)
+private fun formatMB(context: android.content.Context, bytes: Long): String =
+    context.getString(com.nuvio.tv.R.string.unit_size_mb, String.format("%.1f", bytes / 1_048_576.0))

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -76,7 +76,8 @@ internal fun StreamItem(
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
-    val streamName = remember(stream) { stream.getDisplayName() }
+    val unknownStreamLabel = stringResource(R.string.stream_unknown)
+    val streamName = remember(stream, unknownStreamLabel) { stream.getDisplayNameOrNull() ?: unknownStreamLabel }
     val streamDescription = remember(stream) { stream.getDisplayDescription() }
     val hasBadges = stream.badges.isNotEmpty() || (showFileSizeBadges && stream.behaviorHints?.videoSize != null)
     // Pre-upscale: decode at 2× target pixels so the hardware compositor

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
@@ -220,12 +220,13 @@ private fun InfoItem(label: String, value: String?, modifier: Modifier = Modifie
     }
 }
 
+@Composable
 private fun formatFileSize(bytes: Long): String {
     return when {
-        bytes >= 1_073_741_824L -> "%.1f GB".format(bytes / 1_073_741_824.0)
-        bytes >= 1_048_576L -> "%.1f MB".format(bytes / 1_048_576.0)
-        bytes >= 1024L -> "%.1f KB".format(bytes / 1024.0)
-        else -> "$bytes B"
+        bytes >= 1_073_741_824L -> stringResource(R.string.unit_size_gb, "%.1f".format(bytes / 1_073_741_824.0))
+        bytes >= 1_048_576L -> stringResource(R.string.unit_size_mb, "%.1f".format(bytes / 1_048_576.0))
+        bytes >= 1024L -> stringResource(R.string.unit_size_kb, "%.1f".format(bytes / 1024.0))
+        else -> stringResource(R.string.unit_size_b, bytes)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/TorrentOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/TorrentOverlay.kt
@@ -77,10 +77,11 @@ fun TorrentOverlay(
     }
 }
 
+@Composable
 private fun formatSpeed(bytesPerSec: Long): String {
     return when {
-        bytesPerSec >= 1_048_576 -> String.format("%.1f MB/s", bytesPerSec / 1_048_576.0)
-        bytesPerSec >= 1_024 -> String.format("%.0f KB/s", bytesPerSec / 1_024.0)
-        else -> "$bytesPerSec B/s"
+        bytesPerSec >= 1_048_576 -> stringResource(R.string.unit_speed_mb_s, String.format("%.1f", bytesPerSec / 1_048_576.0))
+        bytesPerSec >= 1_024 -> stringResource(R.string.unit_speed_kb_s, String.format("%.0f", bytesPerSec / 1_024.0))
+        else -> stringResource(R.string.unit_speed_b_s, bytesPerSec)
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DiagnosticsCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DiagnosticsCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Border
@@ -28,6 +29,7 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.nuvio.tv.R
 import com.nuvio.tv.core.player.DolbyVisionCodecFallback
 import com.nuvio.tv.core.player.LastPlaybackDiagnostics
 import java.text.SimpleDateFormat
@@ -48,13 +50,13 @@ internal fun LazyListScope.diagnosticsCardItems(
         item(key = "diagnostics_empty_intro") {
             DiagnosticsSectionCard {
                 Text(
-                    text = "Last Playback Diagnostics",
+                    text = stringResource(R.string.diag_last_playback_title),
                     style = MaterialTheme.typography.labelMedium,
                     color = NuvioTheme.colors.Primary
                 )
                 Spacer(modifier = Modifier.height(NuvioTheme.spacing.xs))
                 Text(
-                    text = "No playback data yet. Play a stream and return here to see DV decision details for that playback.",
+                    text = stringResource(R.string.diag_no_data),
                     style = MaterialTheme.typography.bodySmall,
                     color = NuvioTheme.colors.TextSecondary
                 )
@@ -80,13 +82,17 @@ internal fun LazyListScope.diagnosticsCardItems(
 
     // Card 1: Source + Display + Decoder + Bridge (the input side)
     item(key = "diag_card_input") {
+        val unknownLabel = stringResource(R.string.type_unknown)
         DiagnosticsSectionCard {
-            SectionHeader("Source & Hardware", "Take a photo of this card if reporting an issue.")
-            DiagnosticRow("Host", diagnostics.host)
-            DiagnosticRow("When", formatTimestamp(diagnostics.timestampMs))
-            DiagnosticRow("Device", deviceName())
+            SectionHeader(
+                stringResource(R.string.diag_section_source_hardware),
+                stringResource(R.string.diag_section_source_hardware_sub)
+            )
+            DiagnosticRow(stringResource(R.string.diag_label_host), diagnostics.host)
+            DiagnosticRow(stringResource(R.string.diag_label_when), formatTimestamp(diagnostics.timestampMs))
+            DiagnosticRow(stringResource(R.string.diag_label_device), deviceName(unknownLabel))
             DiagnosticRow(
-                "Display",
+                stringResource(R.string.diag_label_display),
                 dv(
                     if (diagnostics.hdrCapsKnown) {
                         buildString {
@@ -94,31 +100,37 @@ internal fun LazyListScope.diagnosticsCardItems(
                             if (diagnostics.displayHdr10Plus) append("HDR10+ ")
                             else if (diagnostics.displayHdr10) append("HDR10 ")
                             if (!diagnostics.displayDv && !diagnostics.displayHdr10) append("SDR")
-                        }.trim().ifBlank { "Unknown" }
+                        }.trim().ifBlank { unknownLabel }
                     } else {
-                        "Unknown"
+                        unknownLabel
                     }
                 )
             )
             DiagnosticRow(
-                "DV7 Decoder",
-                dv(if (diagnostics.codecDv7Supported) "Available" else "Not available")
-            )
-            DiagnosticRow(
-                "DV Decoder",
+                stringResource(R.string.diag_label_dv7_decoder),
                 dv(
-                    diagnostics.dv81DecoderName
-                        ?: findAnyDvDecoderName()?.let { "$it (hidden)" }
-                        ?: "None"
+                    if (diagnostics.codecDv7Supported) stringResource(R.string.diag_value_available)
+                    else stringResource(R.string.diag_value_not_available)
                 )
             )
             DiagnosticRow(
-                "DV Bridge",
-                dv(if (diagnostics.bridgeReady) "Ready" else "Not ready")
+                stringResource(R.string.diag_label_dv_decoder),
+                dv(
+                    diagnostics.dv81DecoderName
+                        ?: findAnyDvDecoderName()?.let { stringResource(R.string.diag_value_decoder_hidden, it) }
+                        ?: stringResource(R.string.diag_value_none)
+                )
+            )
+            DiagnosticRow(
+                stringResource(R.string.diag_label_dv_bridge),
+                dv(
+                    if (diagnostics.bridgeReady) stringResource(R.string.diag_value_ready)
+                    else stringResource(R.string.diag_value_not_ready)
+                )
             )
             if (dvEngaged) {
-                diagnostics.bridgeVersion?.let { DiagnosticRow("Bridge Version", it) }
-                diagnostics.bridgeReason?.let { DiagnosticRow("Bridge Reason", it) }
+                diagnostics.bridgeVersion?.let { DiagnosticRow(stringResource(R.string.diag_label_bridge_version), it) }
+                diagnostics.bridgeReason?.let { DiagnosticRow(stringResource(R.string.diag_label_bridge_reason), it) }
             }
         }
     }
@@ -126,31 +138,37 @@ internal fun LazyListScope.diagnosticsCardItems(
     // Card 2: Decision + Settings (the configured/effective behaviour)
     item(key = "diag_card_decision") {
         DiagnosticsSectionCard {
-            SectionHeader("Decision & Settings")
-            DiagnosticRow("DV Mode (requested)", dv(diagnostics.dv7ModeRequested))
+            SectionHeader(stringResource(R.string.diag_section_decision_settings))
+            DiagnosticRow(stringResource(R.string.diag_label_dv_mode_requested), dv(diagnostics.dv7ModeRequested))
             if (dvEngaged && diagnostics.dv7ModeRequested != diagnostics.dv7ModeEffective) {
-                DiagnosticRow("DV Mode (effective)", dv(diagnostics.dv7ModeEffective))
+                DiagnosticRow(stringResource(R.string.diag_label_dv_mode_effective), dv(diagnostics.dv7ModeEffective))
             }
-            DiagnosticRow("AUTO Decision", dv(diagnostics.dv7AutoDecision))
+            DiagnosticRow(stringResource(R.string.diag_label_auto_decision), dv(diagnostics.dv7AutoDecision))
             if (dvEngaged) {
-                diagnostics.dvSourceProfile?.let { DiagnosticRow("Source Profile", it) }
+                diagnostics.dvSourceProfile?.let { DiagnosticRow(stringResource(R.string.diag_label_source_profile), it) }
                 if (diagnostics.dv7DoviCalls > 0) {
                     DiagnosticRow(
-                        "Conversions",
-                        "${diagnostics.dv7DoviSuccess} of ${diagnostics.dv7DoviCalls} successful"
+                        stringResource(R.string.diag_label_conversions),
+                        stringResource(
+                            R.string.diag_value_conversions_fmt,
+                            diagnostics.dv7DoviSuccess,
+                            diagnostics.dv7DoviCalls
+                        )
                     )
                 }
                 if (diagnostics.dv7DoviSignalRewrites > 0) {
-                    DiagnosticRow("Signal Rewrites", diagnostics.dv7DoviSignalRewrites.toString())
+                    DiagnosticRow(stringResource(R.string.diag_label_signal_rewrites), diagnostics.dv7DoviSignalRewrites.toString())
                 }
             }
             DiagnosticRow(
-                "Custom Buffers",
-                if (diagnostics.bufferEngineEnabled) "On" else "Off"
+                stringResource(R.string.diag_label_custom_buffers),
+                if (diagnostics.bufferEngineEnabled) stringResource(R.string.diag_value_on)
+                else stringResource(R.string.diag_value_off)
             )
             DiagnosticRow(
-                "Custom Network/Cache",
-                if (diagnostics.parallelNetworkEnabled) "On" else "Off"
+                stringResource(R.string.diag_label_custom_network_cache),
+                if (diagnostics.parallelNetworkEnabled) stringResource(R.string.diag_value_on)
+                else stringResource(R.string.diag_value_off)
             )
         }
     }
@@ -158,20 +176,21 @@ internal fun LazyListScope.diagnosticsCardItems(
     // Card 3: Outcome
     item(key = "diag_card_outcome") {
         DiagnosticsSectionCard {
-            SectionHeader("Outcome")
-            DiagnosticRow("HDR Format (intended)", diagnostics.videoHdrType?.takeIf { it.isNotBlank() } ?: "-")
+            SectionHeader(stringResource(R.string.diag_section_outcome))
+            DiagnosticRow(stringResource(R.string.diag_label_hdr_format_intended), diagnostics.videoHdrType?.takeIf { it.isNotBlank() } ?: "-")
             DiagnosticRow(
-                "First Frame",
-                if (diagnostics.firstFrameMs >= 0) "${diagnostics.firstFrameMs} ms" else "Never rendered"
+                stringResource(R.string.diag_label_first_frame),
+                if (diagnostics.firstFrameMs >= 0) "${diagnostics.firstFrameMs} ms"
+                else stringResource(R.string.diag_value_never_rendered)
             )
             DiagnosticRow(
-                "Rebuffers",
+                stringResource(R.string.diag_label_rebuffers),
                 if (diagnostics.rebufferCount > 0)
                     "${diagnostics.rebufferCount} (${diagnostics.rebufferTotalMs} ms)"
                 else "0"
             )
             DiagnosticRow(
-                "Result",
+                stringResource(R.string.diag_label_result),
                 diagnostics.result,
                 valueColor = when {
                     diagnostics.result.startsWith("Error", ignoreCase = true) -> Color(0xFFF44336)
@@ -264,11 +283,11 @@ private fun formatTimestamp(ms: Long): String {
 }
 
 /** "Manufacturer Model", de-duplicated (e.g. avoids "Xiaomi Xiaomi ..."). */
-private fun deviceName(): String {
+private fun deviceName(unknownLabel: String): String {
     val manufacturer = android.os.Build.MANUFACTURER?.trim().orEmpty()
     val model = android.os.Build.MODEL?.trim().orEmpty()
     return when {
-        model.isBlank() -> manufacturer.ifBlank { "Unknown" }
+        model.isBlank() -> manufacturer.ifBlank { unknownLabel }
         manufacturer.isBlank() -> model
         model.startsWith(manufacturer, ignoreCase = true) -> model
         else -> "$manufacturer $model"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
+import androidx.compose.runtime.Composable
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.PlayArrow
@@ -445,12 +446,13 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     }
 }
 
+@Composable
 private fun formatStorageSize(bytes: Long): String {
     val gb = bytes / (1024.0 * 1024.0 * 1024.0)
-    if (gb >= 10.0) return String.format("%.0f GB", gb)
-    if (gb >= 1.0) return String.format("%.1f GB", gb)
+    if (gb >= 10.0) return stringResource(R.string.unit_size_gb, String.format("%.0f", gb))
+    if (gb >= 1.0) return stringResource(R.string.unit_size_gb, String.format("%.1f", gb))
     val mb = bytes / (1024.0 * 1024.0)
-    return String.format("%.0f MB", mb)
+    return stringResource(R.string.unit_size_mb, String.format("%.0f", mb))
 }
 
 private fun resolveManualVodCacheMaxMb(freeDiskBytes: Long): Int {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -419,7 +419,7 @@ fun PlaybackSettingsContent(
                     .padding(horizontal = 14.dp, vertical = 10.dp)
             ) {
                 Text(
-                    text = "Estimated memory usage: $totalUsageMb / ${MemoryBudget.budgetMb} MB",
+                    text = stringResource(R.string.playback_estimated_memory_usage, totalUsageMb, MemoryBudget.budgetMb),
                     style = MaterialTheme.typography.bodySmall,
                     color = usageColor
                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -1111,7 +1111,8 @@ private fun StreamCard(
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
-    val streamName = remember(stream) { stream.getDisplayName() }
+    val unknownStreamLabel = stringResource(R.string.stream_unknown)
+    val streamName = remember(stream, unknownStreamLabel) { stream.getDisplayNameOrNull() ?: unknownStreamLabel }
     val streamDescription = remember(stream) { stream.getDisplayDescription() }
     val hasBadges = stream.badges.isNotEmpty() || (showFileSizeBadges && stream.behaviorHints?.videoSize != null) || reserveBadgeSpace
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2654,6 +2654,9 @@
     <string name="settings_stream_badge_urls_title">URL de badges Fusion</string>
     <string name="settings_stream_size_badges_description">Affiche les badges de taille de fichier dans les résultats de flux et les panneaux de source du lecteur.</string>
     <string name="settings_stream_size_badges_title">Badges de taille</string>
+    <string name="settings_stream_addon_logo_title">Logo de l’addon</string>
+    <string name="settings_stream_addon_logo_description">Affiche le logo et le nom de l’addon à côté des sources de streams.</string>
+    <string name="settings_stream_display_section">Affichage</string>
     <string name="settings_stream_badge_position_title">Position des badges</string>
     <string name="settings_stream_badge_position_description">Choisis si les badges Fusion et de taille apparaissent au-dessus ou en dessous des cartes de flux.</string>
     <string name="settings_stream_badge_position_dialog_title">Position des badges</string>
@@ -2741,4 +2744,61 @@
     <string name="playback_net_connection_count_sub">Nombre de connexions TCP parallèles. Des valeurs plus élevées augmentent l’utilisation de la mémoire et le débit, mais avec un rendement décroissant.</string>
     <string name="playback_net_chunk_size">Taille des blocs</string>
     <string name="playback_net_chunk_size_sub">Taille de chaque bloc de téléchargement par connexion. Des blocs plus grands réduisent la surcharge mais utilisent plus de mémoire.</string>
+
+    <!-- Playback diagnostics card -->
+    <string name="diag_last_playback_title">Derniers diagnostics de lecture</string>
+    <string name="diag_no_data">Aucune donnée de lecture pour l’instant. Lance un stream et reviens ici pour voir les détails de la décision DV de cette lecture.</string>
+    <string name="diag_section_source_hardware">Source et matériel</string>
+    <string name="diag_section_source_hardware_sub">Prends une photo de cette carte si tu signales un problème.</string>
+    <string name="diag_label_host">Hôte</string>
+    <string name="diag_label_when">Quand</string>
+    <string name="diag_label_device">Appareil</string>
+    <string name="diag_label_display">Écran</string>
+    <string name="diag_label_dv7_decoder">Décodeur DV7</string>
+    <string name="diag_label_dv_decoder">Décodeur DV</string>
+    <string name="diag_label_dv_bridge">Bridge DV</string>
+    <string name="diag_label_bridge_version">Version du bridge</string>
+    <string name="diag_label_bridge_reason">Raison du bridge</string>
+    <string name="diag_section_decision_settings">Décision et paramètres</string>
+    <string name="diag_label_dv_mode_requested">Mode DV (demandé)</string>
+    <string name="diag_label_dv_mode_effective">Mode DV (effectif)</string>
+    <string name="diag_label_auto_decision">Décision AUTO</string>
+    <string name="diag_label_source_profile">Profil de la source</string>
+    <string name="diag_label_conversions">Conversions</string>
+    <string name="diag_label_signal_rewrites">Réécritures du signal</string>
+    <string name="diag_label_custom_buffers">Tampons personnalisés</string>
+    <string name="diag_label_custom_network_cache">Réseau/cache personnalisés</string>
+    <string name="diag_section_outcome">Bilan</string>
+    <string name="diag_label_hdr_format_intended">Format HDR (prévu)</string>
+    <string name="diag_label_first_frame">Première image</string>
+    <string name="diag_label_rebuffers">Remises en tampon</string>
+    <string name="diag_label_result">Résultat</string>
+    <string name="diag_value_available">Disponible</string>
+    <string name="diag_value_not_available">Indisponible</string>
+    <string name="diag_value_none">Aucun</string>
+    <string name="diag_value_ready">Prêt</string>
+    <string name="diag_value_not_ready">Pas prêt</string>
+    <string name="diag_value_decoder_hidden">%1$s (masqué)</string>
+    <string name="diag_value_on">Activé</string>
+    <string name="diag_value_off">Désactivé</string>
+    <string name="diag_value_conversions_fmt">%1$d sur %2$d réussies</string>
+    <string name="diag_value_never_rendered">Jamais affichée</string>
+
+    <!-- Player errors -->
+    <string name="player_error_play_stream_failed">Impossible de lire le stream sélectionné</string>
+
+    <!-- Size and speed units -->
+    <string name="unit_size_b">%1$d o</string>
+    <string name="unit_size_kb">%1$s ko</string>
+    <string name="unit_size_mb">%1$s Mo</string>
+    <string name="unit_size_gb">%1$s Go</string>
+    <string name="unit_speed_b_s">%1$d o/s</string>
+    <string name="unit_speed_kb_s">%1$s ko/s</string>
+    <string name="unit_speed_mb_s">%1$s Mo/s</string>
+
+    <!-- Misc fallbacks -->
+    <string name="playback_estimated_memory_usage">Utilisation mémoire estimée&#8239;: %1$d / %2$d Mo</string>
+    <string name="profile_default_name">Profil %1$d</string>
+    <string name="detail_tmdb_fallback_title">TMDB %1$d</string>
+    <string name="collections_editor_tmdb_collection_fallback">Collection TMDB %1$d</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2660,4 +2660,61 @@
     <string name="playback_net_connection_count_sub">Number of parallel TCP connections. Higher values increase memory usage and throughput but with diminishing returns.</string>
     <string name="playback_net_chunk_size">Chunk Size</string>
     <string name="playback_net_chunk_size_sub">Size of each download chunk per connection. Larger chunks reduce overhead but use more memory.</string>
+
+    <!-- Playback diagnostics card -->
+    <string name="diag_last_playback_title">Last Playback Diagnostics</string>
+    <string name="diag_no_data">No playback data yet. Play a stream and return here to see DV decision details for that playback.</string>
+    <string name="diag_section_source_hardware">Source &amp; Hardware</string>
+    <string name="diag_section_source_hardware_sub">Take a photo of this card if reporting an issue.</string>
+    <string name="diag_label_host">Host</string>
+    <string name="diag_label_when">When</string>
+    <string name="diag_label_device">Device</string>
+    <string name="diag_label_display">Display</string>
+    <string name="diag_label_dv7_decoder">DV7 Decoder</string>
+    <string name="diag_label_dv_decoder">DV Decoder</string>
+    <string name="diag_label_dv_bridge">DV Bridge</string>
+    <string name="diag_label_bridge_version">Bridge Version</string>
+    <string name="diag_label_bridge_reason">Bridge Reason</string>
+    <string name="diag_section_decision_settings">Decision &amp; Settings</string>
+    <string name="diag_label_dv_mode_requested">DV Mode (requested)</string>
+    <string name="diag_label_dv_mode_effective">DV Mode (effective)</string>
+    <string name="diag_label_auto_decision">AUTO Decision</string>
+    <string name="diag_label_source_profile">Source Profile</string>
+    <string name="diag_label_conversions">Conversions</string>
+    <string name="diag_label_signal_rewrites">Signal Rewrites</string>
+    <string name="diag_label_custom_buffers">Custom Buffers</string>
+    <string name="diag_label_custom_network_cache">Custom Network/Cache</string>
+    <string name="diag_section_outcome">Outcome</string>
+    <string name="diag_label_hdr_format_intended">HDR Format (intended)</string>
+    <string name="diag_label_first_frame">First Frame</string>
+    <string name="diag_label_rebuffers">Rebuffers</string>
+    <string name="diag_label_result">Result</string>
+    <string name="diag_value_available">Available</string>
+    <string name="diag_value_not_available">Not available</string>
+    <string name="diag_value_none">None</string>
+    <string name="diag_value_ready">Ready</string>
+    <string name="diag_value_not_ready">Not ready</string>
+    <string name="diag_value_decoder_hidden">%1$s (hidden)</string>
+    <string name="diag_value_on">On</string>
+    <string name="diag_value_off">Off</string>
+    <string name="diag_value_conversions_fmt">%1$d of %2$d successful</string>
+    <string name="diag_value_never_rendered">Never rendered</string>
+
+    <!-- Player errors -->
+    <string name="player_error_play_stream_failed">Failed to play selected stream</string>
+
+    <!-- Size and speed units -->
+    <string name="unit_size_b">%1$d B</string>
+    <string name="unit_size_kb">%1$s KB</string>
+    <string name="unit_size_mb">%1$s MB</string>
+    <string name="unit_size_gb">%1$s GB</string>
+    <string name="unit_speed_b_s">%1$d B/s</string>
+    <string name="unit_speed_kb_s">%1$s KB/s</string>
+    <string name="unit_speed_mb_s">%1$s MB/s</string>
+
+    <!-- Misc fallbacks -->
+    <string name="playback_estimated_memory_usage">Estimated memory usage: %1$d / %2$d MB</string>
+    <string name="profile_default_name">Profile %1$d</string>
+    <string name="detail_tmdb_fallback_title">TMDB %1$d</string>
+    <string name="collections_editor_tmdb_collection_fallback">TMDB Collection %1$d</string>
 </resources>


### PR DESCRIPTION
## Summary

Extracts the remaining hardcoded UI strings into string resources and adds the matching French translations (tutoiement, consistent with the existing FR file). Covers the DV diagnostics card (37 labels/values/formats), shared size/speed units (GB→Go, MB→Mo, KB→ko, B→o), player error fallbacks, default profile name, TMDB title fallbacks, and the torrent buffering message (now reusing the existing `player_torrent_peer_info` / `player_torrent_buffered_status` resources instead of an inline duplicate). Also translates the 3 new addon-logo/display-section keys. Follow-up to #2233 (batch10).

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

Recent upstream work introduced user-facing strings hardcoded in Kotlin, so they could not be localized. This pass externalizes them and completes the French file so FR users get a fully localized UI, following the same approach as the previously merged batches.

## Issue or approval

No linked issue: localization-only update, same scope as previously merged localization batches (#2233).

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only string resources (`values/strings.xml`, `values-fr/strings.xml`) and the minimal code changes required to reference them (`stringResource` / `getString`). Data values compared in code (`Played`, `STRIP_DV`, HDR format names) were intentionally left untouched to avoid behavior changes. No features, no UI layout changes, no unrelated refactors.

## Testing

`./gradlew compileFullDebugKotlin` passes. Both XML files validated with xmllint (UTF-8, no mojibake). Key parity EN↔FR: 2487/2487 (excluding 15 `translatable="false"`), 0 missing, 0 orphan, 0 duplicate keys. Placeholders preserved and verified against argument types at every call site. Re-scan of all touched files confirms no remaining hardcoded UI strings.

## Screenshots / Video

None - text-only localization change, no UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.
