### PR TITLE
Refresh addon manifests when same-version content changes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -186,7 +186,7 @@ class AddonRepositoryImpl @Inject constructor(
                     }
                     val fresh = refreshed.mapNotNull { it.first }
 
-                    if (refreshed.any { it.second }) {
+                    if (shouldAdvanceInstalledAddonRefreshTime(cacheStale, refreshed.any { it.second })) {
                         lastManifestRefreshTime = System.currentTimeMillis()
                     }
                     if (fresh.isNotEmpty() && (!emittedCached || fresh != cached)) {
@@ -379,6 +379,10 @@ internal fun shouldFetchInstalledAddonManifest(cacheStale: Boolean, cachedManife
 
 internal fun shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale: Boolean, cachedAddons: List<Addon>): Boolean {
     return cachedAddons.isNotEmpty() && !cacheStale
+}
+
+internal fun shouldAdvanceInstalledAddonRefreshTime(cacheStale: Boolean, refreshedAnyManifest: Boolean): Boolean {
+    return cacheStale && refreshedAnyManifest
 }
 
 private fun Addon.manifestComparable(): Addon {

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -156,26 +156,38 @@ class AddonRepositoryImpl @Inject constructor(
                     val canonical = canonicalizeUrl(url)
                     (enabledByUrl[canonical] ?: true) && manifestCache[canonical] == null
                 }
-                if (hasCacheMiss || isCacheStale()) {
-                    val fresh = coroutineScope {
+                val cacheStale = isCacheStale()
+                if (hasCacheMiss || cacheStale) {
+                    val refreshed = coroutineScope {
                         urls.map { url ->
                             async {
                                 val canonical = canonicalizeUrl(url)
                                 val enabled = enabledByUrl[canonical] ?: true
                                 if (!enabled) {
-                                    return@async manifestCache[canonical]
+                                    val addon = manifestCache[canonical]
                                         ?.copy(enabled = false)
                                         ?: placeholderAddon(canonical, userNames, enabled = false)
+                                    return@async addon to false
                                 }
-                                (manifestCache[canonical] ?: when (val result = fetchAddon(url)) {
-                                    is NetworkResult.Success -> result.data
-                                    else -> null
-                                })?.copy(enabled = enabled)
-                            }
-                        }.awaitAll().filterNotNull()
-                    }
 
-                    lastManifestRefreshTime = System.currentTimeMillis()
+                                val cachedManifest = manifestCache[canonical]
+                                val (addon, fetched) = if (shouldFetchInstalledAddonManifest(cacheStale, cachedManifest)) {
+                                    when (val result = fetchAddon(url)) {
+                                        is NetworkResult.Success -> result.data to true
+                                        else -> cachedManifest to false
+                                    }
+                                } else {
+                                    cachedManifest to false
+                                }
+                                addon?.copy(enabled = enabled) to fetched
+                            }
+                        }.awaitAll()
+                    }
+                    val fresh = refreshed.mapNotNull { it.first }
+
+                    if (refreshed.any { it.second }) {
+                        lastManifestRefreshTime = System.currentTimeMillis()
+                    }
                     if (fresh != cached) {
                         emit(applyDisplayNames(fresh, userNames, enabledByUrl))
                     }
@@ -358,6 +370,10 @@ internal fun shouldReplaceCachedManifest(cached: Addon, fresh: Addon): Boolean {
     if (cached.version != fresh.version) return true
     if (cached.configVersion != fresh.configVersion) return true
     return cached.manifestComparable() != fresh.manifestComparable()
+}
+
+internal fun shouldFetchInstalledAddonManifest(cacheStale: Boolean, cachedManifest: Addon?): Boolean {
+    return cacheStale || cachedManifest == null
 }
 
 private fun Addon.manifestComparable(): Addon {

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -148,7 +148,9 @@ class AddonRepositoryImpl @Inject constructor(
                         ?.copy(enabled = enabled)
                         ?: if (!enabled) placeholderAddon(canonical, userNames, enabled) else null
                 }
-                if (cached.isNotEmpty()) {
+                val cacheStale = isCacheStale()
+                val emittedCached = shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale, cached)
+                if (emittedCached) {
                     emit(applyDisplayNames(cached, userNames, enabledByUrl))
                 }
 
@@ -156,7 +158,6 @@ class AddonRepositoryImpl @Inject constructor(
                     val canonical = canonicalizeUrl(url)
                     (enabledByUrl[canonical] ?: true) && manifestCache[canonical] == null
                 }
-                val cacheStale = isCacheStale()
                 if (hasCacheMiss || cacheStale) {
                     val refreshed = coroutineScope {
                         urls.map { url ->
@@ -188,7 +189,7 @@ class AddonRepositoryImpl @Inject constructor(
                     if (refreshed.any { it.second }) {
                         lastManifestRefreshTime = System.currentTimeMillis()
                     }
-                    if (fresh != cached) {
+                    if (fresh.isNotEmpty() && (!emittedCached || fresh != cached)) {
                         emit(applyDisplayNames(fresh, userNames, enabledByUrl))
                     }
                 }
@@ -374,6 +375,10 @@ internal fun shouldReplaceCachedManifest(cached: Addon, fresh: Addon): Boolean {
 
 internal fun shouldFetchInstalledAddonManifest(cacheStale: Boolean, cachedManifest: Addon?): Boolean {
     return cacheStale || cachedManifest == null
+}
+
+internal fun shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale: Boolean, cachedAddons: List<Addon>): Boolean {
+    return cachedAddons.isNotEmpty() && !cacheStale
 }
 
 private fun Addon.manifestComparable(): Addon {

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -91,7 +91,6 @@ class AddonRepositoryImpl @Inject constructor(
     private val manifestCache = mutableMapOf<String, Addon>()
     @Volatile
     private var lastManifestRefreshTime = 0L
-    private var manifestRefreshJob: Job? = null
 
     init {
         syncScope.launch { loadManifestCacheFromDisk() }
@@ -99,22 +98,6 @@ class AddonRepositoryImpl @Inject constructor(
 
     private fun isCacheStale(): Boolean =
         System.currentTimeMillis() - lastManifestRefreshTime > MANIFEST_CACHE_TTL_MS
-
-    private fun scheduleManifestRefresh(urls: List<String>) {
-        if (manifestRefreshJob?.isActive == true) return
-        manifestRefreshJob = syncScope.launch {
-            val refreshed = urls.map { url ->
-                async {
-                    fetchAddon(url)
-                }
-            }.awaitAll()
-            val anyUpdated = refreshed.any { it is NetworkResult.Success }
-            if (anyUpdated) {
-                lastManifestRefreshTime = System.currentTimeMillis()
-                Log.d(TAG, "Background manifest refresh completed")
-            }
-        }
-    }
 
     private suspend fun loadManifestCacheFromDisk() = kotlinx.coroutines.withContext(Dispatchers.IO) {
         try {
@@ -173,7 +156,7 @@ class AddonRepositoryImpl @Inject constructor(
                     val canonical = canonicalizeUrl(url)
                     (enabledByUrl[canonical] ?: true) && manifestCache[canonical] == null
                 }
-                if (hasCacheMiss) {
+                if (hasCacheMiss || isCacheStale()) {
                     val fresh = coroutineScope {
                         urls.map { url ->
                             async {
@@ -192,13 +175,10 @@ class AddonRepositoryImpl @Inject constructor(
                         }.awaitAll().filterNotNull()
                     }
 
+                    lastManifestRefreshTime = System.currentTimeMillis()
                     if (fresh != cached) {
                         emit(applyDisplayNames(fresh, userNames, enabledByUrl))
                     }
-                } else if (isCacheStale() && urls.isNotEmpty()) {
-                    scheduleManifestRefresh(
-                        urls.filter { url -> enabledByUrl[canonicalizeUrl(url)] ?: true }
-                    )
                 }
             }.flowOn(Dispatchers.IO)
         }
@@ -214,7 +194,7 @@ class AddonRepositoryImpl @Inject constructor(
             is NetworkResult.Success -> {
                 val addon = result.data.toDomain(cleanBaseUrl)
                 val existing = manifestCache[cleanBaseUrl]
-                if (existing == null || existing.version != addon.version) {
+                if (existing == null || shouldReplaceCachedManifest(existing, addon)) {
                     manifestCache[cleanBaseUrl] = addon
                     persistManifestCacheToDisk()
                 }
@@ -372,4 +352,18 @@ class AddonRepositoryImpl @Inject constructor(
             }
         }
     }
+}
+
+internal fun shouldReplaceCachedManifest(cached: Addon, fresh: Addon): Boolean {
+    if (cached.version != fresh.version) return true
+    if (cached.configVersion != fresh.configVersion) return true
+    return cached.manifestComparable() != fresh.manifestComparable()
+}
+
+private fun Addon.manifestComparable(): Addon {
+    return copy(
+        displayName = name,
+        timestamp = null,
+        enabled = true
+    )
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -28,7 +28,7 @@ internal fun buildHomeCatalogLoadSignature(addons: List<Addon>, disabledHomeCata
 private fun Addon.homeCatalogSignature(): String {
     val catalogSignature = catalogs
         .joinToString(separator = ";") { catalog -> catalog.homeCatalogSignature() }
-    return "${id}|${baseUrl}|${version}|${configVersion}|${catalogSignature}"
+    return "${id}|${name}|${displayName}|${baseUrl}|${version}|${configVersion}|${catalogSignature}"
 }
 
 private fun CatalogDescriptor.homeCatalogSignature(): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.home
 
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogExtra
 import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.MetaPreview
 import kotlinx.coroutines.Job
@@ -16,18 +17,48 @@ internal fun HomeViewModel.buildHomeCatalogLoadSignature(addons: List<Addon>): S
 
 internal fun buildHomeCatalogLoadSignature(addons: List<Addon>, disabledHomeCatalogKeys: Set<String>): String {
     val addonCatalogSignature = addons
-        .flatMap { addon ->
-            addon.catalogs.map { catalog ->
-                "${addon.id}|${addon.baseUrl}|${addon.version}|${addon.configVersion}|${catalog.apiType}|${catalog.id}|${catalog.name}|${catalog.showInHome}|${catalog.hasExplicitShowInHome}"
-            }
-        }
-        .sorted()
-        .joinToString(separator = ",")
+        .joinToString(separator = ",") { addon -> addon.homeCatalogSignature() }
     val disabledSignature = disabledHomeCatalogKeys
         .asSequence()
         .sorted()
         .joinToString(separator = ",")
     return "$addonCatalogSignature::$disabledSignature"
+}
+
+private fun Addon.homeCatalogSignature(): String {
+    val catalogSignature = catalogs
+        .joinToString(separator = ";") { catalog -> catalog.homeCatalogSignature() }
+    return "${id}|${baseUrl}|${version}|${configVersion}|${catalogSignature}"
+}
+
+private fun CatalogDescriptor.homeCatalogSignature(): String {
+    val extraSignature = extra
+        .joinToString(prefix = "[", postfix = "]", separator = ",") { it.homeCatalogSignature() }
+    val supportedSignature = extraSupported.joinToString(prefix = "[", postfix = "]", separator = ",")
+    val requiredSignature = extraRequired.joinToString(prefix = "[", postfix = "]", separator = ",")
+    return listOf(
+        apiType,
+        rawType,
+        id,
+        name,
+        extraSignature,
+        pageSize?.toString().orEmpty(),
+        showInHome.toString(),
+        hasExplicitShowInHome.toString(),
+        supportedSignature,
+        requiredSignature
+    ).joinToString(separator = "|")
+}
+
+private fun CatalogExtra.homeCatalogSignature(): String {
+    val optionsSignature = options?.joinToString(prefix = "[", postfix = "]", separator = ",").orEmpty()
+    return listOf(
+        name,
+        isRequired.toString(),
+        optionsSignature,
+        defaultValue.orEmpty(),
+        optionsLimit?.toString().orEmpty()
+    ).joinToString(separator = "|")
 }
 
 internal fun HomeViewModel.registerCatalogLoadJob(job: Job) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogUtils.kt
@@ -11,10 +11,14 @@ internal fun HomeViewModel.catalogKey(addonId: String, type: String, catalogId: 
 }
 
 internal fun HomeViewModel.buildHomeCatalogLoadSignature(addons: List<Addon>): String {
+    return buildHomeCatalogLoadSignature(addons, disabledHomeCatalogKeys)
+}
+
+internal fun buildHomeCatalogLoadSignature(addons: List<Addon>, disabledHomeCatalogKeys: Set<String>): String {
     val addonCatalogSignature = addons
         .flatMap { addon ->
             addon.catalogs.map { catalog ->
-                "${addon.id}|${addon.baseUrl}|${catalog.apiType}|${catalog.id}|${catalog.name}|${catalog.showInHome}|${catalog.hasExplicitShowInHome}"
+                "${addon.id}|${addon.baseUrl}|${addon.version}|${addon.configVersion}|${catalog.apiType}|${catalog.id}|${catalog.name}|${catalog.showInHome}|${catalog.hasExplicitShowInHome}"
             }
         }
         .sorted()

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
@@ -60,6 +60,21 @@ class AddonManifestCachePolicyTest {
         assertTrue(shouldFetchInstalledAddonManifest(cacheStale = false, cachedManifest = null))
     }
 
+    @Test
+    fun skipsCachedEmissionBeforeRefreshWhenCacheIsStale() {
+        assertFalse(shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale = true, cachedAddons = listOf(addon())))
+    }
+
+    @Test
+    fun emitsCachedInstalledAddonsBeforeRefreshWhenCacheIsFresh() {
+        assertTrue(shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale = false, cachedAddons = listOf(addon())))
+    }
+
+    @Test
+    fun skipsCachedEmissionWhenThereAreNoCachedAddons() {
+        assertFalse(shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale = false, cachedAddons = emptyList()))
+    }
+
     private fun addon(
         version: String = "1.0.0",
         catalogs: List<CatalogDescriptor> = listOf(catalog()),

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
@@ -45,6 +45,21 @@ class AddonManifestCachePolicyTest {
         assertFalse(shouldReplaceCachedManifest(cached, cached.copy()))
     }
 
+    @Test
+    fun fetchesInstalledAddonManifestWhenCacheIsStaleEvenIfCached() {
+        assertTrue(shouldFetchInstalledAddonManifest(cacheStale = true, cachedManifest = addon()))
+    }
+
+    @Test
+    fun usesCachedInstalledAddonManifestWhenCacheIsFresh() {
+        assertFalse(shouldFetchInstalledAddonManifest(cacheStale = false, cachedManifest = addon()))
+    }
+
+    @Test
+    fun fetchesInstalledAddonManifestWhenCacheIsMissing() {
+        assertTrue(shouldFetchInstalledAddonManifest(cacheStale = false, cachedManifest = null))
+    }
+
     private fun addon(
         version: String = "1.0.0",
         catalogs: List<CatalogDescriptor> = listOf(catalog()),

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
@@ -75,6 +75,21 @@ class AddonManifestCachePolicyTest {
         assertFalse(shouldEmitCachedInstalledAddonsBeforeRefresh(cacheStale = false, cachedAddons = emptyList()))
     }
 
+    @Test
+    fun advancesRefreshTimeAfterStaleRefreshSucceeds() {
+        assertTrue(shouldAdvanceInstalledAddonRefreshTime(cacheStale = true, refreshedAnyManifest = true))
+    }
+
+    @Test
+    fun doesNotAdvanceRefreshTimeForFreshCacheMissFetch() {
+        assertFalse(shouldAdvanceInstalledAddonRefreshTime(cacheStale = false, refreshedAnyManifest = true))
+    }
+
+    @Test
+    fun doesNotAdvanceRefreshTimeWhenStaleRefreshDoesNotFetchAnything() {
+        assertFalse(shouldAdvanceInstalledAddonRefreshTime(cacheStale = true, refreshedAnyManifest = false))
+    }
+
     private fun addon(
         version: String = "1.0.0",
         catalogs: List<CatalogDescriptor> = listOf(catalog()),

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestCachePolicyTest.kt
@@ -1,0 +1,83 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.ContentType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AddonManifestCachePolicyTest {
+    @Test
+    fun replacesCachedManifestWhenCatalogVisibilityChangesWithoutVersionBump() {
+        val cached = addon(
+            version = "2.7.1",
+            catalogs = listOf(catalog(showInHome = true, hasExplicitShowInHome = true))
+        )
+        val fresh = cached.copy(
+            catalogs = listOf(catalog(showInHome = false, hasExplicitShowInHome = true))
+        )
+
+        assertTrue(shouldReplaceCachedManifest(cached, fresh))
+    }
+
+    @Test
+    fun replacesCachedManifestWhenConfigVersionChangesWithoutVersionBump() {
+        val cached = addon(version = "2.7.1", configVersion = 1L)
+        val fresh = cached.copy(configVersion = 2L)
+
+        assertTrue(shouldReplaceCachedManifest(cached, fresh))
+    }
+
+    @Test
+    fun ignoresTimestampOnlyManifestChanges() {
+        val cached = addon(version = "2.7.1", timestamp = 1L)
+        val fresh = cached.copy(timestamp = 2L)
+
+        assertFalse(shouldReplaceCachedManifest(cached, fresh))
+    }
+
+    @Test
+    fun keepsIdenticalCachedManifest() {
+        val cached = addon()
+
+        assertFalse(shouldReplaceCachedManifest(cached, cached.copy()))
+    }
+
+    private fun addon(
+        version: String = "1.0.0",
+        catalogs: List<CatalogDescriptor> = listOf(catalog()),
+        configVersion: Long? = null,
+        timestamp: Long? = null
+    ): Addon {
+        return Addon(
+            id = "aio-addon",
+            name = "AIO Addon",
+            version = version,
+            description = "AIO Addon",
+            logo = null,
+            baseUrl = "https://nuvio.file-host.net/stremio/user",
+            catalogs = catalogs,
+            types = listOf(ContentType.MOVIE),
+            rawTypes = listOf("movie"),
+            resources = listOf(AddonResource(name = "catalog", types = listOf("movie"), idPrefixes = null)),
+            configVersion = configVersion,
+            timestamp = timestamp
+        )
+    }
+
+    private fun catalog(
+        showInHome: Boolean = true,
+        hasExplicitShowInHome: Boolean = true
+    ): CatalogDescriptor {
+        return CatalogDescriptor(
+            type = ContentType.MOVIE,
+            rawType = "movie",
+            id = "trakt.recommendations.movies",
+            name = "Recommended (Movies)",
+            showInHome = showInHome,
+            hasExplicitShowInHome = hasExplicitShowInHome
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeCatalogLoadSignatureTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeCatalogLoadSignatureTest.kt
@@ -38,6 +38,34 @@ class HomeCatalogLoadSignatureTest {
     }
 
     @Test
+    fun changesWhenAddonNameChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(name = "AIO Addon")),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(name = "AIO Addon Updated")),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun changesWhenAddonDisplayNameChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(name = "AIO Addon", displayName = "AIO Addon")),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(name = "AIO Addon", displayName = "Custom AIO")),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
     fun changesWhenCatalogExtraChanges() {
         val first = buildHomeCatalogLoadSignature(
             addons = listOf(addon(catalogs = listOf(catalog(extra = listOf(CatalogExtra(name = "genre")))))),
@@ -80,13 +108,16 @@ class HomeCatalogLoadSignatureTest {
     }
 
     private fun addon(
+        name: String = "AIO Addon",
+        displayName: String = name,
         version: String = "1.0.0",
         configVersion: Long? = null,
         catalogs: List<CatalogDescriptor> = listOf(catalog())
     ): Addon {
         return Addon(
             id = "aio-addon",
-            name = "AIO Addon",
+            name = name,
+            displayName = displayName,
             version = version,
             description = "AIO Addon",
             logo = null,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeCatalogLoadSignatureTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeCatalogLoadSignatureTest.kt
@@ -1,0 +1,69 @@
+package com.nuvio.tv.ui.screens.home
+
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.ContentType
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class HomeCatalogLoadSignatureTest {
+    @Test
+    fun changesWhenAddonConfigVersionChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(configVersion = 1L)),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(configVersion = 2L)),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun changesWhenAddonVersionChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(version = "2.7.1")),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(version = "2.7.2")),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    private fun addon(
+        version: String = "1.0.0",
+        configVersion: Long? = null
+    ): Addon {
+        return Addon(
+            id = "aio-addon",
+            name = "AIO Addon",
+            version = version,
+            description = "AIO Addon",
+            logo = null,
+            baseUrl = "https://nuvio.file-host.net/stremio/user",
+            catalogs = listOf(catalog()),
+            types = listOf(ContentType.MOVIE),
+            rawTypes = listOf("movie"),
+            resources = listOf(AddonResource(name = "catalog", types = listOf("movie"), idPrefixes = null)),
+            configVersion = configVersion,
+            timestamp = null
+        )
+    }
+
+    private fun catalog(): CatalogDescriptor {
+        return CatalogDescriptor(
+            type = ContentType.MOVIE,
+            rawType = "movie",
+            id = "trakt.recommendations.movies",
+            name = "Recommended (Movies)",
+            showInHome = true,
+            hasExplicitShowInHome = true
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeCatalogLoadSignatureTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeCatalogLoadSignatureTest.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.home
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonResource
 import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogExtra
 import com.nuvio.tv.domain.model.ContentType
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
@@ -36,9 +37,52 @@ class HomeCatalogLoadSignatureTest {
         assertNotEquals(first, second)
     }
 
+    @Test
+    fun changesWhenCatalogExtraChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(catalogs = listOf(catalog(extra = listOf(CatalogExtra(name = "genre")))))),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(catalogs = listOf(catalog(extra = listOf(CatalogExtra(name = "search", isRequired = true)))))),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun changesWhenCatalogPageSizeChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(catalogs = listOf(catalog(pageSize = 50)))),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(catalogs = listOf(catalog(pageSize = 100)))),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun changesWhenCatalogOrderChanges() {
+        val first = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(catalogs = listOf(catalog(id = "movies"), catalog(id = "series")))),
+            disabledHomeCatalogKeys = emptySet()
+        )
+        val second = buildHomeCatalogLoadSignature(
+            addons = listOf(addon(catalogs = listOf(catalog(id = "series"), catalog(id = "movies")))),
+            disabledHomeCatalogKeys = emptySet()
+        )
+
+        assertNotEquals(first, second)
+    }
+
     private fun addon(
         version: String = "1.0.0",
-        configVersion: Long? = null
+        configVersion: Long? = null,
+        catalogs: List<CatalogDescriptor> = listOf(catalog())
     ): Addon {
         return Addon(
             id = "aio-addon",
@@ -47,7 +91,7 @@ class HomeCatalogLoadSignatureTest {
             description = "AIO Addon",
             logo = null,
             baseUrl = "https://nuvio.file-host.net/stremio/user",
-            catalogs = listOf(catalog()),
+            catalogs = catalogs,
             types = listOf(ContentType.MOVIE),
             rawTypes = listOf("movie"),
             resources = listOf(AddonResource(name = "catalog", types = listOf("movie"), idPrefixes = null)),
@@ -56,12 +100,18 @@ class HomeCatalogLoadSignatureTest {
         )
     }
 
-    private fun catalog(): CatalogDescriptor {
+    private fun catalog(
+        id: String = "trakt.recommendations.movies",
+        extra: List<CatalogExtra> = emptyList(),
+        pageSize: Int? = null
+    ): CatalogDescriptor {
         return CatalogDescriptor(
             type = ContentType.MOVIE,
             rawType = "movie",
-            id = "trakt.recommendations.movies",
+            id = id,
             name = "Recommended (Movies)",
+            extra = extra,
+            pageSize = pageSize,
             showInHome = true,
             hasExplicitShowInHome = true
         )


### PR DESCRIPTION
## Summary

Updates addon manifest caching and related home reload behavior so NuvioTV refreshes cached addon definitions when meaningful manifest content changes, even if the top-level manifest `version` is unchanged.

The change also makes stale manifest refreshes run before stale cached data is emitted through `getInstalledAddons()`, keeps fresh cache-miss fetches from extending the global stale-refresh timer, and makes home catalog reloads notice addon labels plus ordered catalog descriptor changes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Configurable Stremio addons can change catalog definitions for the same manifest URL without changing the top-level manifest `version`. For example, catalog `showInHome` flags, catalog lists, config versions, poster URLs, catalog paging, extras, catalog ordering, or addon labels may change after a user updates addon configuration.

Before this change, NuvioTV fetched stale manifests again but only replaced the cached manifest when `existing.version != addon.version`. If the version stayed the same, home rows could continue using old catalog definitions.

There were additional cache paths that could keep stale data visible after a refresh became necessary:

- one-shot callers using `getInstalledAddons().first()` could stop at the stale cached emission before the refresh ran
- a fresh cache-miss fetch could advance the global refresh timestamp even though existing cached manifests were not refreshed
- the home catalog load signature did not include addon `version` or `configVersion`, so existing home rows could be reused when only addon configuration metadata changed
- the home catalog load signature only included a subset of catalog fields and sorted catalog entries, so catalog descriptor changes or ordering changes could be missed
- addon label changes could be emitted by the repository while existing home rows kept the old `addonName`

## Issue or approval

Fixes #2466.

Replaces #2454, which was closed by the unlabeled-issue cleanup.

## Reproduction steps

1. Add a Stremio addon that exposes catalogs in its manifest.
2. Let NuvioTV load the addon and cache its manifest.
3. Update the same manifest URL so catalog definitions change while the manifest `version` stays the same. For example, change catalog `showInHome` flags, catalog poster URLs, catalog extras, page size, catalog order, or addon label.
4. Restart NuvioTV or wait for the manifest cache to become stale so the app fetches the manifest again.
5. Open the home screen.

Before this fix, the app could continue using the old cached catalog definitions, one-shot addon reads could stop at stale cached data, and home rows could skip reloads when only addon config metadata, catalog descriptor fields, catalog order, or addon labels changed. After this fix, meaningful manifest changes replace the cached manifest, stale refreshes feed back through `getInstalledAddons()`, the stale-refresh timer is only advanced by stale refreshes, and home rows reload when addon metadata, labels, or ordered catalog descriptor data changes.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This does not change addon ordering controls, catalog rendering UI, UI layout, poster rendering, sync behavior, dependencies, architecture, schema, or the public addon contract.

The change is limited to addon manifest cache replacement, stale installed-addon emission order, stale-refresh timestamp handling, and home catalog reload invalidation when addon metadata, labels, or ordered catalog descriptor data changes.

Timestamp-only manifest changes are intentionally ignored so constantly changing `_timestamp` fields do not invalidate the cache by themselves.

## Testing

- Added `AddonManifestCachePolicyTest` coverage for:
  - same-version catalog visibility changes replacing the cached manifest
  - same-version `configVersion` changes replacing the cached manifest
  - timestamp-only changes not replacing the cached manifest
  - identical manifests not replacing cache state
  - stale cached manifests fetching before emitting to `first()` collectors
  - fresh cached manifests still emitting from cache without a fetch
  - stale refresh success advancing the refresh timestamp
  - fresh cache-miss fetches not advancing the refresh timestamp
- Added `HomeCatalogLoadSignatureTest` coverage for:
  - addon `configVersion` changes invalidating the home catalog load signature
  - addon `version` changes invalidating the home catalog load signature
  - addon `name` changes invalidating the home catalog load signature
  - addon `displayName` changes invalidating the home catalog load signature
  - catalog `extra` changes invalidating the home catalog load signature
  - catalog `pageSize` changes invalidating the home catalog load signature
  - catalog ordering changes invalidating the home catalog load signature
- Ran `git diff --check`.
- Ran `.\gradlew.bat :app:testFullDebugUnitTest --tests com.nuvio.tv.data.repository.AddonManifestCachePolicyTest --tests com.nuvio.tv.ui.screens.home.HomeCatalogLoadSignatureTest` locally with Android SDK 36 available.
- No emulator/device UI flow was run; this is non-UI repository/cache behavior covered by unit tests.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2466.