### PR TITLE
fix(player): resolve Dolby Vision MKV playback mode issues (always playing as HDR10 in Auto/DV8.1, and always playing as DV in HDR baseline)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DolbyVisionCompatibility.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DolbyVisionCompatibility.java
@@ -38,6 +38,16 @@ public final class DolbyVisionCompatibility {
   @Nullable private static volatile Object fragmentedMp4DolbyVisionSampleTransformer;
   @Nullable private static volatile Object tsDolbyVisionNalTransformer;
 
+  private static volatile boolean isHdr10BaseLayerModeActive;
+
+  public static void setHdr10BaseLayerModeActive(boolean active) {
+    isHdr10BaseLayerModeActive = active;
+  }
+
+  public static boolean isHdr10BaseLayerModeActive() {
+    return isHdr10BaseLayerModeActive;
+  }
+
   public static void setMapDv7ToHevcEnabled(boolean enabled) {
     mapDv7ToHevcEnabled = enabled;
   }

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -2865,8 +2865,10 @@ public class MatroskaExtractor implements Extractor {
               }
             }
             if (MimeTypes.VIDEO_DOLBY_VISION.equals(mimeType) && hevcCodecsString != null) {
-              mimeType = MimeTypes.VIDEO_H265;
-              codecs = hevcCodecsString;
+              if (DolbyVisionCompatibility.isHdr10BaseLayerModeActive()) {
+                mimeType = MimeTypes.VIDEO_H265;
+                codecs = hevcCodecsString;
+              }
             }
           }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -706,6 +706,9 @@ internal fun PlayerRuntimeController.initializePlayer(
             val mapDv7ToHevcEnabled = effectiveDv7Mode == Dv7HandlingMode.HDR10_BASE_LAYER ||
                     dv7ToHevcForcedStreamUrls.contains(url)
             //   DolbyVisionCompatibility.setMapDv7ToHevcEnabled(mapDv7ToHevcEnabled)
+            com.nuvio.tv.core.player.dvmkv.DolbyVisionCompatibility.setHdr10BaseLayerModeActive(
+                effectiveDv7Mode == Dv7HandlingMode.HDR10_BASE_LAYER
+            )
             isMapDv7ToHevcActiveForCurrentPlayback = mapDv7ToHevcEnabled
             val convertToDv81Active = !mapDv7ToHevcEnabled &&
                     dv7AutoResult?.decision == DolbyVisionBaseLayerPolicy.Decision.CONVERT_TO_DV81
@@ -756,7 +759,8 @@ internal fun PlayerRuntimeController.initializePlayer(
 
             // The app-level factory performs DV7 conversion for the in-band-RPU containers
             // (MP4/fMP4/TS); MKV goes through the vendored extractor. Pass-through for non-DV.
-            val stripDvRpuEnabled = playerSettings.dv7HandlingMode == Dv7HandlingMode.STRIP_DV
+            val stripDvRpuEnabled = playerSettings.dv7HandlingMode == Dv7HandlingMode.STRIP_DV ||
+                    effectiveDv7Mode == Dv7HandlingMode.HDR10_BASE_LAYER
             if (stripDvRpuEnabled) {
                 Log.i(PlayerRuntimeController.TAG, "DV_RPU_STRIP: enabled — will remove DV RPU NALs")
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -707,7 +707,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                     dv7ToHevcForcedStreamUrls.contains(url)
             //   DolbyVisionCompatibility.setMapDv7ToHevcEnabled(mapDv7ToHevcEnabled)
             com.nuvio.tv.core.player.dvmkv.DolbyVisionCompatibility.setHdr10BaseLayerModeActive(
-                effectiveDv7Mode == Dv7HandlingMode.HDR10_BASE_LAYER
+                effectiveDv7Mode == Dv7HandlingMode.HDR10_BASE_LAYER ||
+                        effectiveDv7Mode == Dv7HandlingMode.STRIP_DV
             )
             isMapDv7ToHevcActiveForCurrentPlayback = mapDv7ToHevcEnabled
             val convertToDv81Active = !mapDv7ToHevcEnabled &&


### PR DESCRIPTION
## Summary

This PR resolves the Dolby Vision MKV playback regressions introduced by PR #2431. It fixes the issue where Dolby Vision MKVs incorrectly played as HDR10 in **Auto** and **Convert to DV8.1** modes, while ensuring they correctly fall back to HDR10 when the **HDR10 base layer** (HDR baseline) mode is manually selected.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

PR #2431 introduced an unconditional HEVC downgrade inside the Matroska extractor (`MatroskaExtractor.java`) when a sample transformer was present. Since the sample transformer is present during DV8.1 conversion, all Dolby Vision MKV streams were incorrectly downgraded and played as HDR10.

When attempting to restrict this downgrade with a settings check (`DolbyVisionCompatibility.isHdr10BaseLayerModeActive()`), the player would fallback to the stock Media3 `MatroskaExtractor` instead of our custom one when `HDR10_BASE_LAYER` was selected. This occurred because `DolbyVisionExtractorsFactory` was not being initialized in HDR baseline mode, causing files to play in Dolby Vision instead of HDR10.

## Issue or approval

Fixes regressions introduced in PR #2431.

## Reproduction steps

1. Play a Dolby Vision Profile 7/8 MKV stream on a Dolby Vision-capable TV in **Auto** or **Convert to DV8.1** mode.
   * *Before:* Plays as HDR10.
   * *After:* Plays correctly as Dolby Vision.
2. Play a Dolby Vision Profile 7/8 MKV stream in **HDR10 base layer** mode.
   * *Before:* Plays as Dolby Vision (setting ignored).
   * *After:* Plays correctly as HDR10.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change is strictly bounded to correcting codec and mime type downgrade logic inside `MatroskaExtractor.java` and ensuring the custom extractor is initialized when the playback requires Dolby Vision stripping/fallback in `PlayerRuntimeControllerInitialization.kt`.

## Testing

1. Verified that Dolby Vision Profile 7/8 MKV streams trigger Dolby Vision playback in Auto mode.
2. Verified that Dolby Vision Profile 7/8 MKV streams trigger HDR10 playback when "HDR10 base layer" mode is selected.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes regressions in PR #2431.
