### PR TITLE
Fix/rtl layout focus

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -921,6 +921,7 @@ private fun LegacySidebarScaffold(
 ) {
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val drawerItemFocusRequesters = rememberDrawerItemFocusRequesters(drawerItems)
+    val keyboardController = androidx.compose.ui.platform.LocalSoftwareKeyboardController.current
     val showSidebar = currentRoute in rootRoutes
 
     LaunchedEffect(currentRoute) {
@@ -1097,6 +1098,7 @@ private fun LegacySidebarScaffold(
                                     selected = selectedDrawerRoute == item.route,
                                     expanded = isExpanded,
                                     onClick = {
+                                        keyboardController?.hide()
                                         onNavigate(item.route)
                                         navigateToDrawerRoute(
                                             navController = navController,
@@ -1284,6 +1286,7 @@ private fun ModernSidebarScaffold(
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val contentFocusRequester = remember { FocusRequester() }
     val drawerItemFocusRequesters = rememberDrawerItemFocusRequesters(drawerItems)
+    val keyboardController = androidx.compose.ui.platform.LocalSoftwareKeyboardController.current
 
     var isSidebarExpanded by remember { mutableStateOf(false) }
     var sidebarCollapsePending by remember { mutableStateOf(false) }
@@ -1618,6 +1621,7 @@ private fun ModernSidebarScaffold(
                         drawerItemFocusRequesters = drawerItemFocusRequesters,
                         onDrawerItemFocused = { focusedDrawerIndex = it },
                         onDrawerItemClick = { targetRoute ->
+                            keyboardController?.hide()
                             onNavigate(targetRoute)
                             navigateToDrawerRoute(
                                 navController = navController,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1059,11 +1059,13 @@ private fun MetaDetailsContent(
         pendingRestoreCompanyId
     ) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME && pendingRestoreType != null) {
-                android.util.Log.d("DetailFocus", "ON_RESUME: restoreFocusToken++ pendingRestoreType=$pendingRestoreType")
-                restoreFocusToken += 1
-                if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) {
-                    companyRestoreToken += 1
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (pendingRestoreType != null) {
+                    android.util.Log.d("DetailFocus", "ON_RESUME: restoreFocusToken++ pendingRestoreType=$pendingRestoreType")
+                    restoreFocusToken += 1
+                    if (pendingRestoreType == RestoreTarget.COMPANY_OR_NETWORK) {
+                        companyRestoreToken += 1
+                    }
                 }
             }
         }
@@ -1639,7 +1641,9 @@ private fun MetaDetailsContent(
                                 }
                             }
                             initialHeroFocusRequested = true
-                            clearPendingRestore()
+                            if (pendingRestoreType != RestoreTarget.HERO) {
+                                clearPendingRestore()
+                            }
                         },
                         restorePlayFocusToken = (if (pendingRestoreType == RestoreTarget.HERO) restoreFocusToken else 0) +
                                 restorePlayFocusAfterTrailerBackToken,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalContext
@@ -74,6 +75,9 @@ import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import com.nuvio.tv.ui.util.RtlKeyUtils
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -436,6 +440,7 @@ fun SearchScreen(
         imm.displayCompletions(view, completions)
     }
 
+    var isScreenActive by remember { mutableStateOf(true) }
     val latestPendingDiscoverRestore by rememberUpdatedState(pendingDiscoverRestoreOnResume)
     val latestShouldKeepSearchFocus by rememberUpdatedState(
         focusResults || uiState.isSearching || isVoiceListening
@@ -444,6 +449,7 @@ fun SearchScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
+                isScreenActive = true
                 if (latestPendingDiscoverRestore) {
                     restoreDiscoverFocus = true
                     pendingDiscoverRestoreOnResume = false
@@ -463,6 +469,9 @@ fun SearchScreen(
                         }
                     }
                 }
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                isScreenActive = false
+                keyboardController?.hide()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -500,7 +509,8 @@ fun SearchScreen(
                     onOpenDiscover = onOpenDiscover,
                     showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
                     keyboardController = keyboardController,
-                    clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null
+                    clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null,
+                    isScreenActive = isScreenActive
                 )
 
                 Spacer(modifier = Modifier.height(NuvioTheme.spacing.md))
@@ -563,7 +573,8 @@ fun SearchScreen(
                         onOpenDiscover = onOpenDiscover,
                         showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
                         keyboardController = keyboardController,
-                        clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null
+                        clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null,
+                        isScreenActive = isScreenActive
                     )
                 }
 
@@ -764,6 +775,7 @@ private fun RecentSearchesSection(
     clearHistoryFocusRequester: FocusRequester,
     modifier: Modifier = Modifier
 ) {
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -804,7 +816,8 @@ private fun RecentSearchesSection(
                 modifier = Modifier
                     .fillMaxWidth()
                     .onPreviewKeyEvent { keyEvent ->
-                        if (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                        val clearHistoryKey = RtlKeyUtils.getClearHistoryDpadKey(isRtl)
+                        if (keyEvent.nativeKeyEvent.keyCode == clearHistoryKey) {
                             if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
                                 runCatching { clearHistoryFocusRequester.requestFocus() }
                             }
@@ -848,10 +861,12 @@ private fun SearchInputField(
     onOpenDiscover: () -> Unit,
     showDiscoverButton: Boolean,
     keyboardController: androidx.compose.ui.platform.SoftwareKeyboardController?,
-    clearHistoryFocusRequester: FocusRequester?
+    clearHistoryFocusRequester: FocusRequester?,
+    isScreenActive: Boolean = true
 ) {
     var isDiscoverButtonFocused by remember { mutableStateOf(false) }
     var isVoiceButtonFocused by remember { mutableStateOf(false) }
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 
     Row(
         modifier = Modifier
@@ -985,6 +1000,9 @@ private fun SearchInputField(
             modifier = Modifier
                 .weight(1f)
                 .focusRequester(searchFocusRequester)
+                .focusProperties {
+                    canFocus = isScreenActive
+                }
                 .onFocusChanged { focusState ->
                     onSearchFieldFocusChanged(focusState.isFocused)
                 }
@@ -1007,13 +1025,16 @@ private fun SearchInputField(
                             }
                         }
 
-                        KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                            if (clearHistoryFocusRequester != null) {
-                                if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
-                                    keyboardController?.hide()
-                                    runCatching { clearHistoryFocusRequester.requestFocus() }
+                        else -> {
+                            val clearHistoryKey = RtlKeyUtils.getClearHistoryDpadKey(isRtl)
+                            if (keyEvent.nativeKeyEvent.keyCode == clearHistoryKey) {
+                                if (clearHistoryFocusRequester != null) {
+                                    if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+                                        keyboardController?.hide()
+                                        runCatching { clearHistoryFocusRequester.requestFocus() }
+                                    }
+                                    return@onPreviewKeyEvent true
                                 }
-                                return@onPreviewKeyEvent true
                             }
                         }
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/util/RtlKeyUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/RtlKeyUtils.kt
@@ -1,0 +1,19 @@
+package com.nuvio.tv.ui.util
+
+import android.view.KeyEvent
+
+object RtlKeyUtils {
+    /**
+     * Returns the appropriate DPAD key to navigate from the search text field
+     * to the "Clear search history" button.
+     * In LTR (Left-To-Right) the clear button is on the right -> KEYCODE_DPAD_RIGHT.
+     * In RTL (Right-To-Left) the clear button is on the left -> KEYCODE_DPAD_LEFT.
+     */
+    fun getClearHistoryDpadKey(isRtl: Boolean): Int {
+        return if (isRtl) {
+            KeyEvent.KEYCODE_DPAD_LEFT
+        } else {
+            KeyEvent.KEYCODE_DPAD_RIGHT
+        }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/util/RtlKeyUtilsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/util/RtlKeyUtilsTest.kt
@@ -1,0 +1,17 @@
+package com.nuvio.tv.ui.util
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RtlKeyUtilsTest {
+    @Test
+    fun `getClearHistoryDpadKey returns LEFT when RTL is true`() {
+        assertEquals(KeyEvent.KEYCODE_DPAD_LEFT, RtlKeyUtils.getClearHistoryDpadKey(isRtl = true))
+    }
+
+    @Test
+    fun `getClearHistoryDpadKey returns RIGHT when RTL is false`() {
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, RtlKeyUtils.getClearHistoryDpadKey(isRtl = false))
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves two critical RTL layout and behavior issues observed in the Hebrew translation of NuvioTV:
1. **Focus Restoration**: Prevents sibling buttons in the details screen (such as `WatchedButton` or `LibraryButton`) from prematurely clearing the pending restore target (`RestoreTarget.HERO`) when they receive focus due to Android's default 2D focus finder in RTL. This ensures focus is correctly restored to the Play button when returning from the player.
2. **Keyboard Reappearing**: Prevents the software keyboard from unexpectedly reopening when navigating from the Search screen to Home. We explicitly hide the software keyboard when the Search screen is paused and when sidebar/drawer navigation buttons are clicked. In addition, recent searches item key event intercepts are updated to be direction-aware, letting the `KEYCODE_DPAD_RIGHT` event propagate naturally to open the drawer on the right in RTL.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

- In RTL (Hebrew), the visual layout is mirrored. This caused Android's default focus finder to target sibling buttons instead of the Play button on return from the player. These sibling buttons triggered focus callbacks that cleared the pending restoration target, cancelling the focus request.
- When navigating to the sidebar from the Search screen, the drawer collapsing caused focus to temporarily bounce back to the search text field before the screen was fully paused, popping up the keyboard.
- The `KEYCODE_DPAD_RIGHT` key intercept for clearing search history was hardcoded in recent searches. In RTL layout where the drawer is on the right, pressing DPAD_RIGHT would incorrectly redirect focus to the clear history button, trapping the user.

## Issue or approval

Fixes #2383

## Reproduction steps

1. **Issue 1 (Focus)**: Set app language to Hebrew. Open any movie. Select Play. Press Back on remote to return to details. Verify focus does not land on Play button.
2. **Issue 2 (Keyboard)**: Set app language to Hebrew. Go to Search, type "A" (keyboard opens). Press DPAD_RIGHT to go to the drawer, select Home, and click Home. Verify the keyboard reappears unexpectedly during drawer closing/transition.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only modifies focus target restoration logic on details screen, keyboard dismissal calls in search pause/drawer clicks, and direction-aware key intercepts. It does not include any extra UI changes, styling tweaks, or other features.

## Testing

- **Automated Tests**: Added and ran `RtlKeyUtilsTest.kt` to verify layout-direction-based key mappings.
- **Build Verification**: Ran `.\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.util.RtlKeyUtilsTest"` successfully.
- **Manual Verification**: Verified on local emulator/device that:
  1. Play button restores focus correctly in Hebrew (RTL).
  2. Keyboard is dismissed and does not reopen when navigating via drawer.
  3. DPAD_RIGHT on recent searches correctly navigates to the drawer in RTL.

## Screenshots / Video

Not a UI change.

## Breaking changes

No breaking changes.

## Linked issues

Fixes #2383
