### PR TITLE
fix: ASS subtitle gibberish caused by a zlib false-positive on plain-text ASS samples in `NuvioAssMatroskaExtractor`

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
@@ -32,15 +32,13 @@ internal class NuvioAssMatroskaExtractor(
     internal val subtitleSample: ParsableByteArray =
         subtitleSampleField.get(this) as ParsableByteArray
 
-    override fun getElementType(id: Int): Int {
-        return when (id) {
-            ID_ATTACHMENTS -> EbmlProcessor.ELEMENT_TYPE_MASTER
-            ID_ATTACHED_FILE -> EbmlProcessor.ELEMENT_TYPE_MASTER
-            ID_FILE_NAME -> EbmlProcessor.ELEMENT_TYPE_STRING
-            ID_FILE_MIME_TYPE -> EbmlProcessor.ELEMENT_TYPE_STRING
-            ID_FILE_DATA -> EbmlProcessor.ELEMENT_TYPE_BINARY
-            else -> super.getElementType(id)
-        }
+    override fun getElementType(id: Int): Int = when (id) {
+        ID_ATTACHMENTS -> EbmlProcessor.ELEMENT_TYPE_MASTER
+        ID_ATTACHED_FILE -> EbmlProcessor.ELEMENT_TYPE_MASTER
+        ID_FILE_NAME -> EbmlProcessor.ELEMENT_TYPE_STRING
+        ID_FILE_MIME_TYPE -> EbmlProcessor.ELEMENT_TYPE_STRING
+        ID_FILE_DATA -> EbmlProcessor.ELEMENT_TYPE_BINARY
+        else -> super.getElementType(id)
     }
 
     override fun isLevel1Element(id: Int): Boolean {
@@ -49,18 +47,7 @@ internal class NuvioAssMatroskaExtractor(
 
     override fun startMasterElement(id: Int, contentPosition: Long, contentSize: Long) {
         when (id) {
-            ID_EBML -> {
-                if (assHandler.renderType != AssRenderType.CUES) {
-                    val currentExtractor = extractorOutput.get(this) as ExtractorOutput
-                    if (currentExtractor !is NuvioAssSubtitleExtractorOutput) {
-                        extractorOutput.set(
-                            this,
-                            NuvioAssSubtitleExtractorOutput(currentExtractor, assHandler, this)
-                        )
-                    }
-                }
-                super.startMasterElement(id, contentPosition, contentSize)
-            }
+            ID_EBML -> onEbmlStart(contentPosition, contentSize)
             ID_ATTACHED_FILE -> clearAttachment()
             else -> super.startMasterElement(id, contentPosition, contentSize)
         }
@@ -68,11 +55,7 @@ internal class NuvioAssMatroskaExtractor(
 
     override fun endMasterElement(id: Int) {
         when (id) {
-            ID_VIDEO -> {
-                val track = getCurrentTrack(id)
-                assHandler.setVideoSize(track.width, track.height)
-                super.endMasterElement(id)
-            }
+            ID_VIDEO -> onVideoEnd()
             ID_ATTACHED_FILE -> clearAttachment()
             else -> super.endMasterElement(id)
         }
@@ -88,19 +71,40 @@ internal class NuvioAssMatroskaExtractor(
 
     override fun binaryElement(id: Int, contentSize: Int, input: ExtractorInput) {
         when (id) {
-            ID_FILE_DATA -> {
-                val attachmentName = requireNotNull(currentAttachmentName)
-                val attachmentMime = requireNotNull(currentAttachmentMime)
-
-                if (attachmentMime in fontMimeTypes) {
-                    val data = ByteArray(contentSize)
-                    input.readFully(data, 0, contentSize)
-                    assHandler.addFont(attachmentName, data)
-                } else {
-                    input.skipFully(contentSize)
-                }
-            }
+            ID_FILE_DATA -> handleAttachmentData(contentSize, input)
             else -> super.binaryElement(id, contentSize, input)
+        }
+    }
+
+    private fun onEbmlStart(contentPosition: Long, contentSize: Long) {
+        if (assHandler.renderType != AssRenderType.CUES) {
+            val currentExtractor = extractorOutput.get(this) as ExtractorOutput
+            if (currentExtractor !is NuvioAssSubtitleExtractorOutput) {
+                extractorOutput.set(
+                    this,
+                    NuvioAssSubtitleExtractorOutput(currentExtractor, assHandler, this)
+                )
+            }
+        }
+        super.startMasterElement(ID_EBML, contentPosition, contentSize)
+    }
+
+    private fun onVideoEnd() {
+        val track = getCurrentTrack(ID_VIDEO)
+        assHandler.setVideoSize(track.width, track.height)
+        super.endMasterElement(ID_VIDEO)
+    }
+
+    private fun handleAttachmentData(contentSize: Int, input: ExtractorInput) {
+        val attachmentName = requireNotNull(currentAttachmentName)
+        val attachmentMime = requireNotNull(currentAttachmentMime)
+
+        if (attachmentMime in fontMimeTypes) {
+            val data = ByteArray(contentSize)
+            input.readFully(data, 0, contentSize)
+            assHandler.addFont(attachmentName, data)
+        } else {
+            input.skipFully(contentSize)
         }
     }
 
@@ -183,15 +187,16 @@ private class NuvioAssTrackOutput(
     ) {
         if (isAss && timeUs.isValidTs) {
             val sample = extractor.subtitleSample
-            val endIndex = findTokenIndex(sample.data, 1)
-            val lineIndex = findTokenIndex(sample.data, 2)
+            val sampleLimit = sample.limit()
+            val endIndex = findTokenIndex(sample.data, 1, sampleLimit)
+            val lineIndex = findTokenIndex(sample.data, 2, sampleLimit)
             if (endIndex > 0 && lineIndex > endIndex) {
                 val rawDuration = sample.data.decodeToString(endIndex, lineIndex - 1)
                 val durationUs = parseTimecodeUs(rawDuration)
                 if (durationUs.isValidTs) {
                     val dialogue = sample.data.dialoguePayload(
                         offset = lineIndex,
-                        limit = sample.limit()
+                        limit = sampleLimit
                     )
 
                     assHandler.readTrackDialogue(
@@ -220,11 +225,11 @@ private class NuvioAssTrackOutput(
         return timestampUs
     }
 
-    private fun findTokenIndex(array: ByteArray, tokenNumber: Int): Int {
+    private fun findTokenIndex(array: ByteArray, tokenNumber: Int, limit: Int = array.size): Int {
         if (tokenNumber == 0) return 0
         var tokensFound = 0
-        array.forEachIndexed { index, byte ->
-            if (byte == COMMA && ++tokensFound == tokenNumber) {
+        for (index in 0 until limit) {
+            if (array[index] == COMMA && ++tokensFound == tokenNumber) {
                 return index + 1
             }
         }
@@ -232,11 +237,13 @@ private class NuvioAssTrackOutput(
     }
 
     private fun ByteArray.dialoguePayload(offset: Int, limit: Int): ByteArray {
-        if (offset >= size) return EMPTY_BYTE_ARRAY
+        if (offset >= limit) return EMPTY_BYTE_ARRAY
+        if (looksLikeZlib(offset, limit)) {
+            val inflated = maybeInflate(offset, size - offset)
+            if (inflated != null) return inflated
+        }
         val boundedLimit = limit.coerceIn(offset, size)
-        val rawEnd = if (looksLikeZlib(offset, size)) size else boundedLimit
-        val rawPayload = copyOfRange(offset, rawEnd)
-        return maybeInflate(rawPayload)
+        return copyOfRange(offset, boundedLimit)
     }
 
     private fun ByteArray.looksLikeZlib(offset: Int, limit: Int): Boolean {
@@ -246,13 +253,11 @@ private class NuvioAssTrackOutput(
         return cmf and 0x0F == 8 && ((cmf shl 8) + flg) % 31 == 0
     }
 
-    private fun maybeInflate(data: ByteArray): ByteArray {
-        if (!data.looksLikeZlib(offset = 0, limit = data.size)) return data
-
+    private fun ByteArray.maybeInflate(offset: Int, length: Int): ByteArray? {
         val inflater = Inflater()
         return try {
-            inflater.setInput(data)
-            val output = ByteArrayOutputStream(data.size * 4)
+            inflater.setInput(this, offset, length)
+            val output = ByteArrayOutputStream(length * 4)
             val buffer = ByteArray(INFLATE_BUFFER_SIZE)
             while (!inflater.finished()) {
                 val count = inflater.inflate(buffer)
@@ -265,9 +270,9 @@ private class NuvioAssTrackOutput(
                 }
             }
             val inflated = output.toByteArray()
-            if (inflater.finished() && inflated.isNotEmpty()) inflated else data
+            if (inflater.finished() && inflated.isNotEmpty()) inflated else null
         } catch (_: DataFormatException) {
-            data
+            null
         } finally {
             inflater.end()
         }


### PR DESCRIPTION
## Summary

Fix ASS subtitle gibberish caused by a zlib false-positive on plain-text ASS samples in `NuvioAssMatroskaExtractor`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`subtitleSample` is reused across subtitle events. Plain ASS lines can spoof the zlib header check through their `ReadOrder` field, which can make the extractor treat a normal line like compressed data.

When that happens, the parser can read beyond the current sample and pull in stale bytes from the shared buffer, which shows up as random gibberish after the real subtitle text.

This fix keeps plain-text lines bounded by `limit`, only attempts inflation when the payload looks compressed, and falls back safely when inflation fails. That preserves the real zlib case without letting spoofed plain-text samples leak garbage.

## Issue or approval

Fixes #2458

## Reproduction steps

1. Play content with embedded ASS subtitles using the internal player.
2. Wait for a subtitle line with a `ReadOrder` in the 800s to appear.
3. The line can display gibberish appended after the actual dialogue text.
4. The gibberish can differ between playback sessions because the shared subtitle buffer is reused.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

- Only `NuvioAssMatroskaExtractor.kt` is modified.
- No UI changes, no new dependencies, no architecture changes.

## Testing

- Tested with a debug build on content with embedded ASS subtitles - gibberish no longer appears.
- Verified zlib-compressed subtitle payloads still decompress correctly.
- Verified plain-text ASS lines still render normally when the zlib header check is spoofed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2458