### PR TITLE
Show poster titles on the Network/Production browse screen

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
@@ -544,7 +544,7 @@ private fun EntityRailRow(
                     onClick = { onItemClick(item) },
                     onLongPress = { onItemLongPress(item) },
                     posterCardStyle = posterCardStyle,
-                    showLabel = false,
+                    showLabel = true,
                     focusRequester = requester,
                     onFocused = {
                         onFocusedItemIndexChanged(itemIndex)


### PR DESCRIPTION
## Summary

The TMDB entity-browse screen (opened by clicking a **Network** or **Production** company on a title's detail page) rendered its poster grid with show labels hardcoded off, so titles never appeared under the cards. Every other poster grid in the app shows titles (cast/creator filmography, search, folder/collection, "More like this", library), making this screen the lone exception. This flips the single hardcoded `showLabel = false` to `true` so the grid matches the rest.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Network/Production browse was the only poster grid in the app that never showed titles, inconsistent with every other grid. Users browsing a network's or studio's catalog could not see the show names under the posters.

## Issue or approval

Fixes #2428.

## Reproduction steps

1. Open a series or movie detail page that lists a Network or Production company (e.g. an anime aired on "Tokyo MX").
2. Scroll to the Network or Production row and click a logo.
3. Observe the resulting grid: posters have no titles underneath, unlike every other grid in the app.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Titles now render under the posters on the Network/Production browse grid. Nothing else changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

One-line change in `TmdbEntityBrowseScreen` (the entity-browse grid card's `showLabel`). No ViewModels, other screens, or refactors are touched. The poster-labels setting and per-layout behavior of other screens are intentionally left as-is; this only brings the entity-browse grid in line with them.

## Testing

- `./gradlew :app:assembleFullDebug` builds; `:app:compileFullDebugKotlin` clean.
- Installed on an NVIDIA Shield (Android 11) and an Android TV emulator: the Network/Production browse grid now shows titles under the posters, matching the cast/search/library grids.

## Screenshots / Video

**Before** — no titles under the posters:

| Network | Production |
|---|---|
| <img width="420" alt="Network browse, before (no titles)" src="https://github.com/user-attachments/assets/56c71f3c-e384-408a-93db-2cc4b62d59bb" /> | <img width="420" alt="Production browse, before (no titles)" src="https://github.com/user-attachments/assets/6310e39c-df30-465b-bae8-6f2cb60d1e4e" /> |

**After** — titles now shown:

| Network | Production |
|---|---|
| <img width="420" alt="Network browse, after (titles shown)" src="https://github.com/user-attachments/assets/30476cce-64dd-417b-9ea0-e674f629113d" /> | <img width="420" alt="Production browse, after (titles shown)" src="https://github.com/user-attachments/assets/1ebca9e7-0b82-412d-98e7-ba98b0dd992c" /> |

## Breaking changes

None.

## Linked issues

Fixes #2428.
