### PR TITLE
Fix external player auto next on debrid cache sync placeholders

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -126,6 +126,11 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val AUTO_NEXT_OVERLAY_TIMEOUT_MS = 20_000L
         /** Max time to wait for series meta when resolving the next episode. */
         private const val META_FETCH_TIMEOUT_MS = 15_000L
+        /** A "completed" playback shorter than this is treated as a debrid cache-sync placeholder
+         *  (e.g. Comet's few-second clip), not a real episode: not marked watched, no auto-advance. */
+        private const val MIN_REAL_PLAYBACK_DURATION_MS = 60_000L
+        /** A launch within this of an auto-next emit counts as a chain continuation. */
+        private const val CONTINUATION_WINDOW_MS = 12_000L
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -137,6 +142,14 @@ class ExternalPlaybackTracker @Inject constructor(
     // from firing for the current return (e.g. while VLC's duration backfill is still running).
     // Reset on each new launch in startTracking.
     private var autoNextCancelled = false
+    // Durable version of autoNextCancelled: survives the auto-launched chain so one Back press
+    // stops a runaway loop. Reset on a fresh (non-continuation) launch.
+    private var autoNextChainAborted = false
+    // Timestamp of the last auto-next emit. A launch within CONTINUATION_WINDOW_MS of it counts as
+    // a chain continuation (so an abort survives it); a later launch is fresh and clears the abort.
+    // Using a time window instead of a sticky flag means the abort can never get permanently stuck
+    // if a continuation never actually launches (e.g. user backed out before it auto-played).
+    private var lastAutoNextEmitMs = 0L
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
     // the next episode's Stream route. replay = 1 so the event still reaches the
@@ -183,6 +196,11 @@ class ExternalPlaybackTracker @Inject constructor(
         isAutoLaunch = autoLaunch
         // Fresh launch — allow the auto-next loader / advance again.
         autoNextCancelled = false
+        // A continuation of the auto-next chain (a launch right after an emit) keeps a user's abort
+        // in effect; any later launch (manual click, or a replay) is fresh and re-enables auto-next.
+        if (System.currentTimeMillis() - lastAutoNextEmitMs >= CONTINUATION_WINDOW_MS) {
+            autoNextChainAborted = false
+        }
         // Next player is launching and will cover the screen — drop the loader.
         _autoNextOverlay.value = null
         // Persist so progress-save + auto-next survive the player killing our process.
@@ -350,6 +368,19 @@ class ExternalPlaybackTracker @Inject constructor(
 
     /** Completion check + save + auto-next + cleanup for a result with a resolved duration. */
     private fun processResult(metadata: ExternalPlaybackMetadata, result: ExternalPlayerResult) {
+        // Debrid cache-sync placeholders (e.g. Comet) play a few-second clip to its end and report
+        // a normal completion. Ignore an implausibly short playback so it isn't marked watched and
+        // doesn't chain auto-next through the season. A missing/zero duration is left to the normal
+        // path (so Just Player's end-only completion still works).
+        val duration = result.durationMs
+        if (duration != null && duration in 1 until MIN_REAL_PLAYBACK_DURATION_MS) {
+            Log.d(TAG, "Ignoring ${duration}ms playback (likely a cache-sync placeholder)")
+            _autoNextOverlay.value = null
+            clearPersistedMetadata()
+            stopTracking()
+            return
+        }
+
         if (isPlaybackCompleted(result)) {
             // Mark watched even when the player returns no position/duration (e.g. Just
             // Player sends only end_by=playback_completion). An explicit 100% forces
@@ -487,9 +518,9 @@ class ExternalPlaybackTracker @Inject constructor(
         if (season == null || episode == null || type !in listOf("series", "tv")) {
             return
         }
-        // User already backed out of the loader for this return (e.g. during VLC's backfill) —
-        // don't re-raise it or advance.
-        if (autoNextCancelled) {
+        // User backed out of the loader — for this return (autoNextCancelled) or to stop a
+        // runaway chain (autoNextChainAborted). Don't re-raise the loader or advance.
+        if (autoNextCancelled || autoNextChainAborted) {
             _autoNextOverlay.value = null
             return
         }
@@ -549,6 +580,9 @@ class ExternalPlaybackTracker @Inject constructor(
                     "(from S${season}E${episode}, content=${metadata.contentId})"
             )
 
+            // Mark the time of this emit so the resulting launch is recognised as a chain
+            // continuation (and a user abort survives it).
+            lastAutoNextEmitMs = System.currentTimeMillis()
             _autoPlayNext.emit(
                 ExternalAutoNextEpisode(
                     contentId = metadata.contentId,
@@ -578,13 +612,27 @@ class ExternalPlaybackTracker @Inject constructor(
     // loader's text. Cancellation: backing out sets autoNextCancelled (reset per launch in
     // startTracking) so neither the loader nor the advance re-fires for the current return.
 
-    /** Hide the loader and cancel the pending auto-next, so backing out actually stops it
-     *  instead of advancing anyway. Progress is still saved; only the advance is canceled. */
+    /** Hide the loader and cancel the pending auto-next, so backing out actually stops it instead
+     *  of advancing anyway. Sets the durable chain abort too, so one Back press stops a runaway
+     *  auto-next loop (it won't re-fire until a fresh/manual launch). Progress stays saved. */
     fun dismissAutoNextOverlay() {
         autoNextCancelled = true
+        autoNextChainAborted = true
         autoNextJob?.cancel()
         autoNextJob = null
         _autoNextOverlay.value = null
+    }
+
+    /** The next-episode auto-play was navigated to but the user has aborted the chain — the Stream
+     *  screen calls this to skip the auto-launch and fall back to the source list. Only within the
+     *  continuation window, so it can't suppress a fresh first auto-play of an unrelated title. */
+    fun isAutoNextContinuationAborted(): Boolean =
+        autoNextChainAborted && System.currentTimeMillis() - lastAutoNextEmitMs < CONTINUATION_WINDOW_MS
+
+    /** Called by the Stream screen when it skips an aborted continuation, so the window expires and
+     *  the next launch is treated as fresh (re-enabling auto-next). */
+    fun consumeAbortedAutoNextContinuation() {
+        lastAutoNextEmitMs = 0L
     }
 
     /** Raise the loader the instant we return (from MainActivity.onStart, before the result is
@@ -595,7 +643,7 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
-        if (autoNextCancelled) return
+        if (autoNextCancelled || autoNextChainAborted) return
         if (metadata.season == null || metadata.episode == null) return
         if (metadata.contentType.lowercase() !in listOf("series", "tv")) return
         if (_autoNextOverlay.value != null) return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -248,6 +248,12 @@ fun StreamScreen(
 
     LaunchedEffect(uiState.autoPlayStream) {
         val stream = uiState.autoPlayStream ?: return@LaunchedEffect
+        // User aborted the auto-next chain that navigated here — don't auto-launch; show the list.
+        if (viewModel.isAutoNextContinuationAborted()) {
+            viewModel.consumeAbortedAutoNextContinuation()
+            viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
+            return@LaunchedEffect
+        }
         val playbackInfo = viewModel.resolveStreamForPlayback(stream)
         if (playbackInfo == null) {
             viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
@@ -277,6 +283,12 @@ fun StreamScreen(
 
     LaunchedEffect(uiState.autoPlayPlaybackInfo) {
         val playbackInfo = uiState.autoPlayPlaybackInfo ?: return@LaunchedEffect
+        // User aborted the auto-next chain that navigated here — don't auto-launch; show the list.
+        if (viewModel.isAutoNextContinuationAborted()) {
+            viewModel.consumeAbortedAutoNextContinuation()
+            viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
+            return@LaunchedEffect
+        }
         if (playbackInfo.url != null || (playbackInfo.isTorrent && playbackInfo.infoHash != null)) {
             // Torrent cached links still need P2P consent
             if (playbackInfo.isTorrent && !p2pEnabled) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1189,6 +1189,12 @@ class StreamScreenViewModel @Inject constructor(
 
     fun isExternalPlayerAutoLaunch(): Boolean = externalPlaybackTracker.isAutoLaunch
 
+    /** True when this screen was reached by an auto-next that the user has since aborted, so its
+     *  pending auto-launch should be skipped (fall back to the source list). */
+    fun isAutoNextContinuationAborted(): Boolean = externalPlaybackTracker.isAutoNextContinuationAborted()
+
+    fun consumeAbortedAutoNextContinuation() = externalPlaybackTracker.consumeAbortedAutoNextContinuation()
+
     /** Release the MainActivity auto-next loader once this Stream screen has settled. */
     fun dismissExternalAutoNextOverlay() {
         externalPlaybackTracker.dismissAutoNextOverlay()


### PR DESCRIPTION
## Summary

Follow up fix to the external player support added in #2294. Some debrid sources (observed with Comet) occasionally hand the external player a few second "cache sync" placeholder clip instead of the real file. The player plays that clip to its end and reports a normal completion, so the external player tracker treated it as a real watched episode: it marked the episode watched and auto advanced. Because each placeholder completes in seconds, this could chain auto next through a whole season and trap the user on the "Loading next episode" loader, since Back could not keep up with the loop.

Two changes:

- Ignore a "completion" whose known total duration is under 60 seconds, treating it as a cache sync placeholder rather than a real episode: it is not marked watched and does not auto advance. A missing or zero duration is left to the normal path, so end only completions (e.g. Just Player) still work.
- Make a Back press on the "Loading next episode" loader durably abort the whole auto next chain. The abort now survives the auto launched continuation and blocks the next screen from auto launching, so a single Back always stops a runaway loop. It re enables automatically on the next fresh or manual launch.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Without this, a debrid cache sync placeholder marks the episode watched when it was never actually watched, and silently auto advances. In the worst case it loops through placeholders and the user cannot escape the loader except by force exiting to the home screen. Both are regressions in the external player auto next flow added in #2294.

## Issue or approval

No separate bug issue. Follow up to #2294 (external player support). Diagnosed from a device logcat showing an 8 second Comet placeholder returning end_by=playback_completion, with the tracker then marking it watched and auto advancing.

## Reproduction steps

1. Open a series and play an episode through an external player, choosing a debrid source that returns a cache sync placeholder (observed with Comet).
2. The external player opens a few second clip (not the real file) and it plays to its end.
3. Before this change: the episode is marked watched, auto next advances to the next episode, and because each placeholder completes in seconds it keeps chaining forward, so the "Loading next episode" loader stays up and Back cannot break out.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Limited to ExternalPlaybackTracker (the short playback guard plus the durable abort state), the Stream screen's two auto play effects (skip an aborted continuation), and two small ViewModel delegates. Normal playback, normal auto next, and every other flow are untouched: the new paths only run on a sub 60 second completion, or after the user backs out of the loader.

## Testing

Diagnosed from a captured device logcat of the real incident (8 second Comet placeholder returns end_by=playback_completion, tracker marks it watched and auto advances). Builds against current dev (compileFullDebugKotlin). The duration guard directly addresses the logged behavior. On device confirmation of the durable abort path is recommended before relying on it. Both changes fail safe: if the abort logic is imperfect in some timing case it degrades to the prior behavior (at worst one more short clip plays), never a crash or data loss.

## Known issues and risks

- The duration guard keys on total duration, so it assumes players report duration in milliseconds (true for the players this integration handles) and that real episodes are longer than 60 seconds.
- The durable abort is the more involved of the two changes. It is gated entirely behind the user pressing Back on the loader, so it cannot affect a normal auto next, and it fails safe.

## Screenshots / Video

Not a UI change (loader/auto next behavior only).

## Breaking changes

None.

## Linked issues

No separate linked issue. Follow up to #2294.
