### PR TITLE
prevent CW items from disappearing on meta addon timeout

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -864,16 +864,25 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                             }
                                         }
                                     } else {
-                                        // No next-up — mark as validated with smart deadline:
-                                        // use upcoming season date if known, otherwise permanent.
-                                        val nextSeasonMs = cwBadgeNextSeasonMs[seed.contentId]
-                                        val deadline = nextSeasonMs
-                                            ?: (System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000)
-                                        fullyWatchedSeriesIds.updateWithValidation(
-                                            fullyWatchedSeriesIds.fullyWatchedSeriesIds.value,
-                                            setOf(seed.contentId),
-                                            mapOf(seed.contentId to deadline)
-                                        )
+                                        // No next-up — mark as validated with smart deadline
+                                        // ONLY if meta was actually resolved (confirming no next episode).
+                                        // If meta was unavailable (network error), skip marking to avoid
+                                        // incorrectly removing the series from Continue Watching.
+                                        val metaWasResolved = synchronized(cwMetaCache) {
+                                            cwMetaCache["${seed.contentType}:${seed.contentId}"]
+                                                ?: cwMetaCache["series:${seed.contentId}"]
+                                                ?: cwMetaCache["tv:${seed.contentId}"]
+                                        } != null
+                                        if (metaWasResolved) {
+                                            val nextSeasonMs = cwBadgeNextSeasonMs[seed.contentId]
+                                            val deadline = nextSeasonMs
+                                                ?: (System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000)
+                                            fullyWatchedSeriesIds.updateWithValidation(
+                                                fullyWatchedSeriesIds.fullyWatchedSeriesIds.value,
+                                                setOf(seed.contentId),
+                                                mapOf(seed.contentId to deadline)
+                                            )
+                                        }
                                     }
                                     kotlinx.coroutines.yield()
                                 }
@@ -1676,16 +1685,22 @@ private suspend fun HomeViewModel.buildNextUpItem(
                 cwBadgeNextSeasonMs[progress.contentId] = ms
             }
         }
-        // Mark as validated so this seed is skipped on subsequent launches.
-        // Uses upcoming season date if known, otherwise 7-day default TTL.
-        val nextSeasonMs = cwBadgeNextSeasonMs[progress.contentId]
-        val deadline = nextSeasonMs
-            ?: (System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000)
-        fullyWatchedSeriesIds.updateWithValidation(
-            fullyWatchedSeriesIds.fullyWatchedSeriesIds.value,
-            setOf(progress.contentId),
-            mapOf(progress.contentId to deadline)
-        )
+        // Only mark as fully watched if meta was actually resolved (i.e. we
+        // confirmed there is no next episode). When meta is unavailable
+        // (network error, addon timeout) we must NOT treat the series as
+        // fully watched — that would incorrectly remove it from Continue
+        // Watching. The cached CW snapshot will keep it visible until the
+        // next successful meta resolution.
+        if (cachedMeta != null) {
+            val nextSeasonMs = cwBadgeNextSeasonMs[progress.contentId]
+            val deadline = nextSeasonMs
+                ?: (System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000)
+            fullyWatchedSeriesIds.updateWithValidation(
+                fullyWatchedSeriesIds.fullyWatchedSeriesIds.value,
+                setOf(progress.contentId),
+                mapOf(progress.contentId to deadline)
+            )
+        }
         return null
     }
     val seedMeta = resolveMetaForProgress(progress, cwMetaCache, debug)


### PR DESCRIPTION
## Summary

Prevent Continue Watching items from disappearing when meta addons are temporarily unreachable. Previously, a meta timeout (e.g. brief network loss on app wake) would mark series as "fully watched" and remove them from CW for up to 7 days.

## PR type

- [x] Critical bug fix

## Why

When meta addons fail to respond (network reconnecting after TV sleep, addon server hiccup), `findNextUpEpisodeFromMetaSeed` returns null. The code treated this identically to "no next episode exists" and added the series to `fullyWatchedSeriesIds` with a 7-day TTL. This caused large chunks of CW to vanish until force stop or TTL expiry.

## Issue or approval

Fixes user-reported bug: CW items disappear on app start

## Reproduction steps

1. Open NuvioTV with multiple series in Continue Watching (Next Up)
2. Simulate unstable network (disconnect WiFi briefly as app launches)
3. Observe CW items disappearing
4. Force stop and reopen - items return temporarily
5. Repeat - items disappear again on each launch with poor connectivity

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change how fully-watched detection works when meta IS available
- Does not change meta fetch logic, timeouts, or retry behavior
- Does not change CW enrichment or display logic
- Only guards the `fullyWatchedSeriesIds` mutation behind a meta-availability check

## Testing

- Verified that when meta resolves successfully but no next episode exists, series is still correctly marked as fully watched
- Verified that when meta fails (null in cwMetaCache), series is NOT marked as fully watched and remains visible from cached CW snapshot
- Tested both code paths: `buildNextUpItem` (recent seeds) and async older-seeds loop
- Device: Android TCL TV

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

User report: CW items disappear after app wake. Most possible scenario is network failure / addon failure 
