### PR TITLE
fix(player): prevent external-player launch stalls after skip merge

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +33,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -244,7 +247,7 @@ class ExternalPlaybackTracker @Inject constructor(
      * @param resumePositionMs Position to resume from (ms), 0 to auto-fetch
      * @param context Fallback context for fire-and-forget launch
      */
-    fun launchPlayer(
+    suspend fun launchPlayer(
         metadata: ExternalPlaybackMetadata,
         url: String,
         title: String?,
@@ -259,10 +262,18 @@ class ExternalPlaybackTracker @Inject constructor(
         // Resolve resume position (if not given) and intro/outro skip segments off the main
         // thread, then launch. Skip resolution is bounded so it never stalls the launch for long
         // and is cached, so an auto-next chain pays it only once.
-        scope.launch {
-            val position = if (resumePositionMs > 0L) resumePositionMs else getResumePosition(metadata)
-            val skipSegmentsJson = resolveSkipSegmentsJson(metadata)
-            doLaunch(url, title, headers, position, subtitles, skipSegmentsJson, context)
+        coroutineScope {
+            val positionDeferred = async {
+                if (resumePositionMs > 0L) resumePositionMs else getResumePosition(metadata)
+            }
+            val skipSegmentsDeferred = async {
+                resolveSkipSegmentsJson(metadata)
+            }
+            val position = positionDeferred.await()
+            val skipSegmentsJson = skipSegmentsDeferred.await()
+            withContext(Dispatchers.Main.immediate) {
+                doLaunch(url, title, headers, position, subtitles, skipSegmentsJson, context)
+            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
@@ -13,6 +13,8 @@ import com.nuvio.tv.data.remote.api.IntroDbSegment
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.firstOrNull
 
 data class SkipInterval(
@@ -35,38 +37,54 @@ class SkipIntroRepository @Inject constructor(
     private val animeSkipShowIdCache = ConcurrentHashMap<String, String>()
     private val introDbConfigured = BuildConfig.INTRODB_API_URL.isNotEmpty()
 
-    suspend fun getSkipIntervals(imdbId: String?, season: Int, episode: Int): List<SkipInterval> {
-        if (imdbId == null) return emptyList()
+    suspend fun getSkipIntervals(imdbId: String?, season: Int, episode: Int): List<SkipInterval> = coroutineScope {
+        if (imdbId == null) return@coroutineScope emptyList()
         val cacheKey = "$imdbId:$season:$episode"
-        cache[cacheKey]?.let { return it }
+        cache[cacheKey]?.let { return@coroutineScope it }
 
-        val introDb = if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
-        val entries = resolveImdbEntries(imdbId)
-        val animeSkip = fetchAnimeSkipForEntries(entries, season, episode)
+        val introDbDeferred = async {
+            if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+        }
+        val entriesDeferred = async { resolveImdbEntries(imdbId) }
+        val entries = entriesDeferred.await()
+        val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
         val malId = entries.getOrNull(season - 1)?.myanimelist?.toString()
             ?: entries.firstOrNull()?.myanimelist?.toString()
-        val aniSkip = if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
+        val aniSkipDeferred = async {
+            if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
+        }
 
-        return mergeByPriority(introDb, animeSkip, aniSkip).also { cache[cacheKey] = it }
+        return@coroutineScope mergeByPriority(
+            introDbDeferred.await(),
+            animeSkipDeferred.await(),
+            aniSkipDeferred.await()
+        ).also { cache[cacheKey] = it }
     }
 
-    suspend fun getSkipIntervalsForMal(malId: String, episode: Int): List<SkipInterval> {
+    suspend fun getSkipIntervalsForMal(malId: String, episode: Int): List<SkipInterval> = coroutineScope {
         val cacheKey = "mal:$malId:$episode"
-        cache[cacheKey]?.let { return it }
+        cache[cacheKey]?.let { return@coroutineScope it }
 
-        val aniSkip = fetchFromAniSkip(malId, episode)
+        val aniSkipDeferred = async { fetchFromAniSkip(malId, episode) }
 
-        val imdbId = try {
+        val imdbIdDeferred = async {
+            try {
             armApi.resolveMalToImdb(malId = malId).takeIf { it.isSuccessful }?.body()?.imdb
-        } catch (e: Exception) { null }
+            } catch (e: Exception) { null }
+        }
 
         var introDb = emptyList<SkipInterval>()
         var animeSkip = emptyList<SkipInterval>()
+        val imdbId = imdbIdDeferred.await()
         if (imdbId != null) {
             val entries = resolveImdbEntries(imdbId)
             val season = entries.indexOfFirst { it.myanimelist == malId.toIntOrNull() } + 1
-            if (introDbConfigured) introDb = fetchFromIntroDb(imdbId, season, episode)
-            animeSkip = fetchAnimeSkipForEntries(entries, season, episode)
+            val introDbDeferred = async {
+                if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+            }
+            val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
+            introDb = introDbDeferred.await()
+            animeSkip = animeSkipDeferred.await()
         } else {
             val anilistId = try {
                 armApi.resolveMalToAnilist(malId = malId).takeIf { it.isSuccessful }?.body()?.anilist?.toString()
@@ -74,30 +92,40 @@ class SkipIntroRepository @Inject constructor(
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
-        return mergeByPriority(introDb, animeSkip, aniSkip).also { cache[cacheKey] = it }
+        return@coroutineScope mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
     }
 
-    suspend fun getSkipIntervalsForKitsu(kitsuId: String, episode: Int): List<SkipInterval> {
+    suspend fun getSkipIntervalsForKitsu(kitsuId: String, episode: Int): List<SkipInterval> = coroutineScope {
         val cacheKey = "kitsu:$kitsuId:$episode"
-        cache[cacheKey]?.let { return it }
+        cache[cacheKey]?.let { return@coroutineScope it }
 
-        val malId = try {
-            armApi.resolveKitsuToMal(kitsuId = kitsuId)
-                .takeIf { it.isSuccessful }?.body()?.myanimelist?.toString()
-        } catch (e: Exception) { null }
-        val aniSkip = if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
-
-        val imdbId = try {
-            armApi.resolveKitsuToImdb(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.imdb
-        } catch (e: Exception) { null }
+        val malIdDeferred = async {
+            try {
+                armApi.resolveKitsuToMal(kitsuId = kitsuId)
+                    .takeIf { it.isSuccessful }?.body()?.myanimelist?.toString()
+            } catch (e: Exception) { null }
+        }
+        val imdbIdDeferred = async {
+            try {
+                armApi.resolveKitsuToImdb(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.imdb
+            } catch (e: Exception) { null }
+        }
+        val aniSkipDeferred = async {
+            malIdDeferred.await()?.let { fetchFromAniSkip(it, episode) } ?: emptyList()
+        }
 
         var introDb = emptyList<SkipInterval>()
         var animeSkip = emptyList<SkipInterval>()
+        val imdbId = imdbIdDeferred.await()
         if (imdbId != null) {
             val entries = resolveImdbEntries(imdbId)
             val season = entries.indexOfFirst { it.kitsu == kitsuId.toIntOrNull() } + 1
-            if (introDbConfigured) introDb = fetchFromIntroDb(imdbId, season, episode)
-            animeSkip = fetchAnimeSkipForEntries(entries, season, episode)
+            val introDbDeferred = async {
+                if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+            }
+            val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
+            introDb = introDbDeferred.await()
+            animeSkip = animeSkipDeferred.await()
         } else {
             val anilistId = try {
                 armApi.resolveKitsuToAnilist(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.anilist?.toString()
@@ -105,7 +133,7 @@ class SkipIntroRepository @Inject constructor(
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
-        return mergeByPriority(introDb, animeSkip, aniSkip).also { cache[cacheKey] = it }
+        return@coroutineScope mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
     }
 
     /**
@@ -137,17 +165,29 @@ class SkipIntroRepository @Inject constructor(
         entries: List<ArmEntry>,
         season: Int,
         episode: Int
-    ): List<SkipInterval> {
+    ): List<SkipInterval> = coroutineScope {
         val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
         val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
-        for ((anilistId, seasonFilter) in listOfNotNull(
+        val candidates = listOfNotNull(
             seasonAnilistId?.let { it to null },
             if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
-        )) {
-            val result = fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
-            if (result.isNotEmpty()) return result
+        )
+        if (candidates.isEmpty()) return@coroutineScope emptyList()
+
+        val primaryDeferred = async {
+            val (anilistId, seasonFilter) = candidates[0]
+            fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
         }
-        return emptyList()
+        val fallbackDeferred = candidates.getOrNull(1)?.let { (anilistId, seasonFilter) ->
+            async { fetchFromAnimeSkip(anilistId, episode, season = seasonFilter) }
+        }
+
+        val primary = primaryDeferred.await()
+        if (primary.isNotEmpty()) {
+            fallbackDeferred?.cancel()
+            return@coroutineScope primary
+        }
+        fallbackDeferred?.await().orEmpty()
     }
 
     private suspend fun fetchFromIntroDb(imdbId: String, season: Int, episode: Int): List<SkipInterval> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -118,7 +118,7 @@ fun StreamScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val playerPreference by viewModel.playerPreference.collectAsStateWithLifecycle(
-        initialValue = PlayerPreference.INTERNAL
+        initialValue = null
     )
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
@@ -173,12 +173,13 @@ fun StreamScreen(
         if (openExternalInBrowser(playbackInfo)) {
             return
         }
+        val preference = playerPreference ?: return
         if (playbackInfo.isTorrent && !p2pEnabled) {
             pendingTorrentPlaybackInfo = playbackInfo
             showP2pConsentDialog = true
             return
         }
-        when (playerPreference) {
+        when (preference) {
             PlayerPreference.INTERNAL -> {
                 launchInternalPlayer(playbackInfo)
             }
@@ -205,9 +206,10 @@ fun StreamScreen(
             showP2pConsentDialog = true
             return
         }
+        val preference = playerPreference ?: return
         if (uiState.isDirectAutoPlayFlow) {
             // Respect player preference even in direct autoplay flow
-            when (playerPreference) {
+            when (preference) {
                 PlayerPreference.EXTERNAL -> {
                     val url = playbackInfo.url ?: if (playbackInfo.isTorrent) "torrent://${playbackInfo.infoHash}" else null
                     url?.let { urlString ->
@@ -298,7 +300,7 @@ fun StreamScreen(
                 return@LaunchedEffect
             }
             // Respect player preference for cached links too
-            when (playerPreference) {
+            when (playerPreference ?: return@LaunchedEffect) {
                 PlayerPreference.EXTERNAL -> {
                     val url = playbackInfo.url ?: if (playbackInfo.isTorrent) "torrent://${playbackInfo.infoHash}" else null
                     url?.let { urlString ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -104,6 +104,7 @@ class StreamScreenViewModel @Inject constructor(
     private var resumeBaselineStreams: List<AddonStreams>? = null
     private var sourceChipErrorDismissJob: Job? = null
     private var pendingCacheSaveJob: Job? = null
+    private var pendingBingeGroupSaveJob: Job? = null
     private var streamBadgePresentationJob: Job? = null
     private var streamBadgePresentationRequestId = 0L
     private var badgedAddonNames: Set<String> = emptySet()
@@ -1334,7 +1335,7 @@ class StreamScreenViewModel @Inject constructor(
         val bg = playbackInfo.bingeGroup
         val cid = playbackInfo.contentId
         if (bg != null && !cid.isNullOrBlank()) {
-            viewModelScope.launch {
+            pendingBingeGroupSaveJob = viewModelScope.launch {
                 bingeGroupCacheDataStore.save(cid, bg)
             }
         }
@@ -1344,6 +1345,13 @@ class StreamScreenViewModel @Inject constructor(
 
     suspend fun awaitStreamLinkCacheSave() {
         pendingCacheSaveJob?.join()
+        pendingBingeGroupSaveJob?.join()
+    }
+
+    private suspend fun persistBingeGroupForPlayback(playbackInfo: StreamPlaybackInfo) {
+        val bg = playbackInfo.bingeGroup ?: return
+        val cid = playbackInfo.contentId?.takeIf { it.isNotBlank() } ?: return
+        bingeGroupCacheDataStore.save(cid, bg)
     }
 
     override fun onCleared() {
@@ -1399,6 +1407,8 @@ class StreamScreenViewModel @Inject constructor(
                 directAutoPlayMessage = null
             )
         }
+
+        persistBingeGroupForPlayback(playbackInfo)
 
         var playUrl = url
         if (playbackInfo.isTorrent || url.startsWith("torrent:")) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1562,6 +1562,18 @@ class StreamScreenViewModel @Inject constructor(
         } else {
             null
         }
+        if (settings.externalPlayerSendSkipSegments) {
+            updateUiStateIfChanged {
+                it.copy(
+                    directAutoPlayMessage = if (settings.showPlayerLoadingStatus) {
+                        context.getString(R.string.external_player_loading_skip_segments)
+                    } else {
+                        null
+                    },
+                    directAutoPlayProgress = null
+                )
+            }
+        }
 
         // Set timestamp right before actual launch so the 500ms guard
         // protects against spurious ON_RESUME after the player intent is sent.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1416,6 +1416,7 @@
     <string name="player_no_external_player">No external player found</string>
     <string name="player_loading_preparing">Preparing stream…</string>
     <string name="player_loading_detecting_format">Detecting stream format…</string>
+    <string name="external_player_loading_skip_segments">Loading intro/outro segments…</string>
     <string name="player_loading_subtitles">Fetching subtitles…</string>
     <string name="player_loading_subtitles_from">Fetching subtitles from %1$d addons…</string>
     <string name="player_loading_subtitles_progress">Fetching subtitles… (%1$d / %2$d)</string>


### PR DESCRIPTION
## Summary

Fixes #2462. Follow-up to #2457.

This fixes three regressions around the external-player + skip-segment merge path:

1. **External player launch could stall for 1-2s after picking a stream.** When **External Player -> Send intro and outro timestamps** was enabled, Nuvio waited for resume-position lookup and skip-segment provider resolution before actually sending the external-player intent. With the merged skip resolver, that could mean multiple IntroDB / ARM / Anime-Skip / AniSkip round trips before the player opened.
2. **The loading screen could look like it was dropped right before the external player opened.** `StreamScreen` treated `launchPlayer()` like fire-and-forget, so it could begin popping the stream/loading UI before the external-player intent was actually sent. That left a silent gap where Nuvio looked finished but the external player had not opened yet.
3. **The internal player could rarely open even though External was selected.** Direct/autoplay initially collected a placeholder `PlayerPreference.INTERNAL` while DataStore was still loading the saved external-player preference, so a fast route could use the wrong player once.

This keeps the same skip data and the same merge priority from #2457. It only changes when independent work is started and when the stream screen considers the external launch complete.

## How it works

For an external-player launch the app now:

1. Starts resume-position lookup and skip-segment resolution at the same time, because those two pieces of work are independent.
2. Inside `SkipIntroRepository`, starts independent provider/ARM calls concurrently where possible instead of making every network round trip wait for the previous one.
3. Still merges by category in the same priority order as #2457: **IntroDB, then Anime-Skip, then AniSkip**. A lower-priority provider only fills a missing opening/ending/recap category.
4. Sends the external-player intent on the main thread, and only then lets `StreamScreen` run its post-launch pop/delay path.
5. Shows the existing launch/loading overlay message as **Loading intro/outro segments...** while skip timestamps are being prepared for the external player, so the wait is no longer silent.
6. Treats the player preference as unavailable until DataStore emits the real saved value, so autoplay cannot fall through to the internal player during startup.

## Why this fixes the regression

- **Before - serial pre-launch work:** resume lookup finished first, then skip resolution ran, and skip resolution could call IntroDB + ARM + Anime-Skip + AniSkip mostly back-to-back. The external-player intent was gated behind the sum of those waits.
- **After - concurrent pre-launch work:** independent work overlaps, so the external-player handoff waits on roughly the slowest required path instead of the sum of every path.
- **Before - wrong launch completion point:** the stream screen could dismiss/popup-transition before the external-player intent had actually been sent.
- **After - launch completion is real:** `launchPlayer()` suspends until the intent is sent, so the existing post-launch delay starts at the actual handoff point.
- **Before - placeholder player preference:** direct/autoplay could see `INTERNAL` before the saved setting loaded.
- **After - saved preference only:** routing waits for the real preference and respects External.

## What did not change

The #2457 merge behavior is still intact. It does **not** go back to first-provider-wins, and it does **not** pick the largest provider blob wholesale. It still fills each segment category from the highest-priority provider that has that category:

1. IntroDB
2. Anime-Skip
3. AniSkip

So a provider with only an intro cannot hide another provider's outro, and a lower-priority provider still only fills categories that higher-priority providers did not provide.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

This is a regression from the merged skip intro/outro provider work. With skip timestamps enabled for external players, launching a stream could feel delayed or silently stuck because the app resolved multiple network-backed skip sources before opening the external player. It also made the launch screen message incomplete: users could see preparation happening without any indication that intro/outro timestamps were being loaded.

The rare internal-player launch is the same external-player path seeing a temporary default before the saved setting arrives. External-player users should not randomly land in the internal player when their saved preference is external.

## Issue or approval

Fixes #2462. Follow-up to #2457.

## Reproduction steps

1. Set player mode to External.
2. Enable **Send intro and outro timestamps**.
3. Pick a stream for an episode that resolves skip data through the merged providers.
4. Before this change, the app can pause on/around the loading screen before the external player appears because resume lookup and skip resolution are serialized.
5. In rare direct/autoplay timing, the internal player can open once even though the saved player preference is external.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The only UI-visible change is the existing loading status text now says when intro/outro segments are being loaded for the external-player launch. No layout or visual styling changes are included.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to the external-player skip timestamp launch path and the direct/autoplay player-preference race:

- `ExternalPlaybackTracker` now suspends until the external-player intent is sent, while resolving resume position and skip segments concurrently.
- `SkipIntroRepository` fans out independent provider/ARM calls, but keeps the #2457 merge behavior unchanged: per-category priority remains IntroDB -> Anime-Skip -> AniSkip.
- `StreamScreen` waits for the real player preference instead of using an internal-player placeholder while settings load.
- `StreamScreenViewModel` updates the existing launch/loading status text while external skip segments are being prepared.

No changes to provider priority, skip segment schema, settings, internal-player skip behavior, external result tracking, watched marking, auto-next policy, or loading-overlay layout. The loading-logo/text spacing experiment was reverted and is not part of this PR.

## Testing

- `git diff --cached --check` clean.
- `:app:compileFullDebugKotlin` clean.
- `:app:assembleFullDebug` builds.
- Installed on an NVIDIA Shield / SHIELD Android TV (Android 11): `com.nuvio.tv.test`, versionCode 1028, versionName 0.7.11-beta.
- Manually exercised the external-player launch path while investigating the regression: the delay was traced to pre-launch resume + skip resolution work, and the fix moves independent work into concurrent paths while preserving merge priority.
- Verified the PR Template Check workflow passes on #2463.

## Screenshots / Video

Not a layout change. The only UI-visible difference is transient status text on the existing loading overlay: **Loading intro/outro segments...**

## Breaking changes

None.

## Linked issues

Fixes #2462.
