### PR TITLE
Fix advanced focus navigation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -268,6 +269,9 @@ fun AdvancedSettingsContent(
 
     val networkListState = rememberLazyListState()
     val performanceFocusRequester = remember { initialFocusRequester ?: FocusRequester() }
+    val nuvioFocusScrollFocusRequester = remember { FocusRequester() }
+    val rememberLastProfileFocusRequester = remember { FocusRequester() }
+    val playbackIssueReportsFocusRequester = remember { FocusRequester() }
     var showExperienceModeConfirmation by remember { mutableStateOf(false) }
     Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
@@ -349,7 +353,8 @@ fun AdvancedSettingsContent(
                                 !uiState.smoothBringIntoViewEnabled
                             )
                         )
-                    }
+                    },
+                    modifier = Modifier.focusRequester(nuvioFocusScrollFocusRequester)
                 )
                 val profileManager = remember {
                     dagger.hilt.android.EntryPointAccessors.fromApplication(
@@ -366,7 +371,12 @@ fun AdvancedSettingsContent(
                         scope.launch {
                             profileManager.setRememberLastProfileEnabled(!rememberLastProfileEnabled)
                         }
-                    }
+                    },
+                    modifier = Modifier
+                        .focusRequester(rememberLastProfileFocusRequester)
+                        .focusProperties {
+                            up = nuvioFocusScrollFocusRequester
+                        }
                 )
             }
         }
@@ -392,7 +402,12 @@ fun AdvancedSettingsContent(
                                 !uiState.playbackIssueReportsEnabled
                             )
                         )
-                    }
+                    },
+                    modifier = Modifier
+                        .focusRequester(playbackIssueReportsFocusRequester)
+                        .focusProperties {
+                            up = rememberLastProfileFocusRequester
+                        }
                 )
             }
         }
@@ -413,7 +428,10 @@ fun AdvancedSettingsContent(
                             else -> R.string.network_testing_download
                         }
                     ) else null,
-                    onClick = { if (!isRunning) runSpeedTest() }
+                    onClick = { if (!isRunning) runSpeedTest() },
+                    modifier = Modifier.focusProperties {
+                        up = playbackIssueReportsFocusRequester
+                    }
                 )
             }
         }


### PR DESCRIPTION
## Summary

Fix Advanced settings D-pad navigation so upward focus follows Run Speed Test → Playback issue reports → Remember last profile → Nuvio Focus Scrolling instead of skipping to Fast Horizontal Navigation.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Compose spatial focus search was selecting a row in the earlier Performance & navigation card when moving up across separate lazy-list cards. The affected rows now have explicit Up focus targets for the expected sequential path.

## Issue or approval

Fixes #2487

## Reproduction steps

1. Open Settings.
2. Select the Advanced tab.
3. Navigate down to Run Speed Test.
4. Press Up on the remote.
5. Before: focus skips Playback issue reports and moves to Fast Horizontal Navigation.
6. After: focus moves to Playback issue reports.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Only the upward focus path from Run Speed Test through Playback issue reports, Remember last profile, and Nuvio Focus Scrolling is made explicit. No settings values, speed-test behavior, layout, styling, playback behavior, or unrelated focus routes are modified.

## Testing

- Test APK built successfully.
- Tested on Android TV and confirmed the upward remote-navigation chain works as expected: Run Speed Test → Playback issue reports → Remember last profile → Nuvio Focus Scrolling.
- Confirmed the settings remain selectable and retain their existing behavior.

## Screenshots / Video

A video can be presented if needed within 24 hours.
## Breaking changes

None.

## Linked issues

Fixes #2487