### PR TITLE
fix(meta): per-addon meta cache so addons stop overwriting each other

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -50,7 +50,8 @@ class MetaRepositoryImpl @Inject constructor(
 
     private val repositoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    // In-memory cache: "type:id" -> Meta
+    // In-memory cache: "addonBaseUrl|type:id" -> Meta. Keyed per addon so two
+    // addons serving meta for the same content id never overwrite each other.
     private val metaCache = ConcurrentHashMap<String, Meta>()
     // Separate cache for full meta fetched from addons (bypasses catalog-level cache)
     private val addonMetaCache = ConcurrentHashMap<String, Meta>()
@@ -66,7 +67,7 @@ class MetaRepositoryImpl @Inject constructor(
         type: String,
         id: String
     ): Flow<NetworkResult<Meta>> = flow {
-        val cacheKey = "$type:$id"
+        val cacheKey = addonMetaCacheKey(addonBaseUrl, type, id)
         metaCache[cacheKey]?.let { cached ->
             emit(NetworkResult.Success(cached))
             return@flow
@@ -184,7 +185,7 @@ class MetaRepositoryImpl @Inject constructor(
                             val episodeLabel = context.getString(R.string.episodes_episode)
                             val meta = metaDto.toDomain(episodeLabel)
                             addonMetaCache[cacheKey] = meta
-                            metaCache[cacheKey] = meta
+                            metaCache[addonMetaCacheKey(addon.baseUrl, requestedType, id)] = meta
                             emit(NetworkResult.Success(meta))
                             return@flow
                         } else {
@@ -224,7 +225,7 @@ class MetaRepositoryImpl @Inject constructor(
                                 if (metaDto != null) {
                                     val meta = metaDto.toDomain(context.getString(R.string.episodes_episode))
                                     addonMetaCache[cacheKey] = meta
-                                    metaCache[cacheKey] = meta
+                                    metaCache[addonMetaCacheKey(addon.baseUrl, candidateType, id)] = meta
                                     Log.d(TAG, "Meta fetch success addonId=${addon.id} type=$candidateType id=$id")
                                     return@async meta
                                 }
@@ -301,7 +302,7 @@ class MetaRepositoryImpl @Inject constructor(
                             val metaDto = result.data.meta ?: return@async null
                             val meta = metaDto.toDomain(context.getString(R.string.episodes_episode))
                             primaryAddonMetaCache[cacheKey] = meta
-                            metaCache[cacheKey] = meta
+                            metaCache[addonMetaCacheKey(addon.baseUrl, candidateType, id)] = meta
                             meta
                         }
                         else -> null
@@ -324,6 +325,9 @@ class MetaRepositoryImpl @Inject constructor(
             )))
         }
     }
+
+    private fun addonMetaCacheKey(addonBaseUrl: String, type: String, id: String): String =
+        "${addonBaseUrl.trimEnd('/')}|$type:$id"
 
     private fun buildMetaUrl(baseUrl: String, type: String, id: String): String {
         val cleanBaseUrl = baseUrl.trimEnd('/')

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -326,14 +326,26 @@ class MetaRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun addonMetaCacheKey(addonBaseUrl: String, type: String, id: String): String =
-        "${addonBaseUrl.trimEnd('/')}|$type:$id"
-
-    private fun buildMetaUrl(baseUrl: String, type: String, id: String): String {
+    /**
+     * Splits an addon base URL into its path (trailing slashes trimmed) and
+     * query portions. Shared by URL construction and cache keying so the two
+     * always normalize equivalent base URLs identically.
+     */
+    private fun splitAddonBaseUrl(baseUrl: String): Pair<String, String> {
         val cleanBaseUrl = baseUrl.trimEnd('/')
         val queryStart = cleanBaseUrl.indexOf('?')
         val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
         val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
+        return basePath to baseQuery
+    }
+
+    private fun addonMetaCacheKey(addonBaseUrl: String, type: String, id: String): String {
+        val (basePath, baseQuery) = splitAddonBaseUrl(addonBaseUrl)
+        return "$basePath$baseQuery|$type:$id"
+    }
+
+    private fun buildMetaUrl(baseUrl: String, type: String, id: String): String {
+        val (basePath, baseQuery) = splitAddonBaseUrl(baseUrl)
         val encodedType = encodePathSegment(type)
         val encodedId = encodePathSegment(id)
         return "$basePath/meta/$encodedType/$encodedId.json$baseQuery"

--- a/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryAddonCacheTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryAddonCacheTest.kt
@@ -60,6 +60,18 @@ class MetaRepositoryAddonCacheTest {
         coVerify(exactly = 1) { api.getMeta(any()) }
     }
 
+    @Test
+    fun `query-bearing base url maps to the same cache entry regardless of slash placement`() = runTest {
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } returns metaResponse("Query Meta")
+        val repository = newRepository(api)
+
+        repository.getMeta("https://addon.example/cfg/?token=abc", "series", contentId).last()
+        repository.getMeta("https://addon.example/cfg?token=abc", "series", contentId).last()
+
+        coVerify(exactly = 1) { api.getMeta(any()) }
+    }
+
     private fun newRepository(vararg responsesByUrl: Pair<String, String>): MetaRepositoryImpl {
         val api = mockk<AddonApi>()
         responsesByUrl.forEach { (url, name) ->

--- a/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryAddonCacheTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryAddonCacheTest.kt
@@ -1,0 +1,93 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.MetaDto
+import com.nuvio.tv.data.remote.dto.MetaResponseDto
+import com.nuvio.tv.domain.repository.AddonRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+class MetaRepositoryAddonCacheTest {
+
+    private val contentId = "tt3711878"
+
+    @Test
+    fun `meta from one addon is not served for another addon with the same content id`() = runTest {
+        val repository = newRepository(
+            "https://cinemeta.example/meta/series/$contentId.json" to "Cinemeta Meta",
+            "https://aiometadata.example/meta/series/$contentId.json" to "AioMetadata Meta"
+        )
+
+        val first = repository.getMeta("https://cinemeta.example", "series", contentId).last()
+        val second = repository.getMeta("https://aiometadata.example", "series", contentId).last()
+
+        assertEquals("Cinemeta Meta", (first as NetworkResult.Success).data.name)
+        assertEquals("AioMetadata Meta", (second as NetworkResult.Success).data.name)
+    }
+
+    @Test
+    fun `repeat request for the same addon is served from cache`() = runTest {
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } returns metaResponse("Cached Meta")
+        val repository = newRepository(api)
+
+        val first = repository.getMeta("https://cinemeta.example", "series", contentId).last()
+        val second = repository.getMeta("https://cinemeta.example", "series", contentId).last()
+
+        assertEquals("Cached Meta", (first as NetworkResult.Success).data.name)
+        assertEquals("Cached Meta", (second as NetworkResult.Success).data.name)
+        coVerify(exactly = 1) { api.getMeta(any()) }
+    }
+
+    @Test
+    fun `trailing slash in addon base url maps to the same cache entry`() = runTest {
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } returns metaResponse("Slash Meta")
+        val repository = newRepository(api)
+
+        repository.getMeta("https://cinemeta.example/", "series", contentId).last()
+        repository.getMeta("https://cinemeta.example", "series", contentId).last()
+
+        coVerify(exactly = 1) { api.getMeta(any()) }
+    }
+
+    private fun newRepository(vararg responsesByUrl: Pair<String, String>): MetaRepositoryImpl {
+        val api = mockk<AddonApi>()
+        responsesByUrl.forEach { (url, name) ->
+            coEvery { api.getMeta(url) } returns metaResponse(name)
+        }
+        return newRepository(api)
+    }
+
+    private fun newRepository(api: AddonApi): MetaRepositoryImpl {
+        val context = mockk<Context> {
+            every { getString(any()) } returns "Episode"
+        }
+        val addonRepository = mockk<AddonRepository>(relaxed = true)
+        return MetaRepositoryImpl(
+            context = context,
+            api = api,
+            addonRepository = addonRepository
+        )
+    }
+
+    private fun metaResponse(name: String): Response<MetaResponseDto> =
+        Response.success(
+            MetaResponseDto(
+                meta = MetaDto(
+                    id = contentId,
+                    type = "series",
+                    name = name
+                )
+            )
+        )
+}


### PR DESCRIPTION
## Summary

Fixes #2194. Opening a title from one metadata addon could show another addon's cached metadata. With Cinemeta and AIOMetadata both installed, the AIOMetadata entry for a series incorrectly displayed Cinemeta's metadata (3 seasons instead of theTVDB Alternative Order's 5).

## PR type

- [x] Critical bug fix

## Why

`getMeta(addonBaseUrl, type, id)` fetches a specific addon's meta response but cached it under `"type:id"` alone, so two addons serving meta for the same content id collided: whichever addon was fetched first won the cache, and subsequent detail opens from any other addon returned that stale entry. The all-addons and primary-addon fetch paths also wrote their winners into the same bare key, polluting addon-specific lookups in both directions.

The addon-specific cache (and its in-flight dedup map) is now keyed `addonBaseUrl|type:id`, and the cross-path writes use the winning addon's own key. The aggregated `addonMetaCache`/`primaryAddonMetaCache` stay bare-keyed because their semantics are cross-addon by design ("best meta from any addon" / "primary addon's meta").

## Issue or approval

Fixes #2194

## Reproduction steps

1. Enable the Cinemeta addon.
2. Search for and open "Money Heist" (this caches Cinemeta's meta).
3. Enable AIOMetadata with theTVDB provider set to "Alternative Order".
4. Search "Money Heist" again and open the AIOMetadata entry.
5. The AIOMetadata entry shows Cinemeta's metadata (3 seasons) instead of theTVDB Alternative Order (5 seasons).

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Cache keying only. No changes to fetch priority, addon candidate selection, URL building, or the aggregated cross-addon caches.
- Per-addon keying means one cache entry per addon per title viewed instead of one per title; bounded by the existing in-memory map and typical usage (a handful of meta addons).
- Trailing slashes in addon base URLs are normalized in the key so equivalent URLs share an entry.

## Testing

`./gradlew :app:compileFullDebugKotlin` and `:app:compileFullDebugUnitTestKotlin` pass clean.

New `MetaRepositoryAddonCacheTest`:
- two addons requesting the same content id each receive their own addon's meta (this test fails against the previous cache keying)
- a repeat request for the same addon is served from cache (single network call)
- trailing-slash and bare base URLs map to the same cache entry

Note: the `AndroidUnitTest` runner cannot execute on my Windows environment (known Gradle "Type T not present" issue), so tests are compile-verified against the codebase rather than executed here.

Manual: follow the reproduction steps; the AIOMetadata entry should show theTVDB Alternative Order seasons while the Cinemeta entry keeps Cinemeta's.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2194