### PR TITLE
Fix ExoPlayer playback startup, seek, and buffering defaults

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -22,13 +22,9 @@ import com.nuvio.tv.NuvioApplication
 import com.nuvio.tv.core.network.IPv4FirstDns
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.VodCacheSizeMode
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
-import java.io.InputStream
-import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
 import java.net.URLDecoder
 import java.security.SecureRandom
@@ -250,20 +246,12 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
     }
 
     companion object {
-        private const val PROBE_TIMEOUT_MS = 4000
-        private const val PROBE_BYTES = 1024
-        private const val MIME_PROBE_CACHE_SIZE = 64
         private const val MIME_VIDEO_QUICK_TIME = "video/quicktime"
         private const val ENABLE_VOD_CACHE = true
         private const val VOD_CACHE_FREE_SPACE_RESERVE_BYTES = 1024L * 1024L * 1024L
         internal const val DEFAULT_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-        private val mimeProbeCache = object : LinkedHashMap<String, String>(MIME_PROBE_CACHE_SIZE, 0.75f, true) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>?): Boolean {
-                return size > MIME_PROBE_CACHE_SIZE
-            }
-        }
 
         @Volatile private var sharedSimpleCache: SimpleCache? = null
         @Volatile private var configuredVodCacheMaxBytes: Long = -1L
@@ -362,14 +350,6 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                 ?: inferMimeTypeFromPath(url)
         }
 
-        fun evictMimeType(url: String, headers: Map<String, String>) {
-            val sanitizedHeaders = sanitizeHeaders(headers)
-            val cacheKey = buildMimeProbeCacheKey(url, sanitizedHeaders)
-            synchronized(mimeProbeCache) {
-                mimeProbeCache.remove(cacheKey)
-            }
-        }
-
         internal fun normalizeMimeType(contentType: String?): String? {
             val normalized = contentType
                 ?.substringBefore(';')
@@ -425,48 +405,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             filename: String? = null,
             responseHeaders: Map<String, String>? = null
         ): String? {
-            inferMimeType(
+            return inferMimeType(
                 url = url,
                 filename = filename,
                 responseHeaders = responseHeaders
-            )?.let { return it }
-
-            val sanitizedHeaders = sanitizeHeaders(headers)
-            val cacheKey = buildMimeProbeCacheKey(url, sanitizedHeaders)
-
-            synchronized(mimeProbeCache) {
-                mimeProbeCache[cacheKey]
-            }?.let { return it }
-
-            val probeRequestHeaders = sanitizedHeaders.toMutableMap().apply {
-                put("Connection", "close")
-            }
-
-            val probedMimeType = withContext(Dispatchers.IO) {
-                probeMimeTypeWithRangeGet(url, probeRequestHeaders)
-                    ?: probeMimeTypeWithHead(url, probeRequestHeaders)
-            }
-
-            if (probedMimeType != null) {
-                synchronized(mimeProbeCache) {
-                    mimeProbeCache[cacheKey] = probedMimeType
-                }
-            }
-
-            return probedMimeType
-        }
-
-        private fun buildMimeProbeCacheKey(url: String, headers: Map<String, String>): String {
-            if (headers.isEmpty()) return url
-            return buildString {
-                append(url)
-                headers.toSortedMap(String.CASE_INSENSITIVE_ORDER).forEach { (key, value) ->
-                    append('|')
-                    append(key)
-                    append('=')
-                    append(value)
-                }
-            }
+            )
         }
 
         private fun inferMimeTypeFromResponseHeaders(headers: Map<String, String>?): String? {
@@ -584,72 +527,6 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             }
         }
 
-        private fun probeMimeTypeWithHead(url: String, headers: Map<String, String>): String? {
-            val connection = openConnection(url = url, headers = headers, method = "HEAD")
-            return try {
-                connection.responseCode
-                val responseHeaders = readResponseHeaders(connection)
-                normalizeMimeType(connection.contentType)
-                    ?: inferMimeType(
-                        url = connection.url?.toString().orEmpty(),
-                        filename = null,
-                        responseHeaders = responseHeaders
-                    )
-            } catch (_: Exception) {
-                null
-            } finally {
-                connection.disconnect()
-            }
-        }
-
-        private fun probeMimeTypeWithRangeGet(url: String, headers: Map<String, String>): String? {
-            val connection = openConnection(
-                url = url,
-                headers = headers,
-                method = "GET",
-                range = "bytes=0-${PROBE_BYTES - 1}"
-            )
-            return try {
-                connection.responseCode
-                val responseHeaders = readResponseHeaders(connection)
-                normalizeMimeType(connection.contentType)
-                    ?: inferMimeType(
-                        url = connection.url?.toString().orEmpty(),
-                        filename = null,
-                        responseHeaders = responseHeaders
-                    )
-                    ?: sniffManifestMimeType(readProbeSnippet(connection.inputStream))
-            } catch (_: Exception) {
-                null
-            } finally {
-                connection.disconnect()
-            }
-        }
-
-        private fun openConnection(
-            url: String,
-            headers: Map<String, String>,
-            method: String,
-            range: String? = null
-        ): HttpURLConnection {
-            return PlayerPlaybackNetworking.openConnection(
-                url = url,
-                headers = headers,
-                method = method,
-                connectTimeoutMs = PROBE_TIMEOUT_MS,
-                readTimeoutMs = PROBE_TIMEOUT_MS,
-                range = range
-            )
-        }
-
-        private fun readProbeSnippet(inputStream: InputStream?): String? {
-            if (inputStream == null) return null
-            val buffer = ByteArray(PROBE_BYTES)
-            val read = inputStream.read(buffer)
-            if (read <= 0) return null
-            return String(buffer, 0, read, Charsets.UTF_8)
-        }
-
         private fun wrapAudioDelay(
             mediaSource: MediaSource,
             audioDelayUsProvider: (() -> Long)?
@@ -661,19 +538,6 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                     mediaSource = mediaSource,
                     audioDelayUsProvider = audioDelayUsProvider
                 )
-            }
-        }
-
-        private fun readResponseHeaders(connection: HttpURLConnection): Map<String, String> {
-            return buildMap {
-                connection.headerFields.forEach { (key, values) ->
-                    if (key.isNullOrBlank()) return@forEach
-                    val value = values
-                        ?.firstOrNull { it.isNotBlank() }
-                        ?.trim()
-                        ?: return@forEach
-                    put(key, value)
-                }
             }
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -434,9 +434,8 @@ private fun PlayerRuntimeController.handleParsingErrorFallback(error: PlaybackEx
             Log.w(
                 PlayerRuntimeController.TAG,
                 "Parsing error [${error.errorCode}] detected with mimeType=$currentStreamMimeType. " +
-                        "Evicting cache and clearing mimeType override for fallback probe."
+                        "Clearing mimeType override for fallback."
             )
-            PlayerMediaSourceFactory.evictMimeType(currentStreamUrl, currentHeaders)
             currentStreamMimeType = null
             currentStreamResponseHeaders = emptyMap()
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
+import androidx.media3.exoplayer.SeekParameters
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -476,7 +477,10 @@ internal fun PlayerRuntimeController.isPlaybackCurrentlyPlaying(): Boolean {
     }
 }
 
-internal fun PlayerRuntimeController.seekPlaybackTo(positionMs: Long) {
+internal fun PlayerRuntimeController.seekPlaybackTo(
+    positionMs: Long,
+    seekParameters: SeekParameters = SeekParameters.CLOSEST_SYNC
+) {
     if (isUsingMpvEngine()) {
         mpvView?.let { view ->
             view.seekToMs(positionMs)
@@ -508,6 +512,7 @@ internal fun PlayerRuntimeController.seekPlaybackTo(positionMs: Long) {
                     player.setScrubbingModeParameters(params)
                 }
             }
+            player.setSeekParameters(seekParameters)
             player.seekTo(positionMs)
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -718,7 +718,7 @@ internal fun PlayerRuntimeController.maybeScheduleStallWatchdog() {
 internal fun PlayerRuntimeController.maybeScheduleFirstFrameWatchdog() {
     if (hasRenderedFirstFrame || !currentStreamHasVideoTrack) return
     val player = _exoPlayer ?: return
-    if (player.playbackState != Player.STATE_READY || !player.playWhenReady) return
+    if (player.playbackState != Player.STATE_READY) return
     if (firstFrameWatchdogJob?.isActive == true) return
 
     firstFrameWatchdogJob = scope.launch {
@@ -726,11 +726,16 @@ internal fun PlayerRuntimeController.maybeScheduleFirstFrameWatchdog() {
 
         val livePlayer = _exoPlayer ?: return@launch
         if (hasRenderedFirstFrame) return@launch
-        if (livePlayer.playbackState != Player.STATE_READY || !livePlayer.playWhenReady) return@launch
+        if (livePlayer.playbackState != Player.STATE_READY) return@launch
+
+        if (!livePlayer.playWhenReady && !userPausedManually) {
+            livePlayer.playWhenReady = true
+            livePlayer.play()
+            return@launch
+        }
+        if (!livePlayer.playWhenReady) return@launch
 
         val currentPosition = livePlayer.currentPosition
-        // Manual Convert-to-DV8.1 mode 2 produced no first frame (e.g. black
-        // screen): retry the stream at libdovi mode 1 before other fallbacks.
         if (isManualDv81Mode2ActiveForCurrentPlayback &&
             !dv7Mode1ForcedStreamUrls.contains(currentStreamUrl)
         ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
 import com.nuvio.tv.core.player.OpenSubtitlesHasher
+import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.data.local.FrameRateMatchingMode
@@ -698,10 +699,40 @@ internal fun PlayerRuntimeController.maybeScheduleStallWatchdog() {
             val stalledForMs = nowMs - lastAdvanceAtMs
             if (stalledForMs >= PlayerRuntimeController.STALL_WATCHDOG_THRESHOLD_MS) {
                 val playheadMs = livePlayer.currentPosition.coerceAtLeast(0L)
-                // Seek past buffered edge to force Media3 to cancel the stuck Range request.
-                val durationMs = livePlayer.duration.coerceAtLeast(0L)
-                val seekTargetMs = (bufferedNow + STALL_WATCHDOG_SKIP_PAST_BUFFERED_MS)
-                    .coerceAtMost(durationMs)
+                val durationMs = livePlayer.duration
+                if (durationMs == C.TIME_UNSET || durationMs <= 0L) {
+                    Log.w(
+                        PlayerRuntimeController.TAG,
+                        "STALL_WATCHDOG: bufferedPosition stuck at $bufferedNow for ${stalledForMs}ms " +
+                            "during STATE_BUFFERING (playhead=$playheadMs); skipping self-seek " +
+                            "because duration is unknown"
+                    )
+                    return@launch
+                }
+                if (bufferedNow <= playheadMs) {
+                    Log.w(
+                        PlayerRuntimeController.TAG,
+                        "STALL_WATCHDOG: bufferedPosition stuck at $bufferedNow for ${stalledForMs}ms " +
+                            "during STATE_BUFFERING (playhead=$playheadMs); skipping self-seek " +
+                            "because buffered position is not ahead"
+                    )
+                    return@launch
+                }
+                val targetPastBufferedMs = if (bufferedNow > Long.MAX_VALUE - STALL_WATCHDOG_SKIP_PAST_BUFFERED_MS) {
+                    Long.MAX_VALUE
+                } else {
+                    bufferedNow + STALL_WATCHDOG_SKIP_PAST_BUFFERED_MS
+                }
+                val seekTargetMs = targetPastBufferedMs.coerceAtMost((durationMs - 1L).coerceAtLeast(0L))
+                if (seekTargetMs <= playheadMs || seekTargetMs <= 0L) {
+                    Log.w(
+                        PlayerRuntimeController.TAG,
+                        "STALL_WATCHDOG: bufferedPosition stuck at $bufferedNow for ${stalledForMs}ms " +
+                            "during STATE_BUFFERING (playhead=$playheadMs); skipping self-seek " +
+                            "because target=$seekTargetMs is not forward"
+                    )
+                    return@launch
+                }
                 Log.w(
                     PlayerRuntimeController.TAG,
                     "STALL_WATCHDOG: bufferedPosition stuck at $bufferedNow for ${stalledForMs}ms " +

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.net.Uri
 import android.util.Log
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.SeekParameters
 import com.nuvio.tv.R
 import com.nuvio.tv.core.player.LastPlaybackDiagnostics
 import com.nuvio.tv.data.local.SubtitleStyleSettings
@@ -52,7 +53,7 @@ internal fun PlayerRuntimeController.skipInterval(interval: SkipInterval): Boole
     } else {
         (interval.endTime * 1000).toLong()
     }
-    seekPlaybackTo(seekMs.coerceAtMost(duration))
+    seekPlaybackTo(seekMs.coerceAtMost(duration), SeekParameters.NEXT_SYNC)
     scheduleProgressSyncAfterSeek()
     _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = true) }
     return true
@@ -989,7 +990,12 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             val target = (current + event.deltaMs)
                 .coerceAtLeast(0L)
                 .coerceAtMost(maxDuration)
-            seekPlaybackTo(target)
+            val seekParameters = if (event.deltaMs < 0L) {
+                SeekParameters.PREVIOUS_SYNC
+            } else {
+                SeekParameters.NEXT_SYNC
+            }
+            seekPlaybackTo(target, seekParameters)
             updatePlaybackTimeline(currentPosition = target)
             scheduleProgressSyncAfterSeek()
             if (_uiState.value.showControls) {
@@ -1015,7 +1021,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         PlayerEvent.OnCommitPreviewSeek -> {
             val target = pendingPreviewSeekPosition
             if (target != null) {
-                seekPlaybackTo(target)
+                seekPlaybackTo(target, SeekParameters.CLOSEST_SYNC)
                 updatePlaybackTimeline(currentPosition = target)
                 pendingPreviewSeekPosition = null
                 scheduleProgressSyncAfterSeek()
@@ -1028,7 +1034,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         is PlayerEvent.OnSeekTo -> {
             pendingPreviewSeekPosition = null
-            seekPlaybackTo(event.position)
+            seekPlaybackTo(event.position, SeekParameters.CLOSEST_SYNC)
             updatePlaybackTimeline(currentPosition = event.position)
             scheduleProgressSyncAfterSeek()
             if (_uiState.value.showControls) {


### PR DESCRIPTION
## Summary

Fixes several playback reliability regressions around startup, seeking, MIME detection, and buffering recovery.

Changes included:
- Add a first-frame startup fallback so non-tunneled Exo playback does not remain paused forever on devices that never render the first frame while paused.
- Use sync-frame seek parameters for ExoPlayer seeks to reduce seek stalls and fragile exact-seek behavior.
- Remove active MIME preflight probing before playback; MIME is now inferred passively from filename, URL, and known response headers.
- Harden the buffering stall watchdog so it only self-seeks when duration, buffer position, and target position are valid.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Recent playback reports show stalls, freezing after seek, startup playback hangs, and streams that work in other Exo-based players but fail or buffer in Nuvio.

These fixes reduce risky default behavior in the playback path:
- Exact seeks can stall on some formats/devices, especially MKV/progressive/HEVC/high-bitrate streams.
- Active MIME probing can cause extra network requests before playback and can break fragile tokenized/redirected streams.
- First-frame-gated startup can remain stuck if a device does not render a frame while paused.
- Stall watchdog self-seek needed stronger guards to avoid invalid or non-forward recovery seeks.

## Issue or approval

No linked issue: critical playback stability fixes based on recent user playback reports and internal investigation.

## Reproduction steps

Reported/relevant flows:
1. Start playback on a non-tunneled Exo stream where the player reaches `STATE_READY` but video does not render while paused.
2. Seek forward/backward on progressive, MKV, HEVC, or high-bitrate streams.
3. Open streams with tokenized or redirected URLs where MIME type is unclear before playback.
4. Enter `STATE_BUFFERING` where `bufferedPosition` stops advancing and the stall watchdog attempts recovery.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR does not add new playback settings, UI controls, telemetry, or player features.

It intentionally avoids changing unrelated player behavior outside the targeted playback stability fixes:
- startup first-frame fallback
- Exo seek parameter defaults
- active MIME probing removal
- stall watchdog guard hardening

## Testing

Commands run:

```bash
./gradlew :app:compileFullReleaseKotlin :app:testFullReleaseUnitTest --tests com.nuvio.tv.ui.screens.player.PlayerMediaSourceFactoryTest
./gradlew :app:compileFullReleaseKotlin
```

Results:
- Release Kotlin compile passed.
- Focused `PlayerMediaSourceFactoryTest` passed.
- Tested behaviour on Emu

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue: critical playback stability fixes based on recent user playback reports and internal investigation.