### PR TITLE
fix: correct Polish time-unit abbreviations in continue-watching strings

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -16,8 +16,8 @@
     <string name="cw_next_up">Następny odcinek</string>
     <string name="cw_resume">Wznów</string>
     <string name="cw_percent_watched">%1$d%% obejrzane</string>
-    <string name="cw_hours_min_left">Zostało %1$dg %2$dm</string>
-    <string name="cw_min_left">Zostało %1$dm</string>
+    <string name="cw_hours_min_left">Zostało %1$d h %2$d min</string>
+    <string name="cw_min_left">Zostało %1$d min</string>
     <string name="cw_almost_done">Prawie koniec</string>
     <string name="cw_airs_date">Emisja %1$s</string>
     <string name="cw_airs_today">Emisja dzisiaj</string>


### PR DESCRIPTION
## Summary

Corrects the Polish time-unit abbreviations on continue-watching countdown badges. `cw_hours_min_left` changes from `Zostało %1$dg %2$dm` to `Zostało %1$d h %2$d min`, and `cw_min_left` changes from `Zostało %1$dm` to `Zostało %1$d min`.

Fixes #2324

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

In Polish, the bare letters `g` and `m` read as grams and meters, not hours and minutes, so the badge looked unnatural to Polish users. The maintainer agreed on the issue thread that the existing form was awkward, and the discussion converged on the shorter `h` + `min` form (`Zostało %1$d h %2$d min`) rather than `godz.` to keep the badge compact and consistent with the German translation. See https://github.com/NuvioMedia/NuvioTV/issues/2324.

## Issue or approval

Fixes #2324. Maintainer agreed on the wording in the issue thread.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [ ] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the two Polish strings `cw_hours_min_left` and `cw_min_left` in `values-pl/strings.xml` are touched. Positional format specifiers (`%1$d`, `%2$d`) and argument order are preserved. No code, layout, or other-language changes.

## Testing

Verified the two edited strings keep the same positional specifiers and argument order as the source `values/strings.xml`, so the hours value precedes the minutes value and no `IllegalFormatException` can occur at runtime. Android build tooling was not available in this environment; the change is a values-only string edit with unchanged placeholders.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2324.
