### PR TITLE
fix(player): resolve RTL subtitle punctuation positioning and layouts in LTR rendering

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1746,31 +1746,98 @@ private class CueNormalizingTextOutput(
 
     private fun fixRtlCueText(cue: Cue): Cue {
         val text = cue.text ?: return cue
-        if (!containsRtlChars(text)) return cue
-        val original = text.toString()
-        val fixed = original.split('\n').joinToString("\n") { line ->
-            fixRtlPunctuationForLtr(line)
+        
+        // Arabic subtitles use the RLE (\u202B) / PDF (\u202C) wrapping method on each line.
+        // This forces both physical and auto-wrapped lines to be correctly rendered as RTL.
+        if (containsArabic(text)) {
+            val original = text.toString()
+            if (original.startsWith("\u202B") && original.endsWith("\u202C")) {
+                return cue
+            }
+            val builder = android.text.SpannableStringBuilder()
+            val lines = text.splitByNewlines()
+            for (i in lines.indices) {
+                if (i > 0) {
+                    builder.append("\n")
+                }
+                val line = lines[i]
+                if (line.isNotEmpty()) {
+                    builder.append("\u202B")
+                    builder.append(line)
+                    builder.append("\u202C")
+                } else {
+                    builder.append(line)
+                }
+            }
+            return cue.buildUpon().setText(builder).build()
         }
-        if (fixed == original) return cue
-        return cue.buildUpon().setText(android.text.SpannableString(fixed)).build()
+        
+        // Other RTL subtitles (e.g. Hebrew) use the pre-commit character swapping method.
+        if (containsRtlChars(text)) {
+            val original = text.toString()
+            val fixed = original.split('\n').joinToString("\n") { line ->
+                fixRtlPunctuationForLtr(line)
+            }
+            if (fixed == original) return cue
+            return cue.buildUpon().setText(android.text.SpannableString(fixed)).build()
+        }
+        
+        return cue
+    }
+
+    private fun containsArabic(text: CharSequence): Boolean {
+        var i = 0
+        while (i < text.length) {
+            val codePoint = Character.codePointAt(text, i)
+            if (codePoint in 0x0600..0x06FF || // Arabic block
+                codePoint in 0x0750..0x077F || // Arabic Supplement
+                codePoint in 0x0870..0x08FF || // Arabic Extended
+                codePoint in 0xFB50..0xFDFF || // Arabic Presentation Forms-A
+                codePoint in 0xFE70..0xFEFF || // Arabic Presentation Forms-B
+                Character.getDirectionality(codePoint) == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC
+            ) {
+                return true
+            }
+            i += Character.charCount(codePoint)
+        }
+        return false
     }
 
     private fun fixRtlPunctuationForLtr(line: String): String {
         if (line.isEmpty()) return line
+        val hasCr = line.endsWith('\r')
+        val cleanLine = if (hasCr) line.substring(0, line.length - 1) else line
+        if (cleanLine.isEmpty()) return line
         
         var start = 0
-        while (start < line.length && isRtlPunctuation(line[start])) start++
+        while (start < cleanLine.length && isRtlPunctuation(cleanLine[start])) start++
         
-        var end = line.length
-        while (end > start && isRtlPunctuation(line[end - 1])) end--
+        var end = cleanLine.length
+        while (end > start && isRtlPunctuation(cleanLine[end - 1])) end--
         
-        if (start == 0 && end == line.length) return line
+        if (start == 0 && end == cleanLine.length) return line
         
-        val leadingPunct = line.substring(0, start)
-        val middle = line.substring(start, end)
-        val trailingPunct = line.substring(end)
+        val leadingPunct = cleanLine.substring(0, start)
+        val middle = cleanLine.substring(start, end)
+        val trailingPunct = cleanLine.substring(end)
         
-        return "$trailingPunct$middle$leadingPunct"
+        val fixed = "$trailingPunct$middle$leadingPunct"
+        return if (hasCr) "$fixed\r" else fixed
+    }
+
+    private fun CharSequence.splitByNewlines(): List<CharSequence> {
+        val result = mutableListOf<CharSequence>()
+        var start = 0
+        var i = 0
+        while (i < this.length) {
+            if (this[i] == '\n') {
+                result.add(this.subSequence(start, i))
+                start = i + 1
+            }
+            i++
+        }
+        result.add(this.subSequence(start, this.length))
+        return result
     }
 
     private fun isRtlPunctuation(ch: Char): Boolean {
@@ -1778,10 +1845,27 @@ private class CueNormalizingTextOutput(
     }
 
     private fun containsRtlChars(text: CharSequence): Boolean {
-        for (ch in text) {
-            val d = Character.getDirectionality(ch)
+        var i = 0
+        while (i < text.length) {
+            val codePoint = Character.codePointAt(text, i)
+            
+            // Direct Unicode range checks for Hebrew and Arabic scripts
+            if (codePoint in 0x0590..0x05FF || // Hebrew block (letters, points, punctuation)
+                codePoint in 0xFB1D..0xFB4F || // Hebrew Presentation Forms
+                codePoint in 0x0600..0x06FF || // Arabic block
+                codePoint in 0x0750..0x077F || // Arabic Supplement
+                codePoint in 0x0870..0x08FF || // Arabic Extended
+                codePoint in 0xFB50..0xFDFF || // Arabic Presentation Forms-A
+                codePoint in 0xFE70..0xFEFF    // Arabic Presentation Forms-B
+            ) {
+                return true
+            }
+            
+            val d = Character.getDirectionality(codePoint)
             if (d == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
-                d == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC) return true
+                d == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC ||
+                d == Character.DIRECTIONALITY_ARABIC_NUMBER) return true
+            i += Character.charCount(codePoint)
         }
         return false
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1746,42 +1746,51 @@ private class CueNormalizingTextOutput(
 
     private fun fixRtlCueText(cue: Cue): Cue {
         val text = cue.text ?: return cue
-        
-        // Arabic subtitles use the RLE (\u202B) / PDF (\u202C) wrapping method on each line.
-        // This forces both physical and auto-wrapped lines to be correctly rendered as RTL.
+
+        // Arabic: wrap each physical line with RLE (\u202B) ... PDF (\u202C).
+        // This renders boundary punctuation and auto-wrapped lines as RTL in an LTR container.
         if (containsArabic(text)) {
-            val original = text.toString()
-            if (original.startsWith("\u202B") && original.endsWith("\u202C")) {
-                return cue
-            }
             val builder = android.text.SpannableStringBuilder()
             val lines = text.splitByNewlines()
             for (i in lines.indices) {
-                if (i > 0) {
-                    builder.append("\n")
-                }
-                val line = lines[i]
-                if (line.isNotEmpty()) {
-                    builder.append("\u202B")
+                if (i > 0) builder.append("\n")
+                // Clear existing directional markers -> prevents double wrapping upon re-execution (idempotent).
+                val line = lines[i].stripDirectionalWrap()
+                if (line.isEmpty()) {
                     builder.append(line)
-                    builder.append("\u202C")
-                } else {
-                    builder.append(line)
+                    continue
                 }
+                // Keep the trailing CR (paragraph separator) OUTSIDE of the embedding; otherwise
+                // it terminates the RLE run and leaves the PDF orphan.
+                val hasCr = line[line.length - 1] == '\r'
+                val core = if (hasCr) line.subSequence(0, line.length - 1) else line
+                if (core.isEmpty()) {
+                    builder.append(line)
+                    continue
+                }
+                builder.append("\u202B").append(core).append("\u202C")
+                if (hasCr) builder.append("\r")
             }
+            if (builder.contentEquals(text)) return cue
             return cue.buildUpon().setText(builder).build()
         }
-        
-        // Other RTL subtitles (e.g. Hebrew) use the pre-commit character swapping method.
+
+        // Hebrew / other RTL: punctuation boundary-swap method (span preserving).
         if (containsRtlChars(text)) {
-            val original = text.toString()
-            val fixed = original.split('\n').joinToString("\n") { line ->
-                fixRtlPunctuationForLtr(line)
+            val builder = android.text.SpannableStringBuilder()
+            val lines = text.splitByNewlines()
+            var changed = false
+            for (i in lines.indices) {
+                if (i > 0) builder.append("\n")
+                val line = lines[i]
+                val fixed = fixRtlPunctuationForLtr(line)
+                if (fixed !== line) changed = true
+                builder.append(fixed)
             }
-            if (fixed == original) return cue
-            return cue.buildUpon().setText(android.text.SpannableString(fixed)).build()
+            if (!changed) return cue
+            return cue.buildUpon().setText(builder).build()
         }
-        
+
         return cue
     }
 
@@ -1803,27 +1812,44 @@ private class CueNormalizingTextOutput(
         return false
     }
 
-    private fun fixRtlPunctuationForLtr(line: String): String {
+    // Take CharSequence instead of String -> preserve spans.
+    private fun fixRtlPunctuationForLtr(line: CharSequence): CharSequence {
         if (line.isEmpty()) return line
-        val hasCr = line.endsWith('\r')
-        val cleanLine = if (hasCr) line.substring(0, line.length - 1) else line
-        if (cleanLine.isEmpty()) return line
-        
+        val hasCr = line[line.length - 1] == '\r'
+        val end0 = if (hasCr) line.length - 1 else line.length
+        if (end0 == 0) return line
+
         var start = 0
-        while (start < cleanLine.length && isRtlPunctuation(cleanLine[start])) start++
-        
-        var end = cleanLine.length
-        while (end > start && isRtlPunctuation(cleanLine[end - 1])) end--
-        
-        if (start == 0 && end == cleanLine.length) return line
-        
-        val leadingPunct = cleanLine.substring(0, start)
-        val middle = cleanLine.substring(start, end)
-        val trailingPunct = cleanLine.substring(end)
-        
-        val fixed = "$trailingPunct$middle$leadingPunct"
-        return if (hasCr) "$fixed\r" else fixed
+        while (start < end0 && isRtlPunctuation(line[start])) start++
+
+        var end = end0
+        while (end > start && isRtlPunctuation(line[end - 1])) end--
+
+        if (start == 0 && end == end0) return line
+
+        val out = android.text.SpannableStringBuilder()
+        out.append(line.subSequence(end, end0))   // trailing punct -> front
+            .append(line.subSequence(start, end)) // middle
+            .append(line.subSequence(0, start))   // leading punct -> end
+        if (hasCr) out.append("\r")
+        return out
     }
+
+    // Clears existing directional control characters (idempotency + legacy RLM/LRE remnants).
+    private fun CharSequence.stripDirectionalWrap(): CharSequence {
+        val hasMarker = (0 until length).any { isDirectionalMark(this[it]) }
+        if (!hasMarker) return this
+        val sb = android.text.SpannableStringBuilder(this)
+        var k = 0
+        while (k < sb.length) {
+            if (isDirectionalMark(sb[k])) sb.delete(k, k + 1) else k++
+        }
+        return sb
+    }
+
+    private fun isDirectionalMark(c: Char): Boolean =
+        c == '\u202A' || c == '\u202B' || c == '\u202C' || // LRE / RLE / PDF
+        c == '\u200E' || c == '\u200F'                     // LRM / RLM
 
     private fun CharSequence.splitByNewlines(): List<CharSequence> {
         val result = mutableListOf<CharSequence>()


### PR DESCRIPTION
## Summary

Resolves the Right-to-Left (RTL) subtitle rendering and boundary-punctuation regression
(periods, exclamation/question marks, commas, colons, semicolons, ellipsis, brackets, quotes)
for Arabic and Hebrew subtitles rendered inside an LTR container (standard ExoPlayer/Media3
text view on TV).

Hybrid, per-line approach in `CueNormalizingTextOutput.fixRtlCueText`:
- **Arabic** — each physical line is wrapped in RLE (`\u202B`) … PDF (`\u202C`), forcing both
  physical and auto-wrapped lines to render as a single RTL run.
- **Hebrew / other RTL** — boundary punctuation swap (`fixRtlPunctuationForLtr`).

Hardening applied:
- A trailing CR (`\r`, a Unicode paragraph separator) is kept **outside** the RLE/PDF run so it
  cannot terminate the embedding and orphan the PDF (fixes CRLF subtitles).
- Pass is **idempotent**: existing directional marks (`\u202A/\u202B/\u202C/\u200E/\u200F`) are
  stripped per line before re-wrapping, and the cue is rebuilt only when content actually changes
  (`contentEquals`), avoiding double wrapping and redundant `Cue` allocations on cue re-delivery.
- Span-preserving: Arabic and Hebrew paths now operate on `CharSequence`/`SpannableStringBuilder`
  so subtitle styling (italics/colors) is retained.
- Unicode scanning is surrogate-pair safe (`codePointAt` + `charCount`).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Under LTR rendering, neutral punctuation at the boundaries of an RTL sentence resolves to the
wrong visual side.
- Setting the view's layout direction to RTL works for Arabic but not Hebrew.
- A single RLM (`\u200F`) marker fixes single-line subtitles but fails on auto-wrapped multi-line
  sentences (only the first visual line inherits direction).
- Per-line RLE/PDF wrapping for Arabic plus character swapping for Hebrew resolves both regressions
  while keeping layout structure consistent. CRLF handling and idempotency prevent the embedding
  from breaking or compounding across repeated cue callbacks.

## Issue or approval

Fixes #2392 (critical RTL subtitle punctuation positioning on TV).

## Reproduction steps

1. Play media with Arabic or Hebrew subtitles containing boundary punctuation
   (e.g. `(إيثان).` or `"كارتر"!`).
2. Use a subtitle file with CRLF line endings and a line long enough to auto-wrap.
3. Observe that on device the punctuation (period, exclamation, etc.) renders on the wrong visual
   side, and wrapped lines lose RTL direction.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to RTL subtitle text normalization in `CueNormalizingTextOutput`. No changes to player
controls, cue positioning logic, renderer wiring, audio, or any UI layout. No formatting/refactor
of unrelated code.

## Testing


- Device/emulator: Android TV emulator API 34
- Arabic subtitles (CRLF, with auto-wrapping long line): punctuation now on correct visual side
  on every wrapped line.
- Hebrew subtitles with boundary punctuation: correct positioning, styling spans preserved.
- LTR-only and mixed (Arabic + embedded English) subtitles: no regression.
- Repeated cue callbacks: no double wrapping (idempotency verified).

## Screenshots / Video

None.

## Breaking changes

None.

## Linked issues

Fixes #2392