### PR TITLE
Send resolved intro/outro skip segments to external players

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -11,6 +11,7 @@ import com.nuvio.tv.data.repository.TraktScrobbleService
 import com.nuvio.tv.data.repository.TraktScrobbleItem
 import com.nuvio.tv.data.repository.TraktEpisodeMappingService
 import com.nuvio.tv.data.repository.TraktAuthService
+import com.nuvio.tv.data.repository.SkipIntroRepository
 import com.nuvio.tv.data.repository.parseContentIds
 import com.nuvio.tv.data.repository.extractYear
 import com.nuvio.tv.data.repository.toTraktIds
@@ -117,7 +118,8 @@ class ExternalPlaybackTracker @Inject constructor(
     private val traktEpisodeMappingService: TraktEpisodeMappingService,
     private val traktAuthService: TraktAuthService,
     private val metaRepository: MetaRepository,
-    private val playerSettingsDataStore: PlayerSettingsDataStore
+    private val playerSettingsDataStore: PlayerSettingsDataStore,
+    private val skipIntroRepository: SkipIntroRepository
 ) {
     companion object {
         private const val TAG = "ExtPlaybackTracker"
@@ -131,6 +133,8 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val MIN_REAL_PLAYBACK_DURATION_MS = 30_000L
         /** A launch within this of an auto-next emit counts as a chain continuation. */
         private const val CONTINUATION_WINDOW_MS = 12_000L
+        /** Upper bound on how long resolving skip segments may delay an external launch. */
+        private const val SKIP_RESOLVE_TIMEOUT_MS = 4_000L
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -252,15 +256,65 @@ class ExternalPlaybackTracker @Inject constructor(
     ) {
         startTracking(metadata, autoLaunch = autoLaunch)
 
-        // Fetch resume position if not provided, then launch
-        if (resumePositionMs > 0L) {
-            doLaunch(url, title, headers, resumePositionMs, subtitles, context)
-        } else {
-            scope.launch {
-                val position = getResumePosition(metadata)
-                doLaunch(url, title, headers, position, subtitles, context)
+        // Resolve resume position (if not given) and intro/outro skip segments off the main
+        // thread, then launch. Skip resolution is bounded so it never stalls the launch for long
+        // and is cached, so an auto-next chain pays it only once.
+        scope.launch {
+            val position = if (resumePositionMs > 0L) resumePositionMs else getResumePosition(metadata)
+            val skipSegmentsJson = resolveSkipSegmentsJson(metadata)
+            doLaunch(url, title, headers, position, subtitles, skipSegmentsJson, context)
+        }
+    }
+
+    /**
+     * Resolves intro/outro skip segments for [metadata] via the same repository the internal
+     * player uses, and serializes them to a JSON array string for the external player. Mirrors
+     * the id-format handling in `fetchSkipIntervals`. Returns null when skip is disabled, the
+     * content can't be identified, or nothing is found.
+     */
+    private suspend fun resolveSkipSegmentsJson(metadata: ExternalPlaybackMetadata): String? {
+        // Opt-in via the External Player setting (not the internal player's "Skip Intro", which is
+        // greyed out while external player is selected).
+        if (!playerSettingsDataStore.playerSettings.first().externalPlayerSendSkipSegments) return null
+
+        // videoId carries the episode-specific id (e.g. mal:/kitsu:/imdb); fall back to contentId.
+        val effectiveId = metadata.videoId.takeIf { it.isNotBlank() } ?: metadata.contentId
+
+        val intervals = withTimeoutOrNull(SKIP_RESOLVE_TIMEOUT_MS) {
+            when {
+                effectiveId.startsWith("mal:") -> {
+                    val parts = effectiveId.split(":")
+                    val malId = parts.getOrNull(1) ?: return@withTimeoutOrNull null
+                    val ep = parts.getOrNull(2)?.toIntOrNull() ?: metadata.episode ?: return@withTimeoutOrNull null
+                    skipIntroRepository.getSkipIntervalsForMal(malId, ep)
+                }
+                effectiveId.startsWith("kitsu:") -> {
+                    val parts = effectiveId.split(":")
+                    val kitsuId = parts.getOrNull(1) ?: return@withTimeoutOrNull null
+                    val ep = parts.getOrNull(2)?.toIntOrNull() ?: metadata.episode ?: return@withTimeoutOrNull null
+                    skipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep)
+                }
+                else -> {
+                    val imdbId = effectiveId.split(":").firstOrNull()?.takeIf { it.startsWith("tt") }
+                        ?: return@withTimeoutOrNull null
+                    val s = metadata.season ?: return@withTimeoutOrNull null
+                    val e = metadata.episode ?: return@withTimeoutOrNull null
+                    skipIntroRepository.getSkipIntervals(imdbId, s, e)
+                }
             }
         }
+        if (intervals.isNullOrEmpty()) return null
+
+        val arr = org.json.JSONArray()
+        intervals.forEach { iv ->
+            arr.put(
+                org.json.JSONObject()
+                    .put("type", iv.type)
+                    .put("start", iv.startTime)
+                    .put("end", iv.endTime)
+            )
+        }
+        return arr.toString()
     }
 
     private fun doLaunch(
@@ -269,6 +323,7 @@ class ExternalPlaybackTracker @Inject constructor(
         headers: Map<String, String>?,
         resumePositionMs: Long,
         subtitles: List<SubtitleInput>?,
+        skipSegmentsJson: String?,
         context: Context
     ) {
 
@@ -277,7 +332,8 @@ class ExternalPlaybackTracker @Inject constructor(
             title = title,
             headers = headers,
             resumePositionMs = resumePositionMs,
-            subtitles = subtitles
+            subtitles = subtitles,
+            skipSegmentsJson = skipSegmentsJson
         )
 
         if (ZidooPlayerMonitor.isZidooDevice()) {
@@ -288,7 +344,8 @@ class ExternalPlaybackTracker @Inject constructor(
                 title = title,
                 headers = headers,
                 resumePositionMs = resumePositionMs,
-                subtitles = subtitles
+                subtitles = subtitles,
+                skipSegmentsJson = skipSegmentsJson
             )
         } else {
             // Use Activity-level launcher for ActivityResult
@@ -304,7 +361,8 @@ class ExternalPlaybackTracker @Inject constructor(
                         title = title,
                         headers = headers,
                         resumePositionMs = resumePositionMs,
-                        subtitles = subtitles
+                        subtitles = subtitles,
+                        skipSegmentsJson = skipSegmentsJson
                     )
                 }
             } else {
@@ -315,7 +373,8 @@ class ExternalPlaybackTracker @Inject constructor(
                     title = title,
                     headers = headers,
                     resumePositionMs = resumePositionMs,
-                    subtitles = subtitles
+                    subtitles = subtitles,
+                    skipSegmentsJson = skipSegmentsJson
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerLauncher.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerLauncher.kt
@@ -18,11 +18,15 @@ object ExternalPlayerLauncher {
         title: String? = null,
         headers: Map<String, String>? = null,
         resumePositionMs: Long = 0L,
-        subtitles: List<SubtitleInput>? = null
+        subtitles: List<SubtitleInput>? = null,
+        skipSegmentsJson: String? = null
     ): Boolean {
         return try {
             val intent = Intent(Intent.ACTION_VIEW).apply {
                 setDataAndType(Uri.parse(url), "video/*")
+
+                // Pre-resolved intro/outro skip segments (mpvNova reads this; others ignore it).
+                skipSegmentsJson?.let { putExtra("skip_segments", it) }
 
                 title?.let {
                     putExtra("title", it)
@@ -104,12 +108,14 @@ object ExternalPlayerLauncher {
         title: String? = null,
         headers: Map<String, String>? = null,
         resumePositionMs: Long = 0L,
-        subtitles: List<SubtitleInput>? = null
+        subtitles: List<SubtitleInput>? = null,
+        skipSegmentsJson: String? = null
     ): ExternalPlayerInput = ExternalPlayerInput(
         url = url,
         title = title,
         headers = headers,
         resumePositionMs = resumePositionMs,
-        subtitles = subtitles
+        subtitles = subtitles,
+        skipSegmentsJson = skipSegmentsJson
     )
 }

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
@@ -23,7 +23,10 @@ data class ExternalPlayerInput(
     val title: String? = null,
     val headers: Map<String, String>? = null,
     val resumePositionMs: Long = 0L,
-    val subtitles: List<SubtitleInput>? = null
+    val subtitles: List<SubtitleInput>? = null,
+    // Pre-resolved intro/outro skip segments as a JSON array string
+    // (`[{"type","start","end"}]`, times in seconds). Read by mpvNova.
+    val skipSegmentsJson: String? = null
 )
 
 /**
@@ -80,6 +83,9 @@ class ExternalPlayerResultContract : ActivityResultContract<ExternalPlayerInput,
             // Request that the player returns result with position/duration.
             // Required by MX Player; harmless for other players.
             putExtra("return_result", true)
+
+            // Pre-resolved intro/outro skip segments (mpvNova reads this; other players ignore it).
+            input.skipSegmentsJson?.let { putExtra("skip_segments", it) }
 
             // Subtitle extras for external players
             val subs = input.subtitles

--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -97,6 +97,7 @@ private val localOnlyPlayerProfileSettingsKeys = setOf(
     "frame_rate_matching_mode",
     "resolution_matching_enabled",
     "external_player_forward_subtitles",
+    "external_player_send_skip_segments",
     "vod_cache_enabled",
     "vod_cache_size_mode",
     "vod_cache_size_mb",

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -272,6 +272,7 @@ data class PlayerSettings(
     val streamReuseLastLinkEnabled: Boolean = false,
     val streamReuseLastLinkCacheHours: Int = 24,
     val externalPlayerForwardSubtitles: Boolean = false,
+    val externalPlayerSendSkipSegments: Boolean = false,
     val subtitleOrganizationMode: SubtitleOrganizationMode = SubtitleOrganizationMode.NONE,
 
     // Networking
@@ -515,6 +516,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val streamReuseLastLinkEnabledKey = booleanPreferencesKey("stream_reuse_last_link_enabled")
     private val streamReuseLastLinkCacheHoursKey = intPreferencesKey("stream_reuse_last_link_cache_hours")
     private val externalPlayerForwardSubtitlesKey = booleanPreferencesKey("external_player_forward_subtitles")
+    private val externalPlayerSendSkipSegmentsKey = booleanPreferencesKey("external_player_send_skip_segments")
     private val subtitleOrganizationModeKey = stringPreferencesKey("subtitle_organization_mode")
 
     // Network Keys
@@ -888,6 +890,7 @@ class PlayerSettingsDataStore @Inject constructor(
                 streamReuseLastLinkEnabled = prefs[streamReuseLastLinkEnabledKey] ?: false,
                 streamReuseLastLinkCacheHours = (prefs[streamReuseLastLinkCacheHoursKey] ?: 24).coerceIn(1, 168),
                 externalPlayerForwardSubtitles = prefs[externalPlayerForwardSubtitlesKey] ?: false,
+                externalPlayerSendSkipSegments = prefs[externalPlayerSendSkipSegmentsKey] ?: false,
                 subtitleOrganizationMode = parseSubtitleOrganizationMode(prefs[subtitleOrganizationModeKey]),
                 vodCacheEnabled = prefs[vodCacheEnabledKey] ?: PlayerSettings.DEFAULT_VOD_CACHE_ENABLED,
                 vodCacheSizeMode = prefs[vodCacheSizeModeKey]?.let {
@@ -1276,6 +1279,12 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setExternalPlayerForwardSubtitles(enabled: Boolean) {
         store().edit { prefs ->
             prefs[externalPlayerForwardSubtitlesKey] = enabled
+        }
+    }
+
+    suspend fun setExternalPlayerSendSkipSegments(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[externalPlayerSendSkipSegmentsKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -241,6 +241,9 @@ fun PlaybackSettingsContent(
                 onSetExternalPlayerForwardSubtitles = { enabled ->
                     coroutineScope.launch { viewModel.setExternalPlayerForwardSubtitles(enabled) }
                 },
+                onSetExternalPlayerSendSkipSegments = { enabled ->
+                    coroutineScope.launch { viewModel.setExternalPlayerSendSkipSegments(enabled) }
+                },
                 onSetNextEpisodeThresholdPercent = { percent ->
                     coroutineScope.launch { viewModel.setNextEpisodeThresholdPercent(percent) }
                 },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -135,6 +135,7 @@ internal fun PlaybackSettingsSections(
     onSetStreamAutoPlayReuseBingeGroup: (Boolean) -> Unit,
     onSetAutoSwitchInternalPlayerOnError: (Boolean) -> Unit,
     onSetExternalPlayerForwardSubtitles: (Boolean) -> Unit,
+    onSetExternalPlayerSendSkipSegments: (Boolean) -> Unit,
     onSetNextEpisodeThresholdPercent: (Float) -> Unit,
     onSetNextEpisodeThresholdMinutesBeforeEnd: (Float) -> Unit,
     onSetStreamAutoPlayTimeoutSeconds: (Int) -> Unit,
@@ -482,6 +483,17 @@ internal fun PlaybackSettingsSections(
                         subtitle = stringResource(R.string.playback_external_forward_subtitles_sub),
                         isChecked = playerSettings.externalPlayerForwardSubtitles,
                         onCheckedChange = onSetExternalPlayerForwardSubtitles,
+                        onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION }
+                    )
+                }
+
+                item(key = "external_player_send_skip_segments") {
+                    ToggleSettingsItem(
+                        icon = Icons.Default.Info,
+                        title = stringResource(R.string.playback_external_send_skip_segments),
+                        subtitle = stringResource(R.string.playback_external_send_skip_segments_sub),
+                        isChecked = playerSettings.externalPlayerSendSkipSegments,
+                        onCheckedChange = onSetExternalPlayerSendSkipSegments,
                         onFocused = { focusedSection = PlaybackSection.STREAM_SELECTION }
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -89,6 +89,10 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setExternalPlayerForwardSubtitles(enabled)
     }
 
+    suspend fun setExternalPlayerSendSkipSegments(enabled: Boolean) {
+        playerSettingsDataStore.setExternalPlayerSendSkipSegments(enabled)
+    }
+
     suspend fun setTrailerEnabled(enabled: Boolean) {
         trailerSettingsDataStore.setEnabled(enabled)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -584,6 +584,8 @@
     <string name="playback_auto_switch_internal_player_on_error_sub">If stream startup fails, switch between ExoPlayer and libmpv automatically.</string>
     <string name="playback_external_forward_subtitles">Forward subtitles to external player</string>
     <string name="playback_external_forward_subtitles_sub">Fetch subtitles in your preferred language from addons and pass them to the external player.</string>
+    <string name="playback_external_send_skip_segments">Send intro and outro timestamps</string>
+    <string name="playback_external_send_skip_segments_sub">Pass resolved intro/outro skip timestamps to the external player for auto-skipping. Only works in players that support it; other players ignore it.</string>
     <string name="playback_section_audio">Audio &amp; Video</string>
     <string name="playback_section_audio_desc">Audio controls and video compatibility.</string>
     <string name="playback_section_subtitles">Subtitles</string>


### PR DESCRIPTION
## Summary

Adds an **opt-in** setting that lets Nuvio hand the resolved intro/outro skip timestamps to external players, so a supporting player can auto-skip OP/ED the same way the internal player already does.

When **External Player, "Send intro and outro timestamps"** is enabled, the external launch intent carries a `skip_segments` JSON extra. Nuvio resolves the segments with the **existing `SkipIntroRepository`**, the same one the internal player uses (IntroDB, ARM, AniSkip, Anime-Skip), so there is **no new API, key, provider, or dependency**. Players that don't read the extra simply ignore it.

- Off by default; resolution runs off the main thread, is bounded (4s) and cached.
- The toggle is in the External Player section (only shown for external playback) and is local-only/per-device, matching "Forward subtitles to external player".
- Resume, watched-marking, and auto-play-next are untouched: the launch/result tracking path is unchanged and resolution is gated behind the new off-by-default setting.

### Implementing this in another external player

The contract is a single intent extra, and it's trivial to adopt.

**Extra:** `skip_segments`, a `String` (`intent.getStringExtra("skip_segments")`).

**Value:** a JSON array of segment objects, with times in **seconds**:

```json
[
  { "type": "op", "start": 84.5,   "end": 174.5  },
  { "type": "ed", "start": 1320.0, "end": 1410.0 }
]
```

**`type`** is one of: `intro`, `op`, `mixed-op`, `recap`, `outro`, `ed`, `mixed-ed`, `credits`, `ending`
(`op`/`mixed-op`/`intro`/`recap` map to the opening; `ed`/`mixed-ed`/`outro`/`credits`/`ending` map to the ending). Unknown types can be treated as a generic skippable segment.

**How a player uses it:**
1. On launch, read and parse the extra. It is absent or empty when the user hasn't enabled the feature or no data was found, so just ignore that case.
2. On each playback position tick, if the current time is within `[start, end)`, either auto-seek to `end` or show a "Skip" button that seeks to `end`.

That's the entire contract: no SDK, no callback, no auth. Reference implementation: mpvNova reads this extra and auto-skips.

## PR type

This is an opt-in feature/enhancement (off by default), not localization or a critical bug fix, so neither box is checked.
- [ ] Translation/localization only
- [ ] Critical bug fix

## Why

Nuvio already resolves intro/outro segments and auto-skips them in the internal player, but external-player users get none of it. This forwards the already-resolved timestamps so a supporting external player can offer the same skip experience, with zero extra API work (it reuses the internal resolution).

## Issue or approval

Feature request: #2436. Maintainer-approved by @tapframe and @skoruppa. The NuvioMobile counterpart is now done in NuvioMedia/NuvioMobile#1415.

## Reproduction steps

N/A (feature). To see it: set player to External, enable "Send intro and outro timestamps", and play an episode that has skip data (an anime via AniSkip, or an IMDb title via IntroDB) in a player that reads `skip_segments`; the intro/outro is skipped.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

Adds one opt-in toggle in the External Player settings and, when enabled, attaches the `skip_segments` extra to the external launch intent. No box above is checked because this is a new opt-in feature without maintainer sign-off, not a bug fix or a pre-approved change.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

The two policy boxes about "critical bug fix / no features" are left unchecked honestly: this is an opt-in feature with explicit maintainer approval (@tapframe, @skoruppa), not a bug fix, so ticking those bug-fix-policy boxes would be inaccurate.

## Scope boundaries

- Adds the `externalPlayerSendSkipSegments` setting (datastore field/key/setter, ViewModel, settings UI, strings, sync key) and segment resolution plus a `skip_segments` intent extra in the external-player launch path.
- Reuses the existing `SkipIntroRepository`; no new networking, API keys, or providers.
- Does not touch internal-player skip, the external result/tracking path (resume, watched, auto-next), or any unrelated screen.
- Off by default.

## Testing

- Built `:app:assembleFullDebug`; `:app:compileFullDebugKotlin` clean.
- On an NVIDIA Shield (Android 11) with mpvNova as the external player:
  - IMDb title (Family Guy) via IntroDB: intro skipped.
  - Anime (Frieren) via AniSkip: OP and ED skipped.
  - With the setting OFF: no `skip_segments` sent (verified in logs), and resume, watched-marking, and auto-play-next behave exactly as before.

## Screenshots / Video

The new "Send intro and outro timestamps" toggle, directly under "Forward subtitles to external player" in the External Player settings (shown only when the player preference is External):

https://github.com/user-attachments/assets/00767941-e92c-4a40-a6fb-d08ec0d3e9f0

## Breaking changes

None.

## Linked issues

Implements #2436.

