### PR TITLE
fix(player): add m3u and playlist pattern support to MIME type detection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -327,7 +327,7 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             val fileName = pathPart.substringAfterLast('/')
             val extension = fileName.substringAfterLast('.', missingDelimiterValue = "")
             return when (extension) {
-                "m3u8" -> MimeTypes.APPLICATION_M3U8
+                "m3u8", "m3u" -> MimeTypes.APPLICATION_M3U8
                 "mpd" -> MimeTypes.APPLICATION_MPD
                 "ism", "isml" -> MimeTypes.APPLICATION_SS
                 else -> null
@@ -447,7 +447,7 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             val extension = fileName.substringAfterLast('.', missingDelimiterValue = "")
 
             return when {
-                extension == "m3u8" -> MimeTypes.APPLICATION_M3U8
+                extension == "m3u8" || extension == "m3u" -> MimeTypes.APPLICATION_M3U8
                 extension == "mpd" -> MimeTypes.APPLICATION_MPD
                 extension == "ism" || extension == "isml" -> MimeTypes.APPLICATION_SS
                 extension == "mkv" -> MimeTypes.VIDEO_MATROSKA
@@ -480,9 +480,13 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                     "type",
                     "ext",
                     "extension",
-                    "output" -> {
+                    "output",
+                    "protocol",
+                    "mode",
+                    "stream",
+                    "service" -> {
                         when (value.substringAfterLast('/').substringAfterLast('.')) {
-                            "m3u8" -> return MimeTypes.APPLICATION_M3U8
+                            "m3u8", "m3u" -> return MimeTypes.APPLICATION_M3U8
                             "mpd" -> return MimeTypes.APPLICATION_MPD
                             "ism", "isml" -> return MimeTypes.APPLICATION_SS
                             "mkv" -> return MimeTypes.VIDEO_MATROSKA
@@ -503,6 +507,8 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                     "audio/mpegurl",
                     "audio/x-mpegurl",
                     "application/m3u8",
+                    "m3u8",
+                    "m3u",
                     "hls" -> return MimeTypes.APPLICATION_M3U8
                     "application/dash+xml",
                     "video/vnd.mpeg.dash.mpd",
@@ -521,6 +527,7 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
             return when {
                 DELIMITED_M3U8_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_M3U8
+                PLAYLIST_HLS_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_M3U8
                 DELIMITED_MPD_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_MPD
                 DELIMITED_SS_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_SS
                 else -> null
@@ -541,7 +548,8 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             }
         }
 
-        private val DELIMITED_M3U8_PATTERN = Regex("(^|[=/_.?&-])m3u8($|[=/_.?&-])")
+        private val DELIMITED_M3U8_PATTERN = Regex("(^|[=/_.?&-])(m3u8|m3u)($|[=/_.?&-])")
+        private val PLAYLIST_HLS_PATTERN = Regex("/(playlist|hls|manifest|master)/(?!stream$|list$|info$|details$)[a-zA-Z0-9_-]+$")
         private val DELIMITED_MPD_PATTERN = Regex("(^|[=/_.?&-])mpd($|[=/_.?&-])")
         private val DELIMITED_SS_PATTERN = Regex("(^|[=/_.?&-])(ism|isml)($|[=/_.?&-])")
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
@@ -91,4 +91,26 @@ class PlayerMediaSourceFactoryTest {
 
         assertEquals(MimeTypes.APPLICATION_MPD, mimeType)
     }
+
+    @Test
+    fun `inferMimeType recognizes playlist endpoints with numeric or token ids as HLS`() {
+        val urls = listOf(
+            "https://example.com/playlist/759755?token=mock_token_123&expires=1788170323&h=1&lang=it",
+            "https://example.com/playlist/123456",
+            "https://example.com/playlist/a1b2c3d4e5f6?h=1",
+            "https://example.com/hls/759755",
+            "https://example.com/manifest/abc123456",
+            "https://example.com/master/stream99",
+            "https://example.com/live/stream.m3u",
+            "https://example.com/playback?protocol=hls"
+        )
+
+        for (url in urls) {
+            val mimeType = PlayerMediaSourceFactory.inferMimeType(
+                url = url,
+                filename = null
+            )
+            assertEquals("Expected HLS mimeType for $url", MimeTypes.APPLICATION_M3U8, mimeType)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes MIME type detection in `PlayerMediaSourceFactory` by adding support for `.m3u` file extensions and URL path patterns containing playlist identifiers (e.g. `/playlist/123456`, `/hls/`, `/manifest/`, `/master/`).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Player playback failover occurs when HLS streams ending with `.m3u` or using dynamic `/playlist/<id>` endpoints fail to infer `MimeTypes.APPLICATION_M3U8`, causing playback failure or incorrect decoder fallback.

## Issue or approval

[Reported on Discord](https://discord.com/channels/1379902184207941732/1458552195904573513/threads/1522146001995960400)

## Reproduction steps

1. Play an HLS stream URL using a playlist format such as `https://example.com/playlist/759755` or ending with `.m3u`.
2. Observe that `inferMimeType` previously returned `null` instead of `MimeTypes.APPLICATION_M3U8`.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change only updates MIME type inference logic in `PlayerMediaSourceFactory` and associated unit tests. It does not alter player UI, ExoPlayer configuration, or other media decoders.

## Testing

Ran local unit tests in `PlayerMediaSourceFactoryTest`:
- Verified `inferMimeType` correctly resolves `.m3u` extension to `MimeTypes.APPLICATION_M3U8`.
- Verified regex pattern matching for `/playlist/{id}` and `/hls/{id}` stream links.
- Executed `./gradlew test` to ensure all player unit tests pass.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

[Reported on Discord](https://discord.com/channels/1379902184207941732/1458552195904573513/threads/1522146001995960400)
