### PR TITLE
revert: fix(stream): prevent loading overlay flicker when resolving d…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -171,14 +171,12 @@ fun StreamScreen(
 
     fun routePlayback(playbackInfo: StreamPlaybackInfo) {
         if (openExternalInBrowser(playbackInfo)) {
-            viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
             return
         }
         val preference = playerPreference ?: return
         if (playbackInfo.isTorrent && !p2pEnabled) {
             pendingTorrentPlaybackInfo = playbackInfo
             showP2pConsentDialog = true
-            viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
             return
         }
         when (preference) {
@@ -188,14 +186,11 @@ fun StreamScreen(
             PlayerPreference.EXTERNAL -> {
                 if (playbackInfo.url != null || playbackInfo.isTorrent) {
                     launchExternalPlayer(playbackInfo)
-                } else {
-                    viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
                 }
             }
             PlayerPreference.ASK_EVERY_TIME -> {
                 pendingPlaybackInfo = playbackInfo
                 showPlayerChoiceDialog = true
-                viewModel.onEvent(StreamScreenEvent.OnAutoPlayConsumed)
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -282,12 +282,6 @@ class StreamScreenViewModel @Inject constructor(
             StreamScreenEvent.OnRetry -> loadStreams()
             StreamScreenEvent.OnBackPress -> { /* Handle in screen */ }
             StreamScreenEvent.OnResume -> {
-                updateUiStateIfChanged {
-                    it.copy(
-                        showDirectAutoPlayOverlay = false,
-                        directAutoPlayMessage = null
-                    )
-                }
                 // If loading was cancelled (e.g. user went to player) and
                 // hasn't completed yet, resume it. The baseline snapshot
                 // captured at cancel time keeps existing results visible
@@ -1137,8 +1131,17 @@ class StreamScreenViewModel @Inject constructor(
 
         return when (result) {
             is DirectDebridResolveResult.Success -> {
-                updateUiStateIfChanged {
-                    it.copy(directAutoPlayMessage = null)
+                if (!_uiState.value.isDirectAutoPlayFlow) {
+                    updateUiStateIfChanged {
+                        it.copy(
+                            showDirectAutoPlayOverlay = false,
+                            directAutoPlayMessage = null
+                        )
+                    }
+                } else {
+                    updateUiStateIfChanged {
+                        it.copy(directAutoPlayMessage = null)
+                    }
                 }
                 cancelStreamsLoad()
                 val resolved = basePlaybackInfo.copy(
@@ -1193,7 +1196,7 @@ class StreamScreenViewModel @Inject constructor(
 
     fun onInternalPlayerLaunching() {
         updateUiStateIfChanged {
-            it.copy(directAutoPlayMessage = null)
+            it.copy(showDirectAutoPlayOverlay = false, directAutoPlayMessage = null)
         }
     }
 


### PR DESCRIPTION
## Summary

Reverts commit `4278209530e5d35860099e980a785ea60b40deb2` from PR #2493, which caused a regression in the auto-play flow.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Commit `4278209530e5d35860099e980a785ea60b40deb2` introduced unexpected state changes in `StreamScreenViewModel` and `StreamScreen` during stream routing, causing auto-play to be prematurely consumed or fail during playback transitions. Reverting this commit restores the expected auto-play functionality.

## Issue or approval

Fixes #2493

## Reproduction steps

1. Enable Auto Play in player settings.
2. Navigate to a series episode or start playback with auto-play enabled.
3. Observe stream resolution and auto-play routing.
4. Without this revert, auto-play state was prematurely consumed during stream routing.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Reverts only commit `4278209530e5d35860099e980a785ea60b40deb2` from PR #2493. Does not include any extra UI tweaks or refactors.

## Testing

Tested manual stream selection and auto-play flow navigation on Android TV device and emulator to verify auto-play completes without premature consumption.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #2493
