### PR TITLE
fix(player): restrict Dolby Vision MIME type override to Dolby Vision track only

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
@@ -283,7 +283,7 @@ private class NativeOptimizedVideoTrackOutput(
         if (codecsToUse != null && codecsToUse != format.codecs) {
             outFormat = format.buildUpon().setCodecs(codecsToUse).build()
         }
-        if (stripDvRpu && outFormat.sampleMimeType?.startsWith("video/") == true) {
+        if (stripDvRpu && strippedCodecs != null) {
             outFormat = outFormat.buildUpon().setSampleMimeType(MimeTypes.VIDEO_H265).build()
         }
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/TrackSelectionInvestigationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/TrackSelectionInvestigationTest.kt
@@ -552,4 +552,54 @@ class TrackSelectionInvestigationTest {
         assertEquals("640 × 360 (360p)", formatResolution(640, 360))
         assertEquals("720 × 576 (576p)", formatResolution(720, 576))
     }
+
+    @Test
+    fun testDolbyVisionExtractorsFactoryFormatRewriting() {
+        val mockExtractor = mockk<androidx.media3.extractor.mp4.Mp4Extractor>(relaxed = true)
+        val delegateFactory = androidx.media3.extractor.ExtractorsFactory { arrayOf(mockExtractor) }
+
+        val factory = com.nuvio.tv.core.player.DolbyVisionExtractorsFactory(
+            delegate = delegateFactory,
+            config = com.nuvio.tv.core.player.DolbyVisionConversionConfig(active = false),
+            stripDvRpu = true
+        )
+
+        val extractors = factory.createExtractors()
+        assertEquals(1, extractors.size)
+        val wrappedExtractor = extractors[0]
+
+        val mockExtractorOutput = mockk<androidx.media3.extractor.ExtractorOutput>(relaxed = true)
+        val mockTrackOutput = mockk<androidx.media3.extractor.TrackOutput>(relaxed = true)
+        every { mockExtractorOutput.track(any(), C.TRACK_TYPE_VIDEO) } returns mockTrackOutput
+
+        val extractorOutputSlot = io.mockk.slot<androidx.media3.extractor.ExtractorOutput>()
+        every { mockExtractor.init(capture(extractorOutputSlot)) } returns Unit
+
+        wrappedExtractor.init(mockExtractorOutput)
+
+        val wrappedTrackOutput = extractorOutputSlot.captured.track(1, C.TRACK_TYPE_VIDEO)
+
+        val formatSlot = io.mockk.slot<Format>()
+        every { mockTrackOutput.format(capture(formatSlot)) } returns Unit
+
+        // 1. Dolby Vision format -> should be rewritten to HEVC (H.265)
+        val dvFormat = Format.Builder()
+            .setId("1")
+            .setSampleMimeType(MimeTypes.VIDEO_DOLBY_VISION)
+            .setCodecs("dvhe.07.06")
+            .build()
+
+        wrappedTrackOutput.format(dvFormat)
+        assertEquals(MimeTypes.VIDEO_H265, formatSlot.captured.sampleMimeType)
+
+        // 2. Standard H.264 format -> should NOT be rewritten to HEVC (H.265)
+        val avcFormat = Format.Builder()
+            .setId("2")
+            .setSampleMimeType(MimeTypes.VIDEO_H264)
+            .setCodecs("avc1.64001F")
+            .build()
+
+        wrappedTrackOutput.format(avcFormat)
+        assertEquals(MimeTypes.VIDEO_H264, formatSlot.captured.sampleMimeType)
+    }
 }


### PR DESCRIPTION
## Summary

This PR resolves a critical playback bug where standard, non-Dolby-Vision video streams (like H.264/AVC) would fail to play, causing either a permanent loading stall (infinite buffering) or a decoder crash (`ERROR_CODE_DECODING_FAILED`).

The bug was caused by `DolbyVisionExtractorsFactory` incorrectly overriding the sample MIME type of all video tracks to `video/hevc` (H.265) when Dolby Vision RPU stripping (`stripDvRpu`) was active, due to an overly broad `startsWith("video/")` check. This forced ExoPlayer to initialize and feed H.264 bytes to an HEVC decoder (e.g. `OMX.MS.HEVC.Decoder` or `c2.amlogic.hevc.decoder`).

We corrected the condition to only override the MIME type when `strippedCodecs != null` (meaning the track was successfully matched and stripped to standard HEVC).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When TV display capabilities are unknown or when `stripDvRpu` is manually/automatically enabled, `DolbyVisionExtractorsFactory` overrode the MIME type of all video tracks to `video/hevc` due to an overly broad `startsWith("video/")` check.

This led to severe decoding errors and hangs because ExoPlayer initialized an HEVC (H.265) hardware decoder and fed it H.264/AVC frame bytes.

Here are the diagnostic log snippets proving this root cause:

### 1. Buffering Stall on Hisilicon/Amlogic (NUV-F9DC77)
The H.264 video track (`codecs: avc1.4D401F`) was incorrectly mapped to `video/hevc`, forcing the initialization of `OMX.hisi.video.decoder.hevc`, which hung indefinitely in `BUFFERING` state:
```json
  "loading": {
    "phase": "starting_stream",
    "reportReason": "loading_stall",
    "elapsedMs": 2286499,
    "exoPlaybackStateName": "BUFFERING"
  },
  "playbackAnalytics": {
    "videoDecoderName": "OMX.hisi.video.decoder.hevc",
    "videoFormat": {
      "trackType": "video",
      "sampleMimeType": "video/hevc",
      "containerMimeType": "video/mp4",
      "codecs": "avc1.4D401F",
      "width": 640,
      "height": 480
    }
  }
```

### 2. Decoder Crash on MediaTek/Philips (NUV-BD2FF8)
The H.264 video track (`codecs: avc1.64002A`) was mapped to `video/hevc`, forcing the initialization of `OMX.MS.HEVC.Decoder`, which crashed with `ERROR_CODE_DECODING_FAILED` immediately upon receiving H.264 bytes:
```json
  "loading": {
    "reportReason": "playback_error",
    "exoPlaybackStateName": "READY",
    "hasRenderedFirstFrame": false
  },
  "error": {
    "errorCode": 4003,
    "errorCodeName": "ERROR_CODE_DECODING_FAILED",
    "message": "Decoder failed: OMX.MS.HEVC.Decoder"
  },
  "playbackAnalytics": {
    "videoDecoderName": "OMX.MS.HEVC.Decoder",
    "videoFormat": {
      "trackType": "video",
      "sampleMimeType": "video/hevc",
      "containerMimeType": "video/mp4",
      "codecs": "avc1.64002A"
    }
  }
```

## Issue or approval

Fixes #NUV-BD2FF8, #NUV-F9DC77

## Reproduction steps

1. Use a device with unknown HDR capabilities or enable HDR10 base layer mapping mode.
2. Play any standard H.264/AVC video stream (e.g. `video/avc` container MP4).
3. Observe either a permanent `BUFFERING` loading loop or a decoder crash with `ERROR_CODE_DECODING_FAILED` (decoder: `OMX.MS.HEVC.Decoder` / `c2.amlogic.hevc.decoder`).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change is strictly bounded to the format MIME type override check in `DolbyVisionExtractorsFactory.kt`. It does not modify any extraction logic, audio rendering, or UI components.

## Testing

- **Unit tests:** Added `testDolbyVisionExtractorsFactoryFormatRewriting` to `TrackSelectionInvestigationTest` verifying that `video/avc` tracks are left untouched while `video/dolby-vision` tracks are correctly rewritten when `stripDvRpu` is true. Verified using `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.TrackSelectionInvestigationTest"`.
- **Device tests:** Verified on target hardware that H.264 and Dolby Vision streams now correctly select their respective decoders and play smoothly.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

- Fixes playback issues reported in:
  - Report ID: `NUV-F9DC77` (Stall in `BUFFERING`)
  - Report ID: `NUV-BD2FF8` (Crash with `OMX.MS.HEVC.Decoder` / `ERROR_CODE_DECODING_FAILED`)
