### PR TITLE
Fix in-app language switching

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -267,6 +267,15 @@ android {
         }
     }
 
+    bundle {
+        language {
+            // Keep all string resources in the
+            // base install so Play Store installs can switch languages at runtime.
+            // https://developer.android.com/guide/app-bundle/configure-base
+            enableSplit = false
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary

Fix Play Store language switching by bundling strings with the base install

## PR type

- [ ] Translation/localization
- [x] Critical bug fix

## Why

The Play Store version is delivered as an Android App Bundle. By default, Play splits language resources and only installs languages matching the device settings. Nuvio has an in-app language picker, so selecting Ukrainian inside the app did not work if the Ukrainian resource split was not installed.

https://developer.android.com/guide/app-bundle/configure-base#:~:text=For%20apps,resources,-Was

>For apps that offer a language picker inside the application and dynamically change the app's language, independent of the system level language setting, you must make some changes to prevent crashes due to missing resources. Either set the android.bundle.language.enableSplit property to false, or consider implementing on-demand language downloads using the Play Core library


## Issue or approval

Did not find find it reported on Github, self-testing

## Reproduction steps

1. Install the Play Store version on a device whose system language is English.
2. Open Nuvio settings.
3. Change app language to Language X.
4. Restart the app.
5. Observe that UI remains English because Language X resources were not installed by Play Store.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Will add one-two megabytes to the size of the bundle

## Testing

Successful build

## Screenshots / Video

Not a UI layout change.

## Breaking changes

None.

## Linked issues

-