### PR TITLE
fix(player): merge skip-intro providers instead of first-match-wins

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
@@ -40,72 +40,41 @@ class SkipIntroRepository @Inject constructor(
         val cacheKey = "$imdbId:$season:$episode"
         cache[cacheKey]?.let { return it }
 
-        if (introDbConfigured) {
-            val result = fetchFromIntroDb(imdbId, season, episode)
-            if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-        }
-
+        val introDb = if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
         val entries = resolveImdbEntries(imdbId)
+        val animeSkip = fetchAnimeSkipForEntries(entries, season, episode)
         val malId = entries.getOrNull(season - 1)?.myanimelist?.toString()
             ?: entries.firstOrNull()?.myanimelist?.toString()
-        if (malId != null) {
-            val result = fetchFromAniSkip(malId, episode)
-            if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-        }
+        val aniSkip = if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
 
-        // AnimeSkip: try season-specific AniList ID first, then season-1 as fallback with season filter
-        val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
-        val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
-        for ((anilistId, seasonFilter) in listOfNotNull(
-            seasonAnilistId?.let { it to null },
-            if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
-        )) {
-            val result = fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
-            if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-        }
-
-        return emptyList<SkipInterval>().also { cache[cacheKey] = it }
+        return mergeByPriority(introDb, animeSkip, aniSkip).also { cache[cacheKey] = it }
     }
 
     suspend fun getSkipIntervalsForMal(malId: String, episode: Int): List<SkipInterval> {
         val cacheKey = "mal:$malId:$episode"
         cache[cacheKey]?.let { return it }
 
-        val aniSkipResult = fetchFromAniSkip(malId, episode)
-        if (aniSkipResult.isNotEmpty()) return aniSkipResult.also { cache[cacheKey] = it }
+        val aniSkip = fetchFromAniSkip(malId, episode)
 
         val imdbId = try {
             armApi.resolveMalToImdb(malId = malId).takeIf { it.isSuccessful }?.body()?.imdb
         } catch (e: Exception) { null }
 
+        var introDb = emptyList<SkipInterval>()
+        var animeSkip = emptyList<SkipInterval>()
         if (imdbId != null) {
             val entries = resolveImdbEntries(imdbId)
             val season = entries.indexOfFirst { it.myanimelist == malId.toIntOrNull() } + 1
-
-            if (introDbConfigured) {
-                val result = fetchFromIntroDb(imdbId, season, episode)
-                if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-            }
-            val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
-            val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
-            for ((anilistId, seasonFilter) in listOfNotNull(
-                seasonAnilistId?.let { it to null },
-                if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
-            )) {
-                val result = fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
-                if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-            }
+            if (introDbConfigured) introDb = fetchFromIntroDb(imdbId, season, episode)
+            animeSkip = fetchAnimeSkipForEntries(entries, season, episode)
         } else {
             val anilistId = try {
                 armApi.resolveMalToAnilist(malId = malId).takeIf { it.isSuccessful }?.body()?.anilist?.toString()
             } catch (e: Exception) { null }
-            if (anilistId != null) {
-                val result = fetchFromAnimeSkip(anilistId, episode, season = null)
-                if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-            }
+            if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
-        return emptyList<SkipInterval>().also { cache[cacheKey] = it }
+        return mergeByPriority(introDb, animeSkip, aniSkip).also { cache[cacheKey] = it }
     }
 
     suspend fun getSkipIntervalsForKitsu(kitsuId: String, episode: Int): List<SkipInterval> {
@@ -116,44 +85,69 @@ class SkipIntroRepository @Inject constructor(
             armApi.resolveKitsuToMal(kitsuId = kitsuId)
                 .takeIf { it.isSuccessful }?.body()?.myanimelist?.toString()
         } catch (e: Exception) { null }
-
-        if (malId != null) {
-            val result = fetchFromAniSkip(malId, episode)
-            if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-        }
+        val aniSkip = if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
 
         val imdbId = try {
             armApi.resolveKitsuToImdb(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.imdb
         } catch (e: Exception) { null }
 
+        var introDb = emptyList<SkipInterval>()
+        var animeSkip = emptyList<SkipInterval>()
         if (imdbId != null) {
             val entries = resolveImdbEntries(imdbId)
             val season = entries.indexOfFirst { it.kitsu == kitsuId.toIntOrNull() } + 1
-
-            if (introDbConfigured) {
-                val result = fetchFromIntroDb(imdbId, season, episode)
-                if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-            }
-            val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
-            val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
-            for ((anilistId, seasonFilter) in listOfNotNull(
-                seasonAnilistId?.let { it to null },
-                if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
-            )) {
-                val result = fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
-                if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-            }
+            if (introDbConfigured) introDb = fetchFromIntroDb(imdbId, season, episode)
+            animeSkip = fetchAnimeSkipForEntries(entries, season, episode)
         } else {
             val anilistId = try {
                 armApi.resolveKitsuToAnilist(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.anilist?.toString()
             } catch (e: Exception) { null }
-            if (anilistId != null) {
-                val result = fetchFromAnimeSkip(anilistId, episode, season = null)
-                if (result.isNotEmpty()) return result.also { cache[cacheKey] = it }
-            }
+            if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
-        return emptyList<SkipInterval>().also { cache[cacheKey] = it }
+        return mergeByPriority(introDb, animeSkip, aniSkip).also { cache[cacheKey] = it }
+    }
+
+    /**
+     * Merge provider results into one best-of: fill each segment category (opening / ending /
+     * recap) from the highest-priority provider that has it. Arguments MUST be passed in priority
+     * order (IntroDB has the broadest coverage, then Anime-Skip, then AniSkip), so a partial
+     * result from one provider never shadows a complete segment from another.
+     */
+    private fun mergeByPriority(vararg providerResults: List<SkipInterval>): List<SkipInterval> {
+        val chosen = LinkedHashMap<String, SkipInterval>()
+        for (result in providerResults) {
+            for (interval in result) {
+                val category = segmentCategory(interval.type) ?: continue
+                chosen.putIfAbsent(category, interval)
+            }
+        }
+        return chosen.values.toList()
+    }
+
+    private fun segmentCategory(type: String): String? = when (type.lowercase()) {
+        "intro", "op", "mixed-op" -> "opening"
+        "outro", "ed", "mixed-ed", "credits", "ending" -> "ending"
+        "recap" -> "recap"
+        else -> null
+    }
+
+    // AnimeSkip: season-specific AniList ID first, then season-1 as a season-filtered fallback.
+    private suspend fun fetchAnimeSkipForEntries(
+        entries: List<ArmEntry>,
+        season: Int,
+        episode: Int
+    ): List<SkipInterval> {
+        val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
+        val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
+        for ((anilistId, seasonFilter) in listOfNotNull(
+            seasonAnilistId?.let { it to null },
+            if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
+        )) {
+            val result = fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
+            if (result.isNotEmpty()) return result
+        }
+        return emptyList()
     }
 
     private suspend fun fetchFromIntroDb(imdbId: String, season: Int, episode: Int): List<SkipInterval> {


### PR DESCRIPTION
## Summary

Fixes #2456. `SkipIntroRepository` returned the result of the **first provider that had any data** and stopped, so a provider with only a partial result shadowed a more complete one (e.g. AniSkip's intro-only result hid IntroDB's intro + outro, dropping the outro entirely). This changes the resolver to query the applicable providers and **merge their results by segment category**, so the most complete set is always used.

## How it works

For a title/episode the resolver now:
1. Resolves the cross-IDs it needs (IMDb for IntroDB, MAL for AniSkip, AniList for Anime-Skip) via ARM - exactly as before.
2. Queries each applicable provider and **collects** all their segments, instead of returning at the first non-empty one.
3. Merges by category - **opening** (`intro`/`op`/`mixed-op`), **ending** (`outro`/`ed`/`mixed-ed`/`credits`/`ending`) and **recap** - filling each category from the highest-priority provider that actually has it: **IntroDB, then Anime-Skip, then AniSkip**.

Because the merge is per-category, a provider that only has an intro can no longer hide another provider's outro (or vice versa). Each segment type comes from whoever actually has it, in priority order.

## Why this is much better than the previous method

- **Before - first-non-empty-wins:** whichever provider was queried first and returned anything "won", and everything else was discarded. A provider that listed only the intro silently dropped the outro the app could have gotten elsewhere. The outcome depended on provider ordering rather than data completeness.
- **After - best-of-all-providers:** no provider can shadow another in either direction. The user gets the complete intro + outro (+ recap) whenever *any* provider has each piece.
- Verified on-device (NVIDIA Shield):
  - **Angel Beats S1E1:** was intro-only (AniSkip shadowing IntroDB); now **intro + outro**, both from IntroDB.
  - **Absolute Duo S1E1:** IntroDB has nothing; now **intro + ending**, both from Anime-Skip.
  - **Re:Zero S1E1:** IntroDB has the outro, Anime-Skip has the intro; the merge **combines** them.
- Same caching as before - the extra provider lookups only run once per episode on a cache miss.

## PR type

- [x] Critical bug fix

## Why

The skip feature silently drops intros/outros the app actually has access to, purely because of provider query ordering. Users miss outros (or intros) that a lower-priority provider has, with no way to tell why. This makes intro/outro skipping behave correctly and completely.

## Issue or approval

Fixes #2456.

## Reproduction steps

1. Enable Skip Intro.
2. Play an episode where the first-matched provider has only a partial result (e.g. **Angel Beats S1E1**: AniSkip has only the intro, IntroDB has intro + outro).
3. Before this change only the intro is skipped and the outro is dropped; after, both are skipped.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the three resolve entry points (`getSkipIntervals`, `getSkipIntervalsForMal`, `getSkipIntervalsForKitsu`) change from return-first to collect-and-merge, plus two small private helpers (`mergeByPriority`, `segmentCategory`) and one extraction (`fetchAnimeSkipForEntries`). The per-provider fetch logic, ID resolution, provider gating, and caching are unchanged. No UI, settings, or unrelated code touched. One file: `SkipIntroRepository.kt`.

## Testing

- `:app:compileFullDebugKotlin` clean.
- On an NVIDIA Shield (Android 11), internal + external player:
  - Angel Beats S1E1: intro + outro (both IntroDB) - was intro-only before.
  - Absolute Duo S1E1: intro + ending (both Anime-Skip) - IntroDB has nothing.
  - Re:Zero S1E1: mixed (Anime-Skip intro + IntroDB outro).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2456.
