### PR TITLE
fix: next episode stuck on loading overlay when loading status disabled

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -21,7 +21,7 @@ internal fun PlayerRuntimeController.showRecoveryOverlay() {
             error = null,
             isBuffering = true,
             showLoadingOverlay = true,
-            loadingMessage = if (state.showPlayerLoadingStatus) context.getString(R.string.player_loading_buffering) else null,
+            loadingMessage = context.getString(R.string.player_loading_buffering),
             showPauseOverlay = false
         )
     }
@@ -51,7 +51,7 @@ internal fun PlayerRuntimeController.attemptStartupRecovery(
                 error = null,
                 isBuffering = true,
                 showLoadingOverlay = it.loadingOverlayEnabled,
-                loadingMessage = if (it.showPlayerLoadingStatus) context.getString(R.string.player_loading_buffering) else null,
+                loadingMessage = context.getString(R.string.player_loading_buffering),
                 showPauseOverlay = false
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -201,7 +201,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                 resolvedAutoPlayerEngine = null
             }
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
-            val showLoadingStatus = playerSettings.showPlayerLoadingStatus
             val deviceAspectMode = deviceLocalPlayerPreferences.aspectMode.first()
             _uiState.update {
                 it.copy(
@@ -211,7 +210,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     aspectMode = deviceAspectMode,
                     tunnelingEnabled = playerSettings.tunnelingEnabled &&
                             effectiveInternalPlayerEngine != InternalPlayerEngine.MVP_PLAYER,
-                    loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_detecting_format) else null
+                    loadingMessage = context.getString(R.string.player_loading_detecting_format)
                 )
             }
 
@@ -488,7 +487,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             isAudioDisabledForCurrentPlayback = audioDisabledForStream
             isVc1TrackSelectionBypassActiveForCurrentPlayback = vc1TrackSelectionBypassActive
 
-            val startupSubtitlePreparation = prepareStreamStartSubtitles(playerSettings, showLoadingStatus)
+            val startupSubtitlePreparation = prepareStreamStartSubtitles(playerSettings)
             afrJob.await()
 
             // ── Libass Setup (From 0.5.7-beta/Left) ──
@@ -736,7 +735,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 .build()
             val bandwidthMeter = SafeBandwidthMeter(rawBandwidthMeter, isHls)
 
-            if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
+            _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_building)) }
             // ── Build ExoPlayer ──
             val buildDefaultPlayer = {
                 // The actual MediaSource is built by mediaSourceFactory.createMediaSource()
@@ -842,7 +841,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     )
                 )
 
-                if (showLoadingStatus) _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }
+                _uiState.update { it.copy(loadingMessage = context.getString(R.string.player_loading_starting)) }
                 val isTunneledPlayback = playerSettings.tunnelingEnabled
                 // Always start paused — playback begins in onRenderedFirstFrame()
                 // so audio and video start in perfect sync. Without this, the
@@ -893,9 +892,9 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (playbackState == Player.STATE_BUFFERING && !hasRenderedFirstFrame) {
                             _uiState.update { state ->
                                 if (state.loadingOverlayEnabled && !state.showLoadingOverlay) {
-                                    state.copy(showLoadingOverlay = true, showControls = false, loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_buffering) else null)
+                                    state.copy(showLoadingOverlay = true, showControls = false, loadingMessage = context.getString(R.string.player_loading_buffering))
                                 } else {
-                                    state.copy(loadingMessage = if (showLoadingStatus) context.getString(R.string.player_loading_buffering) else null)
+                                    state.copy(loadingMessage = context.getString(R.string.player_loading_buffering))
                                 }
                             }
                         }
@@ -1396,8 +1395,7 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
     mode: AddonSubtitleStartupMode,
     preferredLanguage: String,
     secondaryLanguage: String?,
-    showOnlyPreferredLanguages: Boolean = false,
-    showLoadingStatus: Boolean = true
+    showOnlyPreferredLanguages: Boolean = false
 ): StartupSubtitlePreparation {
     val effectiveMode = if (showOnlyPreferredLanguages && mode == AddonSubtitleStartupMode.ALL_SUBTITLES) {
         AddonSubtitleStartupMode.PREFERRED_ONLY
@@ -1438,7 +1436,7 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
 
     val fetchedSubtitles = withTimeoutOrNull(STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS) {
         fetchAddonSubtitlesNow(
-            onProgress = if (showLoadingStatus) { completed, total, addonName ->
+            onProgress = { completed, total, addonName ->
                 val msg = if (completed == 0) {
                     context.getString(R.string.player_loading_subtitles_from, total)
                 } else if (addonName != null) {
@@ -1447,7 +1445,7 @@ internal suspend fun PlayerRuntimeController.prepareStartupSubtitles(
                     context.getString(R.string.player_loading_subtitles_progress, completed, total)
                 }
                 _uiState.update { it.copy(loadingMessage = msg) }
-            } else null
+            }
         )
     } ?: return StartupSubtitlePreparation(emptyList(), emptyList(), false)
 
@@ -1487,8 +1485,7 @@ internal fun PlayerRuntimeController.resetAddonSubtitleStateForNewStream() {
 }
 
 internal suspend fun PlayerRuntimeController.prepareStreamStartSubtitles(
-    playerSettings: PlayerSettings,
-    showLoadingStatus: Boolean = true
+    playerSettings: PlayerSettings
 ): StartupSubtitlePreparation {
     requestedUseLibassByUser = playerSettings.useLibass
     if (libassPipelineDecisionStreamUrl != currentStreamUrl) {
@@ -1502,8 +1499,7 @@ internal suspend fun PlayerRuntimeController.prepareStreamStartSubtitles(
         mode = playerSettings.addonSubtitleStartupMode,
         preferredLanguage = playerSettings.subtitleStyle.preferredLanguage,
         secondaryLanguage = playerSettings.subtitleStyle.secondaryPreferredLanguage,
-        showOnlyPreferredLanguages = playerSettings.subtitleStyle.showOnlyPreferredLanguages,
-        showLoadingStatus = showLoadingStatus
+        showOnlyPreferredLanguages = playerSettings.subtitleStyle.showOnlyPreferredLanguages
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -285,7 +285,6 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     loadingOverlayEnabled = settings.loadingOverlayEnabled,
                     showPlayerLoadingStatus = settings.showPlayerLoadingStatus,
                     showLoadingOverlay = shouldShowOverlay,
-                    loadingMessage = if (settings.showPlayerLoadingStatus || state.isTorrentStream) state.loadingMessage else null,
                     pauseOverlayEnabled = settings.pauseOverlayEnabled,
                     osdClockEnabled = settings.osdClockEnabled,
                     internalPlayerEngine = resolvedInternalPlayerEngine,


### PR DESCRIPTION
## Summary

Always emit loadingMessage to UI state during player initialization, regardless of the "show loading status" setting. Previously, when the setting was off, _uiState.update calls were skipped entirely, which on some devices prevented the Compose recomposition needed to properly attach the video SurfaceView. This caused next-episode playback to hang on the loading overlay indefinitely.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On certain devices/Android versions, skipping _uiState.update calls (when "show loading status" was disabled) meant no Compose recomposition occurred between player init and STATE_READY. Without that recomposition, the SurfaceView never received a layout pass, onRenderedFirstFrame never fired, and playback never started. Enabling the setting added intermediate state updates that triggered recomposition as a side effect, masking the issue.

## Issue or approval

No linked issue - reported by users in community channels. Confirmed fixed by affected user after this change.

## Reproduction steps

1. Disable "Show loading status" in Settings > Playback
2. Play any series episode to completion
3. Let next episode auto-play
4. Observe: player stuck on loading overlay with logo, never starts playback
5. Re-enable "Show loading status" and repeat - works fine

Device-specific: not reproducible on all hardware. Confirmed on low-end Android TV boxes.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

The loadingMessage is now always written to state, but the UI still hides it when the setting is off (filtered in PlayerScreen via .takeIf { showPlayerLoadingStatus }).

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No UI changes - text visibility still gated by showPlayerLoadingStatus in PlayerScreen
- No new features or settings added
- Removed dead code (unused showLoadingStatus param) as part of the fix, not a separate cleanup

## Testing

- Build: ./gradlew :app:compileFullBenchmarkKotlin passes
- Verified with "show loading status" OFF: next episode auto-play works
- Verified with "show loading status" ON: behavior unchanged, status text still displays
- Confirmed by affected user on their device

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - reported on Discord