### PR TITLE
fix(player): refresh subtitle cues after manual delay change while paused

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -608,11 +608,7 @@ internal fun PlayerRuntimeController.adjustSubtitleDelay(deltaMs: Int, showOverl
         }
     }
 
-    _exoPlayer?.let { player ->
-        player.trackSelectionParameters = player.trackSelectionParameters
-            .buildUpon()
-            .build()
-    }
+    refreshActiveSubtitleTrackAfterTimingChange()
     // Remember the delay so it survives to the next session (issue #1063).
     persistTrackPreference()
 


### PR DESCRIPTION
## Summary

Moving the subtitle delay slider while the video is paused only updated the on-screen cue in one direction. `adjustSubtitleDelay()` now calls `refreshActiveSubtitleTrackAfterTimingChange()` (the helper already used by subtitle auto-sync) instead of a no-op `trackSelectionParameters` rebuild, so the active cue is reloaded at the current position with the new offset in both directions.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

ExoPlayer subtitle timing is applied by `SubtitleOffsetRenderer.render()`, which reads `subtitleDelayUs` on every render call. While playing, `render()` is called continuously so a new delay is picked up on the next frame; while paused, `render()` is not called again, so the new offset is never applied and the displayed cue stays stale. The previous no-op `trackSelectionParameters` rebuild does not force a render while paused, so subtitle delay is effectively broken in one direction when paused (#2205).

## Issue or approval

Fixes #2205.

## Reproduction steps

1. Play a video with a subtitle track selected.
2. Pause so a subtitle cue is on screen.
3. Open the subtitle delay overlay and slide the delay to the right (positive offset).
4. Before: the cue stays on screen unchanged. After: it updates to reflect the new delay within 90 ms.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Single change inside `adjustSubtitleDelay()`: the no-op `trackSelectionParameters` rebuild is replaced with the existing `refreshActiveSubtitleTrackAfterTimingChange()` helper. No new helper is added, there are no UI changes, and the MPV path (`mpvView.setSubtitleDelayMs`) is untouched. No other files are changed.

## Testing

Built the full debug variant with `./gradlew :app:compileFullDebugKotlin` (BUILD SUCCESSFUL) and compiled the unit test sources with `./gradlew :app:compileFullDebugUnitTestKotlin` (BUILD SUCCESSFUL). Confirmed the helper guards against a null player and no active subtitle track, and that it is the same mechanism already used by `applySubtitleAutoSyncCue`. Unit test execution and on-device runtime testing were not performed (the only JDK available is 24, which Gradle 8.13 cannot use for the test task, and no physical Android TV device is available).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2205.
