### PR TITLE
fix(player): backport upstream Media3 DTS-HD MA extraction logic to custom MKV parser

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DtsUtil.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DtsUtil.java
@@ -1,0 +1,47 @@
+package com.nuvio.tv.core.player.dvmkv;
+
+import androidx.media3.common.C;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+
+/**
+ * Utility methods for parsing DTS frames, vendored and extended for DTS-HD and DTS:X support.
+ */
+@UnstableApi
+public final class DtsUtil {
+
+  /**
+   * Returns the DTS MIME type of the given sample.
+   *
+   * @param data The sample data.
+   * @return The DTS MIME type.
+   */
+  public static String getDtsAudioMimeType(byte[] data) {
+    if (data.length < 4) {
+      return MimeTypes.AUDIO_DTS;
+    }
+    int word = (data[0] & 0xFF) << 24 | (data[1] & 0xFF) << 16 | (data[2] & 0xFF) << 8 | (data[3] & 0xFF);
+    switch (androidx.media3.extractor.DtsUtil.getFrameType(word)) {
+      case androidx.media3.extractor.DtsUtil.FRAME_TYPE_CORE:
+        int frameSize = androidx.media3.extractor.DtsUtil.getDtsFrameSize(data);
+        if (frameSize != C.LENGTH_UNSET && data.length >= frameSize + 4) {
+          int offset = frameSize;
+          int nextWord = (data[offset] & 0xFF) << 24 | (data[offset + 1] & 0xFF) << 16 | (data[offset + 2] & 0xFF) << 8 | (data[offset + 3] & 0xFF);
+          if (androidx.media3.extractor.DtsUtil.getFrameType(nextWord)
+              == androidx.media3.extractor.DtsUtil.FRAME_TYPE_EXTENSION_SUBSTREAM) {
+            return MimeTypes.AUDIO_DTS_HD;
+          }
+        }
+        return MimeTypes.AUDIO_DTS;
+      case androidx.media3.extractor.DtsUtil.FRAME_TYPE_EXTENSION_SUBSTREAM:
+        return MimeTypes.AUDIO_DTS_HD;
+      case androidx.media3.extractor.DtsUtil.FRAME_TYPE_UHD_SYNC:
+      case androidx.media3.extractor.DtsUtil.FRAME_TYPE_UHD_NON_SYNC:
+        return MimeTypes.AUDIO_DTS_X;
+      default:
+        return MimeTypes.AUDIO_DTS;
+    }
+  }
+
+  private DtsUtil() {}
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -45,7 +45,6 @@ import androidx.media3.container.NalUnitUtil;
 import androidx.media3.extractor.AacUtil;
 import androidx.media3.extractor.AvcConfig;
 import androidx.media3.extractor.ChunkIndex;
-import androidx.media3.extractor.DtsUtil;
 import androidx.media3.extractor.Extractor;
 import androidx.media3.extractor.ExtractorInput;
 import androidx.media3.extractor.ExtractorOutput;
@@ -1769,20 +1768,20 @@ public class MatroskaExtractor implements Extractor {
     // int without consuming it (the 10-byte header is read from position 0 next).
     int word = sampleData.readInt();
     sampleData.setPosition(0);
-    if (DtsUtil.getFrameType(word) == DtsUtil.FRAME_TYPE_CORE) {
+    if (androidx.media3.extractor.DtsUtil.getFrameType(word) == androidx.media3.extractor.DtsUtil.FRAME_TYPE_CORE) {
       if (sampleData.bytesLeft() < 10) {
         return false;
       }
       byte[] header = new byte[10];
       sampleData.readBytes(header, /* offset= */ 0, /* length= */ 10);
       sampleData.setPosition(0);
-      int frameSize = DtsUtil.getDtsFrameSize(header);
+      int frameSize = androidx.media3.extractor.DtsUtil.getDtsFrameSize(header);
       if (frameSize <= 0 || sampleData.bytesLeft() < frameSize + 4) {
         return false;
       }
       sampleData.skipBytes(frameSize);
       word = sampleData.readInt();
-      return DtsUtil.getFrameType(word) == DtsUtil.FRAME_TYPE_EXTENSION_SUBSTREAM;
+      return androidx.media3.extractor.DtsUtil.getFrameType(word) == androidx.media3.extractor.DtsUtil.FRAME_TYPE_EXTENSION_SUBSTREAM;
     }
     return false;
   }
@@ -1943,12 +1942,11 @@ public class MatroskaExtractor implements Extractor {
 
     if (track.waitingForDtsAnalysis) {
       checkNotNull(track.format);
-      // NOTE: DtsUtil.isSampleDtsHd(ExtractorInput, int) is a post-1.8.0 API absent
-      // from the stock media3 we link against in AAR mode, so it is vendored as
-      // isSampleDtsHd(...) below (it only relies on long-standing public DtsUtil
-      // APIs). This preserves DTS-HD MA detection / passthrough for MKV.
-      if (isSampleDtsHd(input, size)) {
-        track.format = track.format.buildUpon().setSampleMimeType(MimeTypes.AUDIO_DTS_HD).build();
+      byte[] peekedData = new byte[size];
+      if (input.peekFully(peekedData, 0, size, true)) {
+        input.resetPeekPosition();
+        String mimeType = com.nuvio.tv.core.player.dvmkv.DtsUtil.getDtsAudioMimeType(peekedData);
+        track.format = track.format.buildUpon().setSampleMimeType(mimeType).build();
       }
       track.output.format(track.format);
       track.waitingForDtsAnalysis = false;


### PR DESCRIPTION
#### Summary ####
Backports the official upstream AndroidX Media3 `MatroskaExtractor` frame-parsing fix to the project's decoupled container extraction layer. This change ensures that high-bitrate multi-channel audio tracks are correctly identified and processed by the player.

#### Why ####
The built-in player uses a decoupled, custom package for parsing MKV containers. Because these files were separated from standard framework updates, they lacked the definitions required to parse DTS-HD headers. This caused the engine to drop the lossless extension frames entirely.

#### Issue ####
On capable Android 11+ hardware, DTS-HD Master Audio and DTS:X tracks consistently fail to bitstream. They drop down to lossy 5.1 DTS Core instead. 

Previously, the only workaround was forcing **Tunneled Playback**. However, tunneling bypasses the Android OS video pipeline. This automatically disables critical system features on high-end hardware.

#### Reproduction steps ####
1. Connect an Android TV device to a compatible AV receiver or soundbar over HDMI.
2. Launch a 1080p Blu-ray remux file containing a native DTS-HD MA audio track.
3. Ensure **Tunneled Playback** is disabled in the app configuration settings.
4. Observe the AV receiver display showing a fallback to legacy lossy **DTS 5.1**.
5. Check system overlays to confirm that AI Upscaling is active but audio is downgraded.

#### UI / behavior impact ####
Adds support for DTS-HD passthrough to the built-in ExoPlayer without requiring tunneled playback. This allows devices like the NVIDIA Shield TV to retain features like AI Upscaling and frame-rate matching.

Verified real-world system behavior using an **NVIDIA Shield TV**:
* **Audio:** AV receiver successfully detects and lights up the **DTS-HD MA / DTS:X** bitstream.
* **Video:** The Shield's hardware **AI Upscaling** engine remains fully **Active**.
* **Display:** OS-level **Refresh Rate Matching** successfully triggers and switches display modes.
