### PR TITLE
Fix: artwork fallback to external addon when TMDB enrichment skips artwork

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -921,7 +921,10 @@ class FolderDetailViewModel @Inject constructor(
         if (_enrichingItemId.value != null && _enrichingItemId.value != item.id) {
             _enrichingItemId.value = null
         }
-        if (item.id in enrichedItemIds) return
+        if (item.id in enrichedItemIds) {
+            return
+        }
+
 
         enrichFocusJob?.cancel()
         enrichFocusJob = viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
@@ -1044,22 +1047,37 @@ class FolderDetailViewModel @Inject constructor(
                 }
             }
 
-            // External meta addon fallback when TMDB didn't enrich.
-            if (enrichment == null && externalMetaEnabled) {
+            // External meta addon fallback:
+            // 1. When TMDB didn't enrich at all, OR
+            // 2. When TMDB enriched but useArtwork is off and the item still lacks a logo.
+            val artworkStillMissing = enrichment != null && !tmdbSettings.useArtwork &&
+                item.logo.isNullOrBlank()
+            val needsExternalAddon = enrichment == null || artworkStillMissing
+            if (needsExternalAddon && externalMetaEnabled) {
                 val metaResult = metaRepository.getMetaFromAllAddons(item.apiType, item.id)
                     .first { it is NetworkResult.Success || it is NetworkResult.Error }
                 if (metaResult is NetworkResult.Success) {
                     val meta = metaResult.data
-                    updateItemInTabs(item.id) { merged ->
-                        merged.copy(
-                            name = meta.name.takeIf { it.isNotBlank() } ?: merged.name,
-                            description = meta.description?.takeIf { it.isNotBlank() } ?: merged.description,
-                            background = meta.background?.takeIf { it.isNotBlank() } ?: merged.background,
-                            logo = meta.logo?.takeIf { it.isNotBlank() } ?: merged.logo,
-                            genres = meta.genres.takeIf { it.isNotEmpty() } ?: merged.genres,
-                            imdbRating = meta.imdbRating ?: merged.imdbRating,
-                            releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: merged.releaseInfo
-                        )
+                    if (artworkStillMissing) {
+                        // Only apply artwork — TMDB already provided the rest.
+                        updateItemInTabs(item.id) { merged ->
+                            merged.copy(
+                                background = meta.background?.takeIf { it.isNotBlank() } ?: merged.background,
+                                logo = meta.logo?.takeIf { it.isNotBlank() } ?: merged.logo
+                            )
+                        }
+                    } else {
+                        updateItemInTabs(item.id) { merged ->
+                            merged.copy(
+                                name = meta.name.takeIf { it.isNotBlank() } ?: merged.name,
+                                description = meta.description?.takeIf { it.isNotBlank() } ?: merged.description,
+                                background = meta.background?.takeIf { it.isNotBlank() } ?: merged.background,
+                                logo = meta.logo?.takeIf { it.isNotBlank() } ?: merged.logo,
+                                genres = meta.genres.takeIf { it.isNotEmpty() } ?: merged.genres,
+                                imdbRating = meta.imdbRating ?: merged.imdbRating,
+                                releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: merged.releaseInfo
+                            )
+                        }
                     }
                 } else {
                     // External meta also failed — mark as failed enrichment.
@@ -1214,8 +1232,11 @@ class FolderDetailViewModel @Inject constructor(
                         }.getOrNull()
                         if (enrichment != null) {
                             prefetchedTmdbIds.add(item.id)
-                            prefetchedExternalMetaIds.add(item.id)
-                            enrichedItemIds.add(item.id)
+                            // Only mark fully done if artwork was applied or not needed.
+                            if (tmdbSettings.useArtwork || !item.logo.isNullOrBlank()) {
+                                prefetchedExternalMetaIds.add(item.id)
+                                enrichedItemIds.add(item.id)
+                            }
                             updateItemInTabs(item.id) { merged ->
                                 var result = merged
                                 if (tmdbSettings.useBasicInfo) {
@@ -1246,14 +1267,19 @@ class FolderDetailViewModel @Inject constructor(
                                 }
                                 result
                             }
-                            val enrichedItem = _uiState.value.tabs
-                                .firstNotNullOfOrNull { tab ->
-                                    tab.catalogRow?.items?.firstOrNull { it.id == item.id }
+                            // Don't emit enrichedPreviews yet if artwork fallback is pending —
+                            // avoids flashing hero without logo.
+                            val artworkWillFollow = !tmdbSettings.useArtwork && item.logo.isNullOrBlank() && externalMetaEnabled
+                            if (!artworkWillFollow) {
+                                val enrichedItem = _uiState.value.tabs
+                                    .firstNotNullOfOrNull { tab ->
+                                        tab.catalogRow?.items?.firstOrNull { it.id == item.id }
+                                    }
+                                if (enrichedItem != null) {
+                                    _enrichedPreviews.update { it + (item.id to enrichedItem) }
                                 }
-                            if (enrichedItem != null) {
-                                _enrichedPreviews.update { it + (item.id to enrichedItem) }
+                                rebuildFollowLayoutState()
                             }
-                            rebuildFollowLayoutState()
                             tmdbEnriched = true
                         }
                     }
@@ -1276,6 +1302,23 @@ class FolderDetailViewModel @Inject constructor(
                                 releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() } ?: merged.releaseInfo
                             )
                         }
+                    }
+                }
+                // Artwork-only fallback: TMDB enriched but useArtwork is off and item lacks logo.
+                val adjArtworkMissing = tmdbEnriched && !tmdbSettings.useArtwork &&
+                    item.logo.isNullOrBlank() && item.id !in prefetchedExternalMetaIds
+                if (adjArtworkMissing && externalMetaEnabled) {
+                    prefetchedExternalMetaIds.add(item.id)
+                    val result = metaRepository.getMetaFromAllAddons(item.apiType, item.id)
+                        .first { it is com.nuvio.tv.core.network.NetworkResult.Success || it is com.nuvio.tv.core.network.NetworkResult.Error }
+                    if (result is com.nuvio.tv.core.network.NetworkResult.Success) {
+                        val meta = result.data
+                        updateItemInTabs(item.id) { merged ->
+                            merged.copy(
+                                background = meta.background?.takeIf { it.isNotBlank() } ?: merged.background,
+                                logo = meta.logo?.takeIf { it.isNotBlank() } ?: merged.logo
+                            )
+                        }
                         val enrichedItem = _uiState.value.tabs
                             .firstNotNullOfOrNull { tab ->
                                 tab.catalogRow?.items?.firstOrNull { it.id == item.id }
@@ -1283,7 +1326,11 @@ class FolderDetailViewModel @Inject constructor(
                         if (enrichedItem != null) {
                             _enrichedPreviews.update { it + (item.id to enrichedItem) }
                         }
+                        enrichedItemIds.add(item.id)
                         rebuildFollowLayoutState()
+                    } else {
+                        // External addon failed — still mark as enriched to avoid infinite retries.
+                        enrichedItemIds.add(item.id)
                     }
                 }
             } finally {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -430,7 +430,14 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
         deferredEnrichItem = item
         return
     }
-    if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) return
+    if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) {
+        // Even if TMDB enriched, re-enter when artwork is still missing and external addon can help.
+        val artworkStillNeeded = item.id !in prefetchedExternalMetaIds &&
+            externalMetaPrefetchEnabled &&
+            !currentTmdbSettings.useArtwork &&
+            item.logo.isNullOrBlank()
+        if (!artworkStillNeeded) return
+    }
     if (pendingTmdbEnrichItemId == item.id) return
 
     // Clear enriching for previous item immediately when focus moves away
@@ -453,8 +460,14 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
             return@launch
         }
         if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) {
-            if (_enrichingItemId.value == item.id) setEnrichingItemId(null)
-            return@launch
+            val artworkStillNeeded = item.id !in prefetchedExternalMetaIds &&
+                externalMetaPrefetchEnabled &&
+                !currentTmdbSettings.useArtwork &&
+                item.logo.isNullOrBlank()
+            if (!artworkStillNeeded) {
+                if (_enrichingItemId.value == item.id) setEnrichingItemId(null)
+                return@launch
+            }
         }
 
         try {
@@ -477,12 +490,21 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
 
                 if (enrichment != null) {
                     prefetchedTmdbIds.add(item.id)
-                    prefetchedExternalMetaIds.add(item.id)
+                    // Only mark external meta as done if TMDB covered artwork too.
+                    if (currentTmdbSettings.useArtwork || !item.logo.isNullOrBlank()) {
+                        prefetchedExternalMetaIds.add(item.id)
+                    }
                     updateCatalogItemWithTmdb(item.id, enrichment)
                     tmdbEnriched = true
                 }
             }
-            if (!tmdbEnriched && externalMetaPrefetchEnabled &&
+            // Fall through to external addon when:
+            // 1. TMDB didn't enrich at all, OR
+            // 2. TMDB enriched but useArtwork is off and the item still lacks a logo.
+            val artworkStillMissing = tmdbEnriched && !currentTmdbSettings.useArtwork &&
+                item.logo.isNullOrBlank()
+            val needsExternalAddon = !tmdbEnriched || artworkStillMissing
+            if (needsExternalAddon && externalMetaPrefetchEnabled &&
                 item.id !in prefetchedExternalMetaIds &&
                 externalMetaPrefetchInFlightIds.add(item.id)) {
                 try {
@@ -490,7 +512,11 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
                         .first { it is NetworkResult.Success || it is NetworkResult.Error }
                     if (result is NetworkResult.Success) {
                         prefetchedExternalMetaIds.add(item.id)
-                        updateCatalogItemWithMeta(item.id, result.data)
+                        if (artworkStillMissing) {
+                            updateCatalogItemArtworkOnly(item.id, result.data)
+                        } else {
+                            updateCatalogItemWithMeta(item.id, result.data)
+                        }
                     }
                 } finally {
                     externalMetaPrefetchInFlightIds.remove(item.id)
@@ -538,12 +564,17 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
                 }.getOrNull() else null
                 if (enrichment != null) {
                     prefetchedTmdbIds.add(item.id)
-                    prefetchedExternalMetaIds.add(item.id)
+                    if (currentTmdbSettings.useArtwork || !item.logo.isNullOrBlank()) {
+                        prefetchedExternalMetaIds.add(item.id)
+                    }
                     updateCatalogItemWithTmdb(item.id, enrichment)
                     tmdbEnriched = true
                 }
             }
-            if (!tmdbEnriched &&
+            val artworkStillMissing = tmdbEnriched && !currentTmdbSettings.useArtwork &&
+                item.logo.isNullOrBlank()
+            val needsExternalAddon = !tmdbEnriched || artworkStillMissing
+            if (needsExternalAddon &&
                 externalMetaPrefetchEnabled &&
                 item.id !in prefetchedExternalMetaIds &&
                 externalMetaPrefetchInFlightIds.add(item.id)
@@ -553,7 +584,11 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
                         .first { it is NetworkResult.Success || it is NetworkResult.Error }
                     if (result is NetworkResult.Success) {
                         prefetchedExternalMetaIds.add(item.id)
-                        updateCatalogItemWithMeta(item.id, result.data)
+                        if (artworkStillMissing) {
+                            updateCatalogItemArtworkOnly(item.id, result.data)
+                        } else {
+                            updateCatalogItemWithMeta(item.id, result.data)
+                        }
                     }
                 } finally {
                     externalMetaPrefetchInFlightIds.remove(item.id)
@@ -716,6 +751,40 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
         trailerPreviewRequestVersion++
         val currentItem = findCatalogItemById(itemId) ?: return
         requestTrailerPreviewPipeline(currentItem)
+    }
+}
+
+private fun HomeViewModel.updateCatalogItemArtworkOnly(itemId: String, meta: Meta) {
+    fun mergeItem(currentItem: MetaPreview): MetaPreview = currentItem.copy(
+        background = meta.backdropUrl ?: currentItem.backdropUrl,
+        logo = meta.logo ?: currentItem.logo
+    )
+
+    updateIndexedCatalogItem(itemId, ::mergeItem)
+
+    _uiState.update { state ->
+        var changed = false
+        val updatedRows = state.catalogRows.map { row ->
+            val itemIndex = row.items.indexOfFirst { it.id == itemId }
+            if (itemIndex < 0) {
+                row
+            } else {
+                val mergedItem = mergeItem(row.items[itemIndex])
+                if (mergedItem == row.items[itemIndex]) {
+                    row
+                } else {
+                    changed = true
+                    val mutableItems = row.items.toMutableList()
+                    mutableItems[itemIndex] = mergedItem
+                    row.copy(items = mutableItems)
+                }
+            }
+        }
+        if (changed) state.copy(catalogRows = updatedRows) else state
+    }
+    findCatalogItemById(itemId)?.let { enriched ->
+        _lastEnrichedPreview.value = enriched
+        _enrichedPreviews.update { it + (itemId to enriched) }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -591,8 +591,10 @@ fun ModernHomeContent(
                             description = enrichedItem.description,
                             contentTypeText = activeCarouselItem?.heroPreview?.contentTypeText,
                             isSeries = isSeriesType(enrichedItem.apiType),
-                            yearText = activeCarouselItem?.heroPreview?.yearText,
-                            runtimeText = activeCarouselItem?.heroPreview?.runtimeText,
+                            yearText = extractYearText(enrichedItem.type, enrichedItem.releaseInfo, enrichedItem.released)
+                                ?: activeCarouselItem?.heroPreview?.yearText,
+                            runtimeText = formatHeroRuntime(enrichedItem.runtime)
+                                ?: activeCarouselItem?.heroPreview?.runtimeText,
                             imdbText = enrichedItem.imdbRating?.let { String.format(java.util.Locale.US, "%.1f", it) },
                             ageRatingText = enrichedItem.ageRating,
                             statusText = enrichedItem.status,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -637,7 +637,7 @@ internal fun extractYearText(type: ContentType, releaseInfo: String?, released: 
 private val HOURS_REGEX = "(\\d+)\\s*h".toRegex()
 private val MINUTES_REGEX = "(\\d+)\\s*m(?:in)?".toRegex()
 
-private fun formatHeroRuntime(runtime: String?): String? {
+internal fun formatHeroRuntime(runtime: String?): String? {
     val normalized = runtime?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return null
     val hours = HOURS_REGEX.find(normalized)?.groupValues?.getOrNull(1)?.toIntOrNull()
     val minutes = MINUTES_REGEX.find(normalized)?.groupValues?.getOrNull(1)?.toIntOrNull()


### PR DESCRIPTION
## Summary

Fix external addon artwork fallback when TMDB enrichment is enabled but useArtwork is off. Previously TMDB "success" blocked external addon fetch even when logo/backdrop weren't applied. Now falls through to external addon for artwork-only fetch when:
- TMDB enriched successfully but useArtwork=false, AND
- The original catalog item doesn't already have a clear logo

If the item already has a logo from the catalog/addon response, no extra fetch is made.

Also fixes:
- Hero yearText/runtimeText not updating from enriched data
- Adjacent prefetch in folder collections emitting enrichedPreviews too early (causing flash without logo)
- Adjacent prefetch marking items as fully enriched before artwork fetch completes

## PR type

- [x] Critical bug fix

## Why

When user has TMDB enrichment enabled but "use artwork" disabled, and "prefer meta from external addon" enabled:
1. TMDB enrichment returns success -> blocks external addon fallback
2. Artwork (logo/backdrop) never gets applied because useArtwork=false
3. External addon never runs because code gates on `enrichment == null`
4. Result: no logo/backdrop on focus in modern home and collection folders

Additionally in collection folders, adjacent prefetch was adding items to enrichedItemIds before artwork fetch completed, causing focus handler to skip them.

## Issue or approval

Fixes reported bug: "TMDB collection items in modern home don't update logo/backdrop on focus when TMDB artwork enrichment is disabled"

## Reproduction steps

1. Enable TMDB enrichment with useArtwork OFF
2. Enable "prefer meta from external addon"
3. Open a collection folder in follow-layout (modern) mode
4. Focus items that don't have a logo in catalog response -> no logo appears in hero
5. With fix: logo fetched from external addon on focus

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Fallback only triggers when original item has no logo AND useArtwork=off
- Does not change behavior when useArtwork=true (unchanged path)
- Does not add runtime fallback for TV shows (separate issue)
- formatHeroRuntime visibility changed from private to internal (required for hero yearText/runtimeText fix)

## Testing

- TMDB enabled, useArtwork=off, external meta enabled
- Collection folder (modern follow-layout): focus items without logo -> logo appears from external addon
- Items that already have logo from catalog: no extra fetch triggered
- Adjacent prefetch: +1 item gets logo before user navigates to it
- No flash: hero waits until artwork fetch completes before showing
- Normal flow (useArtwork=on): unchanged, TMDB artwork applied directly
- External meta disabled: no extra fetches, items show without logo as expected

## Screenshots / Video

Not a UI change (same hero component, data source corrected)

## Breaking changes

None.

## Linked issues

Fixes: TMDB collection artwork enrichment blocked by useArtwork gate

## Files changed

- `HomeViewModelPresentationPipeline.kt` - artwork fallback in focus + adjacent pipelines, new updateCatalogItemArtworkOnly
- `FolderDetailViewModel.kt` - same fix for collection folder enrichment + adjacent prefetch
- `ModernHomeContent.kt` - hero yearText/runtimeText from enriched data
- `ModernHomeModels.kt` - formatHeroRuntime visibility (private -> internal)
