### PR TITLE
fix(player): early-exit next-episode stream search on binge-group/regex match

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -18,6 +18,7 @@ import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.ui.components.SourceChipItem
 import com.nuvio.tv.ui.components.SourceChipStatus
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -1529,6 +1530,9 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
             var autoSelectTriggered = false
             var timeoutElapsed = false
             var lastError: NetworkResult.Error? = null
+            // Completed as soon as a stream is selected or the addon search
+            // finishes, so the waiting code below resumes without polling.
+            val searchSettled = CompletableDeferred<Unit>()
 
             fun trySelectStream(data: List<AddonStreams>): Stream? {
                 val orderedStreams = StreamAutoPlaySelector.orderAddonStreams(data, installedAddonOrder)
@@ -1569,8 +1573,13 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                 )
             }
 
+            fun recordSelection(candidate: Stream) {
+                autoSelectTriggered = true
+                selectedStream = candidate
+                searchSettled.complete(Unit)
+            }
+
             val timeoutSeconds = playerSettings.streamAutoPlayTimeoutSeconds
-            val isUnlimitedTimeout = timeoutSeconds == PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_UNLIMITED
 
             val innerJob = launch {
                 streamRepository.getStreamsFromAllAddons(
@@ -1582,86 +1591,65 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                     when (result) {
                         is NetworkResult.Success -> {
                             lastSuccessData = result.data
-                            if (autoSelectTriggered) {
-                                // Already resolved.
-                            } else if (timeoutElapsed) {
-                                // Timeout elapsed: full select (binge group +
-                                // fallback to mode).
-                                val candidate = trySelectStream(result.data)
-                                if (candidate != null) {
-                                    autoSelectTriggered = true
-                                    selectedStream = candidate
+                            if (!autoSelectTriggered) {
+                                val candidate = when {
+                                    // After the timeout: full select (binge group + mode fallback).
+                                    timeoutElapsed -> trySelectStream(result.data)
+                                    // Before the timeout with binge preference on: only an exact
+                                    // binge group match wins; the mode fallback waits for the timeout.
+                                    playerSettings.streamAutoPlayPreferBingeGroupForNextEpisode ->
+                                        tryBingeGroupOnly(result.data)
+                                    // Before the timeout with binge preference off: the configured
+                                    // mode is the primary selector, so take the first match now
+                                    // instead of waiting the full timeout (#2144).
+                                    else -> trySelectStream(result.data)
                                 }
-                            } else {
-                                // Before timeout: eagerly check binge group only.
-                                val earlyMatch = tryBingeGroupOnly(result.data)
-                                if (earlyMatch != null) {
-                                    autoSelectTriggered = true
-                                    selectedStream = earlyMatch
-                                }
+                                if (candidate != null) recordSelection(candidate)
                             }
                         }
                         is NetworkResult.Error -> lastError = result
                         NetworkResult.Loading -> Unit
                     }
                 }
+                // Every addon has responded: take whatever matched, then settle so
+                // the waiting code below resumes even if nothing was selected.
                 if (!autoSelectTriggered) {
-                    autoSelectTriggered = true
-                    lastSuccessData?.let { selectedStream = trySelectStream(it) }
+                    lastSuccessData?.let { data -> trySelectStream(data)?.let { recordSelection(it) } }
                 }
+                searchSettled.complete(Unit)
             }
 
             val timeoutMs = timeoutSeconds * 1_000L
             if (PlayerSettings.isBoundedTimeout(timeoutSeconds)) {
-                // Wait for timeout, but break early if an early binge group match is found.
-                val pollIntervalMs = 200L
-                var waited = 0L
-                while (waited < timeoutMs && !autoSelectTriggered) {
-                    delay(pollIntervalMs)
-                    waited += pollIntervalMs
-                }
+                // Wait for the timeout, resuming as soon as a stream is settled.
+                withTimeoutOrNull(timeoutMs) { searchSettled.await() }
                 timeoutElapsed = true
-                if (!autoSelectTriggered && lastSuccessData != null) {
-                    val candidate = trySelectStream(lastSuccessData!!)
-                    if (candidate != null) {
-                        autoSelectTriggered = true
-                        selectedStream = candidate
-                    }
-                }
-                if (selectedStream != null) {
-                    // Found a match (early binge group or post-timeout full select).
-                    innerJob.cancel()
-                } else if (lastSuccessData != null) {
-                    // Streams arrived but no match after full select.
-                    // Respect the original timeout - don't wait further.
-                    innerJob.cancel()
-                    autoSelectTriggered = true
-                } else {
-                    // No addon responded yet - wait for the first result with
-                    // a hard ceiling so we never hang indefinitely.
-                    val completed = withTimeoutOrNull(timeoutMs) { innerJob.join() }
-                    if (completed == null) {
-                        innerJob.cancel()
-                        // One last attempt with whatever data arrived
-                        if (!autoSelectTriggered && lastSuccessData != null) {
-                            selectedStream = trySelectStream(lastSuccessData!!)
+                if (!autoSelectTriggered) {
+                    val data = lastSuccessData
+                    if (data != null) {
+                        // Streams arrived: full select once. If nothing matches,
+                        // respect the timeout and stop (the caller shows the picker).
+                        trySelectStream(data)?.let { recordSelection(it) }
+                    } else {
+                        // No addon responded yet: keep waiting for the first usable
+                        // result, bounded so we never hang indefinitely.
+                        withTimeoutOrNull(timeoutMs) { searchSettled.await() }
+                        if (!autoSelectTriggered) {
+                            lastSuccessData?.let { trySelectStream(it)?.let { s -> recordSelection(s) } }
                         }
                     }
                 }
+                innerJob.cancel()
             } else {
-                // Instant (0) or unlimited: timeoutElapsed immediately so each
-                // addon response triggers a full select attempt in the collect.
-                // For unlimited we wait up to the hard ceiling; for instant (0)
-                // we also wait but the first Success will resolve via collect.
+                // Instant (0) or unlimited: timeoutElapsed immediately so each addon
+                // response triggers a full select attempt in the collect. Resume on
+                // the first match, bounded by the hard ceiling so we never hang.
                 timeoutElapsed = true
-                val hardTimeout = if (isUnlimitedTimeout) NEXT_EPISODE_HARD_TIMEOUT_MS else NEXT_EPISODE_HARD_TIMEOUT_MS
-                val completed = withTimeoutOrNull(hardTimeout) { innerJob.join() }
-                if (completed == null) {
-                    innerJob.cancel()
-                    if (!autoSelectTriggered && lastSuccessData != null) {
-                        selectedStream = trySelectStream(lastSuccessData!!)
-                    }
+                withTimeoutOrNull(NEXT_EPISODE_HARD_TIMEOUT_MS) { searchSettled.await() }
+                if (!autoSelectTriggered) {
+                    lastSuccessData?.let { data -> trySelectStream(data)?.let { recordSelection(it) } }
                 }
+                innerJob.cancel()
             }
 
             val streamToPlay = selectedStream?.let {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1593,16 +1593,10 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                             lastSuccessData = result.data
                             if (!autoSelectTriggered) {
                                 val candidate = when {
-                                    // After the timeout: full select (binge group + mode fallback).
                                     timeoutElapsed -> trySelectStream(result.data)
-                                    // Before the timeout with binge preference on: only an exact
-                                    // binge group match wins; the mode fallback waits for the timeout.
                                     playerSettings.streamAutoPlayPreferBingeGroupForNextEpisode ->
                                         tryBingeGroupOnly(result.data)
-                                    // Before the timeout with binge preference off: the configured
-                                    // mode is the primary selector, so take the first match now
-                                    // instead of waiting the full timeout (#2144).
-                                    else -> trySelectStream(result.data)
+                                    else -> null
                                 }
                                 if (candidate != null) recordSelection(candidate)
                             }
@@ -1640,11 +1634,14 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                     }
                 }
                 innerJob.cancel()
-            } else {
-                // Instant (0) or unlimited: timeoutElapsed immediately so each addon
-                // response triggers a full select attempt in the collect. Resume on
-                // the first match, bounded by the hard ceiling so we never hang.
+            } else if (timeoutSeconds == 0) {
                 timeoutElapsed = true
+                withTimeoutOrNull(NEXT_EPISODE_HARD_TIMEOUT_MS) { searchSettled.await() }
+                if (!autoSelectTriggered) {
+                    lastSuccessData?.let { data -> trySelectStream(data)?.let { recordSelection(it) } }
+                }
+                innerJob.cancel()
+            } else {
                 withTimeoutOrNull(NEXT_EPISODE_HARD_TIMEOUT_MS) { searchSettled.await() }
                 if (!autoSelectTriggered) {
                     lastSuccessData?.let { data -> trySelectStream(data)?.let { recordSelection(it) } }


### PR DESCRIPTION
## Summary

`playNextEpisode()` now exits the addon search as soon as a binge-group match is found, instead of waiting for every addon to respond or the full timeout to elapse. The wait is driven by a `CompletableDeferred` so the binge-group match is noticed immediately (replacing a 200 ms polling loop), and the collection job is cancelled by reference once settled.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With "Prefer Binge Group" on and a slow addon present, the next episode could take 30+ seconds to start (#2229): the addon search ran to completion before any selection was made, so even though the binge-group stream arrived in ~2 s the app waited the full duration of the slowest addon. Bounded timeouts and Unlimited both respect the user's addon order and accumulated result set; only a confirmed binge-group match exits early.

## Issue or approval

Fixes #2229.

## Reproduction steps

1. Configure Stream Auto-play with Prefer Binge Group. Enable one fast addon and one slow addon (20+ s response time).
2. Play a series episode, then let it end (or press Play Next Episode).
3. Before: the next episode hangs on "Finding source" for 20+ s even though the binge-group stream arrived in ~2 s. After: it starts within ~2 s.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the coroutine flow inside `playNextEpisode()` changes. Bounded timeouts still wait out the configured duration before selecting; Unlimited still waits for all addons to respond; the user's addon order is respected in both cases. Only a confirmed binge-group match causes an early exit. Stream selection logic in `StreamAutoPlaySelector` is unchanged and there are no UI changes.

## Testing

Built the full debug variant with `./gradlew :app:compileFullDebugKotlin` (BUILD SUCCESSFUL) and compiled the unit test sources with `./gradlew :app:compileFullDebugUnitTestKotlin` (BUILD SUCCESSFUL). Traced the coroutine paths for bounded, instant, and unlimited timeouts with binge preference both on and off, including the no-addon-responded fallback and the flow-completes-early path. Unit test execution and on-device runtime testing were not performed (the only JDK available is 24, which Gradle 8.13 cannot use for the test task, and no physical Android TV device is available).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2229.
