### PR TITLE
fix(player): harden external auto-next loader dismiss, fast fallback, and season-less anime

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -805,9 +806,8 @@ class MainActivity : ComponentActivity() {
                     // of the NavHost) to hide the app cold-starting while the next source resolves.
                     val autoNextOverlay by externalPlaybackTracker.autoNextOverlay.collectAsState()
                     autoNextOverlay?.let { ov ->
-                        BackHandler(enabled = true) {
-                            externalPlaybackTracker.dismissAutoNextOverlay()
-                        }
+                        // Back is intercepted at the Activity level (dispatchKeyEvent) so it reliably
+                        // beats the destination screen's BackHandler.
                         com.nuvio.tv.ui.screens.player.LoadingOverlay(
                             visible = true,
                             backdropUrl = ov.backdrop,
@@ -850,6 +850,22 @@ class MainActivity : ComponentActivity() {
     override fun onPause() {
         super.onPause()
         if (::jankStats.isInitialized) jankStats.isTrackingEnabled = false
+    }
+
+    // Intercept Back at the Activity level, before any Compose BackHandler, so the auto-next loader
+    // can always be dismissed. Compose back-dispatch ordering kept putting the destination screen's
+    // handler above the loader's, so Back never reached it.
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (event.keyCode == KeyEvent.KEYCODE_BACK &&
+            externalPlaybackTracker.autoNextOverlay.value != null
+        ) {
+            if (event.action == KeyEvent.ACTION_UP) {
+                Log.d("ExtAutoNext", "dispatchKeyEvent BACK -> dismissAutoNextOverlay (loader showing)")
+                externalPlaybackTracker.dismissAutoNextOverlay()
+            }
+            return true
+        }
+        return super.dispatchKeyEvent(event)
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.core.player
+
+/**
+ * Pure decision rules for the external-player auto-next state machine, split out from
+ * [ExternalPlaybackTracker] so the flag/timing logic is unit-testable without Android dependencies.
+ */
+internal object ExternalAutoNextPolicy {
+
+    private val SERIES_TYPES = setOf("series", "tv")
+
+    /**
+     * Whether a launch should clear a pending chain abort. A launch is "fresh" (clears the abort)
+     * unless it is an auto-next continuation: an auto-launch within [continuationWindowMs] of the
+     * last emit. A manual launch is always fresh, so manually starting an episode right after a
+     * Back-abort re-enables auto-next.
+     */
+    fun shouldResetChainAbort(
+        autoLaunch: Boolean,
+        nowMs: Long,
+        lastAutoNextEmitMs: Long,
+        continuationWindowMs: Long
+    ): Boolean = !(autoLaunch && nowMs - lastAutoNextEmitMs < continuationWindowMs)
+
+    /**
+     * Whether a user's abort should still skip the pending auto-launch. Only while inside the
+     * continuation window, so a stale abort can't suppress a fresh auto-play of an unrelated title.
+     */
+    fun isAbortedContinuation(
+        chainAborted: Boolean,
+        nowMs: Long,
+        lastAutoNextEmitMs: Long,
+        continuationWindowMs: Long
+    ): Boolean = chainAborted && nowMs - lastAutoNextEmitMs < continuationWindowMs
+
+    /**
+     * Whether the auto-advance loader may be raised. Only for a series/tv episode that hasn't been
+     * aborted, released on settle, or already raised. Season may be null (absolute-numbered content).
+     */
+    fun shouldRaiseLoader(
+        episode: Int?,
+        contentType: String,
+        cancelled: Boolean,
+        chainAborted: Boolean,
+        overlaySuppressed: Boolean,
+        alreadyShowing: Boolean
+    ): Boolean {
+        if (cancelled || chainAborted || overlaySuppressed || alreadyShowing) return false
+        return isSeriesEpisode(episode, contentType)
+    }
+
+    /**
+     * Whether auto-advance should be attempted. Only for a series/tv episode the user hasn't aborted.
+     * Season may be null (absolute-numbered content); only the episode number is required.
+     */
+    fun shouldAttemptAdvance(
+        episode: Int?,
+        contentType: String,
+        cancelled: Boolean,
+        chainAborted: Boolean
+    ): Boolean {
+        if (cancelled || chainAborted) return false
+        return isSeriesEpisode(episode, contentType)
+    }
+
+    private fun isSeriesEpisode(episode: Int?, contentType: String): Boolean =
+        episode != null && contentType.lowercase() in SERIES_TYPES
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -81,7 +81,7 @@ data class ExternalAutoNextEpisode(
     val logo: String?,
     val year: String?,
     val nextVideoId: String,
-    val nextSeason: Int,
+    val nextSeason: Int?,
     val nextEpisode: Int,
     // Lets the collector skip a value replayed after a config change while still
     // acting on a genuinely new event after a process restart.
@@ -199,9 +199,14 @@ class ExternalPlaybackTracker @Inject constructor(
         isAutoLaunch = autoLaunch
         // Fresh launch — allow the auto-next loader / advance again.
         autoNextCancelled = false
-        // A continuation of the auto-next chain (a launch right after an emit) keeps a user's abort
-        // in effect; any later launch (manual click, or a replay) is fresh and re-enables auto-next.
-        if (System.currentTimeMillis() - lastAutoNextEmitMs >= CONTINUATION_WINDOW_MS) {
+        // A manual launch is always fresh; only an auto-launch within the window is a continuation
+        // that keeps a user's abort in effect (so one Back press stops a runaway chain).
+        if (ExternalAutoNextPolicy.shouldResetChainAbort(
+                autoLaunch = autoLaunch,
+                nowMs = System.currentTimeMillis(),
+                lastAutoNextEmitMs = lastAutoNextEmitMs,
+                continuationWindowMs = CONTINUATION_WINDOW_MS
+            )) {
             autoNextChainAborted = false
         }
         autoNextOverlaySuppressed = false
@@ -518,15 +523,17 @@ class ExternalPlaybackTracker @Inject constructor(
     private fun maybeTriggerAutoNextEpisode(metadata: ExternalPlaybackMetadata) {
         val season = metadata.season
         val episode = metadata.episode
-        val type = metadata.contentType.lowercase()
-        if (season == null || episode == null || type !in listOf("series", "tv")) {
-            Log.d(AUTO_NEXT_TAG, "Auto-next skipped: season=$season episode=$episode type=$type")
-            return
-        }
-        // User backed out of the loader — for this return (autoNextCancelled) or to stop a
-        // runaway chain (autoNextChainAborted). Don't re-raise the loader or advance.
-        if (autoNextCancelled || autoNextChainAborted) {
-            Log.d(AUTO_NEXT_TAG, "Auto-next suppressed (cancelled=$autoNextCancelled, chainAborted=$autoNextChainAborted)")
+        // Season may be null (absolute-numbered anime); only the episode and a series/tv type are
+        // required. The `episode == null` here is redundant with the policy but gives the smart cast.
+        val attemptAdvance = ExternalAutoNextPolicy.shouldAttemptAdvance(
+            episode = episode,
+            contentType = metadata.contentType,
+            cancelled = autoNextCancelled,
+            chainAborted = autoNextChainAborted
+        )
+        if (!attemptAdvance || episode == null) {
+            Log.d(AUTO_NEXT_TAG, "Auto-next not attempted: season=$season episode=$episode " +
+                "type=${metadata.contentType} cancelled=$autoNextCancelled chainAborted=$autoNextChainAborted")
             _autoNextOverlay.value = null
             return
         }
@@ -572,13 +579,13 @@ class ExternalPlaybackTracker @Inject constructor(
                 currentSeason = season,
                 currentEpisode = episode
             )
-            val nextSeason = nextVideo?.season
             val nextEpisode = nextVideo?.episode
-            if (nextVideo == null || nextSeason == null || nextEpisode == null) {
+            if (nextVideo == null || nextEpisode == null) {
                 Log.d(AUTO_NEXT_TAG, "No next episode after S${season}E${episode} for ${metadata.contentId}")
                 dismissOverlayIfCurrent()
                 return@launch
             }
+            val nextSeason = nextVideo.season
 
             Log.d(
                 AUTO_NEXT_TAG,
@@ -643,7 +650,12 @@ class ExternalPlaybackTracker @Inject constructor(
      *  screen calls this to skip the auto-launch and fall back to the source list. Only within the
      *  continuation window, so it can't suppress a fresh first auto-play of an unrelated title. */
     fun isAutoNextContinuationAborted(): Boolean =
-        autoNextChainAborted && System.currentTimeMillis() - lastAutoNextEmitMs < CONTINUATION_WINDOW_MS
+        ExternalAutoNextPolicy.isAbortedContinuation(
+            chainAborted = autoNextChainAborted,
+            nowMs = System.currentTimeMillis(),
+            lastAutoNextEmitMs = lastAutoNextEmitMs,
+            continuationWindowMs = CONTINUATION_WINDOW_MS
+        )
 
     /** Called by the Stream screen when it skips an aborted continuation, so the window expires and
      *  the next launch is treated as fresh (re-enabling auto-next). */
@@ -659,10 +671,15 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
-        if (autoNextCancelled || autoNextChainAborted || autoNextOverlaySuppressed) return
-        if (metadata.season == null || metadata.episode == null) return
-        if (metadata.contentType.lowercase() !in listOf("series", "tv")) return
-        if (_autoNextOverlay.value != null) return
+        val shouldRaise = ExternalAutoNextPolicy.shouldRaiseLoader(
+            episode = metadata.episode,
+            contentType = metadata.contentType,
+            cancelled = autoNextCancelled,
+            chainAborted = autoNextChainAborted,
+            overlaySuppressed = autoNextOverlaySuppressed,
+            alreadyShowing = _autoNextOverlay.value != null
+        )
+        if (!shouldRaise) return
         _autoNextOverlay.value = ExternalAutoNextOverlay(
             backdrop = metadata.backdrop ?: metadata.poster,
             logo = metadata.logo,

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -150,6 +150,9 @@ class ExternalPlaybackTracker @Inject constructor(
     // Using a time window instead of a sticky flag means the abort can never get permanently stuck
     // if a continuation never actually launches (e.g. user backed out before it auto-played).
     private var lastAutoNextEmitMs = 0L
+    // Set when the loader is released on a routine screen settle, so a later onStart can't re-raise a
+    // loader that no longer has a job behind it (which would leave it stuck). Reset on a fresh launch.
+    private var autoNextOverlaySuppressed = false
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
     // the next episode's Stream route. replay = 1 so the event still reaches the
@@ -201,6 +204,7 @@ class ExternalPlaybackTracker @Inject constructor(
         if (System.currentTimeMillis() - lastAutoNextEmitMs >= CONTINUATION_WINDOW_MS) {
             autoNextChainAborted = false
         }
+        autoNextOverlaySuppressed = false
         // Next player is launching and will cover the screen — drop the loader.
         _autoNextOverlay.value = null
         // Persist so progress-save + auto-next survive the player killing our process.
@@ -516,11 +520,13 @@ class ExternalPlaybackTracker @Inject constructor(
         val episode = metadata.episode
         val type = metadata.contentType.lowercase()
         if (season == null || episode == null || type !in listOf("series", "tv")) {
+            Log.d(AUTO_NEXT_TAG, "Auto-next skipped: season=$season episode=$episode type=$type")
             return
         }
         // User backed out of the loader — for this return (autoNextCancelled) or to stop a
         // runaway chain (autoNextChainAborted). Don't re-raise the loader or advance.
         if (autoNextCancelled || autoNextChainAborted) {
+            Log.d(AUTO_NEXT_TAG, "Auto-next suppressed (cancelled=$autoNextCancelled, chainAborted=$autoNextChainAborted)")
             _autoNextOverlay.value = null
             return
         }
@@ -623,6 +629,16 @@ class ExternalPlaybackTracker @Inject constructor(
         _autoNextOverlay.value = null
     }
 
+    /** Hide the loader overlay when the Stream screen settles, without aborting the chain, so a
+     *  routine return to the screen never suppresses the next auto-advance. Suppresses re-raising so
+     *  a later onStart can't bring back a loader that no longer has a job behind it. */
+    fun releaseAutoNextOverlay() {
+        autoNextOverlaySuppressed = true
+        autoNextJob?.cancel()
+        autoNextJob = null
+        _autoNextOverlay.value = null
+    }
+
     /** The next-episode auto-play was navigated to but the user has aborted the chain — the Stream
      *  screen calls this to skip the auto-launch and fall back to the source list. Only within the
      *  continuation window, so it can't suppress a fresh first auto-play of an unrelated title. */
@@ -643,7 +659,7 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
-        if (autoNextCancelled || autoNextChainAborted) return
+        if (autoNextCancelled || autoNextChainAborted || autoNextOverlaySuppressed) return
         if (metadata.season == null || metadata.episode == null) return
         if (metadata.contentType.lowercase() !in listOf("series", "tv")) return
         if (_autoNextOverlay.value != null) return

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -123,7 +123,7 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val TAG = "ExtPlaybackTracker"
         private const val AUTO_NEXT_TAG = "ExtAutoNext"
         /** Max time the auto-advance loader stays up if the next player never launches. */
-        private const val AUTO_NEXT_OVERLAY_TIMEOUT_MS = 20_000L
+        private const val AUTO_NEXT_OVERLAY_TIMEOUT_MS = 10_000L
         /** Max time to wait for series meta when resolving the next episode. */
         private const val META_FETCH_TIMEOUT_MS = 15_000L
         /** A "completed" playback shorter than this is treated as a debrid cache-sync placeholder
@@ -614,7 +614,10 @@ class ExternalPlaybackTracker @Inject constructor(
             // Safety net: normally cleared when the next player launches, but in Manual
             // mode the Stream screen waits for the user, so don't leave the loader stuck.
             delay(AUTO_NEXT_OVERLAY_TIMEOUT_MS)
-            dismissOverlayIfCurrent()
+            Log.d(AUTO_NEXT_TAG, "safety-net timeout -> clearing loader")
+            // Clear unconditionally: the identity-guarded variant left a stale overlay stuck when a
+            // re-raise had replaced the object this job captured.
+            _autoNextOverlay.value = null
         }
     }
 
@@ -629,6 +632,7 @@ class ExternalPlaybackTracker @Inject constructor(
      *  of advancing anyway. Sets the durable chain abort too, so one Back press stops a runaway
      *  auto-next loop (it won't re-fire until a fresh/manual launch). Progress stays saved. */
     fun dismissAutoNextOverlay() {
+        Log.d(AUTO_NEXT_TAG, "dismissAutoNextOverlay (user back) overlayWasShowing=${_autoNextOverlay.value != null}")
         autoNextCancelled = true
         autoNextChainAborted = true
         autoNextJob?.cancel()
@@ -640,6 +644,7 @@ class ExternalPlaybackTracker @Inject constructor(
      *  routine return to the screen never suppresses the next auto-advance. Suppresses re-raising so
      *  a later onStart can't bring back a loader that no longer has a job behind it. */
     fun releaseAutoNextOverlay() {
+        Log.d(AUTO_NEXT_TAG, "releaseAutoNextOverlay (settle) overlayWasShowing=${_autoNextOverlay.value != null}")
         autoNextOverlaySuppressed = true
         autoNextJob?.cancel()
         autoNextJob = null
@@ -685,6 +690,7 @@ class ExternalPlaybackTracker @Inject constructor(
             logo = metadata.logo,
             title = metadata.contentName
         )
+        Log.d(AUTO_NEXT_TAG, "raised loader for ${metadata.videoId}")
     }
 
     // ===================== Tracking lifecycle + Zidoo =====================

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -13,9 +13,19 @@ import java.time.ZoneId
 object PlayerNextEpisodeRules {
     fun resolveNextEpisode(
         videos: List<Video>,
-        currentSeason: Int,
+        currentSeason: Int?,
         currentEpisode: Int
     ): Video? {
+        // Absolute-numbered content (e.g. some anime via Kitsu) carries no season; order by episode
+        // number alone and advance to the next one.
+        if (currentSeason == null) {
+            val sorted = videos
+                .filter { it.episode != null }
+                .sortedWith(compareBy<Video>({ it.season ?: 0 }, { it.episode ?: 0 }))
+            val index = sorted.indexOfFirst { it.episode == currentEpisode }
+            return if (index < 0) null else sorted.getOrNull(index + 1)
+        }
+
         val sortedEpisodes = videos
             .filter { it.season != null && it.episode != null }
             .sortedWith(compareBy<Video> { it.season ?: Int.MAX_VALUE }.thenBy { it.episode ?: Int.MAX_VALUE })

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1208,9 +1208,10 @@ class StreamScreenViewModel @Inject constructor(
 
     fun consumeAbortedAutoNextContinuation() = externalPlaybackTracker.consumeAbortedAutoNextContinuation()
 
-    /** Release the MainActivity auto-next loader once this Stream screen has settled. */
+    /** Release the MainActivity auto-next loader once this Stream screen has settled. Hides the
+     *  overlay only; it must not abort the chain, or a fast settle would suppress the next advance. */
     fun dismissExternalAutoNextOverlay() {
-        externalPlaybackTracker.dismissAutoNextOverlay()
+        externalPlaybackTracker.releaseAutoNextOverlay()
     }
 
     /** Set to true when external player is launched, reset on stop. */

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -742,13 +742,18 @@ class StreamScreenViewModel @Inject constructor(
                 markRemainingSourceChipsAsError()
                 if (directAutoPlayFlowEnabledForSession && !resolvedAutoPlayTarget) {
                     directAutoPlayFlowEnabledForSession = false
+                    // All addons finished with no instant stream to auto-play: drop the loader and
+                    // reveal the manual picker now instead of holding until the hard timeout. Clear
+                    // isLoading too, so an empty result set doesn't leave the screen stuck loading.
                     updateUiStateIfChanged {
                         it.copy(
+                            isLoading = false,
                             isDirectAutoPlayFlow = false,
                             showDirectAutoPlayOverlay = false,
                             directAutoPlayMessage = null
                         )
                     }
+                    externalPlaybackTracker.releaseAutoNextOverlay()
                 }
             }
 
@@ -825,6 +830,7 @@ class StreamScreenViewModel @Inject constructor(
                                 directAutoPlayMessage = null
                             )
                         }
+                        externalPlaybackTracker.releaseAutoNextOverlay()
                         streamLoadInner.cancel()
                         markRemainingSourceChipsAsError()
                     }

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
@@ -1,0 +1,139 @@
+package com.nuvio.tv.core.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExternalAutoNextPolicyTest {
+
+    private val window = 12_000L
+
+    // ---- shouldResetChainAbort: the 12s manual-relaunch fix ----
+
+    @Test
+    fun `manual launch always resets the chain abort, even inside the window`() {
+        assertTrue(
+            ExternalAutoNextPolicy.shouldResetChainAbort(
+                autoLaunch = false, nowMs = 5_000L, lastAutoNextEmitMs = 0L, continuationWindowMs = window
+            )
+        )
+    }
+
+    @Test
+    fun `auto-launch inside the window is a continuation and keeps the abort`() {
+        assertFalse(
+            ExternalAutoNextPolicy.shouldResetChainAbort(
+                autoLaunch = true, nowMs = 5_000L, lastAutoNextEmitMs = 0L, continuationWindowMs = window
+            )
+        )
+    }
+
+    @Test
+    fun `auto-launch after the window is fresh and resets the abort`() {
+        assertTrue(
+            ExternalAutoNextPolicy.shouldResetChainAbort(
+                autoLaunch = true, nowMs = 20_000L, lastAutoNextEmitMs = 0L, continuationWindowMs = window
+            )
+        )
+    }
+
+    // ---- isAbortedContinuation ----
+
+    @Test
+    fun `abort skips the auto-launch only inside the window`() {
+        assertTrue(
+            ExternalAutoNextPolicy.isAbortedContinuation(
+                chainAborted = true, nowMs = 5_000L, lastAutoNextEmitMs = 0L, continuationWindowMs = window
+            )
+        )
+        assertFalse(
+            ExternalAutoNextPolicy.isAbortedContinuation(
+                chainAborted = true, nowMs = 20_000L, lastAutoNextEmitMs = 0L, continuationWindowMs = window
+            )
+        )
+    }
+
+    @Test
+    fun `no abort means no continuation skip`() {
+        assertFalse(
+            ExternalAutoNextPolicy.isAbortedContinuation(
+                chainAborted = false, nowMs = 1_000L, lastAutoNextEmitMs = 0L, continuationWindowMs = window
+            )
+        )
+    }
+
+    // ---- shouldRaiseLoader: overlay re-raise fix + season-less ----
+
+    @Test
+    fun `loader raises for a normal series episode`() {
+        assertTrue(raise(episode = 3, type = "series"))
+    }
+
+    @Test
+    fun `loader raises for a season-less series episode`() {
+        assertTrue(raise(episode = 7, type = "series"))
+    }
+
+    @Test
+    fun `loader does not raise when suppressed by a settle release`() {
+        assertFalse(raise(episode = 3, type = "series", overlaySuppressed = true))
+    }
+
+    @Test
+    fun `loader does not raise when the chain was aborted or cancelled`() {
+        assertFalse(raise(episode = 3, type = "series", chainAborted = true))
+        assertFalse(raise(episode = 3, type = "series", cancelled = true))
+    }
+
+    @Test
+    fun `loader does not raise when already showing`() {
+        assertFalse(raise(episode = 3, type = "series", alreadyShowing = true))
+    }
+
+    @Test
+    fun `loader does not raise for movies or non-series content`() {
+        assertFalse(raise(episode = null, type = "movie"))
+        assertFalse(raise(episode = 3, type = "movie"))
+    }
+
+    // ---- shouldAttemptAdvance ----
+
+    @Test
+    fun `advance attempted for a season-less series episode`() {
+        assertTrue(
+            ExternalAutoNextPolicy.shouldAttemptAdvance(
+                episode = 7, contentType = "series", cancelled = false, chainAborted = false
+            )
+        )
+    }
+
+    @Test
+    fun `advance not attempted when aborted or for a movie`() {
+        assertFalse(
+            ExternalAutoNextPolicy.shouldAttemptAdvance(
+                episode = 7, contentType = "series", cancelled = false, chainAborted = true
+            )
+        )
+        assertFalse(
+            ExternalAutoNextPolicy.shouldAttemptAdvance(
+                episode = null, contentType = "movie", cancelled = false, chainAborted = false
+            )
+        )
+    }
+
+    private fun raise(
+        episode: Int?,
+        type: String,
+        cancelled: Boolean = false,
+        chainAborted: Boolean = false,
+        overlaySuppressed: Boolean = false,
+        alreadyShowing: Boolean = false
+    ) = ExternalAutoNextPolicy.shouldRaiseLoader(
+        episode = episode,
+        contentType = type,
+        cancelled = cancelled,
+        chainAborted = chainAborted,
+        overlaySuppressed = overlaySuppressed,
+        alreadyShowing = alreadyShowing
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRulesTest.kt
@@ -1,0 +1,70 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.domain.model.Video
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PlayerNextEpisodeRulesTest {
+
+    private fun ep(season: Int?, episode: Int?, id: String = "s${season}e${episode}") =
+        Video(
+            id = id,
+            title = id,
+            released = null,
+            thumbnail = null,
+            season = season,
+            episode = episode,
+            overview = null
+        )
+
+    @Test
+    fun `advances to next episode in same season`() {
+        val videos = listOf(ep(1, 1), ep(1, 2), ep(1, 3))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = 1, currentEpisode = 2)
+        assertEquals("s1e3", next?.id)
+    }
+
+    @Test
+    fun `crosses into next season after the season finale`() {
+        val videos = listOf(ep(1, 1), ep(1, 2), ep(2, 1))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = 1, currentEpisode = 2)
+        assertEquals("s2e1", next?.id)
+    }
+
+    @Test
+    fun `returns null after the very last episode`() {
+        val videos = listOf(ep(1, 1), ep(1, 2))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = 1, currentEpisode = 2)
+        assertNull(next)
+    }
+
+    @Test
+    fun `returns null when the current episode is not in the list`() {
+        val videos = listOf(ep(1, 1), ep(1, 2))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = 3, currentEpisode = 9)
+        assertNull(next)
+    }
+
+    @Test
+    fun `absolute numbering advances by episode when the caller has no season`() {
+        // Season-less anime: the caller has no season but the meta videos still carry one.
+        val videos = listOf(ep(1, 5), ep(1, 6), ep(1, 7))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = null, currentEpisode = 6)
+        assertEquals("s1e7", next?.id)
+    }
+
+    @Test
+    fun `absolute numbering advances when the meta videos also lack a season`() {
+        val videos = listOf(ep(null, 5, "e5"), ep(null, 6, "e6"), ep(null, 7, "e7"))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = null, currentEpisode = 6)
+        assertEquals("e7", next?.id)
+    }
+
+    @Test
+    fun `absolute numbering returns null after the last episode`() {
+        val videos = listOf(ep(null, 5, "e5"), ep(null, 6, "e6"))
+        val next = PlayerNextEpisodeRules.resolveNextEpisode(videos, currentSeason = null, currentEpisode = 6)
+        assertNull(next)
+    }
+}


### PR DESCRIPTION
For context on what this fixes: external player auto next had a few problems. It would intermittently fail to advance to the next episode, the Loading Next Episode screen could get stuck with no way to back out, a next episode with no instant source left you on that loader instead of the source list, and absolute numbered anime with no season never advanced. This addresses all four. I am about 90% confident in external player auto next now.

## Summary

Hardens the external-player auto-next flow. Several related fixes:

**1. Stop a routine screen settle from suppressing auto-next.** The Stream-screen settle path (`isLoading` going false) routed into `dismissAutoNextOverlay`, which set the durable `autoNextChainAborted` flag meant only for a user Back press. `startTracking` cleared that flag only when the next launch was >12s after the last emit, so a fast source resolve left it set and the next completion silently skipped auto-next, which looked intermittent. Adds `releaseAutoNextOverlay` (hide-only, no abort) for the settle path and a separate `autoNextOverlaySuppressed` flag so a routine release still blocks `onStart` from re-raising a loader with no job behind it.

**2. Make the "Loading Next Episode" loader reliably dismissable.** Compose back-dispatch ordering kept putting the freshly-navigated Stream screen's `BackHandler` above the loader's, so Back never reached it. Back is now intercepted in `MainActivity.dispatchKeyEvent` (Activity level, before any Compose handler), so it always wins while the loader is up. The loader's safety net now clears unconditionally and is shortened to 10s (the identity-guarded clear could leave a stale overlay stuck).

**3. Fail fast to the source picker.** When the direct-auto-play flow gives up with no instant stream (all addons finished, or the 60s hard timeout), it now clears `isLoading` and releases the auto-next loader, so a non-cached next episode drops the user onto the source list immediately instead of holding the loader.

**4. Absolute-numbered (season-less) anime.** `resolveNextEpisode` now accepts a null season and orders by episode number; the advance and loader guards no longer require a season. `ExternalAutoNextEpisode.nextSeason` is nullable.

**5. Manual relaunch after an abort.** A manual launch now always clears the chain abort (it previously kept a stale abort if it landed inside the 12s continuation window).

Flag/timing logic is extracted into a pure, `Log`-free `ExternalAutoNextPolicy`, covered by unit tests.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

External-player auto-next was intermittently skipping episodes, the "Loading Next Episode" loader could get stuck with no way to back out, and non-cached next episodes left the user waiting on the loader. Anime with absolute episode numbering never auto-advanced.

## Issue or approval

Hardens the external-player auto-next introduced in #2338 (intermittent skipped episodes, an un-dismissable stuck loader, and no fallback for non-cached next episodes). No separate issue was filed.

## Reproduction steps

With an external player + debrid: auto-next through several episodes. Intermittently the next episode would not auto-advance; on a non-cached episode the "Loading Next Episode" loader could not be dismissed with Back.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

External auto-next now advances reliably, the loader is always dismissable, and a non-cached next episode falls back to the source list. No layout changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to the external-player auto-next path (`ExternalPlaybackTracker`, `ExternalAutoNextPolicy`, `PlayerNextEpisodeRules`, the auto-next loader in `MainActivity`, and the direct-auto-play give-up points in `StreamScreenViewModel`). The 60s direct-auto-play hard timeout and the configured auto-play timeout are unchanged. Internal-player playback is untouched.

## Testing

- `./gradlew :app:assembleFullDebug` builds; `:app:compileFullDebugKotlin` clean.
- New unit tests pass: `ExternalAutoNextPolicyTest` (13) and `PlayerNextEpisodeRulesTest` (7).
- Installed on an NVIDIA Shield and manually verified: auto-next chains across episodes; episode-card watched-marking; loader dismiss. On-device testing is ongoing (this is a draft).

## Screenshots / Video

Not a UI change. (Behavior fix.)

## Breaking changes

None.

## Linked issues

No linked issue.
