### PR TITLE
i18n(fr): extract residual hardcoded web-config strings (batch12)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/AddonWebPage.kt
@@ -1479,17 +1479,17 @@ function tmdbSourceSubtitle(src) {
 }
 
 var EMOJI_CATEGORIES = [
-  {name:'Streaming', emojis:['🎬','🎭','🎥','📺','🍿','🎞️','📽️','🎦','📡','📻']},
-  {name:'Genres', emojis:['💀','👻','🔪','💣','🚀','🛸','🧙','🦸','🧟','🤖','💘','😂','😱','🤯','🥺','😈']},
-  {name:'Sports', emojis:['⚽','🏀','🏈','⚾','🎾','🏐','🏒','🥊','🏎️','🏆','🎯','🏋️']},
-  {name:'Music', emojis:['🎵','🎶','🎤','🎸','🥁','🎹','🎷','🎺','🎻','🪗']},
-  {name:'Nature', emojis:['🌍','🌊','🏔️','🌋','🌅','🌙','⭐','🔥','❄️','🌈','🌸','🍀']},
-  {name:'Animals', emojis:['🐕','🐈','🦁','🐻','🦊','🐺','🦅','🐉','🦋','🐬','🦈','🐙']},
-  {name:'Food', emojis:['🍕','🍔','🍣','🍜','🍩','🍰','🍷','🍺','☕','🧁','🌮','🥗']},
-  {name:'Travel', emojis:['✈️','🚂','🚗','⛵','🏖️','🗼','🏰','🗽','🎡','🏕️','🌆','🛣️']},
-  {name:'People', emojis:['👨‍👩‍👧‍👦','👫','👶','🧒','👩','👨','🧓','💃','🕺','🥷','🧑‍🚀','🧑‍🎨']},
-  {name:'Objects', emojis:['📱','💻','🎮','🕹️','📷','🔮','💡','🔑','💎','🎁','📚','✏️']},
-  {name:'Flags', emojis:[
+  {name:'${jsString(R.string.collections_editor_emoji_category_streaming)}', emojis:['🎬','🎭','🎥','📺','🍿','🎞️','📽️','🎦','📡','📻']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_genres)}', emojis:['💀','👻','🔪','💣','🚀','🛸','🧙','🦸','🧟','🤖','💘','😂','😱','🤯','🥺','😈']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_sports)}', emojis:['⚽','🏀','🏈','⚾','🎾','🏐','🏒','🥊','🏎️','🏆','🎯','🏋️']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_music)}', emojis:['🎵','🎶','🎤','🎸','🥁','🎹','🎷','🎺','🎻','🪗']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_nature)}', emojis:['🌍','🌊','🏔️','🌋','🌅','🌙','⭐','🔥','❄️','🌈','🌸','🍀']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_animals)}', emojis:['🐕','🐈','🦁','🐻','🦊','🐺','🦅','🐉','🦋','🐬','🦈','🐙']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_food)}', emojis:['🍕','🍔','🍣','🍜','🍩','🍰','🍷','🍺','☕','🧁','🌮','🥗']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_travel)}', emojis:['✈️','🚂','🚗','⛵','🏖️','🗼','🏰','🗽','🎡','🏕️','🌆','🛣️']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_people)}', emojis:['👨‍👩‍👧‍👦','👫','👶','🧒','👩','👨','🧓','💃','🕺','🥷','🧑‍🚀','🧑‍🎨']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_objects)}', emojis:['📱','💻','🎮','🕹️','📷','🔮','💡','🔑','💎','🎁','📚','✏️']},
+  {name:'${jsString(R.string.collections_editor_emoji_category_flags)}', emojis:[
     '🏳️‍🌈','🏴‍☠️',
     '🇦🇫','🇦🇱','🇩🇿','🇦🇸','🇦🇩','🇦🇴','🇦🇮','🇦🇬','🇦🇷','🇦🇲','🇦🇼','🇦🇺',
     '🇦🇹','🇦🇿','🇧🇸','🇧🇭','🇧🇩','🇧🇧','🇧🇾','🇧🇪','🇧🇿','🇧🇯','🇧🇲','🇧🇹',
@@ -1509,7 +1509,7 @@ var EMOJI_CATEGORIES = [
     '🇹🇭','🇹🇱','🇹🇬','🇹🇴','🇹🇹','🇹🇳','🇹🇷','🇹🇲','🇹🇻','🇺🇬','🇺🇦','🇦🇪',
     '🇬🇧','🇺🇸','🇺🇾','🇺🇿','🇻🇺','🇻🇪','🇻🇳','🇾🇪','🇿🇲','🇿🇼'
   ]},
-  {name:'Symbols', emojis:['❤️','💜','💙','💚','💛','🧡','🖤','🤍','✅','❌','⚡','💯']}
+  {name:'${jsString(R.string.collections_editor_emoji_category_symbols)}', emojis:['❤️','💜','💙','💚','💛','🧡','🖤','🤍','✅','❌','⚡','💯']}
 ];
 
 var openEmojiPicker = null;

--- a/app/src/main/java/com/nuvio/tv/core/server/DebridFormatterConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/DebridFormatterConfigServer.kt
@@ -86,7 +86,7 @@ class DebridFormatterConfigServer(
             gson.fromJson(gson.toJson(parsed?.get("streamPreferences")), DebridStreamPreferences::class.java)
         }.getOrNull() ?: currentSettings.streamPreferences
         if (nameTemplate == null || descriptionTemplate == null) {
-            return errorResponse("Both templates are required")
+            return errorResponse(context?.getString(com.nuvio.tv.R.string.web_debrid_error_templates_required) ?: "Both templates are required")
         }
 
         onSettingsChanged(

--- a/app/src/main/java/com/nuvio/tv/core/server/StreamBadgeConfigServer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/server/StreamBadgeConfigServer.kt
@@ -98,13 +98,13 @@ class StreamBadgeConfigServer(
         val rawSourceUrl = (parsed?.get("sourceUrl") as? String).orEmpty().trim()
         val pastedPayload = (parsed?.get("payload") as? String).orEmpty()
         if (rawSourceUrl.isBlank() && pastedPayload.isBlank()) {
-            return errorResponse("Enter a badge JSON URL.")
+            return errorResponse(context?.getString(com.nuvio.tv.R.string.web_stream_badge_error_url_required) ?: "Enter a badge JSON URL.")
         }
         if (pastedPayload.isBlank() &&
             !rawSourceUrl.startsWith("https://", ignoreCase = true) &&
             !rawSourceUrl.startsWith("http://", ignoreCase = true)
         ) {
-            return errorResponse("Badge URL must start with http:// or https://.")
+            return errorResponse(context?.getString(com.nuvio.tv.R.string.web_stream_badge_error_url_scheme) ?: "Badge URL must start with http:// or https://.")
         }
 
         val currentSettings = currentSettingsProvider()
@@ -114,7 +114,7 @@ class StreamBadgeConfigServer(
             import.sourceUrl.equals(sourceUrl, ignoreCase = true)
         }
         if (!isExistingImport && currentRules.imports.size >= STREAM_BADGE_IMPORT_LIMIT) {
-            return errorResponse("You can import up to $STREAM_BADGE_IMPORT_LIMIT badge URLs.")
+            return errorResponse(context?.getString(com.nuvio.tv.R.string.web_stream_badge_error_import_limit, STREAM_BADGE_IMPORT_LIMIT) ?: "You can import up to $STREAM_BADGE_IMPORT_LIMIT badge URLs.")
         }
 
         return try {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2675,6 +2675,7 @@
     <string name="web_debrid_template_fields">Champs de modèle</string>
     <string name="web_debrid_name_template">Modèle de nom</string>
     <string name="web_debrid_description_template">Modèle de description</string>
+    <string name="web_debrid_error_templates_required">Les deux modèles sont requis</string>
     <string name="web_debrid_stream_rules">Règles de flux</string>
     <string name="web_debrid_per_resolution">Par résolution</string>
     <string name="web_debrid_per_quality">Par qualité</string>
@@ -2695,6 +2696,9 @@
     <string name="web_stream_badge_import_error">Échec de l’import du badge.</string>
     <string name="web_stream_badge_deleted">URL de badge supprimée.</string>
     <string name="web_stream_badge_load_error">Impossible de charger les réglages des badges de flux</string>
+    <string name="web_stream_badge_error_url_required">Saisis une URL JSON de badge.</string>
+    <string name="web_stream_badge_error_url_scheme">L’URL du badge doit commencer par http:// ou https://.</string>
+    <string name="web_stream_badge_error_import_limit">Tu peux importer jusqu’à %1$d URL de badge.</string>
 
     <!-- Playback — Buffer & Network settings -->
     <string name="playback_section_buffer_network">Mémoire tampon et réseau</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2591,6 +2591,7 @@
     <string name="web_debrid_template_fields">Template fields</string>
     <string name="web_debrid_name_template">Name Template</string>
     <string name="web_debrid_description_template">Description Template</string>
+    <string name="web_debrid_error_templates_required">Both templates are required</string>
     <string name="web_debrid_stream_rules">Stream rules</string>
     <string name="web_debrid_per_resolution">Per Resolution</string>
     <string name="web_debrid_per_quality">Per Quality</string>
@@ -2611,6 +2612,9 @@
     <string name="web_stream_badge_import_error">Badge import failed.</string>
     <string name="web_stream_badge_deleted">Deleted badge URL.</string>
     <string name="web_stream_badge_load_error">Could not load stream badge settings</string>
+    <string name="web_stream_badge_error_url_required">Enter a badge JSON URL.</string>
+    <string name="web_stream_badge_error_url_scheme">Badge URL must start with http:// or https://.</string>
+    <string name="web_stream_badge_error_import_limit">You can import up to %1$d badge URLs.</string>
 
     <!-- Playback — Buffer & Network settings -->
     <string name="playback_section_buffer_network">Buffer &amp; Network</string>


### PR DESCRIPTION
## Summary

Extracts the last user-facing strings still hardcoded in the embedded web-config UI (`core/server/`). Four server error responses and the 12 emoji-picker category names are now localized. The emoji categories reuse the **existing** `collections_editor_emoji_category_*` keys (already translated in EN + FR), so only 4 new keys are added. The native Compose-TV UI is already fully internationalized; this only closes the residual gap in the web layer.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

The web config UI returned four English-only error strings (`Enter a badge JSON URL.`, the badge URL scheme check, the badge import limit, `Both templates are required`) and rendered the emoji-picker category labels (`Streaming`, `Genres`, …) hardcoded in the generated JS, so they could not follow the user's language. This pass routes them through the existing i18n mechanism (`context?.getString(R.string.x)` and `jsString(R.string.x)`).

## Issue or approval

No linked issue: localization-only update, same scope as previous localization batches.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the two string resource files and the three `core/server/*` files needed to reference the keys. The 12 emoji categories reuse existing keys (no duplication). Intentionally NOT touched: codec/standard names, brand/studio names, and other non-translatable technical labels.

## Testing

Both XML files validated with `xmllint`. Translatable EN↔FR parity verified (the only EN keys without FR are `translatable=\"false\"` Dolby Vision diagnostics). The 4 new keys exist in EN + FR; the 12 emoji wirings resolve to existing `collections_editor_emoji_category_*` keys (12/12). No hardcoded `errorResponse(\"…\")` or `name:'…'` literals remain in the touched files. Placeholders preserved (`%1$d`). Tutoiement, apostrophes typographiques, UTF-8, no mojibake.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.