### PR TITLE
fix(player): refine 23.976 AFR probe bias

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -101,7 +101,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
             )
         }
 
-        val prefer23976ProbeBias = detection.raw in 23.95f..24.12f
+        val prefer23976ProbeBias = detection.raw in 23.95f..23.999f
         val targetFrameRate = FrameRateUtils.refineFrameRateForDisplay(
             activity = activity,
             detectedFps = detection.snapped,


### PR DESCRIPTION
## Summary
Refines the AFR 23.976 fps probe bias range for ambiguous near-24 fps detections.
This adjusts prefer23976ProbeBias to 23.95f..23.999f.
The new range is intended to handle affected MKV files that are actually 23.976 fps but are detected slightly above 23.988 fps, without forcing true 24.000 fps content to 23.976 Hz.

## PR type
<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [X] Critical bug fix

## Why

Some MKV files encoded at 23.976 fps can be reported by the AFR probe as a near-24 fps value. With the previous strict range of 23.95f..23.988f, these files could be matched to 24.000 Hz instead of 23.976 Hz.
A broader previous range, 23.95f..24.12f, fixed those affected files but risked incorrectly biasing true 24.000 fps content toward 23.976 Hz.
After several manual tests, 23.95f..23.999f appears to be a better compromise:
it catches ambiguous near-24 detections for affected 23.976 fps MKV files;
it avoids exact 24.000 fps content;
it is more reliable than both previous thresholds.

## Issue or approval

Fixes #2351

## Reproduction steps

Enable automatic frame rate matching.
Play an affected MKV file that is actually encoded at 23.976 fps.
Observe that the AFR probe reports a near-24 fps value above the old 23.988f threshold.
The display may switch to 24.000 Hz instead of 23.976 Hz.
With this PR, ambiguous detections up to 23.999f are biased back toward 23.976 Hz.

## UI / behavior impact

- [X] No UI change
- [X] No behavior change
- [] UI changed only to fix a documented glitch/bug
- [X] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [X] I have read and understood `CONTRIBUTING.md`.
- [X] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [X] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [X] This PR is small, focused, and limited to one issue.
- [X] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [X] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [X] I listed the testing performed below.

## Scope boundaries

This PR only adjusts the AFR ambiguous 23.976 fps probe bias threshold. It does not change the duplicate AFR preflight guard, add settings, change UI, or include unrelated playback behavior changes.

## Testing

Built successfully with ./gradlew.bat :app:assembleDebug --console=plain.
Manually tested affected 23.976 fps MKV files after adjusting the threshold.
Compared the behavior against the previous 23.95f..23.988f and 23.95f..24.12f ranges.
Confirmed the new range appears more reliable for affected files while avoiding exact 24.000 fps.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2351