### PR TITLE
Lower debrid cache-sync placeholder threshold to 30s

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -128,7 +128,7 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val META_FETCH_TIMEOUT_MS = 15_000L
         /** A "completed" playback shorter than this is treated as a debrid cache-sync placeholder
          *  (e.g. Comet's few-second clip), not a real episode: not marked watched, no auto-advance. */
-        private const val MIN_REAL_PLAYBACK_DURATION_MS = 60_000L
+        private const val MIN_REAL_PLAYBACK_DURATION_MS = 30_000L
         /** A launch within this of an auto-next emit counts as a chain continuation. */
         private const val CONTINUATION_WINDOW_MS = 12_000L
     }


### PR DESCRIPTION
## Summary

Follow-up to #2338. Lowers `MIN_REAL_PLAYBACK_DURATION_MS` from 60s to 30s. That floor exists to ignore debrid cache-sync placeholder clips (e.g. Comet's few-second clip) so they aren't marked watched or auto-advanced. At 60s it also swallowed real one-minute mini-series episodes, which were then not marked watched and didn't auto-advance. 30s still sits well above the few-second placeholder clips while letting sub-60s real episodes count.

One-line constant change; no logic touched.

## PR type

<!-- Behavior fix for a regression in merged #2338, not localization or a critical bug fix, so neither box is checked. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

After #2338 shipped I found there are real mini-series episodes around one minute long. With the placeholder threshold at 60s, those genuine episodes fell under the limit and were treated as cache-sync placeholders: not marked watched, no auto-advance. Dropping the threshold to 30s fixes that and is still far above the few-second placeholder clips it's meant to catch.

## Issue or approval

No linked issue. Follow-up tweak to merged #2338.

## Reproduction steps

With an external player on a debrid source, play a real episode shorter than 60s (e.g. a ~1 minute mini-series episode) to completion. It is not marked watched and auto-next does not advance.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Real sub-60s episodes are no longer misclassified as placeholders. No UI change.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the `MIN_REAL_PLAYBACK_DURATION_MS` constant changed (60_000L to 30_000L). The placeholder-filter logic, watched/auto-next flow, and everything else from #2338 are untouched.

## Testing

Single-constant change to the existing placeholder filter added in #2338. The surrounding `processResult` logic is unchanged; the only effect is that completed playbacks between 30s and 60s now count as real episodes (marked watched, auto-advance) instead of being ignored.

## Breaking changes

None.

## Linked issues

No linked issue.

@skoruppa
