### PR TITLE
fix(player): wrap bandwidth meter to clamp minimum estimate for HLS s…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -44,6 +44,7 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.trackselection.ExoTrackSelection
 import androidx.media3.exoplayer.trackselection.MappingTrackSelector.MappedTrackInfo
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
+import androidx.media3.exoplayer.upstream.BandwidthMeter
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
@@ -724,9 +725,16 @@ internal fun PlayerRuntimeController.initializePlayer(
                     extractorsFactory
                 }
 
-            val bandwidthMeter = DefaultBandwidthMeter.Builder(context)
+            val streamMime = currentStreamMimeType
+            val isHls = streamMime != null && (
+                streamMime.equals(MimeTypes.APPLICATION_M3U8, ignoreCase = true) ||
+                streamMime.lowercase().contains("mpegurl") ||
+                streamMime.lowercase().contains("m3u8")
+            )
+            val rawBandwidthMeter = DefaultBandwidthMeter.Builder(context)
                 .setInitialBitrateEstimate(ADAPTIVE_INITIAL_BITRATE_ESTIMATE_BPS)
                 .build()
+            val bandwidthMeter = SafeBandwidthMeter(rawBandwidthMeter, isHls)
 
             if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             // ── Build ExoPlayer ──
@@ -1953,4 +1961,29 @@ private fun buildStableAudioCapabilities(context: Context): AudioCapabilities {
         supportedEncodings += C.ENCODING_DTS
     }
     return AudioCapabilities(supportedEncodings.toIntArray(), detected.maxChannelCount)
+}
+
+private class SafeBandwidthMeter(
+    private val delegate: BandwidthMeter,
+    private val isHls: Boolean
+) : BandwidthMeter {
+    override fun getBitrateEstimate(): Long {
+        val raw = delegate.bitrateEstimate
+        return if (isHls) maxOf(raw, 25_000_000L) else raw
+    }
+
+    override fun getTimeToFirstByteEstimateUs(): Long = delegate.timeToFirstByteEstimateUs
+
+    override fun getTransferListener(): androidx.media3.datasource.TransferListener? = delegate.transferListener
+
+    override fun addEventListener(
+        eventHandler: android.os.Handler,
+        eventListener: BandwidthMeter.EventListener
+    ) {
+        delegate.addEventListener(eventHandler, eventListener)
+    }
+
+    override fun removeEventListener(eventListener: BandwidthMeter.EventListener) {
+        delegate.removeEventListener(eventListener)
+    }
 }


### PR DESCRIPTION
## Summary

This PR wraps ExoPlayer's DefaultBandwidthMeter in a custom SafeBandwidthMeter for HLS playbacks, clamping the minimum estimated bandwidth to 25 Mbps. This prevents artificial quality drops (locking the player in 480p/720p) caused by small HLS chunk request overhead (Time to First Byte / server latency).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When HLS streams drop to lower resolutions, the small chunk sizes make connection establishment overhead a significant fraction of total download time. This causes ExoPlayer's default bandwidth estimator to estimate extremely low bandwidths (e.g., 3 Mbps), locking the stream at low quality and preventing it from scaling back up to 1080p, even on high-speed internet connections (e.g. 300 Mbps).

## Issue or approval

Fixes #2274 and references regression in #2237.

## Reproduction steps

1. Start playing an HLS stream on a device with high speed internet.
2. Force or wait for a transient drop to 480p/720p.
3. Observe that the stream never recovers to 1080p even after connection speed returns to normal.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change is strictly scoped to wrapping DefaultBandwidthMeter in SafeBandwidthMeter in PlayerRuntimeControllerInitialization.kt. No player control or UI flow is modified.

## Testing

Verified compiling the project and running playback tests on the device.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Ref: #2274
Ref: #2237
