### PR TITLE
fix(debrid): resolve stream size from title text for Torrentio-style streams

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamFormatter.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamFormatter.kt
@@ -86,7 +86,12 @@ class DebridStreamFormatter @Inject constructor(
             "stream.audioChannels" to audioChannels,
             "stream.languages" to languages,
             "stream.languageEmojis" to languages.map { languageEmoji(it) },
-            "stream.size" to (raw?.size ?: stream.behaviorHints?.videoSize ?: stream.debridCacheStatus?.cachedSize),
+            "stream.size" to (
+                raw?.size
+                    ?: stream.behaviorHints?.videoSize
+                    ?: stream.debridCacheStatus?.cachedSize
+                    ?: StreamTextSizeParser.sizeBytesFromStreamText(stream)
+                ),
             "stream.folderSize" to raw?.folderSize,
             "stream.encode" to (parsed?.codec?.uppercase() ?: facts.encode.labelUnlessUnknown()),
             "stream.indexer" to (raw?.indexer ?: raw?.tracker),

--- a/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamFormatter.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamFormatter.kt
@@ -86,12 +86,7 @@ class DebridStreamFormatter @Inject constructor(
             "stream.audioChannels" to audioChannels,
             "stream.languages" to languages,
             "stream.languageEmojis" to languages.map { languageEmoji(it) },
-            "stream.size" to (
-                raw?.size
-                    ?: stream.behaviorHints?.videoSize
-                    ?: stream.debridCacheStatus?.cachedSize
-                    ?: StreamTextSizeParser.sizeBytesFromStreamText(stream)
-                ),
+            "stream.size" to StreamTextSizeParser.effectiveSizeBytes(stream),
             "stream.folderSize" to raw?.folderSize,
             "stream.encode" to (parsed?.codec?.uppercase() ?: facts.encode.labelUnlessUnknown()),
             "stream.indexer" to (raw?.indexer ?: raw?.tracker),

--- a/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridStreamFilter.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridStreamFilter.kt
@@ -382,6 +382,7 @@ object DirectDebridStreamFilter {
         return stream.clientResolve?.stream?.raw?.size
             ?: stream.behaviorHints?.videoSize
             ?: stream.debridCacheStatus?.cachedSize
+            ?: StreamTextSizeParser.sizeBytesFromStreamText(stream)
     }
 
     private fun streamSearchText(stream: Stream): String {

--- a/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridStreamFilter.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridStreamFilter.kt
@@ -378,12 +378,8 @@ object DirectDebridStreamFilter {
             normalized == "hlg"
     }
 
-    private fun streamSize(stream: Stream): Long? {
-        return stream.clientResolve?.stream?.raw?.size
-            ?: stream.behaviorHints?.videoSize
-            ?: stream.debridCacheStatus?.cachedSize
-            ?: StreamTextSizeParser.sizeBytesFromStreamText(stream)
-    }
+    private fun streamSize(stream: Stream): Long? =
+        StreamTextSizeParser.effectiveSizeBytes(stream)
 
     private fun streamSearchText(stream: Stream): String {
         val resolve = stream.clientResolve

--- a/app/src/main/java/com/nuvio/tv/core/debrid/StreamTextSizeParser.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/StreamTextSizeParser.kt
@@ -1,0 +1,38 @@
+package com.nuvio.tv.core.debrid
+
+import com.nuvio.tv.domain.model.Stream
+
+/**
+ * Parses a file size out of free-text stream metadata. Addons like Torrentio
+ * embed the size in the stream title (e.g. "👤 12 💾 1.81 GB ⚙️ TPB") instead
+ * of providing a structured size field, so this is the last-resort fallback
+ * for size display, filtering, and sorting.
+ */
+object StreamTextSizeParser {
+
+    private val SIZE_REGEX = Regex(
+        """(\d+(?:[.,]\d+)?)\s*(TB|GB|MB|KB)\b""",
+        RegexOption.IGNORE_CASE
+    )
+
+    private const val KILO = 1024.0
+
+    fun sizeBytesFromText(text: String?): Long? {
+        if (text.isNullOrBlank()) return null
+        val match = SIZE_REGEX.find(text) ?: return null
+        val value = match.groupValues[1].replace(',', '.').toDoubleOrNull() ?: return null
+        val multiplier = when (match.groupValues[2].uppercase()) {
+            "TB" -> KILO * KILO * KILO * KILO
+            "GB" -> KILO * KILO * KILO
+            "MB" -> KILO * KILO
+            "KB" -> KILO
+            else -> return null
+        }
+        return (value * multiplier).toLong().takeIf { it > 0L }
+    }
+
+    fun sizeBytesFromStreamText(stream: Stream): Long? =
+        sizeBytesFromText(stream.description)
+            ?: sizeBytesFromText(stream.title)
+            ?: sizeBytesFromText(stream.name)
+}

--- a/app/src/main/java/com/nuvio/tv/core/debrid/StreamTextSizeParser.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/StreamTextSizeParser.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.core.debrid
 
 import com.nuvio.tv.domain.model.Stream
+import java.util.Locale
 
 /**
  * Parses a file size out of free-text stream metadata. Addons like Torrentio
@@ -17,11 +18,22 @@ object StreamTextSizeParser {
 
     private const val KILO = 1024.0
 
+    /**
+     * Canonical stream size resolution: structured fields first, free-text
+     * parsing as last resort. Shared by formatting, filtering, and sorting so
+     * the fallback chain cannot drift between call sites.
+     */
+    fun effectiveSizeBytes(stream: Stream): Long? =
+        stream.clientResolve?.stream?.raw?.size
+            ?: stream.behaviorHints?.videoSize
+            ?: stream.debridCacheStatus?.cachedSize
+            ?: sizeBytesFromStreamText(stream)
+
     fun sizeBytesFromText(text: String?): Long? {
         if (text.isNullOrBlank()) return null
         val match = SIZE_REGEX.find(text) ?: return null
         val value = match.groupValues[1].replace(',', '.').toDoubleOrNull() ?: return null
-        val multiplier = when (match.groupValues[2].uppercase()) {
+        val multiplier = when (match.groupValues[2].uppercase(Locale.ROOT)) {
             "TB" -> KILO * KILO * KILO * KILO
             "GB" -> KILO * KILO * KILO
             "MB" -> KILO * KILO

--- a/app/src/test/java/com/nuvio/tv/core/debrid/StreamTextSizeParserTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/debrid/StreamTextSizeParserTest.kt
@@ -1,0 +1,71 @@
+package com.nuvio.tv.core.debrid
+
+import com.nuvio.tv.domain.model.Stream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StreamTextSizeParserTest {
+
+    @Test
+    fun `parses torrentio style size line`() {
+        val torrentioTitle = "Movie.Name.2024.1080p.WEB-DL\n👤 12 💾 1.81 GB ⚙️ ThePirateBay"
+        assertEquals(
+            (1.81 * 1024 * 1024 * 1024).toLong(),
+            StreamTextSizeParser.sizeBytesFromText(torrentioTitle)
+        )
+    }
+
+    @Test
+    fun `parses plain sizes across units`() {
+        assertEquals(700L * 1024 * 1024, StreamTextSizeParser.sizeBytesFromText("700 MB"))
+        assertEquals(
+            (1.5 * 1024 * 1024 * 1024 * 1024).toLong(),
+            StreamTextSizeParser.sizeBytesFromText("1.5 TB")
+        )
+        assertEquals(512L * 1024, StreamTextSizeParser.sizeBytesFromText("512KB"))
+    }
+
+    @Test
+    fun `parses comma decimal separator`() {
+        assertEquals(
+            (2.4 * 1024 * 1024 * 1024).toLong(),
+            StreamTextSizeParser.sizeBytesFromText("💾 2,4 GB")
+        )
+    }
+
+    @Test
+    fun `does not misread resolution year or bitrate tokens`() {
+        assertNull(StreamTextSizeParser.sizeBytesFromText("Movie.2024.2160p.x265.10bit"))
+        assertNull(StreamTextSizeParser.sizeBytesFromText("audio 320kbps AAC"))
+        assertNull(StreamTextSizeParser.sizeBytesFromText(null))
+        assertNull(StreamTextSizeParser.sizeBytesFromText("  "))
+    }
+
+    @Test
+    fun `stream text lookup prefers description then title then name`() {
+        val stream = sampleStream(
+            name = "Torrentio 4k",
+            title = "Movie\n💾 2 GB",
+            description = "💾 1 GB"
+        )
+        assertEquals(1024L * 1024 * 1024, StreamTextSizeParser.sizeBytesFromStreamText(stream))
+
+        val titleOnly = sampleStream(name = "Torrentio 4k", title = "Movie\n💾 2 GB", description = null)
+        assertEquals(2048L * 1024 * 1024, StreamTextSizeParser.sizeBytesFromStreamText(titleOnly))
+    }
+
+    private fun sampleStream(name: String?, title: String?, description: String?): Stream = Stream(
+        name = name,
+        title = title,
+        description = description,
+        url = null,
+        ytId = null,
+        infoHash = "abc",
+        fileIdx = null,
+        externalUrl = null,
+        behaviorHints = null,
+        addonName = "Torrentio",
+        addonLogo = null
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/core/debrid/StreamTextSizeParserTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/debrid/StreamTextSizeParserTest.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.core.debrid
 
 import com.nuvio.tv.domain.model.Stream
+import com.nuvio.tv.domain.model.StreamBehaviorHints
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -53,6 +54,27 @@ class StreamTextSizeParserTest {
 
         val titleOnly = sampleStream(name = "Torrentio 4k", title = "Movie\n💾 2 GB", description = null)
         assertEquals(2048L * 1024 * 1024, StreamTextSizeParser.sizeBytesFromStreamText(titleOnly))
+    }
+
+    @Test
+    fun `effective size prefers structured fields over text parsing`() {
+        val structured = sampleStream(
+            name = null,
+            title = "Movie\n💾 2 GB",
+            description = null
+        ).copy(
+            behaviorHints = StreamBehaviorHints(
+                notWebReady = null,
+                bingeGroup = null,
+                countryWhitelist = null,
+                proxyHeaders = null,
+                videoSize = 123L
+            )
+        )
+        assertEquals(123L, StreamTextSizeParser.effectiveSizeBytes(structured))
+
+        val textOnly = sampleStream(name = null, title = "Movie\n💾 2 GB", description = null)
+        assertEquals(2048L * 1024 * 1024, StreamTextSizeParser.effectiveSizeBytes(textOnly))
     }
 
     private fun sampleStream(name: String?, title: String?, description: String?): Stream = Stream(


### PR DESCRIPTION
## Summary

Fixes #2064. Custom formatters using `{stream.size}` rendered nothing for Torrentio streams handled by a local debrid integration (e.g. Torbox), and size-based filters and sorting silently skipped those streams, because Torrentio embeds the size in the stream title text instead of a structured field.

## PR type

- [x] Critical bug fix

## Why

The stream size chain consulted `clientResolve.stream.raw.size`, `behaviorHints.videoSize`, and `debridCacheStatus.cachedSize` - all null for plain Torrentio streams, whose size only exists as text in the title (e.g. `👤 12 💾 1.81 GB ⚙️ TPB`). AIOStreams parses that server-side and ships a structured size, which is why the same custom format works there. The identical gap exists in `DirectDebridStreamFilter.streamSize`, so size min/max filters and size sorting also ignored these streams.

A shared `StreamTextSizeParser` now extracts the first size token (TB/GB/MB/KB, dot or comma decimals) from the stream description, title, or name as a last-resort fallback, wired into both the formatter and the filter. The regex requires a unit word boundary, so resolution (`2160p`), year (`2024`), and bitrate (`320kbps`) tokens are never misread.

## Issue or approval

Fixes #2064

## Reproduction steps

1. Sign into Torbox on the Torbox integration page.
2. Set a custom stream format using a size segment, e.g. `{stream.size::>0["💾 {stream.size::sbytes} "||""]}`.
3. Install the Torrentio addon without debrid configuration (the local Torbox integration resolves the torrents).
4. Load streams for any movie/show.
5. The size segment renders empty, while the same format shows the size when streams come from AIOStreams.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Text parsing is a last-resort fallback only: structured size fields keep absolute precedence, so streams that already resolved a size are byte-identical before and after.
- No changes to template syntax, filter semantics, or sort orders beyond previously-null sizes now resolving.
- Field precedence for the text lookup is description, then title, then name.

## Testing

`./gradlew :app:compileFullDebugKotlin` and `:app:compileFullDebugUnitTestKotlin` pass clean.

New `StreamTextSizeParserTest`:
- parses the Torrentio multi-line title format
- unit conversions for KB/MB/GB/TB and comma decimal separators
- false-positive guards: resolution, year, and bitrate tokens return null
- stream field precedence (description over title over name)

Note: the `AndroidUnitTest` runner cannot execute on my Windows environment (known Gradle "Type T not present" issue), so tests are compile-verified against the codebase rather than executed here.

Manual: follow the reproduction steps; the size segment should render for Torrentio + Torbox streams, and size min/max filters should now apply to them.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2064