### PR TITLE
fix(player): resolve Hebrew (RTL) subtitle punctuation positioning 

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1721,23 +1721,32 @@ private class CueNormalizingTextOutput(
         if (!containsRtlChars(text)) return cue
         val original = text.toString()
         val fixed = original.split('\n').joinToString("\n") { line ->
-            moveLeadingRtlPunctuationToEnd(line)
+            fixRtlPunctuationForLtr(line)
         }
         if (fixed == original) return cue
         return cue.buildUpon().setText(android.text.SpannableString(fixed)).build()
     }
 
-    // In RTL subtitle files punctuation is stored at the logical start of the string,
-    // which should visually appear at the right (end) in RTL. Since SubtitlePainter
-    // renders LTR, we physically move the punctuation to the end of each line.
-    private fun moveLeadingRtlPunctuationToEnd(line: String): String {
+    private fun fixRtlPunctuationForLtr(line: String): String {
         if (line.isEmpty()) return line
-        var end = 0
-        while (end < line.length && line[end] in RTL_PUNCTUATION) end++
-        if (end == 0) return line
-        val punct = line.substring(0, end)
-        val rest = line.substring(end)
-        return "$rest$punct"
+        
+        var start = 0
+        while (start < line.length && isRtlPunctuation(line[start])) start++
+        
+        var end = line.length
+        while (end > start && isRtlPunctuation(line[end - 1])) end--
+        
+        if (start == 0 && end == line.length) return line
+        
+        val leadingPunct = line.substring(0, start)
+        val middle = line.substring(start, end)
+        val trailingPunct = line.substring(end)
+        
+        return "$trailingPunct$middle$leadingPunct"
+    }
+
+    private fun isRtlPunctuation(ch: Char): Boolean {
+        return ch in RTL_PUNCTUATION || ch.isWhitespace()
     }
 
     private fun containsRtlChars(text: CharSequence): Boolean {
@@ -1750,7 +1759,7 @@ private class CueNormalizingTextOutput(
     }
 
     companion object {
-        private val RTL_PUNCTUATION = setOf('.', ',', '?', '!', '-', ':', ';', '…', ')', '(')
+        private val RTL_PUNCTUATION = setOf('.', ',', '?', '!', '-', ':', ';', '…', ')', '(', '\'', '"')
     }
 }
 


### PR DESCRIPTION
## Summary

This PR resolves incorrect positioning of punctuation characters in Hebrew (RTL) subtitles by physically swapping starting and ending punctuation to match the player's LTR layout rendering context.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The player's text rendering engine (Media3 `SubtitleView`) renders subtitle lines in an LTR layout on Android TV devices. In an LTR layout:
- Punctuation at the logical start is rendered on the left.
- Punctuation at the logical end is rendered on the right.

For Hebrew (RTL), this is visually reversed (dialogue dashes should be on the right, and periods/question marks/quotes should be on the left). 

To fix this natively on LTR-only layout renderers:
1. Punctuation at the logical start (like `-`) is moved to the end of the string so that it renders on the right.
2. Punctuation at the logical end (like `.`, `?`, `'`, `"`) is moved to the start of the string so that it renders on the left.
3. Whitespace characters are treated as part of the punctuation blocks, ensuring spaces (such as the space next to dialogue dashes: `- `) are correctly moved together with the symbols, maintaining correct visual spacing.

## Issue or approval

Fixes #2299

## Reproduction steps

1. Play any video with Hebrew (RTL) subtitles.
2. Load subtitle lines that contain punctuation characters (such as `-`, `'`, `"`, `.`) at the start or end of the sentence.
3. Observe that these characters are rendered at the wrong end of the line (e.g., a trailing quote or period appearing on the right/beginning of the sentence).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change is strictly bounded to the `fixRtlCueText` helper within [PlayerRuntimeControllerInitialization.kt](file:///c:/Users/halil/Desktop/nuvio/NuvioTV/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt). No other files or player core components are affected.

## Testing

1. Sideloaded and manually tested on device (Android TV), validating that:
   - Dialogue dashes (`- שלום`) remain correctly on the right (start) with correct spacing.
   - Trailing punctuation (`שלום.`, `שלום -`, `שלום'`, `שלום"`) correctly remain on the left (end) with correct spacing.
   - Quotes enclosing words (`"שלום"`, `'שלום'`) correctly render on both sides.

## Screenshots / Video

Fixed a documented subtitle rendering glitch.

## Breaking changes

None.

## Linked issues

Fixes #2299
