### PR TITLE
i18n(fr): convert French translations from tutoiement to vouvoiement

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,27 +25,27 @@
     <string name="web_btn_disable">Désactiver</string>
     <string name="web_error_addon_exists">Cet addon est déjà dans la liste</string>
     <string name="web_status_waiting_tv">En attente de la TV</string>
-    <string name="web_status_msg_waiting_tv">Confirme les modifications sur ta TV pour les appliquer.</string>
+    <string name="web_status_msg_waiting_tv">Confirmez les modifications sur votre TV pour les appliquer.</string>
     <string name="web_status_changes_applied">Modifications appliquées</string>
-    <string name="web_status_msg_addon_updated">La configuration de tes addons a été mise à jour sur la TV.</string>
-    <string name="web_status_msg_repo_updated">La configuration de tes dépôts a été mise à jour sur la TV.</string>
+    <string name="web_status_msg_addon_updated">La configuration de vos addons a été mise à jour sur la TV.</string>
+    <string name="web_status_msg_repo_updated">La configuration de vos dépôts a été mise à jour sur la TV.</string>
     <string name="web_status_changes_rejected">Modifications refusées</string>
-    <string name="web_status_msg_changes_rejected">Les modifications ont été refusées sur la TV. Ta liste a été restaurée.</string>
+    <string name="web_status_msg_changes_rejected">Les modifications ont été refusées sur la TV. Votre liste a été restaurée.</string>
     <string name="web_status_error">Un problème est survenu</string>
-    <string name="web_error_failed_save">Échec de l’enregistrement. Vérifie ta connexion à la TV.</string>
+    <string name="web_error_failed_save">Échec de l’enregistrement. Vérifiez votre connexion à la TV.</string>
     <string name="web_btn_dismiss">Fermer</string>
     <string name="web_status_timeout">Délai dépassé</string>
-    <string name="web_status_msg_timeout">Aucune réponse de la TV. Réessaie.</string>
+    <string name="web_status_msg_timeout">Aucune réponse de la TV. Réessayez.</string>
     <string name="web_status_msg_connection_lost">Le serveur TV n’est plus joignable. Les modifications ont peut-être été appliquées.</string>
     <string name="web_manage_repos_title">Gérer les dépôts</string>
-    <string name="web_manage_repos_subtitle">Gérer tes dépôts</string>
+    <string name="web_manage_repos_subtitle">Gérer vos dépôts</string>
     <string name="web_add_repo_url">Ajouter un dépôt par URL</string>
     <string name="web_installed">Installé</string>
     <string name="web_no_repos">Aucun dépôt installé</string>
     <string name="web_error_repo_exists">Ce dépôt est déjà dans la liste</string>
     <string name="web_manage_collections_title">Gérer les collections</string>
-    <string name="web_manage_collections_subtitle">Créer et gérer tes collections personnalisées</string>
-    <string name="web_status_msg_collections_updated">Tes collections ont été mises à jour sur la TV.</string>
+    <string name="web_manage_collections_subtitle">Créer et gérer vos collections personnalisées</string>
+    <string name="web_status_msg_collections_updated">Vos collections ont été mises à jour sur la TV.</string>
     <string name="web_tab_addons">Addons</string>
     <string name="web_tab_home_layout">Disposition de l’accueil</string>
     <string name="web_tab_collections">Collections</string>
@@ -62,8 +62,8 @@
     <string name="web_import_tab_paste">Coller</string>
     <string name="web_import_tab_file">Fichier</string>
     <string name="web_import_tab_url">URL</string>
-    <string name="web_import_paste_placeholder">Colle le JSON des collections ici…</string>
-    <string name="web_import_file_select">Appuie pour sélectionner un fichier .json</string>
+    <string name="web_import_paste_placeholder">Collez le JSON des collections ici…</string>
+    <string name="web_import_file_select">Appuyez pour sélectionner un fichier .json</string>
     <string name="web_order_send_to_top">Envoyer tout en haut</string>
     <string name="web_order_send_to_bottom">Envoyer tout en bas</string>
     <string name="web_title_show">Afficher</string>
@@ -74,8 +74,8 @@
     <string name="web_source_plural">sources</string>
     <string name="web_source_added">Ajouté</string>
     <string name="web_no_sources_added">Aucune source ajoutée pour le moment</string>
-    <string name="web_import_select_file_first">Sélectionne d’abord un fichier</string>
-    <string name="web_import_enter_url">Saisis une URL</string>
+    <string name="web_import_select_file_first">Sélectionnez d’abord un fichier</string>
+    <string name="web_import_enter_url">Saisissez une URL</string>
     <string name="web_import_failed_fetch_url">Échec de la récupération de l’URL</string>
     <string name="web_import_no_json">Aucun JSON fourni</string>
     <string name="web_import_expected_array">Un tableau JSON de collections est attendu</string>
@@ -92,39 +92,39 @@
     <string name="web_import_error_source_missing_addon_fields">Collection \"{collection}\", dossier \"{folder}\", source {index} : champs requis manquants (addonId, type, catalogId)</string>
     <string name="web_import_error_source_missing_tmdb_type">Collection \"{collection}\", dossier \"{folder}\", source {index} : type de source TMDB manquant</string>
     <string name="web_import_error_source_missing_trakt_id">Collection \"{collection}\", dossier \"{folder}\", source {index} : ID de liste Trakt manquant</string>
-    <string name="web_import_success">{count} collection(s) importée(s). Vérifie puis appuie sur « Enregistrer les modifications » pour appliquer.</string>
+    <string name="web_import_success">{count} collection(s) importée(s). Vérifiez puis appuyez sur « Enregistrer les modifications » pour appliquer.</string>
     <string name="web_import_invalid_json">JSON invalide</string>
 
     <!-- HomeScreen -->
-    <string name="home_no_addons">Aucun addon installé. Ajoute-en un pour commencer.</string>
-    <string name="home_no_catalog_addons">Aucun addon de catalogue installé. Installe un addon de catalogue pour voir du contenu.</string>
-    <string name="auth_notice_nuvio_logged_out">Tu as été déconnecté de Nuvio. Reconnecte-toi.</string>
-    <string name="auth_notice_trakt_logged_out">Tu as été déconnecté de Trakt. Reconnecte-toi.</string>
+    <string name="home_no_addons">Aucun addon installé. Ajoutez-en un pour commencer.</string>
+    <string name="home_no_catalog_addons">Aucun addon de catalogue installé. Installez un addon de catalogue pour voir du contenu.</string>
+    <string name="auth_notice_nuvio_logged_out">Vous avez été déconnecté de Nuvio. Reconnectez-vous.</string>
+    <string name="auth_notice_trakt_logged_out">Vous avez été déconnecté de Trakt. Reconnectez-vous.</string>
     <string name="error_generic">Une erreur est survenue</string>
 
     <!-- ErrorState -->
     <string name="action_retry">Réessayer</string>
     <string name="error_state_generic_issue">Une erreur est survenue.</string>
     <string name="error_state_possible_fix">Solution possible : %1$s</string>
-    <string name="error_state_fix_retry_soon">réessaie dans un instant.</string>
+    <string name="error_state_fix_retry_soon">réessayez dans un instant.</string>
     <string name="error_state_issue_no_metadata_any_addon">Impossible de charger les détails, car aucun des addons installés n’a renvoyé de métadonnées.</string>
-    <string name="error_state_fix_no_metadata_any_addon">essaie un autre addon, désactive « Préférer les métadonnées de l’addon externe » dans les paramètres de disposition ou vérifie qu’un addon installé prend en charge cet ID.</string>
+    <string name="error_state_fix_no_metadata_any_addon">essayez un autre addon, désactivez « Préférer les métadonnées de l’addon externe » dans les paramètres de disposition ou vérifiez qu’un addon installé prend en charge cet ID.</string>
     <string name="error_state_prefix_no_supported_metadata">Aucun addon installé ne fournit de métadonnées pour</string>
     <string name="error_state_prefix_no_addon_for_id">Aucun addon installé n’a pu fournir de métadonnées pour l’ID=</string>
-    <string name="error_state_fix_no_supported_metadata">installe ou mets à jour un addon qui prend en charge ce type de contenu, puis réessaie.</string>
+    <string name="error_state_fix_no_supported_metadata">installez ou mettez à jour un addon qui prend en charge ce type de contenu, puis réessayez.</string>
     <string name="error_state_prefix_tried_meta_addons">Addons de métadonnées tentés :</string>
-    <string name="error_state_fix_tried_meta_addons">installe un addon qui prend en charge cet ID, ou reconfigure/mets à jour l’addon et réessaie.</string>
+    <string name="error_state_fix_tried_meta_addons">installez un addon qui prend en charge cet ID, ou reconfigurez/mettez à jour l’addon et réessayez.</string>
     <string name="error_state_issue_missing_metadata_for_id">ne contient pas de métadonnées pour cet ID</string>
-    <string name="error_state_fix_missing_metadata_for_id">ouvre cet ID depuis un autre addon, désactive « Préférer les métadonnées de l’addon externe », ou vérifie que l’addon prend en charge cet ID.</string>
+    <string name="error_state_fix_missing_metadata_for_id">ouvrez cet ID depuis un autre addon, désactivez « Préférer les métadonnées de l’addon externe », ou vérifiez que l’addon prend en charge cet ID.</string>
     <string name="error_state_issue_addon_unreachable">n’a pas pu être joint</string>
-    <string name="error_state_fix_addon_unreachable">vérifie ta connexion internet, assure-toi que l’URL de l’addon est valide, puis réessaie.</string>
+    <string name="error_state_fix_addon_unreachable">vérifiez votre connexion internet, assurez-vous que l’URL de l’addon est valide, puis réessayez.</string>
     <string name="error_state_issue_addon_connection_failed">a refusé la connexion</string>
-    <string name="error_state_fix_addon_connection_failed">vérifie que le serveur de l’addon est en ligne et accessible, puis réessaie.</string>
+    <string name="error_state_fix_addon_connection_failed">vérifiez que le serveur de l’addon est en ligne et accessible, puis réessayez.</string>
     <string name="error_state_issue_addon_timeout">a mis trop de temps à répondre</string>
-    <string name="error_state_fix_addon_timeout">réessaie plus tard, ou tente un autre addon si cela se reproduit.</string>
+    <string name="error_state_fix_addon_timeout">réessayez plus tard, ou tentez un autre addon si cela se reproduit.</string>
     <string name="error_state_issue_addon_cleartext">utilise une connexion HTTP non sécurisée bloquée par Android</string>
-    <string name="error_state_fix_addon_cleartext">passe l’URL de l’addon en HTTPS ou mets à jour sa configuration.</string>
-    <string name="error_state_fix_addon_generic">réessaie, mets à jour ou réinstalle l’addon, ou tentes-en un autre.</string>
+    <string name="error_state_fix_addon_cleartext">passez l’URL de l’addon en HTTPS ou mettez à jour sa configuration.</string>
+    <string name="error_state_fix_addon_generic">réessayez, mettez à jour ou réinstallez l’addon, ou tentez-en un autre.</string>
     <string name="error_state_addon_issue_template">%1$s : %2$s.</string>
     <string name="error_meta_not_found">Métadonnées introuvables</string>
     <string name="error_meta_no_supported_addon">Aucun addon installé ne fournit de métadonnées pour \"%1$s\".</string>
@@ -159,7 +159,7 @@
     <string name="cw_action_go_to_details">Voir les détails</string>
     <string name="cw_action_start_from_beginning">Revoir depuis le début</string>
     <string name="cw_action_remove">Supprimer</string>
-    <string name="cw_dialog_subtitle">Choisis ce que tu souhaites faire avec cet élément.</string>
+    <string name="cw_dialog_subtitle">Choisissez ce que vous souhaitez faire avec cet élément.</string>
     <string name="home_poster_dialog_subtitle">Actions sur le titre</string>
 
     <!-- CatalogRowSection -->
@@ -178,7 +178,7 @@
     <string name="hero_mark_watched">Marquer comme vu</string>
     <string name="hero_mark_unwatched">Marquer comme non vu</string>
     <string name="hero_play_trailer">Regarder la bande-annonce</string>
-    <string name="hero_press_back_trailer">Appuie sur «&#160;Retour&#160;» pour quitter la bande-annonce</string>
+    <string name="hero_press_back_trailer">Appuyez sur «&#160;Retour&#160;» pour quitter la bande-annonce</string>
     <string name="cd_rating">Note</string>
 
     <!-- EpisodesSection -->
@@ -234,17 +234,17 @@
     <string name="detail_comments_mode_episode">Épisode</string>
     <string name="detail_comments_mode_episode_change">Changer d’épisode (%1$s)</string>
     <string name="detail_comments_episode_picker_title">Choisir un épisode</string>
-    <string name="detail_comments_episode_picker_subtitle">Choisis un épisode pour voir ses critiques Trakt</string>
+    <string name="detail_comments_episode_picker_subtitle">Choisissez un épisode pour voir ses critiques Trakt</string>
     <string name="detail_section_network">Chaîne</string>
     <string name="detail_section_production">Production</string>
     <string name="detail_comments_empty">Aucune critique Trakt n’est encore disponible.</string>
     <string name="detail_comments_error">Impossible de charger les critiques Trakt pour le moment.</string>
     <string name="detail_trailer_loading">Chargement de la bande-annonce…</string>
     <string name="detail_trailer_error">Impossible de charger la bande-annonce pour le moment.</string>
-    <string name="detail_comments_spoiler_hidden">Critique avec spoiler. Appuie sur OK pour révéler.</string>
+    <string name="detail_comments_spoiler_hidden">Critique avec spoiler. Appuyez sur OK pour révéler.</string>
     <string name="detail_comments_reveal_spoiler">Révéler le spoiler</string>
-    <string name="detail_comments_reveal_spoiler_hint">Appuie sur OK pour révéler le spoiler.</string>
-    <string name="detail_comments_back_hint">Appuie sur « Retour » pour fermer</string>
+    <string name="detail_comments_reveal_spoiler_hint">Appuyez sur OK pour révéler le spoiler.</string>
+    <string name="detail_comments_back_hint">Appuyez sur « Retour » pour fermer</string>
     <string name="detail_comments_badge_review">Critique</string>
     <string name="detail_comments_badge_spoiler">Spoiler</string>
     <string name="detail_comments_badge_rating">%1$d/10</string>
@@ -289,7 +289,7 @@
     <string name="movie_status_in_production">En production</string>
     <string name="movie_status_post_production">En post-production</string>
     <string name="detail_lists_fallback">Listes</string>
-    <string name="detail_lists_subtitle">Sélectionne les listes auxquelles ajouter ce titre.</string>
+    <string name="detail_lists_subtitle">Sélectionnez les listes auxquelles ajouter ce titre.</string>
     <string name="action_save">Enregistrer</string>
     <string name="action_saving">Enregistrement…</string>
 
@@ -298,18 +298,18 @@
     <string name="appearance_language_subtitle">Remplacer la langue du système</string>
     <string name="appearance_language_system">Par défaut (système)</string>
     <string name="appearance_language_dialog_title">Choisir la langue</string>
-    <string name="appearance_language_restart_hint">Redémarre l’application pour appliquer le changement de langue.</string>
+    <string name="appearance_language_restart_hint">Redémarrez l’application pour appliquer le changement de langue.</string>
 
     <!-- Font -->
     <string name="appearance_font">Police de l’application</string>
-    <string name="appearance_font_subtitle">Choisis ta police préférée</string>
+    <string name="appearance_font_subtitle">Choisissez votre police préférée</string>
     <string name="appearance_font_dialog_title">Choisir la police</string>
 
     <!-- ThemeSettingsScreen -->
     <string name="appearance_title">Apparence</string>
-    <string name="appearance_subtitle">Choisis ton thème de couleur, ta police et ta langue</string>
+    <string name="appearance_subtitle">Choisissez votre thème de couleur, votre police et votre langue</string>
     <string name="appearance_color_theme">Thème de couleur</string>
-    <string name="appearance_color_theme_subtitle">Choisis la couleur d’accent utilisée dans toute l’application</string>
+    <string name="appearance_color_theme_subtitle">Choisissez la couleur d’accent utilisée dans toute l’application</string>
     <string name="theme_color_crimson">Cramoisi</string>
     <string name="theme_color_ocean">Océan</string>
     <string name="theme_color_violet">Violet</string>
@@ -322,7 +322,7 @@
     <string name="appearance_amoled_surfaces_mode">Surfaces noir pur</string>
     <string name="appearance_amoled_surfaces_mode_subtitle">Mettre aussi les cartes, panneaux et conteneurs en noir pur</string>
     <string name="appearance_font_and_language">Police et langue</string>
-    <string name="appearance_font_and_language_subtitle">Choisis la police et la langue utilisées dans toute l’application</string>
+    <string name="appearance_font_and_language_subtitle">Choisissez la police et la langue utilisées dans toute l’application</string>
     <string name="cd_selected">Sélectionné</string>
 
     <!-- AboutScreen -->
@@ -414,11 +414,11 @@
     <string name="supporters_contributors_title">Soutiens et contributeurs</string>
     <string name="supporters_contributors_subtitle">Les personnes qui soutiennent Nuvio et les contributeurs qui le développent sur TV et mobile.</string>
     <string name="supporters_contributors_supporters_copy">Les soutiens et les donateurs permettent au projet de continuer à avancer, de financer l’infrastructure et de laisser la place à des fonctionnalités ambitieuses.</string>
-    <string name="supporters_contributors_donate_copy">Nuvio restera gratuit et open source. Si tu souhaites soutenir le projet, tu peux aider à couvrir le temps et l’infrastructure nécessaires à son développement.</string>
+    <string name="supporters_contributors_donate_copy">Nuvio restera gratuit et open source. Si vous souhaitez soutenir le projet, vous pouvez aider à couvrir le temps et l’infrastructure nécessaires à son développement.</string>
     <string name="supporters_contributors_donate_button">Faire un don</string>
     <string name="supporters_contributors_qr_title">Scanner pour faire un don</string>
-    <string name="supporters_contributors_qr_subtitle">Ouvre le lien sur ton téléphone et soutiens Nuvio via Ko-fi.</string>
-    <string name="supporters_contributors_qr_hint">Pointe ta caméra vers le code QR ou utilise le bouton ci-dessous.</string>
+    <string name="supporters_contributors_qr_subtitle">Ouvrez le lien sur votre téléphone et soutenez Nuvio via Ko-fi.</string>
+    <string name="supporters_contributors_qr_hint">Pointez votre caméra vers le code QR ou utilisez le bouton ci-dessous.</string>
     <string name="supporters_contributors_back_button">Retour aux détails</string>
     <string name="supporters_tab">Soutiens</string>
     <string name="sponsors_tab">Sponsors</string>
@@ -467,7 +467,7 @@
     <string name="playback_auto_switch_internal_player_on_error">Changement auto du moteur en cas d’erreur au démarrage</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Si le démarrage du flux échoue, bascule automatiquement entre ExoPlayer et libmpv.</string>
     <string name="playback_external_forward_subtitles">Transférer les sous-titres au lecteur externe</string>
-    <string name="playback_external_forward_subtitles_sub">Récupère les sous-titres dans ta langue préférée depuis les addons et les transmet au lecteur externe.</string>
+    <string name="playback_external_forward_subtitles_sub">Récupère les sous-titres dans votre langue préférée depuis les addons et les transmet au lecteur externe.</string>
     <string name="playback_section_audio">Audio et vidéo</string>
     <string name="playback_section_audio_desc">Contrôles audio et compatibilité vidéo.</string>
     <string name="playback_section_subtitles">Sous-titres</string>
@@ -484,9 +484,9 @@
     <string name="playback_resolution_matching_sub">Autoriser les changements de mode d’affichage pour correspondre à la résolution vidéo.</string>
     <string name="playback_resolution_matching_unsupported_sub">L’écran ne signale qu’une seule résolution ; l’adaptation peut ne pas avoir d’effet.</string>
     <string name="playback_afr_capability_unsupported_title">Certains paramètres peuvent ne pas fonctionner</string>
-    <string name="playback_afr_capability_both_problem_body">Le réglage automatique de la fréquence d’images et l’adaptation de résolution sont tous deux activés, mais ton écran ne signale qu’une seule fréquence de rafraîchissement et une seule résolution. Aucun des deux ne prendra peut-être effet, et il est recommandé de désactiver les deux.</string>
-    <string name="playback_afr_capability_only_afr_unsupported_body">Le réglage automatique de la fréquence d’images est activé, mais ton écran ne signale qu’une seule fréquence de rafraîchissement. Le changement peut ne pas avoir d’effet et il est recommandé de le désactiver.</string>
-    <string name="playback_afr_capability_only_res_unsupported_body">L’adaptation de résolution est activée, mais ton écran ne signale qu’une seule résolution. L’adaptation peut ne pas avoir d’effet et il est recommandé de la désactiver.</string>
+    <string name="playback_afr_capability_both_problem_body">Le réglage automatique de la fréquence d’images et l’adaptation de résolution sont tous deux activés, mais votre écran ne signale qu’une seule fréquence de rafraîchissement et une seule résolution. Aucun des deux ne prendra peut-être effet, et il est recommandé de désactiver les deux.</string>
+    <string name="playback_afr_capability_only_afr_unsupported_body">Le réglage automatique de la fréquence d’images est activé, mais votre écran ne signale qu’une seule fréquence de rafraîchissement. Le changement peut ne pas avoir d’effet et il est recommandé de le désactiver.</string>
+    <string name="playback_afr_capability_only_res_unsupported_body">L’adaptation de résolution est activée, mais votre écran ne signale qu’une seule résolution. L’adaptation peut ne pas avoir d’effet et il est recommandé de la désactiver.</string>
     <string name="playback_afr_capability_disable_button">Désactiver AFR</string>
     <string name="playback_afr_capability_disable_resolution_button">Désactiver l’adaptation de résolution</string>
     <string name="playback_afr_capability_disable_both_button">Désactiver les deux</string>
@@ -514,7 +514,7 @@
     <string name="audio_remember_delay_per_device">Mémoriser le délai audio par appareil</string>
     <string name="audio_remember_delay_per_device_sub">Enregistrer et restaurer le délai audio du lecteur pour la sortie audio actuelle</string>
     <string name="audio_advanced_section">Audio avancé</string>
-    <string name="audio_advanced_warning">Ces paramètres peuvent causer des problèmes sur certains appareils. Ne modifie que si tu sais ce que tu fais.</string>
+    <string name="audio_advanced_warning">Ces paramètres peuvent causer des problèmes sur certains appareils. Ne modifiez que si vous savez ce que vous faites.</string>
     <string name="audio_decoder_device_only">Décodeurs de l’appareil uniquement</string>
     <string name="audio_decoder_prefer_device">Préférer les décodeurs de l’appareil</string>
     <string name="audio_decoder_prefer_app">Préférer les décodeurs de l’application (FFmpeg)</string>
@@ -522,7 +522,7 @@
     <string name="audio_tunneled">Lecture tunnelisée</string>
     <string name="audio_tunneled_sub">Synchronisation audio/vidéo au niveau matériel. Peut améliorer la lecture sur certains appareils Android TV</string>
     <string name="audio_mpv_hwdec_title">Décodage matériel (MPV uniquement)</string>
-    <string name="audio_mpv_hwdec_dialog_subtitle">Choisis comment libmpv doit utiliser les décodeurs matériels.</string>
+    <string name="audio_mpv_hwdec_dialog_subtitle">Choisissez comment libmpv doit utiliser les décodeurs matériels.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Ancien mode (direct -&gt; copy)</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy_desc">Comportement précédent par défaut : essaie d’abord le matériel direct, puis le copy-back.</string>
     <string name="audio_mpv_hwdec_auto_safe">Auto (auto-safe)</string>
@@ -587,7 +587,7 @@
 
     <!-- PlaybackAutoPlaySettings -->
     <string name="autoplay_reuse_last_link">Réutiliser le dernier lien</string>
-    <string name="autoplay_reuse_last_link_sub">Lire automatiquement ton dernier flux fonctionnel pour ce même film/épisode tant que le cache est valide</string>
+    <string name="autoplay_reuse_last_link_sub">Lire automatiquement votre dernier flux fonctionnel pour ce même film/épisode tant que le cache est valide</string>
     <string name="autoplay_last_link_cache">Durée du cache du dernier lien</string>
     <string name="cache_duration_hour_one">%1$d heure</string>
     <string name="cache_duration_hour_other">%1$d heures</string>
@@ -626,11 +626,11 @@
     <string name="autoplay_regex_placeholder">Aucun motif défini. Exemple : 4K|2160p|Remux</string>
     <string name="autoplay_regex_title">Motif regex</string>
     <string name="autoplay_no_items">Aucun élément disponible</string>
-    <string name="autoplay_mode_manual_desc">Toujours afficher la liste des sources pour que tu choisisses.</string>
+    <string name="autoplay_mode_manual_desc">Toujours afficher la liste des sources pour que vous choisissiez.</string>
     <string name="autoplay_mode_first_desc">Lire automatiquement la première source disponible.</string>
-    <string name="autoplay_mode_regex_desc">Lire la première source dont le texte correspond à ton motif regex.</string>
+    <string name="autoplay_mode_regex_desc">Lire la première source dont le texte correspond à votre motif regex.</string>
     <string name="autoplay_scope_all_desc">La lecture automatique peut utiliser les addons installés et les plugins activés.</string>
-    <string name="autoplay_scope_addons_desc">La lecture automatique ne considère que les flux provenant de tes addons installés.</string>
+    <string name="autoplay_scope_addons_desc">La lecture automatique ne considère que les flux provenant de vos addons installés.</string>
     <string name="autoplay_scope_plugins_desc">La lecture automatique ne considère que les flux provenant des plugins activés.</string>
     <string name="autoplay_threshold_pct_desc">Afficher par pourcentage de lecture en l’absence de marqueur de fin.</string>
     <string name="autoplay_threshold_min_desc">Afficher ce nombre de minutes avant la fin de l’épisode en l’absence de marqueur de fin.</string>
@@ -690,7 +690,7 @@
     <string name="layout_blur_cw_next_up">Flouter les épisodes non vus dans Continuer à regarder</string>
     <string name="layout_blur_cw_next_up_sub">Flouter les miniatures des épisodes suivants dans Continuer à regarder pour éviter les spoilers.</string>
     <string name="layout_next_up_furthest_episode">Suivant à partir de l’épisode le plus avancé</string>
-    <string name="layout_next_up_furthest_episode_sub">Affiche l’épisode suivant à partir de l’épisode le plus avancé que tu as regardé. Désactive cette option pour les revisionnages afin d’utiliser plutôt l’épisode regardé le plus récemment.</string>
+    <string name="layout_next_up_furthest_episode_sub">Affiche l’épisode suivant à partir de l’épisode le plus avancé que vous avez regardé. Désactivez cette option pour les revisionnages afin d’utiliser plutôt l’épisode regardé le plus récemment.</string>
     <string name="layout_show_unaired_next_up">Afficher les épisodes à venir</string>
     <string name="layout_show_unaired_next_up_sub">Inclut les épisodes à venir dans Continuer à regarder avant leur diffusion.</string>
     <string name="layout_trailer_button">Afficher le bouton bande-annonce</string>
@@ -761,21 +761,21 @@
     <string name="mdblist_metacritic_title">Metacritic</string>
     <string name="mdblist_metacritic_subtitle">Afficher la note Metacritic</string>
     <string name="mdblist_dialog_title">Clé API MDBList</string>
-    <string name="mdblist_dialog_subtitle">Entre ta clé API pour récupérer les notes externes</string>
-    <string name="mdblist_dialog_placeholder">Entre la clé API MDBList</string>
+    <string name="mdblist_dialog_subtitle">Entrez votre clé API pour récupérer les notes externes</string>
+    <string name="mdblist_dialog_placeholder">Entrez la clé API MDBList</string>
     <string name="mdblist_not_set">Non défini</string>
     <string name="mdblist_invalid_api_key">Clé API MDBList non valide</string>
 
     <!-- Anime-Skip -->
     <string name="animeskip_title">Anime Skip</string>
-    <string name="animeskip_subtitle">Configure ton ID client Anime Skip pour passer les intros/outros des animés</string>
+    <string name="animeskip_subtitle">Configurez votre ID client Anime Skip pour passer les intros/outros des animés</string>
     <string name="animeskip_enable_title">Activer Anime Skip</string>
     <string name="animeskip_enable_subtitle">Récupérer les horodatages de saut depuis anime-skip.com</string>
     <string name="animeskip_client_id_title">ID client</string>
     <string name="animeskip_client_id_subtitle">Requis pour récupérer les horodatages de saut depuis anime-skip.com</string>
     <string name="animeskip_dialog_title">ID client Anime Skip</string>
-    <string name="animeskip_dialog_subtitle">Crée ton propre ID client sur anime-skip.com/account/settings</string>
-    <string name="animeskip_dialog_placeholder">Entre l’ID client</string>
+    <string name="animeskip_dialog_subtitle">Créez votre propre ID client sur anime-skip.com/account/settings</string>
+    <string name="animeskip_dialog_placeholder">Entrez l’ID client</string>
     <string name="animeskip_invalid_client_id">ID client non valide</string>
     <string name="action_clear">Effacer</string>
 
@@ -816,24 +816,24 @@
     <string name="tmdb_language_dialog_title">Langue TMDB</string>
 
     <!-- TraktScreen -->
-    <string name="trakt_description">Synchronise ta liste de suivi, ta progression, tes visionnages en cours, tes scrobbles et tes listes personnelles avec Trakt.</string>
+    <string name="trakt_description">Synchronisez votre liste de suivi, votre progression, vos visionnages en cours, vos scrobbles et vos listes personnelles avec Trakt.</string>
     <string name="trakt_connected_as">Connecté en tant que %1$s</string>
     <string name="trakt_account_login">Connexion au compte</string>
-    <string name="trakt_awaiting_instruction">Va sur trakt.tv/activate et entre ce code :</string>
+    <string name="trakt_awaiting_instruction">Allez sur trakt.tv/activate et entrez ce code :</string>
     <string name="trakt_waiting_approval">En attente d’approbation…</string>
     <string name="qr_login_approved">Identification approuvée. Finalisation de la connexion…</string>
-    <string name="qr_login_pending">En attente d’approbation sur ton téléphone…</string>
-    <string name="qr_login_expired">Code QR expiré. Génère un nouveau code.</string>
+    <string name="qr_login_pending">En attente d’approbation sur votre téléphone…</string>
+    <string name="qr_login_expired">Code QR expiré. Générez un nouveau code.</string>
     <string name="qr_login_preparing">Préparation de la connexion QR…</string>
     <string name="qr_login_device_auth_failed">Impossible d’authentifier l’appareil</string>
-    <string name="qr_login_scan_prompt">Scanne le code QR et connecte-toi sur ton téléphone</string>
+    <string name="qr_login_scan_prompt">Scannez le code QR et connectez-vous sur votre téléphone</string>
     <string name="qr_login_start_failed">Impossible de démarrer la connexion QR</string>
     <string name="qr_login_signing_in">Connexion en cours…</string>
     <string name="qr_login_success">Connexion réussie</string>
     <string name="qr_login_exchange_failed">Impossible de finaliser la connexion QR</string>
     <string name="trakt_code_expires">Le code expire dans %1$s</string>
     <string name="trakt_token_refreshes">Le jeton d’accès Trakt sera actualisé dans %1$s</string>
-    <string name="trakt_login_instruction">Appuie sur Connexion pour démarrer l’authentification Trakt. Un code QR apparaîtra ici.</string>
+    <string name="trakt_login_instruction">Appuyez sur Connexion pour démarrer l’authentification Trakt. Un code QR apparaîtra ici.</string>
     <string name="trakt_missing_credentials">TRAKT_CLIENT_ID / TRAKT_CLIENT_SECRET manquants dans local.properties.</string>
     <string name="trakt_watch_progress_title">Progression</string>
     <string name="trakt_watch_progress_subtitle">Choisir quelle source de progression alimente la reprise et Continuer à regarder</string>
@@ -842,9 +842,9 @@
     <string name="trakt_watch_progress_source_trakt">Trakt</string>
     <string name="trakt_watch_progress_source_nuvio">Nuvio Sync</string>
     <string name="trakt_library_source_title">Source de la bibliothèque</string>
-    <string name="trakt_library_source_subtitle">Choisir quelle bibliothèque utiliser pour enregistrer et afficher ta collection</string>
+    <string name="trakt_library_source_subtitle">Choisir quelle bibliothèque utiliser pour enregistrer et afficher votre collection</string>
     <string name="trakt_library_source_dialog_title">Source de la bibliothèque</string>
-    <string name="trakt_library_source_dialog_subtitle">Choisir où enregistrer et gérer les éléments de ta bibliothèque</string>
+    <string name="trakt_library_source_dialog_subtitle">Choisir où enregistrer et gérer les éléments de votre bibliothèque</string>
     <string name="trakt_library_source_trakt">Trakt</string>
     <string name="trakt_library_source_nuvio">Bibliothèque Nuvio</string>
     <string name="trakt_library_source_trakt_selected">Bibliothèque Trakt sélectionnée</string>
@@ -864,7 +864,7 @@
     <string name="trakt_comments_title">Commentaires</string>
     <string name="trakt_comments_subtitle">Afficher les critiques Trakt sur les pages de métadonnées</string>
     <string name="trakt_comments_dialog_title">Commentaires</string>
-    <string name="trakt_comments_dialog_subtitle">Choisis si les pages de métadonnées doivent afficher les critiques Trakt lorsque ton compte est connecté.</string>
+    <string name="trakt_comments_dialog_subtitle">Choisissez si les pages de métadonnées doivent afficher les critiques Trakt lorsque votre compte est connecté.</string>
     <string name="trakt_comments_now_shown">Les critiques Trakt sont désormais affichées sur les pages de métadonnées</string>
     <string name="trakt_comments_now_hidden">Les critiques Trakt sont désormais masquées des pages de métadonnées</string>
     <string name="trakt_cached_label">En cache</string>
@@ -874,7 +874,7 @@
     <string name="trakt_stat_watched_hours">Heures visionnées</string>
     <string name="trakt_disconnect">Déconnecter</string>
     <string name="trakt_disconnect_title">Déconnecter Trakt ?</string>
-    <string name="trakt_disconnect_subtitle">Cela déconnectera ton compte Trakt de Nuvio.</string>
+    <string name="trakt_disconnect_subtitle">Cela déconnectera votre compte Trakt de Nuvio.</string>
     <string name="trakt_login">Connexion</string>
     <string name="trakt_retry">Réessayer</string>
     <string name="trakt_back">Retour</string>
@@ -923,7 +923,7 @@
     <string name="profile_manage_button">Gérer les profils</string>
     <string name="profile_manage_title">Gérer les profils</string>
     <string name="profile_manage_subtitle">Choisir, modifier ou créer un profil</string>
-    <string name="profile_manage_hint">Sélectionne un profil à gérer</string>
+    <string name="profile_manage_hint">Sélectionnez un profil à gérer</string>
     <string name="profile_primary_label">Principal</string>
     <string name="profile_shares_primary">Partage les %1$s du profil principal</string>
     <string name="profile_edit_label">Modifier</string>
@@ -943,7 +943,7 @@
     <string name="profile_plugins">plugins</string>
     <string name="profile_choose_avatar">Choisir un avatar</string>
     <string name="profile_avatar_none_selected">Aucun avatar sélectionné</string>
-    <string name="profile_avatar_focus_hint">Sélectionne un avatar pour voir son nom</string>
+    <string name="profile_avatar_focus_hint">Sélectionnez un avatar pour voir son nom</string>
     <string name="profile_avatar_category_all">Tous</string>
     <string name="profile_avatar_category_anime">Animés</string>
     <string name="profile_avatar_category_animation">Animation</string>
@@ -955,42 +955,42 @@
     <string name="profile_save">Enregistrer</string>
     <string name="profile_pin_title">Verrouillage du profil par code PIN</string>
     <string name="profile_pin_enabled_subtitle">Un code PIN à 4 chiffres est requis pour accéder à ce profil.</string>
-    <string name="profile_pin_disabled_subtitle">Définis un code PIN à 4 chiffres pour verrouiller ce profil.</string>
+    <string name="profile_pin_disabled_subtitle">Définissez un code PIN à 4 chiffres pour verrouiller ce profil.</string>
     <string name="profile_pin_set">Définir le code PIN</string>
     <string name="profile_pin_change">Modifier le code PIN</string>
     <string name="profile_pin_remove">Supprimer le code PIN</string>
     <string name="profile_pin_set_title">Définir le code PIN du profil</string>
-    <string name="profile_pin_set_subtitle">Saisis un code PIN à 4 chiffres et confirme-le.</string>
+    <string name="profile_pin_set_subtitle">Saisissez un code PIN à 4 chiffres et confirmez-le.</string>
     <string name="profile_pin_enter">Saisir le code PIN à 4 chiffres</string>
     <string name="profile_pin_confirm">Confirmer le code PIN à 4 chiffres</string>
     <string name="profile_pin_mismatch">Les codes PIN ne correspondent pas.</string>
     <string name="profile_pin_save">Enregistrer le code PIN</string>
     <string name="profile_pin_unlock_title">Déverrouiller %1$s</string>
-    <string name="profile_pin_unlock_subtitle">Saisis le code PIN à 4 chiffres pour continuer.</string>
+    <string name="profile_pin_unlock_subtitle">Saisissez le code PIN à 4 chiffres pour continuer.</string>
     <string name="profile_pin_verifying">Vérification…</string>
     <string name="profile_pin_unlock_action">Déverrouiller</string>
-    <string name="profile_pin_overlay_unlock_heading">Saisis ton code PIN pour accéder à %1$s.</string>
-    <string name="profile_pin_overlay_set_heading">Crée un code PIN à 4 chiffres pour %1$s.</string>
-    <string name="profile_pin_overlay_confirm_heading">Confirme ton nouveau code PIN.</string>
-    <string name="profile_pin_overlay_unlock_support">Utilise ta télécommande ou ton clavier pour saisir les 4 chiffres.</string>
+    <string name="profile_pin_overlay_unlock_heading">Saisissez votre code PIN pour accéder à %1$s.</string>
+    <string name="profile_pin_overlay_set_heading">Créez un code PIN à 4 chiffres pour %1$s.</string>
+    <string name="profile_pin_overlay_confirm_heading">Confirmez votre nouveau code PIN.</string>
+    <string name="profile_pin_overlay_unlock_support">Utilisez votre télécommande ou votre clavier pour saisir les 4 chiffres.</string>
     <string name="profile_pin_overlay_change_verify_kicker">Contrôle de sécurité requis.</string>
-    <string name="profile_pin_overlay_change_verify_heading">Saisis le code PIN actuel de %1$s pour le modifier.</string>
-    <string name="profile_pin_overlay_change_verify_support">Saisis le code PIN actuel à 4 chiffres avant d’en définir un nouveau.</string>
+    <string name="profile_pin_overlay_change_verify_heading">Saisissez le code PIN actuel de %1$s pour le modifier.</string>
+    <string name="profile_pin_overlay_change_verify_support">Saisissez le code PIN actuel à 4 chiffres avant d’en définir un nouveau.</string>
     <string name="profile_pin_overlay_remove_verify_kicker">Contrôle de sécurité requis.</string>
-    <string name="profile_pin_overlay_remove_verify_heading">Saisis le code PIN actuel de %1$s pour le supprimer.</string>
-    <string name="profile_pin_overlay_remove_verify_support">Saisis le code PIN actuel à 4 chiffres pour le supprimer.</string>
-    <string name="profile_pin_overlay_delete_verify_heading">Saisis le code PIN actuel pour supprimer %1$s.</string>
-    <string name="profile_pin_overlay_delete_verify_support">Saisis le code PIN actuel à 4 chiffres avant de supprimer ce profil.</string>
+    <string name="profile_pin_overlay_remove_verify_heading">Saisissez le code PIN actuel de %1$s pour le supprimer.</string>
+    <string name="profile_pin_overlay_remove_verify_support">Saisissez le code PIN actuel à 4 chiffres pour le supprimer.</string>
+    <string name="profile_pin_overlay_delete_verify_heading">Saisissez le code PIN actuel pour supprimer %1$s.</string>
+    <string name="profile_pin_overlay_delete_verify_support">Saisissez le code PIN actuel à 4 chiffres avant de supprimer ce profil.</string>
     <string name="profile_pin_overlay_set_support">Le code PIN sera requis pour accéder à ce profil.</string>
-    <string name="profile_pin_overlay_confirm_support">Saisis à nouveau les 4 chiffres pour terminer la configuration.</string>
-    <string name="profile_pin_overlay_mismatch">Les codes PIN ne correspondent pas. Recommence la saisie.</string>
-    <string name="profile_pin_overlay_forgot_hint">Code PIN oublié ? Réinitialise-le depuis ton compte Nuvio sur le site web.</string>
-    <string name="profile_pin_overlay_back_hint">Appuie sur « Retour » pour annuler</string>
+    <string name="profile_pin_overlay_confirm_support">Saisissez à nouveau les 4 chiffres pour terminer la configuration.</string>
+    <string name="profile_pin_overlay_mismatch">Les codes PIN ne correspondent pas. Recommencez la saisie.</string>
+    <string name="profile_pin_overlay_forgot_hint">Code PIN oublié ? Réinitialisez-le depuis votre compte Nuvio sur le site web.</string>
+    <string name="profile_pin_overlay_back_hint">Appuyez sur « Retour » pour annuler</string>
 
 
     <!-- Assistant d’installation des addons (mode essentiel) -->
     <string name="essential_addon_setup_title">Installer un addon</string>
-    <string name="essential_addon_setup_subtitle">Installe un addon pour commencer à diffuser. Tu pourras en ajouter d’autres plus tard depuis Addons.</string>
+    <string name="essential_addon_setup_subtitle">Installez un addon pour commencer à diffuser. Vous pourrez en ajouter d’autres plus tard depuis Addons.</string>
     <string name="essential_addon_show_qr">Afficher le QR</string>
     <!-- Repli éditeur de collection -->
     <string name="collection_editor_no_trakt_lists_found">Aucune liste Trakt trouvée</string>
@@ -1004,21 +1004,21 @@
     <string name="addon_installing">Installation en cours</string>
     <string name="addon_install_btn">Installer</string>
     <string name="addon_install_success">%1$s installé</string>
-    <string name="addon_error_invalid_url">Entre une URL d’addon valide</string>
+    <string name="addon_error_invalid_url">Entrez une URL d’addon valide</string>
     <string name="addon_error_invalid_scheme">L’URL de l’addon doit commencer par http ou https</string>
     <string name="addon_installed_section">Installés</string>
-    <string name="addon_empty">Aucun addon installé. Ajoute-en un pour commencer.</string>
+    <string name="addon_empty">Aucun addon installé. Ajoutez-en un pour commencer.</string>
     <string name="addon_remove">Supprimer</string>
     <string name="addon_manage_from_phone_title">Gérer depuis le téléphone</string>
-    <string name="addon_manage_from_phone_subtitle">Scanne un code QR pour gérer les addons et les catalogues depuis ton téléphone</string>
-    <string name="addon_manage_collections_from_phone_subtitle">Scanne un code QR pour gérer les collections depuis ton téléphone</string>
+    <string name="addon_manage_from_phone_subtitle">Scannez un code QR pour gérer les addons et les catalogues depuis votre téléphone</string>
+    <string name="addon_manage_collections_from_phone_subtitle">Scannez un code QR pour gérer les collections depuis votre téléphone</string>
     <string name="addon_reorder_title">Réorganiser les catalogues de l’accueil</string>
     <string name="addon_reorder_subtitle">Contrôle l’ordre des rangées de catalogues sur l’accueil (classique + moderne + grille)</string>
-    <string name="addon_qr_scan_instruction">Scanne avec ton téléphone pour gérer les addons et les catalogues</string>
-    <string name="addon_qr_collections_scan_instruction">Scanne avec ton téléphone pour gérer les collections</string>
+    <string name="addon_qr_scan_instruction">Scannez avec votre téléphone pour gérer les addons et les catalogues</string>
+    <string name="addon_qr_collections_scan_instruction">Scannez avec votre téléphone pour gérer les collections</string>
     <string name="addon_qr_close">Fermer</string>
     <string name="addon_confirm_title">Confirmer les modifications d’addons et de catalogues</string>
-    <string name="addon_confirm_subtitle">Les modifications suivantes ont été effectuées depuis ton téléphone :</string>
+    <string name="addon_confirm_subtitle">Les modifications suivantes ont été effectuées depuis votre téléphone :</string>
     <string name="addon_confirm_added">Ajoutés :</string>
     <string name="addon_confirm_removed">Supprimés :</string>
     <string name="addon_confirm_catalog_reordered">L’ordre des catalogues a été modifié</string>
@@ -1047,12 +1047,12 @@
     <!-- StreamScreen -->
     <string name="stream_retry">Réessayer</string>
     <string name="stream_no_streams">Aucun flux trouvé</string>
-    <string name="stream_no_streams_hint">Essaie d’installer plus d’addons pour trouver des flux</string>
+    <string name="stream_no_streams_hint">Essayez d’installer plus d’addons pour trouver des flux</string>
     <string name="stream_finding_source">Recherche de la source du flux</string>
     <string name="stream_type_torrent">Torrent</string>
     <string name="stream_type_youtube">YouTube</string>
     <string name="p2p_consent_title">Streaming P2P</string>
-    <string name="p2p_consent_body">Ce flux utilise la technologie pair-à-pair (P2P). En activant le P2P, tu reconnais et acceptes que :\n\n\u2022 Ton adresse IP sera visible par les autres pairs du réseau\n\u2022 Tu es seul responsable du contenu auquel tu accèdes\n\u2022 Tu confirmes avoir le droit légal de visionner ce contenu dans ta juridiction\n\u2022 Nuvio n’héberge, ne distribue ni ne contrôle aucun contenu P2P\n\u2022 Nuvio ne peut être tenu responsable des conséquences légales liées à ton utilisation du streaming P2P\n\nTu utilises cette fonctionnalité entièrement à tes propres risques. Le P2P peut être désactivé à tout moment dans les paramètres.</string>
+    <string name="p2p_consent_body">Ce flux utilise la technologie pair-à-pair (P2P). En activant le P2P, vous reconnaissez et acceptez que :\n\n\u2022 Votre adresse IP sera visible par les autres pairs du réseau\n\u2022 Vous êtes seul responsable du contenu auquel vous accédez\n\u2022 Vous confirmez avoir le droit légal de visionner ce contenu dans votre juridiction\n\u2022 Nuvio n’héberge, ne distribue ni ne contrôle aucun contenu P2P\n\u2022 Nuvio ne peut être tenu responsable des conséquences légales liées à votre utilisation du streaming P2P\n\nVous utilisez cette fonctionnalité entièrement à vos propres risques. Le P2P peut être désactivé à tout moment dans les paramètres.</string>
     <string name="p2p_consent_enable">Activer le P2P</string>
     <string name="p2p_consent_cancel">Annuler</string>
     <string name="settings_p2p_title">Streaming P2P</string>
@@ -1086,14 +1086,14 @@
     <string name="playback_show_loading_status">Afficher l’état de chargement</string>
     <string name="playback_show_loading_status_sub">Afficher la progression étape par étape pendant l’initialisation du lecteur.</string>
     <string name="player_sync_line">Synchroniser la ligne</string>
-    <string name="subtitle_timing_press_sync">Appuie sur « Synchroniser » quand tu entends une réplique.</string>
+    <string name="subtitle_timing_press_sync">Appuyez sur « Synchroniser » quand vous entendez une réplique.</string>
     <string name="subtitle_timing_sync_button">Synchroniser</string>
-    <string name="subtitle_timing_select_addon_first">Sélectionne d’abord une piste de sous-titres d’addon.</string>
-    <string name="subtitle_auto_sync_select_addon_track">Sélectionne une piste de sous-titres d’addon pour utiliser la synchronisation automatique.</string>
+    <string name="subtitle_timing_select_addon_first">Sélectionnez d’abord une piste de sous-titres d’addon.</string>
+    <string name="subtitle_auto_sync_select_addon_track">Sélectionnez une piste de sous-titres d’addon pour utiliser la synchronisation automatique.</string>
     <string name="subtitle_auto_sync_applied">Synchronisation appliquée : %1$s</string>
     <string name="subtitle_timing_loading">Chargement des lignes de sous-titres…</string>
     <string name="subtitle_timing_no_lines_found">Aucune ligne de sous-titre trouvée autour de ce moment.</string>
-    <string name="subtitle_timing_press_back_cancel">Appuie sur « Retour » pour annuler</string>
+    <string name="subtitle_timing_press_back_cancel">Appuyez sur « Retour » pour annuler</string>
     <string name="subtitle_timing_captured_at">Capturé à %1$s</string>
     <string name="subtitle_timing_capturing">Capture…</string>
 
@@ -1220,7 +1220,7 @@
     <string name="panel_failed_load_episodes">Échec du chargement des épisodes</string>
 
     <!-- PauseOverlay -->
-    <string name="pause_you_are_watching">Tu regardes</string>
+    <string name="pause_you_are_watching">Vous regardez</string>
     <string name="pause_cast_label">Distribution</string>
     <string name="pause_back_to_details">Retour aux détails</string>
     <string name="pause_as_character">dans le rôle de %1$s</string>
@@ -1241,16 +1241,16 @@
 
 
     <!-- SearchScreen -->
-    <string name="search_keyboard_hint">Appuie sur OK sur le clavier pour rechercher</string>
+    <string name="search_keyboard_hint">Appuyez sur OK sur le clavier pour rechercher</string>
     <string name="search_placeholder">Rechercher des films et séries</string>
     <string name="search_start_title">Lancer une recherche</string>
-    <string name="search_start_subtitle">Saisis au moins 2 caractères</string>
-    <string name="search_start_subtitle_no_discover">Découvrir est désactivé. Saisis au moins 2 caractères</string>
+    <string name="search_start_subtitle">Saisissez au moins 2 caractères</string>
+    <string name="search_start_subtitle_no_discover">Découvrir est désactivé. Saisissez au moins 2 caractères</string>
     <string name="search_recent_title">Recherches récentes</string>
     <string name="search_recent_clear">Effacer l’historique</string>
-    <string name="search_voice_no_speech">Aucune voix détectée. Réessaie.</string>
+    <string name="search_voice_no_speech">Aucune voix détectée. Réessayez.</string>
     <string name="search_voice_mic_permission">L’autorisation d’utiliser le micro est requise pour la recherche vocale.</string>
-    <string name="search_voice_failed">Échec de la reconnaissance vocale. Réessaie.</string>
+    <string name="search_voice_failed">Échec de la reconnaissance vocale. Réessayez.</string>
     <string name="search_voice_unavailable">La recherche vocale n’est pas disponible sur cet appareil.</string>
 
     <!-- LibraryScreen -->
@@ -1305,7 +1305,7 @@
     <string name="library_list_delete">Supprimer</string>
     <string name="library_list_close">Fermer</string>
     <string name="library_list_name_label">Nom</string>
-    <string name="library_error_list_name_required">Saisis un nom de liste</string>
+    <string name="library_error_list_name_required">Saisissez un nom de liste</string>
     <string name="library_list_description_label">Description</string>
     <string name="library_list_privacy">Confidentialité</string>
     <string name="library_delete_title">Supprimer cette liste ?</string>
@@ -1320,17 +1320,17 @@
     <string name="library_type_items">éléments</string>
     <string name="library_empty_local_title">Aucun %1$s pour le moment</string>
     <string name="library_empty_trakt_title">Aucun %1$s dans cette liste</string>
-    <string name="library_empty_local_subtitle">Commence à enregistrer tes favoris pour les voir ici</string>
-    <string name="library_empty_trakt_subtitle">Utilise + dans les détails pour ajouter des éléments à la liste de suivi ou aux listes</string>
+    <string name="library_empty_local_subtitle">Commencez à enregistrer vos favoris pour les voir ici</string>
+    <string name="library_empty_trakt_subtitle">Utilisez + dans les détails pour ajouter des éléments à la liste de suivi ou aux listes</string>
     <string name="library_empty_trakt_not_auth_title">Trakt non connecté</string>
-    <string name="library_empty_trakt_not_auth_subtitle">Connecte ton compte Trakt dans les paramètres pour voir ta bibliothèque Trakt</string>
+    <string name="library_empty_trakt_not_auth_subtitle">Connectez votre compte Trakt dans les paramètres pour voir votre bibliothèque Trakt</string>
 
     <!-- AccountSettingsContent -->
     <string name="account_loading">Chargement\u2026</string>
-    <string name="account_sync_description">Synchronise ta bibliothèque, ta progression, tes addons et plugins entre tes appareils.</string>
-    <string name="account_sync_restart_note">La synchronisation n’est pas en temps réel entre les appareils actifs. Redémarre cet appareil après t’être connecté ou pour récupérer les modifications effectuées ailleurs.</string>
+    <string name="account_sync_description">Synchronisez votre bibliothèque, votre progression, vos addons et plugins entre vos appareils.</string>
+    <string name="account_sync_restart_note">La synchronisation n’est pas en temps réel entre les appareils actifs. Redémarrez cet appareil après vous être connecté ou pour récupérer les modifications effectuées ailleurs.</string>
     <string name="account_signin_qr_title">Connexion par code QR</string>
-    <string name="account_signin_qr_subtitle">Scanne un code QR et complète la connexion par e-mail sur ton téléphone</string>
+    <string name="account_signin_qr_subtitle">Scannez un code QR et complétez la connexion par e-mail sur votre téléphone</string>
     <string name="account_signed_in_label">Connecté</string>
     <string name="account_total_label">Total</string>
     <string name="account_loading_sync">Chargement des données de synchronisation\u2026</string>
@@ -1338,7 +1338,7 @@
 
     <!-- AuthSignInScreen -->
     <string name="auth_signin_title">Connexion</string>
-    <string name="auth_signin_tv_disabled">La saisie par e-mail/mot de passe sur TV est désactivée. Continue avec la connexion par code QR.</string>
+    <string name="auth_signin_tv_disabled">La saisie par e-mail/mot de passe sur TV est désactivée. Continuez avec la connexion par code QR.</string>
     <string name="auth_signin_qr_btn">Continuer avec le code QR</string>
 
     <!-- AuthQrSignInScreen -->
@@ -1347,37 +1347,37 @@
     <string name="auth_qr_finishing">Finalisation de la connexion\u2026</string>
     <string name="auth_qr_code_label">Code : %1$s</string>
     <string name="auth_qr_expires">Expire dans %1$s</string>
-    <string name="auth_qr_phone_hint">Utilise ton téléphone pour te connecter avec une adresse e-mail et un mot de passe. La TV affiche uniquement le code QR pour une connexion plus rapide.</string>
-    <string name="auth_qr_scan_instruction">Scanne le code QR, valide dans le navigateur, puis reviens ici.</string>
+    <string name="auth_qr_phone_hint">Utilisez votre téléphone pour vous connecter avec une adresse e-mail et un mot de passe. La TV affiche uniquement le code QR pour une connexion plus rapide.</string>
+    <string name="auth_qr_scan_instruction">Scannez le code QR, validez dans le navigateur, puis revenez ici.</string>
     <string name="auth_qr_code_display">Code : %1$s</string>
     <string name="auth_qr_refresh">Actualiser le code QR</string>
     <string name="auth_qr_continue_without_account">Continuer sans compte</string>
-    <string name="auth_qr_connected">Ton compte est connecté sur ce téléviseur.</string>
-    <string name="auth_qr_synced_data">Tes données synchronisées</string>
+    <string name="auth_qr_connected">Votre compte est connecté sur ce téléviseur.</string>
+    <string name="auth_qr_synced_data">Vos données synchronisées</string>
     <string name="auth_qr_generating">Génération du code QR\u2026</string>
-    <string name="auth_qr_unavailable">Code QR indisponible. Actualise pour réessayer.</string>
-    <string name="auth_qr_please_wait">Patiente\u2026</string>
+    <string name="auth_qr_unavailable">Code QR indisponible. Actualisez pour réessayer.</string>
+    <string name="auth_qr_please_wait">Patientez\u2026</string>
     <string name="auth_qr_continue">Continuer</string>
     <string name="auth_qr_back">Retour</string>
 
     <!-- SyncCodeGenerateScreen -->
     <string name="sync_generate_title">Générer un code de synchronisation</string>
-    <string name="sync_generate_subtitle">Crée un PIN pour protéger ton code de synchronisation. Partage le code avec tes autres appareils.</string>
-    <string name="sync_generate_code_label">Ton code de synchronisation</string>
-    <string name="sync_generate_instruction">Entre ce code et ton PIN sur ton autre appareil pour les lier.</string>
+    <string name="sync_generate_subtitle">Créez un PIN pour protéger votre code de synchronisation. Partagez le code avec vos autres appareils.</string>
+    <string name="sync_generate_code_label">Votre code de synchronisation</string>
+    <string name="sync_generate_instruction">Entrez ce code et votre PIN sur votre autre appareil pour les lier.</string>
     <string name="sync_generate_done">Terminé</string>
-    <string name="sync_generate_pin_label">Choisis un PIN (4-8 caractères)</string>
-    <string name="sync_generate_pin_placeholder">Entre le PIN</string>
+    <string name="sync_generate_pin_label">Choisissez un PIN (4-8 caractères)</string>
+    <string name="sync_generate_pin_placeholder">Entrez le PIN</string>
 
     <!-- SyncCodeClaimScreen -->
     <string name="sync_claim_title">Lier un appareil</string>
-    <string name="sync_claim_subtitle">Entre le code de synchronisation et le PIN de ton autre appareil pour lier cet appareil.</string>
-    <string name="sync_claim_success">Appareil lié avec succès ! Tes addons et plugins seront désormais synchronisés.</string>
+    <string name="sync_claim_subtitle">Entrez le code de synchronisation et le PIN de votre autre appareil pour lier cet appareil.</string>
+    <string name="sync_claim_success">Appareil lié avec succès ! Vos addons et plugins seront désormais synchronisés.</string>
     <string name="sync_claim_done">Terminé</string>
     <string name="sync_claim_code_label">Code de synchronisation</string>
     <string name="sync_claim_code_placeholder">XXXX-XXXX-XXXX-XXXX-XXXX</string>
     <string name="sync_claim_pin_label">PIN</string>
-    <string name="sync_claim_pin_placeholder">Entre le PIN</string>
+    <string name="sync_claim_pin_placeholder">Entrez le PIN</string>
 
     <!-- PluginScreen -->
     <string name="plugin_readonly_notice">Utilise les plugins du profil principal et ne peut pas être modifié</string>
@@ -1388,11 +1388,11 @@
     <string name="plugin_add_repository">Ajouter un dépôt</string>
     <string name="plugin_add_btn">Ajouter</string>
     <string name="plugin_manage_from_phone_title">Gérer depuis le téléphone</string>
-    <string name="plugin_manage_from_phone_subtitle">Scanne un code QR pour ajouter ou supprimer des dépôts depuis ton téléphone</string>
-    <string name="plugin_qr_instruction">Scanne avec ton téléphone pour gérer les dépôts</string>
+    <string name="plugin_manage_from_phone_subtitle">Scannez un code QR pour ajouter ou supprimer des dépôts depuis votre téléphone</string>
+    <string name="plugin_qr_instruction">Scannez avec votre téléphone pour gérer les dépôts</string>
     <string name="plugin_qr_close">Fermer</string>
     <string name="plugin_confirm_title">Confirmer les modifications de dépôts</string>
-    <string name="plugin_confirm_subtitle">Les modifications suivantes ont été effectuées depuis ton téléphone :</string>
+    <string name="plugin_confirm_subtitle">Les modifications suivantes ont été effectuées depuis votre téléphone :</string>
     <string name="plugin_confirm_added">Ajoutés :</string>
     <string name="plugin_confirm_removed">Supprimés :</string>
     <string name="plugin_confirm_no_changes">Aucune modification détectée</string>
@@ -1400,8 +1400,8 @@
     <string name="plugin_confirm_reject">Rejeter</string>
     <string name="plugin_confirm_confirm">Confirmer</string>
     <string name="plugin_url_or_short_code_placeholder">URL ou code court</string>
-    <string name="plugin_diagnostics_collapse">Diagnostics (appuie pour réduire)</string>
-    <string name="plugin_diagnostics_expand">Diagnostics (appuie pour développer)</string>
+    <string name="plugin_diagnostics_collapse">Diagnostics (appuyez pour réduire)</string>
+    <string name="plugin_diagnostics_expand">Diagnostics (appuyez pour développer)</string>
     <string name="plugin_risky_enable_title">Activer le fournisseur ?</string>
     <string name="plugin_risky_enable_message">%1$s est connu pour provoquer des plantages sur certains contenus. L’activer quand même ?</string>
     <string name="plugin_risky_enable_cancel">Annuler</string>
@@ -1412,8 +1412,8 @@
 
     <!-- ProfileSelectionScreen -->
     <string name="profile_selection_title">Qui regarde ?</string>
-    <string name="profile_selection_subtitle">Sélectionne un profil pour continuer</string>
-    <string name="profile_selection_hint">Maintiens enfoncé pour gérer le profil</string>
+    <string name="profile_selection_subtitle">Sélectionnez un profil pour continuer</string>
+    <string name="profile_selection_hint">Maintenez enfoncé pour gérer le profil</string>
     <string name="profile_selection_empty">Aucun profil trouvé</string>
     <string name="profile_selection_primary_badge">Principal</string>
     <string name="profile_selection_options_title">Options du profil</string>
@@ -1433,11 +1433,11 @@
     <!-- CatalogSeeAllScreen -->
     <string name="catalog_see_all_from">depuis %1$s</string>
     <string name="catalog_see_all_empty_title">Aucun élément disponible</string>
-    <string name="catalog_see_all_empty_subtitle">Essaie un autre catalogue ou reviens plus tard</string>
+    <string name="catalog_see_all_empty_subtitle">Essayez un autre catalogue ou revenez plus tard</string>
 
     <!-- LayoutSelectionScreen -->
     <string name="layout_selection_welcome">Bienvenue sur Nuvio</string>
-    <string name="layout_selection_subtitle">Choisis la disposition de ton écran d’accueil</string>
+    <string name="layout_selection_subtitle">Choisissez la disposition de votre écran d’accueil</string>
     <string name="layout_selection_continue">Continuer</string>
 
     <!-- UpdatePromptDialog -->
@@ -1445,10 +1445,10 @@
     <string name="update_downloading">Téléchargement de la mise à jour</string>
     <string name="update_download">Télécharger</string>
     <string name="update_downloading_ellipsis">Téléchargement…</string>
-    <string name="update_unknown_sources">Autorise l’installation depuis des sources inconnues pour continuer.</string>
+    <string name="update_unknown_sources">Autorisez l’installation depuis des sources inconnues pour continuer.</string>
     <!-- AccountScreen -->
     <string name="account_title">Compte</string>
-    <string name="account_sign_in_description">Connecte-toi pour synchroniser ta bibliothèque, ta progression, tes addons et plugins entre tes appareils. La synchronisation de la bibliothèque utilise Nuvio Sync quand Trakt n’est pas connecté, et la progression peut utiliser Trakt ou Nuvio Sync.</string>
+    <string name="account_sign_in_description">Connectez-vous pour synchroniser votre bibliothèque, votre progression, vos addons et plugins entre vos appareils. La synchronisation de la bibliothèque utilise Nuvio Sync quand Trakt n’est pas connecté, et la progression peut utiliser Trakt ou Nuvio Sync.</string>
     <string name="account_sync_code_title">Code de synchronisation</string>
     <string name="account_sync_code_description">Synchroniser entre appareils sans créer de compte.</string>
     <string name="account_linked_devices">Appareils liés (%1$d)</string>
@@ -1470,10 +1470,10 @@
     <string name="discover_filter_genre">Genre</string>
     <string name="discover_select_catalog">Sélectionner</string>
     <string name="discover_genre_default">Par défaut</string>
-    <string name="discover_empty_no_catalog_title">Sélectionne un catalogue</string>
-    <string name="discover_empty_no_catalog_subtitle">Choisis un catalogue à parcourir</string>
+    <string name="discover_empty_no_catalog_title">Sélectionnez un catalogue</string>
+    <string name="discover_empty_no_catalog_subtitle">Choisissez un catalogue à parcourir</string>
     <string name="discover_empty_no_content_title">Aucun contenu trouvé</string>
-    <string name="discover_empty_no_content_subtitle">Essaie un autre genre ou catalogue</string>
+    <string name="discover_empty_no_content_subtitle">Essayez un autre genre ou catalogue</string>
 
     <!-- AddonManagerScreen -->
     <string name="addon_confirm_total_addons">Total des addons : %1$d</string>
@@ -1485,7 +1485,7 @@
     <string name="plugin_providers_count">%1$d fournisseurs</string>
     <string name="plugin_enabled">Activé</string>
     <string name="plugin_disabled">Désactivé</string>
-    <string name="plugin_no_repos">Aucun dépôt ajouté pour le moment.\nAjoute un dépôt pour commencer.</string>
+    <string name="plugin_no_repos">Aucun dépôt ajouté pour le moment.\nAjoutez un dépôt pour commencer.</string>
 
     <!-- ProfileSettingsContent -->
     <string name="profile_edit_title_id">Modifier le profil %1$d</string>
@@ -1497,9 +1497,9 @@
 
     <!-- DV7 Handling Mode -->
     <string name="dv7_handling_title">Gestion de Dolby Vision Profile 7</string>
-    <string name="dv7_handling_dialog_subtitle">Choisis comment les flux DV Profile 7 sont traités à la lecture.</string>
+    <string name="dv7_handling_dialog_subtitle">Choisissez comment les flux DV Profile 7 sont traités à la lecture.</string>
     <string name="dv7_mode_auto">Auto (recommandé)</string>
-    <string name="dv7_mode_auto_desc">Détecte ton écran et choisit le meilleur mode. En cas de problème de lecture, essaie «&#160;Couche HDR10 de base&#160;».</string>
+    <string name="dv7_mode_auto_desc">Détecte votre écran et choisit le meilleur mode. En cas de problème de lecture, essayez «&#160;Couche HDR10 de base&#160;».</string>
     <string name="dv7_mode_hdr10_base_layer">Couche HDR10 de base</string>
     <string name="dv7_mode_hdr10_base_layer_desc">Supprime systématiquement Dolby Vision et lit la couche HEVC HDR10 de base.</string>
     <string name="dv7_mode_dv81_libdovi">Convertir en DV8.1</string>
@@ -1543,20 +1543,20 @@
     <string name="watchlist_removed">Retiré de la liste de suivi</string>
 
     <!-- Profile PIN errors -->
-    <string name="profile_pin_save_error">Impossible d’enregistrer le code PIN. Réessaie.</string>
-    <string name="profile_pin_locked">Profil verrouillé. Réessaie dans %1$ds.</string>
-    <string name="profile_pin_invalid">Code PIN invalide. Réessaie.</string>
-    <string name="profile_pin_verify_error">Impossible de vérifier le code PIN. Réessaie.</string>
+    <string name="profile_pin_save_error">Impossible d’enregistrer le code PIN. Réessayez.</string>
+    <string name="profile_pin_locked">Profil verrouillé. Réessayez dans %1$ds.</string>
+    <string name="profile_pin_invalid">Code PIN invalide. Réessayez.</string>
+    <string name="profile_pin_verify_error">Impossible de vérifier le code PIN. Réessayez.</string>
     <string name="profile_pin_incorrect">Le code PIN actuel est incorrect.</string>
-    <string name="profile_pin_current_required">Ce profil a déjà un code PIN. Saisis le code PIN actuel pour le modifier.</string>
+    <string name="profile_pin_current_required">Ce profil a déjà un code PIN. Saisissez le code PIN actuel pour le modifier.</string>
 
     <!-- Account Screen -->
     <string name="account_signin_create_title">Se connecter / créer un compte</string>
-    <string name="account_signin_create_desc">Utilise ton e-mail et ton mot de passe pour créer ton compte ou t’y connecter.</string>
-    <string name="account_generate_sync_desc">Crée un code sur cet appareil pour que d’autres appareils puissent s’y lier.</string>
-    <string name="account_enter_sync_desc">Lie cet appareil à un autre en utilisant un code de synchronisation.</string>
+    <string name="account_signin_create_desc">Utilisez votre e-mail et votre mot de passe pour créer votre compte ou vous y connecter.</string>
+    <string name="account_generate_sync_desc">Créez un code sur cet appareil pour que d’autres appareils puissent s’y lier.</string>
+    <string name="account_enter_sync_desc">Liez cet appareil à un autre en utilisant un code de synchronisation.</string>
     <string name="account_signed_in_as">Connecté en tant que</string>
-    <string name="account_generate_sync_signed_in_desc">Crée un code pour que d’autres appareils puissent se synchroniser avec ce compte.</string>
+    <string name="account_generate_sync_signed_in_desc">Créez un code pour que d’autres appareils puissent se synchroniser avec ce compte.</string>
     <string name="account_unknown_device">Appareil inconnu</string>
 
     <!-- Sync screens -->
@@ -1566,9 +1566,9 @@
 
     <!-- Search -->
     <string name="search_no_results_title">Aucun résultat</string>
-    <string name="search_no_results_subtitle">Essaie avec d’autres mots-clés</string>
+    <string name="search_no_results_subtitle">Essayez avec d’autres mots-clés</string>
     <string name="discover_disabled_title">Découvrir est désactivé</string>
-    <string name="discover_disabled_subtitle">Active Découvrir dans les paramètres</string>
+    <string name="discover_disabled_subtitle">Activez Découvrir dans les paramètres</string>
 
     <!-- Library -->
     <string name="library_list_create_dialog_title">Créer une liste</string>
@@ -1577,11 +1577,11 @@
     <string name="library_syncing_btn">Synchronisation\u2026</string>
 
     <!-- Error messages (shared) -->
-    <string name="error_network_required">Connecte-toi au Wi-Fi ou à l’Ethernet pour utiliser cette fonctionnalité</string>
+    <string name="error_network_required">Connectez-vous au Wi-Fi ou à l’Ethernet pour utiliser cette fonctionnalité</string>
     <string name="error_server_ports_unavailable">Impossible de démarrer le serveur. Tous les ports sont utilisés.</string>
 
     <!-- Plugin errors -->
-    <string name="plugin_error_invalid_url">Entre une URL valide</string>
+    <string name="plugin_error_invalid_url">Entrez une URL valide</string>
     <string name="plugin_error_add_repo">Échec de l’ajout du dépôt : %1$s</string>
     <string name="plugin_error_refresh">Échec de l’actualisation : %1$s</string>
     <string name="plugin_error_test">Échec du test : %1$s</string>
@@ -1592,13 +1592,13 @@
     <string name="plugin_repo_refreshed">Dépôt actualisé</string>
 
     <!-- Trakt errors -->
-    <string name="trakt_error_code_expired">Le code a expiré. Recommence.</string>
-    <string name="trakt_error_code_used">Le code a déjà été utilisé. Recommence.</string>
+    <string name="trakt_error_code_expired">Le code a expiré. Recommencez.</string>
+    <string name="trakt_error_code_used">Le code a déjà été utilisé. Recommencez.</string>
     <string name="trakt_error_denied">Autorisation refusée par Trakt.</string>
     <string name="trakt_error_missing_credentials">Identifiants Trakt manquants</string>
-    <string name="trakt_error_network_retry">Erreur réseau, réessaie</string>
+    <string name="trakt_error_network_retry">Erreur réseau, réessayez</string>
     <string name="trakt_error_network_will_retry">Erreur réseau, nouvelle tentative à venir</string>
-    <string name="trakt_error_rate_limited_minutes">Trakt limite les requêtes. Réessaie dans ~%1$d min</string>
+    <string name="trakt_error_rate_limited_minutes">Trakt limite les requêtes. Réessayez dans ~%1$d min</string>
     <string name="trakt_error_failed_start_code">Impossible de démarrer l’authentification Trakt (%1$d)</string>
     <string name="trakt_error_no_active_device_code">Aucun code d’appareil Trakt actif</string>
     <string name="trakt_error_invalid_device_code">Code d’appareil invalide</string>
@@ -1606,7 +1606,7 @@
     <string name="trakt_error_public_request_failed">Échec de la requête Trakt</string>
     <string name="trakt_error_list_not_found_or_private">Liste Trakt introuvable ou non publique</string>
     <string name="trakt_error_rate_limit_reached">Limite de débit Trakt atteinte</string>
-    <string name="trakt_status_enter_activation_code">Entre le code sur trakt.tv/activate</string>
+    <string name="trakt_status_enter_activation_code">Entrez le code sur trakt.tv/activate</string>
     <string name="trakt_status_syncing">Synchronisation…</string>
     <string name="trakt_status_sync_completed">Synchronisation terminée</string>
     <string name="trakt_status_disconnected">Déconnecté de Trakt</string>
@@ -1620,7 +1620,7 @@
     <string name="addon_error_not_found">Addon introuvable</string>
 
     <!-- Account errors -->
-    <string name="account_error_signin_required">Connecte-toi d’abord avec un compte.</string>
+    <string name="account_error_signin_required">Connectez-vous d’abord avec un compte.</string>
 
     <!-- Search errors -->
     <string name="search_error_no_catalogs">Aucun catalogue de recherche trouvé dans les addons installés</string>
@@ -1698,21 +1698,21 @@
 
     <!-- Collection Management -->
     <string name="collections_header">Collections</string>
-    <string name="collections_empty">Aucune collection pour le moment. Crée-en une pour organiser tes catalogues.</string>
+    <string name="collections_empty">Aucune collection pour le moment. Créez-en une pour organiser vos catalogues.</string>
     <string name="collections_new">Nouvelle collection</string>
     <string name="collections_import">Importer</string>
     <string name="collections_export_file">Exporter le fichier</string>
     <string name="collections_saved_downloads">Enregistré dans le dossier Téléchargements</string>
     <string name="collections_export_failed">Échec de l’export</string>
     <string name="collections_import_header">Importer des collections</string>
-    <string name="collections_import_description">Importe des collections depuis du JSON. Les catalogues provenant d’addons non installés afficheront un avertissement.</string>
+    <string name="collections_import_description">Importez des collections depuis du JSON. Les catalogues provenant d’addons non installés afficheront un avertissement.</string>
     <string name="collections_import_url_placeholder">https://example.com/collections.json</string>
     <string name="collections_import_failed_fetch_http">Échec de la récupération : HTTP %1$d</string>
     <string name="collections_import_failed_fetch_url">Échec de la récupération de l’URL : %1$s</string>
-    <string name="collections_import_paste_json_required">Colle un JSON de collections à importer</string>
+    <string name="collections_import_paste_json_required">Collez un JSON de collections à importer</string>
     <string name="collections_import_no_data">Aucune donnée à importer</string>
     <string name="collections_import_invalid_or_empty">Format invalide ou collections vides</string>
-    <string name="collections_import_file_not_found_downloads">Fichier introuvable dans Téléchargements.\nExporte d’abord les collections pour le créer.</string>
+    <string name="collections_import_file_not_found_downloads">Fichier introuvable dans Téléchargements.\nExportez d’abord les collections pour le créer.</string>
     <string name="collections_import_failed_read_file">Échec de la lecture du fichier : %1$s</string>
     <string name="collections_cancel">Annuler</string>
     <string name="collections_mode_paste">Coller le JSON</string>
@@ -1720,7 +1720,7 @@
     <string name="collections_mode_url">Depuis une URL</string>
     <string name="collections_paste_clipboard">Coller depuis le presse-papiers</string>
     <string name="collections_validate">Valider</string>
-    <string name="collections_paste_hint">Colle le JSON des collections ici…</string>
+    <string name="collections_paste_hint">Collez le JSON des collections ici…</string>
     <string name="collections_file_description">Lit nuvio-collections.json depuis le dossier Téléchargements.</string>
     <string name="collections_load_file">Charger le fichier</string>
     <string name="collections_file_loaded">Fichier chargé (%1$d caractères)</string>
@@ -1812,12 +1812,12 @@
     <string name="collections_editor_tmdb_person_credits">Crédits de personne</string>
     <string name="collections_editor_tmdb_director_credits">Crédits de réalisateur</string>
     <string name="collections_editor_tmdb_company_fallback">Société TMDB %1$d</string>
-    <string name="collections_editor_tmdb_help_presets">Choisis une source prête à l’emploi. Tu peux la modifier ou la supprimer après l’ajout.</string>
-    <string name="collections_editor_tmdb_help_list">Colle une URL de liste TMDB publique ou uniquement le numéro de l’URL.</string>
-    <string name="collections_editor_tmdb_help_production">Recherche par nom de studio ou colle un ID/URL de société TMDB et ajoute-la directement.</string>
-    <string name="collections_editor_tmdb_help_network">Saisis un ID de chaîne. Les chaînes courantes sont disponibles dans les préréglages et les filtres rapides.</string>
-    <string name="collections_editor_tmdb_help_collection">Recherche le nom d’une collection de films ou colle l’ID de collection depuis TMDB.</string>
-    <string name="collections_editor_tmdb_help_discover">Crée une rangée TMDB dynamique avec des filtres optionnels. Laisse les champs vides quand tu n’as pas besoin de ce filtre.</string>
+    <string name="collections_editor_tmdb_help_presets">Choisissez une source prête à l’emploi. Vous pouvez la modifier ou la supprimer après l’ajout.</string>
+    <string name="collections_editor_tmdb_help_list">Collez une URL de liste TMDB publique ou uniquement le numéro de l’URL.</string>
+    <string name="collections_editor_tmdb_help_production">Recherchez par nom de studio ou collez un ID/URL de société TMDB et ajoutez-la directement.</string>
+    <string name="collections_editor_tmdb_help_network">Saisissez un ID de chaîne. Les chaînes courantes sont disponibles dans les préréglages et les filtres rapides.</string>
+    <string name="collections_editor_tmdb_help_collection">Recherchez le nom d’une collection de films ou collez l’ID de collection depuis TMDB.</string>
+    <string name="collections_editor_tmdb_help_discover">Créez une rangée TMDB dynamique avec des filtres optionnels. Laissez les champs vides quand vous n’avez pas besoin de ce filtre.</string>
     <string name="collections_editor_tmdb_search_helper">Exemples : Marvel Studios, 420 ou https://www.themoviedb.org/company/420.</string>
     <string name="collections_editor_tmdb_collection_helper">Exemple : Star Wars Collection, Harry Potter Collection ou une URL de collection.</string>
     <string name="collections_editor_tmdb_network_helper">Exemples d’ID : Netflix 213, HBO 49, Disney+ 2739.</string>
@@ -1830,27 +1830,27 @@
     <string name="collections_editor_tmdb_quick_companies">Studios rapides</string>
     <string name="collections_editor_tmdb_quick_networks">Chaînes rapides</string>
     <string name="collections_editor_tmdb_genres">ID de genre</string>
-    <string name="collections_editor_tmdb_genres_helper">Utilise les numéros de genre TMDB. Sépare plusieurs valeurs par des virgules pour ET, ou des barres verticales pour OU.</string>
+    <string name="collections_editor_tmdb_genres_helper">Utilisez les numéros de genre TMDB. Séparez plusieurs valeurs par des virgules pour ET, ou des barres verticales pour OU.</string>
     <string name="collections_editor_tmdb_date_from">Date de sortie ou de diffusion à partir du</string>
     <string name="collections_editor_tmdb_date_to">Date de sortie ou de diffusion jusqu’au</string>
-    <string name="collections_editor_tmdb_date_helper">Utilise le format AAAA-MM-JJ, par exemple 2024-01-01.</string>
+    <string name="collections_editor_tmdb_date_helper">Utilisez le format AAAA-MM-JJ, par exemple 2024-01-01.</string>
     <string name="collections_editor_tmdb_rating_min">Note minimale</string>
     <string name="collections_editor_tmdb_rating_max">Note maximale</string>
     <string name="collections_editor_tmdb_rating_helper">Note TMDB de 0 à 10. Exemple : 7.0.</string>
     <string name="collections_editor_tmdb_votes_min">Nombre minimum de votes</string>
-    <string name="collections_editor_tmdb_votes_helper">Utilise ceci pour éviter les titres obscurs avec peu de votes. Exemple : 100.</string>
+    <string name="collections_editor_tmdb_votes_helper">Utilisez ceci pour éviter les titres obscurs avec peu de votes. Exemple : 100.</string>
     <string name="collections_editor_tmdb_language">Langue originale</string>
-    <string name="collections_editor_tmdb_language_helper">Utilise des codes de langue à deux lettres, par exemple en, ko, ja, hi.</string>
+    <string name="collections_editor_tmdb_language_helper">Utilisez des codes de langue à deux lettres, par exemple en, ko, ja, hi.</string>
     <string name="collections_editor_tmdb_country">Pays d’origine</string>
-    <string name="collections_editor_tmdb_country_helper">Utilise des codes pays à deux lettres, par exemple US, KR, JP, IN.</string>
+    <string name="collections_editor_tmdb_country_helper">Utilisez des codes pays à deux lettres, par exemple US, KR, JP, IN.</string>
     <string name="collections_editor_tmdb_keywords">ID de mots-clés</string>
-    <string name="collections_editor_tmdb_keywords_helper">Utilise les numéros de mots-clés TMDB. Les puces rapides remplissent des exemples courants.</string>
+    <string name="collections_editor_tmdb_keywords_helper">Utilisez les numéros de mots-clés TMDB. Les puces rapides remplissent des exemples courants.</string>
     <string name="collections_editor_tmdb_companies">ID de société</string>
-    <string name="collections_editor_tmdb_companies_helper">Utilise des ID de studio/société. Les puces rapides remplissent des exemples courants.</string>
+    <string name="collections_editor_tmdb_companies_helper">Utilisez des ID de studio/société. Les puces rapides remplissent des exemples courants.</string>
     <string name="collections_editor_tmdb_networks">ID de chaîne</string>
-    <string name="collections_editor_tmdb_networks_helper">Pour les séries uniquement. Utilise des ID de chaîne comme Netflix 213 ou HBO 49.</string>
+    <string name="collections_editor_tmdb_networks_helper">Pour les séries uniquement. Utilisez des ID de chaîne comme Netflix 213 ou HBO 49.</string>
     <string name="collections_editor_tmdb_year">Année</string>
-    <string name="collections_editor_tmdb_year_helper">Utilise une année à quatre chiffres, par exemple 2024.</string>
+    <string name="collections_editor_tmdb_year_helper">Utilisez une année à quatre chiffres, par exemple 2024.</string>
     <string name="collections_editor_sort_original">Original</string>
     <string name="collections_editor_sort_list_order">Ordre de la liste</string>
     <string name="collections_editor_sort_recently_added">Ajouté récemment</string>
@@ -1865,10 +1865,10 @@
     <string name="collections_editor_trakt_public_list">Liste publique Trakt</string>
     <string name="collections_editor_trakt_items_count">%1$d éléments</string>
     <string name="collections_editor_trakt_likes_count">%1$d mentions J’aime</string>
-    <string name="collections_editor_error_valid_tmdb_id_or_url">Saisis un ID ou une URL TMDB valide</string>
+    <string name="collections_editor_error_valid_tmdb_id_or_url">Saisissez un ID ou une URL TMDB valide</string>
     <string name="collections_editor_error_load_tmdb_source">Impossible de charger la source TMDB</string>
-    <string name="collections_editor_error_trakt_list_id_or_url">Saisis un ID ou une URL de liste Trakt</string>
-    <string name="collections_editor_error_trakt_list_name_id_or_url">Saisis un nom, une URL ou un ID de liste Trakt</string>
+    <string name="collections_editor_error_trakt_list_id_or_url">Saisissez un ID ou une URL de liste Trakt</string>
+    <string name="collections_editor_error_trakt_list_name_id_or_url">Saisissez un nom, une URL ou un ID de liste Trakt</string>
     <string name="collections_editor_error_load_trakt_list">Impossible de charger la liste Trakt</string>
     <string name="collections_editor_error_load_trakt_lists">Impossible de charger les listes Trakt</string>
     <string name="collections_editor_error_search_trakt_lists">Impossible de chercher les listes Trakt</string>
@@ -1925,13 +1925,13 @@
     <string name="collections_editor_genre_required">Genre requis</string>
     <string name="collections_editor_genre_optional">Filtre de genre disponible</string>
     <string name="collections_card_title">Collections</string>
-    <string name="collections_card_subtitle">Regroupe les catalogues dans des dossiers sur ton écran d’accueil</string>
+    <string name="collections_card_subtitle">Regroupez les catalogues dans des dossiers sur votre écran d’accueil</string>
     <string name="collections_tab_all">Tout</string>
     <string name="collections_tab_combined">Combiné</string>
     <string name="collection_editor_remove_cd">Supprimer</string>
     <string name="collection_editor_choice_both">Les deux</string>
     <string name="collection_editor_resolved_trakt_list">Liste Trakt résolue</string>
-    <string name="collection_editor_trakt_search_placeholder">Cherche un titre, une URL Trakt ou un ID de liste</string>
+    <string name="collection_editor_trakt_search_placeholder">Cherchez un titre, une URL Trakt ou un ID de liste</string>
     <string name="collection_editor_trakt_name_placeholder">Soirée du week-end, films primés</string>
     <string name="collection_editor_folder_count_one">%1$d élément</string>
     <string name="collection_editor_folder_count_other">%1$d éléments</string>
@@ -1947,8 +1947,8 @@
 
 
     <!-- Locale parity (matches values/strings.xml additions on dev) -->
-    <string name="addon_manage_addons_only_from_phone_subtitle">Scanne un code QR pour installer ou supprimer des addons depuis ton téléphone</string>
-    <string name="addon_qr_addons_only_scan_instruction">Scanne avec ton téléphone pour installer ou supprimer des addons</string>
+    <string name="addon_manage_addons_only_from_phone_subtitle">Scannez un code QR pour installer ou supprimer des addons depuis votre téléphone</string>
+    <string name="addon_qr_addons_only_scan_instruction">Scannez avec votre téléphone pour installer ou supprimer des addons</string>
     <string name="web_manage_addons_only_subtitle">Installer ou supprimer des addons</string>
     <string name="auto_skip_intro">Intro / Générique de début</string>
     <string name="auto_skip_intro_sub">Passer automatiquement les intros et les génériques d’anime.</string>
@@ -1957,10 +1957,10 @@
     <string name="auto_skip_recap">Résumé</string>
     <string name="auto_skip_recap_sub">Passer automatiquement les segments de résumé.</string>
     <string name="playback_auto_skip_segments">Saut automatique</string>
-    <string name="playback_auto_skip_segments_sub">Choisis les segments à passer automatiquement.</string>
+    <string name="playback_auto_skip_segments_sub">Choisissez les segments à passer automatiquement.</string>
     <string name="collections_editor_tmdb_director_title_placeholder">Films de Christopher Nolan, réalisateurs favoris</string>
-    <string name="collections_editor_tmdb_help_director">Saisis un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de réalisation.</string>
-    <string name="collections_editor_tmdb_help_person">Saisis un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de casting.</string>
+    <string name="collections_editor_tmdb_help_director">Saisissez un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de réalisation.</string>
+    <string name="collections_editor_tmdb_help_person">Saisissez un ID ou une URL de personne TMDB pour construire une rangée à partir des crédits de casting.</string>
     <string name="collections_editor_tmdb_mode_director">Réalisateur</string>
     <string name="collections_editor_tmdb_mode_person">Personne</string>
     <string name="collections_editor_tmdb_person_helper">Exemple&#160;: https://www.themoviedb.org/person/31-tom-hanks ou 31.</string>
@@ -1969,12 +1969,12 @@
     <string name="collections_editor_tmdb_person_title_placeholder">Films de Tom Hanks, acteurs favoris</string>
     <string name="experience_mode_confirm_advanced_subtitle">Ce mode révèle l’ensemble des paramètres, y compris la configuration avancée et les contrôles de catalogue, de collection et de réglage fin.</string>
     <string name="experience_mode_confirm_advanced_title">Passer en mode avancé&#160;?</string>
-    <string name="experience_mode_confirm_essential_subtitle">Les écrans de configuration avancée seront masqués, mais tes paramètres enregistrés restent inchangés. Tu peux revenir en arrière à tout moment.</string>
+    <string name="experience_mode_confirm_essential_subtitle">Les écrans de configuration avancée seront masqués, mais vos paramètres enregistrés restent inchangés. Vous pouvez revenir en arrière à tout moment.</string>
     <string name="experience_mode_confirm_essential_title">Passer en mode essentiel&#160;?</string>
     <string name="experience_mode_essential">Essentiel</string>
     <string name="experience_mode_advanced">Avancé</string>
-    <string name="experience_mode_choose_title">Choisis ton expérience Nuvio</string>
-    <string name="experience_mode_choose_subtitle">Commence simple ou débloque toutes les options. Tu peux changer à tout moment.</string>
+    <string name="experience_mode_choose_title">Choisissez votre expérience Nuvio</string>
+    <string name="experience_mode_choose_subtitle">Commencez simple ou débloquez toutes les options. Vous pouvez changer à tout moment.</string>
     <string name="experience_mode_essential_card_subtitle">Configuration ciblée, addons, options de lecture de base, Trakt et paramètres de compte.</string>
     <string name="experience_mode_advanced_card_subtitle">Tous les paramètres&#160;: mise en page, ordre des catalogues, collections, plug-ins et diagnostics.</string>
     <string name="experience_mode_group_title">Mode d’expérience</string>
@@ -1990,7 +1990,7 @@
     <string name="audio_lang_media_default">Par défaut du média</string>
     <string name="essential_playback_header_title">Lecture</string>
     <string name="essential_playback_header_subtitle">Préférences simples de lecture, sous-titres, audio et P2P.</string>
-    <string name="essential_stream_selection_subtitle">Choisis manuellement ou lance automatiquement le premier flux disponible.</string>
+    <string name="essential_stream_selection_subtitle">Choisissez manuellement ou lancez automatiquement le premier flux disponible.</string>
     <string name="essential_autoplay_next_episode">Lecture automatique de l’épisode suivant</string>
     <string name="essential_autoplay_next_episode_subtitle">Enchaîne vers l’épisode suivant à la fin d’un flux.</string>
     <string name="external_auto_next_loading">Chargement de l’épisode suivant…</string>
@@ -2004,28 +2004,28 @@
     <string name="account_error_invalid_sync_code">Code de synchronisation invalide.</string>
     <string name="account_error_sync_code_not_found">Code de synchronisation introuvable.</string>
     <string name="account_error_device_already_linked">Cet appareil est déjà associé.</string>
-    <string name="account_error_generic_retry">Une erreur est survenue. Réessaie.</string>
+    <string name="account_error_generic_retry">Une erreur est survenue. Réessayez.</string>
     <string name="account_error_invalid_credentials">Adresse e-mail ou mot de passe incorrect.</string>
-    <string name="account_error_email_not_confirmed">Confirme d’abord ton adresse e-mail.</string>
+    <string name="account_error_email_not_confirmed">Confirmez d’abord votre adresse e-mail.</string>
     <string name="account_error_email_already_registered">Un compte avec cette adresse existe déjà.</string>
-    <string name="account_error_invalid_email">Saisis une adresse e-mail valide.</string>
+    <string name="account_error_invalid_email">Saisissez une adresse e-mail valide.</string>
     <string name="account_error_password_too_short">Le mot de passe est trop court.</string>
     <string name="account_error_password_too_weak">Le mot de passe est trop faible.</string>
     <string name="account_error_signup_disabled">Les inscriptions sont actuellement désactivées.</string>
-    <string name="account_error_rate_limited">Trop de tentatives. Réessaie plus tard.</string>
-    <string name="account_error_qr_login_expired">La connexion par QR code a expiré. Réessaie.</string>
+    <string name="account_error_rate_limited">Trop de tentatives. Réessayez plus tard.</string>
+    <string name="account_error_qr_login_expired">La connexion par QR code a expiré. Réessayez.</string>
     <string name="account_error_invalid_qr_login">Code de connexion QR invalide.</string>
     <string name="account_error_qr_login_other_device">Cette connexion QR a été demandée depuis un autre appareil.</string>
-    <string name="account_error_qr_login_outdated">Le service de connexion QR est obsolète. Réapplique la configuration SQL TV login.</string>
-    <string name="account_error_qr_login_missing_setup">Le backend de connexion QR n’est pas configuré. Mets à jour la configuration SQL TV login.</string>
+    <string name="account_error_qr_login_outdated">Le service de connexion QR est obsolète. Réappliquez la configuration SQL TV login.</string>
+    <string name="account_error_qr_login_missing_setup">Le backend de connexion QR n’est pas configuré. Mettez à jour la configuration SQL TV login.</string>
     <string name="account_error_qr_login_misconfigured">L’URL de connexion QR est mal configurée.</string>
-    <string name="account_error_qr_login_invalid_request">La requête de connexion QR est invalide. Réessaie.</string>
+    <string name="account_error_qr_login_invalid_request">La requête de connexion QR est invalide. Réessayez.</string>
     <string name="account_error_no_internet">Aucune connexion Internet.</string>
-    <string name="account_error_connection_timeout">Délai de connexion dépassé. Réessaie.</string>
+    <string name="account_error_connection_timeout">Délai de connexion dépassé. Réessayez.</string>
     <string name="account_error_connection_refused">Impossible de se connecter au serveur.</string>
-    <string name="account_error_not_authenticated">Connecte-toi d’abord.</string>
-    <string name="account_error_service_unavailable">Service indisponible. Réessaie plus tard.</string>
-    <string name="account_error_invalid_request">Requête invalide. Vérifie tes informations.</string>
+    <string name="account_error_not_authenticated">Connectez-vous d’abord.</string>
+    <string name="account_error_service_unavailable">Service indisponible. Réessayez plus tard.</string>
+    <string name="account_error_invalid_request">Requête invalide. Vérifiez vos informations.</string>
     <string name="account_error_unexpected">Une erreur inattendue s’est produite.</string>
     <string name="experience_mode_switch_to_advanced">Passer en mode avancé</string>
     <string name="experience_mode_switch_to_advanced_header_subtitle">Passe en mode avancé pour accéder à l’ensemble des paramètres.</string>
@@ -2094,14 +2094,14 @@
     <string name="player_track_subtitle_fallback">Sous-titres %1$d</string>
 
     <!-- Lecteur&#160;: récupération d’erreur -->
-    <string name="player_error_stream_blocked">\n\nLa source du flux est bloquée ou restreinte. Essaie une autre source.</string>
-    <string name="player_error_stream_removed">\n\nLe lien du flux a expiré ou a été supprimé. Essaie une autre source.</string>
-    <string name="player_error_stream_expired">\n\nLe lien du flux a expiré. Essaie une autre source.</string>
-    <string name="player_error_stream_rate_limited">\n\nTrop de requêtes vers la source du flux. Patiente un instant et réessaie.</string>
-    <string name="player_error_stream_unavailable">\n\nLe serveur du flux est actuellement indisponible. Essaie une autre source.</string>
-    <string name="player_error_source_invalid_content">Erreur de source&#160;: la source du flux a renvoyé du contenu invalide ou non lisible. Le lien a peut-être expiré ou le serveur a renvoyé une page d’erreur au lieu de la vidéo.\n\nEssaie une autre source. [%1$s]</string>
+    <string name="player_error_stream_blocked">\n\nLa source du flux est bloquée ou restreinte. Essayez une autre source.</string>
+    <string name="player_error_stream_removed">\n\nLe lien du flux a expiré ou a été supprimé. Essayez une autre source.</string>
+    <string name="player_error_stream_expired">\n\nLe lien du flux a expiré. Essayez une autre source.</string>
+    <string name="player_error_stream_rate_limited">\n\nTrop de requêtes vers la source du flux. Patientez un instant et réessayez.</string>
+    <string name="player_error_stream_unavailable">\n\nLe serveur du flux est actuellement indisponible. Essayez une autre source.</string>
+    <string name="player_error_source_invalid_content">Erreur de source&#160;: la source du flux a renvoyé du contenu invalide ou non lisible. Le lien a peut-être expiré ou le serveur a renvoyé une page d’erreur au lieu de la vidéo.\n\nEssayez une autre source. [%1$s]</string>
     <string name="player_error_decoder">Erreur de décodeur</string>
-    <string name="player_error_unsupported_format">Ce flux utilise un format que ton appareil ne prend peut-être pas en charge. Essaie une autre source. [%1$s]</string>
+    <string name="player_error_unsupported_format">Ce flux utilise un format que votre appareil ne prend peut-être pas en charge. Essayez une autre source. [%1$s]</string>
     <string name="player_error_initialize_failed">Échec de l’initialisation du lecteur</string>
     <string name="player_error_mpv_surface_failed">Échec de l’initialisation de la surface libmpv</string>
     <string name="player_error_mpv_playback_failed">Échec de l’initialisation de la lecture libmpv</string>
@@ -2333,24 +2333,24 @@
 
     <!-- Trakt&#160;: source des recommandations Similaires -->
     <string name="trakt_more_like_this_source_title">Source de la section Similaires</string>
-    <string name="trakt_more_like_this_source_subtitle">Choisis la provenance des recommandations sur les pages de détails</string>
+    <string name="trakt_more_like_this_source_subtitle">Choisissez la provenance des recommandations sur les pages de détails</string>
     <string name="trakt_more_like_this_source_dialog_title">Source de la section Similaires</string>
-    <string name="trakt_more_like_this_source_dialog_subtitle">Sélectionne la source des recommandations affichées sur les pages de détails.</string>
+    <string name="trakt_more_like_this_source_dialog_subtitle">Sélectionnez la source des recommandations affichées sur les pages de détails.</string>
     <string name="trakt_more_like_this_source_trakt">Trakt</string>
     <string name="trakt_more_like_this_source_tmdb">TMDB</string>
 
     <!-- Lecteur&#160;: invite épisode suivant -->
     <string name="player_next_episode_prompt_title">Continuer le visionnage&#160;?</string>
-    <string name="player_next_episode_prompt_message">Veux-tu lire l’épisode suivant&#160;?</string>
+    <string name="player_next_episode_prompt_message">Voulez-vous lire l’épisode suivant&#160;?</string>
     <string name="player_next_episode_prompt_yes">Oui</string>
     <string name="player_next_episode_prompt_no">Non, revenir aux détails</string>
 
-    <!-- Lecteur&#160;: invite «&#160;Tu regardes toujours&#160;» -->
-    <string name="still_watching_title">Tu regardes toujours&#160;?</string>
+    <!-- Lecteur&#160;: invite «&#160;Vous regardez toujours&#160;» -->
+    <string name="still_watching_title">Vous regardez toujours&#160;?</string>
     <string name="still_watching_continue">Regarder</string>
     <string name="still_watching_exit">Quitter</string>
     <string name="still_watching_countdown">Arrêt dans %1$d</string>
-    <string name="still_watching_setting_title">Tu regardes toujours&#160;?</string>
+    <string name="still_watching_setting_title">Vous regardez toujours&#160;?</string>
     <string name="still_watching_setting_sub">Demander après plusieurs épisodes lus automatiquement à la suite.</string>
     <string name="still_watching_threshold_title">Seuil d’épisodes</string>
     <string name="still_watching_threshold_sub">Nombre d’épisodes lus automatiquement avant de demander.</string>
@@ -2397,14 +2397,14 @@
     <string name="debrid_provider_torbox">Torbox</string>
     <string name="debrid_provider_available">Torbox</string>
     <string name="debrid_api_key_title">Torbox</string>
-    <string name="debrid_api_key_subtitle">Connecte ton compte Torbox.</string>
+    <string name="debrid_api_key_subtitle">Connectez votre compte Torbox.</string>
     <string name="debrid_dialog_title">Clé API Torbox</string>
-    <string name="debrid_dialog_subtitle">Saisis ta clé API Torbox.</string>
+    <string name="debrid_dialog_subtitle">Saisissez votre clé API Torbox.</string>
     <string name="debrid_dialog_placeholder">Saisir la clé API Torbox</string>
     <string name="debrid_real_debrid_api_key_title">Jeton API Real-Debrid</string>
     <string name="debrid_real_debrid_api_key_subtitle">Requis pour la résolution locale des liens Real-Debrid</string>
     <string name="debrid_real_debrid_dialog_title">Jeton API Real-Debrid</string>
-    <string name="debrid_real_debrid_dialog_subtitle">Saisis ton jeton API Real-Debrid pour Direct Debrid</string>
+    <string name="debrid_real_debrid_dialog_subtitle">Saisissez votre jeton API Real-Debrid pour Direct Debrid</string>
     <string name="debrid_real_debrid_dialog_placeholder">Saisir le jeton API Real-Debrid</string>
     <string name="debrid_not_set">Non défini</string>
     <string name="debrid_invalid_torbox_api_key">Impossible de valider cette clé API.</string>
@@ -2412,7 +2412,7 @@
     <string name="debrid_prepare_instant_playback">Préparer les liens</string>
     <string name="debrid_prepare_instant_playback_description">Résoudre les premières sources avant le début de la lecture.</string>
     <string name="debrid_prepare_stream_count">Sources à préparer</string>
-    <string name="debrid_prepare_stream_count_warning">Utilise une valeur plus faible si possible. Les services Debrid peuvent limiter le nombre de liens résolus sur une période donnée. Ouvrir un film ou un épisode peut compter dans ces limites même sans appuyer sur Lecture, car les liens sont préparés à l’avance.</string>
+    <string name="debrid_prepare_stream_count_warning">Utilisez une valeur plus faible si possible. Les services Debrid peuvent limiter le nombre de liens résolus sur une période donnée. Ouvrir un film ou un épisode peut compter dans ces limites même sans appuyer sur Lecture, car les liens sont préparés à l’avance.</string>
     <string name="debrid_prepare_count_one">1 source</string>
     <string name="debrid_prepare_count_many">%1$d sources</string>
     <string name="debrid_stream_max_results_title">Résultats max</string>
@@ -2420,7 +2420,7 @@
     <string name="debrid_stream_max_results_all">Tous les flux</string>
     <string name="debrid_stream_max_results_count">%1$d flux</string>
     <string name="debrid_stream_sort_title">Trier les flux</string>
-    <string name="debrid_stream_sort_subtitle">Choisis l’ordre des sources Direct Debrid.</string>
+    <string name="debrid_stream_sort_subtitle">Choisissez l’ordre des sources Direct Debrid.</string>
     <string name="debrid_stream_sort_default">Ordre d’origine</string>
     <string name="debrid_stream_sort_quality">Meilleure qualité en premier</string>
     <string name="debrid_stream_sort_size_desc">Plus gros en premier</string>
@@ -2481,28 +2481,28 @@
     <string name="debrid_stream_languages_excluded">Langues exclues</string>
     <string name="debrid_stream_release_groups_required">Groupes de release requis</string>
     <string name="debrid_stream_release_groups_excluded">Groupes de release exclus</string>
-    <string name="debrid_stream_release_groups_input_subtitle">Saisis un groupe par ligne.</string>
+    <string name="debrid_stream_release_groups_input_subtitle">Saisissez un groupe par ligne.</string>
 
     <string name="debrid_formatter_title">Éditeur web</string>
-    <string name="debrid_formatter_subtitle">Configure l’affichage des sources, les filtres et le tri depuis un autre appareil.</string>
+    <string name="debrid_formatter_subtitle">Configurez l’affichage des sources, les filtres et le tri depuis un autre appareil.</string>
     <string name="debrid_formatter_configure">Ouvrir l’éditeur web</string>
     <string name="debrid_formatter_reset_title">Réinitialiser le formatage</string>
     <string name="debrid_formatter_reset_subtitle">Restaurer le formatage des sources par défaut.</string>
-    <string name="debrid_formatter_qr_instruction">Scanne ce QR code sur ton téléphone pour configurer les paramètres des sources Debrid.</string>
+    <string name="debrid_formatter_qr_instruction">Scannez ce QR code sur votre téléphone pour configurer les paramètres des sources Debrid.</string>
     <string name="debrid_resolving_stream">Résolution du flux debrid</string>
     <string name="debrid_stale_stream">Ce résultat Debrid a expiré. Actualisation des flux.</string>
-    <string name="debrid_missing_api_key">Ajoute une clé API Debrid dans les Paramètres.</string>
+    <string name="debrid_missing_api_key">Ajoutez une clé API Debrid dans les Paramètres.</string>
     <string name="debrid_resolution_failed">Impossible de résoudre ce flux Debrid.</string>
 
     <!-- Debrid&#160;: cloud library, connexion par compte et appairage par appareil -->
     <string name="debrid_cloud_library">Bibliothèque cloud</string>
-    <string name="debrid_cloud_library_description">Parcours et lis les fichiers déjà présents dans tes comptes connectés.</string>
+    <string name="debrid_cloud_library_description">Parcourez et lisez les fichiers déjà présents dans vos comptes connectés.</string>
     <string name="debrid_resolve_with">Résoudre avec</string>
-    <string name="debrid_resolve_with_description">Choisis le compte connecté qui gère les liens lisibles.</string>
-    <string name="debrid_provider_description">Connecte ton compte %1$s.</string>
-    <string name="debrid_provider_device_description">Associe ton compte %1$s dans le navigateur.</string>
+    <string name="debrid_resolve_with_description">Choisissez le compte connecté qui gère les liens lisibles.</string>
+    <string name="debrid_provider_description">Connectez votre compte %1$s.</string>
+    <string name="debrid_provider_device_description">Associez votre compte %1$s dans le navigateur.</string>
     <string name="debrid_api_key_dialog_title">Clé API %1$s</string>
-    <string name="debrid_api_key_dialog_subtitle">Saisis ta clé API %1$s.</string>
+    <string name="debrid_api_key_dialog_subtitle">Saisissez votre clé API %1$s.</string>
     <string name="debrid_api_key_dialog_placeholder">Saisir la clé API %1$s</string>
     <string name="debrid_connected">Connecté</string>
     <string name="debrid_connect_provider">Connecter %1$s</string>
@@ -2510,12 +2510,12 @@
     <string name="debrid_disconnect">Déconnecter</string>
     <string name="debrid_device_auth_connected">%1$s est connecté sur cet appareil.</string>
     <string name="debrid_device_auth_starting">Démarrage de la connexion sécurisée…</string>
-    <string name="debrid_device_auth_instructions">Scanne le code QR et saisis ce code pour autoriser Nuvio.</string>
+    <string name="debrid_device_auth_instructions">Scannez le code QR et saisissez ce code pour autoriser Nuvio.</string>
     <string name="debrid_device_auth_code_copied">Code copié.</string>
     <string name="debrid_device_auth_waiting">En attente d’approbation…</string>
     <string name="debrid_device_auth_failed">Impossible de démarrer la connexion.</string>
     <string name="debrid_device_auth_missing_configuration">Cette méthode de connexion n’est pas configurée dans cette version.</string>
-    <string name="debrid_device_auth_expired">Ce code a expiré. Réessaie.</string>
+    <string name="debrid_device_auth_expired">Ce code a expiré. Réessayez.</string>
     <string name="debrid_key_invalid">Impossible de valider cette clé API.</string>
     <string name="debrid_not_cached">Non mis en cache sur ce service.</string>
 
@@ -2528,10 +2528,10 @@
 
     <!-- Bibliothèque cloud -->
     <string name="cloud_library_connect_title">Aucun compte cloud connecté</string>
-    <string name="cloud_library_connect_message">Connecte un compte dans les paramètres Services connectés pour parcourir les fichiers lisibles depuis ta bibliothèque cloud.</string>
+    <string name="cloud_library_connect_message">Connectez un compte dans les paramètres Services connectés pour parcourir les fichiers lisibles depuis votre bibliothèque cloud.</string>
     <string name="cloud_library_connect_action">Connecter un compte</string>
     <string name="cloud_library_disabled_title">La bibliothèque cloud est désactivée</string>
-    <string name="cloud_library_disabled_message">Active la bibliothèque cloud dans les paramètres Services connectés pour parcourir les fichiers des comptes connectés.</string>
+    <string name="cloud_library_disabled_message">Activez la bibliothèque cloud dans les paramètres Services connectés pour parcourir les fichiers des comptes connectés.</string>
     <string name="cloud_library_disabled_action">Ouvrir Services connectés</string>
     <string name="cloud_library_empty_title">Rien ici pour l’instant</string>
     <string name="cloud_library_empty_message">Aucun fichier cloud lisible ne correspond aux filtres actuels.</string>
@@ -2649,8 +2649,8 @@
     <string name="settings_fusion_badge_urls_imported">%1$d/%2$d URL Fusion importées</string>
     <string name="settings_fusion_badge_url_status_summary">%1$s · %2$d badges activés · %3$d groupes</string>
     <string name="settings_stream_badges_section">Style Fusion</string>
-    <string name="settings_stream_badge_urls_description">Importe jusqu’à %1$d URL JSON de badges de flux de style Fusion. Chaque URL peut être mise à jour ou supprimée séparément.</string>
-    <string name="settings_stream_badge_urls_search_description">Gère les URL JSON de badges de flux de style Fusion importées.</string>
+    <string name="settings_stream_badge_urls_description">Importez jusqu’à %1$d URL JSON de badges de flux de style Fusion. Chaque URL peut être mise à jour ou supprimée séparément.</string>
+    <string name="settings_stream_badge_urls_search_description">Gérez les URL JSON de badges de flux de style Fusion importées.</string>
     <string name="settings_stream_badge_urls_title">URL de badges Fusion</string>
     <string name="settings_stream_size_badges_description">Affiche les badges de taille de fichier dans les résultats de flux et les panneaux de source du lecteur.</string>
     <string name="settings_stream_size_badges_title">Badges de taille</string>
@@ -2658,18 +2658,18 @@
     <string name="settings_stream_addon_logo_description">Affiche le logo et le nom de l’addon à côté des sources de streams.</string>
     <string name="settings_stream_display_section">Affichage</string>
     <string name="settings_stream_badge_position_title">Position des badges</string>
-    <string name="settings_stream_badge_position_description">Choisis si les badges Fusion et de taille apparaissent au-dessus ou en dessous des cartes de flux.</string>
+    <string name="settings_stream_badge_position_description">Choisissez si les badges Fusion et de taille apparaissent au-dessus ou en dessous des cartes de flux.</string>
     <string name="settings_stream_badge_position_dialog_title">Position des badges</string>
-    <string name="settings_stream_badge_position_dialog_description">Choisis où les badges de flux apparaissent sur les cartes de flux.</string>
+    <string name="settings_stream_badge_position_dialog_description">Choisissez où les badges de flux apparaissent sur les cartes de flux.</string>
     <string name="settings_stream_badge_position_top">En haut</string>
     <string name="settings_stream_badge_position_bottom">En bas</string>
-    <string name="stream_badge_qr_instruction">Scanne ce code QR sur ton téléphone pour gérer les URL de badges Fusion.</string>
+    <string name="stream_badge_qr_instruction">Scannez ce code QR sur votre téléphone pour gérer les URL de badges Fusion.</string>
     <string name="streams_size">TAILLE %1$s</string>
 
     <!-- Web config page: Direct Debrid formatter -->
     <string name="web_debrid_title">Réglages Direct Debrid</string>
     <string name="web_debrid_intro_title">Personnaliser les flux Debrid</string>
-    <string name="web_debrid_intro_copy">Ajuste les libellés, filtres et tri des flux utilisés pour les résultats Direct Debrid.</string>
+    <string name="web_debrid_intro_copy">Ajustez les libellés, filtres et tri des flux utilisés pour les résultats Direct Debrid.</string>
     <string name="web_debrid_tab_formatter">Formatage</string>
     <string name="web_debrid_tab_rules">Filtres et tri</string>
     <string name="web_debrid_template_fields">Champs de modèle</string>
@@ -2696,9 +2696,9 @@
     <string name="web_stream_badge_import_error">Échec de l’import du badge.</string>
     <string name="web_stream_badge_deleted">URL de badge supprimée.</string>
     <string name="web_stream_badge_load_error">Impossible de charger les réglages des badges de flux</string>
-    <string name="web_stream_badge_error_url_required">Saisis une URL JSON de badge.</string>
+    <string name="web_stream_badge_error_url_required">Saisissez une URL JSON de badge.</string>
     <string name="web_stream_badge_error_url_scheme">L’URL du badge doit commencer par http:// ou https://.</string>
-    <string name="web_stream_badge_error_import_limit">Tu peux importer jusqu’à %1$d URL de badge.</string>
+    <string name="web_stream_badge_error_import_limit">Vous pouvez importer jusqu’à %1$d URL de badge.</string>
 
     <!-- Playback — Buffer & Network settings -->
     <string name="playback_section_buffer_network">Mémoire tampon et réseau</string>
@@ -2717,13 +2717,13 @@
     <string name="playback_buffer_after_rebuffer">Tampon après interruption</string>
     <string name="playback_buffer_after_rebuffer_sub">Quantité de contenu à mettre en mémoire tampon après une interruption de la lecture due à la mise en tampon. Des valeurs plus élevées réduisent les interruptions répétées.</string>
     <string name="playback_buffer_back">Durée du tampon arrière</string>
-    <string name="playback_buffer_back_sub">Quantité de contenu déjà lu à garder en mémoire. Permet un retour arrière rapide sans retéléchargement. Mets 0 pour désactiver et économiser de la mémoire.</string>
+    <string name="playback_buffer_back_sub">Quantité de contenu déjà lu à garder en mémoire. Permet un retour arrière rapide sans retéléchargement. Mettez 0 pour désactiver et économiser de la mémoire.</string>
     <string name="playback_buffer_back_reserve">Réserve ~%1$d Mo en plus de la taille de tampon cible. Augmenter la durée max. de tampon réduit cette réserve sans perdre de temps de tampon arrière.</string>
     <string name="playback_buffer_managed">Budget mémoire géré</string>
-    <string name="playback_buffer_managed_sub">Limite le tampon à une part sûre de la mémoire de cet appareil. Désactive pour définir toi-même la taille de tampon cible (avancé — de grandes valeurs peuvent faire planter les appareils à faible mémoire).</string>
+    <string name="playback_buffer_managed_sub">Limite le tampon à une part sûre de la mémoire de cet appareil. Désactivez pour définir vous-même la taille de tampon cible (avancé — de grandes valeurs peuvent faire planter les appareils à faible mémoire).</string>
     <string name="playback_buffer_target">Taille de tampon cible</string>
-    <string name="playback_buffer_target_sub">RAM maximale utilisée pour la mise en mémoire tampon anticipée. Le maximum est calculé d’après la mémoire disponible de ton appareil (la limite de tas par application d’Android), donc les appareils dotés de plus de RAM débloquent automatiquement des plafonds plus élevés.</string>
-    <string name="playback_buffer_target_managed_hint">Géré par le budget mémoire de l’appareil. Désactive «&#160;Budget mémoire géré&#160;» pour définir cette valeur.</string>
+    <string name="playback_buffer_target_sub">RAM maximale utilisée pour la mise en mémoire tampon anticipée. Le maximum est calculé d’après la mémoire disponible de votre appareil (la limite de tas par application d’Android), donc les appareils dotés de plus de RAM débloquent automatiquement des plafonds plus élevés.</string>
+    <string name="playback_buffer_target_managed_hint">Géré par le budget mémoire de l’appareil. Désactivez «&#160;Budget mémoire géré&#160;» pour définir cette valeur.</string>
     <string name="playback_buffer_target_warning">Attention&#160;: au-dessus de la limite sûre de l’appareil (%1$d Mo). L’application peut planter pendant la lecture.</string>
     <string name="playback_buffer_allow_large">Autoriser un tampon cible plus grand</string>
     <string name="playback_buffer_allow_large_sub">Supprime le plafond de mémoire de l’appareil sur le curseur de taille de tampon cible, autorisant des valeurs jusqu’à 2 Go. Peut planter sur les appareils avec moins de 2 Go de RAM.</string>
@@ -2731,7 +2731,7 @@
     <string name="playback_cache_vod">Cache disque VOD</string>
     <string name="playback_cache_vod_sub">Conserve sur le disque les octets téléchargés pour le flux en cours. Étend le retour arrière instantané au-delà du tampon arrière en mémoire et survit aux brèves coupures réseau. Ne s’applique qu’aux flux progressifs (pas HLS/DASH).</string>
     <string name="playback_cache_auto_size">Taille automatique</string>
-    <string name="playback_cache_auto_size_sub">Quand c’est activé, la taille du cache est calculée d’après l’espace disque libre. Désactive pour choisir une taille manuellement.</string>
+    <string name="playback_cache_auto_size_sub">Quand c’est activé, la taille du cache est calculée d’après l’espace disque libre. Désactivez pour choisir une taille manuellement.</string>
     <string name="playback_cache_vod_size">Taille du cache VOD</string>
     <string name="playback_cache_vod_size_sub">Utilisation disque maximale pour le cache VOD progressif (éviction LRU).</string>
     <string name="playback_cache_info_range">Plage&#160;: %1$d-%2$d Mo.</string>
@@ -2743,7 +2743,7 @@
     <string name="playback_net_custom">Réseau personnalisé</string>
     <string name="playback_net_custom_sub">Utilise plusieurs connexions parallèles pour récupérer les flux progressifs. Quand c’est désactivé, une seule connexion est utilisée.</string>
     <string name="playback_net_parallel">Connexions parallèles</string>
-    <string name="playback_net_parallel_sub">Utilise plusieurs connexions en parallèle pour récupérer les flux. Active cette option si tu rencontres des mises en mémoire tampon alors que ta vitesse de téléchargement est largement suffisante.</string>
+    <string name="playback_net_parallel_sub">Utilise plusieurs connexions en parallèle pour récupérer les flux. Activez cette option si vous rencontrez des mises en mémoire tampon alors que votre vitesse de téléchargement est largement suffisante.</string>
     <string name="playback_net_connection_count">Nombre de connexions</string>
     <string name="playback_net_connection_count_sub">Nombre de connexions TCP parallèles. Des valeurs plus élevées augmentent l’utilisation de la mémoire et le débit, mais avec un rendement décroissant.</string>
     <string name="playback_net_chunk_size">Taille des blocs</string>
@@ -2751,9 +2751,9 @@
 
     <!-- Playback diagnostics card -->
     <string name="diag_last_playback_title">Derniers diagnostics de lecture</string>
-    <string name="diag_no_data">Aucune donnée de lecture pour l’instant. Lance un stream et reviens ici pour voir les détails de la décision DV de cette lecture.</string>
+    <string name="diag_no_data">Aucune donnée de lecture pour l’instant. Lancez un stream et revenez ici pour voir les détails de la décision DV de cette lecture.</string>
     <string name="diag_section_source_hardware">Source et matériel</string>
-    <string name="diag_section_source_hardware_sub">Prends une photo de cette carte si tu signales un problème.</string>
+    <string name="diag_section_source_hardware_sub">Prenez une photo de cette carte si vous signalez un problème.</string>
     <string name="diag_label_host">Hôte</string>
     <string name="diag_label_when">Quand</string>
     <string name="diag_label_device">Appareil</string>


### PR DESCRIPTION
## Summary

Converts the entire French translation file from informal address (tutoiement) to formal address (vouvoiement) for a consistent, professional register. **259 strings** rewritten: pronouns (tu→vous), possessives (ton/ta→votre, tes→vos), and 2nd-person-singular imperatives → 2nd-person-plural (Saisis→Saisissez, Reconnecte-toi→Reconnectez-vous, Vérifie→Vérifiez). No keys added or removed.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

The French strings used informal tutoiement throughout; a single formal register (vouvoiement) is more consistent and appropriate for the audience. This pass makes the whole FR file uniformly vouvoiement so there is no mix of "tu" and "vous".

## Issue or approval

No linked issue: localization-only register change, no code or behavior impact.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `app/src/main/res/values-fr/strings.xml` is touched. No EN source strings, no code, no other locales. `translatable="false"` keys (Dolby Vision diagnostics) are untouched. Setting *behavior descriptions* already written in the 3rd person ("Affiche les badges…", "Désactive le décodage matériel…", which describe what the option does) were intentionally left as-is — they contain no form of address.

## Testing

`xmllint --noout` passes. Key parity verified: 2493 ↔ 2493, identical key set before/after (no add/remove). Zero residual tutoiement pronouns/possessives. Past participles/adjectives kept singular for the politeness "vous" ("Vous avez été déconnecté de Nuvio") — 0 erroneous plural agreement. Placeholders (`%1$s`, `\n`, bullets), HTML entities and typographic apostrophes preserved. No mojibake, UTF-8.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.