### PR TITLE
fix(player): restore 23.976 AFR probe bias

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -101,7 +101,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
             )
         }
 
-        val prefer23976ProbeBias = detection.raw in 23.95f..23.988f
+        val prefer23976ProbeBias = detection.raw in 23.95f..24.12f
         val targetFrameRate = FrameRateUtils.refineFrameRateForDisplay(
             activity = activity,
             detectedFps = detection.snapped,


### PR DESCRIPTION
## Summary

Restores the previous AFR probe bias range for ambiguous cinema-rate detection.

This changes `prefer23976ProbeBias` from `23.95f..23.988f` back to `23.95f..24.12f`, so MKV sources that are actually `23.976 fps` can still be matched to `23.976 Hz` instead of incorrectly switching to `24.000 Hz`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some MKV movies encoded at `23.976 fps` are being detected as `24.0 fps` by the AFR probe. Since PR #2038 narrowed the `23.976` bias range, those files no longer get corrected to NTSC film rate and the display may switch to `24.000 Hz` instead of `23.976 Hz`.

This restores the previous bias behavior while keeping the duplicate AFR preflight guard intact.

## Issue or approval

#2305. Regression identified while comparing current `dev` against `0.6.17-beta`, where the same affected content matched correctly.


## Reproduction steps

1. Enable automatic frame rate matching.
2. Play an affected MKV movie that is actually `23.976 fps`.
3. Observe that the AFR probe reports/detects it as `24.0 fps`.
4. The display switches to `24.000 Hz` instead of `23.976 Hz`.
5. With this PR, the same ambiguous probe result is biased back to `23.976 Hz`.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only restores the ambiguous `23.976` AFR probe bias range. It does not revert the duplicate AFR preflight guard and does not add UI, settings, refactors, or unrelated playback changes.

## Testing

- Built successfully with `./gradlew.bat :app:assembleFullDebug --console=plain`.
- Verified the code diff only changes the `prefer23976ProbeBias` range.
- Tested some streams and it correctly assigned 23.976.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2305