### PR TITLE
fix: show hero data immediately when enrichment fails for catalog items in Collections FOLLOW_LAYOUT

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -975,7 +975,6 @@ class FolderDetailViewModel @Inject constructor(
                 if (_enrichingItemId.value == item.id) _enrichingItemId.value = null
                 return@launch
             }
-            enrichedItemIds.add(item.id)
 
             // Apply TMDB enrichment if available.
             if (enrichment != null) {
@@ -1054,10 +1053,12 @@ class FolderDetailViewModel @Inject constructor(
             val artworkStillMissing = enrichment != null && !tmdbSettings.useArtwork &&
                 item.logo.isNullOrBlank()
             val needsExternalAddon = enrichment == null || artworkStillMissing
+            var externalMetaSucceeded = false
             if (needsExternalAddon && externalMetaEnabled) {
                 val metaResult = metaRepository.getMetaFromAllAddons(item.apiType, item.id)
                     .first { it is NetworkResult.Success || it is NetworkResult.Error }
                 if (metaResult is NetworkResult.Success) {
+                    externalMetaSucceeded = true
                     val meta = metaResult.data
                     if (artworkStillMissing) {
                         // Only apply artwork — TMDB already provided the rest.
@@ -1081,10 +1082,28 @@ class FolderDetailViewModel @Inject constructor(
                         }
                     }
                 } else {
-                    // External meta also failed — mark as failed enrichment.
-                    if (item.id !in _enrichedPreviews.value) {
-                        _failedEnrichmentIds.value = _failedEnrichmentIds.value + item.id
-                    }
+                    // External meta failed — mark as failed so the hero shows addon data immediately.
+                    _failedEnrichmentIds.value = _failedEnrichmentIds.value + item.id
+                }
+            }
+
+            // Mark this item as enriched now that all enrichment sources have been tried.
+            // Doing this after external meta (rather than before) ensures a failure on the
+            // external-meta path doesn't prevent the failed-enrichment flag from being set.
+            enrichedItemIds.add(item.id)
+
+            // Terminal fallback: if enrichment ran but neither TMDB nor external meta produced
+            // backdrop or logo data, the hero would stay hidden indefinitely. Surface addon data
+            // immediately by marking the item as a failed enrichment.
+            if (item.id !in _failedEnrichmentIds.value) {
+                val hasEnrichedVisuals = run {
+                    val tmdbHasArtwork = enrichment != null && tmdbSettings.useArtwork &&
+                        (!enrichment.backdrop.isNullOrBlank() || !enrichment.logo.isNullOrBlank())
+                    val externalHasArtwork = externalMetaSucceeded
+                    tmdbHasArtwork || externalHasArtwork
+                }
+                if (!hasEnrichedVisuals && item.id !in _enrichedPreviews.value) {
+                    _failedEnrichmentIds.value = _failedEnrichmentIds.value + item.id
                 }
             }
 


### PR DESCRIPTION
## Summary

- Move `enrichedItemIds.add()` to after external meta is attempted so that a failure on the external-meta path can still set the failed-enrichment flag and prevents the item from being silently skipped on any retry.
- Remove the `_enrichedPreviews` guard from the external-meta failure path so the hero surfaces addon data immediately on any network error, regardless of whether a previous enrichment preview exists.
- Add a terminal fallback that adds to `_failedEnrichmentIds` whenever enrichment ran but produced no backdrop or logo from either TMDB or external meta, covering catalog items whose IDs cannot be resolved by any enrichment source.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When a catalog addon is used as a Collection source with FOLLOW_LAYOUT, items whose IDs cannot be resolved to a TMDB ID (common with streaming-catalog addons) would never land in `_failedEnrichmentIds`. The `effectiveEnrichmentActive` flag in `ModernHomeContent` therefore stayed `true` indefinitely, hiding the hero section even though the addon had already supplied backdrop and description data. The hero would stay blank for the entire session.

## Issue or approval

Fixes #2301

## Reproduction steps

1. Add a catalog addon as a Collection source with FOLLOW_LAYOUT.
2. Use items that have non-TMDB IDs (common with streaming-catalog addons).
3. Open the home screen and focus an item in the collection.
4. Observe the hero section stays blank for the entire session even though the addon supplies backdrop and description data.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Change is scoped to `FolderDetailViewModel.onItemFocused()`. Home screen Modern catalog behavior is unaffected. No UI changes, no refactors, no changes to unrelated enrichment paths.

## Testing

- Catalog addon source in a Collection with FOLLOW_LAYOUT where items have non-TMDB IDs: hero backdrop and description appear immediately without waiting for enrichment.
- Catalog addon where TMDB is enabled and items DO resolve to a TMDB ID: hero still receives TMDB-enriched backdrop and logo as before.
- Catalog addon with external meta enabled: if external meta returns a network error, hero falls back to addon data rather than staying blank.
- Home screen Modern catalog behavior is unaffected.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #2301
