### PR TITLE
Fix advanced settings focus navigation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -267,7 +266,6 @@ fun AdvancedSettingsContent(
     }
 
     val networkListState = rememberLazyListState()
-    val performanceFocusRequester = remember { initialFocusRequester ?: FocusRequester() }
     var showExperienceModeConfirmation by remember { mutableStateOf(false) }
     Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
@@ -305,7 +303,12 @@ fun AdvancedSettingsContent(
                     title = stringResource(R.string.experience_mode_switch_to_essential),
                     subtitle = stringResource(R.string.experience_mode_switch_to_essential_subtitle),
                     value = stringResource(R.string.experience_mode_advanced),
-                    onClick = { showExperienceModeConfirmation = true }
+                    onClick = { showExperienceModeConfirmation = true },
+                    modifier = if (initialFocusRequester != null) {
+                        Modifier.focusRequester(initialFocusRequester)
+                    } else {
+                        Modifier
+                    }
                 )
             }
         }
@@ -321,11 +324,6 @@ fun AdvancedSettingsContent(
 
         item(key = "performance_settings") {
             SettingsGroupCard(modifier = Modifier.fillMaxWidth()) {
-                LaunchedEffect(Unit) {
-                    if (initialFocusRequester != null) {
-                        runCatching { performanceFocusRequester.requestFocus() }
-                    }
-                }
                 SettingsToggleRow(
                     title = stringResource(R.string.advanced_fast_horizontal_navigation),
                     subtitle = stringResource(R.string.advanced_fast_horizontal_navigation_subtitle),
@@ -336,8 +334,7 @@ fun AdvancedSettingsContent(
                                 !uiState.fastHorizontalNavigationEnabled
                             )
                         )
-                    },
-                    modifier = Modifier.focusRequester(performanceFocusRequester)
+                    }
                 )
                 SettingsToggleRow(
                     title = stringResource(R.string.advanced_nuvio_focus_scroll),


### PR DESCRIPTION
## Summary

Correct focus ownership in Advanced settings so:

- Opening Advanced initially focuses Switch to Essential.
- Pressing Up from Run Speed Test moves to Playback issue reports and remains there.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The Advanced content focus requester was attached to Fast Horizontal Navigation instead of the first actionable row, Switch to Essential. The Performance settings lazy-list item also contained a `LaunchedEffect(Unit)` that requested focus on Fast Horizontal Navigation whenever that item entered composition.

As a result, Advanced opened on the wrong row, and upward scrolling from Run Speed Test briefly focused Playback issue reports before the recomposed Performance item forced focus back to Fast Horizontal Navigation.

The existing initial-focus requester is now attached to Switch to Essential, and the redundant item-level focus effect is removed. `SettingsScreen` remains the single owner of the initial focus request.

## Issue or approval

Fixes #2487

## Reproduction steps

1. Open Settings and select Advanced.
2. Before: initial focus lands on Fast Horizontal Navigation.
3. After: initial focus lands on Switch to Essential.
4. Navigate down to Run Speed Test and press Up once.
5. Before: Playback issue reports is focused briefly, then focus jumps to Fast Horizontal Navigation.
6. After: focus remains on Playback issue reports.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Only Advanced settings focus ownership is changed. No explicit directional focus graph, settings values, layout, styling, speed-test behavior, playback behavior, or unrelated navigation is modified.

## Testing

- Confirmed with an APK that removing the repeated Performance-item focus request fixes the original Run Speed Test upward-navigation issue.
- Ran `git diff --check` successfully.
- Branch contains one commit changing only one file.
- Traced initial focus ownership to confirm `SettingsScreen` requests the same `FocusRequester` now attached to Switch to Essential.


## Screenshots / Video

Before: 
https://github.com/user-attachments/assets/e0e1002a-d48b-481f-b203-0c22938ed0d4

After: 

https://github.com/user-attachments/assets/6cf4c757-81ad-4909-bd5a-13b288acd6b4


## Breaking changes

None.

## Linked issues

Fixes #2487