### PR TITLE
fix(player): make connectionPoolSize dynamic and recreate connection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioExoPlayerPerformanceHelper.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioExoPlayerPerformanceHelper.kt
@@ -38,9 +38,13 @@ object NuvioExoPlayerPerformanceHelper {
             applyEngineConfig(value)
         }
 
-    val sharedConnectionPool: okhttp3.ConnectionPool by lazy {
-        okhttp3.ConnectionPool(32, 3, java.util.concurrent.TimeUnit.MINUTES)
-    }
+    @Volatile
+    var sharedConnectionPool: okhttp3.ConnectionPool = okhttp3.ConnectionPool(
+        DEFAULT_NUVIO_CONNECTION_POOL_SIZE,
+        3,
+        java.util.concurrent.TimeUnit.MINUTES
+    )
+        private set
 
     // ─── Constants ────────────────────────────────────────────────────────────
     const val DEFAULT_NUVIO_ALLOCATOR_SEGMENT_SIZE = 64 * 1024        // 64 KB
@@ -102,11 +106,19 @@ object NuvioExoPlayerPerformanceHelper {
             safeLimitMb
         }
 
+        val oldPoolSize = connectionPoolSize
         val customNetwork = settings.parallelNetworkEnabled
         connectionPoolSize = if (customNetwork && settings.useParallelConnections) {
             settings.parallelConnectionCount * 2
         } else {
             DEFAULT_NUVIO_CONNECTION_POOL_SIZE
+        }
+        if (connectionPoolSize != oldPoolSize) {
+            sharedConnectionPool = okhttp3.ConnectionPool(
+                connectionPoolSize,
+                3,
+                java.util.concurrent.TimeUnit.MINUTES
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
This PR resolves the issue where `connectionPoolSize` was dead code in `NuvioExoPlayerPerformanceHelper`. It makes the OkHttp `ConnectionPool` dynamically re-initialized whenever the custom parallel connection count settings change.
This is a continuation of #2403.
## PR type
- [ ] Translation/localization only
- [x] Critical bug fix
## Why
The configurable network connection pool size was previously ignored, with the player helper always defaulting to a hardcoded `ConnectionPool(32, 3min)`. This PR ensures that the user's custom network settings and parallel connection count are properly applied to the OkHttp client's connection pool.
## Issue or approval
Continuation of #2403.
## Reproduction steps
1. Enable Custom Network and set parallel connection count.
2. Observe that `NuvioExoPlayerPerformanceHelper.sharedConnectionPool` remains hardcoded with a size of 32 and is never recreated with the updated size.
## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.
## Scope boundaries
This PR is strictly limited to fixing the connection pool initialization and dynamic updates inside `NuvioExoPlayerPerformanceHelper.kt`.
## Testing
Verified using unit tests that changing settings recreate the OkHttp connection pool with the calculated size.
## Screenshots / Video
Not a UI change.
## Breaking changes
None.
## Linked issues
Continuation of #2403.
