### PR TITLE
fix(player): prioritize adaptive extensions and add parsing fallback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -332,14 +332,42 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             // created lazily elsewhere. Kept as the integration point for the VOD cache.
         }
 
+        private fun inferAdaptiveMimeTypeFromPath(path: String?): String? {
+            val normalized = path?.trim()?.lowercase(Locale.US)?.takeIf { it.isNotBlank() } ?: return null
+            val pathWithoutFragment = normalized.substringBefore('#')
+            val pathPart = pathWithoutFragment.substringBefore('?')
+            val fileName = pathPart.substringAfterLast('/')
+            val extension = fileName.substringAfterLast('.', missingDelimiterValue = "")
+            return when (extension) {
+                "m3u8" -> MimeTypes.APPLICATION_M3U8
+                "mpd" -> MimeTypes.APPLICATION_MPD
+                "ism", "isml" -> MimeTypes.APPLICATION_SS
+                else -> null
+            }
+        }
+
         internal fun inferMimeType(
             url: String,
             filename: String?,
             responseHeaders: Map<String, String>? = null
         ): String? {
+            val adaptiveMime = inferAdaptiveMimeTypeFromPath(filename)
+                ?: inferAdaptiveMimeTypeFromPath(url)
+            if (adaptiveMime != null) {
+                return adaptiveMime
+            }
+
             return inferMimeTypeFromResponseHeaders(responseHeaders)
                 ?: inferMimeTypeFromPath(filename)
                 ?: inferMimeTypeFromPath(url)
+        }
+
+        fun evictMimeType(url: String, headers: Map<String, String>) {
+            val sanitizedHeaders = sanitizeHeaders(headers)
+            val cacheKey = buildMimeProbeCacheKey(url, sanitizedHeaders)
+            synchronized(mimeProbeCache) {
+                mimeProbeCache.remove(cacheKey)
+            }
         }
 
         internal fun normalizeMimeType(contentType: String?): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -35,6 +35,8 @@ internal fun PlayerRuntimeController.attemptStartupRecovery(
     if (!isRetryablePlaybackError(error)) return false
     if (startupRetryCount >= MAX_STARTUP_AUTO_RETRIES) return false
 
+    handleParsingErrorFallback(error)
+
     val paused = userPausedManually
     val attempt = startupRetryCount
     startupRetryCount++
@@ -233,6 +235,8 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
     if (!isRetryablePlaybackError(error)) return false
     if (errorRetryCount >= MAX_AUTO_RETRIES) return false
 
+    handleParsingErrorFallback(error)
+
     val paused = userPausedManually
     val attempt = errorRetryCount
     errorRetryCount++
@@ -418,4 +422,23 @@ internal fun PlayerRuntimeController.tryDv7HevcFallback(
         initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
     }
     return true
+}
+
+private fun PlayerRuntimeController.handleParsingErrorFallback(error: PlaybackException) {
+    if (error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
+        error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
+        error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_UNSUPPORTED ||
+        error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED
+    ) {
+        if (currentStreamMimeType != null) {
+            Log.w(
+                PlayerRuntimeController.TAG,
+                "Parsing error [${error.errorCode}] detected with mimeType=$currentStreamMimeType. " +
+                        "Evicting cache and clearing mimeType override for fallback probe."
+            )
+            PlayerMediaSourceFactory.evictMimeType(currentStreamUrl, currentHeaders)
+            currentStreamMimeType = null
+            currentStreamResponseHeaders = emptyMap()
+        }
+    }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
@@ -69,4 +69,26 @@ class PlayerMediaSourceFactoryTest {
 
         assertEquals(MimeTypes.VIDEO_MATROSKA, mimeType)
     }
+
+    @Test
+    fun `inferMimeType prefers URL extension for adaptive formats even if headers specify different type`() {
+        val mimeType = PlayerMediaSourceFactory.inferMimeType(
+            url = "https://example.com/stream.m3u8",
+            filename = null,
+            responseHeaders = mapOf("Content-Type" to "video/mp4")
+        )
+
+        assertEquals(MimeTypes.APPLICATION_M3U8, mimeType)
+    }
+
+    @Test
+    fun `inferMimeType prefers filename extension for adaptive formats even if headers specify different type`() {
+        val mimeType = PlayerMediaSourceFactory.inferMimeType(
+            url = "https://example.com/download?id=42",
+            filename = "movie.mpd",
+            responseHeaders = mapOf("Content-Type" to "video/mp4")
+        )
+
+        assertEquals(MimeTypes.APPLICATION_MPD, mimeType)
+    }
 }


### PR DESCRIPTION
## Summary

This PR optimizes the stream format detection and error recovery behavior of the media player to handle incorrect or misconfigured response headers returned by addon plugins (e.g. `Content-Type: video/mp4` for a `.m3u8` playlist), which previously resulted in playback failures with error code `3003`.

Key improvements:
1. **Adaptive Format Extension Priority**: `PlayerMediaSourceFactory.inferMimeType` now checks if the filename or URL has an adaptive streaming extension (`.m3u8`, `.mpd`, `.ism`, `.isml`) first. If an adaptive format is detected, we immediately return the corresponding mimetype, ignoring the incorrect headers.
2. **Parsing Error Recovery Fallback**: If the player encounters a container/manifest parsing error (`3002`, `3003`, etc.), `PlayerRuntimeControllerErrorRecovery` clears any cached mimetype and response headers, evicts the URL from `PlayerMediaSourceFactory` cache, and triggers a clean active probe on retry.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some streaming addons/CDNs incorrectly return generic headers (like `Content-Type: video/mp4` or `text/plain`) in their stream metadata/responses. The media player would trust these headers blindly, attempt to parse the playlist as a progressive MP4, and fail with `3003` (`ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED`). Additionally, the incorrect mimetype would remain cached, causing all retry attempts to fail in a loop.

## Issue or approval

No linked issue: critical bug fix to resolve HLS stream loading failures (3003 error) caused by misconfigured addon headers.

## Reproduction steps

1. Play an HLS stream (`.m3u8` extension) where the addon specifies response headers containing `"Content-Type": "video/mp4"`.
2. Observe that player tries to open it as progressive MP4 and fails with error `3003` (`ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED`).

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR is strictly confined to `PlayerMediaSourceFactory.kt` and `PlayerRuntimeControllerErrorRecovery.kt` to fix stream format resolution and error retry fallback. It does not contain any UI changes or feature additions.

## Testing

- **Automated Tests**: Added new test cases to `PlayerMediaSourceFactoryTest.kt` verifying that adaptive streaming extensions are correctly prioritized over incorrect headers.
- **Verification Command**: Ran unit tests locally:
  ```bash
  .\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.PlayerMediaSourceFactoryTest"
  ```
  Result: `BUILD SUCCESSFUL`

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

- Reported on Reddit: [Dramayo addon returns streams on mobile app but...](https://www.reddit.com/r/Nuvio/comments/1ua4qmt/dramayo_addon_returns_streams_on_mobile_app_but/)
