### PR TITLE
fix: Use `AssHandler.addFont(name, data)` API directly in the Matroska extractor so embedded ASS font attachments are registered reliably.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
@@ -16,7 +16,6 @@ import androidx.media3.extractor.text.SubtitleParser
 import io.github.peerless2012.ass.media.AssHandler
 import io.github.peerless2012.ass.media.type.AssRenderType
 import java.io.ByteArrayOutputStream
-import java.lang.reflect.Method
 import java.util.regex.Pattern
 import java.util.zip.DataFormatException
 import java.util.zip.Inflater
@@ -96,7 +95,7 @@ internal class NuvioAssMatroskaExtractor(
                 if (attachmentMime in fontMimeTypes) {
                     val data = ByteArray(contentSize)
                     input.readFully(data, 0, contentSize)
-                    addFontMethod?.invoke(assHandler, attachmentName, data)
+                    assHandler.addFont(attachmentName, data)
                 } else {
                     input.skipFully(contentSize)
                 }
@@ -139,15 +138,6 @@ internal class NuvioAssMatroskaExtractor(
         val subtitleSampleField = MatroskaExtractor::class.java
             .getDeclaredField("subtitleSample")
             .apply { isAccessible = true }
-
-        val addFontMethod: Method? = AssHandler::class.java.declaredMethods.firstOrNull { method ->
-            method.name == "addFont" &&
-                method.parameterTypes.size == 2 &&
-                method.parameterTypes[0] == String::class.java &&
-                method.parameterTypes[1] == ByteArray::class.java
-        }?.apply {
-            isAccessible = true
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Use `AssHandler.addFont(name, data)` API directly in the Matroska extractor so embedded ASS font attachments are registered reliably.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Embedded ASS font attachments were not being registered reliably when the extractor used reflection. This update matches the extractor to the `0.4.0` API directly.

## Issue or approval

#2432 

## Reproduction steps

1. Play an affected MKV with embedded ASS subtitles and font attachments.
2. Observe that styled text/sign fonts can fall back or render incorrectly when the font attachment is not registered.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Only the font attachment registration path in `NuvioAssMatroskaExtractor.kt` was changed.

## Testing

Tested an affected MKV with debug build on device to confirm embedded ASS font attachments register correctly.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

#2432
