### PR TITLE
i18n(fr): backfill missing French translations (vouvoiement)

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -179,6 +179,8 @@
     <string name="hero_mark_unwatched">Marquer comme non vu</string>
     <string name="hero_play_trailer">Regarder la bande-annonce</string>
     <string name="hero_press_back_trailer">Appuyez sur «&#160;Retour&#160;» pour quitter la bande-annonce</string>
+    <string name="hero_synopsis_read_more">Lire la suite</string>
+    <string name="hero_synopsis_dismiss_hint">Appuyez sur Retour pour fermer</string>
     <string name="cd_rating">Note</string>
 
     <!-- EpisodesSection -->
@@ -344,6 +346,10 @@
     <string name="settings_profiles_subtitle">Gérer les profils utilisateurs</string>
     <string name="settings_layout">Disposition</string>
     <string name="settings_layout_subtitle">Structure de l’accueil et styles d’affiches</string>
+    <string name="settings_content_discovery">Contenu et découverte</string>
+    <string name="settings_content_discovery_subtitle">Addons, plugins, catalogues et sources de découverte</string>
+    <string name="settings_content_discovery_addons_subtitle">Gérer les addons, l’ordre des catalogues et les collections</string>
+    <string name="settings_content_discovery_plugins_subtitle">Gérer les dépôts et les fournisseurs de flux</string>
     <string name="settings_plugins">Plugins</string>
     <string name="settings_plugins_subtitle">Dépôts et fournisseurs</string>
     <string name="settings_integration">Intégrations</string>
@@ -370,9 +376,18 @@
     <string name="network_connection_offline">Hors ligne</string>
     <string name="advanced_section_performance">Performance et navigation</string>
     <string name="advanced_section_diagnostics">Diagnostics</string>
+    <string name="advanced_playback_issue_reports">Rapports de problèmes de lecture</string>
+    <string name="advanced_playback_issue_reports_subtitle">Affiche des boutons de signalement pendant la lecture, les chargements longs et les erreurs de lecture</string>
     <string name="advanced_section_cache">Cache</string>
     <string name="advanced_fast_horizontal_navigation">Navigation horizontale rapide</string>
     <string name="advanced_fast_horizontal_navigation_subtitle">Augmenter la vitesse de répétition du D-pad dans les rangées tout en conservant la limitation de répétition.</string>
+    <string name="advanced_nuvio_performance_mode">Mémoire native ExoPlayer</string>
+    <string name="advanced_nuvio_performance_mode_subtitle">Active l’allocateur natif haute performance, la mémoire hors tas et les optimisations réseau pour une lecture plus fluide</string>
+    <string name="buffer_device_ram_info">RAM de l’appareil : %s</string>
+    <string name="buffer_safe_limit_info">Limite de sécurité recommandée : %d Mo</string>
+    <string name="buffer_safe_status">Sûr : dans la limite recommandée pour votre appareil.</string>
+    <string name="buffer_unsafe_warning">Avertissement : dépasse la limite de sécurité recommandée (%1$d Mo) pour votre appareil %2$s. Peut provoquer des plantages de l’app.</string>
+    <string name="buffer_auto_limit_active">Limite de sécurité auto-ajustée : %d Mo</string>
     <string name="advanced_nuvio_focus_scroll">Défilement de la sélection Nuvio</string>
     <string name="advanced_nuvio_focus_scroll_subtitle">Utiliser l’animation et le positionnement globaux personnalisés du défilement de sélection de Nuvio.</string>
     <string name="advanced_memory_only_vertical_scroll">Défilement vertical en mémoire uniquement</string>
@@ -405,6 +420,7 @@
     <string name="cd_decrease">Diminuer</string>
     <string name="cd_increase">Augmenter</string>
     <string name="action_cancel">Annuler</string>
+    <string name="action_switch">Changer</string>
     <string name="action_apply">Appliquer</string>
     <string name="sub_opacity">Opacité</string>
     <string name="action_none">Aucun</string>
@@ -415,6 +431,10 @@
     <string name="supporters_contributors_subtitle">Les personnes qui soutiennent Nuvio et les contributeurs qui le développent sur TV et mobile.</string>
     <string name="supporters_contributors_supporters_copy">Les soutiens et les donateurs permettent au projet de continuer à avancer, de financer l’infrastructure et de laisser la place à des fonctionnalités ambitieuses.</string>
     <string name="supporters_contributors_donate_copy">Nuvio restera gratuit et open source. Si vous souhaitez soutenir le projet, vous pouvez aider à couvrir le temps et l’infrastructure nécessaires à son développement.</string>
+    <string name="supporters_contributors_donation_progress_title">Serveur et maintenance de ce mois-ci</string>
+    <string name="supporters_contributors_donation_progress_complete">Couvert. Le soutien supplémentaire va désormais au développement.</string>
+    <string name="supporters_contributors_donation_progress_remaining">Au-delà de 100 %%, le soutien supplémentaire va au développement.</string>
+    <string name="supporters_contributors_loading_donation_progress">Chargement de la progression du financement…</string>
     <string name="supporters_contributors_donate_button">Faire un don</string>
     <string name="supporters_contributors_qr_title">Scanner pour faire un don</string>
     <string name="supporters_contributors_qr_subtitle">Ouvrez le lien sur votre téléphone et soutenez Nuvio via Ko-fi.</string>
@@ -468,6 +488,8 @@
     <string name="playback_auto_switch_internal_player_on_error_sub">Si le démarrage du flux échoue, bascule automatiquement entre ExoPlayer et libmpv.</string>
     <string name="playback_external_forward_subtitles">Transférer les sous-titres au lecteur externe</string>
     <string name="playback_external_forward_subtitles_sub">Récupère les sous-titres dans votre langue préférée depuis les addons et les transmet au lecteur externe.</string>
+    <string name="playback_external_send_skip_segments">Envoyer les horodatages d’intro et d’outro</string>
+    <string name="playback_external_send_skip_segments_sub">Transmet les horodatages de saut d’intro/outro résolus au lecteur externe pour le saut automatique. Ne fonctionne que dans les lecteurs compatibles ; les autres l’ignorent.</string>
     <string name="playback_section_audio">Audio et vidéo</string>
     <string name="playback_section_audio_desc">Contrôles audio et compatibilité vidéo.</string>
     <string name="playback_section_subtitles">Sous-titres</string>
@@ -521,6 +543,8 @@
     <string name="audio_decoder_priority">Priorité du décodeur</string>
     <string name="audio_tunneled">Lecture tunnelisée</string>
     <string name="audio_tunneled_sub">Synchronisation audio/vidéo au niveau matériel. Peut améliorer la lecture sur certains appareils Android TV</string>
+    <string name="audio_force_optical_passthrough">Forcer le transcodage AC-3 (optique/SPDIF)</string>
+    <string name="audio_force_optical_passthrough_sub">Transcode les formats multicanaux (TrueHD, DTS, AAC, etc.) en Dolby Digital 5.1 en temps réel pour les connexions optiques/SPDIF.</string>
     <string name="audio_mpv_hwdec_title">Décodage matériel (MPV uniquement)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Choisissez comment libmpv doit utiliser les décodeurs matériels.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Ancien mode (direct -&gt; copy)</string>
@@ -1071,6 +1095,7 @@
     <string name="player_no_external_player">Aucun lecteur externe trouvé</string>
     <string name="player_loading_preparing">Préparation du flux…</string>
     <string name="player_loading_detecting_format">Détection du format du flux…</string>
+    <string name="external_player_loading_skip_segments">Chargement des segments d’intro/outro…</string>
     <string name="player_loading_subtitles">Récupération des sous-titres…</string>
     <string name="player_loading_subtitles_from">Récupération des sous-titres depuis %1$d addons…</string>
     <string name="player_loading_subtitles_progress">Récupération des sous-titres… (%1$d / %2$d)</string>
@@ -1113,6 +1138,17 @@
     <string name="player_subtitle_delay">Délai des sous-titres</string>
     <string name="player_error_title">Erreur de lecture</string>
     <string name="player_go_back">Retour</string>
+    <string name="player_report_issue">Signaler un problème</string>
+    <string name="player_report_issue_sending">Envoi du rapport de lecture…</string>
+    <string name="player_report_issue_sending_button">Envoi…</string>
+    <string name="player_report_issue_sent">Rapport envoyé : %1$s</string>
+    <string name="player_report_issue_sent_button">Rapport envoyé</string>
+    <string name="player_report_issue_failed">Impossible d’envoyer le rapport</string>
+    <string name="player_report_loading_issue">Signaler un problème de chargement</string>
+    <plurals name="player_report_loading_issue_prompt">
+        <item quantity="one">Toujours en chargement après %1$d seconde</item>
+        <item quantity="other">Toujours en chargement après %1$d secondes</item>
+    </plurals>
     <string name="player_speed_title">Vitesse de lecture</string>
     <string name="player_more_actions_title">Plus d’actions</string>
     <string name="player_more_speed">Vitesse de lecture</string>
@@ -1343,6 +1379,7 @@
 
     <!-- AuthQrSignInScreen -->
     <string name="auth_qr_title">Connexion par code QR</string>
+    <string name="auth_qr_tagline">Regardez votre bibliothèque, où que vous soyez</string>
     <string name="auth_qr_account_login">Connexion au compte</string>
     <string name="auth_qr_finishing">Finalisation de la connexion\u2026</string>
     <string name="auth_qr_code_label">Code : %1$s</string>
@@ -1359,6 +1396,8 @@
     <string name="auth_qr_please_wait">Patientez\u2026</string>
     <string name="auth_qr_continue">Continuer</string>
     <string name="auth_qr_back">Retour</string>
+    <string name="auth_qr_terms_prefix">En m’inscrivant / me connectant, j’accepte les</string>
+    <string name="auth_qr_terms_link">Conditions d’utilisation</string>
 
     <!-- SyncCodeGenerateScreen -->
     <string name="sync_generate_title">Générer un code de synchronisation</string>
@@ -1510,6 +1549,8 @@
     <string name="dv7_mode_strip_dv_desc">Supprime la couche RPU Dolby Vision de tous les flux.</string>
     <string name="audio_dv5_to_dv81_title">Convertir DV5 en DV8.1</string>
     <string name="audio_dv5_to_dv81_sub">Signale les flux Profile 5 comme Profile 8.1 pour une sortie compatible HDR10. Utile sur les appareils sans décodeur DV5 natif.</string>
+    <string name="audio_strip_hdr10plus_title">Supprimer les métadonnées HDR10+</string>
+    <string name="audio_strip_hdr10plus_sub">Supprime les métadonnées dynamiques HDR10+ des flux. Quand « Convertir en DV8.1 » est aussi activé, la suppression a lieu après la conversion.</string>
     <string name="audio_dv7_preserve_mapping_title">Préserver le mapping DV (DV7 vers DV8.1)</string>
     <string name="audio_dv7_preserve_mapping_sub">Conserve le tone-mapping voulu par le créateur, au prix d’un traitement légèrement plus lourd par image.</string>
 
@@ -1556,6 +1597,10 @@
     <string name="account_generate_sync_desc">Créez un code sur cet appareil pour que d’autres appareils puissent s’y lier.</string>
     <string name="account_enter_sync_desc">Liez cet appareil à un autre en utilisant un code de synchronisation.</string>
     <string name="account_signed_in_as">Connecté en tant que</string>
+    <string name="account_sync_backend_label">Serveur de synchronisation</string>
+    <string name="debug_backend_switch_confirm_title">Changer de serveur de synchronisation ?</string>
+    <string name="debug_backend_switch_confirm_message">Basculer vers %1$s et se déconnecter ? Vous pourrez vous reconnecter sur le serveur de synchronisation sélectionné.</string>
+    <string name="debug_backend_switching">Changement…</string>
     <string name="account_generate_sync_signed_in_desc">Créez un code pour que d’autres appareils puissent se synchroniser avec ce compte.</string>
     <string name="account_unknown_device">Appareil inconnu</string>
 
@@ -2703,6 +2748,10 @@
     <!-- Playback — Buffer & Network settings -->
     <string name="playback_section_buffer_network">Mémoire tampon et réseau</string>
     <string name="playback_section_buffer_network_desc">Quelle quantité de contenu garder en mémoire et comment récupérer les flux.</string>
+    <string name="playback_net_device_memory_info">Mémoire de l’appareil : %1$s | Limite de sécurité recommandée : %2$d Mo</string>
+    <string name="playback_net_nuvio_performance_mode">Mémoire native ExoPlayer</string>
+    <string name="playback_net_nuvio_performance_mode_sub">Active l’allocateur natif hors tas et les optimisations de défilement.</string>
+    <string name="playback_net_nuvio_performance_mode_not_supported">Cette fonctionnalité n’est pas prise en charge par votre appareil.</string>
     <string name="playback_buffer_custom">Tampons de lecture personnalisés</string>
     <string name="playback_buffer_custom_sub">Remplace la mise en mémoire tampon par défaut de Media3 par les valeurs ci-dessous. Quand c’est désactivé, le lecteur utilise les durées de tampon et la taille cible d’origine de Media3.</string>
     <string name="playback_buffer_header">Mémoire tampon</string>
@@ -2725,6 +2774,7 @@
     <string name="playback_buffer_target_sub">RAM maximale utilisée pour la mise en mémoire tampon anticipée. Le maximum est calculé d’après la mémoire disponible de votre appareil (la limite de tas par application d’Android), donc les appareils dotés de plus de RAM débloquent automatiquement des plafonds plus élevés.</string>
     <string name="playback_buffer_target_managed_hint">Géré par le budget mémoire de l’appareil. Désactivez «&#160;Budget mémoire géré&#160;» pour définir cette valeur.</string>
     <string name="playback_buffer_target_warning">Attention&#160;: au-dessus de la limite sûre de l’appareil (%1$d Mo). L’application peut planter pendant la lecture.</string>
+    <string name="playback_buffer_target_danger_warning">Danger : au-dessus de la limite d’avertissement (%1$d Mo). Risque élevé de plantage.</string>
     <string name="playback_buffer_allow_large">Autoriser un tampon cible plus grand</string>
     <string name="playback_buffer_allow_large_sub">Supprime le plafond de mémoire de l’appareil sur le curseur de taille de tampon cible, autorisant des valeurs jusqu’à 2 Go. Peut planter sur les appareils avec moins de 2 Go de RAM.</string>
     <string name="playback_cache_header">Cache disque</string>
@@ -2742,6 +2792,8 @@
     <string name="playback_reset_to_default">Réinitialiser les valeurs par défaut</string>
     <string name="playback_net_custom">Réseau personnalisé</string>
     <string name="playback_net_custom_sub">Utilise plusieurs connexions parallèles pour récupérer les flux progressifs. Quand c’est désactivé, une seule connexion est utilisée.</string>
+    <string name="playback_net_http2">Activer HTTP/2</string>
+    <string name="playback_net_http2_sub">Active le protocole HTTP/2 pour les connexions réseau, permettant le multiplexage des requêtes et des établissements de connexion plus rapides.</string>
     <string name="playback_net_parallel">Connexions parallèles</string>
     <string name="playback_net_parallel_sub">Utilise plusieurs connexions en parallèle pour récupérer les flux. Activez cette option si vous rencontrez des mises en mémoire tampon alors que votre vitesse de téléchargement est largement suffisante.</string>
     <string name="playback_net_connection_count">Nombre de connexions</string>


### PR DESCRIPTION
## Summary

Backfills **49** missing French translations (48 strings + 1 plural) for recently-added features, in vouvoiement. Restores translatable EN↔FR parity (the only EN-only keys left are `translatable="false"` Dolby Vision diagnostics). No code, no EN strings, no other locales touched.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

Recent features (playback issue report, buffer/network/performance-mode settings, audio passthrough and HDR10+ stripping, content & discovery settings, hero synopsis, sync-server backend switch, donation progress, QR auth, HTTP/2, original-language option) added English strings without French. This pass translates them so the French UI is complete and uniformly vouvoiement.

## Issue or approval

No linked issue: localization-only update, same scope as previous localization batches.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `app/src/main/res/values-fr/strings.xml` is touched. No EN source strings, no code, no other locales. `translatable="false"` keys untouched. Hardcoded-string audit found nothing extractable in live code paths (only rare fallback labels), so no code changes are included.

## Testing

`xmllint --noout` passes. Translatable parity verified: 2554 EN strings / 2539 FR (the 15 EN-only keys are all `translatable="false"`), 3/3 plurals, 0 translatable missing, 0 orphan. Backfill placeholders verified consistent with EN (`%1$s`, `%2$d`, `%d`, `%%`). Vouvoiement, units Mo/Go, non-breaking spaces before `: ; ? !`, typographic apostrophes. No mojibake, UTF-8.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.