### PR TITLE
Add Xtream Codes IPTV (Live TV, VOD, Series)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -46,6 +46,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LiveTv
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -727,6 +728,13 @@ class MainActivity : ComponentActivity() {
                                     route = Screen.Library.route,
                                     label = strNavLibrary,
                                     iconRes = R.raw.sidebar_library
+                                )
+                            )
+                            add(
+                                DrawerItem(
+                                    route = Screen.XtreamHub.route,
+                                    label = "IPTV",
+                                    icon = Icons.Default.LiveTv
                                 )
                             )
                             add(

--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -87,6 +87,7 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideMoshi(): Moshi = Moshi.Builder()
+        .add(com.nuvio.tv.data.remote.dto.FlexIntAdapter)
         .add(KotlinJsonAdapterFactory())
         .build()
 
@@ -249,6 +250,11 @@ object NetworkModule {
     @Singleton
     fun provideAddonApi(retrofit: Retrofit): AddonApi =
         retrofit.create(AddonApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideXtreamApi(retrofit: Retrofit): com.nuvio.tv.data.remote.api.XtreamApi =
+        retrofit.create(com.nuvio.tv.data.remote.api.XtreamApi::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/nuvio/tv/core/iptv/XtreamClient.kt
+++ b/app/src/main/java/com/nuvio/tv/core/iptv/XtreamClient.kt
@@ -1,0 +1,249 @@
+package com.nuvio.tv.core.iptv
+
+import com.nuvio.tv.data.remote.api.XtreamApi
+import com.nuvio.tv.data.remote.dto.XtreamEpgEntryDto
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import retrofit2.Response
+import java.util.Base64
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** A configured Xtream panel the user has added. */
+data class XtreamAccount(
+    val id: String,            // stable key (the normalized base url)
+    val name: String,          // user-facing label
+    val baseUrl: String,       // e.g. http://host:port  (no trailing slash, no path)
+    val username: String,
+    val password: String,
+    val enabled: Boolean = true
+)
+
+// --- Domain models (what the UI consumes) -----------------------------------
+
+data class XtreamChannel(
+    val streamId: Int,
+    val name: String,
+    val logo: String?,
+    val epgChannelId: String?,
+    val categoryId: String?,
+    val hasArchive: Boolean,
+    val streamUrl: String
+)
+
+data class XtreamMovie(
+    val streamId: Int,
+    val name: String,
+    val poster: String?,
+    val categoryId: String?,
+    val rating: String?,
+    val streamUrl: String
+)
+
+data class XtreamSeriesItem(
+    val seriesId: Int,
+    val name: String,
+    val poster: String?,
+    val categoryId: String?,
+    val plot: String?,
+    val rating: String?
+)
+
+data class XtreamCategory(val id: String, val name: String)
+
+data class XtreamEpisode(
+    val episodeId: String,
+    val season: Int,
+    val episodeNum: Int,
+    val title: String,
+    val plot: String?,
+    val still: String?,
+    val streamUrl: String
+)
+
+data class XtreamSeriesDetail(
+    val tmdbId: Int?,
+    val plot: String?,
+    val backdrop: String?,
+    val episodes: List<XtreamEpisode>
+)
+
+data class XtreamProgram(
+    val title: String,
+    val description: String,
+    val startMs: Long,
+    val endMs: Long,
+    val nowPlaying: Boolean
+)
+
+/**
+ * Talks to one Xtream panel. Builds the `player_api.php` URLs and the live/vod/series
+ * stream URLs, then maps the raw DTOs to domain models.
+ *
+ * ponytail: stream URLs reuse the account's entered baseUrl. Some panels send a
+ * different host in server_info.url for load-balancing — switch to that if a panel
+ * 302s the .ts requests away.
+ */
+@Singleton
+class XtreamClient @Inject constructor(
+    private val api: XtreamApi
+) {
+    /** Verifies credentials. Success only when the panel reports auth=1 and an active status. */
+    suspend fun verify(acc: XtreamAccount): Result<Unit> = call {
+        val info = api.getAccount(playerApi(acc)).requireBody().userInfo
+        check(info?.auth == 1) { "Authentication failed" }
+        val status = info.status?.lowercase().orEmpty()
+        check(status.isEmpty() || status == "active") { "Account status: ${info.status}" }
+    }
+
+    suspend fun liveCategories(acc: XtreamAccount): Result<List<XtreamCategory>> =
+        categories(acc, "get_live_categories")
+
+    suspend fun vodCategories(acc: XtreamAccount): Result<List<XtreamCategory>> =
+        categories(acc, "get_vod_categories")
+
+    suspend fun seriesCategories(acc: XtreamAccount): Result<List<XtreamCategory>> =
+        categories(acc, "get_series_categories")
+
+    suspend fun liveChannels(acc: XtreamAccount, categoryId: String? = null): Result<List<XtreamChannel>> = call {
+        api.getLiveStreams(playerApi(acc, "get_live_streams", categoryId)).requireBody().mapNotNull { dto ->
+            val id = dto.streamId ?: return@mapNotNull null
+            XtreamChannel(
+                streamId = id,
+                name = dto.name.orEmpty(),
+                logo = dto.streamIcon?.takeIf { it.isNotBlank() },
+                epgChannelId = dto.epgChannelId?.takeIf { it.isNotBlank() },
+                categoryId = dto.categoryId,
+                hasArchive = (dto.tvArchive ?: 0) > 0,
+                streamUrl = streamUrl(acc, "live", id, "ts")
+            )
+        }
+    }
+
+    suspend fun vodMovies(acc: XtreamAccount, categoryId: String? = null): Result<List<XtreamMovie>> = call {
+        api.getVodStreams(playerApi(acc, "get_vod_streams", categoryId)).requireBody().mapNotNull { dto ->
+            val id = dto.streamId ?: return@mapNotNull null
+            XtreamMovie(
+                streamId = id,
+                name = dto.name.orEmpty(),
+                poster = dto.streamIcon?.takeIf { it.isNotBlank() },
+                categoryId = dto.categoryId,
+                rating = dto.rating,
+                streamUrl = streamUrl(acc, "movie", id, dto.containerExtension?.takeIf { it.isNotBlank() } ?: "mp4")
+            )
+        }
+    }
+
+    suspend fun series(acc: XtreamAccount, categoryId: String? = null): Result<List<XtreamSeriesItem>> = call {
+        api.getSeries(playerApi(acc, "get_series", categoryId)).requireBody().mapNotNull { dto ->
+            val id = dto.seriesId ?: return@mapNotNull null
+            XtreamSeriesItem(id, dto.name.orEmpty(), dto.cover?.takeIf { it.isNotBlank() }, dto.categoryId, dto.plot, dto.rating)
+        }
+    }
+
+    /** Now + next few programs for a channel (cheap, one call). Full XMLTV grid is the upgrade path. */
+    suspend fun shortEpg(acc: XtreamAccount, streamId: Int, limit: Int = 4): Result<List<XtreamProgram>> = call {
+        val url = playerApi(acc, "get_short_epg").toHttpUrl().newBuilder()
+            .addQueryParameter("stream_id", streamId.toString())
+            .addQueryParameter("limit", limit.toString())
+            .build().toString()
+        api.getShortEpg(url).requireBody().listings.orEmpty().map { it.toProgram() }
+    }
+
+    /** Full episode list (across seasons) for a series, each with its built stream URL. */
+    suspend fun seriesInfo(acc: XtreamAccount, seriesId: Int): Result<XtreamSeriesDetail> = call {
+        val url = playerApi(acc, "get_series_info").toHttpUrl().newBuilder()
+            .addQueryParameter("series_id", seriesId.toString())
+            .build().toString()
+        val resp = api.getSeriesInfo(url).requireBody()
+        val episodes = resp.episodes.orEmpty().flatMap { (seasonKey, list) ->
+            list.mapNotNull { e ->
+                val epId = e.id?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val ext = e.containerExtension?.takeIf { it.isNotBlank() } ?: "mp4"
+                XtreamEpisode(
+                    episodeId = epId,
+                    season = e.season ?: seasonKey.toIntOrNull() ?: 1,
+                    episodeNum = e.episodeNum ?: 0,
+                    title = e.title.orEmpty().ifBlank { "Episode" },
+                    plot = e.info?.plot,
+                    still = e.info?.movieImage?.takeIf { it.isNotBlank() },
+                    streamUrl = seriesEpisodeUrl(acc, epId, ext)
+                )
+            }
+        }.sortedWith(compareBy({ it.season }, { it.episodeNum }))
+        XtreamSeriesDetail(
+            tmdbId = resp.info?.tmdbId?.takeIf { it > 0 },
+            plot = resp.info?.plot,
+            backdrop = resp.info?.backdropPath?.firstOrNull(),
+            episodes = episodes
+        )
+    }
+
+    private fun seriesEpisodeUrl(acc: XtreamAccount, episodeId: String, ext: String): String =
+        (acc.baseUrl.toHttpUrlOrNull() ?: error("Invalid server URL"))
+            .newBuilder()
+            .addPathSegment("series").addPathSegment(acc.username).addPathSegment(acc.password)
+            .addPathSegment("$episodeId.$ext")
+            .build().toString()
+
+    /** Fetches a VOD item's TMDB id (for native art/metadata enrichment). null if the panel doesn't provide one. */
+    suspend fun vodTmdbId(acc: XtreamAccount, vodId: Int): Result<Int?> = call {
+        val url = playerApi(acc, "get_vod_info").toHttpUrl().newBuilder()
+            .addQueryParameter("vod_id", vodId.toString())
+            .build().toString()
+        api.getVodInfo(url).requireBody().info?.tmdbId?.takeIf { it > 0 }
+    }
+
+    // --- URL building --------------------------------------------------------
+
+    private fun playerApi(acc: XtreamAccount, action: String? = null, categoryId: String? = null): String {
+        val b = (acc.baseUrl.toHttpUrlOrNull() ?: error("Invalid server URL"))
+            .newBuilder()
+            .addPathSegment("player_api.php")
+            .addQueryParameter("username", acc.username)
+            .addQueryParameter("password", acc.password)
+        if (action != null) b.addQueryParameter("action", action)
+        if (categoryId != null) b.addQueryParameter("category_id", categoryId)
+        return b.build().toString()
+    }
+
+    private fun streamUrl(acc: XtreamAccount, kind: String, id: Int, ext: String): String =
+        (acc.baseUrl.toHttpUrlOrNull() ?: error("Invalid server URL"))
+            .newBuilder()
+            .addPathSegment(kind)
+            .addPathSegment(acc.username)
+            .addPathSegment(acc.password)
+            .addPathSegment("$id.$ext")
+            .build().toString()
+
+    private suspend fun categories(acc: XtreamAccount, action: String): Result<List<XtreamCategory>> = call {
+        api.getCategories(playerApi(acc, action)).requireBody().mapNotNull { dto ->
+            val id = dto.categoryId ?: return@mapNotNull null
+            XtreamCategory(id, dto.categoryName.orEmpty())
+        }
+    }
+
+    private fun String.toHttpUrl(): HttpUrl = toHttpUrlOrNull() ?: error("Invalid URL")
+
+    private inline fun <T> call(block: () -> T): Result<T> =
+        runCatching { block() }
+
+    private fun <T> Response<T>.requireBody(): T {
+        if (!isSuccessful) error("HTTP ${code()}: ${message()}")
+        return body() ?: error("Empty response")
+    }
+}
+
+internal fun XtreamEpgEntryDto.toProgram(): XtreamProgram = XtreamProgram(
+    title = decodeXtreamBase64(title),
+    description = decodeXtreamBase64(description),
+    startMs = (startTimestamp?.toLongOrNull() ?: 0L) * 1000,
+    endMs = (stopTimestamp?.toLongOrNull() ?: 0L) * 1000,
+    nowPlaying = nowPlaying == 1
+)
+
+/** Xtream base64-encodes EPG title/description. Returns "" on null/garbage rather than throwing. */
+internal fun decodeXtreamBase64(s: String?): String {
+    if (s.isNullOrBlank()) return ""
+    return runCatching { String(Base64.getDecoder().decode(s.trim()), Charsets.UTF_8) }.getOrDefault(s)
+}

--- a/app/src/main/java/com/nuvio/tv/core/iptv/XtreamItemRegistry.kt
+++ b/app/src/main/java/com/nuvio/tv/core/iptv/XtreamItemRegistry.kt
@@ -1,0 +1,107 @@
+package com.nuvio.tv.core.iptv
+
+import com.nuvio.tv.domain.model.AddonStreams
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.Meta
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.model.Stream
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class XtreamKind { VOD, SERIES, LIVE }
+
+/** A resolved Xtream catalog item, keyed by its `xtream:` content id. */
+data class XtreamResolvedItem(
+    val id: String,
+    val type: ContentType,
+    val name: String,
+    val poster: String?,
+    val background: String? = null,
+    val description: String? = null,
+    val releaseInfo: String? = null,
+    val imdbRating: Float? = null,
+    val genres: List<String> = emptyList(),
+    val runtime: String? = null,
+    val streamUrl: String,
+    val kind: XtreamKind = XtreamKind.VOD,
+    // For on-detail TMDB enrichment + series episode fetch (get_vod_info / get_series_info).
+    val accountId: String = "",
+    val streamId: Int = 0
+)
+
+/**
+ * In-memory map of `xtream:` content id -> resolved item, populated as Xtream catalogs load.
+ * The meta + stream repositories read from it to short-circuit resolution for Xtream ids
+ * (HYBRID LANE: Xtream content resolves its own meta + single direct stream, bypassing
+ * addon/debrid). No id parsing needed — the id is just a unique key checked by [PREFIX].
+ *
+ * ponytail: a process-lifetime cache. Deep-linking to an xtream id never browsed this session
+ * misses; the upgrade path is a get_vod_info fallback fetch (Phase D).
+ */
+@Singleton
+class XtreamItemRegistry @Inject constructor() {
+    private val items = ConcurrentHashMap<String, XtreamResolvedItem>()
+
+    fun register(item: XtreamResolvedItem) { items[item.id] = item }
+    fun get(id: String): XtreamResolvedItem? = items[id]
+    fun isXtreamId(id: String): Boolean = id.startsWith(PREFIX)
+
+    companion object {
+        const val PREFIX = "xtream:"
+        /** Stable, collision-free per-playlist content ids. accountId may contain ':'/'|' — fine, it's only a map key + prefix check. */
+        fun vodId(accountId: String, streamId: Int): String = "$PREFIX$accountId:vod:$streamId"
+        fun seriesId(accountId: String, seriesId: Int): String = "$PREFIX$accountId:series:$seriesId"
+        fun episodeId(accountId: String, episodeId: String): String = "$PREFIX$accountId:episode:$episodeId"
+        fun liveId(accountId: String, streamId: Int): String = "$PREFIX$accountId:live:$streamId"
+        /** True for a live-channel content id. accountId can't be parsed (may contain ':'),
+         *  but the kind segment is unambiguous: vod/series/episode/live are the only suffixes. */
+        fun isLiveContentId(id: String): Boolean = id.startsWith(PREFIX) && id.contains(":live:")
+    }
+}
+
+/** Builds a full [Meta] for Nuvio's native detail screen from a resolved Xtream item. */
+fun XtreamResolvedItem.toMeta(): Meta = Meta(
+    id = id,
+    type = type,
+    name = name,
+    poster = poster,
+    posterShape = PosterShape.POSTER,
+    background = background,
+    logo = null,
+    description = description,
+    releaseInfo = releaseInfo,
+    imdbRating = imdbRating,
+    genres = genres,
+    runtime = runtime,
+    director = emptyList(),
+    cast = emptyList(),
+    videos = emptyList(),
+    country = null,
+    awards = null,
+    language = null,
+    links = emptyList()
+)
+
+/** The single direct stream for an Xtream item, presented as one addon group. */
+fun XtreamResolvedItem.toAddonStreams(): List<AddonStreams> = listOf(
+    AddonStreams(
+        addonName = "Xtream IPTV",
+        addonLogo = null,
+        streams = listOf(
+            Stream(
+                name = "Direct",
+                title = name,
+                description = null,
+                url = streamUrl,
+                ytId = null,
+                infoHash = null,
+                fileIdx = null,
+                externalUrl = null,
+                behaviorHints = null,
+                addonName = "Xtream IPTV",
+                addonLogo = null
+            )
+        )
+    )
+)

--- a/app/src/main/java/com/nuvio/tv/core/iptv/XtreamLivePlaylist.kt
+++ b/app/src/main/java/com/nuvio/tv/core/iptv/XtreamLivePlaylist.kt
@@ -1,0 +1,29 @@
+package com.nuvio.tv.core.iptv
+
+import com.nuvio.tv.data.local.LiveChannelRef
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The ordered channel list currently being watched, so the fullscreen player can zap
+ * up/down to the next/previous channel (TiViMate-style). The guide sets it before launching
+ * a channel; the player reads the neighbour of the channel it's on.
+ *
+ * ponytail: a single process-lifetime list — only one live session is active at a time.
+ */
+@Singleton
+class XtreamLivePlaylist @Inject constructor() {
+    @Volatile private var channels: List<LiveChannelRef> = emptyList()
+
+    fun set(list: List<LiveChannelRef>) { channels = list }
+
+    /** The channel [delta] steps from [contentId] (e.g. +1 = next, -1 = previous), or null
+     *  if there's no list / no neighbour in that direction. */
+    fun relativeTo(contentId: String, delta: Int): LiveChannelRef? {
+        val list = channels
+        val i = list.indexOfFirst { it.id == contentId }
+        if (i < 0) return null
+        val j = i + delta
+        return list.getOrNull(j)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/iptv/XtreamSearchIndex.kt
+++ b/app/src/main/java/com/nuvio/tv/core/iptv/XtreamSearchIndex.kt
@@ -1,0 +1,129 @@
+package com.nuvio.tv.core.iptv
+
+import android.util.Log
+import com.nuvio.tv.data.local.XtreamAccountStore
+import com.nuvio.tv.domain.model.ContentType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Lets Xtream content show up in the platform search. Xtream panels have NO search
+ * endpoint, so we fetch each enabled account's full live/vod/series lists once (lazily,
+ * on the first IPTV search) and filter them in memory on each query.
+ *
+ * ponytail: caps each list at [MAX_INDEX] items to bound memory on a TV — a panel with
+ * 174k VOD won't all fit, so titles past the cap aren't searchable (logged). The upgrade
+ * path is a real on-device index (Room/FTS) if that ceiling ever bites.
+ */
+@Singleton
+class XtreamSearchIndex @Inject constructor(
+    private val store: XtreamAccountStore,
+    private val client: XtreamClient,
+    private val registry: XtreamItemRegistry
+) {
+    /** A search match, ready to become a MetaPreview + click target. */
+    data class Hit(
+        val contentId: String,
+        val name: String,
+        val poster: String?,
+        val isLive: Boolean,
+        val streamUrl: String?,
+        val detailType: String
+    )
+
+    data class Results(val channels: List<Hit>, val movies: List<Hit>, val series: List<Hit>)
+
+    // Cached per accountId so a slow VOD fetch doesn't block channel/series search.
+    private val liveCache = ConcurrentHashMap<String, List<XtreamChannel>>()
+    private val vodCache = ConcurrentHashMap<String, List<XtreamMovie>>()
+    private val seriesCache = ConcurrentHashMap<String, List<XtreamSeriesItem>>()
+    private val vodLoading = ConcurrentHashMap.newKeySet<String>()
+    private val scope = CoroutineScope(SupervisorJob())
+
+    /** Awaits the fast lists (live + series); VOD (often 100k+) loads in the background
+     *  so the channel/series rows appear immediately and movies fill in on a later search. */
+    private suspend fun ensureLoaded() = coroutineScope {
+        val accounts = store.accounts.first().filter { it.enabled }
+        accounts.map { acc ->
+            async {
+                if (!liveCache.containsKey(acc.id)) {
+                    val live = client.liveChannels(acc).getOrDefault(emptyList())
+                    liveCache[acc.id] = live.take(MAX_INDEX)
+                    Log.d(TAG, "indexed live=${live.size} for ${acc.name}")
+                }
+                if (!seriesCache.containsKey(acc.id)) {
+                    val s = client.series(acc).getOrDefault(emptyList())
+                    seriesCache[acc.id] = s.take(MAX_INDEX)
+                    Log.d(TAG, "indexed series=${s.size} for ${acc.name}")
+                }
+                if (!vodCache.containsKey(acc.id) && vodLoading.add(acc.id)) {
+                    scope.launch {
+                        val vod = client.vodMovies(acc).getOrDefault(emptyList())
+                        vodCache[acc.id] = vod.take(MAX_INDEX)
+                        Log.d(TAG, "indexed vod=${vod.size} for ${acc.name}")
+                    }
+                }
+            }
+        }.awaitAll()
+    }
+
+    suspend fun search(query: String): Results {
+        val q = query.trim().lowercase()
+        if (q.length < 2) return Results(emptyList(), emptyList(), emptyList())
+        ensureLoaded()
+        val accounts = store.accounts.first().filter { it.enabled }
+        val channels = ArrayList<Hit>()
+        val movies = ArrayList<Hit>()
+        val series = ArrayList<Hit>()
+        for (acc in accounts) {
+            liveCache[acc.id].orEmpty().asSequence().filter { it.name.lowercase().contains(q) }.take(PER_ACCOUNT).forEach { ch ->
+                val id = XtreamItemRegistry.liveId(acc.id, ch.streamId)
+                registry.register(
+                    XtreamResolvedItem(
+                        id = id, type = ContentType.TV, name = ch.name, poster = ch.logo,
+                        streamUrl = ch.streamUrl, kind = XtreamKind.LIVE, accountId = acc.id, streamId = ch.streamId
+                    )
+                )
+                channels += Hit(id, ch.name, ch.logo, isLive = true, streamUrl = ch.streamUrl, detailType = "tv")
+            }
+            vodCache[acc.id].orEmpty().asSequence().filter { it.name.lowercase().contains(q) }.take(PER_ACCOUNT).forEach { m ->
+                val id = XtreamItemRegistry.vodId(acc.id, m.streamId)
+                registry.register(
+                    XtreamResolvedItem(
+                        id = id, type = ContentType.MOVIE, name = m.name, poster = m.poster,
+                        imdbRating = m.rating?.toFloatOrNull(), streamUrl = m.streamUrl,
+                        accountId = acc.id, streamId = m.streamId
+                    )
+                )
+                movies += Hit(id, m.name, m.poster, isLive = false, streamUrl = null, detailType = "movie")
+            }
+            seriesCache[acc.id].orEmpty().asSequence().filter { it.name.lowercase().contains(q) }.take(PER_ACCOUNT).forEach { s ->
+                val id = XtreamItemRegistry.seriesId(acc.id, s.seriesId)
+                registry.register(
+                    XtreamResolvedItem(
+                        id = id, type = ContentType.SERIES, name = s.name, poster = s.poster,
+                        description = s.plot, imdbRating = s.rating?.toFloatOrNull(),
+                        streamUrl = "", kind = XtreamKind.SERIES, accountId = acc.id, streamId = s.seriesId
+                    )
+                )
+                series += Hit(id, s.name, s.poster, isLive = false, streamUrl = null, detailType = "series")
+            }
+        }
+        return Results(channels.take(DISPLAY), movies.take(DISPLAY), series.take(DISPLAY))
+    }
+
+    companion object {
+        private const val TAG = "XtreamSearchIndex"
+        private const val MAX_INDEX = 40000
+        private const val PER_ACCOUNT = 60
+        private const val DISPLAY = 60
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/iptv/XtreamUrlParser.kt
+++ b/app/src/main/java/com/nuvio/tv/core/iptv/XtreamUrlParser.kt
@@ -1,0 +1,59 @@
+package com.nuvio.tv.core.iptv
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/**
+ * Turns whatever the user pastes into an [XtreamAccount]. IPTV users always have a
+ * portal/M3U URL, so we accept any of:
+ *   http://host:port/get.php?username=U&password=P&type=m3u_plus&output=ts
+ *   http://host:port/player_api.php?username=U&password=P
+ *   http://host:port/?username=U&password=P
+ * The path is ignored; we only need scheme+host+port and the username/password query params.
+ *
+ * ponytail: single paste field beats a 3-field TV form. Manual host/user/pass entry is
+ * the upgrade path if someone has creds without a URL.
+ */
+fun parseXtreamAccount(input: String, name: String? = null): XtreamAccount? {
+    val url = input.trim().toHttpUrlOrNull() ?: return null
+    val user = url.queryParameter("username")?.takeIf { it.isNotBlank() } ?: return null
+    val pass = url.queryParameter("password")?.takeIf { it.isNotBlank() } ?: return null
+    val defaultPort = if (url.scheme == "https") 443 else 80
+    val base = buildString {
+        append(url.scheme).append("://").append(url.host)
+        if (url.port != defaultPort) append(":").append(url.port)
+    }
+    return XtreamAccount(
+        id = "$base|$user",
+        name = name?.trim()?.takeIf { it.isNotEmpty() } ?: url.host,
+        baseUrl = base,
+        username = user,
+        password = pass
+    )
+}
+
+/**
+ * Builds an account from manually-entered fields (server/portal URL + username + password).
+ * The server field may be "host", "host:port", or a full "http(s)://host:port[/path]" — we keep
+ * only scheme+host+port. Defaults to http when no scheme is given (Xtream panels are usually http).
+ */
+fun xtreamAccountFromFields(serverUrl: String, username: String, password: String, name: String? = null): XtreamAccount? {
+    val user = username.trim()
+    val pass = password.trim()
+    if (user.isEmpty() || pass.isEmpty()) return null
+    val raw = serverUrl.trim()
+    if (raw.isEmpty()) return null
+    val withScheme = if (raw.startsWith("http://") || raw.startsWith("https://")) raw else "http://$raw"
+    val url = withScheme.toHttpUrlOrNull() ?: return null
+    val defaultPort = if (url.scheme == "https") 443 else 80
+    val base = buildString {
+        append(url.scheme).append("://").append(url.host)
+        if (url.port != defaultPort) append(":").append(url.port)
+    }
+    return XtreamAccount(
+        id = "$base|$user",
+        name = name?.trim()?.takeIf { it.isNotEmpty() } ?: url.host,
+        baseUrl = base,
+        username = user,
+        password = pass
+    )
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/XtreamAccountStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/XtreamAccountStore.kt
@@ -1,0 +1,71 @@
+package com.nuvio.tv.data.local
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.profile.ProfileManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persists the list of configured Xtream IPTV accounts, profile-scoped, as JSON.
+ * Mirrors [AddonPreferences]' list-in-DataStore pattern.
+ *
+ * ponytail: credentials stored in plaintext, same as the existing Debrid API keys.
+ * Encrypt-at-rest is the upgrade path if the app ever adds it for Debrid too.
+ */
+@Singleton
+class XtreamAccountStore @Inject constructor(
+    private val factory: ProfileDataStoreFactory,
+    private val profileManager: ProfileManager
+) {
+    private val gson = Gson()
+    private val accountsKey = stringPreferencesKey("xtream_accounts")
+
+    private fun store(pid: Int = profileManager.activeProfileId.value) = factory.get(pid, FEATURE)
+
+    val accounts: Flow<List<XtreamAccount>> = profileManager.activeProfileId.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map { prefs -> parse(prefs[accountsKey]) }
+    }
+
+    /** Insert or replace by id (id = baseUrl|username). */
+    suspend fun upsert(account: XtreamAccount) {
+        store().edit { prefs ->
+            val current = parse(prefs[accountsKey]).toMutableList()
+            val i = current.indexOfFirst { it.id == account.id }
+            if (i >= 0) current[i] = account else current.add(account)
+            prefs[accountsKey] = gson.toJson(current)
+        }
+    }
+
+    suspend fun remove(id: String) {
+        store().edit { prefs ->
+            prefs[accountsKey] = gson.toJson(parse(prefs[accountsKey]).filterNot { it.id == id })
+        }
+    }
+
+    suspend fun setEnabled(id: String, enabled: Boolean) {
+        store().edit { prefs ->
+            val updated = parse(prefs[accountsKey]).map { if (it.id == id) it.copy(enabled = enabled) else it }
+            prefs[accountsKey] = gson.toJson(updated)
+        }
+    }
+
+    private fun parse(json: String?): List<XtreamAccount> {
+        if (json.isNullOrBlank()) return emptyList()
+        return try {
+            gson.fromJson(json, object : TypeToken<List<XtreamAccount>>() {}.type) ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    companion object {
+        private const val FEATURE = "xtream_accounts"
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/XtreamLiveStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/XtreamLiveStore.kt
@@ -1,0 +1,107 @@
+package com.nuvio.tv.data.local
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.nuvio.tv.core.profile.ProfileManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** A live channel we can replay later (favorited or recently watched). Carries its own
+ *  stream URL because the `xtream:` id can't be parsed back into one (accountId has ':'). */
+data class LiveChannelRef(
+    val id: String,
+    val name: String,
+    val logo: String?,
+    val streamUrl: String,
+    val playedAt: Long? = null
+)
+
+/**
+ * Profile-scoped persistence for live channels that need to outlive a browse session:
+ * favorites (so the platform Library can play them on click) and recently-watched
+ * (so the hub can show a "Recent Channels" row). Mirrors [XtreamAccountStore].
+ *
+ * ponytail: one flat list capped at 200, LRU-trimmed. Plenty for personal use; a real
+ * DB is the upgrade path only if someone favorites hundreds of channels.
+ */
+@Singleton
+class XtreamLiveStore @Inject constructor(
+    private val factory: ProfileDataStoreFactory,
+    private val profileManager: ProfileManager
+) {
+    private val gson = Gson()
+    private val key = stringPreferencesKey("xtream_live_channels")
+    private val scope = CoroutineScope(SupervisorJob())
+
+    /** In-memory mirror for synchronous url lookup from the Library click router. */
+    private val mirror = ConcurrentHashMap<String, LiveChannelRef>()
+
+    private fun store(pid: Int = profileManager.activeProfileId.value) = factory.get(pid, FEATURE)
+
+    private val all: Flow<List<LiveChannelRef>> = profileManager.activeProfileId.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map { prefs -> parse(prefs[key]) }
+    }
+
+    init {
+        // Keep the mirror warm so urlFor() resolves without suspending.
+        all.onEach { list ->
+            mirror.clear()
+            list.forEach { mirror[it.id] = it }
+        }.launchIn(scope)
+    }
+
+    val recents: Flow<List<LiveChannelRef>> = all.map { list ->
+        list.filter { it.playedAt != null }.sortedByDescending { it.playedAt }.take(RECENTS_LIMIT)
+    }
+
+    /** Synchronous resolution for replaying a favorited/recent channel by id. */
+    fun urlFor(id: String): String? = mirror[id]?.streamUrl
+    fun refFor(id: String): LiveChannelRef? = mirror[id]
+
+    /** Persist a channel so it can be replayed later (favorite path). Preserves recency. */
+    suspend fun remember(ref: LiveChannelRef) = upsert(ref, markPlayed = false)
+
+    /** Record a channel as just-watched (recents + replayable). */
+    suspend fun recordPlayed(ref: LiveChannelRef) = upsert(ref, markPlayed = true)
+
+    private suspend fun upsert(ref: LiveChannelRef, markPlayed: Boolean) {
+        store().edit { prefs ->
+            val current = parse(prefs[key]).toMutableList()
+            val existing = current.firstOrNull { it.id == ref.id }
+            val playedAt = when {
+                markPlayed -> System.currentTimeMillis()
+                else -> existing?.playedAt
+            }
+            current.removeAll { it.id == ref.id }
+            current.add(0, ref.copy(playedAt = playedAt))
+            // LRU trim: keep the most recently touched (front = newest).
+            val trimmed = current.take(MAX_CHANNELS)
+            prefs[key] = gson.toJson(trimmed)
+        }
+    }
+
+    private fun parse(json: String?): List<LiveChannelRef> {
+        if (json.isNullOrBlank()) return emptyList()
+        return try {
+            gson.fromJson(json, object : TypeToken<List<LiveChannelRef>>() {}.type) ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    companion object {
+        private const val FEATURE = "xtream_accounts"   // reuse the IPTV datastore file
+        private const val RECENTS_LIMIT = 20
+        private const val MAX_CHANNELS = 200
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/XtreamApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/XtreamApi.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.data.remote.api
+
+import com.nuvio.tv.data.remote.dto.XtreamAccountDto
+import com.nuvio.tv.data.remote.dto.XtreamCategoryDto
+import com.nuvio.tv.data.remote.dto.XtreamLiveStreamDto
+import com.nuvio.tv.data.remote.dto.XtreamSeriesDto
+import com.nuvio.tv.data.remote.dto.XtreamSeriesInfoResponseDto
+import com.nuvio.tv.data.remote.dto.XtreamShortEpgResponseDto
+import com.nuvio.tv.data.remote.dto.XtreamVodInfoResponseDto
+import com.nuvio.tv.data.remote.dto.XtreamVodStreamDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+/**
+ * Xtream Codes API. Every call hits `player_api.php` on the user's own panel,
+ * so URLs are built by [com.nuvio.tv.core.iptv.XtreamClient] and passed via @Url
+ * (same pattern as [AddonApi]).
+ */
+interface XtreamApi {
+
+    @GET
+    suspend fun getAccount(@Url url: String): Response<XtreamAccountDto>
+
+    @GET
+    suspend fun getCategories(@Url url: String): Response<List<XtreamCategoryDto>>
+
+    @GET
+    suspend fun getLiveStreams(@Url url: String): Response<List<XtreamLiveStreamDto>>
+
+    @GET
+    suspend fun getVodStreams(@Url url: String): Response<List<XtreamVodStreamDto>>
+
+    @GET
+    suspend fun getSeries(@Url url: String): Response<List<XtreamSeriesDto>>
+
+    @GET
+    suspend fun getShortEpg(@Url url: String): Response<XtreamShortEpgResponseDto>
+
+    @GET
+    suspend fun getVodInfo(@Url url: String): Response<XtreamVodInfoResponseDto>
+
+    @GET
+    suspend fun getSeriesInfo(@Url url: String): Response<XtreamSeriesInfoResponseDto>
+}

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/XtreamDto.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/XtreamDto.kt
@@ -1,0 +1,161 @@
+package com.nuvio.tv.data.remote.dto
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+
+/**
+ * Xtream Codes `player_api.php` response shapes. Only the fields we actually use
+ * are modelled.
+ *
+ * Real panels are wildly inconsistent about numeric types: the SAME field is an int
+ * on one panel and a quoted string (or a bool) on another (verified live — e.g.
+ * tmdb_id is "936075" on one server, 24831 on another). So every numeric field that
+ * isn't free-text uses [@FlexInt], which tolerates number | "string" | true/false.
+ * category_id stays String (always quoted in practice).
+ *
+ * ponytail: minimal field set, add fields when a screen needs them.
+ */
+
+/** Marks an Int field that may arrive as a JSON number, a quoted string, or a bool. */
+@Retention(AnnotationRetention.RUNTIME)
+@JsonQualifier
+annotation class FlexInt
+
+/** Coerces number | "string" | true/false | null -> Int?. Registered on the app Moshi. */
+object FlexIntAdapter {
+    @FromJson
+    @FlexInt
+    fun fromJson(reader: JsonReader): Int? = when (reader.peek()) {
+        JsonReader.Token.NUMBER -> reader.nextInt()
+        JsonReader.Token.STRING -> reader.nextString().trim().toIntOrNull()
+        JsonReader.Token.BOOLEAN -> if (reader.nextBoolean()) 1 else 0
+        JsonReader.Token.NULL -> reader.nextNull()
+        else -> { reader.skipValue(); null }
+    }
+
+    @ToJson
+    fun toJson(writer: JsonWriter, @FlexInt value: Int?) {
+        writer.value(value?.toLong())
+    }
+}
+
+// player_api.php?username=U&password=P  (no action)
+data class XtreamAccountDto(
+    @Json(name = "user_info") val userInfo: XtreamUserInfoDto?,
+    @Json(name = "server_info") val serverInfo: XtreamServerInfoDto?
+)
+
+data class XtreamUserInfoDto(
+    val username: String?,
+    val password: String?,
+    @FlexInt val auth: Int?,        // 1 = ok
+    val status: String?,            // "Active", "Expired", ...
+    @Json(name = "exp_date") val expDate: String?,   // unix seconds (string) or null = unlimited
+    @Json(name = "active_cons") val activeConnections: String?,
+    @Json(name = "max_connections") val maxConnections: String?
+)
+
+data class XtreamServerInfoDto(
+    val url: String?,
+    val port: String?,
+    @Json(name = "https_port") val httpsPort: String?,
+    @Json(name = "server_protocol") val serverProtocol: String?   // "http" | "https"
+)
+
+data class XtreamCategoryDto(
+    @Json(name = "category_id") val categoryId: String?,
+    @Json(name = "category_name") val categoryName: String?,
+    @FlexInt @Json(name = "parent_id") val parentId: Int?
+)
+
+// action=get_live_streams
+data class XtreamLiveStreamDto(
+    @FlexInt val num: Int?,
+    val name: String?,
+    @FlexInt @Json(name = "stream_id") val streamId: Int?,
+    @Json(name = "stream_icon") val streamIcon: String?,
+    @Json(name = "epg_channel_id") val epgChannelId: String?,
+    @Json(name = "category_id") val categoryId: String?,
+    @FlexInt @Json(name = "tv_archive") val tvArchive: Int?
+)
+
+// action=get_vod_streams
+data class XtreamVodStreamDto(
+    @FlexInt val num: Int?,
+    val name: String?,
+    @FlexInt @Json(name = "stream_id") val streamId: Int?,
+    @Json(name = "stream_icon") val streamIcon: String?,
+    @Json(name = "category_id") val categoryId: String?,
+    @Json(name = "container_extension") val containerExtension: String?,
+    val rating: String?,
+    @Json(name = "added") val added: String?
+)
+
+// action=get_series
+data class XtreamSeriesDto(
+    @FlexInt @Json(name = "series_id") val seriesId: Int?,
+    val name: String?,
+    val cover: String?,
+    @Json(name = "category_id") val categoryId: String?,
+    val plot: String?,
+    val rating: String?
+)
+
+// action=get_vod_info&vod_id=X -> { info: {...}, movie_data: {...} }
+// If a panel returns "info": [] (empty array) the body fails to parse and the caller
+// falls back to non-enriched meta — acceptable (no tmdb_id available there anyway).
+data class XtreamVodInfoResponseDto(
+    val info: XtreamVodInfoDto?
+)
+
+data class XtreamVodInfoDto(
+    @FlexInt @Json(name = "tmdb_id") val tmdbId: Int?
+)
+
+// action=get_series_info&series_id=X -> { info:{...}, episodes: { "1":[...], "2":[...] } }
+data class XtreamSeriesInfoResponseDto(
+    val info: XtreamSeriesInfoDto?,
+    val episodes: Map<String, List<XtreamEpisodeDto>>?
+)
+
+data class XtreamSeriesInfoDto(
+    val name: String?,
+    val cover: String?,
+    val plot: String?,
+    val genre: String?,
+    @Json(name = "backdrop_path") val backdropPath: List<String>?,
+    @FlexInt @Json(name = "tmdb_id") val tmdbId: Int?
+)
+
+data class XtreamEpisodeDto(
+    val id: String?,                 // episode/stream id (string)
+    @FlexInt @Json(name = "episode_num") val episodeNum: Int?,
+    val title: String?,
+    @Json(name = "container_extension") val containerExtension: String?,
+    @FlexInt val season: Int?,
+    val info: XtreamEpisodeInfoDto?
+)
+
+data class XtreamEpisodeInfoDto(
+    val plot: String?,
+    @Json(name = "movie_image") val movieImage: String?,
+    val duration: String?
+)
+
+// action=get_short_epg -> { epg_listings: [...] }
+data class XtreamShortEpgResponseDto(
+    @Json(name = "epg_listings") val listings: List<XtreamEpgEntryDto>?
+)
+
+data class XtreamEpgEntryDto(
+    val id: String?,
+    val title: String?,            // base64
+    val description: String?,      // base64
+    @Json(name = "start_timestamp") val startTimestamp: String?,  // unix seconds (string)
+    @Json(name = "stop_timestamp") val stopTimestamp: String?,
+    @FlexInt @Json(name = "now_playing") val nowPlaying: Int?
+)

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.nuvio.tv.core.network.safeApiCall
 import com.nuvio.tv.data.mapper.toDomain
 import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.core.iptv.toMeta
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.AddonResource
 import com.nuvio.tv.domain.model.enabledAddons
@@ -31,7 +32,11 @@ import javax.inject.Singleton
 class MetaRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val api: AddonApi,
-    private val addonRepository: AddonRepository
+    private val addonRepository: AddonRepository,
+    private val xtreamRegistry: com.nuvio.tv.core.iptv.XtreamItemRegistry,
+    private val xtreamClient: com.nuvio.tv.core.iptv.XtreamClient,
+    private val xtreamAccountStore: com.nuvio.tv.data.local.XtreamAccountStore,
+    private val tmdbMetadataService: com.nuvio.tv.core.tmdb.TmdbMetadataService
 ) : MetaRepository {
     companion object {
         private const val TAG = "MetaRepository"
@@ -112,11 +117,101 @@ class MetaRepositoryImpl @Inject constructor(
         }
     }
 
+    /**
+     * Builds a [Meta] for an Xtream item. Tries TMDB enrichment (get_vod_info -> tmdb_id ->
+     * fetchEnrichment) for a native-looking detail (backdrop/logo/cast/plot); falls back to the
+     * bare Xtream data if no tmdb_id or enrichment is available.
+     */
+    private suspend fun buildXtreamMeta(item: com.nuvio.tv.core.iptv.XtreamResolvedItem): Meta =
+        when (item.kind) {
+            com.nuvio.tv.core.iptv.XtreamKind.SERIES -> buildXtreamSeriesMeta(item)
+            else -> buildXtreamVodMeta(item)
+        }
+
+    /** Series: fetch episodes (get_series_info), register each for playback, build a Meta with videos. */
+    private suspend fun buildXtreamSeriesMeta(item: com.nuvio.tv.core.iptv.XtreamResolvedItem): Meta {
+        val base = item.toMeta()
+        val account = runCatching { xtreamAccountStore.accounts.first() }.getOrNull()
+            ?.firstOrNull { it.id == item.accountId } ?: return base
+        val detail = xtreamClient.seriesInfo(account, item.streamId).getOrNull() ?: return base
+        val videos = detail.episodes.map { ep ->
+            val epId = com.nuvio.tv.core.iptv.XtreamItemRegistry.episodeId(account.id, ep.episodeId)
+            xtreamRegistry.register(
+                com.nuvio.tv.core.iptv.XtreamResolvedItem(
+                    id = epId, type = com.nuvio.tv.domain.model.ContentType.SERIES, name = ep.title,
+                    poster = ep.still, streamUrl = ep.streamUrl, accountId = account.id
+                )
+            )
+            com.nuvio.tv.domain.model.Video(
+                id = epId, title = ep.title, released = null, thumbnail = ep.still,
+                season = ep.season, episode = ep.episodeNum, overview = ep.plot
+            )
+        }
+        val enrichment = detail.tmdbId?.let {
+            runCatching { tmdbMetadataService.fetchEnrichment(it.toString(), com.nuvio.tv.domain.model.ContentType.SERIES) }.getOrNull()
+        }
+        return base.copy(
+            type = com.nuvio.tv.domain.model.ContentType.SERIES,
+            videos = videos,
+            poster = enrichment?.poster ?: base.poster,
+            background = enrichment?.backdrop ?: detail.backdrop,
+            logo = enrichment?.logo,
+            description = enrichment?.description ?: detail.plot ?: base.description,
+            releaseInfo = enrichment?.releaseInfo ?: base.releaseInfo,
+            imdbRating = enrichment?.rating?.toFloat() ?: base.imdbRating,
+            genres = enrichment?.genres?.ifEmpty { base.genres } ?: base.genres,
+            cast = enrichment?.castMembers?.map { it.name } ?: emptyList(),
+            castMembers = enrichment?.castMembers ?: emptyList()
+        )
+    }
+
+    /** Movies: optional get_vod_info -> tmdb_id -> TMDB enrichment for a native-looking detail. */
+    private suspend fun buildXtreamVodMeta(item: com.nuvio.tv.core.iptv.XtreamResolvedItem): Meta {
+        val base = item.toMeta()
+        val account = runCatching { xtreamAccountStore.accounts.first() }.getOrNull()
+            ?.firstOrNull { it.id == item.accountId } ?: return base
+        val tmdbId = xtreamClient.vodTmdbId(account, item.streamId).getOrNull() ?: return base
+        val enrichment = runCatching {
+            tmdbMetadataService.fetchEnrichment(tmdbId.toString(), item.type)
+        }.getOrNull() ?: return base
+        return base.copy(
+            name = enrichment.localizedTitle ?: enrichment.originalTitle ?: base.name,
+            poster = enrichment.poster ?: base.poster,
+            background = enrichment.backdrop,
+            logo = enrichment.logo,
+            description = enrichment.description ?: base.description,
+            releaseInfo = enrichment.releaseInfo,
+            status = enrichment.status,
+            imdbRating = enrichment.rating?.toFloat() ?: base.imdbRating,
+            genres = enrichment.genres.ifEmpty { base.genres },
+            runtime = enrichment.runtimeMinutes?.toString(),
+            director = enrichment.director,
+            writer = enrichment.writer,
+            cast = enrichment.castMembers.map { it.name },
+            castMembers = enrichment.castMembers,
+            productionCompanies = enrichment.productionCompanies,
+            networks = enrichment.networks,
+            ageRating = enrichment.ageRating,
+            country = enrichment.countries?.joinToString(", "),
+            language = enrichment.language,
+            trailers = enrichment.trailers
+        )
+    }
+
     override fun getMetaFromAllAddons(
         type: String,
         id: String,
         sourceAddonBaseUrl: String?
     ): Flow<NetworkResult<Meta>> = flow {
+        // HYBRID LANE: Xtream ids resolve their own meta, bypassing all addon resolution.
+        // Enriched with TMDB art/metadata (backdrop, logo, cast) when a tmdb_id is available,
+        // so the native detail screen looks identical to addon-backed content.
+        if (xtreamRegistry.isXtreamId(id)) {
+            val item = xtreamRegistry.get(id)
+            if (item != null) emit(NetworkResult.Success(buildXtreamMeta(item)))
+            else emit(NetworkResult.Error("IPTV item is no longer available"))
+            return@flow
+        }
         val cacheKey = "$type:$id"
         addonMetaCache[cacheKey]?.let { cached ->
             emit(NetworkResult.Success(cached))

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.mapper.toDomain
 import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.core.iptv.toAddonStreams
 import com.nuvio.tv.domain.model.AddonStreams
 import com.nuvio.tv.domain.model.LocalScraperResult
 import com.nuvio.tv.domain.model.PluginRepository
@@ -43,7 +44,8 @@ class StreamRepositoryImpl @Inject constructor(
     private val pluginManager: PluginManager,
     private val tmdbService: TmdbService,
     private val debridStreamPresentation: DebridStreamPresentation,
-    private val localDebridAvailabilityService: LocalDebridAvailabilityService
+    private val localDebridAvailabilityService: LocalDebridAvailabilityService,
+    private val xtreamRegistry: com.nuvio.tv.core.iptv.XtreamItemRegistry
 ) : StreamRepository {
     private enum class StreamFailureKind {
         MISSING,
@@ -63,6 +65,12 @@ class StreamRepositoryImpl @Inject constructor(
         episode: Int?
     ): Flow<NetworkResult<List<AddonStreams>>> = flow {
         emit(NetworkResult.Loading)
+        // HYBRID LANE: Xtream ids play their own single direct stream — skip addon + debrid.
+        if (xtreamRegistry.isXtreamId(videoId)) {
+            val item = xtreamRegistry.get(videoId)
+            emit(NetworkResult.Success(item?.toAddonStreams() ?: emptyList()))
+            return@flow
+        }
 
         try {
             val addons = addonRepository.getInstalledAddons().first().enabledAddons()

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -730,8 +730,25 @@ fun NuvioNavHost(
                 }
             )
         ) { backStackEntry ->
+            // Shared live-exit valve used by every player-exit callback (back, error, ended).
+            // Returns true when this was a LIVE channel and we routed back to the IPTV guide;
+            // callers must early-return when true so the VOD/series logic is skipped. Uses the
+            // built-in Detail pattern (pop-by-route, then navigate-fallback for live launched
+            // from Library/Search) — idempotent, so the player's double BACK-dispatch never
+            // overshoots to Home/launcher and the retained hub VM keeps its selected category.
+            fun returnToLiveGuideOrPop(): Boolean {
+                val isLive = backStackEntry.arguments
+                    ?.getString("contentType").equals("live", ignoreCase = true)
+                if (!isLive) return false
+                val popped = navController.popBackStack(Screen.XtreamHub.route, inclusive = false)
+                if (!popped) {
+                    navController.navigate(Screen.XtreamHub.route) { launchSingleTop = true }
+                }
+                return true
+            }
             PlayerScreen(
-                onBackPress = { currentVideoId, currentSeason, currentEpisode, autoPlayEnabled, playbackCompleted ->
+                onBackPress = onBack@{ currentVideoId, currentSeason, currentEpisode, autoPlayEnabled, playbackCompleted ->
+                    if (returnToLiveGuideOrPop()) return@onBack
                     val args = backStackEntry.arguments
                     val initialSeason = args?.getString("season")?.toIntOrNull()
                     val initialEpisode = args?.getString("episode")?.toIntOrNull()
@@ -832,7 +849,8 @@ fun NuvioNavHost(
                         }
                     }
                 },
-                onPlaybackEnded = { nextVideoId, nextSeason, nextEpisode, exitReason ->
+                onPlaybackEnded = onEnded@{ nextVideoId, nextSeason, nextEpisode, exitReason ->
+                    if (returnToLiveGuideOrPop()) return@onEnded
                     val args = backStackEntry.arguments
                     val contentType = args?.getString("contentType").orEmpty()
                     val contentId = args?.getString("contentId").orEmpty()
@@ -942,7 +960,10 @@ fun NuvioNavHost(
                         }
                     }
                 },
-                onPlaybackErrorBack = {
+                onPlaybackErrorBack = onErrBack@{
+                    // Error overlay → BACK. For live, return to the guide (no Stream/Detail exists;
+                    // the old path fabricated a broken Stream screen and then exited to the launcher).
+                    if (returnToLiveGuideOrPop()) return@onErrBack
                     val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
                     if (!returnedToStream) {
                         val args = backStackEntry.arguments
@@ -988,18 +1009,30 @@ fun NuvioNavHost(
         composable(Screen.Search.route) { backStackEntry ->
             val searchViewModel: com.nuvio.tv.ui.screens.search.SearchViewModel =
                 androidx.hilt.navigation.compose.hiltViewModel(backStackEntry)
+            val liveResolver: com.nuvio.tv.ui.screens.iptv.XtreamLiveResolverViewModel = androidx.hilt.navigation.compose.hiltViewModel()
             SearchScreen(
                 viewModel = searchViewModel,
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
-                    val heroBackdrop = HeroBackdropState.consumeAndClear()
-                    navController.navigate(
-                        Screen.Detail.createRoute(
-                            itemId = itemId,
-                            itemType = itemType,
-                            addonBaseUrl = addonBaseUrl,
-                            heroBackdropUrl = heroBackdrop
+                    val live = if (com.nuvio.tv.core.iptv.XtreamItemRegistry.isLiveContentId(itemId)) liveResolver.resolve(itemId) else null
+                    if (live != null) {
+                        liveResolver.recordPlayed(itemId)
+                        navController.navigate(
+                            Screen.Player.createRoute(
+                                streamUrl = live.url, title = live.name,
+                                contentId = itemId, contentType = "live"
+                            )
                         )
-                    )
+                    } else {
+                        val heroBackdrop = HeroBackdropState.consumeAndClear()
+                        navController.navigate(
+                            Screen.Detail.createRoute(
+                                itemId = itemId,
+                                itemType = itemType,
+                                addonBaseUrl = addonBaseUrl,
+                                heroBackdropUrl = heroBackdrop
+                            )
+                        )
+                    }
                 },
                 onNavigateToSeeAll = { catalogId, addonId, type ->
                     navController.navigate(
@@ -1028,10 +1061,23 @@ fun NuvioNavHost(
         }
 
         composable(Screen.Library.route) {
+            val liveResolver: com.nuvio.tv.ui.screens.iptv.XtreamLiveResolverViewModel = androidx.hilt.navigation.compose.hiltViewModel()
             LibraryScreen(
                 showBuiltInHeader = !hideBuiltInHeaders,
                 onNavigateToDetail = { itemId, itemType, addonBaseUrl ->
-                    navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
+                    // A favorited live channel has no detail screen — play it directly.
+                    val live = if (com.nuvio.tv.core.iptv.XtreamItemRegistry.isLiveContentId(itemId)) liveResolver.resolve(itemId) else null
+                    if (live != null) {
+                        liveResolver.recordPlayed(itemId)
+                        navController.navigate(
+                            Screen.Player.createRoute(
+                                streamUrl = live.url, title = live.name,
+                                contentId = itemId, contentType = "live"
+                            )
+                        )
+                    } else {
+                        navController.navigate(Screen.Detail.createRoute(itemId, itemType, addonBaseUrl))
+                    }
                 },
                 onCloudPlaybackResolved = { info ->
                     val filename = info.filename ?: info.file.name
@@ -1066,6 +1112,54 @@ fun NuvioNavHost(
                 },
                 onNavigateToLicensesAttributions = {
                     navController.navigate(Screen.LicensesAttributions.route)
+                },
+                onNavigateToXtreamVod = { accountId ->
+                    navController.navigate(Screen.XtreamVod.createRoute(accountId))
+                },
+                onNavigateToXtreamLive = { accountId ->
+                    navController.navigate(Screen.XtreamLive.createRoute(accountId))
+                }
+            )
+        }
+
+        composable(
+            route = Screen.XtreamVod.route,
+            arguments = listOf(navArgument("accountId") { type = NavType.StringType })
+        ) {
+            com.nuvio.tv.ui.screens.iptv.XtreamVodScreen(
+                onBackPress = { navController.popBackStack() },
+                onMovieSelected = { contentId ->
+                    navController.navigate(Screen.Detail.createRoute(contentId, "movie"))
+                }
+            )
+        }
+
+        composable(Screen.XtreamHub.route) {
+            com.nuvio.tv.ui.screens.iptv.XtreamHubScreen(
+                onPlayChannel = { title, streamUrl, contentId ->
+                    // "live" → forces the libmpv engine (ExoPlayer can't sustain raw continuous
+                    // MPEG-TS). contentId lets the fullscreen player zap up/down the channel list.
+                    navController.navigate(
+                        Screen.Player.createRoute(streamUrl = streamUrl, title = title, contentId = contentId, contentType = "live")
+                    )
+                },
+                onOpenDetail = { contentId, type ->
+                    navController.navigate(Screen.Detail.createRoute(contentId, type))
+                },
+                onAddProvider = { navController.navigate(Screen.Settings.route) }
+            )
+        }
+
+        composable(
+            route = Screen.XtreamLive.route,
+            arguments = listOf(navArgument("accountId") { type = NavType.StringType })
+        ) {
+            com.nuvio.tv.ui.screens.iptv.XtreamLiveScreen(
+                onBackPress = { navController.popBackStack() },
+                onChannelSelected = { title, streamUrl ->
+                    navController.navigate(
+                        Screen.Player.createRoute(streamUrl = streamUrl, title = title, contentType = "tv")
+                    )
                 }
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -141,6 +141,15 @@ sealed class Screen(val route: String) {
     data object SupportersContributors : Screen("supporters_contributors")
     data object LicensesAttributions : Screen("licenses_attributions")
     data object AddonManager : Screen("addon_manager")
+    data object XtreamHub : Screen("xtream_hub")
+    data object XtreamVod : Screen("xtream_vod/{accountId}") {
+        fun createRoute(accountId: String): String =
+            "xtream_vod/${URLEncoder.encode(accountId, "UTF-8").replace("+", "%20")}"
+    }
+    data object XtreamLive : Screen("xtream_live/{accountId}") {
+        fun createRoute(accountId: String): String =
+            "xtream_live/${URLEncoder.encode(accountId, "UTF-8").replace("+", "%20")}"
+    }
     data object CatalogOrder : Screen("catalog_order")
     data object Plugins : Screen("plugins")
     data object ExperienceModeSelection : Screen("experience_mode_selection")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AuthQrSignInScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AuthQrSignInScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
@@ -297,6 +299,14 @@ private fun AuthQrLoginPane(
     onRefreshOrSignOut: () -> Unit,
     onBackOrContinue: () -> Unit
 ) {
+    // Default focus to "Continue without account" during onboarding so it's reachable
+    // immediately (otherwise focus lands on the inline "Terms" link and is awkward to escape).
+    val continueFocus = remember { FocusRequester() }
+    LaunchedEffect(isOnboardingMode, isSignedIn) {
+        if (isOnboardingMode && !isSignedIn) {
+            runCatching { continueFocus.requestFocus() }
+        }
+    }
     Column(
         modifier = modifier.padding(horizontal = 48.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -374,6 +384,7 @@ private fun AuthQrLoginPane(
             }
             Button(
                 onClick = onBackOrContinue,
+                modifier = Modifier.focusRequester(continueFocus),
                 colors = ButtonDefaults.colors(
                     containerColor = AuthSecondaryButtonBackground,
                     focusedContainerColor = Color.White,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamHubScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamHubScreen.kt
@@ -1,0 +1,226 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.unit.dp
+import android.view.KeyEvent
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.ui.components.CatalogRowSection
+import com.nuvio.tv.ui.components.NuvioDialog
+import com.nuvio.tv.ui.theme.NuvioTheme
+
+/**
+ * Top-level IPTV hub (a main-nav destination). Defaults to the first account with a dropdown to
+ * switch playlists; Live/Movies/Series tabs; native category rows. Empty state sends the user to
+ * Settings to add a provider.
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun XtreamHubScreen(
+    onPlayChannel: (title: String, streamUrl: String, contentId: String) -> Unit,
+    onOpenDetail: (contentId: String, type: String) -> Unit,
+    onAddProvider: () -> Unit,
+    viewModel: XtreamHubViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showAccountPicker by remember { mutableStateOf(false) }
+    val firstFocus = remember { FocusRequester() }
+
+    // Movies/Series tile -> native detail. (Live is handled by the TiViMate guide below.)
+    val onActivate: (XtreamHubItem) -> Unit = { hit ->
+        hit.contentId?.let { onOpenDetail(it, hit.detailType) }
+    }
+
+    // Empty state -> prompt to add a provider in Settings.
+    if (!uiState.loading && uiState.accounts.isEmpty()) {
+        LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+        Column(
+            modifier = Modifier.fillMaxSize().padding(NuvioTheme.spacing.xxxl),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("No IPTV provider yet", style = MaterialTheme.typography.headlineSmall, color = NuvioTheme.colors.TextPrimary)
+            Spacer(Modifier.padding(top = NuvioTheme.spacing.sm))
+            Text(
+                "Add your Xtream Codes portal or M3U URL to watch Live TV, Movies and Series.",
+                style = MaterialTheme.typography.bodyMedium, color = NuvioTheme.colors.TextSecondary
+            )
+            Spacer(Modifier.padding(top = NuvioTheme.spacing.lg))
+            HubChip("Add IPTV provider", selected = true, focusRequester = firstFocus, onClick = onAddProvider)
+        }
+        return
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(top = NuvioTheme.spacing.xl)) {
+        // Header: account dropdown + section tabs
+        Row(
+            modifier = Modifier.padding(start = NuvioTheme.spacing.xxxl, bottom = NuvioTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)
+        ) {
+            HubChip(
+                label = (uiState.selectedAccount?.name ?: "Account") + (if (uiState.accounts.size > 1) "  ▾" else ""),
+                selected = true,
+                focusRequester = firstFocus,
+                onClick = { if (uiState.accounts.size > 1) showAccountPicker = true }
+            )
+            Spacer(Modifier.width(NuvioTheme.spacing.md))
+            HubChip("Live TV", uiState.section == XtreamSection.LIVE) { viewModel.selectSection(XtreamSection.LIVE) }
+            HubChip("Movies", uiState.section == XtreamSection.MOVIES) { viewModel.selectSection(XtreamSection.MOVIES) }
+            HubChip("Series", uiState.section == XtreamSection.SERIES) { viewModel.selectSection(XtreamSection.SERIES) }
+        }
+
+        // Live TV = TiViMate-style guide (category col + live preview + EPG channel list).
+        // Movies/Series = native poster rows.
+        val liveAccount = uiState.selectedAccount
+        if (uiState.section == XtreamSection.LIVE && liveAccount != null) {
+            LiveGuide(account = liveAccount, onPlayChannel = onPlayChannel)
+        } else {
+            val status = when {
+                uiState.error != null -> uiState.error
+                uiState.loading -> "Loading…"
+                uiState.categories.isEmpty() -> "Nothing here"
+                else -> null
+            }
+            if (status != null) {
+                Box(Modifier.fillMaxWidth().padding(NuvioTheme.spacing.xxxl)) {
+                    Text(status, style = MaterialTheme.typography.bodyLarge, color = NuvioTheme.colors.TextSecondary)
+                }
+            }
+
+            LazyColumn(
+                contentPadding = PaddingValues(bottom = NuvioTheme.spacing.xxl)
+            ) {
+                items(uiState.categories, key = { "${uiState.section}_${it.id}" }) { category ->
+                    LaunchedEffect(uiState.selectedAccountId, uiState.section, category.id) {
+                        viewModel.loadCategory(category.id)
+                    }
+                    val loaded = uiState.itemsByCategory.containsKey(category.id)
+                    val items = uiState.itemsByCategory[category.id].orEmpty()
+                    if (!loaded || items.isNotEmpty()) {
+                        HubChannelRow(
+                            title = category.name, catalogId = category.id,
+                            items = items, isLoading = !loaded, onActivate = onActivate
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAccountPicker) {
+        NuvioDialog(onDismiss = { showAccountPicker = false }, title = "Choose provider") {
+            uiState.accounts.forEach { acc ->
+                com.nuvio.tv.ui.screens.settings.SettingsActionRow(
+                    title = acc.name,
+                    subtitle = acc.baseUrl,
+                    value = if (acc.id == uiState.selectedAccountId) "Current" else null,
+                    onClick = { viewModel.selectAccount(acc.id); showAccountPicker = false }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HubChannelRow(
+    title: String,
+    catalogId: String,
+    items: List<XtreamHubItem>,
+    isLoading: Boolean,
+    onActivate: (XtreamHubItem) -> Unit,
+) {
+    CatalogRowSection(
+        catalogRow = CatalogRow(
+            addonId = "xtream", addonName = "", addonBaseUrl = "",
+            catalogId = catalogId, catalogName = title,
+            type = ContentType.MOVIE,
+            items = items.map { it.toMetaPreview() },
+            isLoading = isLoading
+        ),
+        onItemClick = { itemId, _, _ -> items.firstOrNull { it.cardId == itemId }?.let(onActivate) },
+        showSeeAll = false,
+        showAddonName = false,
+        showCatalogTypeSuffix = false,
+    )
+}
+
+private fun XtreamHubItem.toMetaPreview(): MetaPreview = MetaPreview(
+    id = cardId,
+    type = if (isLive) ContentType.TV else ContentType.MOVIE,
+    name = name,
+    poster = poster,
+    posterShape = if (isLive) PosterShape.LANDSCAPE else PosterShape.POSTER,
+    background = null, logo = null, description = null, releaseInfo = null,
+    imdbRating = null, genres = emptyList()
+)
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun HubChip(
+    label: String,
+    selected: Boolean,
+    focusRequester: FocusRequester? = null,
+    onClick: () -> Unit
+) {
+    var focused by remember { mutableStateOf(false) }
+    Box(
+        modifier = Modifier
+            .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (selected) NuvioTheme.colors.Primary else NuvioTheme.colors.BackgroundElevated)
+            .border(1.dp, if (focused) NuvioTheme.colors.Primary else NuvioTheme.colors.Border, RoundedCornerShape(8.dp))
+            .focusable()
+            .onFocusChanged { focused = it.isFocused }
+            .onKeyEvent {
+                if ((it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+                        it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ENTER) &&
+                    it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN
+                ) { onClick(); true } else false
+            }
+            .padding(horizontal = 16.dp, vertical = NuvioTheme.spacing.sm),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (selected) NuvioTheme.colors.TextPrimary else NuvioTheme.colors.TextSecondary
+        )
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamHubViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamHubViewModel.kt
@@ -1,0 +1,198 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.iptv.XtreamCategory
+import com.nuvio.tv.core.iptv.XtreamClient
+import com.nuvio.tv.core.iptv.XtreamItemRegistry
+import com.nuvio.tv.core.iptv.XtreamResolvedItem
+import com.nuvio.tv.data.local.XtreamAccountStore
+import com.nuvio.tv.data.local.LiveChannelRef
+import com.nuvio.tv.data.local.XtreamLiveStore
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.repository.LibraryRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class XtreamSection { LIVE, MOVIES, SERIES }
+
+/** One browsable item in the hub: a movie/series opens a detail; a channel plays directly. */
+data class XtreamHubItem(
+    val cardId: String,        // MetaPreview id used for card key + click matching
+    val name: String,
+    val poster: String?,
+    val isLive: Boolean,
+    val contentId: String?,    // movies/series -> xtream: detail id
+    val streamUrl: String?,    // live -> direct play url
+    val detailType: String = "movie"  // "movie" | "series"
+)
+
+data class XtreamHubUiState(
+    val accounts: List<XtreamAccount> = emptyList(),
+    val selectedAccountId: String? = null,
+    val section: XtreamSection = XtreamSection.MOVIES,
+    val categories: List<XtreamCategory> = emptyList(),
+    val itemsByCategory: Map<String, List<XtreamHubItem>> = emptyMap(),
+    val loading: Boolean = true,
+    val error: String? = null
+) {
+    val selectedAccount: XtreamAccount? get() = accounts.firstOrNull { it.id == selectedAccountId }
+}
+
+/**
+ * Drives the top-level IPTV hub: pick an account (dropdown), pick a section (Live/Movies/Series),
+ * browse category rows. Channels play directly; movies/series open the native detail (which the
+ * meta + stream short-circuits handle). Per-category lazy loading (catalogs can be 100k+ items).
+ */
+@HiltViewModel
+class XtreamHubViewModel @Inject constructor(
+    private val store: XtreamAccountStore,
+    private val client: XtreamClient,
+    private val registry: XtreamItemRegistry,
+    private val liveStore: XtreamLiveStore,
+    private val libraryRepository: LibraryRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(XtreamHubUiState())
+    val uiState: StateFlow<XtreamHubUiState> = _uiState.asStateFlow()
+
+    /** Recently-watched channels, newest first — the hub's "Recent Channels" row. */
+    val recents: StateFlow<List<XtreamHubItem>> = liveStore.recents
+        .map { refs -> refs.map { it.toHubItem() } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** Live channel ids currently in the platform Library (for the favorite star). */
+    val favoriteLiveIds: StateFlow<Set<String>> = libraryRepository.libraryItems
+        .map { items -> items.filter { XtreamItemRegistry.isLiveContentId(it.id) }.map { it.id }.toSet() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+
+    private val requested = mutableSetOf<String>()   // "accountId|section|categoryId"
+
+    init {
+        viewModelScope.launch {
+            val accounts = store.accounts.first().filter { it.enabled }
+            _uiState.update { it.copy(accounts = accounts, selectedAccountId = accounts.firstOrNull()?.id) }
+            if (accounts.isEmpty()) _uiState.update { it.copy(loading = false) } else loadCategories()
+        }
+    }
+
+    fun selectAccount(accountId: String) {
+        if (accountId == _uiState.value.selectedAccountId) return
+        _uiState.update { it.copy(selectedAccountId = accountId, categories = emptyList(), itemsByCategory = emptyMap()) }
+        loadCategories()
+    }
+
+    fun selectSection(section: XtreamSection) {
+        if (section == _uiState.value.section) return
+        _uiState.update { it.copy(section = section, categories = emptyList(), itemsByCategory = emptyMap()) }
+        loadCategories()
+    }
+
+    private fun loadCategories() {
+        val acc = _uiState.value.selectedAccount ?: return
+        val section = _uiState.value.section
+        _uiState.update { it.copy(loading = true, error = null) }
+        viewModelScope.launch {
+            val result = when (section) {
+                XtreamSection.LIVE -> client.liveCategories(acc)
+                XtreamSection.MOVIES -> client.vodCategories(acc)
+                XtreamSection.SERIES -> client.seriesCategories(acc)
+            }
+            result
+                .onSuccess { cats -> _uiState.update { it.copy(categories = cats, loading = false) } }
+                .onFailure { e -> _uiState.update { it.copy(loading = false, error = e.message ?: "Failed to load") } }
+        }
+    }
+
+    fun loadCategory(categoryId: String) {
+        val acc = _uiState.value.selectedAccount ?: return
+        val section = _uiState.value.section
+        val key = "${acc.id}|$section|$categoryId"
+        if (!requested.add(key)) return
+        viewModelScope.launch {
+            val items: List<XtreamHubItem> = when (section) {
+                XtreamSection.LIVE -> client.liveChannels(acc, categoryId).getOrDefault(emptyList()).map { ch ->
+                    val id = XtreamItemRegistry.liveId(acc.id, ch.streamId)
+                    registry.register(
+                        XtreamResolvedItem(
+                            id = id, type = ContentType.TV, name = ch.name, poster = ch.logo,
+                            streamUrl = ch.streamUrl, kind = com.nuvio.tv.core.iptv.XtreamKind.LIVE,
+                            accountId = acc.id, streamId = ch.streamId
+                        )
+                    )
+                    XtreamHubItem(id, ch.name, ch.logo, isLive = true, contentId = id, streamUrl = ch.streamUrl)
+                }
+                XtreamSection.MOVIES -> client.vodMovies(acc, categoryId).getOrDefault(emptyList()).map { m ->
+                    val id = XtreamItemRegistry.vodId(acc.id, m.streamId)
+                    registry.register(
+                        XtreamResolvedItem(
+                            id = id, type = ContentType.MOVIE, name = m.name, poster = m.poster,
+                            imdbRating = m.rating?.toFloatOrNull(), streamUrl = m.streamUrl,
+                            accountId = acc.id, streamId = m.streamId
+                        )
+                    )
+                    XtreamHubItem(id, m.name, m.poster, isLive = false, contentId = id, streamUrl = null)
+                }
+                XtreamSection.SERIES -> client.series(acc, categoryId).getOrDefault(emptyList()).map { s ->
+                    val id = XtreamItemRegistry.seriesId(acc.id, s.seriesId)
+                    registry.register(
+                        XtreamResolvedItem(
+                            id = id, type = ContentType.SERIES, name = s.name, poster = s.poster,
+                            description = s.plot, imdbRating = s.rating?.toFloatOrNull(),
+                            streamUrl = "", kind = com.nuvio.tv.core.iptv.XtreamKind.SERIES,
+                            accountId = acc.id, streamId = s.seriesId
+                        )
+                    )
+                    XtreamHubItem(id, s.name, s.poster, isLive = false, contentId = id, streamUrl = null, detailType = "series")
+                }
+            }
+            _uiState.update { it.copy(itemsByCategory = it.itemsByCategory + (categoryId to items)) }
+        }
+    }
+
+    /** Mark a channel as just-watched so it shows in Recent Channels and stays replayable. */
+    fun recordPlayed(item: XtreamHubItem) {
+        val ref = item.toLiveRef() ?: return
+        viewModelScope.launch { liveStore.recordPlayed(ref) }
+    }
+
+    /** Add/remove a live channel from the platform Library (same store as movies). */
+    fun toggleFavorite(item: XtreamHubItem) {
+        val ref = item.toLiveRef() ?: return
+        val adding = item.cardId !in favoriteLiveIds.value
+        viewModelScope.launch {
+            libraryRepository.toggleDefault(
+                LibraryEntryInput(
+                    itemId = item.cardId,
+                    itemType = "tv",
+                    title = item.name,
+                    poster = item.poster,
+                    posterShape = PosterShape.LANDSCAPE,
+                    logo = item.poster
+                )
+            )
+            // Persist the stream url so the Library click can replay it later.
+            if (adding) liveStore.remember(ref)
+        }
+    }
+
+    private fun XtreamHubItem.toLiveRef(): LiveChannelRef? {
+        val url = streamUrl ?: return null
+        return LiveChannelRef(id = cardId, name = name, logo = poster, streamUrl = url)
+    }
+
+    private fun LiveChannelRef.toHubItem(): XtreamHubItem =
+        XtreamHubItem(id, name, logo, isLive = true, contentId = id, streamUrl = streamUrl)
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveGuideScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveGuideScreen.kt
@@ -1,0 +1,284 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import coil3.compose.AsyncImage
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.iptv.XtreamProgram
+import com.nuvio.tv.ui.theme.NuvioTheme
+import java.util.Calendar
+import java.util.Locale
+
+/**
+ * TiViMate-style Live TV guide: category column -> channel list with now/next EPG, and a
+ * live preview of the focused channel up top. Press a channel to go fullscreen.
+ */
+@Composable
+fun LiveGuide(
+    account: XtreamAccount,
+    onPlayChannel: (title: String, streamUrl: String, contentId: String) -> Unit,
+    viewModel: XtreamLiveGuideViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val favoriteIds by viewModel.favoriteLiveIds.collectAsStateWithLifecycle()
+    LaunchedEffect(account.id) { viewModel.setAccount(account) }
+
+    // RIGHT from a category must land on the channel list — without this, focus search looks
+    // rightward at the (non-focusable) preview pane and jumps up to the tabs instead.
+    val channelListFocus = remember { FocusRequester() }
+
+    Row(Modifier.fillMaxSize()) {
+        // Category column
+        LazyColumn(
+            modifier = Modifier.width(260.dp).fillMaxHeight().focusRestorer(),
+            contentPadding = PaddingValues(vertical = NuvioTheme.spacing.sm)
+        ) {
+            items(uiState.categories, key = { it.id }) { cat ->
+                GuideCategoryRow(
+                    label = cat.name,
+                    selected = cat.id == uiState.selectedCategoryId,
+                    rightFocus = channelListFocus,
+                    onFocused = { viewModel.selectCategory(cat.id) }
+                )
+            }
+        }
+
+        // Preview + channel list
+        Column(Modifier.fillMaxSize()) {
+            ChannelPreviewPane(
+                channelName = uiState.focusedChannel?.name,
+                logo = uiState.focusedChannel?.logo,
+                epg = uiState.focusedChannel?.let { uiState.epg[it.streamId] },
+                modifier = Modifier.fillMaxWidth().height(300.dp)
+            )
+
+            when {
+                uiState.loadingChannels -> StatusLine("Loading channels…")
+                uiState.channels.isEmpty() -> StatusLine("No channels here")
+                else -> LazyColumn(
+                    modifier = Modifier.fillMaxSize()
+                        .focusRequester(channelListFocus)
+                        .focusRestorer(),
+                    contentPadding = PaddingValues(bottom = NuvioTheme.spacing.xxl)
+                ) {
+                    items(uiState.channels, key = { it.contentId }) { ch ->
+                        LaunchedEffect(ch.streamId) { viewModel.ensureEpg(ch.streamId) }
+                        GuideChannelRow(
+                            name = ch.name,
+                            logo = ch.logo,
+                            nowTitle = uiState.epg[ch.streamId]?.now?.title,
+                            isFavorite = ch.contentId in favoriteIds,
+                            onFocused = { viewModel.onChannelFocused(ch) },
+                            onClick = { viewModel.recordPlayed(ch); onPlayChannel(ch.name, ch.streamUrl, ch.contentId) },
+                            onLongClick = { viewModel.toggleFavorite(ch) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusLine(text: String) {
+    Box(Modifier.fillMaxWidth().padding(NuvioTheme.spacing.xxxl)) {
+        Text(text, style = MaterialTheme.typography.bodyLarge, color = NuvioTheme.colors.TextSecondary)
+    }
+}
+
+@Composable
+private fun GuideCategoryRow(
+    label: String,
+    selected: Boolean,
+    rightFocus: FocusRequester,
+    onFocused: () -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+    val latestOnFocused by rememberUpdatedState(onFocused)
+    LaunchedEffect(focused) { if (focused) latestOnFocused() }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusProperties { right = rightFocus }
+            .padding(horizontal = NuvioTheme.spacing.sm, vertical = 2.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(
+                when {
+                    focused -> NuvioTheme.colors.Primary
+                    selected -> NuvioTheme.colors.BackgroundElevated
+                    else -> Color.Transparent
+                }
+            )
+            .focusable()
+            .onFocusChanged { focused = it.isFocused }
+            .padding(horizontal = NuvioTheme.spacing.md, vertical = NuvioTheme.spacing.sm)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (focused || selected) NuvioTheme.colors.TextPrimary else NuvioTheme.colors.TextSecondary
+        )
+    }
+}
+
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+@Composable
+private fun GuideChannelRow(
+    name: String,
+    logo: String?,
+    nowTitle: String?,
+    isFavorite: Boolean,
+    onFocused: () -> Unit,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val latestOnFocused by rememberUpdatedState(onFocused)
+    LaunchedEffect(isFocused) { if (isFocused) latestOnFocused() }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = NuvioTheme.spacing.md, vertical = 2.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(if (isFocused) NuvioTheme.colors.Primary else NuvioTheme.colors.BackgroundElevated)
+            .onFocusChanged { isFocused = it.isFocused }
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            .padding(horizontal = NuvioTheme.spacing.md, vertical = NuvioTheme.spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
+    ) {
+        AsyncImage(
+            model = logo,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp).clip(RoundedCornerShape(4.dp))
+        )
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodyMedium,
+                color = NuvioTheme.colors.TextPrimary,
+                maxLines = 1
+            )
+            Text(
+                text = nowTitle ?: "No information",
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isFocused) NuvioTheme.colors.TextPrimary else NuvioTheme.colors.TextSecondary,
+                maxLines = 1
+            )
+        }
+        if (isFavorite) {
+            Text("★", style = MaterialTheme.typography.bodyMedium, color = NuvioTheme.colors.TextPrimary)
+        }
+    }
+}
+
+/**
+ * Preview pane: the focused channel's logo + now/next EPG. Pressing the channel plays it
+ * fullscreen. (Inline live video would need a second mpv instance, which is unstable next to
+ * the fullscreen player on a software GPU — fullscreen-on-press is the reliable path.)
+ */
+@Composable
+private fun ChannelPreviewPane(
+    channelName: String?,
+    logo: String?,
+    epg: GuideEpg?,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier.background(Color.Black), contentAlignment = Alignment.Center) {
+        if (!logo.isNullOrBlank()) {
+            AsyncImage(
+                model = logo,
+                contentDescription = null,
+                modifier = Modifier.fillMaxWidth(0.4f).height(120.dp).align(Alignment.Center)
+            )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomStart)
+                .background(Color(0xCC000000))
+                .padding(NuvioTheme.spacing.lg)
+        ) {
+            Text(
+                text = channelName ?: "",
+                style = MaterialTheme.typography.titleMedium,
+                color = NuvioTheme.colors.TextPrimary,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1
+            )
+            epg?.now?.let { now ->
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = "${timeRange(now)}  ${now.title}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NuvioTheme.colors.TextPrimary,
+                    maxLines = 1
+                )
+            }
+            epg?.next?.let { next ->
+                Text(
+                    text = "Next: ${timeRange(next)}  ${next.title}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioTheme.colors.TextSecondary,
+                    maxLines = 1
+                )
+            }
+            if (epg?.now == null) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = "Press OK to watch live",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioTheme.colors.TextSecondary,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+private fun timeRange(p: XtreamProgram): String = "${hhmm(p.startMs)}–${hhmm(p.endMs)}"
+
+private fun hhmm(ms: Long): String {
+    if (ms <= 0L) return ""
+    val c = Calendar.getInstance().apply { timeInMillis = ms }
+    return String.format(Locale.US, "%02d:%02d", c.get(Calendar.HOUR_OF_DAY), c.get(Calendar.MINUTE))
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveGuideViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveGuideViewModel.kt
@@ -1,0 +1,205 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.iptv.XtreamClient
+import com.nuvio.tv.core.iptv.XtreamItemRegistry
+import com.nuvio.tv.core.iptv.XtreamKind
+import com.nuvio.tv.core.iptv.XtreamLivePlaylist
+import com.nuvio.tv.core.iptv.XtreamProgram
+import com.nuvio.tv.core.iptv.XtreamResolvedItem
+import com.nuvio.tv.data.local.LiveChannelRef
+import com.nuvio.tv.data.local.XtreamLiveStore
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.repository.LibraryRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** A category entry in the guide's left column. [special] marks the synthetic ones. */
+enum class GuideSpecial { FAVORITES, RECENT, ALL }
+data class GuideCategory(val id: String, val name: String, val special: GuideSpecial? = null)
+
+/** One channel row in the guide. */
+data class GuideChannel(
+    val contentId: String,
+    val name: String,
+    val logo: String?,
+    val streamUrl: String,
+    val streamId: Int
+)
+
+/** Now/next programs for a channel (from get_short_epg). */
+data class GuideEpg(val now: XtreamProgram?, val next: XtreamProgram?)
+
+data class LiveGuideUiState(
+    val categories: List<GuideCategory> = emptyList(),
+    val selectedCategoryId: String? = null,
+    val channels: List<GuideChannel> = emptyList(),
+    val epg: Map<Int, GuideEpg> = emptyMap(),
+    val focusedChannelId: String? = null,
+    val loadingChannels: Boolean = false,
+    val error: String? = null
+) {
+    val focusedChannel: GuideChannel? get() = channels.firstOrNull { it.contentId == focusedChannelId }
+}
+
+/**
+ * Drives the TiViMate-style Live TV guide: category column -> channel list with now/next EPG
+ * -> a live preview of the focused channel. Channels register in the registry so pressing one
+ * opens the existing fullscreen live player (which forces mpv for raw TS).
+ *
+ * ponytail: EPG is fetched per focused/visible channel via get_short_epg (1 call each, cached).
+ * Bulk xmltv is the upgrade path if per-channel calls ever feel slow.
+ */
+@HiltViewModel
+class XtreamLiveGuideViewModel @Inject constructor(
+    private val client: XtreamClient,
+    private val registry: XtreamItemRegistry,
+    private val liveStore: XtreamLiveStore,
+    private val livePlaylist: XtreamLivePlaylist,
+    private val libraryRepository: LibraryRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LiveGuideUiState())
+    val uiState: StateFlow<LiveGuideUiState> = _uiState.asStateFlow()
+
+    /** Live channel ids currently in the platform Library (drives the ★ + add/remove). */
+    val favoriteLiveIds: StateFlow<Set<String>> = libraryRepository.libraryItems
+        .map { items -> items.filter { XtreamItemRegistry.isLiveContentId(it.id) }.map { it.id }.toSet() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+
+    private var account: XtreamAccount? = null
+    private var channelsJob: Job? = null
+    private val epgRequested = mutableSetOf<Int>()
+
+    /** Called by the screen when the hub's selected account changes. */
+    fun setAccount(acc: XtreamAccount) {
+        if (acc.id == account?.id) return
+        account = acc
+        epgRequested.clear()
+        viewModelScope.launch {
+            val cats = client.liveCategories(acc).getOrDefault(emptyList())
+            val full = buildList {
+                add(GuideCategory("__fav", "Favorites", GuideSpecial.FAVORITES))
+                add(GuideCategory("__recent", "Recent", GuideSpecial.RECENT))
+                add(GuideCategory("__all", "All channels", GuideSpecial.ALL))
+                cats.forEach { add(GuideCategory(it.id, it.name)) }
+            }
+            _uiState.update { it.copy(categories = full) }
+            // Default to "All channels" so the guide isn't empty for a fresh account.
+            selectCategory(full.firstOrNull { c -> c.special == GuideSpecial.ALL }?.id ?: full.firstOrNull()?.id)
+        }
+    }
+
+    fun selectCategory(categoryId: String?) {
+        val acc = account ?: return
+        val category = _uiState.value.categories.firstOrNull { it.id == categoryId } ?: return
+        if (categoryId == _uiState.value.selectedCategoryId && _uiState.value.channels.isNotEmpty()) return
+        channelsJob?.cancel()
+        _uiState.update { it.copy(selectedCategoryId = categoryId, channels = emptyList(), focusedChannelId = null, loadingChannels = true, error = null) }
+        channelsJob = viewModelScope.launch {
+            val channels: List<GuideChannel> = when (category.special) {
+                GuideSpecial.FAVORITES -> favoriteChannels()
+                GuideSpecial.RECENT -> liveStore.recents.first().map {
+                    GuideChannel(it.id, it.name, it.logo, it.streamUrl, streamIdOf(it.id))
+                }
+                GuideSpecial.ALL -> fetchChannels(acc, null).take(ALL_CAP)
+                null -> fetchChannels(acc, category.id)
+            }
+            _uiState.update { it.copy(channels = channels, loadingChannels = false, focusedChannelId = channels.firstOrNull()?.contentId) }
+            channels.firstOrNull()?.let { ensureEpg(it.streamId) }
+        }
+    }
+
+    /** Channel got D-pad focus: drive the preview + fetch its now/next EPG. */
+    fun onChannelFocused(channel: GuideChannel) {
+        if (channel.contentId == _uiState.value.focusedChannelId) return
+        _uiState.update { it.copy(focusedChannelId = channel.contentId) }
+        ensureEpg(channel.streamId)
+    }
+
+    /** Add/remove a channel from the platform Library (same store as movies). */
+    fun toggleFavorite(channel: GuideChannel) {
+        val adding = channel.contentId !in favoriteLiveIds.value
+        viewModelScope.launch {
+            libraryRepository.toggleDefault(
+                LibraryEntryInput(
+                    itemId = channel.contentId,
+                    itemType = "tv",
+                    title = channel.name,
+                    poster = channel.logo,
+                    posterShape = PosterShape.LANDSCAPE,
+                    logo = channel.logo
+                )
+            )
+            if (adding) liveStore.remember(LiveChannelRef(channel.contentId, channel.name, channel.logo, channel.streamUrl))
+        }
+    }
+
+    /** Record a channel as just-watched + publish the current list so the fullscreen player
+     *  can zap up/down through these channels. Called right before going fullscreen. */
+    fun recordPlayed(channel: GuideChannel) {
+        livePlaylist.set(
+            _uiState.value.channels.map { LiveChannelRef(it.contentId, it.name, it.logo, it.streamUrl) }
+        )
+        viewModelScope.launch {
+            liveStore.recordPlayed(LiveChannelRef(channel.contentId, channel.name, channel.logo, channel.streamUrl))
+        }
+    }
+
+    fun ensureEpg(streamId: Int) {
+        val acc = account ?: return
+        if (streamId <= 0 || !epgRequested.add(streamId)) return
+        viewModelScope.launch {
+            val programs = client.shortEpg(acc, streamId).getOrDefault(emptyList())
+            val nowMs = System.currentTimeMillis()
+            val nowIdx = programs.indexOfFirst { it.nowPlaying || (nowMs in it.startMs until it.endMs) }
+                .takeIf { it >= 0 } ?: 0
+            val now = programs.getOrNull(nowIdx)
+            val next = programs.getOrNull(nowIdx + 1)
+            _uiState.update { it.copy(epg = it.epg + (streamId to GuideEpg(now, next))) }
+        }
+    }
+
+    private suspend fun fetchChannels(acc: XtreamAccount, categoryId: String?): List<GuideChannel> {
+        return client.liveChannels(acc, categoryId).getOrDefault(emptyList()).map { ch ->
+            val id = XtreamItemRegistry.liveId(acc.id, ch.streamId)
+            registry.register(
+                XtreamResolvedItem(
+                    id = id, type = ContentType.TV, name = ch.name, poster = ch.logo,
+                    streamUrl = ch.streamUrl, kind = XtreamKind.LIVE, accountId = acc.id, streamId = ch.streamId
+                )
+            )
+            GuideChannel(id, ch.name, ch.logo, ch.streamUrl, ch.streamId)
+        }
+    }
+
+    private suspend fun favoriteChannels(): List<GuideChannel> {
+        val favIds = libraryRepository.libraryItems.first()
+            .filter { XtreamItemRegistry.isLiveContentId(it.id) }
+            .map { it.id }
+        return favIds.mapNotNull { id ->
+            liveStore.refFor(id)?.let { GuideChannel(it.id, it.name, it.logo, it.streamUrl, streamIdOf(it.id)) }
+        }
+    }
+
+    /** Best-effort streamId from a live content id ("xtream:acc:live:<streamId>"). */
+    private fun streamIdOf(contentId: String): Int = contentId.substringAfterLast(":live:").toIntOrNull() ?: 0
+
+    companion object {
+        private const val ALL_CAP = 600   // ponytail: don't render 26k rows; categories are the real browse path
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveResolverViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveResolverViewModel.kt
@@ -1,0 +1,47 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.iptv.XtreamItemRegistry
+import com.nuvio.tv.core.iptv.XtreamLivePlaylist
+import com.nuvio.tv.data.local.LiveChannelRef
+import com.nuvio.tv.data.local.XtreamLiveStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** Resolves a live-channel content id back to a playable (name, url) so the platform
+ *  Library/Search can replay a channel on click, and resolves up/down zap neighbours for the
+ *  fullscreen player. Session-browsed channels come from the in-memory registry; favorited
+ *  ones survive restarts via the persisted live store. */
+@HiltViewModel
+class XtreamLiveResolverViewModel @Inject constructor(
+    private val registry: XtreamItemRegistry,
+    private val liveStore: XtreamLiveStore,
+    private val livePlaylist: XtreamLivePlaylist
+) : ViewModel() {
+
+    data class ResolvedLive(val id: String, val name: String, val url: String)
+
+    fun resolve(id: String): ResolvedLive? {
+        registry.get(id)?.let { if (it.streamUrl.isNotBlank()) return ResolvedLive(id, it.name, it.streamUrl) }
+        liveStore.refFor(id)?.let { return ResolvedLive(id, it.name, it.streamUrl) }
+        return null
+    }
+
+    /** The channel [delta] steps from [currentId] in the active live playlist (for up/down zap). */
+    fun zap(currentId: String, delta: Int): ResolvedLive? {
+        val ref = livePlaylist.relativeTo(currentId, delta) ?: return null
+        viewModelScope.launch { liveStore.recordPlayed(ref) }
+        return ResolvedLive(ref.id, ref.name, ref.streamUrl)
+    }
+
+    /** Record a channel as just-watched so it lands in Recent Channels, no matter where it played from. */
+    fun recordPlayed(id: String) {
+        val ref = liveStore.refFor(id)
+            ?: registry.get(id)?.takeIf { it.streamUrl.isNotBlank() }
+                ?.let { LiveChannelRef(it.id, it.name, it.poster, it.streamUrl) }
+            ?: return
+        viewModelScope.launch { liveStore.recordPlayed(ref) }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveScreen.kt
@@ -1,0 +1,110 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.core.iptv.XtreamChannel
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.ui.components.CatalogRowSection
+import com.nuvio.tv.ui.theme.NuvioTheme
+
+/**
+ * Live TV browse, Nuvio-style: one horizontal row per live category. Channels show their logo
+ * on a landscape tile; selecting one plays its live .ts stream directly via [onChannelSelected].
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun XtreamLiveScreen(
+    onBackPress: () -> Unit,
+    onChannelSelected: (title: String, streamUrl: String) -> Unit,
+    viewModel: XtreamLiveViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    BackHandler { onBackPress() }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(top = NuvioTheme.spacing.xl, bottom = NuvioTheme.spacing.xxl)
+    ) {
+        item {
+            Text(
+                text = uiState.accountName.ifEmpty { "IPTV" } + " · Live TV",
+                style = MaterialTheme.typography.headlineSmall,
+                color = NuvioTheme.colors.TextPrimary,
+                modifier = Modifier.padding(start = NuvioTheme.spacing.xxxl, bottom = NuvioTheme.spacing.md)
+            )
+        }
+
+        val statusMessage = when {
+            uiState.error != null -> uiState.error
+            uiState.loading -> "Loading…"
+            uiState.categories.isEmpty() -> "No channels available"
+            else -> null
+        }
+        if (statusMessage != null) {
+            item {
+                Box(modifier = Modifier.fillMaxWidth().padding(NuvioTheme.spacing.xxxl)) {
+                    Text(statusMessage, style = MaterialTheme.typography.bodyLarge, color = NuvioTheme.colors.TextSecondary)
+                }
+            }
+        }
+
+        items(uiState.categories, key = { it.id }) { category ->
+            LaunchedEffect(category.id) { viewModel.loadCategory(category.id) }
+            val loaded = uiState.channelsByCategory.containsKey(category.id)
+            val channels = uiState.channelsByCategory[category.id].orEmpty()
+            if (!loaded || channels.isNotEmpty()) {
+                CatalogRowSection(
+                    catalogRow = CatalogRow(
+                        addonId = "xtream",
+                        addonName = "",
+                        addonBaseUrl = "",
+                        catalogId = category.id,
+                        catalogName = category.name,
+                        type = ContentType.TV,
+                        items = channels.map { it.toMetaPreview() },
+                        isLoading = !loaded
+                    ),
+                    onItemClick = { itemId, _, _ ->
+                        channels.firstOrNull { "live:${it.streamId}" == itemId }
+                            ?.let { onChannelSelected(it.name, it.streamUrl) }
+                    },
+                    showSeeAll = false,
+                    showAddonName = false,
+                )
+            }
+        }
+    }
+}
+
+private fun XtreamChannel.toMetaPreview(): MetaPreview = MetaPreview(
+    id = "live:$streamId",
+    type = ContentType.TV,
+    name = name,
+    poster = logo,
+    posterShape = PosterShape.LANDSCAPE,
+    background = null,
+    logo = null,
+    description = null,
+    releaseInfo = null,
+    imdbRating = null,
+    genres = emptyList()
+)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamLiveViewModel.kt
@@ -1,0 +1,75 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.iptv.XtreamCategory
+import com.nuvio.tv.core.iptv.XtreamChannel
+import com.nuvio.tv.core.iptv.XtreamClient
+import com.nuvio.tv.data.local.XtreamAccountStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class XtreamLiveUiState(
+    val accountName: String = "",
+    val categories: List<XtreamCategory> = emptyList(),
+    val channelsByCategory: Map<String, List<XtreamChannel>> = emptyMap(),
+    val loading: Boolean = true,
+    val error: String? = null
+)
+
+/**
+ * Live TV browse: one row per live category, channels lazy-loaded per row (same lazy pattern
+ * as VOD — live catalogs can be tens of thousands of channels). Channels play their .ts stream
+ * directly (no detail/meta needed for a TV channel).
+ */
+@HiltViewModel
+class XtreamLiveViewModel @Inject constructor(
+    private val store: XtreamAccountStore,
+    private val client: XtreamClient,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val accountId: String = savedStateHandle.get<String>("accountId").orEmpty()
+    private var account: XtreamAccount? = null
+    private val requested = mutableSetOf<String>()
+
+    private val _uiState = MutableStateFlow(XtreamLiveUiState())
+    val uiState: StateFlow<XtreamLiveUiState> = _uiState.asStateFlow()
+
+    init { viewModelScope.launch { loadCategories() } }
+
+    private suspend fun loadCategories() {
+        val acc = store.accounts.first().firstOrNull { it.id == accountId }
+        if (acc == null) {
+            _uiState.update { it.copy(loading = false, error = "Account not found") }
+            return
+        }
+        account = acc
+        _uiState.update { it.copy(accountName = acc.name, loading = true, error = null) }
+        client.liveCategories(acc)
+            .onSuccess { cats -> _uiState.update { it.copy(categories = cats, loading = false) } }
+            .onFailure { e -> _uiState.update { it.copy(loading = false, error = e.message ?: "Failed to load") } }
+    }
+
+    fun loadCategory(categoryId: String) {
+        if (!requested.add(categoryId)) return
+        val acc = account ?: return
+        viewModelScope.launch {
+            client.liveChannels(acc, categoryId)
+                .onSuccess { channels ->
+                    _uiState.update { it.copy(channelsByCategory = it.channelsByCategory + (categoryId to channels)) }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(channelsByCategory = it.channelsByCategory + (categoryId to emptyList())) }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamVodScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamVodScreen.kt
@@ -1,0 +1,108 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.core.iptv.XtreamMovie
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.ui.components.CatalogRowSection
+import com.nuvio.tv.ui.theme.NuvioTheme
+
+/**
+ * Nuvio-style VOD browse: one horizontal poster row per VOD category, stacked vertically —
+ * the same arrangement as the home screen, using the home's own [CatalogRowSection]. Each
+ * row lazy-loads its movies when it scrolls into view.
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun XtreamVodScreen(
+    onBackPress: () -> Unit,
+    onMovieSelected: (contentId: String) -> Unit,
+    viewModel: XtreamVodViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    BackHandler { onBackPress() }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(top = NuvioTheme.spacing.xl, bottom = NuvioTheme.spacing.xxl)
+    ) {
+        item {
+            Text(
+                text = uiState.accountName.ifEmpty { "IPTV" } + " · Movies",
+                style = MaterialTheme.typography.headlineSmall,
+                color = NuvioTheme.colors.TextPrimary,
+                modifier = Modifier.padding(start = NuvioTheme.spacing.xxxl, bottom = NuvioTheme.spacing.md)
+            )
+        }
+
+        val statusMessage = when {
+            uiState.error != null -> uiState.error
+            uiState.loading -> "Loading…"
+            uiState.categories.isEmpty() -> "No movies available"
+            else -> null
+        }
+        if (statusMessage != null) {
+            item {
+                Box(modifier = Modifier.fillMaxWidth().padding(NuvioTheme.spacing.xxxl)) {
+                    Text(statusMessage, style = MaterialTheme.typography.bodyLarge, color = NuvioTheme.colors.TextSecondary)
+                }
+            }
+        }
+
+        items(uiState.categories, key = { it.id }) { category ->
+            LaunchedEffect(category.id) { viewModel.loadCategory(category.id) }
+            val loaded = uiState.moviesByCategory.containsKey(category.id)
+            val movies = uiState.moviesByCategory[category.id].orEmpty()
+            // Show while loading, hide once a category resolves to empty (keeps the list tidy).
+            if (!loaded || movies.isNotEmpty()) {
+                CatalogRowSection(
+                    catalogRow = CatalogRow(
+                        addonId = "xtream",
+                        addonName = "",
+                        addonBaseUrl = "",
+                        catalogId = category.id,
+                        catalogName = category.name,
+                        type = ContentType.MOVIE,
+                        items = movies.map { it.toMetaPreview(uiState.accountId) },
+                        isLoading = !loaded
+                    ),
+                    onItemClick = { itemId, _, _ -> onMovieSelected(itemId) },
+                    showSeeAll = false,
+                    showAddonName = false
+                )
+            }
+        }
+    }
+}
+
+private fun XtreamMovie.toMetaPreview(accountId: String): MetaPreview = MetaPreview(
+    id = com.nuvio.tv.core.iptv.XtreamItemRegistry.vodId(accountId, streamId),
+    type = ContentType.MOVIE,
+    name = name,
+    poster = poster,
+    posterShape = PosterShape.POSTER,
+    background = null,
+    logo = null,
+    description = null,
+    releaseInfo = null,
+    imdbRating = rating?.toFloatOrNull(),
+    genres = emptyList()
+)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamVodViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/iptv/XtreamVodViewModel.kt
@@ -1,0 +1,112 @@
+package com.nuvio.tv.ui.screens.iptv
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.iptv.XtreamCategory
+import com.nuvio.tv.core.iptv.XtreamClient
+import com.nuvio.tv.core.iptv.XtreamItemRegistry
+import com.nuvio.tv.core.iptv.XtreamMovie
+import com.nuvio.tv.core.iptv.XtreamResolvedItem
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.data.local.XtreamAccountStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class XtreamVodUiState(
+    val accountId: String = "",
+    val accountName: String = "",
+    val categories: List<XtreamCategory> = emptyList(),
+    val moviesByCategory: Map<String, List<XtreamMovie>> = emptyMap(),
+    val loadingCategories: Set<String> = emptySet(),
+    val loading: Boolean = true,   // initial category-list load
+    val error: String? = null
+)
+
+/**
+ * Drives the Nuvio-style VOD browse screen: one horizontal row per category, each row's
+ * movies loaded lazily as it scrolls into view (catalogs can be 100k+ items, so never
+ * load them all). Mirrors how the home screen lazy-loads each catalog row.
+ */
+@HiltViewModel
+class XtreamVodViewModel @Inject constructor(
+    private val store: XtreamAccountStore,
+    private val client: XtreamClient,
+    private val registry: XtreamItemRegistry,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val accountId: String = savedStateHandle.get<String>("accountId").orEmpty()
+    private var account: XtreamAccount? = null
+    private val requested = mutableSetOf<String>()
+
+    private val _uiState = MutableStateFlow(XtreamVodUiState())
+    val uiState: StateFlow<XtreamVodUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch { loadCategories() }
+    }
+
+    private suspend fun loadCategories() {
+        val acc = store.accounts.first().firstOrNull { it.id == accountId }
+        if (acc == null) {
+            _uiState.update { it.copy(loading = false, error = "Account not found") }
+            return
+        }
+        account = acc
+        _uiState.update { it.copy(accountId = acc.id, accountName = acc.name, loading = true, error = null) }
+        client.vodCategories(acc)
+            .onSuccess { cats -> _uiState.update { it.copy(categories = cats, loading = false) } }
+            .onFailure { e -> _uiState.update { it.copy(loading = false, error = e.message ?: "Failed to load") } }
+    }
+
+    /** Loads one category's movies once (idempotent — safe to call from a row's LaunchedEffect). */
+    fun loadCategory(categoryId: String) {
+        if (!requested.add(categoryId)) return
+        val acc = account ?: return
+        _uiState.update { it.copy(loadingCategories = it.loadingCategories + categoryId) }
+        viewModelScope.launch {
+            client.vodMovies(acc, categoryId)
+                .onSuccess { movies ->
+                    // Register each movie so the meta + stream short-circuits can resolve it
+                    // when its native detail screen opens.
+                    movies.forEach { m ->
+                        registry.register(
+                            XtreamResolvedItem(
+                                id = XtreamItemRegistry.vodId(acc.id, m.streamId),
+                                type = ContentType.MOVIE,
+                                name = m.name,
+                                poster = m.poster,
+                                imdbRating = m.rating?.toFloatOrNull(),
+                                streamUrl = m.streamUrl,
+                                accountId = acc.id,
+                                streamId = m.streamId
+                            )
+                        )
+                    }
+                    _uiState.update {
+                        it.copy(
+                            moviesByCategory = it.moviesByCategory + (categoryId to movies),
+                            loadingCategories = it.loadingCategories - categoryId
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update {
+                        it.copy(
+                            moviesByCategory = it.moviesByCategory + (categoryId to emptyList()),
+                            loadingCategories = it.loadingCategories - categoryId
+                        )
+                    }
+                }
+        }
+    }
+
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -31,7 +31,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     fun ensureInitialized() {
         if (initialized) return
-        Utils.copyAssets(context)
+        // copyAssets re-writes fonts + cacert from assets and is slow on first run; skip it
+        // once the marker file exists so repeat inits (e.g. the Live TV preview) don't block.
+        if (!java.io.File(context.filesDir, "cacert.pem").exists()) {
+            Utils.copyAssets(context)
+        }
         initialize(
             configDir = context.filesDir.path,
             cacheDir = context.cacheDir.path

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
@@ -30,7 +30,13 @@ internal fun ExoPlayer.Builder.buildWithAssSupportCompat(
     renderType: AssRenderType = AssRenderType.CUES,
     playerMediaSourceFactory: PlayerMediaSourceFactory? = null,
     dataSourceFactory: DataSource.Factory = PlayerPlaybackNetworking.createDataSourceFactory(context),
-    extractorsFactory: ExtractorsFactory = DefaultExtractorsFactory(),
+    extractorsFactory: ExtractorsFactory = DefaultExtractorsFactory()
+        // IPTV live MPEG-TS streams often lack AUDs / IDR keyframes -> ExoPlayer buffers forever.
+        // These flags let it detect frame boundaries itself and accept non-IDR keyframes.
+        .setTsExtractorFlags(
+            androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_DETECT_ACCESS_UNITS or
+                androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_ALLOW_NON_IDR_KEYFRAMES
+        ),
     renderersFactory: RenderersFactory = DefaultRenderersFactory(context)
 ): ExoPlayer {
     val assHandler = AssHandler(renderType)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -170,7 +170,14 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             progressiveUpstreamFactory
         }
 
+        // IPTV live MPEG-TS streams frequently lack Access Unit Delimiters / IDR keyframes at the
+        // join point, which makes ExoPlayer buffer forever without ever reaching READY. These TS
+        // extractor flags tell it to detect frame boundaries itself and accept non-IDR keyframes.
         val extractorsFactory = customExtractorsFactory ?: DefaultExtractorsFactory()
+            .setTsExtractorFlags(
+                androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_DETECT_ACCESS_UNITS or
+                    androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_ALLOW_NON_IDR_KEYFRAMES
+            )
         val defaultFactory = DefaultMediaSourceFactory(progressiveFactory, extractorsFactory).apply {
             setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
             customSubtitleParserFactory?.let { parserFactory ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -423,6 +423,9 @@ class PlayerRuntimeController(
     internal var mpvInitializationInProgress: Boolean = false
     internal var mpvTrackRefreshInProgress: Boolean = false
     internal var pendingMpvHardRestartOnNextAttach: Boolean = false
+    // Set when initializeMpvPlayer ran before the mpv surface existed (engine switched
+    // mid-flight, e.g. live-stream override). The next attachMpvView completes the init.
+    internal var mpvNeedsInitOnAttach: Boolean = false
     internal var delayMpvResumeSeekUntilVideoTrack: Boolean = false
     internal var mpvDelayStartAfterAfrSwitch: Boolean = false
     internal var pauseOverlayJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -214,6 +214,11 @@ internal fun PlayerRuntimeController.initializePlayer(
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {
                 effectiveInternalPlayerEngine = resolveAutoInternalPlayerEngine()
             }
+            // IPTV live channels play continuous raw MPEG-TS, which ExoPlayer can't sustain
+            // (it buffers forever). libmpv handles it natively, so force it for live streams.
+            if (contentType.equals("live", ignoreCase = true)) {
+                effectiveInternalPlayerEngine = InternalPlayerEngine.MVP_PLAYER
+            }
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             if (overrideInternalPlayerEngine == null && playerSettings.internalPlayerEngine == InternalPlayerEngine.AUTO) {
                 resolvedAutoPlayerEngine = effectiveInternalPlayerEngine

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -17,7 +17,11 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
     if (view == null) return
     if (!isUsingMpvEngine()) return
     if (currentStreamUrl.isBlank()) return
-    if (mpvInitializationInProgress) return
+    // If init bailed earlier waiting for this surface, finish it now even though the
+    // init coroutine may still be flagged in-progress.
+    val resumingPendingInit = mpvNeedsInitOnAttach
+    if (mpvInitializationInProgress && !resumingPendingInit) return
+    mpvNeedsInitOnAttach = false
 
     runCatching {
         performPendingMpvHardRestartIfNeeded(view)
@@ -87,6 +91,9 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
 
     val view = mpvView
     if (view == null) {
+        // Surface not composed yet (engine switched mid-flight). Mark it so the next
+        // attachMpvView finishes the job instead of deadlocking on "Building player…".
+        mpvNeedsInitOnAttach = true
         setLoadingStatus(
             phase = "mpv_waiting_surface",
             message = context.getString(com.nuvio.tv.R.string.player_loading_building),
@@ -103,6 +110,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         return
     }
 
+    mpvNeedsInitOnAttach = false
     runCatching {
         setLoadingStatus(
             phase = "mpv_starting",

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -799,6 +799,48 @@ internal fun PlayerRuntimeController.switchToSourceStream(
     loadSavedProgressFor(currentSeason, currentEpisode)
 }
 
+/** Zap to another live channel by swapping the stream on the RUNNING mpv instance
+ *  (`loadfile replace`) — no releasePlayer/destroy. Destroying a stuck decoder (e.g. a 4K
+ *  channel the device can't decode) would block the main thread; loadfile-replace aborts the
+ *  current file and loads the new one cleanly, which is also the smoothest zap. */
+internal fun PlayerRuntimeController.switchToLiveChannel(name: String, url: String) {
+    val view = mpvView
+    if (view == null || !isUsingMpvEngine()) {
+        // Fallback for the unexpected non-mpv case: full source switch.
+        switchToSourceStream(
+            com.nuvio.tv.domain.model.Stream(
+                name = name, title = name, description = null, url = url, ytId = null,
+                infoHash = null, fileIdx = null, externalUrl = null, behaviorHints = null,
+                addonName = "Xtream IPTV", addonLogo = null
+            )
+        )
+        return
+    }
+    flushPlaybackSnapshotForSwitchOrExit()
+    currentStreamUrl = url
+    resetLoadingOverlayForNewStream()
+    _uiState.update {
+        it.copy(
+            title = name,
+            contentName = name,
+            currentStreamName = name,
+            currentStreamUrl = url,
+            isBuffering = true,
+            error = null,
+            audioTracks = emptyList(),
+            subtitleTracks = emptyList(),
+            selectedAudioTrackIndex = -1,
+            selectedSubtitleTrackIndex = -1
+        )
+    }
+    hasRenderedFirstFrame = false
+    runCatching {
+        view.setMedia(url, currentHeaders)
+        view.setPaused(false)
+    }
+    emitScrobbleStart()
+}
+
 internal fun PlayerRuntimeController.dismissEpisodesPanel() {
     episodeStreamsScope?.cancel()
     episodeStreamsScope = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -631,7 +631,11 @@ fun PlayerScreen(
                             }
                         }
                         KeyEvent.KEYCODE_DPAD_UP -> {
-                                if (!uiState.showControls) {
+                                val isLive = uiState.contentType.equals("live", ignoreCase = true)
+                                if (!uiState.showControls && isLive) {
+                                    // TiViMate-style zap: up = previous channel (in place, same surface).
+                                    viewModel.zapLive(-1)
+                                } else if (!uiState.showControls) {
                                     viewModel.onEvent(PlayerEvent.OnToggleControls)
                                 } else {
                                     try {
@@ -656,7 +660,12 @@ fun PlayerScreen(
                                 true
                             }
                         KeyEvent.KEYCODE_DPAD_DOWN -> {
-                            if (!uiState.showControls) {
+                            val isLive = uiState.contentType.equals("live", ignoreCase = true)
+                            if (!uiState.showControls && isLive) {
+                                // TiViMate-style zap: down = next channel (in place, same surface).
+                                viewModel.zapLive(1)
+                                true
+                            } else if (!uiState.showControls) {
                                 viewModel.onEvent(PlayerEvent.OnToggleControls)
                                 true
                             } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -66,8 +66,12 @@ class PlayerViewModel @Inject constructor(
     private val playbackIssueReportRepository: com.nuvio.tv.data.repository.PlaybackIssueReportRepository,
     private val externalPlaybackTracker: com.nuvio.tv.core.player.ExternalPlaybackTracker,
     private val subtitleFileCache: com.nuvio.tv.core.player.SubtitleFileCache,
+    private val livePlaylist: com.nuvio.tv.core.iptv.XtreamLivePlaylist,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    // Tracks which live channel is on-screen so up/down can resolve the next/previous one.
+    private var currentLiveContentId: String? = savedStateHandle.get<String>("contentId")
 
     init {
         // Release trailer player codec resources so the full-screen player can
@@ -156,6 +160,14 @@ class PlayerViewModel @Inject constructor(
 
     fun startInitialPlaybackIfNeeded() {
         controller.startInitialPlaybackIfNeeded()
+    }
+
+    /** Zap to the next (delta +1) or previous (delta -1) live channel, in place. */
+    fun zapLive(delta: Int) {
+        val cur = currentLiveContentId ?: return
+        val next = livePlaylist.relativeTo(cur, delta) ?: return
+        currentLiveContentId = next.id
+        controller.switchToLiveChannel(name = next.name, url = next.streamUrl)
     }
 
     fun onEvent(event: PlayerEvent) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -684,7 +684,9 @@ fun SearchScreen(
                                 showSeeAll = hasEnoughForSeeAll,
                                 showPosterLabels = uiState.posterLabelsEnabled,
                                 showAddonName = uiState.catalogAddonNameEnabled,
-                                showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled,
+                                // IPTV rows are already titled (e.g. "IPTV Channels"); the
+                                // generic type suffix would mislabel a channel row as "Series".
+                                showCatalogTypeSuffix = uiState.catalogTypeSuffixEnabled && catalogRow.addonId != "xtream",
                                 enableRowFocusRestorer = true,
                                 rowFocusRequester = rowFocusRequester,
                                 entryFocusRequester = entryFocusRequester,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -48,6 +48,7 @@ class SearchViewModel @Inject constructor(
     private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
     private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     val posterOptions: com.nuvio.tv.ui.components.posteroptions.PosterOptionsController,
+    private val xtreamSearchIndex: com.nuvio.tv.core.iptv.XtreamSearchIndex,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -411,6 +412,9 @@ class SearchViewModel @Inject constructor(
             pendingCatalogResponses = jobs.size
             activeSearchJobs = jobs
 
+            // IPTV results appear as their own rows below the addon rows.
+            loadXtreamResults(query)
+
             // Wait for all jobs to complete so we can stop showing the global loading state.
             viewModelScope.launch {
                 try {
@@ -466,6 +470,47 @@ class SearchViewModel @Inject constructor(
                     // No-op; screen shows global loading when empty.
                 }
             }
+        }
+    }
+
+    /** Fetch IPTV matches (channels/movies/series) and append them as their own rows. */
+    private fun loadXtreamResults(query: String) {
+        viewModelScope.launch {
+            val results = try { xtreamSearchIndex.search(query) } catch (_: Exception) { return@launch }
+            if (uiState.value.submittedQuery.trim() != query) return@launch
+
+            fun putRow(catalogId: String, name: String, rawType: String, hits: List<com.nuvio.tv.core.iptv.XtreamSearchIndex.Hit>) {
+                if (hits.isEmpty()) return
+                val key = catalogKey(addonId = "xtream", type = rawType, catalogId = catalogId)
+                if (key !in catalogOrder) catalogOrder.add(key)
+                catalogsMap[key] = CatalogRow(
+                    addonId = "xtream",
+                    addonName = "IPTV",
+                    addonBaseUrl = "",
+                    catalogId = catalogId,
+                    catalogName = name,
+                    type = ContentType.fromString(rawType),
+                    rawType = rawType,
+                    items = hits.map { hit ->
+                        MetaPreview(
+                            id = hit.contentId,
+                            type = ContentType.fromString(rawType),
+                            rawType = rawType,
+                            name = hit.name,
+                            poster = hit.poster,
+                            posterShape = if (hit.isLive) PosterShape.LANDSCAPE else PosterShape.POSTER,
+                            background = null, logo = null, description = null, releaseInfo = null,
+                            imdbRating = null, genres = emptyList()
+                        )
+                    },
+                    isLoading = false,
+                    hasMore = false
+                )
+            }
+            putRow("xtream_channels", "IPTV Channels", "tv", results.channels)
+            putRow("xtream_movies", "IPTV Movies", "movie", results.movies)
+            putRow("xtream_series", "IPTV Series", "series", results.series)
+            scheduleCatalogRowsUpdate()
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -86,7 +86,8 @@ private enum class IntegrationSettingsSection {
     Debrid,
     Tmdb,
     MdbList,
-    AnimeSkip
+    AnimeSkip,
+    Iptv
 }
 
 internal enum class SettingsSectionDestination {
@@ -210,6 +211,8 @@ fun SettingsScreen(
     onNavigateToManageProfiles: () -> Unit = {},
     onNavigateToSupportersContributors: () -> Unit = {},
     onNavigateToLicensesAttributions: () -> Unit = {},
+    onNavigateToXtreamVod: (accountId: String) -> Unit = {},
+    onNavigateToXtreamLive: (accountId: String) -> Unit = {},
     profileViewModel: ProfileSettingsViewModel = hiltViewModel(),
     experienceModeViewModel: ExperienceModeSettingsViewModel = hiltViewModel()
 ) {
@@ -278,6 +281,7 @@ fun SettingsScreen(
     val integrationTmdbFocusRequester = remember { FocusRequester() }
     val integrationMdbListFocusRequester = remember { FocusRequester() }
     val integrationAnimeSkipFocusRequester = remember { FocusRequester() }
+    val integrationIptvFocusRequester = remember { FocusRequester() }
     var integrationSection by remember { mutableStateOf(IntegrationSettingsSection.Hub) }
     var pendingContentFocusCategory by remember { mutableStateOf<SettingsCategory?>(null) }
     var pendingContentFocusRequestId by remember { mutableLongStateOf(0L) }
@@ -506,6 +510,9 @@ fun SettingsScreen(
                             tmdbFocusRequester = integrationTmdbFocusRequester,
                             mdbListFocusRequester = integrationMdbListFocusRequester,
                             animeSkipFocusRequester = integrationAnimeSkipFocusRequester,
+                            iptvFocusRequester = integrationIptvFocusRequester,
+                            onNavigateToXtreamVod = onNavigateToXtreamVod,
+                            onNavigateToXtreamLive = onNavigateToXtreamLive,
                             autoFocusEnabled = allowDetailAutofocus
                         )
                         SettingsCategory.ABOUT -> AboutSettingsContent(
@@ -663,6 +670,9 @@ private fun IntegrationSettingsContent(
     tmdbFocusRequester: FocusRequester,
     mdbListFocusRequester: FocusRequester,
     animeSkipFocusRequester: FocusRequester,
+    iptvFocusRequester: FocusRequester,
+    onNavigateToXtreamVod: (accountId: String) -> Unit,
+    onNavigateToXtreamLive: (accountId: String) -> Unit,
     autoFocusEnabled: Boolean
 ) {
     BackHandler(enabled = selectedSection != IntegrationSettingsSection.Hub) {
@@ -678,6 +688,7 @@ private fun IntegrationSettingsContent(
             IntegrationSettingsSection.Tmdb -> tmdbFocusRequester
             IntegrationSettingsSection.MdbList -> mdbListFocusRequester
             IntegrationSettingsSection.AnimeSkip -> animeSkipFocusRequester
+            IntegrationSettingsSection.Iptv -> iptvFocusRequester
         }
         runCatching { requester.requestFocus() }
     }
@@ -733,6 +744,13 @@ private fun IntegrationSettingsContent(
                                     onClick = { onSelectSection(IntegrationSettingsSection.AnimeSkip) }
                                 )
                             }
+                            item(key = "integration_hub_iptv") {
+                                SettingsActionRow(
+                                    title = "IPTV (Xtream Codes)",
+                                    subtitle = "Add a live TV / VOD provider by URL",
+                                    onClick = { onSelectSection(IntegrationSettingsSection.Iptv) }
+                                )
+                            }
                         }
                         SettingsVerticalScrollIndicators(state = integrationHubState)
                     }
@@ -761,6 +779,14 @@ private fun IntegrationSettingsContent(
         IntegrationSettingsSection.AnimeSkip -> {
             AnimeSkipSettingsContent(
                 initialFocusRequester = animeSkipFocusRequester
+            )
+        }
+
+        IntegrationSettingsSection.Iptv -> {
+            XtreamSettingsContent(
+                onBrowseVod = onNavigateToXtreamVod,
+                onBrowseLive = onNavigateToXtreamLive,
+                initialFocusRequester = iptvFocusRequester
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/XtreamSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/XtreamSettingsScreen.kt
@@ -1,0 +1,344 @@
+package com.nuvio.tv.ui.screens.settings
+
+import android.view.KeyEvent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.ui.components.NuvioDialog
+import com.nuvio.tv.ui.theme.NuvioTheme
+
+/**
+ * Xtream IPTV accounts settings (inline section, like Debrid). Single paste field:
+ * the user pastes their portal/M3U URL, we verify it live, then it's saved.
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun XtreamSettingsContent(
+    viewModel: XtreamSettingsViewModel = hiltViewModel(),
+    onBrowseVod: (accountId: String) -> Unit = {},
+    onBrowseLive: (accountId: String) -> Unit = {},
+    initialFocusRequester: FocusRequester? = null
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showAddDialog by remember { mutableStateOf(false) }
+    var actionsFor by remember { mutableStateOf<XtreamAccount?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(NuvioTheme.spacing.xl)
+    ) {
+        Text(
+            text = "IPTV (Xtream Codes)",
+            style = MaterialTheme.typography.titleLarge,
+            color = NuvioTheme.colors.TextPrimary
+        )
+        Text(
+            text = "Paste your IPTV portal or M3U URL to add a provider.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = NuvioTheme.colors.TextSecondary,
+            modifier = Modifier.padding(top = NuvioTheme.spacing.xs, bottom = NuvioTheme.spacing.md)
+        )
+
+        SettingsActionRow(
+            title = "Add IPTV account",
+            subtitle = "Paste a portal / M3U URL",
+            onClick = { showAddDialog = true },
+            leadingIcon = Icons.Default.Add,
+            modifier = initialFocusRequester?.let { Modifier.focusRequester(it) } ?: Modifier
+        )
+
+        uiState.accounts.forEach { account ->
+            SettingsActionRow(
+                title = account.name,
+                subtitle = account.baseUrl,
+                value = if (account.enabled) "On" else "Off",
+                onClick = { actionsFor = account }
+            )
+        }
+    }
+
+    if (showAddDialog) {
+        XtreamAddDialog(
+            isValidating = uiState.isValidating,
+            error = uiState.error,
+            onSubmitUrl = { url -> viewModel.addFromUrl(url, name = null) { showAddDialog = false } },
+            onSubmitManual = { server, user, pass, name ->
+                viewModel.addManual(server, user, pass, name) { showAddDialog = false }
+            },
+            onDismiss = {
+                viewModel.clearError()
+                showAddDialog = false
+            }
+        )
+    }
+
+    actionsFor?.let { account ->
+        NuvioDialog(
+            onDismiss = { actionsFor = null },
+            title = account.name,
+            subtitle = account.baseUrl
+        ) {
+            SettingsActionRow(
+                title = "Browse Live TV",
+                subtitle = null,
+                onClick = {
+                    val id = account.id
+                    actionsFor = null
+                    onBrowseLive(id)
+                }
+            )
+            SettingsActionRow(
+                title = "Browse Movies (VOD)",
+                subtitle = null,
+                onClick = {
+                    val id = account.id
+                    actionsFor = null
+                    onBrowseVod(id)
+                }
+            )
+            SettingsActionRow(
+                title = if (account.enabled) "Disable" else "Enable",
+                subtitle = null,
+                onClick = {
+                    viewModel.setEnabled(account.id, !account.enabled)
+                    actionsFor = null
+                }
+            )
+            SettingsActionRow(
+                title = "Remove account",
+                subtitle = null,
+                onClick = {
+                    viewModel.remove(account.id)
+                    actionsFor = null
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun XtreamAddDialog(
+    isValidating: Boolean,
+    error: String?,
+    onSubmitUrl: (String) -> Unit,
+    onSubmitManual: (server: String, user: String, pass: String, name: String?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var manualMode by remember { mutableStateOf(false) }
+    // paste mode
+    var url by remember { mutableStateOf("") }
+    // manual mode
+    var server by remember { mutableStateOf("") }
+    var user by remember { mutableStateOf("") }
+    var pass by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf("") }
+
+    val firstFieldFocus = remember { FocusRequester() }
+    LaunchedEffect(manualMode) { runCatching { firstFieldFocus.requestFocus() } }
+
+    val submit = {
+        if (!isValidating) {
+            if (manualMode) {
+                if (server.isNotBlank() && user.isNotBlank() && pass.isNotBlank()) {
+                    onSubmitManual(server.trim(), user.trim(), pass.trim(), name.trim().ifEmpty { null })
+                }
+            } else if (url.isNotBlank()) {
+                onSubmitUrl(url.trim())
+            }
+        }
+    }
+
+    NuvioDialog(
+        onDismiss = onDismiss,
+        title = "Add IPTV account",
+        subtitle = if (manualMode) "Enter your panel details" else "Paste your portal or M3U URL (it contains your username & password)",
+        width = 760.dp,
+        suppressFirstKeyUp = false
+    ) {
+        // mode toggle
+        Row(modifier = Modifier.padding(top = NuvioTheme.spacing.sm)) {
+            XtreamModeTab("Paste link", selected = !manualMode) { manualMode = false }
+            Spacer(Modifier.width(NuvioTheme.spacing.sm))
+            XtreamModeTab("Enter details", selected = manualMode) { manualMode = true }
+        }
+
+        if (manualMode) {
+            XtreamField(server, { server = it }, "Server URL  (http://host:port)", firstFieldFocus, onSubmit = submit)
+            XtreamField(user, { user = it }, "Username", onSubmit = submit)
+            XtreamField(pass, { pass = it }, "Password", isPassword = true, onSubmit = submit)
+            XtreamField(name, { name = it }, "Name (optional)", onSubmit = submit)
+            XtreamAddButton(isValidating, onClick = submit)
+        } else {
+            XtreamField(url, { url = it }, "http://host:port/get.php?username=…&password=…", firstFieldFocus, onSubmit = submit)
+        }
+
+        val status = when {
+            isValidating -> "Verifying…"
+            error != null -> error
+            else -> null
+        }
+        if (status != null) {
+            Text(
+                text = status,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (error != null && !isValidating) NuvioTheme.colors.Error else NuvioTheme.colors.TextSecondary,
+                modifier = Modifier.padding(top = NuvioTheme.spacing.sm)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun XtreamModeTab(label: String, selected: Boolean, onClick: () -> Unit) {
+    var focused by remember { mutableStateOf(false) }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (selected) NuvioTheme.colors.Primary else NuvioTheme.colors.BackgroundElevated)
+            .border(
+                width = 1.dp,
+                color = if (focused) NuvioTheme.colors.Primary else NuvioTheme.colors.Border,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .focusable()
+            .onFocusChanged { focused = it.isFocused }
+            .onKeyEvent {
+                if ((it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+                        it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ENTER) &&
+                    it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN
+                ) { onClick(); true } else false
+            }
+            .padding(horizontal = 14.dp, vertical = NuvioTheme.spacing.sm)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (selected) NuvioTheme.colors.TextPrimary else NuvioTheme.colors.TextSecondary
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun XtreamField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    focusRequester: FocusRequester? = null,
+    isPassword: Boolean = false,
+    onSubmit: () -> Unit
+) {
+    var focused by remember { mutableStateOf(false) }
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = NuvioTheme.spacing.md)
+            .background(NuvioTheme.colors.BackgroundElevated, RoundedCornerShape(10.dp))
+            .border(
+                width = 1.dp,
+                color = if (focused) NuvioTheme.colors.Primary else NuvioTheme.colors.Border,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(horizontal = 14.dp, vertical = NuvioTheme.spacing.md)
+            .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
+            .onFocusChanged { focused = it.isFocused || it.hasFocus }
+            .onKeyEvent { event ->
+                val native = event.nativeKeyEvent
+                when {
+                    native.keyCode == KeyEvent.KEYCODE_DPAD_CENTER && native.action == KeyEvent.ACTION_DOWN -> true
+                    (native.keyCode == KeyEvent.KEYCODE_ENTER || native.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) &&
+                        native.action == KeyEvent.ACTION_DOWN -> { onSubmit(); true }
+                    else -> false
+                }
+            },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+        visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
+        textStyle = MaterialTheme.typography.bodyMedium.copy(color = NuvioTheme.colors.TextPrimary),
+        cursorBrush = SolidColor(if (focused) NuvioTheme.colors.Primary else Color.Transparent),
+        decorationBox = { inner ->
+            if (value.isEmpty()) {
+                Text(placeholder, style = MaterialTheme.typography.bodyMedium, color = NuvioTheme.colors.TextTertiary)
+            }
+            inner()
+        }
+    )
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun XtreamAddButton(isValidating: Boolean, onClick: () -> Unit) {
+    var focused by remember { mutableStateOf(false) }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = NuvioTheme.spacing.md)
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (focused) NuvioTheme.colors.Primary else NuvioTheme.colors.BackgroundElevated)
+            .border(1.dp, if (focused) NuvioTheme.colors.Primary else NuvioTheme.colors.Border, RoundedCornerShape(10.dp))
+            .focusable()
+            .onFocusChanged { focused = it.isFocused }
+            .onKeyEvent {
+                if ((it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+                        it.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ENTER) &&
+                    it.nativeKeyEvent.action == KeyEvent.ACTION_DOWN
+                ) { onClick(); true } else false
+            }
+            .padding(vertical = NuvioTheme.spacing.md),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = if (isValidating) "Verifying…" else "Add account",
+            style = MaterialTheme.typography.bodyMedium,
+            color = NuvioTheme.colors.TextPrimary
+        )
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/XtreamSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/XtreamSettingsViewModel.kt
@@ -1,0 +1,83 @@
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.iptv.XtreamAccount
+import com.nuvio.tv.core.iptv.XtreamClient
+import com.nuvio.tv.core.iptv.parseXtreamAccount
+import com.nuvio.tv.core.iptv.xtreamAccountFromFields
+import com.nuvio.tv.data.local.XtreamAccountStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class XtreamSettingsUiState(
+    val accounts: List<XtreamAccount> = emptyList(),
+    val isValidating: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class XtreamSettingsViewModel @Inject constructor(
+    private val store: XtreamAccountStore,
+    private val client: XtreamClient
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(XtreamSettingsUiState())
+    val uiState: StateFlow<XtreamSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            store.accounts.collectLatest { accounts ->
+                _uiState.update { it.copy(accounts = accounts) }
+            }
+        }
+    }
+
+    /** Parse a pasted portal/M3U URL, verify the credentials live, then persist. */
+    fun addFromUrl(input: String, name: String?, onSuccess: () -> Unit) {
+        verifyAndSave(parseXtreamAccount(input, name), "Couldn't read a username & password from that URL", onSuccess)
+    }
+
+    /** Add from manually-entered server URL + username + password. */
+    fun addManual(serverUrl: String, username: String, password: String, name: String?, onSuccess: () -> Unit) {
+        verifyAndSave(
+            xtreamAccountFromFields(serverUrl, username, password, name),
+            "Enter a server URL, username and password",
+            onSuccess
+        )
+    }
+
+    private fun verifyAndSave(account: XtreamAccount?, parseError: String, onSuccess: () -> Unit) {
+        if (account == null) {
+            _uiState.update { it.copy(error = parseError) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isValidating = true, error = null) }
+            val result = client.verify(account)
+            _uiState.update { it.copy(isValidating = false) }
+            result.onSuccess {
+                store.upsert(account)
+                onSuccess()
+            }.onFailure { e ->
+                _uiState.update { it.copy(error = e.message ?: "Could not reach the panel") }
+            }
+        }
+    }
+
+    fun setEnabled(id: String, enabled: Boolean) {
+        viewModelScope.launch { store.setEnabled(id, enabled) }
+    }
+
+    fun remove(id: String) {
+        viewModelScope.launch { store.remove(id) }
+    }
+
+    fun clearError() = _uiState.update { it.copy(error = null) }
+}

--- a/app/src/test/java/com/nuvio/tv/core/iptv/XtreamClientTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/iptv/XtreamClientTest.kt
@@ -1,0 +1,121 @@
+package com.nuvio.tv.core.iptv
+
+import com.nuvio.tv.data.remote.api.XtreamApi
+import com.nuvio.tv.data.remote.dto.FlexIntAdapter
+import com.nuvio.tv.data.remote.dto.XtreamLiveStreamDto
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+import java.util.Base64
+
+class XtreamClientTest {
+
+    private val acc = XtreamAccount(
+        id = "http://host:8080",
+        name = "Panel",
+        baseUrl = "http://host:8080",
+        username = "u s+r",          // space + reserved char -> must be encoded
+        password = "p@ss"
+    )
+
+    @Test
+    fun `liveChannels builds player_api url and ts stream url`() = runTest {
+        val api = mockk<XtreamApi>()
+        val urlSlot = slot<String>()
+        coEvery { api.getLiveStreams(capture(urlSlot)) } returns Response.success(
+            listOf(XtreamLiveStreamDto(num = 1, name = "BBC", streamId = 42, streamIcon = "", epgChannelId = "bbc", categoryId = "3", tvArchive = 1))
+        )
+
+        val channels = XtreamClient(api).liveChannels(acc).getOrThrow()
+
+        // request URL: encoded creds, player_api.php, correct action
+        val reqUrl = urlSlot.captured
+        assertTrue(reqUrl, reqUrl.startsWith("http://host:8080/player_api.php?"))
+        assertTrue(reqUrl, reqUrl.contains("action=get_live_streams"))
+        assertTrue(reqUrl, reqUrl.contains("username=u%20s%2Br"))   // space->%20, +->%2B
+        assertTrue(reqUrl, reqUrl.contains("password=p%40ss"))
+
+        // mapped channel + stream url. Path segments keep RFC-3986-legal '+'/'@' literal
+        // (space still -> %20; '/' etc. would still be encoded). Query encoding above differs.
+        assertEquals(1, channels.size)
+        assertEquals("http://host:8080/live/u%20s+r/p@ss/42.ts", channels[0].streamUrl)
+        assertTrue(channels[0].hasArchive)
+    }
+
+    @Test
+    fun `FlexInt tolerates int, quoted string, and bool across panels`() {
+        val moshi = Moshi.Builder().add(FlexIntAdapter).add(KotlinJsonAdapterFactory()).build()
+        val adapter = moshi.adapter(XtreamLiveStreamDto::class.java)
+
+        // panel A: numbers as ints, tv_archive as int
+        val a = adapter.fromJson("""{"num":1,"stream_id":42,"name":"A","category_id":"3","tv_archive":1}""")!!
+        assertEquals(42, a.streamId)
+        assertEquals(1, a.tvArchive)
+
+        // panel B: same fields as quoted strings, tv_archive as bool
+        val b = adapter.fromJson("""{"num":"1","stream_id":"42","name":"B","category_id":"3","tv_archive":true}""")!!
+        assertEquals(42, b.streamId)
+        assertEquals(1, b.tvArchive)
+
+        // garbage/empty id -> null, doesn't throw
+        val c = adapter.fromJson("""{"stream_id":"","name":"C"}""")!!
+        assertEquals(null, c.streamId)
+    }
+
+    @Test
+    fun `parseXtreamAccount extracts host, port, creds from m3u and player_api urls`() {
+        // get.php M3U with :8080 -> port preserved
+        val a = parseXtreamAccount("http://provider.example.com:8080/get.php?username=user1&password=pass1&type=m3u_plus&output=mpegts")!!
+        assertEquals("http://provider.example.com:8080", a.baseUrl)
+        assertEquals("user1", a.username)
+        assertEquals("pass1", a.password)
+
+        // default http port -> omitted from baseUrl
+        val b = parseXtreamAccount("http://panel.example.net/get.php?username=u1&password=p1&type=m3u_plus&output=ts")!!
+        assertEquals("http://panel.example.net", b.baseUrl)
+        assertEquals("panel.example.net", b.name)
+
+        // player_api form works too; custom name honored
+        val c = parseXtreamAccount("http://host.example.org/player_api.php?username=demo&password=secret", name = "Home")!!
+        assertEquals("http://host.example.org", c.baseUrl)
+        assertEquals("Home", c.name)
+
+        // missing creds / non-url -> null
+        assertEquals(null, parseXtreamAccount("http://panel.example.net/get.php?type=m3u_plus"))
+        assertEquals(null, parseXtreamAccount("not a url"))
+    }
+
+    @Test
+    fun `xtreamAccountFromFields normalizes server, defaults http, requires creds`() {
+        // bare host:port -> http scheme added, port kept
+        val a = xtreamAccountFromFields("host.example.org:8080", "demo", "secret", null)!!
+        assertEquals("http://host.example.org:8080", a.baseUrl)
+        assertEquals("demo", a.username)
+        assertEquals("secret", a.password)
+        assertEquals("host.example.org", a.name)
+
+        // full url with path -> path stripped, default port omitted, custom name kept
+        val b = xtreamAccountFromFields("http://panel.example.net/c/", "u", "p", "Home")!!
+        assertEquals("http://panel.example.net", b.baseUrl)
+        assertEquals("Home", b.name)
+
+        // missing creds -> null
+        assertEquals(null, xtreamAccountFromFields("http://panel.example.net", "", "p", null))
+        assertEquals(null, xtreamAccountFromFields("", "u", "p", null))
+    }
+
+    @Test
+    fun `decodeXtreamBase64 decodes, passes through garbage, empties null`() {
+        val enc = Base64.getEncoder().encodeToString("News at Ten".toByteArray())
+        assertEquals("News at Ten", decodeXtreamBase64(enc))
+        assertEquals("", decodeXtreamBase64(null))
+        assertEquals("", decodeXtreamBase64("   "))
+    }
+}


### PR DESCRIPTION
## Xtream Codes IPTV (Live TV · VOD · Series)

Native Xtream Codes integration for Android TV:

- Browse **Live TV / Movies / Series**
- **Now/next EPG** on live tiles (`get_short_epg`)
- **Multi-playlist accounts** with account details (status, expiry, active/max connections)
- **Search** across channels, movies, and series
- **libmpv-backed** live playback (ExoPlayer cannot sustain raw MPEG-TS)

Notes:
- Unit tests use `example.*` placeholder hosts / credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)