### PR TITLE
fix: Watch Next ID overzealous cleanup

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
@@ -104,7 +104,7 @@ class ProgramBuilder @Inject constructor(
                     )
                     if (idIdx >= 0) {
                         val providerId = it.getString(idIdx)
-                        if (providerId != null && providerId.startsWith("wn_${contentId}")) {
+                        if (watchNextIdMatchesContentId(providerId, contentId)) {
                             val pkIdx = it.getColumnIndex(TvContractCompat.WatchNextPrograms._ID)
                             if (pkIdx >= 0) {
                                 val uri = TvContractCompat.buildWatchNextProgramUri(it.getLong(pkIdx))
@@ -197,4 +197,16 @@ class ProgramBuilder @Inject constructor(
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }.toUri(Intent.URI_INTENT_SCHEME)
         )
+}
+
+internal fun watchNextIdMatchesContentId(providerId: String?, contentId: String): Boolean {
+    val baseId = "wn_$contentId"
+    if (providerId == baseId) return true
+    if (providerId?.startsWith("${baseId}_s") != true) return false
+
+    val episodeSeparator = providerId.indexOf('e', startIndex = baseId.length + 2)
+    return episodeSeparator > baseId.length + 2 &&
+        episodeSeparator < providerId.lastIndex &&
+        providerId.substring(baseId.length + 2, episodeSeparator).all { it.isDigit() } &&
+        providerId.substring(episodeSeparator + 1).all { it.isDigit() }
 }

--- a/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
@@ -207,6 +207,6 @@ internal fun watchNextIdMatchesContentId(providerId: String?, contentId: String)
     val episodeSeparator = providerId.indexOf('e', startIndex = baseId.length + 2)
     return episodeSeparator > baseId.length + 2 &&
         episodeSeparator < providerId.lastIndex &&
-        providerId.substring(baseId.length + 2, episodeSeparator).all { it.isDigit() } &&
-        providerId.substring(episodeSeparator + 1).all { it.isDigit() }
+        (baseId.length + 2 until episodeSeparator).all { providerId[it].isDigit() } &&
+        (episodeSeparator + 1..providerId.lastIndex).all { providerId[it].isDigit() }
 }

--- a/app/src/test/java/com/nuvio/tv/core/recommendations/ProgramBuilderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/recommendations/ProgramBuilderTest.kt
@@ -1,0 +1,20 @@
+package com.nuvio.tv.core.recommendations
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProgramBuilderTest {
+
+    @Test
+    fun `watch next content id match does not delete prefix collisions`() {
+        assertTrue(watchNextIdMatchesContentId("wn_tt1", "tt1"))
+        assertTrue(watchNextIdMatchesContentId("wn_tt1_s2e3", "tt1"))
+
+        assertFalse(watchNextIdMatchesContentId("wn_tt10", "tt1"))
+        assertFalse(watchNextIdMatchesContentId("wn_tt10_s2e3", "tt1"))
+        assertFalse(watchNextIdMatchesContentId("wn_tt1extra", "tt1"))
+        assertFalse(watchNextIdMatchesContentId("wn_tt1_series", "tt1"))
+        assertFalse(watchNextIdMatchesContentId(null, "tt1"))
+    }
+}


### PR DESCRIPTION
## Summary

Fix Android TV Watch Next cleanup; removing one NuvioTV recommendation now only matches that exact title or its generated episode entries.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Android TV Watch Next entries use internal provider ids such as `wn_tt1`, `wn_tt1_s2e3`, and `wn_tt10`.

Previously, cleanup by content id used a broad prefix match. Removing entries for `tt1` could also match unrelated entries such as `tt10`, causing other Watch Next recommendations to disappear from the Android TV home screen.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioTV/issues/2309

## Reproduction steps

1. Have Android TV Watch Next entries with similar content id prefixes, for example `wn_tt1` and `wn_tt10`.
2. Trigger cleanup for content id `tt1`, such as by clearing/removing that item from Watch Next.
3. Before this fix, the cleanup matched `wn_tt10` as well because it only checked the `wn_tt1` prefix.
4. After this fix, only `wn_tt1` and generated episode ids like `wn_tt1_s2e3` are matched.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Only Android TV Watch Next provider-id matching was changed. This does not change recommendation creation, playback, in-app Continue Watching UI, sync behavior, or Android TV channel rendering.

## Testing

App works per my usage with standard add ons I have usually installed. Added unit coverage for Watch Next provider-id matching, including exact content ids, generated episode ids, prefix collisions such as `tt1` vs `tt10`, malformed suffixes, and null provider ids.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/2309