### PR TITLE
Fix WebDAV Basic auth playback after redirects

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/OpenSubtitlesHasher.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/OpenSubtitlesHasher.kt
@@ -23,7 +23,7 @@ object OpenSubtitlesHasher {
     suspend fun compute(
         url: String,
         headers: Map<String, String>,
-        client: OkHttpClient = PlayerPlaybackNetworking.playbackHttpClient
+        client: OkHttpClient = PlayerPlaybackNetworking.createHttpClient(headers)
     ): Result? = withContext(Dispatchers.IO) {
         try {
             val fileSize = getContentLength(url, headers, client) ?: return@withContext null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -29,6 +29,7 @@ import java.net.SocketTimeoutException
 import java.net.URLDecoder
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import java.util.Base64
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -280,6 +281,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             }
         }
 
+        data class NormalizedPlaybackRequest(
+            val url: String,
+            val headers: Map<String, String>
+        )
+
         @Volatile private var sharedSimpleCache: SimpleCache? = null
         @Volatile private var configuredVodCacheMaxBytes: Long = -1L
         @Volatile private var isVodCacheDisabled: Boolean = false
@@ -297,6 +303,18 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                 sanitized[key] = value
             }
             return sanitized
+        }
+
+        fun normalizePlaybackRequest(
+            url: String,
+            headers: Map<String, String>?
+        ): NormalizedPlaybackRequest {
+            val sanitizedHeaders = sanitizeHeaders(headers)
+            val (cleanUrl, mergedHeaders) = extractUserInfoAuth(url, sanitizedHeaders)
+            return NormalizedPlaybackRequest(
+                url = cleanUrl,
+                headers = sanitizeHeaders(mergedHeaders)
+            )
         }
 
         fun parseHeaders(headers: String?): Map<String, String> {
@@ -582,11 +600,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
         private val DELIMITED_SS_PATTERN = Regex("(^|[=/_.?&-])(ism|isml)($|[=/_.?&-])")
 
         /**
-         * Extracts `user:password` from a URL's userinfo component and converts it
+         * Extracts `user:pass` from a URL's userinfo component and converts it
          * to a Basic Auth header. Returns the cleaned URL (without userinfo) and
          * merged headers. If the URL has no userinfo, returns the original URL and headers unchanged.
          *
-         * Example: `https://user:pass@host/path` → URL `https://host/path` + header `Authorization: Basic dXNlcjpwYXNz`
+         * The returned URL has no userinfo, and the returned headers carry Basic auth.
          */
         fun extractUserInfoAuth(
             url: String,
@@ -594,29 +612,46 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
         ): Pair<String, Map<String, String>> {
             if (url.isBlank()) return url to headers
             val uri = try { java.net.URI(url) } catch (_: Exception) { return url to headers }
-            val userInfo = uri.userInfo ?: return url to headers
+            val rawUserInfo = uri.rawAuthority
+                ?.substringBeforeLast('@', missingDelimiterValue = "")
+                ?.takeIf { it.isNotBlank() }
+            val userInfo = uri.userInfo ?: rawUserInfo?.let(::decodeRawUserInfo) ?: return url to headers
             if (userInfo.isBlank()) return url to headers
-            // Already has an Authorization header — don't override
-            if (headers.any { it.key.equals("Authorization", ignoreCase = true) }) {
-                return url to headers
-            }
-            val encoded = android.util.Base64.encodeToString(
-                userInfo.toByteArray(Charsets.UTF_8),
-                android.util.Base64.NO_WRAP
-            )
-            val cleanUri = java.net.URI(
-                uri.scheme,
-                null, // no userinfo
-                uri.host,
-                uri.port,
-                uri.path,
-                uri.query,
-                uri.fragment
-            )
+            val cleanUrl = stripRawUserInfo(uri) ?: return url to headers
             val mergedHeaders = LinkedHashMap(headers)
-            mergedHeaders["Authorization"] = "Basic $encoded"
-            return cleanUri.toString() to mergedHeaders
+            if (headers.none { it.key.equals("Authorization", ignoreCase = true) }) {
+                val encoded = Base64.getEncoder().encodeToString(userInfo.toByteArray(Charsets.UTF_8))
+                mergedHeaders["Authorization"] = "Basic $encoded"
+            }
+            return cleanUrl to mergedHeaders
         }
+
+        private fun stripRawUserInfo(uri: java.net.URI): String? {
+            val scheme = uri.scheme?.takeIf { it.isNotBlank() } ?: return null
+            val rawAuthority = uri.rawAuthority?.takeIf { it.isNotBlank() } ?: return null
+            val cleanAuthority = rawAuthority.substringAfterLast('@', missingDelimiterValue = rawAuthority)
+                .takeIf { it != rawAuthority && it.isNotBlank() }
+                ?: return null
+            return buildString {
+                append(scheme)
+                append("://")
+                append(cleanAuthority)
+                append(uri.rawPath.orEmpty())
+                uri.rawQuery?.let {
+                    append('?')
+                    append(it)
+                }
+                uri.rawFragment?.let {
+                    append('#')
+                    append(it)
+                }
+            }
+        }
+
+        private fun decodeRawUserInfo(value: String): String? =
+            runCatching {
+                URLDecoder.decode(value.replace("+", "%2B"), Charsets.UTF_8.name())
+            }.getOrNull()
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackNetworking.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackNetworking.kt
@@ -89,8 +89,7 @@ internal object PlayerPlaybackNetworking {
             .build()
     }
 
-    @UnstableApi
-    fun createHttpDataSourceFactory(defaultHeaders: Map<String, String> = emptyMap()): DataSource.Factory {
+    fun createHttpClient(defaultHeaders: Map<String, String> = emptyMap()): OkHttpClient {
         val builder = playbackHttpClient.newBuilder()
         if (defaultHeaders.any { it.key.equals("Authorization", ignoreCase = true) }) {
             // OkHttp strips the Authorization header on cross-host redirects.
@@ -114,9 +113,14 @@ internal object PlayerPlaybackNetworking {
                 }
             }
         }
-        val client = builder
+        return builder
             .let { NuvioExoPlayerPerformanceHelper.applyNetworkOptimizations(it) }
             .build()
+    }
+
+    @UnstableApi
+    fun createHttpDataSourceFactory(defaultHeaders: Map<String, String> = emptyMap()): DataSource.Factory {
+        val client = createHttpClient(defaultHeaders)
         return OkHttpDataSource.Factory(client).apply {
             setDefaultRequestProperties(defaultHeaders)
             if (defaultHeaders.none { it.key.equals("User-Agent", ignoreCase = true) }) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -190,17 +190,17 @@ class PlayerRuntimeController(
     internal var currentHeaders: Map<String, String>
 
     init {
-        val (cleanInitialUrl, mergedInitialHeaders) = PlayerMediaSourceFactory.extractUserInfoAuth(
+        val initialPlaybackRequest = PlayerMediaSourceFactory.normalizePlaybackRequest(
             initialStreamUrl,
-            PlayerMediaSourceFactory.sanitizeHeaders(PlayerMediaSourceFactory.parseHeaders(headersJson))
+            PlayerMediaSourceFactory.parseHeaders(headersJson)
         )
-        currentStreamUrl = cleanInitialUrl
+        currentStreamUrl = initialPlaybackRequest.url
         currentStreamMimeType = PlayerMediaSourceFactory.inferMimeType(
-            url = cleanInitialUrl,
+            url = initialPlaybackRequest.url,
             filename = currentFilename,
             responseHeaders = currentStreamResponseHeaders
         )
-        currentHeaders = mergedInitialHeaders
+        currentHeaders = initialPlaybackRequest.headers
     }
 
     fun getCurrentStreamUrl(): String = currentStreamUrl

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -12,16 +12,25 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
     headers: Map<String, String>,
     loadSavedProgress: Boolean
 ) {
+    val playbackRequest = PlayerMediaSourceFactory.normalizePlaybackRequest(url, headers)
+    val playbackUrl = playbackRequest.url
+    val playbackHeaders = playbackRequest.headers
+    if (playbackUrl != currentStreamUrl || playbackHeaders != currentHeaders) {
+        currentStreamUrl = playbackUrl
+        currentHeaders = playbackHeaders
+        _uiState.update { it.copy(currentStreamUrl = playbackUrl) }
+    }
+
     logSwitchTrace(
         stage = "prepare-playback-before-start",
-        message = "urlHash=${url.hashCode().toUInt().toString(16)} loadSavedProgress=$loadSavedProgress " +
+        message = "urlHash=${playbackUrl.hashCode().toUInt().toString(16)} loadSavedProgress=$loadSavedProgress " +
             "clearPendingSwitchPref=true"
     )
     val clickElapsedMs = launchStartedAtElapsedMs
         ?.let { (SystemClock.elapsedRealtime() - it).coerceAtLeast(0L) }
         ?: -1L
     queuePlaybackRawEventLine(
-        "PREPARE_PLAYBACK: clickElapsedMs=$clickElapsedMs host=${url.safeScrobbleHost()} " +
+        "PREPARE_PLAYBACK: clickElapsedMs=$clickElapsedMs host=${playbackUrl.safeScrobbleHost()} " +
             "loadSavedProgress=$loadSavedProgress currentSeason=${currentSeason ?: -1} " +
             "currentEpisode=${currentEpisode ?: -1} streamName=${_uiState.value.currentStreamName ?: "n/a"}"
     )
@@ -100,7 +109,7 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
             phase = "initializing_player",
             message = context.getString(com.nuvio.tv.R.string.player_loading_building)
         )
-        initializePlayer(url, headers)
+        initializePlayer(playbackUrl, playbackHeaders)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
@@ -37,7 +37,11 @@ internal fun PlayerRuntimeController.startInitialPlaybackIfNeeded() {
             "S${currentSeason ?: "-"}E${currentEpisode ?: "-"} infoHash=${infoHash != null} " +
             "startFromBeginning=${navigationArgs.startFromBeginning} streamName=${streamName ?: "n/a"}"
     )
-    Log.d("PlayerStartup", "startInitialPlayback: infoHash=$infoHash, streamUrl=${initialStreamUrl.take(80)}")
+    Log.d(
+        "PlayerStartup",
+        "startInitialPlayback: infoHash=$infoHash host=${currentStreamUrl.safeStartupHost()} " +
+            "urlHash=${currentStreamUrl.hashCode().toUInt().toString(16)}"
+    )
     if (infoHash != null && !initialStreamUrl.startsWith("http")) {
         torrentStreamJob = scope.launch {
             try {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -501,13 +501,13 @@ private fun PlayerRuntimeController.applySelectedStreamState(
     url: String,
     headers: Map<String, String>
 ) {
-    val (cleanUrl, mergedHeaders) = PlayerMediaSourceFactory.extractUserInfoAuth(url, headers)
-    currentStreamUrl = cleanUrl
-    currentHeaders = mergedHeaders
+    val playbackRequest = PlayerMediaSourceFactory.normalizePlaybackRequest(url, headers)
+    currentStreamUrl = playbackRequest.url
+    currentHeaders = playbackRequest.headers
     currentFilename = stream.behaviorHints?.filename ?: navigationArgs.filename
     currentStreamResponseHeaders = stream.behaviorHints?.proxyHeaders?.response.orEmpty()
     currentStreamMimeType = PlayerMediaSourceFactory.inferMimeType(
-        url = cleanUrl,
+        url = playbackRequest.url,
         filename = currentFilename,
         responseHeaders = currentStreamResponseHeaders
     )
@@ -729,7 +729,9 @@ internal fun PlayerRuntimeController.switchToSourceStream(
         url = url,
         headers = newHeaders
     )
-    persistSelectedStreamForReuse(stream = stream, url = url, headers = newHeaders)
+    val playbackUrl = currentStreamUrl
+    val playbackHeaders = currentHeaders
+    persistSelectedStreamForReuse(stream = stream, url = playbackUrl, headers = playbackHeaders)
 
     // Reset stream-state error flags for the new stream.
     hasRetriedCurrentStreamAfter416 = false
@@ -748,7 +750,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(
             isBuffering = true,
             error = null,
             currentStreamName = stream.name ?: stream.addonName,
-            currentStreamUrl = url,
+            currentStreamUrl = playbackUrl,
             currentStreamInfoHash = stream.infoHash ?: stream.clientResolve?.infoHash,
             currentStreamFileIdx = stream.clientResolve?.fileIdx,
             currentStreamAddonName = stream.addonName,
@@ -770,8 +772,8 @@ internal fun PlayerRuntimeController.switchToSourceStream(
             try {
                 val playerSettings = playerSettingsDataStore.playerSettings.first()
                 runAfrPreflightIfEnabled(
-                    url = url,
-                    headers = newHeaders,
+                    url = playbackUrl,
+                    headers = playbackHeaders,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
                     resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled,
                     mimeType = currentStreamMimeType
@@ -779,8 +781,8 @@ internal fun PlayerRuntimeController.switchToSourceStream(
                 player.setMediaSource(
                     mediaSourceFactory.createMediaSource(
                         context = context,
-                        url = url,
-                        headers = newHeaders,
+                        url = playbackUrl,
+                        headers = playbackHeaders,
                         filename = currentFilename,
                         responseHeaders = currentStreamResponseHeaders,
                         mimeTypeOverride = currentStreamMimeType,
@@ -794,7 +796,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(
             }
         }
     } ?: run {
-        initializePlayer(url, newHeaders)
+        initializePlayer(playbackUrl, playbackHeaders)
     }
 
     loadSavedProgressFor(currentSeason, currentEpisode)
@@ -1253,8 +1255,6 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     val targetVideo = forcedTargetVideo
         ?: _uiState.value.episodes.firstOrNull { it.id == _uiState.value.episodeStreamsForVideoId }
 
-    currentStreamUrl = url
-    currentHeaders = newHeaders
     currentStreamBingeGroup = stream.behaviorHints?.bingeGroup
     currentVideoHash = stream.behaviorHints?.videoHash
     currentVideoSize = stream.behaviorHints?.videoSize
@@ -1271,6 +1271,8 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
         url = url,
         headers = newHeaders
     )
+    val playbackUrl = currentStreamUrl
+    val playbackHeaders = currentHeaders
     persistedTrackPreference = null
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
@@ -1281,7 +1283,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     currentSeason = targetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
     currentEpisode = targetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode
     currentEpisodeTitle = targetVideo?.title ?: _uiState.value.episodeStreamsTitle ?: currentEpisodeTitle
-    persistSelectedStreamForReuse(stream = stream, url = url, headers = newHeaders)
+    persistSelectedStreamForReuse(stream = stream, url = playbackUrl, headers = playbackHeaders)
     currentTraktEpisodeMapping = null
     currentTraktEpisodeMappingKey = null
     lastSavedPosition = 0L
@@ -1295,7 +1297,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
             currentVideoId = currentVideoId,
             currentEpisodeTitle = currentEpisodeTitle,
             currentStreamName = stream.name ?: stream.addonName,
-            currentStreamUrl = url,
+            currentStreamUrl = playbackUrl,
             currentStreamInfoHash = stream.infoHash ?: stream.clientResolve?.infoHash,
             currentStreamFileIdx = stream.clientResolve?.fileIdx,
             currentStreamAddonName = stream.addonName,
@@ -1335,14 +1337,14 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     fetchSkipIntervals(contentId, currentSeason, currentEpisode)
 
     queuePlaybackRawEventLine(
-        "LINK_SELECTED: source=in_player_source host=${url.safeStreamTraceHost()} " +
+        "LINK_SELECTED: source=in_player_source host=${playbackUrl.safeStreamTraceHost()} " +
             "streamName=${stream.name} addon=${stream.addonName} " +
             "contentId=${contentId ?: "n/a"} videoId=${currentVideoId ?: "n/a"} " +
             "S${currentSeason ?: "-"}E${currentEpisode ?: "-"} torrent=false"
     )
     preparePlaybackBeforeStart(
-        url = url,
-        headers = newHeaders,
+        url = playbackUrl,
+        headers = playbackHeaders,
         loadSavedProgress = true
     )
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
@@ -2,8 +2,10 @@ package com.nuvio.tv.ui.screens.player
 
 import androidx.media3.common.MimeTypes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.util.Base64
 
 class PlayerMediaSourceFactoryTest {
 
@@ -113,4 +115,59 @@ class PlayerMediaSourceFactoryTest {
             assertEquals("Expected HLS mimeType for $url", MimeTypes.APPLICATION_M3U8, mimeType)
         }
     }
+
+    @Test
+    fun `normalizePlaybackRequest converts URL userinfo to authorization header`() {
+        val userInfo = "test-user:test-pass"
+        val request = PlayerMediaSourceFactory.normalizePlaybackRequest(
+            url = "https://" + userInfo + "@webdav.example.org/movies/title.mkv?download=1",
+            headers = mapOf("Range" to "bytes=0-1")
+        )
+
+        assertEquals("https://webdav.example.org/movies/title.mkv?download=1", request.url)
+        assertEquals(userInfo.basicAuthHeader(), request.headers["Authorization"])
+        assertFalse(request.headers.containsKey("Range"))
+    }
+
+    @Test
+    fun `normalizePlaybackRequest strips URL userinfo without replacing explicit authorization`() {
+        val explicitAuth = "explicit:value".basicAuthHeader()
+        val request = PlayerMediaSourceFactory.normalizePlaybackRequest(
+            url = "https://" + "test-user:test-pass" + "@webdav.example.org/movies/title.mkv",
+            headers = mapOf("Authorization" to explicitAuth)
+        )
+
+        assertEquals("https://webdav.example.org/movies/title.mkv", request.url)
+        assertEquals(explicitAuth, request.headers["Authorization"])
+    }
+
+    @Test
+    fun `normalizePlaybackRequest preserves encoded path query and fragment when stripping userinfo`() {
+        val userInfo = "user:p@ss"
+        val request = PlayerMediaSourceFactory.normalizePlaybackRequest(
+            url = "https://" + userInfo.replace("@", "%40") + "@webdav.example.org/files/Show%2FSeason%201/Episode%2001.mkv?name=a%2Fb#frag%2Fment",
+            headers = emptyMap()
+        )
+
+        assertEquals(
+            "https://webdav.example.org/files/Show%2FSeason%201/Episode%2001.mkv?name=a%2Fb#frag%2Fment",
+            request.url
+        )
+        assertEquals(userInfo.basicAuthHeader(), request.headers["Authorization"])
+    }
+
+    @Test
+    fun `normalizePlaybackRequest strips userinfo containing a literal at sign`() {
+        val userInfo = "user:p@ss"
+        val request = PlayerMediaSourceFactory.normalizePlaybackRequest(
+            url = "https://" + userInfo + "@webdav.example.org/files/title.mkv",
+            headers = emptyMap()
+        )
+
+        assertEquals("https://webdav.example.org/files/title.mkv", request.url)
+        assertEquals(userInfo.basicAuthHeader(), request.headers["Authorization"])
+    }
+
+    private fun String.basicAuthHeader(): String =
+        "Basic " + Base64.getEncoder().encodeToString(toByteArray(Charsets.UTF_8))
 }


### PR DESCRIPTION
## Summary

This fixes direct WebDAV playback for streams that require HTTP Basic authentication, including AIOStreams/NZBDav playback URLs.

Playback requests are now normalized before they reach the player: URL-embedded credentials are converted into an explicit `Authorization` header, credentials are stripped from the URL, and the normalized URL/header pair is reused consistently across startup, stream switching, AFR probing, subtitle hashing, and parallel range reads.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some authenticated WebDAV streams can get stuck loading on Android TV even though the same resource works when requested directly with a valid Basic auth header.

This can happen with AIOStreams/NZBDav direct playback because streams may provide credentials through URL userinfo and/or proxy headers, while the playback endpoint redirects to the final WebDAV resource. If auth or range headers are not preserved through that flow, the final WebDAV request can fail with `401` or fail to read ranges correctly.

The reported failure was observed on an NVIDIA Shield TV using the latest Play Store release available on that device.

## Issue or approval

Fixes #2519.

Related to #1255 and #1754.

## Reproduction steps

1. On an NVIDIA Shield TV running the current Play Store release of NuvioTV, configure an AIOStreams/NZBDav stream source that returns a direct WebDAV playback URL requiring HTTP Basic auth.
2. Start playback using the internal player.
3. Search/source resolution succeeds, but playback remains stuck loading.
4. The same WebDAV file responds successfully to direct `HEAD`, `GET`, and ranged `GET` requests when a valid Basic auth header is sent.
5. Requests without Basic auth return `401`.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes authenticated HTTP playback URL/header handling.

It does not add a new WebDAV feature, change stream selection behavior, change addon behavior, add settings, change UI, or add dependencies.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.ui.screens.player.PlayerMediaSourceFactoryTest`
- `./gradlew :app:compileFullReleaseKotlin`

Added focused unit coverage for:

- converting URL userinfo into a Basic auth header
- stripping embedded credentials from playback URLs
- preserving explicit `Authorization` headers
- preserving encoded path, query, and fragment values
- handling userinfo containing `@`
- removing `Range` from reusable playback headers

Manual validation on the affected Shield will require a test build or maintainer build because the device currently uses the Play Store install path.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2519.

Related to #1255 and #1754.