### PR TITLE
Fix CW sync persistence, Trakt flash, and meta addon idPrefix matching

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -51,7 +51,8 @@ class StartupSyncService @Inject constructor(
     private val watchProgressPreferences: WatchProgressPreferences,
     private val libraryPreferences: LibraryPreferences,
     private val profileManager: ProfileManager,
-    private val startupSyncPreferences: StartupSyncPreferences
+    private val startupSyncPreferences: StartupSyncPreferences,
+    private val cwEnrichmentCache: com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var startupPullJob: Job? = null
@@ -516,6 +517,22 @@ class StartupSyncService @Inject constructor(
                 TAG,
                 "Watch progress sync applied ${syncResult.upsertedEntries} upserts and ${syncResult.deletedEntries} deletes (snapshot=${syncResult.usedSnapshot})"
             )
+            // Evict deleted entries from CW enrichment cache so stale items
+            // don't persist on screen via loadContinueWatching() cache restore.
+            if (syncResult.deletedEntries > 0) {
+                val currentContentIds = watchProgressPreferences.getAllRawEntries(profileId)
+                    .values.mapTo(mutableSetOf()) { it.contentId }
+                val cachedInProgress = cwEnrichmentCache.getInProgressSnapshot()
+                val cachedNextUp = cwEnrichmentCache.getNextUpSnapshot()
+                val filteredInProgress = cachedInProgress.filter { it.contentId in currentContentIds }
+                val filteredNextUp = cachedNextUp.filter { it.contentId in currentContentIds }
+                if (filteredInProgress.size != cachedInProgress.size) {
+                    cwEnrichmentCache.saveInProgressSnapshot(filteredInProgress, force = true)
+                }
+                if (filteredNextUp.size != cachedNextUp.size) {
+                    cwEnrichmentCache.saveNextUpSnapshot(filteredNextUp, force = true)
+                }
+            }
             if (pushUnsynced && syncResult.preservedLocalItems) {
                 Log.d(TAG, "Detected unsynced watch progress, pushing to remote")
                 watchProgressSyncService.pushToRemote(profileId)

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
@@ -388,10 +388,12 @@ class WatchProgressSyncService @Inject constructor(
                     if (event.operation.equals(WATCH_PROGRESS_EVENT_DELETE, ignoreCase = true)) {
                         pageChanges[event.progressKey] = null
                     } else if (event.operation.equals(WATCH_PROGRESS_EVENT_UPSERT, ignoreCase = true)) {
-                        normalizePulledEntries(listOf(event.progressKey to event.toWatchProgress()))
-                            .forEach { (key, progress) ->
-                                pageChanges[key] = progress
-                            }
+                        // Don't synthesize series-level mirror keys from individual delta events.
+                        // normalizePulledEntries creates a series key (contentId) from any episode
+                        // key (contentId_s1e5), which would resurrect series entries that were
+                        // explicitly deleted remotely. Only apply normalization on full snapshots.
+                        val progress = event.toWatchProgress()
+                        pageChanges[event.progressKey] = progress
                     }
                 }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -124,29 +124,47 @@ class MetaRepositoryImpl @Inject constructor(
         }
 
         // Priority order:
-        // 1) addons that explicitly support requested type
-        // 2) addons that support inferred canonical type (for custom catalog types)
-        // 3) top addon in installed order that exposes meta resource
+        // 1) addons that explicitly support requested type AND support the ID prefix
+        // 2) addons that support inferred canonical type AND support the ID prefix
+        // 3) addons that support the type but have no idPrefixes (accept all IDs)
+        // 4) top addon in installed order that exposes meta resource
         val prioritizedCandidates = linkedSetOf<Pair<Addon, String>>()
+        // First pass: addons that explicitly match type AND id prefix
         addons.forEach { addon ->
-            if (addon.supportsMetaType(requestedType)) {
+            if (addon.supportsMetaType(requestedType) && addon.supportsMetaId(id)) {
                 prioritizedCandidates.add(addon to requestedType)
             }
         }
         if (!inferredType.equals(requestedType, ignoreCase = true)) {
             addons.forEach { addon ->
-                if (addon.supportsMetaType(inferredType)) {
+                if (addon.supportsMetaType(inferredType) && addon.supportsMetaId(id)) {
                     prioritizedCandidates.add(addon to inferredType)
                 }
             }
         }
-        metaResourceAddons.firstOrNull()?.let { topMetaAddon ->
+        metaResourceAddons.firstOrNull { it.supportsMetaId(id) }?.let { topMetaAddon ->
             val fallbackType = when {
                 topMetaAddon.supportsMetaType(requestedType) -> requestedType
                 topMetaAddon.supportsMetaType(inferredType) -> inferredType
                 else -> inferredType.ifBlank { requestedType }
             }
             prioritizedCandidates.add(topMetaAddon to fallbackType)
+        }
+        // Fallback: if no ID-matching addons found, include addons without idPrefixes
+        if (prioritizedCandidates.isEmpty()) {
+            addons.forEach { addon ->
+                if (addon.supportsMetaType(requestedType) && addon.idPrefixes.isEmpty()) {
+                    prioritizedCandidates.add(addon to requestedType)
+                }
+            }
+            metaResourceAddons.firstOrNull { it.idPrefixes.isEmpty() }?.let { topMetaAddon ->
+                val fallbackType = when {
+                    topMetaAddon.supportsMetaType(requestedType) -> requestedType
+                    topMetaAddon.supportsMetaType(inferredType) -> inferredType
+                    else -> inferredType.ifBlank { requestedType }
+                }
+                prioritizedCandidates.add(topMetaAddon to fallbackType)
+            }
         }
 
         if (prioritizedCandidates.isEmpty()) {
@@ -323,6 +341,27 @@ class MetaRepositoryImpl @Inject constructor(
         return resources.any { resource ->
             resource.name == "meta" && resource.supportsType(target)
         }
+    }
+
+    /**
+     * Check if an addon can handle a specific ID based on idPrefixes.
+     * Returns true if:
+     * - The addon has no idPrefixes (accepts all IDs)
+     * - The resource-level idPrefixes match the ID
+     * - The addon-level idPrefixes match the ID
+     */
+    private fun Addon.supportsMetaId(id: String): Boolean {
+        // Check resource-level idPrefixes first
+        val metaResource = resources.firstOrNull { it.name == "meta" }
+        if (metaResource?.idPrefixes != null && metaResource.idPrefixes.isNotEmpty()) {
+            return metaResource.idPrefixes.any { prefix -> id.startsWith(prefix, ignoreCase = true) }
+        }
+        // Fall back to addon-level idPrefixes
+        if (idPrefixes.isNotEmpty()) {
+            return idPrefixes.any { prefix -> id.startsWith(prefix, ignoreCase = true) }
+        }
+        // No idPrefixes declared — addon accepts all IDs
+        return true
     }
 
     private fun AddonResource.supportsType(type: String): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2430,8 +2430,19 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
         }
         val persistable = localItems.filter { it.hasRenderableMetadata() }
         if (persistable.isEmpty()) return@launch
+        // Only persist metadata for entries still visible in CW. Between the start
+        // of this pipeline cycle and now the user may have removed items — writing
+        // them back would resurrect them on next launch.
+        val visibleContentIds = _uiState.value.continueWatchingItems.mapNotNullTo(mutableSetOf()) { item ->
+            when (item) {
+                is ContinueWatchingItem.InProgress -> item.progress.contentId
+                is ContinueWatchingItem.NextUp -> item.info.contentId
+            }
+        }
+        val stillVisible = persistable.filter { it.contentId in visibleContentIds }
+        if (stillVisible.isEmpty()) return@launch
         runCatching {
-            watchProgressRepository.saveProgressBatch(persistable, syncRemote = false)
+            watchProgressRepository.saveProgressBatch(stillVisible, syncRemote = false)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1047,7 +1047,12 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
 
                 _uiState.update { state ->
                     // Don't overwrite cached CW with empty data while sources are still loading.
-                    if (normalItems.isEmpty() && state.continueWatchingItems.isNotEmpty()) {
+                    // Once remote progress is confirmed loaded (Nuvio Sync completed or Trakt
+                    // responded), trust the empty result — items may have been deleted remotely.
+                    val shouldProtectCache = normalItems.isEmpty() &&
+                        state.continueWatchingItems.isNotEmpty() &&
+                        !snapshot.hasLoadedRemoteProgress
+                    if (shouldProtectCache) {
                         state
                     } else if (state.continueWatchingItems == normalItems) {
                         state

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -542,6 +542,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             state
                         } else if (state.continueWatchingItems == initialItems) {
                             state
+                        } else if (!snapshot.hasLoadedRemoteProgress && state.continueWatchingItems.isNotEmpty() && initialItems.size < state.continueWatchingItems.size) {
+                            state
                         } else {
                             state.copy(continueWatchingItems = initialItems)
                         }
@@ -1052,7 +1054,10 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     val shouldProtectCache = normalItems.isEmpty() &&
                         state.continueWatchingItems.isNotEmpty() &&
                         !snapshot.hasLoadedRemoteProgress
-                    if (shouldProtectCache) {
+                    val shouldPreventShrink = !snapshot.hasLoadedRemoteProgress &&
+                        state.continueWatchingItems.isNotEmpty() &&
+                        normalItems.size < state.continueWatchingItems.size
+                    if (shouldProtectCache || shouldPreventShrink) {
                         state
                     } else if (state.continueWatchingItems == normalItems) {
                         state


### PR DESCRIPTION
## Summary

Three bug fixes:

1. **Fix CW persistence after deletion** - series entries in Continue Watching reappeared after deletion (from app, web, or cross-device). Root causes: delta sync synthesizing phantom mirror keys, stale CW disk cache surviving restart, and pipeline guard preventing UI update after sync confirmed deletions.
2. **Respect idPrefix when selecting a meta addon** - meta addon selection now correctly matches based on content ID prefix (e.g. `tt` for IMDB, `b3tv:` for Live TV).
3. **Fix CW items flashing/disappearing during Trakt load** - pipeline no longer shrinks the CW list while waiting for Trakt to respond, preventing items from briefly disappearing and reappearing on app start.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. CW persistence: Users reported series reappearing in CW after deletion - requiring 3+ attempts or persisting across restarts/devices. Movies deleted correctly but series did not.
2. idPrefix: Wrong meta addon was selected for content with non-IMDB IDs, causing missing or incorrect metadata.
3. Trakt flash: On app start, CW items would briefly disappear while Trakt API responded, then reappear - causing visual instability.

## Issue or approval

Fixes user-reported CW sync persistence bug, meta addon selection bug, and Trakt CW flash.

## Reproduction steps

**CW persistence:**
1. Watch a series episode and a movie briefly
2. Delete both from CW (from app or web)
3. Force close and reopen -> series reappeared (before fix)

**idPrefix:**
1. Have a meta addon with `idPrefixes: ["b3tv:"]`
2. Open content with this id -> wrong meta addon was used

**Trakt flash:**
1. Have Trakt connected with items in CW
2. Force close and reopen -> one or more items briefly disappear and reappear

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- CW fix does not change snapshot pull normalization (only delta path)
- CW fix does not add periodic background sync
- Does not fix pre-existing metadata flash on Trakt startup (cached title language briefly changing - separate issue)

## Testing

- Android TV device, debug build
- CW (Nuvio Sync): watch series + movie -> delete from app -> restart -> both gone
- CW (cross-device): delete from web -> restart app -> both gone
- CW (Trakt): no regression - items don't flash/disappear while Trakt loads
- CW (Trakt): items remain stable during Trakt API response delay
- Meta addon: verified correct addon selected for kitsu: and tt prefixed content

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

CW sync persistence bug - series reappearing after deletion across restarts and devices.
