### PR TITLE
fix(player): survive seek reopens in parallel range data source

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -123,6 +123,7 @@ internal class ParallelRangeDataSource(
 
         private class ChunkSession(
             val requestUri: Uri,
+            val requestHeaders: Map<String, String>,
             val chunkSize: Long,
             val chunkCap: Int
         ) {
@@ -201,6 +202,7 @@ internal class ParallelRangeDataSource(
          */
         private fun obtainSession(
             requestUri: Uri,
+            requestHeaders: Map<String, String>,
             chunkSz: Long,
             chunkCap: Int,
             poolCap: Int
@@ -210,14 +212,15 @@ internal class ParallelRangeDataSource(
                 if (existing != null) {
                     val fresh = SystemClock.uptimeMillis() - existing.lastUsedAtMs <= RETAINED_SESSION_TTL_MS
                     if (fresh && !existing.abandoned.get() &&
-                        existing.requestUri == requestUri && existing.chunkSize == chunkSz
+                        existing.requestUri == requestUri && existing.chunkSize == chunkSz &&
+                        existing.requestHeaders == requestHeaders
                     ) {
                         existing.lastUsedAtMs = SystemClock.uptimeMillis()
                         return existing
                     }
                     teardownSessionLocked(existing, poolCap)
                 }
-                val created = ChunkSession(requestUri, chunkSz, chunkCap)
+                val created = ChunkSession(requestUri, requestHeaders, chunkSz, chunkCap)
                 currentChunkSession = created
                 return created
             }
@@ -417,7 +420,7 @@ internal class ParallelRangeDataSource(
         // re-opens, the failed futures are gone, and downloads retry against
         // the session's URI — with the full probe as the eventual fallback via
         // session teardown on TTL.
-        val attachedSession = obtainSession(dataSpec.uri, chunkSize, sessionChunkCap, maxPoolSize)
+        val attachedSession = obtainSession(dataSpec.uri, dataSpec.httpRequestHeaders, chunkSize, sessionChunkCap, maxPoolSize)
         session = attachedSession
         val warmLength = attachedSession.totalLength
         if (warmLength > 0L && dataSpec.position in 0 until warmLength) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import java.io.InterruptedIOException
@@ -21,6 +22,7 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import com.nuvio.tv.data.local.PlayerSettings
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import android.os.SystemClock
 
 import java.nio.ByteBuffer
@@ -121,6 +123,18 @@ internal class ParallelRangeDataSource(
         // the chunk instead of spinning forever.
         private const val MAX_CONSECUTIVE_ZERO_READS = 3
 
+        // nt-tier2: HTTP 429/503 is server-side rate-limiting, not a stalled
+        // socket. Back off before retrying (immediate retry just re-hits the
+        // limit), and after repeated hits set a one-way session latch so
+        // prefetch drops to a single connection. Only reachable when parallel
+        // connections are enabled (opt-in; off by default).
+        private const val RATE_LIMIT_MAX_BACKOFF_RETRIES = 3
+        private const val RATE_LIMIT_CLAMP_THRESHOLD = 3
+        private const val RATE_LIMIT_BACKOFF_BASE_MS = 500L
+        private const val RATE_LIMIT_BACKOFF_MAX_MS = 3_000L
+        private const val RATE_LIMIT_BACKOFF_JITTER_MS = 250L
+        private const val RATE_LIMIT_SLEEP_SLICE_MS = 100L
+
         private class ChunkSession(
             val requestUri: Uri,
             val requestHeaders: Map<String, String>,
@@ -132,6 +146,11 @@ internal class ParallelRangeDataSource(
             val futures = ConcurrentHashMap<Long, CompletableFuture<DownloadedChunk>>()
             val lastTouch = ConcurrentHashMap<Long, Long>()
             val abandoned = AtomicBoolean(false)
+            // nt-tier2: set once when the server rate-limits us repeatedly; the
+            // read path then holds prefetch to a single connection for this
+            // session. One-way (never cleared) — a new stream gets a new session.
+            val rateLimited = AtomicBoolean(false)
+            val rateLimit429s = AtomicInteger(0)
             val activeSources: MutableSet<DataSource> = java.util.concurrent.ConcurrentHashMap.newKeySet()
             @Volatile var lastUsedAtMs: Long = SystemClock.uptimeMillis()
 
@@ -678,7 +697,13 @@ internal class ParallelRangeDataSource(
         // meaningful sequential run. Side cursors (a few bytes per open on
         // scatter-read files) fetch only the chunk they actually need, instead
         // of fanning out connections+1 chunks of dead prefetch per visit.
-        val maxAhead = if (bytesServedThisOpen >= EARNED_PREFETCH_BYTES) parallelConnections + 1 else 1
+        // nt-tier2: once the session is rate-limited, hold prefetch to a single
+        // connection so we stop fanning out into the limit.
+        val maxAhead = when {
+            session?.rateLimited?.get() == true -> 1
+            bytesServedThisOpen >= EARNED_PREFETCH_BYTES -> parallelConnections + 1
+            else -> 1
+        }
 
         for (i in 0 until maxAhead) {
             val ci = currentChunkIdx + i
@@ -726,6 +751,12 @@ internal class ParallelRangeDataSource(
                 // only future cancellation or session teardown aborts them.
                 if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
                 lastException = e
+                // nt-tier2: 429/503 is server rate-limiting, not a stalled socket.
+                // Hand off to a bounded backoff loop rather than retrying now.
+                val rlError = e.findRateLimitException()
+                if (rlError != null) {
+                    return downloadChunkWithRateLimitBackoff(activeSession, chunkIndex, future, rlError)
+                }
                 if (attempt == 0) {
                     if (e.isTransientInterruption()) {
                         Log.d(TAG, "Chunk $chunkIndex interrupted during prefetch (attempt 1), retrying")
@@ -782,6 +813,100 @@ internal class ParallelRangeDataSource(
         if (this is InterruptedIOException || this is InterruptedException) return true
         val cause = cause
         return cause is InterruptedIOException || cause is InterruptedException
+    }
+
+    /**
+     * nt-tier2: walk the cause chain for an HTTP 429/503 response. Returns the
+     * exception (so the caller can read its Retry-After header) or null for any
+     * other failure — those keep the existing immediate-retry stall handling.
+     */
+    private fun Throwable.findRateLimitException(): HttpDataSource.InvalidResponseCodeException? {
+        var cause: Throwable? = this
+        var depth = 0
+        while (cause != null && depth < 6) {
+            val c = cause
+            if (c is HttpDataSource.InvalidResponseCodeException &&
+                (c.responseCode == 429 || c.responseCode == 503)) {
+                return c
+            }
+            cause = c.cause
+            depth++
+        }
+        return null
+    }
+
+    /**
+     * nt-tier2: dedicated backoff-retry for a rate-limited chunk. Bounded and
+     * cancellation-aware; on repeated hits it latches the session to a single
+     * connection. When the budget is spent it throws, and the existing failure
+     * handling / auto-recovery takes over — i.e. never worse than before.
+     */
+    private fun downloadChunkWithRateLimitBackoff(
+        activeSession: ChunkSession,
+        chunkIndex: Long,
+        future: CompletableFuture<*>,
+        firstError: HttpDataSource.InvalidResponseCodeException
+    ): DownloadedChunk {
+        var rl: HttpDataSource.InvalidResponseCodeException = firstError
+        var lastException: Exception = firstError
+        var attempt = 0
+        while (attempt < RATE_LIMIT_MAX_BACKOFF_RETRIES) {
+            if (activeSession.rateLimit429s.incrementAndGet() >= RATE_LIMIT_CLAMP_THRESHOLD &&
+                activeSession.rateLimited.compareAndSet(false, true)) {
+                Log.w(TAG, "Rate-limited (HTTP ${rl.responseCode}) repeatedly; clamping session to single connection")
+            }
+            val waitMs = rateLimitBackoffMs(attempt, rl)
+            Log.w(TAG, "Chunk $chunkIndex rate-limited (HTTP ${rl.responseCode}); backing off ${waitMs}ms " +
+                "(attempt ${attempt + 1}/$RATE_LIMIT_MAX_BACKOFF_RETRIES)")
+            if (!sleepInterruptibly(waitMs, future, activeSession)) throw IOException("Cancelled during rate-limit backoff")
+            if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
+            try {
+                return downloadChunkOnce(activeSession, chunkIndex, future)
+            } catch (e: Exception) {
+                if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
+                lastException = e
+                // A non-rate-limit error after a 429 is a different failure: surface it.
+                rl = e.findRateLimitException() ?: throw e
+                attempt++
+            }
+        }
+        throw IOException("Chunk $chunkIndex still rate-limited after $RATE_LIMIT_MAX_BACKOFF_RETRIES backoffs", lastException)
+    }
+
+    /** nt-tier2: honour Retry-After (seconds) capped, else exponential + jitter. */
+    private fun rateLimitBackoffMs(attempt: Int, rl: HttpDataSource.InvalidResponseCodeException): Long {
+        val retryAfterMs = rl.headerFields.entries
+            .firstOrNull { it.key.equals("Retry-After", ignoreCase = true) }
+            ?.value?.firstOrNull()?.trim()?.toLongOrNull()
+            ?.let { it * 1000L }
+        val base = retryAfterMs ?: (RATE_LIMIT_BACKOFF_BASE_MS shl attempt.coerceIn(0, 3))
+        val capped = base.coerceIn(RATE_LIMIT_BACKOFF_BASE_MS, RATE_LIMIT_BACKOFF_MAX_MS)
+        return capped + (Math.random() * RATE_LIMIT_BACKOFF_JITTER_MS).toLong()
+    }
+
+    /**
+     * nt-tier2: sleep in short slices so a stop/seek aborts the backoff promptly.
+     * Watches future cancellation and session teardown only — not the instance
+     * closed flag — to stay consistent with the session-owned download model.
+     * Returns false if the wait should abort.
+     */
+    private fun sleepInterruptibly(
+        totalMs: Long,
+        future: CompletableFuture<*>,
+        activeSession: ChunkSession
+    ): Boolean {
+        var slept = 0L
+        while (slept < totalMs) {
+            if (future.isCancelled || activeSession.abandoned.get()) return false
+            val slice = minOf(RATE_LIMIT_SLEEP_SLICE_MS, totalMs - slept)
+            try {
+                Thread.sleep(slice)
+            } catch (_: InterruptedException) {
+                return false
+            }
+            slept += slice
+        }
+        return !(future.isCancelled || activeSession.abandoned.get())
     }
 
     /** Read from an already-opened DataSource into a pooled chunk buffer. */

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -245,10 +245,16 @@ internal class ParallelRangeDataSource(
             synchronized(session) {
                 while (session.futures.size > session.chunkCap) {
                     val now = SystemClock.uptimeMillis()
+                    // The 2 s touch guard makes the cap soft — when every
+                    // candidate is recently touched the loop bails and an
+                    // active file can hold ~cap+2–3 chunks. Beyond cap+2 the
+                    // ceiling is hard: evict the oldest-touched candidate
+                    // regardless of the guard.
+                    val hardOver = session.futures.size > session.chunkCap + 2
                     val victim = session.futures.keys
                         .asSequence()
                         .filter { it != protectIndex }
-                        .filter { now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
+                        .filter { hardOver || now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
                         .minByOrNull { session.lastTouch[it] ?: 0L }
                         ?: return
                     evictFuture(session, victim, poolCap)
@@ -589,8 +595,20 @@ internal class ParallelRangeDataSource(
                 if (closed.get()) return C.RESULT_END_OF_INPUT
                 // A failed download is not retryable by waiting — drop
                 // the future so the next attempt schedules a fresh one.
-                activeSession.futures.remove(chunkIndex, future)
-                activeSession.lastTouch.remove(chunkIndex)
+                // Cancel before dropping: an orphaned in-flight download
+                // otherwise completes into a pooled native buffer nothing will
+                // ever release. Ownership-gated on the two-arg remove so a
+                // future already evicted by another thread is never
+                // double-released.
+                if (activeSession.futures.remove(chunkIndex, future)) {
+                    activeSession.lastTouch.remove(chunkIndex)
+                    if (!future.cancel(true) && future.isDone && !future.isCancelled) {
+                        try {
+                            releaseSessionBuffer(future.get().buffer, activeSession.chunkSize, maxPoolSize)
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
                 throw IOException("Failed to download chunk $chunkIndex", e)
             }
             currentChunkIndex = chunkIndex
@@ -1001,8 +1019,17 @@ internal class ParallelRangeDataSource(
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
-                activeSession.futures.remove(chunkIndex, future)
-                activeSession.lastTouch.remove(chunkIndex)
+                // Mirror of the byte-array path: cancel before dropping,
+                // ownership-gated release if the download won the race.
+                if (activeSession.futures.remove(chunkIndex, future)) {
+                    activeSession.lastTouch.remove(chunkIndex)
+                    if (!future.cancel(true) && future.isDone && !future.isCancelled) {
+                        try {
+                            releaseSessionBuffer(future.get().buffer, activeSession.chunkSize, maxPoolSize)
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
                 throw IOException("Failed to download chunk $chunkIndex", e)
             }
             currentChunkIndex = chunkIndex

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -375,6 +375,7 @@ internal class ParallelRangeDataSource(
 
         val wasClosed = closed.get()
         val isReopen = !wasClosed && 
+                       fallbackSource == null &&
                        originalDataSpec != null && 
                        originalDataSpec?.uri == dataSpec.uri && 
                        position == dataSpec.position &&
@@ -398,6 +399,12 @@ internal class ParallelRangeDataSource(
         continuationSource?.close()
         continuationSource = null
         continuationEndPositionExclusive = C.TIME_UNSET
+        // A fresh open must not inherit fallback/length state from a previous
+        // open on this instance; every path below re-establishes both fields.
+        fallbackSource?.close()
+        fallbackSource = null
+        totalFileLength = C.LENGTH_UNSET.toLong()
+        bytesRemaining = C.LENGTH_UNSET.toLong()
 
         resetLocalReadState()
         bytesServedThisOpen = 0L
@@ -476,6 +483,14 @@ internal class ParallelRangeDataSource(
             // Can't determine length or server doesn't support ranges — reuse probe as single connection
             Log.w(TAG, "Falling back to single connection (length=${openLength}, acceptsRanges=$acceptsRanges)")
             fallbackSource = probeSource
+            // Keep state consistent with the subtitle fallback path (position is
+            // already set above): known length gives a real total, unknown stays unset.
+            totalFileLength = if (openLength != C.LENGTH_UNSET.toLong()) {
+                position + openLength
+            } else {
+                C.LENGTH_UNSET.toLong()
+            }
+            bytesRemaining = openLength
             return openLength
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -116,6 +116,10 @@ internal class ParallelRangeDataSource(
         // Never evict a chunk touched in the last 2 s: closes the narrow race
         // where an overlapping old instance is still copying from the buffer.
         private const val EVICTION_TOUCH_GUARD_MS = 2_000L
+        // A conforming DataSource blocks rather than returning 0 for a
+        // positive-length read; tolerate a few zero-progress reads, then fail
+        // the chunk instead of spinning forever.
+        private const val MAX_CONSECUTIVE_ZERO_READS = 3
 
         private class ChunkSession(
             val requestUri: Uri,
@@ -611,7 +615,10 @@ internal class ParallelRangeDataSource(
         }
 
         val readSize = minOf(toRead, available)
-        val readBuf = chunk.buffer.byteBuffer
+        // Session chunks are shared across instances — mutating the shared
+        // buffer's position races concurrent readers of the same chunk. Read
+        // through a duplicate, as the ByteBuffer read path does.
+        val readBuf = chunk.buffer.byteBuffer.duplicate()
         readBuf.position(currentChunkReadOffset)
         readBuf.get(buffer, offset, readSize)
         currentChunkReadOffset += readSize
@@ -722,7 +729,11 @@ internal class ParallelRangeDataSource(
             if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
             Log.d(TAG, "Starting chunk download: idx=$chunkIndex, range=$start-$end")
             ds.open(spec)
-            val chunk = readIntoChunk(activeSession, ds, future)
+            // With a known session length the requested range is exact — a
+            // chunk that comes back short must fail (and retry) rather than be
+            // cached as if complete.
+            val expectedBytes = if (sessionLength > 0L) end - start else -1L
+            val chunk = readIntoChunk(activeSession, ds, future, expectedBytes)
             Log.d(TAG, "Successfully downloaded chunk $chunkIndex, size=${chunk.size} bytes")
             return chunk
         } finally {
@@ -738,10 +749,16 @@ internal class ParallelRangeDataSource(
     }
 
     /** Read from an already-opened DataSource into a pooled chunk buffer. */
-    private fun readIntoChunk(activeSession: ChunkSession, ds: DataSource, future: CompletableFuture<*>): DownloadedChunk {
+    private fun readIntoChunk(
+        activeSession: ChunkSession,
+        ds: DataSource,
+        future: CompletableFuture<*>,
+        expectedBytes: Long
+    ): DownloadedChunk {
         val buffer = acquireBuffer()
         val tempArray = readBufferLocal.get()!!
         var totalRead = 0
+        var consecutiveZeroReads = 0
         try {
             val byteBufferReader = if (useNativeMemory && ds is androidx.media3.common.ByteBufferDataReader && ds.supportsByteBufferRead()) {
                 ds
@@ -772,7 +789,26 @@ internal class ParallelRangeDataSource(
                 }
 
                 if (read == C.RESULT_END_OF_INPUT) break
+                // A positive-length read returning 0 violates the DataSource
+                // contract; bail after a few rather than busy-spinning until
+                // cancellation.
+                if (read == 0) {
+                    if (++consecutiveZeroReads >= MAX_CONSECUTIVE_ZERO_READS) {
+                        throw IOException(
+                            "No read progress after $MAX_CONSECUTIVE_ZERO_READS attempts " +
+                                "(read $totalRead of $expectedBytes bytes)"
+                        )
+                    }
+                } else {
+                    consecutiveZeroReads = 0
+                }
                 totalRead += read
+            }
+            // A premature EOF inside a known range must not produce a cached
+            // "complete" chunk — a short non-final chunk otherwise dead-ends
+            // both read paths at the phantom chunk boundary.
+            if (expectedBytes > 0L && totalRead < expectedBytes && !activeSession.abandoned.get()) {
+                throw IOException("Short chunk: read $totalRead of $expectedBytes bytes")
             }
         } catch (e: Exception) {
             releaseBuffer(buffer)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -94,6 +94,165 @@ internal class ParallelRangeDataSource(
             }
         }
 
+        // ── Session-owned chunk downloads ───────────────────────────────────
+        // ExoPlayer creates a new instance of this class for every seek,
+        // closing the old one. Previously each close cancelled all in-flight
+        // chunk downloads and each open re-probed the URL and re-downloaded
+        // data. On scatter-read files (poorly interleaved, moov-at-end MP4s
+        // whose track layout forces several distant concurrent read cursors)
+        // this measured as ~66% of transfer discarded — the same 32 MB chunks
+        // restarting up to 30 times inside two minutes (192 chunk starts /
+        // 66 completions), presenting as constant rebuffering.
+        // Downloads therefore belong to a companion-level session: futures
+        // (completed AND in-flight) survive the close→open boundary, run to
+        // completion regardless of instance lifetime, and instances are thin
+        // readers over the shared session. Eviction is touch-LRU under a
+        // memory-tiered cap; teardown happens on stream change, idle TTL, or
+        // player shutdown.
+        private const val RETAINED_SESSION_TTL_MS = 45_000L
+        // Earned prefetch: sequential bytes an open must serve before
+        // lookahead prefetch is granted.
+        private const val EARNED_PREFETCH_BYTES = 1L * 1024L * 1024L
+        // Never evict a chunk touched in the last 2 s: closes the narrow race
+        // where an overlapping old instance is still copying from the buffer.
+        private const val EVICTION_TOUCH_GUARD_MS = 2_000L
+
+        private class ChunkSession(
+            val requestUri: Uri,
+            val chunkSize: Long,
+            val chunkCap: Int
+        ) {
+            @Volatile var resolvedUri: Uri? = null
+            @Volatile var totalLength: Long = -1L
+            val futures = ConcurrentHashMap<Long, CompletableFuture<DownloadedChunk>>()
+            val lastTouch = ConcurrentHashMap<Long, Long>()
+            val abandoned = AtomicBoolean(false)
+            val activeSources: MutableSet<DataSource> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+            @Volatile var lastUsedAtMs: Long = SystemClock.uptimeMillis()
+
+            fun touch(chunkIndex: Long) {
+                val now = SystemClock.uptimeMillis()
+                lastTouch[chunkIndex] = now
+                lastUsedAtMs = now
+            }
+        }
+
+        private val sessionLock = Any()
+        private var currentChunkSession: ChunkSession? = null
+
+        /** Release one session buffer: recycle to the pool, or free directly on teardown. */
+        private fun releaseSessionBuffer(buffer: PooledBuffer, chunkSz: Long, poolCap: Int) {
+            if (poolCap > 0) {
+                val pool = globalBufferPool.computeIfAbsent(chunkSz) { ConcurrentLinkedDeque() }
+                if (pool.size < poolCap) {
+                    pool.offerLast(buffer)
+                    return
+                }
+            }
+            if (buffer.allocation != null) {
+                androidx.media3.exoplayer.upstream.DefaultAllocatorNative.freeAllocation(buffer.allocation)
+            } else if (buffer.byteBuffer.isDirect) {
+                freeDirectBuffer(buffer.byteBuffer)
+            }
+        }
+
+        /**
+         * Evict one future from a session. Handles the complete-vs-cancel race:
+         * if cancel() loses because the download just completed, the buffer is
+         * released via the completed value; if cancel() wins, the download
+         * loop's cancellation checks release the buffer on its own thread.
+         */
+        private fun evictFuture(
+            session: ChunkSession,
+            chunkIndex: Long,
+            poolCap: Int
+        ) {
+            val future = session.futures.remove(chunkIndex) ?: return
+            session.lastTouch.remove(chunkIndex)
+            if (!future.cancel(true) && future.isDone && !future.isCancelled) {
+                try {
+                    releaseSessionBuffer(future.get().buffer, session.chunkSize, poolCap)
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        private fun teardownSessionLocked(session: ChunkSession, poolCap: Int) {
+            session.abandoned.set(true)
+            session.activeSources.forEach { ds ->
+                try { ds.close() } catch (_: Exception) {}
+            }
+            session.activeSources.clear()
+            val indices = session.futures.keys.toList()
+            for (index in indices) {
+                evictFuture(session, index, poolCap)
+            }
+            session.futures.clear()
+            session.lastTouch.clear()
+        }
+
+        /**
+         * Get the shared session for this request URI, creating (and tearing
+         * down any stale/mismatched predecessor) as needed.
+         */
+        private fun obtainSession(
+            requestUri: Uri,
+            chunkSz: Long,
+            chunkCap: Int,
+            poolCap: Int
+        ): ChunkSession {
+            synchronized(sessionLock) {
+                val existing = currentChunkSession
+                if (existing != null) {
+                    val fresh = SystemClock.uptimeMillis() - existing.lastUsedAtMs <= RETAINED_SESSION_TTL_MS
+                    if (fresh && !existing.abandoned.get() &&
+                        existing.requestUri == requestUri && existing.chunkSize == chunkSz
+                    ) {
+                        existing.lastUsedAtMs = SystemClock.uptimeMillis()
+                        return existing
+                    }
+                    teardownSessionLocked(existing, poolCap)
+                }
+                val created = ChunkSession(requestUri, chunkSz, chunkCap)
+                currentChunkSession = created
+                return created
+            }
+        }
+
+        /**
+         * Explicit teardown, wired into PlayerMediaSourceFactory.shutdown() so
+         * chunk buffers and downloads never outlive the player. Buffers are
+         * freed directly (poolCap = 0) — playback is over.
+         */
+        internal fun releaseRetainedSession() {
+            synchronized(sessionLock) {
+                currentChunkSession?.let { teardownSessionLocked(it, poolCap = 0) }
+                currentChunkSession = null
+            }
+        }
+
+        /**
+         * Enforce the session's chunk cap with touch-LRU eviction. Never
+         * evicts [protectIndex] (the chunk being read) or anything touched in
+         * the last EVICTION_TOUCH_GUARD_MS.
+         */
+        private fun enforceSessionCap(session: ChunkSession, protectIndex: Long, poolCap: Int) {
+            if (session.futures.size <= session.chunkCap) return
+            synchronized(session) {
+                while (session.futures.size > session.chunkCap) {
+                    val now = SystemClock.uptimeMillis()
+                    val victim = session.futures.keys
+                        .asSequence()
+                        .filter { it != protectIndex }
+                        .filter { now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
+                        .minByOrNull { session.lastTouch[it] ?: 0L }
+                        ?: return
+                    evictFuture(session, victim, poolCap)
+                }
+            }
+        }
+        // ── end session ─────────────────────────────────────────────────────
+
         private fun clearGlobalPool() {
             globalBufferPool.values.forEach { pool ->
                 while (true) {
@@ -143,9 +302,6 @@ internal class ParallelRangeDataSource(
     private var bytesRemaining: Long = C.LENGTH_UNSET.toLong()
     private val closed = AtomicBoolean(false)
 
-    // Chunk download state
-    private val chunks = ConcurrentHashMap<Long, CompletableFuture<DownloadedChunk>>()
-
     // Buffer pool limit
     private val maxPoolSize = parallelConnections + 2
 
@@ -157,7 +313,6 @@ internal class ParallelRangeDataSource(
     private var bootstrapChunk: DownloadedChunk? = null
     private var bootstrapStartPosition: Long = C.TIME_UNSET
     private var continuationSource: OkHttpDataSource? = null
-    private val activeDataSources = java.util.concurrent.ConcurrentHashMap.newKeySet<DataSource>()
     private var continuationEndPositionExclusive: Long = C.TIME_UNSET
 
     private val transferListeners = mutableListOf<TransferListener>()
@@ -165,11 +320,22 @@ internal class ParallelRangeDataSource(
     // Fallback: if parallel mode fails, use a single upstream DataSource
     private var fallbackSource: OkHttpDataSource? = null
 
+    // Shared download session (null on subtitle/fallback paths).
+    private var session: ChunkSession? = null
+    // Earned prefetch: lookahead is granted only after this open has
+    // demonstrated sequential consumption, so side-cursor opens (tiny reads,
+    // then reopen) never trigger the connections+1 chunk prefetch fan-out.
+    private var bytesServedThisOpen: Long = 0L
+    // Memory-tiered chunk cap: low-RAM devices keep the pre-existing
+    // ceiling (connections + 2); high-RAM gets two extra chunks of headroom.
+    private val sessionChunkCap: Int = parallelConnections +
+        if (com.nuvio.tv.ui.screens.settings.MemoryBudget.isLowRamTier) 2 else 4
+
     override fun open(dataSpec: DataSpec): Long {
         val isSubtitle = dataSpec.uri.getQueryParameter("nuvio_type") == "subtitle"
         if (isSubtitle) {
             closed.set(false)
-            cancelAllChunks()
+            resetLocalReadState()
             
             // Clean the custom query parameter from the subtitle URL before requesting
             val cleanedUri = dataSpec.uri.buildUpon().clearQuery().let { builder ->
@@ -223,7 +389,38 @@ internal class ParallelRangeDataSource(
         continuationSource = null
         continuationEndPositionExclusive = C.TIME_UNSET
 
-        cancelAllChunks()
+        resetLocalReadState()
+        bytesServedThisOpen = 0L
+
+        // Attach to the shared download session for this URI. Downloads
+        // (done AND in-flight) belong to the session and survive the
+        // close→open cycle ExoPlayer performs on every seek. When the session
+        // is warm (length + resolved URI known) the probe request is skipped.
+        // If an adopted CDN URL has expired, chunk downloads fail, ExoPlayer
+        // re-opens, the failed futures are gone, and downloads retry against
+        // the session's URI — with the full probe as the eventual fallback via
+        // session teardown on TTL.
+        val attachedSession = obtainSession(dataSpec.uri, chunkSize, sessionChunkCap, maxPoolSize)
+        session = attachedSession
+        val warmLength = attachedSession.totalLength
+        if (warmLength > 0L && dataSpec.position in 0 until warmLength) {
+            resolvedUri = attachedSession.resolvedUri
+            onResolvedUri(resolvedUri)
+            totalFileLength = warmLength
+            val remaining = (totalFileLength - position).coerceAtLeast(0L)
+            bytesRemaining = if (dataSpec.length != C.LENGTH_UNSET.toLong()) {
+                minOf(dataSpec.length, remaining)
+            } else {
+                remaining
+            }
+            bootstrapPrefetchDeferred = true
+            Log.d(
+                TAG,
+                "Attached to warm session for reopen at $position, " +
+                    "file=${totalFileLength / 1024 / 1024}MB, held=${attachedSession.futures.size} chunk(s) (probe skipped)"
+            )
+            return bytesRemaining
+        }
 
         consumeBootstrapCache(dataSpec)?.let { cached ->
             resolvedUri = cached.resolvedUri
@@ -233,6 +430,9 @@ internal class ParallelRangeDataSource(
             bootstrapChunk = DownloadedChunk(PooledBuffer(null, ByteBuffer.wrap(cached.bootstrapData)), cached.bootstrapSize)
             bootstrapStartPosition = cached.startPosition
             bootstrapPrefetchDeferred = true
+            // Publish to the session so the next reopen is warm.
+            attachedSession.resolvedUri = resolvedUri
+            attachedSession.totalLength = totalFileLength
             Log.d(
                 TAG,
                 "Reusing bootstrap window for immediate reopen at ${cached.startPosition}, " +
@@ -271,6 +471,10 @@ internal class ParallelRangeDataSource(
 
         totalFileLength = position + openLength
         bytesRemaining = openLength
+
+        // Publish to the session so every subsequent reopen is warm.
+        attachedSession.resolvedUri = resolvedUri
+        attachedSession.totalLength = totalFileLength
 
         Log.d(TAG, "Parallel mode: ${parallelConnections} connections, ${chunkSize / 1024 / 1024}MB chunks, " +
                 "file=${totalFileLength / 1024 / 1024}MB, resolved=${resolvedUri?.host}")
@@ -371,19 +575,26 @@ internal class ParallelRangeDataSource(
 
         // Load the chunk for the current position
         if (currentChunkIndex != chunkIndex || currentChunk == null) {
+            val activeSession = session ?: return C.RESULT_END_OF_INPUT
             ensureChunkScheduled(chunkIndex)
-            val future = chunks[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            val future = activeSession.futures[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            activeSession.touch(chunkIndex)
             try {
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
+                // A failed download is not retryable by waiting — drop
+                // the future so the next attempt schedules a fresh one.
+                activeSession.futures.remove(chunkIndex, future)
+                activeSession.lastTouch.remove(chunkIndex)
                 throw IOException("Failed to download chunk $chunkIndex", e)
             }
             currentChunkIndex = chunkIndex
             currentChunkReadOffset = (position % chunkSize).toInt()
 
-            // Clean up old chunks (returns buffers to pool) and schedule new ones
-            cleanupOldChunks(chunkIndex)
+            // LRU cap enforcement lives in ensureChunkScheduled; behind-
+            // chunks are not eagerly released (they serve the backward
+            // cursors on scatter-read files).
             scheduleChunks()
         }
 
@@ -406,6 +617,8 @@ internal class ParallelRangeDataSource(
         currentChunkReadOffset += readSize
         position += readSize
         bytesRemaining -= readSize
+        bytesServedThisOpen += readSize
+        session?.touch(chunkIndex)
 
         return readSize
     }
@@ -418,7 +631,11 @@ internal class ParallelRangeDataSource(
             } else {
                 position / chunkSize
             }
-        val maxAhead = parallelConnections + 1
+        // Earned prefetch: lookahead only after this open has served a
+        // meaningful sequential run. Side cursors (a few bytes per open on
+        // scatter-read files) fetch only the chunk they actually need, instead
+        // of fanning out connections+1 chunks of dead prefetch per visit.
+        val maxAhead = if (bytesServedThisOpen >= EARNED_PREFETCH_BYTES) parallelConnections + 1 else 1
 
         for (i in 0 until maxAhead) {
             val ci = currentChunkIdx + i
@@ -428,16 +645,24 @@ internal class ParallelRangeDataSource(
     }
 
     private fun ensureChunkScheduled(chunkIndex: Long) {
-        chunks.computeIfAbsent(chunkIndex) {
+        val activeSession = session ?: return
+        // Make room under the memory-tiered cap before growing the map.
+        enforceSessionCap(activeSession, protectIndex = chunkIndex, poolCap = maxPoolSize)
+        activeSession.futures.computeIfAbsent(chunkIndex) {
             val future = CompletableFuture<DownloadedChunk>()
+            activeSession.touch(chunkIndex)
             Log.d(TAG, "Scheduling chunk $chunkIndex")
             sharedExecutor.execute {
                 try {
-                    if (!future.isCancelled) {
-                        val result = downloadChunk(chunkIndex, future)
+                    if (!future.isCancelled && !activeSession.abandoned.get()) {
+                        val result = downloadChunk(activeSession, chunkIndex, future)
                         if (!future.complete(result)) {
                             releaseBuffer(result.buffer)
                         }
+                    } else if (future.isCancelled) {
+                        // no-op: never started
+                    } else {
+                        future.completeExceptionally(IOException("Session abandoned"))
                     }
                 } catch (e: Exception) {
                     future.completeExceptionally(e)
@@ -447,14 +672,16 @@ internal class ParallelRangeDataSource(
         }
     }
 
-    private fun downloadChunk(chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
+    private fun downloadChunk(activeSession: ChunkSession, chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
         var lastException: Exception? = null
         for (attempt in 0..1) {
-            if (future.isCancelled) throw IOException("Cancelled")
+            if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
             try {
-                return downloadChunkOnce(chunkIndex, future)
+                return downloadChunkOnce(activeSession, chunkIndex, future)
             } catch (e: Exception) {
-                if (closed.get() || future.isCancelled) throw IOException("DataSource closed or cancelled")
+                // Downloads belong to the session, not the instance —
+                // only future cancellation or session teardown aborts them.
+                if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
                 lastException = e
                 if (attempt == 0) {
                     if (e.isTransientInterruption()) {
@@ -472,33 +699,34 @@ internal class ParallelRangeDataSource(
         throw IOException("Failed to download chunk $chunkIndex after 2 attempts", lastException)
     }
 
-    private fun downloadChunkOnce(chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
+    private fun downloadChunkOnce(activeSession: ChunkSession, chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
+        val sessionLength = activeSession.totalLength
         val start = chunkIndex * chunkSize
-        val end = if (totalFileLength != C.LENGTH_UNSET.toLong()) {
-            minOf(start + chunkSize, totalFileLength)
+        val end = if (sessionLength > 0L) {
+            minOf(start + chunkSize, sessionLength)
         } else {
             start + chunkSize
         }
 
         val ds = upstreamFactory.createDataSource()
         transferListeners.forEach { ds.addTransferListener(it) }
-        activeDataSources.add(ds)
+        activeSession.activeSources.add(ds)
         try {
-            val uri = resolvedUri ?: originalDataSpec?.uri ?: throw IOException("No URI available")
+            val uri = activeSession.resolvedUri ?: activeSession.requestUri
             val spec = DataSpec.Builder()
                 .setUri(uri)
                 .setPosition(start)
                 .setLength(end - start)
                 .build()
 
-            if (future.isCancelled) throw IOException("Cancelled")
+            if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
             Log.d(TAG, "Starting chunk download: idx=$chunkIndex, range=$start-$end")
             ds.open(spec)
-            val chunk = readIntoChunk(ds, future)
+            val chunk = readIntoChunk(activeSession, ds, future)
             Log.d(TAG, "Successfully downloaded chunk $chunkIndex, size=${chunk.size} bytes")
             return chunk
         } finally {
-            activeDataSources.remove(ds)
+            activeSession.activeSources.remove(ds)
             try { ds.close() } catch (_: Exception) {}
         }
     }
@@ -510,7 +738,7 @@ internal class ParallelRangeDataSource(
     }
 
     /** Read from an already-opened DataSource into a pooled chunk buffer. */
-    private fun readIntoChunk(ds: DataSource, future: CompletableFuture<*>): DownloadedChunk {
+    private fun readIntoChunk(activeSession: ChunkSession, ds: DataSource, future: CompletableFuture<*>): DownloadedChunk {
         val buffer = acquireBuffer()
         val tempArray = readBufferLocal.get()!!
         var totalRead = 0
@@ -521,7 +749,10 @@ internal class ParallelRangeDataSource(
                 null
             }
 
-            while (!closed.get()) {
+            // The loop does not watch the instance's closed flag —
+            // downloads run to completion across ExoPlayer's seek reopens and
+            // abort only on future cancellation or session teardown.
+            while (!activeSession.abandoned.get()) {
                 if (future.isCancelled) {
                     throw IOException("Chunk download cancelled")
                 }
@@ -545,12 +776,12 @@ internal class ParallelRangeDataSource(
             }
         } catch (e: Exception) {
             releaseBuffer(buffer)
-            if (closed.get()) throw IOException("DataSource closed")
+            if (activeSession.abandoned.get()) throw IOException("Session abandoned")
             throw e
         }
-        if (closed.get()) {
+        if (activeSession.abandoned.get()) {
             releaseBuffer(buffer)
-            throw IOException("DataSource closed")
+            throw IOException("Session abandoned")
         }
         buffer.byteBuffer.flip()
         return DownloadedChunk(buffer, totalRead)
@@ -616,54 +847,18 @@ internal class ParallelRangeDataSource(
         }
     }
 
-    private fun cleanupOldChunks(currentChunkIndex: Long) {
-        val iter = chunks.entries.iterator()
-        while (iter.hasNext()) {
-            val entry = iter.next()
-            if (entry.key < currentChunkIndex) {
-                val future = entry.value
-                if (future.isDone && !future.isCancelled) {
-                    try { releaseBuffer(future.get().buffer) } catch (_: Exception) {}
-                }
-                future.cancel(true)
-                iter.remove()
-            }
-        }
-    }
-
-    /** Cancel and clean up all in-flight chunks, returning buffers to the pool. */
-    private fun cancelAllChunks() {
-        val releasedBuffers = java.util.Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap<PooledBuffer, Boolean>())
-
-        currentChunk?.let {
-            if (it !== bootstrapChunk) {
-                if (releasedBuffers.add(it.buffer)) {
-                    releaseBuffer(it.buffer)
-                }
-            }
-        }
+    /**
+     * Detach instance-local read state. Session chunks (and in-flight
+     * downloads) are untouched — they belong to the shared session and their
+     * buffers are owned by the session's futures. Releasing anything here
+     * would double-free; eviction and teardown are the session's job.
+     */
+    private fun resetLocalReadState() {
         currentChunk = null
         currentChunkIndex = -1
+        currentChunkReadOffset = 0
         bootstrapChunk = null
         bootstrapStartPosition = C.TIME_UNSET
-
-        activeDataSources.forEach { ds ->
-            try { ds.close() } catch (_: Exception) {}
-        }
-        activeDataSources.clear()
-
-        chunks.values.forEach { future ->
-            if (future.isDone && !future.isCancelled) {
-                try {
-                    val chunk = future.get()
-                    if (releasedBuffers.add(chunk.buffer)) {
-                        releaseBuffer(chunk.buffer)
-                    }
-                } catch (_: Exception) {}
-            }
-            future.cancel(true)
-        }
-        chunks.clear()
     }
 
     override fun close() {
@@ -674,7 +869,9 @@ internal class ParallelRangeDataSource(
             continuationSource = null
             continuationEndPositionExclusive = C.TIME_UNSET
 
-            cancelAllChunks()
+            // Downloads survive this close — detach references only.
+            resetLocalReadState()
+            session = null
 
             val active = activeInstances.decrementAndGet()
             if (active <= 0) {
@@ -760,18 +957,21 @@ internal class ParallelRangeDataSource(
         }
 
         if (currentChunkIndex != chunkIndex || currentChunk == null) {
+            val activeSession = session ?: return C.RESULT_END_OF_INPUT
             ensureChunkScheduled(chunkIndex)
-            val future = chunks[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            val future = activeSession.futures[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            activeSession.touch(chunkIndex)
             try {
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
+                activeSession.futures.remove(chunkIndex, future)
+                activeSession.lastTouch.remove(chunkIndex)
                 throw IOException("Failed to download chunk $chunkIndex", e)
             }
             currentChunkIndex = chunkIndex
             currentChunkReadOffset = (position % chunkSize).toInt()
 
-            cleanupOldChunks(chunkIndex)
             scheduleChunks()
         }
 
@@ -795,6 +995,8 @@ internal class ParallelRangeDataSource(
         currentChunkReadOffset += readSize
         position += readSize
         bytesRemaining -= readSize
+        bytesServedThisOpen += readSize
+        session?.touch(chunkIndex)
 
         return readSize
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -205,7 +205,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
         return wrapAudioDelay(mediaSource = mediaSource, audioDelayUsProvider = audioDelayUsProvider)
     }
 
-    fun shutdown() = Unit
+    fun shutdown() {
+        // Free any chunk buffers retained across seek reopens so native
+        // allocations never outlive the player.
+        ParallelRangeDataSource.releaseRetainedSession()
+    }
 
     private fun buildVodCacheDataSourceFactory(upstreamFactory: DataSource.Factory, cache: SimpleCache): DataSource.Factory {
         val dataSinkFactory = CacheDataSink.Factory().setCache(cache).setFragmentSize(2L * 1024L * 1024L)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.datasource.DataSource
@@ -128,18 +129,38 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
         val mediaItem = mediaItemBuilder.build()
 
-        // 1. Parallel connections (opt-in). ParallelRangeDataSource needs a concrete
-        // OkHttpDataSource.Factory, so build one only on this path.
-        parallelStartupPrefetchUnlocked.set(!(useParallelConnections && !isHls && !isDash))
-        val progressiveUpstreamFactory: DataSource.Factory = if (useParallelConnections && !isHls && !isDash) {
+        // 1. Chunk-session source: parallel connections (opt-in), or MP4 session
+        // mode. Non-faststart / poorly interleaved MP4s force scatter reads, and
+        // ExoPlayer recreates the data source on every seek; the session-owned
+        // chunks in ParallelRangeDataSource are what survive that boundary. That
+        // fix used to be reachable only behind the parallel-connections opt-in,
+        // so progressive MP4 now engages the session source even with parallel
+        // off — pinned to a single connection and an 8 MB chunk, which holds
+        // request concurrency and retained memory at plain-path levels (earned
+        // prefetch caps lookahead at two chunks; side cursors fetch only the
+        // chunk they touch). HLS/DASH, non-MP4 progressive, and parallel-on
+        // behaviour are unchanged.
+        val mp4SessionMode = !useParallelConnections && !isHls && !isDash &&
+            resolvedMimeType == MimeTypes.VIDEO_MP4
+        val useChunkSessionSource = (useParallelConnections || mp4SessionMode) && !isHls && !isDash
+        parallelStartupPrefetchUnlocked.set(!useChunkSessionSource)
+        val progressiveUpstreamFactory: DataSource.Factory = if (useChunkSessionSource) {
+            if (mp4SessionMode) {
+                Log.i(
+                    "PlayerMediaSourceFactory",
+                    "MP4_SESSION engaged: single-connection chunk session " +
+                        "(${MP4_SESSION_CHUNK_BYTES / (1024L * 1024L)} MB chunks) " +
+                        "for progressive MP4 with parallel connections off"
+                )
+            }
             val okHttpFactory = OkHttpDataSource.Factory(playbackHttpClient).apply {
                 setDefaultRequestProperties(sanitizedHeaders)
                 setUserAgent(DEFAULT_USER_AGENT)
             }
             ParallelRangeDataSource.Factory(
                 okHttpFactory,
-                parallelConnectionCount,
-                parallelChunkSizeKb.toLong() * 1024L,
+                if (mp4SessionMode) 1 else parallelConnectionCount,
+                if (mp4SessionMode) MP4_SESSION_CHUNK_BYTES else parallelChunkSizeKb.toLong() * 1024L,
                 useNativeMemory = nuvioPerformanceModeEnabled,
                 shouldAllowBackgroundPrefetch = { true },
                 onResolvedUri = { resolved -> currentVodCacheResolvedUrl = resolved?.toString() }
@@ -256,6 +277,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
     companion object {
         private const val MIME_VIDEO_QUICK_TIME = "video/quicktime"
+        // MP4 session mode: fixed 8 MB chunk, independent of the user's parallel
+        // chunk-size setting — small enough that scatter-read side cursors waste
+        // little per touch, and the retained set (session cap 3 chunks on the
+        // low-RAM tier, 5 otherwise) stays a few tens of MB.
+        private const val MP4_SESSION_CHUNK_BYTES = 8L * 1024L * 1024L
         private const val ENABLE_VOD_CACHE = true
         private const val VOD_CACHE_FREE_SPACE_RESERVE_BYTES = 1024L * 1024L * 1024L
         internal const val DEFAULT_USER_AGENT =

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
@@ -22,7 +22,12 @@ object MemoryBudget {
     private const val LOW_HEAP_RESERVE_MB = 210L
 
     /** ParallelRangeDataSource schedules maxAhead = parallelConnections + 1 chunks concurrently */
-    private const val BUFFER_OVERHEAD = 1
+    // Matches ParallelRangeDataSource reality: the download session holds up
+    // to connections + 2 chunks on low-RAM devices (connections + 4 on
+    // high-RAM; that extra headroom is deliberately not advertised so the
+    // enforcement maths stays conservative). Was 1, which under-stated the
+    // actual ceiling by one chunk.
+    private const val BUFFER_OVERHEAD = 2
 
     const val MIN_CONNECTIONS = 2
     const val MAX_CONNECTIONS = 4

--- a/app/src/test/java/com/nuvio/tv/ui/screens/settings/MemoryBudgetTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/settings/MemoryBudgetTest.kt
@@ -16,10 +16,10 @@ class MemoryBudgetTest {
         assertEquals(50, MemoryBudget.totalUsageMb(50, 4, 32, false))
         
         // case 2: parallel enabled
-        // bufferCount(4) = 4 + 1 = 5
-        // overhead = 5 * 32 = 160
-        // total = 50 + 160 = 210
-        assertEquals(210, MemoryBudget.totalUsageMb(50, 4, 32, true))
+        // bufferCount(4) = 4 + 2 = 6
+        // overhead = 6 * 32 = 192
+        // total = 50 + 192 = 242
+        assertEquals(242, MemoryBudget.totalUsageMb(50, 4, 32, true))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes constant rebuffering on scatter-read MP4s (non-faststart, non-interleaved track layout) when Parallel Connections is enabled. ExoPlayer creates a new data source instance on every seek; ParallelRangeDataSource cancelled all in-flight chunk downloads on close and re-probed on open, so the multi-cursor read pattern these files force made the same 32 MB chunks restart dozens of times — measured 55 chunk starts vs 21 completions in ~84 s, (~60% of transfer discarded). 

Chunk futures (completed and in-flight) now belong to a shared session that survives the close/open boundary; prefetch lookahead is earned (granted after 1 MB served sequentially) so side cursors stop triggering prefetch fan-outs;eviction is touch-LRU under a memory-tiered cap (connections+2 chunks on low-RAM, connections+4 on high-RAM, via the existing MemoryBudget.isLowRamTier); a 2 s touch guard protects chunks mid-read, so occupancy is bounded above by cap + 2 rather than exact; 

MemoryBudget.BUFFER_OVERHEAD corrected 1 → 2 so settings enforcement matches the data source's actual ceiling. 

Result on the pathological sample: zero rebuffering, each chunk downloaded exactly once.

Update: fix decoupled from the parallel-connections opt-in

The session-owned chunk mechanism is the actual fix for the scatter-read MP4 pathology, and the parallel prefetch fan-out is a separate throughput feature. The latest commit decouples them: progressive MP4 (resolved mime video/mp4) now engages the chunk session even when Parallel Connections is off, pinned to a single connection and a fixed 8 MB chunk.

Bounds with the setting off: earned prefetch caps lookahead at two chunks, side cursors fetch only the chunk they touch, and the session cap keeps the existing memory tiers — so request concurrency and retained memory hold at plain-path levels while the re-downloaded transfer measured above disappears. HLS/DASH, non-MP4 progressive, and parallel-on behaviour are unchanged. Engagement is logged as MP4_SESSION for easy verification.

This means users no longer need to enable a multi-connection mode (with its memory and rate-limit trade-offs on some debrid providers) just to make non-faststart MP4s watchable.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Affected files are effectively unwatchable — rebuffering begins within a minute and worsens — despite connection bandwidth comfortably exceeding the file bitrate. The defect wastes roughly two-thirds of downloaded data and applies to a common class of web-DL MP4 releases, so users hit it through no fault of their configuration.

## Issue or approval

Fixes #2543 

## Reproduction steps

Official 0.7.14-beta, Parallel Connections ON (reproduced at 4 connections × 32 MB).
Play a large non-faststart MP4 with non-interleaved track layout over HTTP.
Playback starts, then rebuffers within ~1 minute, worsening over time.
Logcat (tag ParallelRangeDS): the same Starting chunk download: idx=N lines repeat dozens of times per index, with completions far below starts. Full counts and analysis in the linked issue.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Single-connection (Parallel OFF), HLS/DASH, and subtitle-bypass paths untouched. No new settings, UI, or user-facing options. The BUFFER_OVERHEAD correction is included because it makes the settings-screen memory enforcement consistent with the component this PR fixes; it is one constant. A related frame-rate-matching fix for the same file class was deliberately excluded and will be proposed separately if wanted.

## Testing

Device: Homatics Box R 4K Plus (Amlogic S905X4-K, Android 14, armeabi-v7a), TorBox debrid CDN. Fix developed and soak-tested on a fork based on 0.7.14-beta; this branch (upstream dev + this commit) build-verified with CI_USE_DEBUG_SIGNING=true ./gradlew assembleFullRelease (note: the debug build type currently requires the CI release keystore, hence the release-variant verification). Manual flows: pathological 18.5 GB non-faststart MP4 — before: rebuffering within a minute; after: zero rebuffering across full sessions, logcat confirms each chunk index downloads once and reopens attach to the warm session. Regression: well-interleaved MKV remuxes (debrid + direct HTTP) unchanged; aggressive seeking (±10 min jumps) recovers cleanly; sideloaded subtitles unaffected; Parallel OFF unchanged; memory stable via dumpsys meminfo across a soak session on both tiers' maths (4 GB device).

## Screenshots / Video

Not a UI change.

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
