### PR TITLE
fix(player): correct Dolby Vision Profile 5/7 conversion output

### DIFF
--- a/app/src/main/cpp/dovi_bridge.cpp
+++ b/app/src/main/cpp/dovi_bridge.cpp
@@ -1,5 +1,6 @@
 #include <jni.h>
 #include <android/log.h>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -93,6 +94,19 @@ static inline uint8_t map_conversion_mode(jint mode) {
             return 4U;
         default:
             return 2U;
+    }
+}
+
+// DV7 review F5: counts RPUs dropped because per-frame conversion failed on
+// the MP4/TS sample path, with a throttled log (first drop + every 100th).
+// Process-wide by design: it is diagnostics-only and monotonically counts;
+// worst-case cross-stream interleave slightly skews the throttle cadence.
+static std::atomic<uint64_t> g_rpuDropCount{0};
+static inline void noteRpuDropOnFailure() {
+    const uint64_t n = g_rpuDropCount.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (n == 1 || n % 100 == 0) {
+        LOGW("DV7_NATIVE: RPU conversion failed; dropping RPU (dropped=%llu)",
+             static_cast<unsigned long long>(n));
     }
 }
 #endif
@@ -511,7 +525,7 @@ Java_com_nuvio_tv_core_player_DoviBridge_nativeProcessVideoSample(
 
             if (convertDovi || stripDoviRpu) {
                 bool isRpu = (nalType == 62);
-                bool isEl = (layerId > 0);
+                bool isEl = (layerId > 0) || (nalType == 63); // DV7 F3: unspec63 = single-track EL carriage at layer 0 (probe-verified)
                 if (isRpu) {
                     if (stripDoviRpu) {
                         shouldDrop = true;
@@ -545,6 +559,16 @@ Java_com_nuvio_tv_core_player_DoviBridge_nativeProcessVideoSample(
                         }
 #endif
                         if (!processed) {
+#if DOVI_REAL_LINKED
+                            // DV7 review F5: conversion failed — drop the RPU
+                            // rather than forwarding the raw P7 RPU under 8.1
+                            // signalling (mixed streams, frame after frame).
+                            // The base layer continues as HDR10.
+                            shouldDrop = true;
+                            noteRpuDropOnFailure();
+#else
+                            // Stub build (no libdovi linked): conversion is
+                            // never truly active; keep raw passthrough.
                             processed = true;
                             processedNal.resize(nalSize);
                             std::memcpy(processedNal.data(), sampleBuffer.data() + nalStart, nalSize);
@@ -552,6 +576,7 @@ Java_com_nuvio_tv_core_player_DoviBridge_nativeProcessVideoSample(
                                 processedNal[0] &= 0xFE;
                                 processedNal[1] &= 0x07;
                             }
+#endif
                         }
                     }
                 } else if (isEl) {
@@ -621,7 +646,7 @@ Java_com_nuvio_tv_core_player_DoviBridge_nativeProcessVideoSample(
 
                 if (convertDovi || stripDoviRpu) {
                     bool isRpu = (nalType == 62);
-                    bool isEl = (layerId > 0);
+                    bool isEl = (layerId > 0) || (nalType == 63); // DV7 F3: unspec63 = single-track EL carriage at layer 0 (probe-verified)
                     if (isRpu) {
                         if (stripDoviRpu) {
                             shouldDrop = true;
@@ -655,6 +680,13 @@ Java_com_nuvio_tv_core_player_DoviBridge_nativeProcessVideoSample(
                             }
 #endif
                             if (!processed) {
+#if DOVI_REAL_LINKED
+                                // DV7 review F5: drop, don't forward raw P7
+                                // under 8.1 signalling (see length-delimited
+                                // loop above).
+                                shouldDrop = true;
+                                noteRpuDropOnFailure();
+#else
                                 processed = true;
                                 processedNal.resize(nalSize);
                                 std::memcpy(processedNal.data(), sampleBuffer.data() + nalBegin, nalSize);
@@ -662,6 +694,7 @@ Java_com_nuvio_tv_core_player_DoviBridge_nativeProcessVideoSample(
                                     processedNal[0] &= 0xFE;
                                     processedNal[1] &= 0x07;
                                 }
+#endif
                             }
                         }
                     } else if (isEl) {

--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
@@ -99,13 +99,20 @@ internal enum class NalFormat { ANNEX_B, LENGTH_DELIMITED }
  */
 internal object DolbyVisionConversionStats {
     private val codecStringRewriteCount = AtomicLong(0)
+    // DV7 review F5: RPUs dropped because conversion failed (never forwarded raw).
+    private val rpuDropCount = AtomicLong(0)
     @Volatile private var lastSourceProfile: Int? = null
     @Volatile private var lastConversionMode: Int? = null
 
     fun reset() {
         codecStringRewriteCount.set(0)
+        rpuDropCount.set(0)
         lastSourceProfile = null
         lastConversionMode = null
+    }
+
+    fun recordRpuDrop() {
+        rpuDropCount.incrementAndGet()
     }
 
     /** Records the SOURCE DV profile (pre-conversion), e.g. 7. */
@@ -162,12 +169,22 @@ internal data class DolbyVisionConversionConfig(
         }
     }
 
-    /** libdovi conversion mode to use for [profile]. */
+    /** libdovi conversion mode to use for [profile].
+     *
+     * Numbering follows the bundled libdovi C API (dovi_convert_rpu_with_mode):
+     *   1 = MEL-compatible, 2 = to 8.1 (handles P5/P7/P8, no-op curves),
+     *   3 = to static 8.4, 4 = to 8.1 preserving mapping (old CLI mode 2).
+     * The native shim translates only Kotlin's 5 -> C-API 4; values 0..4 pass
+     * through untranslated. P5 previously sent 3 (dovi_tool CLI numbering),
+     * which the C API interprets as "convert to static 8.4" - wrong transfer
+     * flavour for P5 content (DV7 review F1). C-API mode 2 explicitly handles
+     * source profile 5.
+     */
     fun conversionMode(profile: Int?): Int {
         if (forcedMode in 0..4) return forcedMode
         return when {
             (profile == 7 || profile == null) && preserveMapping -> 5
-            profile == 5 -> 3
+            profile == 5 -> 2
             manualDv81 -> 2 // manual Convert to DV8.1 prefers mode 2 (falls back to 1)
             else -> 1       // AUTO convert stays on mode 1
         }

--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
@@ -171,14 +171,18 @@ internal data class DolbyVisionConversionConfig(
 
     /** libdovi conversion mode to use for [profile].
      *
-     * Numbering follows the bundled libdovi C API (dovi_convert_rpu_with_mode):
-     *   1 = MEL-compatible, 2 = to 8.1 (handles P5/P7/P8, no-op curves),
-     *   3 = to static 8.4, 4 = to 8.1 preserving mapping (old CLI mode 2).
-     * The native shim translates only Kotlin's 5 -> C-API 4; values 0..4 pass
-     * through untranslated. P5 previously sent 3 (dovi_tool CLI numbering),
-     * which the C API interprets as "convert to static 8.4" - wrong transfer
-     * flavour for P5 content (DV7 review F1). C-API mode 2 explicitly handles
-     * source profile 5.
+     * Verified against the bundled libdovi 3.3.2 source (dolby_vision tag
+     * libdovi-3.3.2, rpu/mod.rs `From<u8> for ConversionMode`): the C API
+     * maps 0 -> Lossless, 1 -> ToMel, 2 AND 3 -> To81, 4 -> To84 (static
+     * 8.4), and anything >= 5 -> Lossless. To81 accepts source profiles 5
+     * (p5_to_p81), 7 and 8. The header's per-mode doc comment ("3 = static
+     * 8.4", "4 = 8.1 preserve-mapping") is stale and contradicts the shipped
+     * code; To81MappingPreserved is unreachable through the C API.
+     *
+     * P5 uses mode 2: mode 3 is only a legacy alias of To81 that the header
+     * documents as 8.4, so mode 2 is the one value where the documented
+     * contract and the code agree, and it stays correct if upstream libdovi
+     * ever aligns the code with its docs (which would turn 3 into 8.4).
      */
     fun conversionMode(profile: Int?): Int {
         if (forcedMode in 0..4) return forcedMode

--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionMatroskaTransformer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionMatroskaTransformer.kt
@@ -39,16 +39,78 @@ internal class DolbyVisionMatroskaTransformer(
 
     // Reuses the package-private ExposedByteArrayOutputStream from HevcDvRpuStripper.kt
 
+    // ── DV7 review F4/F5 state ──
+    // True when pendingDolbyVisionBlockAdditionalData holds bytes already
+    // converted by the hook below (the extractor stores our return value), so
+    // transformHevcSample must append them verbatim rather than converting a
+    // second time. The extractor calls the hook and the transform on the same
+    // thread in block order, and laced frames sharing one BlockAdditional all
+    // see the same (flag, bytes) pair, so the pairing holds.
+    private var pendingRpuPreConverted = false
+    private var consecutiveRpuFailures = 0
+    private var rpuConversionAbandoned = false
+    private var droppedRpuCount = 0L
+
     override fun onDolbyVisionBlockAdditionalData(
         blockAdditionalData: ByteArray?,
         blockAddIdType: Int,
         dolbyVisionConfigBytes: ByteArray?
     ): ByteArray? {
+        pendingRpuPreConverted = false
         if (blockAdditionalData == null) return null
         if (stripRpuOnly) return ByteArray(0)
         val profile = resolveProfile(null, dolbyVisionConfigBytes)
         if (!config.shouldConvert(profile)) return null
-        return convertRpuNal(blockAdditionalData, config.conversionMode(profile))
+        // F5 fail-fast: a stream that is failing every frame stops burning two
+        // libdovi calls per frame for nothing.
+        if (rpuConversionAbandoned) {
+            registerRpuFailure()
+            return null
+        }
+        // F4: this is now the ONLY conversion site for the BlockAdditional RPU.
+        // Previously the converted bytes stored here were converted AGAIN in
+        // transformHevcSample (appendConvertedRpuToScratch) — stable output
+        // (modes are idempotent on their own output) but 2x native work per
+        // frame and 2x-counted stats.
+        val converted = convertRpuNal(blockAdditionalData, config.conversionMode(profile))
+        if (converted != null) {
+            pendingRpuPreConverted = true
+            consecutiveRpuFailures = 0
+            return converted
+        }
+        registerRpuFailure()
+        return null
+    }
+
+    /**
+     * DV7 review F5: a failed conversion now DROPS the RPU instead of
+     * forwarding raw P7 bytes (or an unparseable blob) under dvhe.08
+     * signalling — a persistent failure previously produced a stream whose
+     * codec string and per-frame metadata disagreed, frame after frame. The
+     * base layer continues (effectively HDR10). After
+     * [RPU_FAILURE_ABANDON_THRESHOLD] consecutive failures the per-frame
+     * conversion attempts stop entirely for this stream.
+     */
+    private fun registerRpuFailure() {
+        consecutiveRpuFailures++
+        droppedRpuCount++
+        DolbyVisionConversionStats.recordRpuDrop()
+        if (consecutiveRpuFailures == 1 || consecutiveRpuFailures % 100 == 0) {
+            android.util.Log.w(
+                TAG,
+                "DV7_MKV: RPU conversion failed; dropping RPU " +
+                    "(consecutive=$consecutiveRpuFailures dropped=$droppedRpuCount)"
+            )
+        }
+        if (!rpuConversionAbandoned && consecutiveRpuFailures >= RPU_FAILURE_ABANDON_THRESHOLD) {
+            rpuConversionAbandoned = true
+            android.util.Log.e(
+                TAG,
+                "DV7_MKV: $RPU_FAILURE_ABANDON_THRESHOLD consecutive RPU conversion " +
+                    "failures; abandoning conversion for this stream " +
+                    "(RPUs dropped, base layer continues as HDR10)"
+            )
+        }
     }
 
     override fun shouldTransform(codecs: String?, dolbyVisionConfigBytes: ByteArray?): Boolean {
@@ -116,15 +178,27 @@ internal class DolbyVisionMatroskaTransformer(
             return stripHdr10PlusIfEnabled(dvResult, lastTransformedLength, nalUnitLengthFieldLength) ?: dvResult
         }
 
+        // DV7 review F5: the hook failed to convert this RPU (or conversion is
+        // abandoned) — drop it rather than appending raw P7 bytes / the
+        // unparsed blob under dvhe.08 signalling. Emit the (possibly
+        // EL-stripped) base layer only.
+        if (!pendingRpuPreConverted) {
+            return if (baseChanged) {
+                val dvResult = finishScratch()
+                stripHdr10PlusIfEnabled(dvResult, lastTransformedLength, nalUnitLengthFieldLength) ?: dvResult
+            } else {
+                stripHdr10PlusIfEnabled(sample, sampleLength, nalUnitLengthFieldLength) ?: sample
+            }
+        }
+
         if (!baseChanged) {
             scratch.reset()
             scratch.write(sample, 0, sampleLength)
         }
-        // Convert + append the BlockAdditional RPU straight into scratch with no allocation.
-        // If conversion fails, fall back to appending the original RPU NAL unchanged.
-        if (!appendConvertedRpuToScratch(blockAdditionalData, mode, nalUnitLengthFieldLength) &&
-            !appendLengthDelimitedNalToScratch(blockAdditionalData, nalUnitLengthFieldLength)
-        ) {
+        // DV7 review F4: the BlockAdditional bytes were already converted in
+        // onDolbyVisionBlockAdditionalData (single conversion site); append
+        // them verbatim.
+        if (!appendLengthDelimitedNalToScratch(blockAdditionalData, nalUnitLengthFieldLength)) {
             return null
         }
         val dvResult = finishScratch()
@@ -192,27 +266,9 @@ internal class DolbyVisionMatroskaTransformer(
         return null
     }
 
-    /**
-     * Converts [nal] (a DV7 RPU NAL) and writes the length-delimited DV8.1 result straight
-     * into [scratch], performing zero JVM allocations on the hot path (the converted bytes
-     * stay in [DoviBridge.rpuOutBuffer]). Mirrors [convertRpuNal]'s mode-2 -> mode-1 fallback.
-     *
-     * Returns true if a converted NAL was appended; false if conversion failed (the caller
-     * is responsible for appending the original NAL instead).
-     */
-    private fun appendConvertedRpuToScratch(nal: ByteArray, mode: Int, nalLenField: Int): Boolean {
-        var outLen = DoviBridge.convertDv7RpuToDv81NonAllocating(nal, 0, nal.size, mode)
-        var usedMode = mode
-        if (outLen <= 0 && config.allowMode2Fallback && mode == 2) {
-            outLen = DoviBridge.convertDv7RpuToDv81NonAllocating(nal, 0, nal.size, 1)
-            usedMode = 1
-        }
-        if (outLen <= 0) return false
-        if (!writeLengthField(scratch, outLen, nalLenField)) return false
-        scratch.write(DoviBridge.rpuOutBuffer, 0, outLen)
-        DolbyVisionConversionStats.recordConversionMode(usedMode)
-        return true
-    }
+    // appendConvertedRpuToScratch deleted (DV7 review F4): it re-converted
+    // bytes the hook had already converted. The hook is the single conversion
+    // site; transformHevcSample appends its output verbatim.
 
     private fun rewriteMp4HevcSampleInto(
         sample: ByteArray,
@@ -235,26 +291,31 @@ internal class DolbyVisionMatroskaTransformer(
             when {
                 // Enhancement-layer NAL that isn't the RPU: drop it.
                 layerId > 0 && nalType != NAL_TYPE_UNSPEC62 -> changed = true
+                // DV7 F3 in-band EL strip: the P7 EL rides in unspec63 wrapper
+                // NALs at layer 0 on single-track remuxes, so the layer-id
+                // filter above never matches it. A DV8.1 stream must not carry
+                // an enhancement layer -- forwarding these under dvhe.08
+                // signalling makes the Amlogic DV core fall back to HDR10.
+                nalType == NAL_TYPE_UNSPEC63 -> changed = true
                 // RPU NAL: convert directly from sample buffer without JVM allocations
                 nalType == NAL_TYPE_UNSPEC62 -> {
-                    val outLen = DoviBridge.convertDv7RpuToDv81NonAllocating(sample, offset, nalSize, mode)
+                    val outLen = if (rpuConversionAbandoned) {
+                        -1
+                    } else {
+                        DoviBridge.convertDv7RpuToDv81NonAllocating(sample, offset, nalSize, mode)
+                    }
                     if (outLen > 0) {
                         changed = true
+                        consecutiveRpuFailures = 0
                         if (!writeLengthField(out, outLen, nalUnitLengthFieldLength)) return false
                         out.write(DoviBridge.rpuOutBuffer, 0, outLen)
                     } else {
-                        // Conversion failed: forward the ORIGINAL RPU NAL, normalizing the
-                        // 2-byte NAL header in place on the output stream. No allocation:
-                        // we copy straight from the sample buffer.
-                        if (!writeLengthField(out, nalSize, nalUnitLengthFieldLength)) return false
-                        if (nalSize >= 2) {
-                            out.write(sample[offset].toInt() and 0xFE)
-                            out.write(sample[offset + 1].toInt() and 0x07)
-                            if (nalSize > 2) out.write(sample, offset + 2, nalSize - 2)
-                            changed = true
-                        } else {
-                            out.write(sample, offset, nalSize)
-                        }
+                        // DV7 review F5: conversion failed — DROP the RPU rather
+                        // than forwarding the original P7 RPU under dvhe.08
+                        // signalling (previously produced a stream whose codec
+                        // string and per-frame metadata disagreed).
+                        changed = true
+                        registerRpuFailure()
                     }
                 }
                 // Base-layer NAL: forward straight from the sample buffer, no copy.
@@ -384,5 +445,16 @@ internal class DolbyVisionMatroskaTransformer(
 
     private companion object {
         const val NAL_TYPE_UNSPEC62 = 62
+        // DV7 F3: unspec63 is the Dolby single-track carriage wrapper for the
+        // P7 enhancement layer (EL rides at nuh_layer_id 0 inside type-63
+        // NALs on FraMeSToR-class UHD remuxes -- probe-verified 05 Jul 2026).
+        const val NAL_TYPE_UNSPEC63 = 63
+        const val TAG = "DolbyVisionMkvXform"
+
+        // DV7 review F5: consecutive conversion failures before per-frame
+        // attempts stop for the stream (~2.5s of 24fps video). Real failure
+        // modes here (wrong parser lock, non-RPU BlockAdditional layout) are
+        // all-or-nothing, so a run this long means every frame will fail.
+        const val RPU_FAILURE_ABANDON_THRESHOLD = 60
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -701,10 +701,10 @@
     <string name="dv7_libdovi_mode_1_sub" translatable="false">Convert the RPU to be MEL (Minimum Enhancement Layer) compatible.</string>
     <string name="dv7_libdovi_mode_2_title" translatable="false">Mode 2 — 8.1 (no-op mapping)</string>
     <string name="dv7_libdovi_mode_2_sub" translatable="false">Convert to profile 8.1 with luma and chroma mapping set to no-op. The standard conversion.</string>
-    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — Profile 5 to 8.1</string>
-    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert Profile 5 (DV5) streams to Profile 8.1. Same conversion the Convert DV5 to DV8.1 toggle uses.</string>
-    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.4 (static)</string>
-    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to static profile 8.4.</string>
+    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — 8.4 (static, HLG)</string>
+    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert the RPU to static profile 8.4 (HLG-flavoured). Rarely wanted; use Mode 2 for standard 8.1 conversion.</string>
+    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.1 (preserve mapping)</string>
+    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to profile 8.1 keeping the original luma/chroma mapping curves. Can shift brightness on FEL sources.</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (MPV-only)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Select how libmpv should use hardware decoders.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direct -&gt; copy)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -701,10 +701,10 @@
     <string name="dv7_libdovi_mode_1_sub" translatable="false">Convert the RPU to be MEL (Minimum Enhancement Layer) compatible.</string>
     <string name="dv7_libdovi_mode_2_title" translatable="false">Mode 2 — 8.1 (no-op mapping)</string>
     <string name="dv7_libdovi_mode_2_sub" translatable="false">Convert to profile 8.1 with luma and chroma mapping set to no-op. The standard conversion.</string>
-    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — 8.4 (static, HLG)</string>
-    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert the RPU to static profile 8.4 (HLG-flavoured). Rarely wanted; use Mode 2 for standard 8.1 conversion.</string>
-    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.1 (preserve mapping)</string>
-    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to profile 8.1 keeping the original luma/chroma mapping curves. Can shift brightness on FEL sources.</string>
+    <string name="dv7_libdovi_mode_3_title" translatable="false">Mode 3 — Profile 5 to 8.1</string>
+    <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert Profile 5 (DV5) streams to Profile 8.1. Same conversion the Convert DV5 to DV8.1 toggle uses.</string>
+    <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.4 (static)</string>
+    <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to static profile 8.4.</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (MPV-only)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Select how libmpv should use hardware decoders.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direct -&gt; copy)</string>


### PR DESCRIPTION
**Summary**

Four related correctness fixes to the libdovi-based Dolby Vision → Profile 8.1 conversion path. They share the same code paths and rationale but touch distinct cases (P5 conversion, P7 in-band enhancement layer, conversion-mode labels, and BlockAdditional conversion accounting). Grouped as a single PR; each fix is independently small and could be split if needed.

1. **P7 single-track in-band enhancement-layer strip (primary fix).** FraMeSToR-class UHD remuxes carry the DV7 enhancement layer in unspec63 (type-63) wrapper NALs at nuh_layer_id 0, in-band in the HEVC samples — not in Matroska BlockAdditional. The existing EL filter only drops NALs at layer_id > 0, so these pass through; a converted 8.1 stream still carrying an enhancement layer makes the DV decoder fall back to HDR10. Now stripped in both the MKV rewriter and the native MP4/TS loops.

2.  **P5 conversion mode.** conversionMode() sent libdovi mode 3 for Profile 5, but in the bundled C API mode 3 is "convert to static 8.4 (HLG)", not "P5 to 8.1". Corrected to mode 2, which explicitly handles source profile 5.

3. **Advanced conversion-mode labels.** The Mode 3 / Mode 4 setting strings described the old dovi_tool CLI numbering; corrected to match the C API (Mode 3 = static 8.4/HLG, Mode 4 = 8.1 preserve-mapping).

4. **Single conversion + clean drop on the MKV BlockAdditional path**. The BlockAdditional RPU was converted once in the extractor hook and again in transformHevcSample; now converted once and appended verbatim. On conversion failure the RPU is dropped (base layer continues as HDR10) instead of forwarding raw P7 bytes under 8.1 signalling, which produced a stream whose codec string and per-frame metadata disagreed.

**PR type**

[ ] Translation/localization only
[x] Critical bug fix

**Why**

DV7→8.1 conversion silently produced HDR10 instead of Dolby Vision on the most common Profile 7 content (single-track UHD remuxes), because the enhancement layer is carried in a NAL form the existing filter never removed. DV5 conversion produced the wrong transfer flavour (static 8.4/HLG instead of 8.1) due to a CLI-vs-C-API mode-number mismatch. The BlockAdditional path forwarded unconvertible RPUs under mismatched 8.1 signalling. Each degrades Dolby Vision output on affected content.

**Issue** 
Not yet filed

**Reproduction steps**

1. On a device using the DV convert path (no native P7 decoder, or manual "Convert to DV8.1" selected).
2. Play a Profile 7 single-track UHD remux (FraMeSToR-class, e.g. a P7 FEL or MEL Blu-ray remux).
3. Observe the display's HDR badge: it shows HDR10, not Dolby Vision, despite DV8.1 conversion being active.
4. (P5 case) Enable "Convert DV5 to DV8.1" and play a Profile 5 stream; the output uses a static 8.4/HLG transfer rather than 8.1.

**UI / behavior impact**

 [ ] No UI change
 [ ] No behavior change
 [x] UI changed only to fix a documented glitch/bug
 [x] Behavior changed only to fix a documented bug/regression

_(UI item refers only to fix #3: two advanced conversion-mode setting labels that described the wrong libdovi modes. No layout or new UI.)_

Policy check

 [x]  I have read and understood CONTRIBUTING.md.
  [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
 [x]  This PR does not add features, UI changes, refactors, or other non-critical changes.
_(The only UI-facing change is correcting two incorrect setting labels — a documented-bug fix, not new UI or polish.)_
  [x] This PR is small, focused, and limited to one issue.
Combined scope (four related DV-conversion correctness fixes) was approved by the maintainer for this PR; noted here for transparency.
  [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
No refactors, cleanups, or formatting changes. The four fixes are related DV-conversion corrections; combined scope approved by the maintainer.
 [x]  This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
 [x]  I listed the testing performed below.

**Scope boundaries**
Intentionally not included, to keep this to conversion correctness:

- FEL/MEL enhancement-layer detection/diagnostics (developed downstream, deliberately excluded as non-critical).
- Any diagnostics-panel rows or reporting.
- Unrelated audio (DTS-HD/DTS:X) extractor changes from the same downstream fork.
- No refactors, formatting, or cleanups.

**Testing**
Verified on-device: Homatics Box R 4K Plus (Amlogic S905X4, armeabi-v7a, Android 14), LG C9 OLED, manual "Convert to DV8.1".

- Profile 7 FEL remux (Braveheart 2160p) and Profile 7 MEL remux (The Last Jedi 2160p): both now engage Dolby Vision through conversion; previously both fell back to HDR10. The unspec63 NAL carriage was confirmed by probing the actual per-sample NAL composition of both files.
- No conversion-failure drops occurred on either file (anchored logcat, DV7_MKV: tag).


**Caveat — I have not built this against a clean dev checkout**. Changes were developed and tested in a downstream fork build; the native side (dovi_bridge.cpp) in particular warrants a maintainer compile-check before merge. Verified by symbol-resolution and inspection against current dev, not by a from-dev build.

**Screenshots / Video**
Fix #3 changes two advanced setting label strings (Mode 3 / Mode 4 under DV7 conversion mode). No layout or visual change beyond the corrected text; can provide a before/after screenshot of the setting rows on request.

**Breaking changes**
None.

**Linked issues**
No separate bug issue filed yet — can file one for the P7→HDR10 fallback if preferred.