### PR TITLE
fix(player): handle torrent:// stream URLs without crashing

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
@@ -14,6 +14,7 @@ import com.nuvio.tv.domain.model.StreamClientResolve
 import com.nuvio.tv.domain.model.StreamClientResolveParsed
 import com.nuvio.tv.domain.model.StreamClientResolveRaw
 import com.nuvio.tv.domain.model.StreamClientResolveStream
+import com.nuvio.tv.domain.model.extractInfoHashFromTorrentLink
 
 fun StreamDto.toDomain(addonName: String, addonLogo: String?): Stream = Stream(
     name = name,
@@ -21,7 +22,13 @@ fun StreamDto.toDomain(addonName: String, addonLogo: String?): Stream = Stream(
     description = description,
     url = url,
     ytId = ytId,
-    infoHash = infoHash,
+    // Some addons embed the info hash inside a `magnet:` or `torrent://` URL
+    // instead of the dedicated `infoHash` field. Resolve it here so torrent
+    // detection and TorrServer handoff work and the raw URL never reaches
+    // ExoPlayer (which crashes with "unknown protocol: torrent").
+    infoHash = infoHash?.takeIf { it.isNotBlank() }
+        ?: extractInfoHashFromTorrentLink(url)
+        ?: extractInfoHashFromTorrentLink(externalUrl),
     fileIdx = fileIdx,
     externalUrl = externalUrl,
     behaviorHints = behaviorHints?.toDomain(),

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -31,11 +31,11 @@ data class Stream(
      */
     fun getStreamUrl(): String? =
         listOfNotNull(url, externalUrl)
-            .firstOrNull { !it.isMagnetLink() }
+            .firstOrNull { !it.isTorrentSourceLink() }
 
     fun torrentMagnetUri(): String? =
         listOfNotNull(url, externalUrl)
-            .firstOrNull { it.isMagnetLink() }
+            .firstOrNull { it.isTorrentSourceLink() }
 
     /**
      * Returns true if this is a torrent-only stream (no HTTP URL available).
@@ -65,7 +65,7 @@ data class Stream(
     /**
      * Returns true if this is an external URL (opens in browser)
      */
-    fun isExternal(): Boolean = externalUrl != null && url == null && !externalUrl.isMagnetLink()
+    fun isExternal(): Boolean = externalUrl != null && url == null && !externalUrl.isTorrentSourceLink()
 
     /**
      * Returns a display name for the stream, or null when no field is usable.
@@ -225,3 +225,26 @@ data class AddonStreams(
 
 private fun String?.isMagnetLink(): Boolean =
     this?.trimStart()?.startsWith("magnet:", ignoreCase = true) == true
+
+private fun String?.isTorrentSchemeLink(): Boolean =
+    this?.trimStart()?.startsWith("torrent://", ignoreCase = true) == true
+
+/**
+ * True for any URL that identifies a torrent source rather than a playable HTTP
+ * stream, i.e. `magnet:` and `torrent://` links. Such URLs must never be handed
+ * to ExoPlayer; they go through TorrServer instead.
+ */
+internal fun String?.isTorrentSourceLink(): Boolean =
+    isMagnetLink() || isTorrentSchemeLink()
+
+private val BTIH_HASH_REGEX = Regex("[0-9a-fA-F]{40}|[2-7A-Za-z]{32}")
+
+/**
+ * Extracts a BitTorrent info hash from a `magnet:` or `torrent://` URL. Returns
+ * the hex (40 char) or base32 (32 char) hash when present, otherwise null.
+ */
+internal fun extractInfoHashFromTorrentLink(rawUrl: String?): String? {
+    val trimmed = rawUrl?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    if (!trimmed.isTorrentSourceLink()) return null
+    return BTIH_HASH_REGEX.find(trimmed)?.value
+}

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -243,7 +243,13 @@ internal fun String?.isTorrentSourceLink(): Boolean =
     isMagnetLink() || isTorrentSchemeLink()
 
 private val BTIH_HASH_REGEX = Regex("[0-9a-fA-F]{40}|[2-7A-Za-z]{32}")
-private val MAGNET_BTIH_PARAM_REGEX = Regex("xt=urn:btih:([^&#]+)", RegexOption.IGNORE_CASE)
+
+// Anchored at a parameter boundary, allows BEP 9 multi-source params (xt.1=)
+// and percent-encoded colons (urn%3Abtih%3A).
+private val MAGNET_BTIH_PARAM_REGEX = Regex(
+    """[?&]xt(?:\.\d+)?=urn(?::|%3a)btih(?::|%3a)([^&#]+)""",
+    RegexOption.IGNORE_CASE
+)
 private const val TORRENT_SCHEME_PREFIX = "torrent://"
 
 /**

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -33,9 +33,14 @@ data class Stream(
         listOfNotNull(url, externalUrl)
             .firstOrNull { !it.isTorrentSourceLink() }
 
+    /**
+     * Returns a `magnet:` URI when one is present. Intentionally magnet-only:
+     * debrid callers pass the value straight to provider APIs that reject
+     * other schemes; `torrent://` streams resolve through [infoHash] instead.
+     */
     fun torrentMagnetUri(): String? =
         listOfNotNull(url, externalUrl)
-            .firstOrNull { it.isTorrentSourceLink() }
+            .firstOrNull { it.isMagnetLink() }
 
     /**
      * Returns true if this is a torrent-only stream (no HTTP URL available).
@@ -238,13 +243,26 @@ internal fun String?.isTorrentSourceLink(): Boolean =
     isMagnetLink() || isTorrentSchemeLink()
 
 private val BTIH_HASH_REGEX = Regex("[0-9a-fA-F]{40}|[2-7A-Za-z]{32}")
+private val MAGNET_BTIH_PARAM_REGEX = Regex("xt=urn:btih:([^&#]+)", RegexOption.IGNORE_CASE)
+private const val TORRENT_SCHEME_PREFIX = "torrent://"
 
 /**
- * Extracts a BitTorrent info hash from a `magnet:` or `torrent://` URL. Returns
- * the hex (40 char) or base32 (32 char) hash when present, otherwise null.
+ * Extracts a BitTorrent info hash from a `magnet:` or `torrent://` URL.
+ * Parses each format explicitly — the `xt=urn:btih:` parameter for magnets and
+ * the authority segment for `torrent://` — and validates the candidate is a
+ * full hex (40 char) or base32 (32 char) hash, so hash-like sequences in other
+ * query parameters or path segments are never misattributed. Returns null when
+ * the URL is not a torrent source link or carries no valid hash.
  */
 internal fun extractInfoHashFromTorrentLink(rawUrl: String?): String? {
     val trimmed = rawUrl?.trim()?.takeIf { it.isNotBlank() } ?: return null
-    if (!trimmed.isTorrentSourceLink()) return null
-    return BTIH_HASH_REGEX.find(trimmed)?.value
+    val candidate = when {
+        trimmed.isMagnetLink() ->
+            MAGNET_BTIH_PARAM_REGEX.find(trimmed)?.groupValues?.get(1)
+        trimmed.isTorrentSchemeLink() ->
+            trimmed.substring(TORRENT_SCHEME_PREFIX.length)
+                .takeWhile { it != '/' && it != '?' && it != '#' }
+        else -> null
+    }?.takeIf { it.isNotBlank() } ?: return null
+    return candidate.takeIf { BTIH_HASH_REGEX.matches(it) }
 }

--- a/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperTorrentTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperTorrentTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 class StreamMapperTorrentTest {
 
     private val hex40 = "0123456789abcdef0123456789abcdef01234567"
+    private val base32 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
     @Test
     fun `torrent scheme url resolves info hash and is treated as torrent`() {
@@ -21,18 +22,20 @@ class StreamMapperTorrentTest {
         // A torrent:// URL must never be surfaced as a playable HTTP stream.
         assertNull(stream.getStreamUrl())
         assertTrue(stream.isTorrent())
+        // And it is not a magnet, so debrid magnet consumers must not receive it.
+        assertNull(stream.torrentMagnetUri())
     }
 
     @Test
     fun `magnet url without infoHash field resolves info hash`() {
-        val stream = StreamDto(
-            url = "magnet:?xt=urn:btih:$hex40&dn=Example",
-            infoHash = null
-        ).toDomain(addonName = "Test", addonLogo = null)
+        val magnet = "magnet:?xt=urn:btih:$hex40&dn=Example"
+        val stream = StreamDto(url = magnet, infoHash = null)
+            .toDomain(addonName = "Test", addonLogo = null)
 
         assertEquals(hex40, stream.infoHash)
         assertNull(stream.getStreamUrl())
         assertTrue(stream.isTorrent())
+        assertEquals(magnet, stream.torrentMagnetUri())
     }
 
     @Test
@@ -55,13 +58,41 @@ class StreamMapperTorrentTest {
     }
 
     @Test
-    fun `extractInfoHashFromTorrentLink handles hex base32 and rejects non-torrent`() {
-        val base32 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" // 32 base32 chars
+    fun `torrent url without extractable hash is unplayable rather than a torrent sentinel`() {
+        val stream = StreamDto(url = "torrent://null", infoHash = null)
+            .toDomain(addonName = "Test", addonLogo = null)
+
+        assertNull(stream.infoHash)
+        assertNull(stream.getStreamUrl())
+        // Not classified as a torrent: there is no hash to hand to TorrServer,
+        // so the player must not be launched with a torrent://null URL.
+        assertFalse(stream.isTorrent())
+    }
+
+    @Test
+    fun `extraction parses hash from expected position only`() {
         assertEquals(hex40, extractInfoHashFromTorrentLink("torrent://$hex40"))
+        assertEquals(hex40, extractInfoHashFromTorrentLink("torrent://$hex40/0?probe=1"))
         assertEquals(hex40, extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:$hex40"))
-        assertEquals(base32, extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:$base32"))
-        assertNull(extractInfoHashFromTorrentLink("https://example.com/x.mkv"))
-        assertNull(extractInfoHashFromTorrentLink(null))
+        assertEquals(hex40, extractInfoHashFromTorrentLink("magnet:?xt=URN:BTIH:$hex40"))
+        assertEquals(base32, extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:$base32&dn=x"))
+        // dn parameter before xt must not be mistaken for the hash.
+        assertEquals(
+            hex40,
+            extractInfoHashFromTorrentLink(
+                "magnet:?dn=SomeStraightAlphaNumericRunName32&xt=urn:btih:$hex40"
+            )
+        )
+    }
+
+    @Test
+    fun `extraction rejects non-torrent urls and invalid hashes`() {
+        assertNull(extractInfoHashFromTorrentLink("https://example.com/$hex40.mkv"))
+        assertNull(extractInfoHashFromTorrentLink("magnet:?dn=NoHashHere"))
         assertNull(extractInfoHashFromTorrentLink("torrent://null"))
+        assertNull(extractInfoHashFromTorrentLink("torrent://nothexor32chars"))
+        assertNull(extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:tooshort"))
+        assertNull(extractInfoHashFromTorrentLink(null))
+        assertNull(extractInfoHashFromTorrentLink("   "))
     }
 }

--- a/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperTorrentTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperTorrentTest.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.data.mapper
+
+import com.nuvio.tv.data.remote.dto.StreamDto
+import com.nuvio.tv.domain.model.extractInfoHashFromTorrentLink
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamMapperTorrentTest {
+
+    private val hex40 = "0123456789abcdef0123456789abcdef01234567"
+
+    @Test
+    fun `torrent scheme url resolves info hash and is treated as torrent`() {
+        val stream = StreamDto(url = "torrent://$hex40", infoHash = null)
+            .toDomain(addonName = "Test", addonLogo = null)
+
+        assertEquals(hex40, stream.infoHash)
+        // A torrent:// URL must never be surfaced as a playable HTTP stream.
+        assertNull(stream.getStreamUrl())
+        assertTrue(stream.isTorrent())
+    }
+
+    @Test
+    fun `magnet url without infoHash field resolves info hash`() {
+        val stream = StreamDto(
+            url = "magnet:?xt=urn:btih:$hex40&dn=Example",
+            infoHash = null
+        ).toDomain(addonName = "Test", addonLogo = null)
+
+        assertEquals(hex40, stream.infoHash)
+        assertNull(stream.getStreamUrl())
+        assertTrue(stream.isTorrent())
+    }
+
+    @Test
+    fun `dedicated infoHash field is preferred over url extraction`() {
+        val stream = StreamDto(url = "torrent://$hex40", infoHash = "DEDICATED")
+            .toDomain(addonName = "Test", addonLogo = null)
+
+        assertEquals("DEDICATED", stream.infoHash)
+    }
+
+    @Test
+    fun `plain http url is unaffected and not a torrent`() {
+        val httpUrl = "https://cdn.example.com/video.mkv"
+        val stream = StreamDto(url = httpUrl, infoHash = null)
+            .toDomain(addonName = "Test", addonLogo = null)
+
+        assertNull(stream.infoHash)
+        assertEquals(httpUrl, stream.getStreamUrl())
+        assertFalse(stream.isTorrent())
+    }
+
+    @Test
+    fun `extractInfoHashFromTorrentLink handles hex base32 and rejects non-torrent`() {
+        val base32 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" // 32 base32 chars
+        assertEquals(hex40, extractInfoHashFromTorrentLink("torrent://$hex40"))
+        assertEquals(hex40, extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:$hex40"))
+        assertEquals(base32, extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:$base32"))
+        assertNull(extractInfoHashFromTorrentLink("https://example.com/x.mkv"))
+        assertNull(extractInfoHashFromTorrentLink(null))
+        assertNull(extractInfoHashFromTorrentLink("torrent://null"))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperTorrentTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperTorrentTest.kt
@@ -83,6 +83,9 @@ class StreamMapperTorrentTest {
                 "magnet:?dn=SomeStraightAlphaNumericRunName32&xt=urn:btih:$hex40"
             )
         )
+        // BEP 9 multi-source parameter and percent-encoded colons.
+        assertEquals(hex40, extractInfoHashFromTorrentLink("magnet:?xt.1=urn:btih:$hex40"))
+        assertEquals(hex40, extractInfoHashFromTorrentLink("magnet:?xt=urn%3Abtih%3A$hex40&dn=x"))
     }
 
     @Test
@@ -92,6 +95,8 @@ class StreamMapperTorrentTest {
         assertNull(extractInfoHashFromTorrentLink("torrent://null"))
         assertNull(extractInfoHashFromTorrentLink("torrent://nothexor32chars"))
         assertNull(extractInfoHashFromTorrentLink("magnet:?xt=urn:btih:tooshort"))
+        // A parameter merely ending in "xt" is not the xt parameter.
+        assertNull(extractInfoHashFromTorrentLink("magnet:?next=urn:btih:$hex40"))
         assertNull(extractInfoHashFromTorrentLink(null))
         assertNull(extractInfoHashFromTorrentLink("   "))
     }


### PR DESCRIPTION
## Summary

Fixes #2173. Addons that return torrent streams via a `torrent://` or `magnet:` URL in the stream's `url` field (rather than the dedicated `infoHash` field) crashed the internal player with `unknown protocol: torrent`.

## PR type

- [x] Critical bug fix

## Why

`getStreamUrl()` only excluded `magnet:` links, so a `torrent://` URL was treated as a playable HTTP source and handed straight to ExoPlayer. The info hash was also never extracted from the URL, so torrent detection failed and the app built a `torrent://null` sentinel. Both crash an entire class of addons (Torrentio, Comet, MediaFusion, All-in-One, etc.).

## Issue or approval

Fixes #2173

## Reproduction steps

1. Install a Stremio addon that returns torrent streams via `torrent://` or `magnet:` URLs in the `url` field (e.g. All-in-One Torrentio).
2. Browse to any movie or series that has torrent streams.
3. Select a torrent stream from the stream list.
4. The player fails to start; logcat shows `streamUrl=torrent://null` and `unknown protocol: torrent`.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Domain model (`Stream`) and `StreamMapper` only. Recognizes `torrent://` alongside `magnet:` as a torrent source link so it is never surfaced as an HTTP URL, and resolves the BitTorrent info hash from the URL when the dedicated `infoHash` field is absent.
- No change to the TorrServer handoff or debrid resolution paths; this only ensures a valid hash reaches the existing torrent pipeline.

## Testing

`./gradlew :app:compileFullDebugKotlin` and `:app:compileFullDebugUnitTestKotlin` pass clean.

New `StreamMapperTorrentTest` covers:
- info hash extraction from `torrent://` and `magnet:` URLs (hex + base32)
- the dedicated `infoHash` field taking precedence over URL extraction
- torrent detection (`isTorrent()` true, `getStreamUrl()` null) for torrent-source URLs
- a plain-HTTP regression guard (unaffected, not a torrent)

Note: the `AndroidUnitTest` runner cannot execute on my Windows environment (known Gradle `Type T not present` issue), so the tests are compile-verified against the codebase rather than executed here.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2173