### PR TITLE
fix: Upgrade `ass-media` so Nuvio's custom ASS Matroska extractor can register embedded MKV font attachments through `AssHandler.addFont(...)`.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -430,7 +430,7 @@ dependencies {
     }
 
     // libass-android for ASS/SSA subtitle support (from Maven Central)
-    implementation("io.github.peerless2012:ass-media:0.4.0-beta01")
+    implementation("io.github.peerless2012:ass-media:0.4.0")
     // Local nextlib-mediainfo fork (static FFmpeg; no libav*.so in final AAR)
     implementation(files("libs/nextlib-mediainfo-local.aar"))
     implementation("io.github.abdallahmehiz:mpv-android-lib:0.1.12")


### PR DESCRIPTION
## Summary

Upgrade `ass-media` from `0.4.0-beta01` to `0.4.0` so Nuvio's custom `NuvioAssMatroskaExtractor` can register embedded MKV font attachments through `AssHandler.addFont(...)`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Embedded ASS/SSA subtitles can render with incorrect fonts or broken sign styling when MKV font attachments are not registered with libass. Nuvio uses a custom `NuvioAssMatroskaExtractor` rather than the stock `ass-media` extractor because it also carries Nuvio-specific ASS sample handling, including zlib-compressed dialogue sample support.

That custom extractor already parses MKV `Attachments`, reads font payloads from `FileData`, and attempts to register them. The missing piece is a stable public font registration API on `AssHandler`. `ass-media:0.4.0` exposes `AssHandler.addFont(name, data)`, matching the library's own extractor behavior and allowing Nuvio's custom extractor to pass embedded fonts to libass reliably.

Relevant extractor logic:

```kotlin
if (attachmentMime in fontMimeTypes) {
    val data = ByteArray(contentSize)
    input.readFully(data, 0, contentSize)
    assHandler.addFont(attachmentName, data)
} else {
    input.skipFully(contentSize)
}
```

This keeps Nuvio's custom dialogue handling intact while restoring embedded font registration for styled ASS signs/dialogue.

## Issue or approval

Fixes #2379 

## Reproduction steps

1. Play an MKV containing ASS subtitles that reference embedded fonts, such as Trebuchet/Arial/Noto variants.
2. Select the embedded ASS subtitle track.
3. Observe that signs and styled text render with fallback/system fonts instead of the embedded font.
4. In logcat, libass reports font fallback such as `fontselect: (...) -> /system/fonts/...`.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only updates the ASS media dependency path needed for `NuvioAssMatroskaExtractor` to register embedded ASS fonts through `AssHandler.addFont(...)`. It does not change subtitle UI, subtitle selection behavior, renderer modes, styling controls, zlib dialogue handling, or unrelated playback behavior.

## Testing

Tested with MKV files containing embedded ASS subtitles and font attachments. Verified that `NuvioAssMatroskaExtractor` detects embedded font attachments and that `ass-media:0.4.0` provides `AssHandler.addFont(...)`, which registers fonts through libass before rendering styled ASS events. Also verified that the existing zlib-compressed ASS dialogue sample handling remains in the extractor path.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue yet.
