### PR TITLE
Fix external player progress, watched, and auto next for VLC, MPV Android, and Just Player

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -825,6 +825,11 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onStart() {
+        // Returning from an external player: raise the auto-next loader before the player's
+        // result is dispatched and before the window repaints, so the transition shows the
+        // loader instantly with no episode-list flash. No-op unless a series episode is being
+        // tracked; onActivityResult keeps it for a completion or dismisses it otherwise.
+        externalPlaybackTracker.raiseAutoNextOverlayOnReturn()
         super.onStart()
         profileSettingsSyncService.requestForegroundPull()
         androidTvChannelSyncService.onForegroundChanged(true)

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -303,24 +303,101 @@ class ExternalPlaybackTracker @Inject constructor(
             Log.d(TAG, "onActivityResult recovered metadata from disk (process was recreated)")
         }
 
-        if (result != null) {
-            Log.d(TAG, "External player returned: pos=${result.positionMs}ms, dur=${result.durationMs}ms, endedByUser=${result.endedByUser}")
-            saveProgress(metadata, result.positionMs, result.durationMs)
-            // If the episode finished naturally, try to auto-advance to the next one.
-            if (isPlaybackCompleted(result)) {
-                maybeTriggerAutoNextEpisode(metadata)
-            }
-        } else {
+        if (result == null) {
             Log.d(TAG, "External player returned no progress data")
+            clearPersistedMetadata()
+            // On Zidoo, the monitor job handles progress - don't stop it prematurely.
+            if (!ZidooPlayerMonitor.isZidooDevice()) stopTracking()
+            return
+        }
+
+        Log.d(TAG, "External player returned: pos=${result.positionMs}ms, dur=${result.durationMs}ms, endedByUser=${result.endedByUser}")
+
+        // Some players (notably VLC on network streams) return a real position but no usable
+        // duration, so Nuvio can't compute a % and nothing is saved as resumable/watched.
+        // Backfill the duration (saved progress, else episode/movie runtime) off-thread, then
+        // process. Players that DO report a duration keep the synchronous path below unchanged.
+        if ((result.durationMs == null || result.durationMs <= 0L) && result.positionMs > 0L) {
+            scope.launch {
+                val fallback = resolveFallbackDurationMs(metadata)
+                val enriched = if (fallback > 0L) {
+                    Log.d(TAG, "Backfilled missing duration: ${fallback}ms")
+                    result.copy(durationMs = fallback)
+                } else {
+                    result
+                }
+                processResult(metadata, enriched)
+            }
+            return
+        }
+
+        processResult(metadata, result)
+    }
+
+    /** Completion check + save + auto-next + cleanup for a result with a resolved duration. */
+    private fun processResult(metadata: ExternalPlaybackMetadata, result: ExternalPlayerResult) {
+        if (isPlaybackCompleted(result)) {
+            // Mark watched even when the player returns no position/duration (e.g. Just
+            // Player sends only end_by=playback_completion). An explicit 100% forces
+            // WatchProgress.isCompleted(), which makes the repository flag the item watched
+            // (and sync it) regardless of the reported position/duration.
+            saveProgress(metadata, result.positionMs, result.durationMs, explicitPercent = 100f)
+            // Try to auto-advance to the next episode.
+            maybeTriggerAutoNextEpisode(metadata)
+        } else {
+            saveProgress(metadata, result.positionMs, result.durationMs)
         }
 
         // Result consumed — safe to drop the persisted copy now.
         clearPersistedMetadata()
+        stopTracking()
+    }
 
-        // On Zidoo, the monitor job handles progress - don't stop it prematurely
-        if (!ZidooPlayerMonitor.isZidooDevice() || result != null) {
-            stopTracking()
+    /**
+     * Best-effort duration (ms) for a player that returned a position but no usable duration.
+     * Tries the previously-saved duration for this item, then the runtime from meta
+     * (episode runtime for series, top-level runtime for movies). Returns 0 if unknown.
+     */
+    private suspend fun resolveFallbackDurationMs(metadata: ExternalPlaybackMetadata): Long {
+        val existing = currentSavedProgress(metadata)
+        if (existing != null && existing.duration > 0L) return existing.duration
+        return fetchRuntimeMsFromMeta(metadata)
+    }
+
+    private suspend fun currentSavedProgress(metadata: ExternalPlaybackMetadata): WatchProgress? {
+        val flow = if (metadata.season != null && metadata.episode != null) {
+            watchProgressRepository.getEpisodeProgress(metadata.contentId, metadata.season, metadata.episode)
+        } else {
+            watchProgressRepository.getProgress(metadata.contentId)
         }
+        return flow.firstOrNull()
+    }
+
+    private suspend fun fetchRuntimeMsFromMeta(metadata: ExternalPlaybackMetadata): Long {
+        val fetched = withTimeoutOrNull(META_FETCH_TIMEOUT_MS) {
+            metaRepository
+                .getMetaFromAllAddons(type = metadata.contentType, id = metadata.contentId)
+                .first { it !is NetworkResult.Loading }
+        }
+        val meta = (fetched as? NetworkResult.Success)?.data ?: return 0L
+        val season = metadata.season
+        val episode = metadata.episode
+        val minutes: Int? = if (season != null && episode != null) {
+            meta.videos.firstOrNull { it.season == season && it.episode == episode }?.runtime
+                ?: parseRuntimeMinutes(meta.runtime)
+        } else {
+            parseRuntimeMinutes(meta.runtime)
+        }
+        return (minutes ?: 0).toLong() * 60_000L
+    }
+
+    /** Parses "24 min", "120", or "1h 30m" style runtime strings into minutes. */
+    private fun parseRuntimeMinutes(runtime: String?): Int? {
+        if (runtime.isNullOrBlank()) return null
+        val hours = Regex("(\\d+)\\s*h").find(runtime)?.groupValues?.get(1)?.toIntOrNull()
+        val mins = Regex("(\\d+)\\s*m").find(runtime)?.groupValues?.get(1)?.toIntOrNull()
+        if (hours != null || mins != null) return (hours ?: 0) * 60 + (mins ?: 0)
+        return Regex("\\d+").find(runtime)?.value?.toIntOrNull()
     }
 
     // --- Disk persistence for pendingMetadata (survives process death) -------------
@@ -522,7 +599,12 @@ class ExternalPlaybackTracker @Inject constructor(
         }
     }
 
-    private fun saveProgress(metadata: ExternalPlaybackMetadata, positionMs: Long, durationMs: Long?) {
+    private fun saveProgress(
+        metadata: ExternalPlaybackMetadata,
+        positionMs: Long,
+        durationMs: Long?,
+        explicitPercent: Float? = null
+    ) {
         val effectiveDuration = durationMs ?: 0L
 
         scope.launch {
@@ -539,6 +621,7 @@ class ExternalPlaybackTracker @Inject constructor(
                 episodeTitle = metadata.episodeTitle,
                 position = positionMs,
                 duration = effectiveDuration,
+                progressPercent = explicitPercent,
                 lastWatched = System.currentTimeMillis()
             )
             Log.d(TAG, "Saving progress: pos=${positionMs}ms, dur=${effectiveDuration}ms, " +

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -294,10 +294,10 @@ class ExternalPlaybackTracker @Inject constructor(
         }
     }
 
-    /**
-     * Called when ActivityResult is received from external player.
-     * Processes the result and saves progress.
-     */
+    // ===================== External-player result handling =====================
+
+    /** Entry point for the player's ActivityResult: recover metadata, backfill a missing
+     *  duration if needed, save progress, and auto-advance on completion. */
     fun onActivityResult(result: ExternalPlayerResult?) {
         // If the player killed our process, pendingMetadata is null after recreation —
         // fall back to the persisted copy so we still save progress and auto-advance.
@@ -321,9 +321,8 @@ class ExternalPlaybackTracker @Inject constructor(
             return
         }
 
-        // Raise the auto-next loader now (covers the process-recreated case, where onStart had
-        // no in-memory metadata to raise from). Kept for a completion; dismissed in processResult
-        // if this turns out not to be one.
+        // Raise the loader here too (covers the process-recreated case, where onStart had no
+        // in-memory metadata). Kept for a completion; dismissed below otherwise.
         raiseAutoNextOverlay(metadata)
 
         Log.d(TAG, "External player returned: pos=${result.positionMs}ms, dur=${result.durationMs}ms, endedByUser=${result.endedByUser}")
@@ -370,6 +369,10 @@ class ExternalPlaybackTracker @Inject constructor(
         clearPersistedMetadata()
         stopTracking()
     }
+
+    // --- Duration backfill: for players that report a position but no usable duration (VLC) ---
+    // NOTE: meta runtime is approximate, so the 90% completion check / saved % can be slightly
+    // off — still far better than saving 0% and losing resume + watched entirely.
 
     /**
      * Best-effort duration (ms) for a player that returned a position but no usable duration.
@@ -460,8 +463,10 @@ class ExternalPlaybackTracker @Inject constructor(
         persistedPrefs.edit().clear().apply()
     }
 
-    // True on a natural end (end_by != "user") or, for players that don't report
-    // end_by, when position reached COMPLETED_THRESHOLD (90%).
+    // ===================== Completion + auto-next =====================
+
+    // True on a natural end (end_by != "user"), or for players without end_by once the
+    // position reaches COMPLETED_THRESHOLD (90%).
     private fun isPlaybackCompleted(result: ExternalPlayerResult): Boolean {
         if (!result.endedByUser) return true
         val duration = result.durationMs ?: 0L
@@ -566,8 +571,15 @@ class ExternalPlaybackTracker @Inject constructor(
         }
     }
 
-    /** Hide the auto-advance loader and cancel the pending auto-next, so backing out of the
-     *  "Loading next episode" loader actually stops it instead of advancing anyway. */
+    // ===================== "Loading next episode" loader =====================
+    // WARNING: autoNextOverlay is the ONLY cover for the player->Nuvio transition. To hide the
+    // episode-list flash, raise THIS loader early (raiseAutoNextOverlayOnReturn). Do NOT add a
+    // second full-screen cover to mask the gap — a competing overlay caused flicker and hid this
+    // loader's text. Cancellation: backing out sets autoNextCancelled (reset per launch in
+    // startTracking) so neither the loader nor the advance re-fires for the current return.
+
+    /** Hide the loader and cancel the pending auto-next, so backing out actually stops it
+     *  instead of advancing anyway. Progress is still saved; only the advance is canceled. */
     fun dismissAutoNextOverlay() {
         autoNextCancelled = true
         autoNextJob?.cancel()
@@ -575,13 +587,9 @@ class ExternalPlaybackTracker @Inject constructor(
         _autoNextOverlay.value = null
     }
 
-    /**
-     * Raise the auto-advance loader the instant we return from an external player, before the
-     * result is even parsed, so the transition shows the loader with no episode-list flash.
-     * Called from MainActivity.onStart (earliest point on return) and onActivityResult. No-op
-     * for movies / non-episodes, and idempotent (won't replace an already-shown loader).
-     * Kept if the playback turns out completed; dismissed by onActivityResult otherwise.
-     */
+    /** Raise the loader the instant we return (from MainActivity.onStart, before the result is
+     *  parsed and the window repaints) so there's no episode-list flash. No-op for non-episodes;
+     *  idempotent. Kept for a completion, dismissed by onActivityResult otherwise. */
     fun raiseAutoNextOverlayOnReturn() {
         raiseAutoNextOverlay(pendingMetadata ?: return)
     }
@@ -598,9 +606,9 @@ class ExternalPlaybackTracker @Inject constructor(
         )
     }
 
-    /**
-     * Stop tracking and clean up resources.
-     */
+    // ===================== Tracking lifecycle + Zidoo =====================
+
+    /** Stop tracking and clean up resources. */
     fun stopTracking() {
         zidooMonitorJob?.cancel()
         zidooMonitorJob = null
@@ -650,6 +658,8 @@ class ExternalPlaybackTracker @Inject constructor(
             wp.position
         }
     }
+
+    // ===================== Progress save + Trakt scrobble =====================
 
     private fun saveProgress(
         metadata: ExternalPlaybackMetadata,

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -130,6 +130,13 @@ class ExternalPlaybackTracker @Inject constructor(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var zidooMonitorJob: Job? = null
+    // The in-flight auto-next resolution (meta fetch -> emit next episode). Held so the user can
+    // cancel it by backing out of the "Loading next episode" loader before it navigates.
+    private var autoNextJob: Job? = null
+    // Set when the user backs out of the loader; blocks the loader from re-raising and auto-next
+    // from firing for the current return (e.g. while VLC's duration backfill is still running).
+    // Reset on each new launch in startTracking.
+    private var autoNextCancelled = false
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
     // the next episode's Stream route. replay = 1 so the event still reaches the
@@ -174,6 +181,8 @@ class ExternalPlaybackTracker @Inject constructor(
     fun startTracking(metadata: ExternalPlaybackMetadata, autoLaunch: Boolean = false) {
         pendingMetadata = metadata
         isAutoLaunch = autoLaunch
+        // Fresh launch — allow the auto-next loader / advance again.
+        autoNextCancelled = false
         // Next player is launching and will cover the screen — drop the loader.
         _autoNextOverlay.value = null
         // Persist so progress-save + auto-next survive the player killing our process.
@@ -305,11 +314,17 @@ class ExternalPlaybackTracker @Inject constructor(
 
         if (result == null) {
             Log.d(TAG, "External player returned no progress data")
+            _autoNextOverlay.value = null
             clearPersistedMetadata()
             // On Zidoo, the monitor job handles progress - don't stop it prematurely.
             if (!ZidooPlayerMonitor.isZidooDevice()) stopTracking()
             return
         }
+
+        // Raise the auto-next loader now (covers the process-recreated case, where onStart had
+        // no in-memory metadata to raise from). Kept for a completion; dismissed in processResult
+        // if this turns out not to be one.
+        raiseAutoNextOverlay(metadata)
 
         Log.d(TAG, "External player returned: pos=${result.positionMs}ms, dur=${result.durationMs}ms, endedByUser=${result.endedByUser}")
 
@@ -346,6 +361,9 @@ class ExternalPlaybackTracker @Inject constructor(
             maybeTriggerAutoNextEpisode(metadata)
         } else {
             saveProgress(metadata, result.positionMs, result.durationMs)
+            // Not a completion — drop the optimistic auto-next loader so we fall back to the
+            // stream screen instead of leaving the loader stuck.
+            _autoNextOverlay.value = null
         }
 
         // Result consumed — safe to drop the persisted copy now.
@@ -464,6 +482,12 @@ class ExternalPlaybackTracker @Inject constructor(
         if (season == null || episode == null || type !in listOf("series", "tv")) {
             return
         }
+        // User already backed out of the loader for this return (e.g. during VLC's backfill) —
+        // don't re-raise it or advance.
+        if (autoNextCancelled) {
+            _autoNextOverlay.value = null
+            return
+        }
 
         // Show the loader before the async work below so it covers the cold-start window.
         val overlay = ExternalAutoNextOverlay(
@@ -476,7 +500,8 @@ class ExternalPlaybackTracker @Inject constructor(
             if (_autoNextOverlay.value === overlay) _autoNextOverlay.value = null
         }
 
-        scope.launch {
+        autoNextJob?.cancel()
+        autoNextJob = scope.launch {
             // Gate exactly like the internal path does.
             val autoPlayNextEnabled = playerSettingsDataStore.playerSettings.first()
                 .streamAutoPlayNextEpisodeEnabled
@@ -541,9 +566,36 @@ class ExternalPlaybackTracker @Inject constructor(
         }
     }
 
-    /** Hide the auto-advance loader (e.g. user pressed Back to cancel waiting). */
+    /** Hide the auto-advance loader and cancel the pending auto-next, so backing out of the
+     *  "Loading next episode" loader actually stops it instead of advancing anyway. */
     fun dismissAutoNextOverlay() {
+        autoNextCancelled = true
+        autoNextJob?.cancel()
+        autoNextJob = null
         _autoNextOverlay.value = null
+    }
+
+    /**
+     * Raise the auto-advance loader the instant we return from an external player, before the
+     * result is even parsed, so the transition shows the loader with no episode-list flash.
+     * Called from MainActivity.onStart (earliest point on return) and onActivityResult. No-op
+     * for movies / non-episodes, and idempotent (won't replace an already-shown loader).
+     * Kept if the playback turns out completed; dismissed by onActivityResult otherwise.
+     */
+    fun raiseAutoNextOverlayOnReturn() {
+        raiseAutoNextOverlay(pendingMetadata ?: return)
+    }
+
+    private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
+        if (autoNextCancelled) return
+        if (metadata.season == null || metadata.episode == null) return
+        if (metadata.contentType.lowercase() !in listOf("series", "tv")) return
+        if (_autoNextOverlay.value != null) return
+        _autoNextOverlay.value = ExternalAutoNextOverlay(
+            backdrop = metadata.backdrop ?: metadata.poster,
+            logo = metadata.logo,
+            title = metadata.contentName
+        )
     }
 
     /**

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
@@ -68,6 +68,7 @@ class ExternalPlayerResultContract : ActivityResultContract<ExternalPlayerInput,
             // Resume position — supported by MX Player, VLC, Just Player, mpv-android, Vimu
             if (input.resumePositionMs > 0L) {
                 putExtra("position", input.resumePositionMs.toInt())  // MX Player / Just Player / mpv (Int ms)
+                putExtra("extra_position", input.resumePositionMs)    // VLC (Long ms)
                 putExtra("startfrom", input.resumePositionMs.toInt()) // Vimu Player (Int ms)
                 putExtra("forceresume", true)                         // Vimu: enable resume for network streams
                 putExtra("from_start", false)                         // VLC: don't force start from beginning
@@ -126,47 +127,68 @@ class ExternalPlayerResultContract : ActivityResultContract<ExternalPlayerInput,
         android.util.Log.d("ExtPlayerContract", "parseResult: resultCode=$resultCode, intent=$intent, extras=${intent?.extras?.keySet()?.toList()}")
         val data = intent ?: return null
 
-        val position = parsePosition(data) ?: return null
+        val position = parsePosition(data)
         val duration = parseDuration(data)
-        val endedByUser = parseEndReason(data)
+        // MX Player / Just Player / mpvNova report the end reason here (vanilla mpv-android and
+        // VLC do not).
+        val endBy = data.getStringExtra("end_by")
+        val completedByEndReason = endBy == "playback_completion"
+
+        // Vanilla mpv-android (is.xyz.mpv) includes a position only on a back-press exit; when a
+        // started playback reaches EOF it returns its result action with RESULT_OK and NO extras
+        // at all (no position, duration, or end_by). Treat that exact shape as a completion so it
+        // still auto-advances + marks watched. mpvNova (the fork) sends full data and never hits
+        // this branch.
+        val mpvFinishedWithNoData = resultCode == android.app.Activity.RESULT_OK &&
+            data.action == "is.xyz.mpv.MPVActivity.result" &&
+            position == null && duration == null && endBy == null
+
+        // Players that signal completion via end_by often reset the returned position to 0 at
+        // EOF — don't discard those, or the episode never marks watched / auto-advances. Only
+        // bail when there is genuinely nothing to act on: no position AND no completion signal.
+        if (position == null && !completedByEndReason && !mpvFinishedWithNoData) {
+            android.util.Log.d("ExtPlayerContract", "parseResult: no position and no completion signal; dropping")
+            return null
+        }
+
+        // On a bare completion signal with no/zero position, report the end position so the
+        // 90%-of-duration completion check passes and progress is saved as watched (not 0%).
+        val effectivePosition = position ?: duration ?: 0L
+        // Only an explicit "playback_completion" or the mpv EOF shape counts as a natural end.
+        // Absent end_by (VLC/Vimu) stays endedByUser=true and relies on the 90% rule, so a
+        // genuine mid-video user exit is NOT treated as a completion.
+        val endedByUser = !mpvFinishedWithNoData && endBy != "playback_completion"
+
         android.util.Log.d(
             "ExtPlayerContract",
-            "parseResult parsed position=${position}ms, duration=${duration}ms, " +
-                "end_by=${data.getStringExtra("end_by")}; endedByUser=$endedByUser"
+            "parseResult parsed position=${effectivePosition}ms, duration=${duration}ms, " +
+                "end_by=$endBy; endedByUser=$endedByUser"
         )
 
         return ExternalPlayerResult(
-            positionMs = position,
+            positionMs = effectivePosition,
             durationMs = duration,
             endedByUser = endedByUser
         )
     }
 
-    private fun parsePosition(data: Intent): Long? {
-        // VLC uses Long extras
-        val vlcPosition = data.getLongExtra("extra_position", -1L)
-        if (vlcPosition > 0) return vlcPosition
+    // Robust against key + type variants across players:
+    // - VLC: extra_position (Long)
+    // - MX Player / Just Player / mpv-android / Nova: position (Int)
+    private fun parsePosition(data: Intent): Long? =
+        firstPositiveExtra(data, "extra_position", "position")
 
-        // MX Player / Just Player / mpv use Int extras
-        val mxPosition = data.getIntExtra("position", -1)
-        if (mxPosition > 0) return mxPosition.toLong()
+    private fun parseDuration(data: Intent): Long? =
+        firstPositiveExtra(data, "extra_duration", "duration")
 
+    /** Reads the first key that holds a positive Long or Int value, trying both types. */
+    private fun firstPositiveExtra(data: Intent, vararg keys: String): Long? {
+        for (key in keys) {
+            val asLong = data.getLongExtra(key, -1L)
+            if (asLong > 0) return asLong
+            val asInt = data.getIntExtra(key, -1)
+            if (asInt > 0) return asInt.toLong()
+        }
         return null
-    }
-
-    private fun parseDuration(data: Intent): Long? {
-        val vlcDuration = data.getLongExtra("extra_duration", -1L)
-        if (vlcDuration > 0) return vlcDuration
-
-        val mxDuration = data.getIntExtra("duration", -1)
-        if (mxDuration > 0) return mxDuration.toLong()
-
-        return null
-    }
-
-    private fun parseEndReason(data: Intent): Boolean {
-        // MX Player returns "end_by" with values "user" or "playback_completion"
-        val endBy = data.getStringExtra("end_by")
-        return endBy != "playback_completion"
     }
 }

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
@@ -37,14 +37,17 @@ data class ExternalPlayerResult(
 )
 
 /**
- * ActivityResultContract that launches an external video player via ACTION_VIEW
- * and parses the playback position returned by the player (if supported).
- *
- * Supported players:
- * - MX Player: returns "position" (Int, ms), "duration" (Int, ms), "end_by" (String)
- * - VLC: returns "extra_position" (Long, ms), "extra_duration" (Long, ms)
- * - Just Player: returns "position" (Int, ms), "duration" (Int, ms)
- * - mpv-android: returns "position" (Int, ms), "duration" (Int, ms)
+ * ActivityResultContract that launches an external video player via ACTION_VIEW and parses the
+ * playback result. Players disagree wildly on what they return, so [parseResult] is deliberately
+ * lenient. Observed contracts (verified on-device):
+ * - MX Player / mpvNova: position + duration (Int ms) + end_by.
+ * - Just Player: on completion returns ONLY end_by=playback_completion (no position/duration).
+ * - mpv-android (vanilla is.xyz.mpv): position/duration (Int) only on a back-press; at EOF returns
+ *   RESULT_OK with NO extras and no end_by (handled by the heuristic in [parseResult]).
+ * - VLC: extra_position/extra_duration (Long ms), no end_by; duration is <= 0 for network streams
+ *   (the tracker backfills it). Ignores our launch resume extras, so resume into VLC won't take.
+ * - Vimu: position.
+ * - NovaPlayer: returns nothing usable (RESULT_CANCELED + null intent) — cannot be supported here.
  */
 class ExternalPlayerResultContract : ActivityResultContract<ExternalPlayerInput, ExternalPlayerResult?>() {
 
@@ -134,11 +137,12 @@ class ExternalPlayerResultContract : ActivityResultContract<ExternalPlayerInput,
         val endBy = data.getStringExtra("end_by")
         val completedByEndReason = endBy == "playback_completion"
 
-        // Vanilla mpv-android (is.xyz.mpv) includes a position only on a back-press exit; when a
-        // started playback reaches EOF it returns its result action with RESULT_OK and NO extras
-        // at all (no position, duration, or end_by). Treat that exact shape as a completion so it
-        // still auto-advances + marks watched. mpvNova (the fork) sends full data and never hits
-        // this branch.
+        // Vanilla mpv-android (is.xyz.mpv) includes a position only on a back-press; at EOF it
+        // returns its result action with RESULT_OK and NO extras (no position/duration/end_by).
+        // Treat that exact shape as a completion so it still auto-advances + marks watched.
+        // mpvNova (the fork) sends full data and never hits this branch.
+        // WARNING: heuristic — if a future mpv-android build returned this shape for a non-EOF
+        // exit, it would be mis-counted as completed.
         val mpvFinishedWithNoData = resultCode == android.app.Activity.RESULT_OK &&
             data.action == "is.xyz.mpv.MPVActivity.result" &&
             position == null && duration == null && endBy == null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1219,12 +1219,10 @@ class StreamScreenViewModel @Inject constructor(
                 directAutoPlayMessage = null
             )
         }
-        // Keep the loading cover up for a short grace window after returning, so the tracker's
-        // auto-next loader (or its navigation) can take over seamlessly. Without this the
-        // episode list paints for a frame between this overlay hiding and the auto-next overlay
-        // appearing — the "episodes flash then loading screen" on the way back to Nuvio. If
-        // auto-next fires, navigation replaces this screen before the hide runs; on a plain
-        // user exit the cover simply lingers ~0.7s before the episode list shows.
+        // Secondary cover. The primary flash fix is the tracker's auto-next loader (raised in
+        // MainActivity.onStart on return); this just keeps the stream-screen loader up ~0.7s so
+        // the episode list can't paint underneath during the handoff. On auto-next, navigation
+        // replaces this screen first; on a plain exit the cover lingers ~0.7s then the list shows.
         externalOverlayHideJob?.cancel()
         externalOverlayHideJob = viewModelScope.launch {
             kotlinx.coroutines.delay(700L)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1197,6 +1197,7 @@ class StreamScreenViewModel @Inject constructor(
     /** Set to true when external player is launched, reset on stop. */
     private var externalPlayerLaunched = false
     private var externalPlayerLaunchTimeMs = 0L
+    private var externalOverlayHideJob: kotlinx.coroutines.Job? = null
 
     fun stopExternalPlayerTracking() {
         if (!externalPlayerLaunched) return
@@ -1215,9 +1216,19 @@ class StreamScreenViewModel @Inject constructor(
         updateUiStateIfChanged {
             it.copy(
                 showDirectAutoPlayOverlay = false,
-                externalPlayerOverlayVisible = false,
                 directAutoPlayMessage = null
             )
+        }
+        // Keep the loading cover up for a short grace window after returning, so the tracker's
+        // auto-next loader (or its navigation) can take over seamlessly. Without this the
+        // episode list paints for a frame between this overlay hiding and the auto-next overlay
+        // appearing — the "episodes flash then loading screen" on the way back to Nuvio. If
+        // auto-next fires, navigation replaces this screen before the hide runs; on a plain
+        // user exit the cover simply lingers ~0.7s before the episode list shows.
+        externalOverlayHideJob?.cancel()
+        externalOverlayHideJob = viewModelScope.launch {
+            kotlinx.coroutines.delay(700L)
+            updateUiStateIfChanged { it.copy(externalPlayerOverlayVisible = false) }
         }
     }
 
@@ -1309,6 +1320,7 @@ class StreamScreenViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
+        externalOverlayHideJob?.cancel()
         streamLoadScope?.cancel()
         streamLoadScope = null
         streamLoadJob = null
@@ -1347,6 +1359,7 @@ class StreamScreenViewModel @Inject constructor(
         autoLaunch: Boolean = false,
         context: android.content.Context
     ) {
+        externalOverlayHideJob?.cancel()
         updateUiStateIfChanged {
             it.copy(
                 showDirectAutoPlayOverlay = true,


### PR DESCRIPTION
## Summary

This extends external player support beyond mpvNova and Vimu so that VLC, MPV Android, and Just Player also record watch progress, mark episodes watched, and auto advance to the next episode. Most of the work was figuring out that every player returns its playback result differently (and that some return almost nothing), then filling the gaps so Nuvio can act on what little each one provides. It also makes the return transition show the "Loading next episode" loader instantly (no episode list flash) and lets the user back out of it.

What each player does now:

* mpvNova: records position, marks watched, and auto advances.
* Vimu: records position. This already worked before and is unchanged.
* Just Player: records position, marks watched, auto advances, and resumes.
* MPV Android: records position, marks watched, and auto advances.
* VLC: records position, marks watched, and auto advances. Resuming back into VLC itself does not take because VLC ignores the resume extra we send (it reads PLAY_EXTRA_START_TIME, not extra_position), but Nuvio's continue watching and watched state populate correctly.
* NovaPlayer: not possible. See "Known issues and risks" below.

What was figured out (per player result contracts):

* Just Player (MX style API): on completion it returns only end_by=playback_completion, with no position and no duration.
* MPV Android (vanilla is.xyz.mpv): returns position and duration as Int only when you exit with the back button. When playback reaches the end it returns RESULT_OK with no extras at all and no end_by.
* VLC (org.videolan.vlc): returns extra_position and extra_duration as Long, where position is the current time, and never sends end_by. On network and debrid streams VLC reports extra_duration as 0 or less because it does not know the stream length.
* mpvNova (the fork) and Vimu already returned usable data, so they needed no contract work.

How the gaps were filled:

* ExternalPlayerResultContract now parses all of these robustly: it tries both key names and both Long and Int types, and it no longer discards a result just because the position is 0 (that was dropping Just Player and the MPV Android end case). MPV Android's end shape (RESULT_OK plus the mpv result action plus no extras) is treated as a completion. VLC's Long resume extra is sent on launch.
* ExternalPlaybackTracker marks the item watched on completion using an explicit 100 percent, so the repository flags it watched and syncs it even when the player gives back no position or duration. When a player reports a position but no usable duration (VLC on streams), it backfills the duration from saved progress, and if there is none, from the episode or movie runtime in the meta, so the 90 percent completion rule and resume both have something to work with.

Return transition:

* The loader is raised at the earliest point on return (MainActivity.onStart, before the player result is dispatched and before the window repaints), and again at the start of onActivityResult to cover the case where the player killed and recreated the process. It is the existing auto next loader, kept for a completion and dismissed otherwise, so there is no second competing overlay and no episode list flash. No op for movies and non episodes.
* Pressing Back on the loader cancels the in flight auto next (it cancels the resolve job and blocks it from re firing, including during VLC's duration backfill) instead of only hiding the loader and advancing anyway. Watch progress is still saved; only the advance is canceled.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

External player playback was effectively broken for every player except mpvNova and Vimu: VLC, MPV Android, and Just Player would launch and play, but on return Nuvio recorded no progress, never marked the episode watched, and never auto advanced. This fixes that by handling each player's actual return contract and supplying the data Nuvio needs when the player omits it. It also fixes the episode list flashing during the return transition and the loader holding the user hostage with no way to cancel.

## Issue or approval

No separate bug issue. This continues and fixes the external player support originally added in #2198. Happy to open a tracking issue if maintainers want one.

## Reproduction steps

1. Open a series and start an episode using VLC, MPV Android, or Just Player as the external player.
2. Let the episode finish, or watch most of it and exit.
3. Return to Nuvio.
4. Before this change: the episode is not marked watched, no resume position is saved, and the next episode does not auto play. On return the episode list also flashed before the loader, and once the loader showed there was no way to cancel the auto advance.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Intentionally limited to external player result handling (ExternalPlayerResultContract), the playback tracker (ExternalPlaybackTracker), the stream screen loader timing (StreamScreenViewModel), and the return transition hook (MainActivity.onStart). The internal player is untouched. The only non functional change is a comment pass on these same files (section headers, shorter comments, and documenting each player's result contract in the contract class) with no logic or behavior change. NovaPlayer support is intentionally not attempted because it is not technically possible (see below).

## Testing

Tested manually on an NVIDIA Shield. For each of mpvNova, Vimu, Just Player, MPV Android, and VLC: played an episode to the end and confirmed the episode is marked watched and the next episode auto plays, and watched part way and confirmed the resume position is saved. Confirmed the return transition now shows the loader instantly with no episode list flash, and that pressing Back on the loader cancels the auto advance and returns to the stream screen. NovaPlayer was tested and confirmed to return nothing usable. Built with assembleFullDebug and installed over adb.

## Known issues and risks

NovaPlayer cannot be supported. It returns RESULT_CANCELED with a null intent and reports nothing back through the activity result, because it keeps its own internal resume database instead. There is no key to read, so Nuvio cannot record progress, mark watched, or auto advance from it. No fix exists through the standard player intent API.

Risks to be aware of:

1. The duration backfill uses the meta runtime when there is no saved duration, and that runtime is approximate, so the 90 percent threshold and the saved percentage can be slightly off for VLC. This is still far better than the 0 percent it saved before.
2. Players with no end_by (VLC) rely entirely on the 90 percent rule, so exiting above 90 percent counts as completed and marks watched.
3. The MPV Android end detection is a heuristic based on observed behavior (RESULT_OK plus the mpv result action plus no extras), and a future MPV Android build could in theory return that same shape for an exit that is not a completion.
4. Because completion is only known after the result is parsed, the loader also appears briefly on a mid episode exit before it is dismissed. It is near instant on the players that report synchronously, and on VLC it can linger for the short duration backfill window. The user can back out at any time.

## Screenshots / Video

Not a UI change beyond the loader timing and the Back to cancel behavior.

## Breaking changes

None.

## Linked issues

No separate linked issue. This continues the external player support from #2198.
