### PR TITLE
fix: auto-skip each segment only once per playback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -333,7 +333,7 @@ class PlayerRuntimeController(
     internal var autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet()
     internal var playerSettingsInitialized: Boolean = false
     internal var skipIntroFetchedKey: String? = null
-    internal var lastAutoSkippedIntervalKey: String? = null
+    internal val autoSkippedIntervalKeys: MutableSet<String> = mutableSetOf()
     internal var lastActiveSkipType: String? = null
     internal var autoSubtitleSelected: Boolean = false
     internal var lastSubtitlePreferredLanguage: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -359,7 +359,6 @@ internal fun PlayerRuntimeController.showStreamSourceIndicator(stream: Stream) {
 
 internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) {
     if (skipIntervals.isEmpty()) {
-        lastAutoSkippedIntervalKey = null
         if (_uiState.value.activeSkipInterval != null) {
             _uiState.update { it.copy(activeSkipInterval = null) }
         }
@@ -388,14 +387,12 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
         if (
             segmentType != null &&
             segmentType in autoSkipSegmentTypes &&
-            lastAutoSkippedIntervalKey != activeKey
+            activeKey !in autoSkippedIntervalKeys
         ) {
-            lastAutoSkippedIntervalKey = activeKey
+            autoSkippedIntervalKeys.add(activeKey)
             skipInterval(active)
         }
     } else if (currentActive != null) {
-
-        lastAutoSkippedIntervalKey = null
         _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = false) }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -428,7 +428,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                 if (skipIntervals.isNotEmpty() || _uiState.value.activeSkipInterval != null) {
                     skipIntervals = emptyList()
                     skipIntroFetchedKey = null
-                    lastAutoSkippedIntervalKey = null
+                    autoSkippedIntervalKeys.clear()
                     _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = true) }
                 }
             } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1313,6 +1313,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     skipIntervals = emptyList()
     skipIntroFetchedKey = null
     lastActiveSkipType = null
+    autoSkippedIntervalKeys.clear()
 
     fetchParentalGuide(contentId, contentType, currentSeason, currentEpisode)
     fetchSkipIntervals(contentId, currentSeason, currentEpisode)
@@ -1407,6 +1408,7 @@ private fun PlayerRuntimeController.switchToEpisodeStreamCommon(
     skipIntervals = emptyList()
     skipIntroFetchedKey = null
     lastActiveSkipType = null
+    autoSkippedIntervalKeys.clear()
 
     fetchParentalGuide(contentId, contentType, currentSeason, currentEpisode)
     fetchSkipIntervals(contentId, currentSeason, currentEpisode)


### PR DESCRIPTION
## Summary

Auto-skip now skips each intro/recap/outro segment at most once per
playback. Previously, seeking back into a segment that had already been
auto-skipped (e.g. back to 0:10 because the skip timecodes were off) caused
it to immediately auto-skip again, making that part unwatchable.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Auto-skip kept only the last skipped segment in a single
`lastAutoSkippedIntervalKey`, and cleared it the moment playback left the
segment. Once that key was cleared, rewinding back into the segment detected
it as active and skipped it again, so the user could never go back into an
auto-skipped region.

## Issue or approval

Fixes #2413

## Reproduction steps

1. In Playback settings, enable auto-skip for an intro, recap, or outro.
2. Play an episode and let that segment auto-skip.
3. Rewind back into that part and it immediately auto-skips again.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only the tracking changed: skipped segments are now remembered in a set
  scoped to the current content, instead of a single key that got cleared
  whenever playback left the segment.
- The manual Skip button is unchanged and still appears when you seek back,
  so manual skipping stays available.
- No changes to segment fetching or auto-skip detection.

## Testing

- Episode with intro, recap, and outro: each auto-skips once. Seeking back
  into one no longer re-skips it, and the manual Skip button still works.
- New episode or stream: auto-skip starts over and skips each segment once.
- Tested on Chromecast with Google TV (4K) with a debug build.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #2413