### PR TITLE
Refresh settings icons to match each setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -31,8 +31,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Timelapse
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -566,14 +569,20 @@ fun LayoutSettingsContent(
                         onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
                     )
                     NavigationSettingsItem(
-                        icon = Icons.Default.Image,
+                        icon = ImageVector.vectorResource(
+                            if (streamBadgeUiState.badgePlacement == StreamBadgePlacement.TOP) {
+                                R.drawable.ic_badge_pos_top
+                            } else {
+                                R.drawable.ic_badge_pos_bottom
+                            }
+                        ),
                         title = stringResource(R.string.settings_stream_badge_position_title),
                         subtitle = streamBadgePlacementLabel(streamBadgeUiState.badgePlacement),
                         onClick = { showStreamBadgePositionDialog = true },
                         onFocused = { focusedSection = LayoutSettingsSection.STREAMS }
                     )
                     NavigationSettingsItem(
-                        icon = Icons.Default.Image,
+                        icon = Icons.Default.Link,
                         title = stringResource(R.string.settings_stream_badge_urls_title),
                         subtitle = streamBadgeRulesPreview(streamBadgeUiState),
                         onClick = viewModel::startStreamBadgeQrMode,
@@ -701,7 +710,7 @@ fun LayoutSettingsContent(
 
                     if (!isModernLandscape && uiState.focusedPosterBackdropExpandEnabled) {
                         SliderSettingsItem(
-                            icon = Icons.Default.Timer,
+                            icon = Icons.Default.Timelapse,
                             title = stringResource(R.string.layout_expand_delay),
                             subtitle = stringResource(R.string.layout_expand_delay_sub),
                             value = uiState.focusedPosterBackdropExpandDelaySeconds,
@@ -876,12 +885,12 @@ private fun StreamBadgePositionDialog(
 ) {
     val options = listOf(
         SettingsPickerOption(
-            StreamBadgePlacement.BOTTOM,
-            stringResource(R.string.settings_stream_badge_position_bottom)
-        ),
-        SettingsPickerOption(
             StreamBadgePlacement.TOP,
             stringResource(R.string.settings_stream_badge_position_top)
+        ),
+        SettingsPickerOption(
+            StreamBadgePlacement.BOTTOM,
+            stringResource(R.string.settings_stream_badge_position_bottom)
         )
     )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -21,12 +21,22 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Cable
+import androidx.compose.material.icons.filled.CallMerge
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DeveloperBoard
+import androidx.compose.material.icons.filled.HdrAuto
+import androidx.compose.material.icons.filled.HdrOff
+import androidx.compose.material.icons.filled.HdrOn
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LowPriority
+import androidx.compose.material.icons.filled.MoreTime
+import androidx.compose.material.icons.filled.RecordVoiceOver
+import androidx.compose.material.icons.filled.SurroundSound
+import androidx.compose.material.icons.filled.Transform
+import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -118,7 +128,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         }
 
         NavigationSettingsItem(
-            icon = Icons.Default.Language,
+            icon = Icons.Default.RecordVoiceOver,
             title = stringResource(R.string.audio_preferred_lang),
             subtitle = audioLangName,
             onClick = onShowAudioLanguageDialog,
@@ -148,7 +158,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     if (isExoEngine) {
         item(key = "audio_skip_silence") {
             ToggleSettingsItem(
-                icon = Icons.Default.Speed,
+                icon = Icons.Default.VolumeOff,
                 title = stringResource(R.string.audio_skip_silence),
                 subtitle = stringResource(R.string.audio_skip_silence_sub),
                 isChecked = playerSettings.skipSilence,
@@ -160,7 +170,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
 
         item(key = "audio_remember_delay_per_device") {
             ToggleSettingsItem(
-                icon = Icons.Default.Timer,
+                icon = Icons.Default.MoreTime,
                 title = stringResource(R.string.audio_remember_delay_per_device),
                 subtitle = stringResource(R.string.audio_remember_delay_per_device_sub),
                 isChecked = playerSettings.rememberAudioDelayPerDevice,
@@ -200,7 +210,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
             }
 
             NavigationSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.LowPriority,
                 title = stringResource(R.string.audio_decoder_priority),
                 subtitle = decoderName,
                 onClick = onShowDecoderPriorityDialog,
@@ -211,7 +221,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
 
         item(key = "audio_enable_downmix") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.CallMerge,
                 title = stringResource(R.string.audio_enable_downmix_title),
                 subtitle = stringResource(R.string.audio_enable_downmix_subtitle),
                 isChecked = playerSettings.downmixEnabled,
@@ -224,7 +234,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         if (playerSettings.downmixEnabled) {
             item(key = "audio_number_of_channels") {
                 NavigationSettingsItem(
-                    icon = Icons.Default.VolumeUp,
+                    icon = Icons.Default.SurroundSound,
                     title = stringResource(R.string.audio_number_of_channels),
                     subtitle = playerSettings.audioOutputChannels.displayLabel,
                     onClick = onShowAudioOutputChannelsDialog,
@@ -235,7 +245,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
 
             item(key = "audio_downmix_normalization") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Tune,
+                    icon = Icons.Default.Lock,
                     title = stringResource(R.string.audio_maintain_original_audio_on_downmix_title),
                     subtitle = stringResource(R.string.audio_maintain_original_audio_on_downmix_subtitle),
                     isChecked = playerSettings.maintainOriginalAudioOnDownmix,
@@ -248,7 +258,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
 
         item(key = "audio_tunneled_playback") {
             ToggleSettingsItem(
-                icon = Icons.Default.VolumeUp,
+                icon = Icons.Default.Bolt,
                 title = stringResource(R.string.audio_tunneled),
                 subtitle = stringResource(R.string.audio_tunneled_sub),
                 isChecked = playerSettings.tunnelingEnabled,
@@ -261,7 +271,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         if (isExoEngine || isMpvEngine) {
             item(key = "audio_force_optical_passthrough") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.VolumeUp,
+                    icon = Icons.Default.Cable,
                     title = stringResource(R.string.audio_force_optical_passthrough),
                     subtitle = stringResource(R.string.audio_force_optical_passthrough_sub),
                     isChecked = playerSettings.forceOpticalPassthrough && playerSettings.decoderPriority != 0,
@@ -295,7 +305,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
                 Dv7HandlingMode.OFF -> stringResource(R.string.dv7_mode_off)
             }
             NavigationSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.HdrOn,
                 title = stringResource(R.string.dv7_handling_title),
                 subtitle = modeName,
                 onClick = onShowDv7HandlingModeDialog,
@@ -305,7 +315,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         }
         item(key = "audio_dv7_preserve_mapping") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.HdrAuto,
                 title = stringResource(R.string.audio_dv7_preserve_mapping_title),
                 subtitle = stringResource(R.string.audio_dv7_preserve_mapping_sub),
                 // Show off outside Convert to DV8.1 so a persisted value doesn't read as active.
@@ -319,7 +329,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
 
         item(key = "audio_dv5_to_dv81") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.Transform,
                 title = stringResource(R.string.audio_dv5_to_dv81_title),
                 subtitle = stringResource(R.string.audio_dv5_to_dv81_sub),
                 // Show off outside Convert to DV8.1 so a persisted value doesn't read as active.
@@ -333,7 +343,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
 
         item(key = "audio_strip_hdr10plus") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.HdrOff,
                 title = stringResource(R.string.audio_strip_hdr10plus_title),
                 subtitle = stringResource(R.string.audio_strip_hdr10plus_sub),
                 isChecked = playerSettings.stripHdr10PlusSei,
@@ -355,7 +365,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
         }
 
         NavigationSettingsItem(
-            icon = Icons.Default.Tune,
+            icon = Icons.Default.DeveloperBoard,
             title = stringResource(R.string.audio_mpv_hwdec_title),
             subtitle = hwDecodeModeName,
             onClick = onShowMpvHardwareDecodeModeDialog,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -25,15 +25,22 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.AvTimer
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Cached
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Extension
-import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Repeat
-import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Numbers
+import androidx.compose.material.icons.filled.Percent
+import androidx.compose.material.icons.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.Power
+import androidx.compose.material.icons.filled.Rule
 import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -104,7 +111,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
 
     item(key = "autoplay_reuse_last_link") {
         ToggleSettingsItem(
-            icon = Icons.Default.History,
+            icon = Icons.Default.Cached,
             title = stringResource(R.string.autoplay_reuse_last_link),
             subtitle = stringResource(R.string.autoplay_reuse_last_link_sub),
             isChecked = playerSettings.streamReuseLastLinkEnabled,
@@ -116,7 +123,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
     if (playerSettings.streamReuseLastLinkEnabled) {
         item(key = "autoplay_reuse_cache_duration") {
             NavigationSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.HourglassEmpty,
                 title = stringResource(R.string.autoplay_last_link_cache),
                 subtitle = formatReuseCacheDuration(playerSettings.streamReuseLastLinkCacheHours),
                 onClick = onShowReuseLastLinkCacheDialog,
@@ -132,7 +139,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
             StreamAutoPlayMode.REGEX_MATCH -> stringResource(R.string.autoplay_mode_regex)
         }
         NavigationSettingsItem(
-            icon = Icons.Default.PlayArrow,
+            icon = Icons.Default.AutoAwesome,
             title = stringResource(R.string.autoplay_stream_selection),
             subtitle = modeLabel,
             onClick = onShowModeDialog,
@@ -149,7 +156,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
             else -> "${timeoutSec}s"
         }
         SliderSettingsItem(
-            icon = Icons.Default.Timer,
+            icon = Icons.Default.AvTimer,
             title = stringResource(R.string.autoplay_timeout_title),
             subtitle = stringResource(R.string.autoplay_timeout_sub),
             values = PlayerSettings.STREAM_AUTOPLAY_TIMEOUT_VALUES,
@@ -162,7 +169,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
 
     item(key = "autoplay_next_episode") {
         ToggleSettingsItem(
-            icon = Icons.Default.SkipNext,
+            icon = Icons.Default.PlaylistPlay,
             title = stringResource(R.string.autoplay_next_episode),
             subtitle = stringResource(R.string.autoplay_next_episode_sub),
             isChecked = playerSettings.streamAutoPlayNextEpisodeEnabled,
@@ -187,7 +194,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
             item(key = "still_watching_threshold") {
                 val threshold = playerSettings.stillWatchingEpisodeThreshold
                 SliderSettingsItem(
-                    icon = Icons.Default.Repeat,
+                    icon = Icons.Default.Numbers,
                     title = stringResource(R.string.still_watching_threshold_title),
                     subtitle = stringResource(R.string.still_watching_threshold_sub),
                     value = threshold,
@@ -204,7 +211,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
 
     item(key = "autoplay_next_episode_prefer_binge_group") {
         ToggleSettingsItem(
-            icon = Icons.Default.Tune,
+            icon = Icons.Default.Layers,
             title = stringResource(R.string.autoplay_prefer_binge_group),
             subtitle = stringResource(R.string.autoplay_prefer_binge_group_sub),
             isChecked = playerSettings.streamAutoPlayPreferBingeGroupForNextEpisode,
@@ -216,7 +223,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
     if (playerSettings.streamAutoPlayPreferBingeGroupForNextEpisode) {
         item(key = "autoplay_reuse_binge_group") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.Bookmarks,
                 title = stringResource(R.string.autoplay_reuse_binge_group),
                 subtitle = stringResource(R.string.autoplay_reuse_binge_group_sub),
                 isChecked = playerSettings.streamAutoPlayReuseBingeGroup,
@@ -232,7 +239,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
             NextEpisodeThresholdMode.MINUTES_BEFORE_END -> stringResource(R.string.autoplay_threshold_min)
         }
         NavigationSettingsItem(
-            icon = Icons.Default.Tune,
+            icon = Icons.Default.Rule,
             title = stringResource(R.string.autoplay_threshold_mode),
             subtitle = thresholdModeSubtitle,
             onClick = onShowNextEpisodeThresholdModeDialog,
@@ -244,7 +251,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
         when (playerSettings.nextEpisodeThresholdMode) {
             NextEpisodeThresholdMode.PERCENTAGE -> {
                 SliderSettingsItem(
-                    icon = Icons.Default.Tune,
+                    icon = Icons.Default.Percent,
                     title = stringResource(R.string.autoplay_threshold_pct_title),
                     subtitle = stringResource(R.string.autoplay_threshold_pct_sub),
                     value = (playerSettings.nextEpisodeThresholdPercent * 2f).roundToInt(),
@@ -258,7 +265,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
             }
             NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
                 SliderSettingsItem(
-                    icon = Icons.Default.Tune,
+                    icon = Icons.Default.Timer,
                     title = stringResource(R.string.autoplay_threshold_min_title),
                     subtitle = stringResource(R.string.autoplay_threshold_pct_sub),
                     value = (playerSettings.nextEpisodeThresholdMinutesBeforeEnd * 2f).roundToInt(),
@@ -282,7 +289,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                 StreamAutoPlaySource.ENABLED_PLUGINS_ONLY -> stringResource(R.string.autoplay_scope_plugins)
             }
             NavigationSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.FilterList,
                 title = stringResource(R.string.autoplay_scope),
                 subtitle = sourceLabel,
                 onClick = onShowSourceDialog,
@@ -298,7 +305,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                     "${playerSettings.streamAutoPlaySelectedAddons.size} selected"
                 }
                 NavigationSettingsItem(
-                    icon = Icons.Default.Language,
+                    icon = Icons.Default.Extension,
                     title = stringResource(R.string.autoplay_allowed_addons),
                     subtitle = addonSubtitle,
                     onClick = onShowAddonSelectionDialog,
@@ -318,7 +325,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                     "${playerSettings.streamAutoPlaySelectedPlugins.size} selected"
                 }
                 NavigationSettingsItem(
-                    icon = Icons.Default.Extension,
+                    icon = Icons.Default.Power,
                     title = stringResource(R.string.autoplay_allowed_plugins),
                     subtitle = pluginSubtitle,
                     onClick = onShowPluginSelectionDialog,
@@ -335,7 +342,7 @@ internal fun LazyListScope.autoPlaySettingsItems(
                 strRegexPlaceholder
             }
             NavigationSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.Code,
                 title = stringResource(R.string.autoplay_regex_title),
                 subtitle = regexSubtitle,
                 onClick = onShowRegexDialog,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
@@ -10,19 +10,29 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AltRoute
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Autorenew
+import androidx.compose.material.icons.filled.DataUsage
+import androidx.compose.material.icons.filled.DownloadForOffline
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.HourglassFull
+import androidx.compose.material.icons.filled.Http
+import androidx.compose.material.icons.filled.Hub
+import androidx.compose.material.icons.filled.Lan
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.NotStarted
+import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material.icons.filled.SdStorage
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material.icons.filled.ViewModule
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Hub
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Storage
-import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -74,7 +84,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         Column {
             ToggleSettingsItem(
-                icon = Icons.Default.Speed,
+                icon = Icons.Default.Memory,
                 title = stringResource(R.string.playback_net_nuvio_performance_mode),
                 subtitle = stringResource(R.string.playback_net_nuvio_performance_mode_sub),
                 isChecked = isSupported && playerSettings.nuvioPerformanceModeEnabled,
@@ -113,7 +123,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     // ── Master toggle: custom buffer engine ──
     item(key = "buffer_net_custom_buffers") {
         ToggleSettingsItem(
-            icon = Icons.Default.Tune,
+            icon = Icons.Default.DataUsage,
             title = stringResource(R.string.playback_buffer_custom),
             subtitle = stringResource(R.string.playback_buffer_custom_sub),
             isChecked = playerSettings.bufferEngineEnabled,
@@ -146,7 +156,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_min_buffer") {
             SliderSettingsItem(
-                icon = Icons.Default.Speed,
+                icon = Icons.Default.HourglassEmpty,
                 title = stringResource(R.string.playback_buffer_min),
                 subtitle = stringResource(R.string.playback_buffer_min_sub),
                 value = playerSettings.bufferSettings.minBufferMs / 1000,
@@ -162,7 +172,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
             val minBufferSeconds = playerSettings.bufferSettings.minBufferMs / 1000
             val maxBufferSeconds = playerSettings.bufferSettings.maxBufferMs / 1000
             SliderSettingsItem(
-                icon = Icons.Default.Speed,
+                icon = Icons.Default.HourglassFull,
                 title = stringResource(R.string.playback_buffer_max),
                 subtitle = stringResource(R.string.playback_buffer_max_sub),
                 value = maxBufferSeconds,
@@ -180,7 +190,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_initial_buffer") {
             SliderSettingsItem(
-                icon = Icons.Default.PlayArrow,
+                icon = Icons.Default.NotStarted,
                 title = stringResource(R.string.playback_buffer_initial),
                 subtitle = stringResource(R.string.playback_buffer_initial_sub),
                 value = playerSettings.bufferSettings.bufferForPlaybackMs / 1000,
@@ -194,7 +204,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_rebuffer") {
             SliderSettingsItem(
-                icon = Icons.Default.Refresh,
+                icon = Icons.Default.Autorenew,
                 title = stringResource(R.string.playback_buffer_after_rebuffer),
                 subtitle = stringResource(R.string.playback_buffer_after_rebuffer_sub),
                 value = playerSettings.bufferSettings.bufferForPlaybackAfterRebufferMs / 1000,
@@ -208,7 +218,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_back_buffer") {
             SliderSettingsItem(
-                icon = Icons.Default.History,
+                icon = Icons.Default.FastRewind,
                 title = stringResource(R.string.playback_buffer_back),
                 subtitle = stringResource(R.string.playback_buffer_back_sub),
                 value = playerSettings.bufferSettings.backBufferDurationMs / 1000,
@@ -236,7 +246,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_managed") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.PieChart,
                 title = stringResource(R.string.playback_buffer_managed),
                 subtitle = stringResource(R.string.playback_buffer_managed_sub),
                 isChecked = playerSettings.bufferBudgetManaged,
@@ -313,7 +323,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_allow_large") {
             ToggleSettingsItem(
-                icon = Icons.Default.Tune,
+                icon = Icons.Default.UnfoldMore,
                 title = stringResource(R.string.playback_buffer_allow_large),
                 subtitle = stringResource(R.string.playback_buffer_allow_large_sub),
                 isChecked = playerSettings.allowLargeTargetBuffer,
@@ -336,7 +346,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_vod_cache") {
             ToggleSettingsItem(
-                icon = Icons.Default.Storage,
+                icon = Icons.Default.DownloadForOffline,
                 title = stringResource(R.string.playback_cache_vod),
                 subtitle = stringResource(R.string.playback_cache_vod_sub),
                 isChecked = playerSettings.vodCacheEnabled,
@@ -352,7 +362,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 val autoMode = playerSettings.vodCacheSizeMode == VodCacheSizeMode.AUTO
                 Box(modifier = Modifier.padding(start = NuvioTheme.spacing.xxl)) {
                     ToggleSettingsItem(
-                        icon = Icons.Default.Tune,
+                        icon = Icons.Default.AutoAwesome,
                         title = stringResource(R.string.playback_cache_auto_size),
                         subtitle = stringResource(R.string.playback_cache_auto_size_sub),
                         isChecked = autoMode,
@@ -373,7 +383,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                         maxManualCacheMb
                     )
                     SliderSettingsItem(
-                        icon = Icons.Default.Storage,
+                        icon = Icons.Default.SdStorage,
                         title = stringResource(R.string.playback_cache_vod_size),
                         subtitle = stringResource(R.string.playback_cache_vod_size_sub),
                         value = manualCacheMb,
@@ -453,7 +463,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     // ── Master toggle: parallel connections ──
     item(key = "buffer_net_parallel_custom") {
         ToggleSettingsItem(
-            icon = Icons.Default.Hub,
+            icon = Icons.Default.Lan,
             title = stringResource(R.string.playback_net_custom),
             subtitle = stringResource(R.string.playback_net_custom_sub),
             isChecked = playerSettings.parallelNetworkEnabled,
@@ -464,7 +474,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
     if (playerSettings.parallelNetworkEnabled) {
         item(key = "buffer_net_http2") {
             ToggleSettingsItem(
-                icon = Icons.Default.Wifi,
+                icon = Icons.Default.Http,
                 title = stringResource(R.string.playback_net_http2),
                 subtitle = stringResource(R.string.playback_net_http2_sub),
                 isChecked = playerSettings.enableHttp2,
@@ -474,7 +484,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
 
         item(key = "buffer_net_parallel_wifi") {
             ToggleSettingsItem(
-                icon = Icons.Default.Wifi,
+                icon = Icons.Default.AltRoute,
                 title = stringResource(R.string.playback_net_parallel),
                 subtitle = stringResource(R.string.playback_net_parallel_sub),
                 isChecked = playerSettings.useParallelConnections,
@@ -506,7 +516,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
                 }
                 val chunkSizeMb = playerSettings.parallelChunkSizeMb.coerceAtMost(maxChunkSizeMb)
                 SliderSettingsItem(
-                    icon = Icons.Default.Storage,
+                    icon = Icons.Default.ViewModule,
                     title = stringResource(R.string.playback_net_chunk_size),
                     subtitle = stringResource(R.string.playback_net_chunk_size_sub),
                     value = chunkSizeMb,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -86,13 +86,6 @@ import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.components.P2pConsentDialog
 import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
 import kotlinx.coroutines.launch
-import androidx.compose.material.icons.filled.PlayCircle
-import androidx.compose.material.icons.filled.PauseCircle
-import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material.icons.filled.VolumeUp
-import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material.icons.filled.Extension
-import androidx.compose.material.icons.filled.Image
 
 @Composable
 fun PlaybackSettingsScreen(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -27,18 +27,26 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.DisplaySettings
+import androidx.compose.material.icons.filled.Dvr
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.Hd
 import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PauseCircle
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.ScheduleSend
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SkipNext
-import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.SwapHoriz
-import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.runtime.Composable
@@ -340,7 +348,7 @@ internal fun PlaybackSettingsSections(
         ) {
             item(key = "general_loading_overlay") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Image,
+                    icon = Icons.Default.Sync,
                     title = stringResource(R.string.playback_loading_overlay),
                     subtitle = stringResource(R.string.playback_loading_overlay_sub),
                     isChecked = playerSettings.loadingOverlayEnabled,
@@ -364,7 +372,7 @@ internal fun PlaybackSettingsSections(
 
             item(key = "general_osd_clock") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Timer,
+                    icon = Icons.Default.Schedule,
                     title = stringResource(R.string.playback_osd_clock),
                     subtitle = stringResource(R.string.playback_show_clock_sub),
                     isChecked = playerSettings.osdClockEnabled,
@@ -376,7 +384,7 @@ internal fun PlaybackSettingsSections(
 
             item(key = "general_skip_intro") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.History,
+                    icon = Icons.Default.FastForward,
                     title = stringResource(R.string.playback_skip_intro),
                     subtitle = stringResource(R.string.playback_skip_intro_sub),
                     isChecked = playerSettings.skipIntroEnabled,
@@ -388,7 +396,7 @@ internal fun PlaybackSettingsSections(
 
             item(key = "general_parental_guide") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Info,
+                    icon = Icons.Default.Shield,
                     title = stringResource(R.string.playback_parental_guide),
                     subtitle = stringResource(R.string.playback_parental_guide_sub),
                     isChecked = playerSettings.parentalGuideEnabled,
@@ -427,7 +435,7 @@ internal fun PlaybackSettingsSections(
 
                 item(key = "general_auto_skip_recap") {
                     ToggleSettingsItem(
-                        icon = Icons.Default.SkipNext,
+                        icon = Icons.Default.History,
                         title = stringResource(R.string.auto_skip_recap),
                         subtitle = stringResource(R.string.auto_skip_recap_sub),
                         isChecked = AutoSkipSegmentType.RECAP in playerSettings.autoSkipSegmentTypes,
@@ -441,7 +449,7 @@ internal fun PlaybackSettingsSections(
 
                 item(key = "general_auto_skip_outro") {
                     ToggleSettingsItem(
-                        icon = Icons.Default.SkipNext,
+                        icon = Icons.Default.Flag,
                         title = stringResource(R.string.auto_skip_outro),
                         subtitle = stringResource(R.string.auto_skip_outro_sub),
                         isChecked = AutoSkipSegmentType.OUTRO in playerSettings.autoSkipSegmentTypes,
@@ -478,7 +486,7 @@ internal fun PlaybackSettingsSections(
             if (playerSettings.playerPreference != PlayerPreference.INTERNAL) {
                 item(key = "external_player_forward_subtitles") {
                     ToggleSettingsItem(
-                        icon = Icons.Default.Info,
+                        icon = Icons.Default.Send,
                         title = stringResource(R.string.playback_external_forward_subtitles),
                         subtitle = stringResource(R.string.playback_external_forward_subtitles_sub),
                         isChecked = playerSettings.externalPlayerForwardSubtitles,
@@ -489,7 +497,7 @@ internal fun PlaybackSettingsSections(
 
                 item(key = "external_player_send_skip_segments") {
                     ToggleSettingsItem(
-                        icon = Icons.Default.Info,
+                        icon = Icons.Default.ScheduleSend,
                         title = stringResource(R.string.playback_external_send_skip_segments),
                         subtitle = stringResource(R.string.playback_external_send_skip_segments_sub),
                         isChecked = playerSettings.externalPlayerSendSkipSegments,
@@ -501,7 +509,7 @@ internal fun PlaybackSettingsSections(
 
             item(key = "stream_internal_player_engine") {
                 NavigationSettingsItem(
-                    icon = Icons.Default.PlayArrow,
+                    icon = Icons.Default.Dvr,
                     title = stringResource(R.string.playback_internal_player_engine),
                     subtitle = streamSelectionUi.internalEngineLabel,
                     onClick = onShowInternalPlayerEngineDialog,
@@ -545,7 +553,7 @@ internal fun PlaybackSettingsSections(
 
             item(key = "stream_show_loading_status") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Info,
+                    icon = Icons.Default.Checklist,
                     title = stringResource(R.string.playback_show_loading_status),
                     subtitle = stringResource(R.string.playback_show_loading_status_sub),
                     isChecked = playerSettings.showPlayerLoadingStatus,
@@ -594,7 +602,7 @@ internal fun PlaybackSettingsSections(
                             onFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                             enabled = !generalUi.isExternalPlayer,
                             showWarningIcon = showAfrWarning,
-                            icon = Icons.Default.Speed
+                            icon = Icons.Default.DisplaySettings
                         )
                     }
 
@@ -670,7 +678,7 @@ internal fun PlaybackSettingsSections(
         ) {
             item(key = "p2p_enabled") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Info,
+                    icon = Icons.Default.Share,
                     title = strSectionP2p,
                     subtitle = strSectionP2pDesc,
                     isChecked = p2pEnabled,
@@ -680,7 +688,7 @@ internal fun PlaybackSettingsSections(
             }
             item(key = "p2p_hide_stats") {
                 ToggleSettingsItem(
-                    icon = Icons.Default.Info,
+                    icon = Icons.Default.VisibilityOff,
                     title = strHideTorrentStats,
                     subtitle = strHideTorrentStatsDesc,
                     isChecked = hideTorrentStats,
@@ -841,7 +849,7 @@ private fun FrameRateMatchingModeOptions(
         Spacer(modifier = Modifier.height(NuvioTheme.spacing.sm))
 
         ToggleSettingsItem(
-            icon = Icons.Default.Image,
+            icon = Icons.Default.Hd,
             title = stringResource(R.string.playback_resolution_matching),
             subtitle = stringResource(
                 if (!resolutionSwitchingSupported) R.string.playback_resolution_matching_unsupported_sub

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSubtitleSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSubtitleSettings.kt
@@ -14,14 +14,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BorderColor
+import androidx.compose.material.icons.filled.BorderStyle
 import androidx.compose.material.icons.filled.ClosedCaption
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.FormatBold
+import androidx.compose.material.icons.filled.FormatColorFill
+import androidx.compose.material.icons.filled.FormatColorText
 import androidx.compose.material.icons.filled.FormatSize
+import androidx.compose.material.icons.filled.Height
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material.icons.filled.Subtitles
-import androidx.compose.material.icons.filled.VerticalAlignBottom
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -106,7 +111,7 @@ internal fun LazyListScope.subtitleSettingsItems(
         }
 
         NavigationSettingsItem(
-            icon = Icons.Default.Language,
+            icon = Icons.Default.Translate,
             title = stringResource(R.string.sub_preferred_lang),
             subtitle = languageName,
             onClick = onShowLanguageDialog,
@@ -144,7 +149,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_show_only_preferred_languages") {
         ToggleSettingsItem(
-            icon = Icons.Default.Language,
+            icon = Icons.Default.FilterList,
             title = stringResource(R.string.sub_show_only_preferred_languages),
             subtitle = stringResource(R.string.sub_show_only_preferred_languages_desc),
             isChecked = playerSettings.subtitleStyle.showOnlyPreferredLanguages,
@@ -156,7 +161,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_startup_mode") {
         NavigationSettingsItem(
-            icon = Icons.Default.Subtitles,
+            icon = Icons.Default.CloudDownload,
             title = stringResource(R.string.sub_startup_mode_title),
             subtitle = subtitleStartupModeLabel(playerSettings.addonSubtitleStartupMode),
             onClick = onShowSubtitleStartupModeDialog,
@@ -182,7 +187,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_vertical_offset") {
         SliderSettingsItem(
-            icon = Icons.Default.VerticalAlignBottom,
+            icon = Icons.Default.Height,
             title = stringResource(R.string.sub_vertical_offset),
             value = playerSettings.subtitleStyle.verticalOffset,
             valueText = "${playerSettings.subtitleStyle.verticalOffset}%",
@@ -209,7 +214,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_text_color") {
         ColorSettingsItem(
-            icon = Icons.Default.Palette,
+            icon = Icons.Default.FormatColorText,
             title = stringResource(R.string.sub_text_color),
             currentColor = Color(playerSettings.subtitleStyle.textColor),
             onClick = onShowTextColorDialog,
@@ -220,7 +225,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_background_color") {
         ColorSettingsItem(
-            icon = Icons.Default.Palette,
+            icon = Icons.Default.FormatColorFill,
             title = stringResource(R.string.sub_bg_color),
             currentColor = Color(playerSettings.subtitleStyle.backgroundColor),
             showTransparent = playerSettings.subtitleStyle.backgroundColor == Color.Transparent.toArgb(),
@@ -232,7 +237,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_outline_toggle") {
         ToggleSettingsItem(
-            icon = Icons.Default.ClosedCaption,
+            icon = Icons.Default.BorderStyle,
             title = stringResource(R.string.sub_outline),
             subtitle = stringResource(R.string.sub_outline_sub),
             isChecked = playerSettings.subtitleStyle.outlineEnabled,
@@ -245,7 +250,7 @@ internal fun LazyListScope.subtitleSettingsItems(
     if (playerSettings.subtitleStyle.outlineEnabled) {
         item(key = "subtitle_outline_color") {
             ColorSettingsItem(
-                icon = Icons.Default.Palette,
+                icon = Icons.Default.BorderColor,
                 title = stringResource(R.string.sub_outline_color),
                 currentColor = Color(playerSettings.subtitleStyle.outlineColor),
                 onClick = onShowOutlineColorDialog,
@@ -267,7 +272,7 @@ internal fun LazyListScope.subtitleSettingsItems(
 
     item(key = "subtitle_libass") {
         ToggleSettingsItem(
-            icon = Icons.Default.Subtitles,
+            icon = Icons.Default.Science,
             title = stringResource(R.string.sub_libass),
             subtitle = stringResource(R.string.sub_libass_sub),
             isChecked = playerSettings.useLibass,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -20,18 +20,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material.icons.filled.People
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -117,21 +116,21 @@ private fun rememberSettingsSectionSpecs() = listOf(
     SettingsSectionSpec(
         category = SettingsCategory.EXPERIENCE,
         title = stringResource(R.string.settings_experience),
-        icon = Icons.Default.Tune,
+        icon = Icons.Default.AutoAwesome,
         subtitle = stringResource(R.string.settings_experience_subtitle),
         destination = SettingsSectionDestination.Inline
     ),
     SettingsSectionSpec(
         category = SettingsCategory.ACCOUNT,
         title = stringResource(R.string.settings_account),
-        icon = Icons.Default.Person,
+        icon = Icons.Default.AccountCircle,
         subtitle = stringResource(R.string.settings_account_subtitle),
         destination = SettingsSectionDestination.Inline
     ),
     SettingsSectionSpec(
         category = SettingsCategory.PROFILES,
         title = stringResource(R.string.settings_profiles),
-        icon = Icons.Default.People,
+        icon = Icons.Default.ManageAccounts,
         subtitle = stringResource(R.string.settings_profiles_subtitle),
         destination = SettingsSectionDestination.Inline
     ),

--- a/app/src/main/res/drawable/ic_badge_pos_bottom.xml
+++ b/app/src/main/res/drawable/ic_badge_pos_bottom.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.5"
+        android:pathData="M3.5,6 L20.5,6 A1,1 0 0 1 21.5,7 L21.5,17 A1,1 0 0 1 20.5,18 L3.5,18 A1,1 0 0 1 2.5,17 L2.5,7 A1,1 0 0 1 3.5,6 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M5.8,14.7 h3.3 v1.7 h-3.3 z M10.35,14.7 h3.3 v1.7 h-3.3 z M14.9,14.7 h3.3 v1.7 h-3.3 z" />
+</vector>

--- a/app/src/main/res/drawable/ic_badge_pos_top.xml
+++ b/app/src/main/res/drawable/ic_badge_pos_top.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.5"
+        android:pathData="M3.5,6 L20.5,6 A1,1 0 0 1 21.5,7 L21.5,17 A1,1 0 0 1 20.5,18 L3.5,18 A1,1 0 0 1 2.5,17 L2.5,7 A1,1 0 0 1 3.5,6 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M5.8,7.6 h3.3 v1.7 h-3.3 z M10.35,7.6 h3.3 v1.7 h-3.3 z M14.9,7.6 h3.3 v1.7 h-3.3 z" />
+</vector>


### PR DESCRIPTION
## Summary

QOL/UI polish. The settings screens reused a small set of generic icons (`Tune` on 20+ rows, plus repeated `Info` / `Image` / `Speed`) that didn't relate to what each row does. This gives every applicable setting a purpose-fit icon, adds a custom **position-aware** badge-position icon (three badges that sit at the top or bottom to mirror the current selection), and **fixes the badge-position picker, which had its options reversed** (Top was listed at the bottom and Bottom at the top). 74 icons changed across 8 settings screens. No logic or behavior changed, and no new dependencies (icons come from `material-icons-extended`, already in the project).

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [ ] Critical bug fix

> Full transparency: this is a **QOL / UI improvement**, so it fits neither accepted type. Opening it for consideration; I understand it may be deferred while NuvioTV is prepared for a stable release.

## Why

The settings list leaned on a handful of generic icons (`Tune` alone appeared on 20+ different rows), so most settings had no icon that related to what they do. Purpose-fit icons make the settings far easier to scan at a glance.

## Issue or approval

No linked issue. QOL improvement offered for review; no maintainer pre-approval.

## Reproduction steps

N/A - not a bug fix.

## UI / behavior impact

- [x] No behavior change

UI icons changed; the badge-position picker order fix is cosmetic (same two options, corrected order).

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] I listed the testing performed below.

> The remaining policy boxes are intentionally left unchecked because they aren't true for a QOL/UI PR (this does change UI). Flagging honestly rather than mis-checking.

## Scope boundaries

Only the leading icons on settings rows changed. Left untouched: the Trakt brand glyph, QR codes, and icons that already fit their setting. No behavior or logic changes. Local build/test config not included.

## Testing

Built `:app:assembleFullDebug` (arm64) and installed to an NVIDIA Shield; walked every settings screen (Layout + all Playback sub-screens + top-level) confirming each icon renders and the badge-position icon flips between top/bottom to match the selection. Compiles clean against latest `dev` (`0.7.13-beta`).

## Screenshots / Video

https://github.com/user-attachments/assets/8d46dfcf-3595-461f-b0a8-b9cdfd9e159d

## Breaking changes

None.

---

## Every icon changed (74)

**Top-level:** Experience `Tune → AutoAwesome` · Account `Person → AccountCircle` · Profiles `People → ManageAccounts`

**Layout:** Badge position `Image → custom position-aware icon` · Fusion badge URLs `Image → Link` · Backdrop Expand Delay `Timer → Timelapse`

**Playback › Audio:** Preferred Audio Language `Language → RecordVoiceOver` · Skip Silence `Speed → VolumeOff` · Remember audio delay per device `Timer → MoreTime` · Decoder Priority `Tune → LowPriority` · Enable downmix `Tune → CallMerge` · Number of channels `VolumeUp → SurroundSound` · Maintain original audio on downmix `Tune → Lock` · Tunneled Playback `VolumeUp → Bolt` · Force AC-3 Transcoding (Optical/SPDIF) `VolumeUp → Cable` · Dolby Vision Handling `Tune → HdrOn` · Preserve DV mapping (DV7 to DV8.1) `Tune → HdrAuto` · Convert DV5 to DV8.1 `Tune → Transform` · Strip HDR10+ Metadata `Tune → HdrOff` · Hardware Decoding (MPV-only) `Tune → DeveloperBoard`

**Playback › Auto-play:** Reuse Last Link `History → Cached` · Last Link Cache Duration `Tune → HourglassEmpty` · Auto Stream Selection `PlayArrow → AutoAwesome` · Stream Selection Timeout `Timer → AvTimer` · Auto-play Next Episode `SkipNext → PlaylistPlay` · Episode Threshold `Repeat → Numbers` · Prefer Binge Group `Tune → Layers` · Reuse Binge Group `Tune → Bookmarks` · Next Episode Threshold Mode `Tune → Rule` · Threshold Percentage `Tune → Percent` · Threshold Minutes `Tune → Timer` · Auto-play Source Scope `Tune → FilterList` · Allowed Addons `Language → Extension` · Allowed Plugins `Extension → Power` · Regex Pattern `Tune → Code`

**Playback › Buffering & Network:** ExoPlayer Native Memory `Speed → Memory` · Custom Playback Buffers `Tune → DataUsage` · Min Buffer Duration `Speed → HourglassEmpty` · Max Buffer Duration `Speed → HourglassFull` · Initial Buffer `PlayArrow → NotStarted` · Buffer After Rebuffer `Refresh → Autorenew` · Back Buffer Duration `History → FastRewind` · Managed Memory Budget `Tune → PieChart` · Allow Larger Target Buffer `Tune → UnfoldMore` · VOD Disk Cache `Storage → DownloadForOffline` · Auto Size `Tune → AutoAwesome` · VOD Cache Size `Storage → SdStorage` · Custom Network `Hub → Lan` · Enable HTTP/2 `Wifi → Http` · Parallel Connections `Wifi → AltRoute` · Chunk Size `Storage → ViewModule`

**Playback › General:** Loading Overlay `Image → Sync` · OSD Clock `Timer → Schedule` · Skip Intro `History → FastForward` · Content Warnings `Info → Shield` · Recap `SkipNext → History` · Outro / Ending `SkipNext → Flag` · Forward subtitles to external player `Info → Send` · Send intro and outro timestamps `Info → ScheduleSend` · Internal Engine `PlayArrow → Dvr` · Show loading status `Info → Checklist` · Auto Frame Rate & Resolution `Speed → DisplaySettings` · Resolution matching `Image → Hd` · P2P Streaming `Info → Share` · Hide torrent stats `Info → VisibilityOff`

**Playback › Subtitles:** Preferred Language `Language → Translate` · Show Only Preferred Languages `Language → FilterList` · Addon Subtitle Loading `Subtitles → CloudDownload` · Vertical Offset `VerticalAlignBottom → Height` · Text Color `Palette → FormatColorText` · Background Color `Palette → FormatColorFill` · Outline `ClosedCaption → BorderStyle` · Outline Color `Palette → BorderColor` · Use libass for ASS/SSA subtitles `Subtitles → Science`
