### PR TITLE
fix: Add a full-description overlay so long synopses don't hide the detail metadata row

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -106,7 +108,8 @@ fun HeroContentSection(
     playButtonFocusRequester: FocusRequester? = null,
     restorePlayFocusToken: Int = 0,
     onHeroActionFocused: () -> Unit = {},
-    onPlayFocusRestored: () -> Unit = {}
+    onPlayFocusRestored: () -> Unit = {},
+    onShowFullDescription: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val isSeriesApi = remember(meta.apiType) {
@@ -313,17 +316,72 @@ fun HeroContentSection(
                         Spacer(modifier = Modifier.height(14.dp))
                     }
 
-                    // Always show series/movie description, not episode description
-                    if (meta.description != null) {
-                        Text(
-                            text = meta.description,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = NuvioTheme.colors.TextPrimary,
-                            overflow = TextOverflow.Clip,
+                    // Series/movie description (not the episode one). Clamp it so the meta row
+                    // below stays on-screen (the hero is a fixed 540dp = full height on a 1080p
+                    // TV). When the synopsis is long enough to be truncated it becomes focusable;
+                    // pressing OK opens the full, scrollable text overlay.
+                    meta.description?.let { description ->
+                        var descriptionFocused by remember { mutableStateOf(false) }
+                        var descriptionTruncated by remember(description) { mutableStateOf(false) }
+                        val descriptionInteraction = remember { MutableInteractionSource() }
+                        // Inset of the focus highlight; offset back by the same amount so the text
+                        // stays left-aligned with the rest of the hero while the highlight gets
+                        // even padding on all sides.
+                        val highlightInset = 12.dp
+
+                        Column(
                             modifier = Modifier
                                 .fillMaxWidth(0.6f)
                                 .padding(bottom = NuvioTheme.spacing.md)
-                        )
+                                .then(
+                                    if (descriptionTruncated) {
+                                        Modifier
+                                            .offset(x = -highlightInset)
+                                            .onFocusChanged { descriptionFocused = it.isFocused }
+                                            .background(
+                                                color = if (descriptionFocused) {
+                                                    Color.White.copy(alpha = 0.10f)
+                                                } else {
+                                                    Color.Transparent
+                                                },
+                                                shape = RoundedCornerShape(8.dp)
+                                            )
+                                            .clickable(
+                                                interactionSource = descriptionInteraction,
+                                                indication = null,
+                                                onClick = onShowFullDescription
+                                            )
+                                            .padding(horizontal = highlightInset, vertical = 8.dp)
+                                    } else {
+                                        Modifier
+                                    }
+                                )
+                        ) {
+                            Text(
+                                text = description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = NuvioTheme.colors.TextPrimary,
+                                maxLines = 8,
+                                overflow = TextOverflow.Ellipsis,
+                                onTextLayout = { result ->
+                                    if (result.hasVisualOverflow != descriptionTruncated) {
+                                        descriptionTruncated = result.hasVisualOverflow
+                                    }
+                                }
+                            )
+                            if (descriptionTruncated) {
+                                Text(
+                                    text = stringResource(R.string.hero_synopsis_read_more),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = if (descriptionFocused) {
+                                        NuvioTheme.colors.TextPrimary
+                                    } else {
+                                        NuvioTheme.extendedColors.textSecondary
+                                    },
+                                    modifier = Modifier.padding(top = 4.dp)
+                                )
+                            }
+                        }
                     }
 
                     MetaInfoRow(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -9,6 +9,9 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -54,8 +57,14 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
@@ -968,6 +977,7 @@ private fun MetaDetailsContent(
     var companyRestoreToken by rememberSaveable { mutableIntStateOf(0) }
     var initialHeroFocusRequested by rememberSaveable(meta.id) { mutableStateOf(false) }
     var showHeroPlayOptionsDialog by rememberSaveable(meta.id) { mutableStateOf(false) }
+    var showSynopsisOverlay by rememberSaveable(meta.id) { mutableStateOf(false) }
     var initialDetailReturnFocusHandled by rememberSaveable(
         meta.id,
         detailReturnEpisodeFocusRequest?.season,
@@ -1651,7 +1661,8 @@ private fun MetaDetailsContent(
                             onPlayButtonFocused()
                             initialHeroFocusRequested = true
                             clearPendingRestore()
-                        }
+                        },
+                        onShowFullDescription = { showSynopsisOverlay = true }
                     )
                 }
             }
@@ -2086,6 +2097,107 @@ private fun MetaDetailsContent(
                 onDismiss = onDismissSharedTrailer,
                 onRetry = onRetrySharedTrailer
             )
+        }
+
+        meta.description?.takeIf { showSynopsisOverlay && it.isNotBlank() }?.let { synopsis ->
+            SynopsisOverlay(
+                title = meta.name,
+                description = synopsis,
+                onDismiss = { showSynopsisOverlay = false }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SynopsisOverlay(
+    title: String,
+    description: String,
+    onDismiss: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+    val contentFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        contentFocusRequester.requestFocus()
+        scrollState.scrollTo(0)
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            Color(0xFF070707),
+                            Color(0xFF101010),
+                            Color(0xFF151515)
+                        )
+                    )
+                )
+                .padding(horizontal = NuvioTheme.spacing.xxxl, vertical = NuvioTheme.spacing.xl)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.78f)
+                        .weight(1f)
+                        .verticalScroll(scrollState)
+                        .focusRequester(contentFocusRequester)
+                        .focusable()
+                        .onPreviewKeyEvent { event ->
+                            when {
+                                event.type != KeyEventType.KeyDown -> false
+                                event.key == Key.DirectionDown && scrollState.value < scrollState.maxValue -> {
+                                    coroutineScope.launch {
+                                        scrollState.animateScrollTo(
+                                            (scrollState.value + 260).coerceAtMost(scrollState.maxValue)
+                                        )
+                                    }
+                                    true
+                                }
+                                event.key == Key.DirectionUp && scrollState.value > 0 -> {
+                                    coroutineScope.launch {
+                                        scrollState.animateScrollTo(
+                                            (scrollState.value - 260).coerceAtLeast(0)
+                                        )
+                                    }
+                                    true
+                                }
+                                else -> false
+                            }
+                        }
+                ) {
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = Color.White.copy(alpha = 0.92f),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                Text(
+                    text = stringResource(R.string.hero_synopsis_dismiss_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.4f)
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,8 @@
     <string name="hero_mark_unwatched">Mark as unwatched</string>
     <string name="hero_play_trailer">Play trailer</string>
     <string name="hero_press_back_trailer">Press back to exit trailer</string>
+    <string name="hero_synopsis_read_more">Read more</string>
+    <string name="hero_synopsis_dismiss_hint">Press back to close</string>
     <string name="cd_rating">Rating</string>
 
     <string name="episodes_season">Season %1$d</string>


### PR DESCRIPTION
## Summary

Long series/movie descriptions overflowed the fixed-height detail hero and pushed the bottom metadata row (age rating, runtime, country of origin) off the bottom edge, making that info unreadable. It is most visible on displays whose usable height is at or below the hero's fixed 540dp (e.g. a 1080p Android TV).

This PR:
- Clamps the hero synopsis to 8 lines with an ellipsis so the metadata row always stays on-screen.
- When the synopsis is actually truncated, it becomes focusable and shows a "Read more" hint; pressing OK opens a full-screen, D-pad-scrollable overlay with the complete text (Back to close).
- Adds a "View full description" item at the bottom of the episode long-press menu that opens the same overlay for that episode's overview.
- Both entry points share one reusable `SynopsisOverlay` composable.

## PR type

This is a UI change: it fixes a documented layout glitch (the cut-off metadata row) and adds an overlay so the now-clamped text stays fully readable. It is not localization, and it is broader than a single critical-bug one-liner, so neither box below is checked.
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Without the clamp, a long description hides the age rating, runtime, and country of origin behind the bottom screen edge, so users cannot see them at all. Clamping the text fixes that; the overlay and the episode-menu entry point ensure no description content is lost as a result of the clamp.

## Issue or approval

No linked issue; the glitch was found while testing on a 1080p Android TV. No maintainer approval is on record. Opening as a draft for maintainer consideration.

## Reproduction steps

1. Open a series or movie whose description is long (e.g. "A Galaxy Next Door").
2. View the detail screen on a display whose usable height is around the hero's 540dp (a 1080p Android TV, or an emulator at 3840x2160 / density 640).
3. Observe that the bottom metadata row (age rating, runtime, country) is pushed off the bottom edge and cannot be read.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

The hero synopsis is now clamped and (when truncated) focusable, and a new scrollable description overlay opens from the hero and from the episode menu.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

The two unchecked boxes are left unchecked on purpose: this PR does include a UI change (the overlay), so claiming otherwise would be inaccurate. Flagged here for maintainer review rather than hidden.

## Scope boundaries

- Changes are limited to the detail hero, the episode options menu, and the new overlay.
- The episode card itself is intentionally left unchanged (no new on-card affordances).
- The clamp is a fixed 8 lines; no display-size-adaptive logic was added.
- No refactors, formatting passes, or unrelated changes.

## Testing

- Built with `./gradlew :app:assembleFullDebug` (passes, including `lintVitalFullDebug`).
- Installed and manually verified on an Android TV (AOSP) emulator at 3840x2160 / density 640 (540dp height) and an NVIDIA Shield (1080p, ~596dp height):
  - Hero: long descriptions clamp to 8 lines; the age rating / runtime / country row stays visible. Short descriptions are unchanged and non-focusable.
  - Focusing a clamped synopsis shows the "Read more" hint; OK opens the overlay; D-pad up/down scrolls; Back closes.
  - Episode long-press menu shows "View full description" only when the episode has an overview; it opens the overlay with the episode title and overview.

## Screenshots / Video

Before (long synopsis pushes the age rating / runtime / country row off the bottom edge):

<img width="3840" height="2160" alt="Before" src="https://github.com/user-attachments/assets/23dda12d-8460-4e12-b019-36259db0b8e4" />

After (synopsis clamped so the metadata row stays visible, plus the focusable "Read more" hint and the scrollable full-description overlay):

https://github.com/user-attachments/assets/0218da74-770a-4e62-bd81-2a4ef6b5fad2

## Breaking changes

None.

## Linked issues

No linked issue; opening as a draft for maintainer review.
