### PR TITLE
fix(player): recover from AudioTrack write failures (5002), not just init failures

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -123,9 +123,8 @@ internal fun isRetryablePlaybackError(error: PlaybackException): Boolean {
 internal fun isAudioTrackFailure(errorCode: Int, combinedMessage: String): Boolean {
     if (errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED) return true
     if (errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED) return true
-    val haystack = combinedMessage.lowercase()
-    return haystack.contains("audiotrack init failed") ||
-        haystack.contains("audiotrack write failed")
+    return combinedMessage.contains("audiotrack init failed", ignoreCase = true) ||
+        combinedMessage.contains("audiotrack write failed", ignoreCase = true)
 }
 
 internal fun PlaybackException.findInvalidResponseCodeException(): HttpDataSource.InvalidResponseCodeException? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -103,6 +103,31 @@ internal fun isRetryablePlaybackError(error: PlaybackException): Boolean {
     }
 }
 
+/**
+ * Audio-track failures that the safe-audio → audio-disabled fallback ladder can recover from.
+ *
+ * - [PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED] (5001): the AudioTrack could not be
+ *   created (e.g. the requested passthrough/offload encoding is not actually accepted by the sink).
+ * - [PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED] (5002): a write to the AudioTrack
+ *   failed, most commonly with `AudioTrack.ERROR_DEAD_OBJECT` (-6) when an HDMI/audio-route
+ *   renegotiation invalidates an E-AC-3/AC-3 passthrough or offload track mid-playback.
+ *
+ * Both are remedied by re-selecting audio with tunneling/passthrough off and the channel count
+ * constrained to the device's capabilities (safe-audio mode), or by dropping audio entirely — so
+ * a write failure must take the same recovery path as an init failure rather than landing on the
+ * fatal error screen.
+ *
+ * [combinedMessage] is the concatenated exception/cause messages; the string checks are a safety
+ * net for devices that surface the same failure under a generic error code.
+ */
+internal fun isAudioTrackFailure(errorCode: Int, combinedMessage: String): Boolean {
+    if (errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED) return true
+    if (errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED) return true
+    val haystack = combinedMessage.lowercase()
+    return haystack.contains("audiotrack init failed") ||
+        haystack.contains("audiotrack write failed")
+}
+
 internal fun PlaybackException.findInvalidResponseCodeException(): HttpDataSource.InvalidResponseCodeException? {
     var current: Throwable? = cause
     while (current != null) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1211,7 +1211,12 @@ internal fun PlayerRuntimeController.initializePlayer(
                             }
                         }
 
-                        if (error.isAudioTrackInitializationFailure()) {
+                        // AudioTrack init (5001) or write (5002, e.g. ERROR_DEAD_OBJECT on an
+                        // E-AC-3/AC-3 passthrough or offload track) failure: re-select audio with
+                        // passthrough/tunneling off and the channel count constrained to the
+                        // device's capabilities, then fall back to disabling audio so video keeps
+                        // playing — instead of surfacing the fatal error screen.
+                        if (error.isAudioTrackFailure()) {
                             if (!isSafeAudioModeActiveForCurrentPlayback) {
                                 safeAudioForcedStreamUrls.add(currentStreamUrl)
                                 retryCurrentStreamWithSafeAudioFallback(currentPosition)
@@ -1830,8 +1835,7 @@ private fun PlaybackException.isUnexpectedLoaderNullPointer(): Boolean {
             (details.contains("nullpointerexception", ignoreCase = true) && details.contains("matroskaextractor", ignoreCase = true))
 }
 
-private fun PlaybackException.isAudioTrackInitializationFailure(): Boolean {
-    if (errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED) return true
+private fun PlaybackException.isAudioTrackFailure(): Boolean {
     val details = buildString {
         append(message ?: "")
         append(' ')
@@ -1839,7 +1843,7 @@ private fun PlaybackException.isAudioTrackInitializationFailure(): Boolean {
         append(' ')
         append(cause?.cause?.message ?: "")
     }
-    return details.contains("audiotrack init failed", ignoreCase = true)
+    return isAudioTrackFailure(errorCode, details)
 }
 
 private fun PlaybackException.isStuckPlayingNoProgress(): Boolean {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/AudioTrackFailureClassificationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/AudioTrackFailureClassificationTest.kt
@@ -1,0 +1,74 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.PlaybackException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for [isAudioTrackFailure].
+ *
+ * A fatal AudioTrack *write* failure (`ERROR_CODE_AUDIO_TRACK_WRITE_FAILED` / 5002, e.g.
+ * `AudioTrack.ERROR_DEAD_OBJECT` (-6) on an E-AC-3 passthrough track) must be classified the
+ * same as an *init* failure (5001) so it routes into the safe-audio → audio-disabled recovery
+ * ladder instead of landing on the fatal "Playback Error" screen.
+ */
+class AudioTrackFailureClassificationTest {
+
+    @Test
+    fun `init failure code is an audio-track failure`() {
+        assertTrue(isAudioTrackFailure(PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED, ""))
+    }
+
+    @Test
+    fun `write failure code is an audio-track failure`() {
+        assertTrue(isAudioTrackFailure(PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED, ""))
+    }
+
+    @Test
+    fun `on-screen 5002 code is an audio-track failure`() {
+        // Mirrors "AudioTrack write failed: -6 [5002]" reported on Android TV (Hisense 65U6G).
+        assertTrue(isAudioTrackFailure(5002, ""))
+    }
+
+    @Test
+    fun `write failure message is matched under a generic error code`() {
+        assertTrue(
+            isAudioTrackFailure(
+                PlaybackException.ERROR_CODE_UNSPECIFIED,
+                "MediaCodecAudioRenderer error ... AudioTrack write failed: -6"
+            )
+        )
+    }
+
+    @Test
+    fun `init failure message is matched under a generic error code`() {
+        assertTrue(
+            isAudioTrackFailure(PlaybackException.ERROR_CODE_UNSPECIFIED, "AudioTrack init failed")
+        )
+    }
+
+    @Test
+    fun `message matching is case-insensitive`() {
+        assertTrue(
+            isAudioTrackFailure(PlaybackException.ERROR_CODE_UNSPECIFIED, "AUDIOTRACK WRITE FAILED")
+        )
+    }
+
+    @Test
+    fun `unrelated decoder error is not an audio-track failure`() {
+        assertFalse(
+            isAudioTrackFailure(
+                PlaybackException.ERROR_CODE_DECODING_FAILED,
+                "MediaCodecVideoRenderer error ... decoder failed"
+            )
+        )
+    }
+
+    @Test
+    fun `unrelated io error with empty message is not an audio-track failure`() {
+        assertFalse(
+            isAudioTrackFailure(PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED, "")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

E-AC-3 / AC-3 passthrough playback can die on a fatal **"Playback Error"** screen showing `AudioTrack write failed: -6 [5002]` (`AudioTrack.ERROR_DEAD_OBJECT`) when an HDMI/audio-route renegotiation invalidates the AudioTrack mid-playback.

The audio recovery ladder in `onPlayerError` only classified `ERROR_CODE_AUDIO_TRACK_INIT_FAILED` (**5001**) as an audio-track failure, so a *write* failure (`ERROR_CODE_AUDIO_TRACK_WRITE_FAILED` / **5002**) fell through every recovery branch and surfaced the fatal error. This broadens the classifier so 5002 routes into the **same** safe-audio → audio-disabled fallback that already recovers init failures (passthrough/tunneling off, channel count constrained to device capabilities, position preserved).

The classification is extracted into a pure, unit-tested helper `isAudioTrackFailure(errorCode, combinedMessage)`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

A single mid-stream `DEAD_OBJECT` on a DD+/AC-3 passthrough track ends playback with an unrecoverable error and only a "Go Back" button, even though the existing safe-audio fallback would recover it — it was simply never reached for write failures. The exact same content would auto-recover had ExoPlayer reported 5001 instead of 5002.

## Issue or approval

Fixes #2339

## Reproduction steps

1. On an Android TV (reported: **Hisense 65U6G**) connected to an HDMI sink/AVR, play an MP4 stream with an **E-AC-3 (Dolby Digital Plus) 5.1, 48 kHz** audio track.
2. During playback the audio route renegotiates (sink wakes/sleeps, receiver handshake), the `AudioTrack` write returns `DEAD_OBJECT` (-6), and ExoPlayer raises `ERROR_CODE_AUDIO_TRACK_WRITE_FAILED [5002]`.
3. **Before:** fatal "Playback Error" screen. **After:** the stream auto-rebuilds in safe-audio mode (no passthrough/tunneling, channels constrained to device caps) and resumes at the same position; if that still fails, audio is dropped so video keeps playing.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

<sub>(No new UI; the user now sees the existing recovery/loading path instead of the fatal error screen.)</sub>

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally **not** changed:
- The safe-audio / audio-disabled fallback implementations themselves — this only widens which error codes enter that existing ladder.
- `isRetryablePlaybackError()` and the generic auto-retry path are untouched (the audio branch fully owns 5001/5002 and returns early before them).
- No attempt at a lighter in-place AudioTrack recreate first: `DefaultAudioSink` already retries transient `DEAD_OBJECT` internally, so a *fatal* 5002 reaching the app means the simple recreate already failed — going straight to safe-audio is the correct first app-level response.

## Testing

- `./gradlew :app:compileFullDebugUnitTestKotlin --offline` → **BUILD SUCCESSFUL** (compiles both the production change and the new test; no warnings on the changed files).
- Added `AudioTrackFailureClassificationTest` covering: 5001 and 5002 error codes, the literal on-screen `5002`, message-based matching ("audiotrack write/init failed") under a generic code, case-insensitivity, and negative cases.
- **Note:** I could not *execute* `:app:testFullDebugUnitTest` in my environment — only JDK 24 is installed locally, and Gradle 8.13 cannot instantiate the `AndroidUnitTest` task type under JDK 24 (`DefaultReportContainer ... Type T not present`). This is an environmental limitation unrelated to the change; the test compiles and is pure boolean logic. Please run it in CI / on a JDK 17/21 toolchain to confirm green.
- Manual on-device repro of `DEAD_OBJECT` is timing-dependent (route renegotiation) and not reliably reproducible on demand.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2339
