### PR TITLE
fix (player): Frame-rate matching (AFR) for the ExoPlayer engine + MKV frame-rate restoration

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionExtractorsFactory.kt
@@ -55,10 +55,16 @@ internal class DolbyVisionExtractorsFactory(
         delegate.createExtractors(uri, responseHeaders).map(::wrap).toTypedArray()
 
     private fun wrap(extractor: Extractor): Extractor {
-        if (!config.active && !stripDvRpu && !stripHdr10PlusSei) return extractor
-        // Matroska: the DV7 RPU rides in BlockAdditional, which the stock
-        // MatroskaExtractor discards before any TrackOutput. Swap it for the
-        // vendored extractor that surfaces the RPU through a transformer.
+        // Matroska is swapped unconditionally. The vendored extractor does two
+        // things the stock MatroskaExtractor cannot: it surfaces the DV7 RPU
+        // (which rides in BlockAdditional and the stock extractor discards
+        // before any TrackOutput), and it declares the container frame rate on
+        // the video Format from TrackEntry DefaultDuration. The latter is what
+        // the ExoPlayer track-format AFR path consumes, and it is needed for
+        // plain (non-DV) MKVs too - so the swap must happen before the DV guard
+        // below, not after it. With an inactive DV config the transformer's
+        // shouldTransform() returns false, so non-DV HEVC samples still stream
+        // through the stock write path at no extra cost.
         if (extractor.javaClass.name == STOCK_MATROSKA_EXTRACTOR) {
             return DvMatroskaExtractor(
                 DefaultSubtitleParserFactory(),
@@ -70,6 +76,7 @@ internal class DolbyVisionExtractorsFactory(
                 )
             )
         }
+        if (!config.active && !stripDvRpu && !stripHdr10PlusSei) return extractor
         val nalFormat = nalFormatFor(extractor) ?: return extractor
         return DolbyVisionExtractor(extractor, config, nalFormat, stripDvRpu, stripHdr10PlusSei)
     }

--- a/app/src/main/java/com/nuvio/tv/core/player/FrameRateUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/FrameRateUtils.kt
@@ -210,9 +210,15 @@ object FrameRateUtils {
         videoHeight: Int
     ): List<Display.Mode> {
         if (modes.isEmpty()) return modes
+        // Floor resolution matching at 720p. "Nearest resolution" with no lower
+        // bound meant an SD file could drop the whole HDMI output - UI included -
+        // to a 480p/576p mode (Amlogic boxes commonly expose them). The intended
+        // 4K<->1080p use case is unaffected.
+        val flooredModes = modes.filter { it.physicalHeight >= 720 && it.physicalWidth >= 1280 }
+            .ifEmpty { modes }
         val (targetWidth, targetHeight) = normalizedSize(videoWidth, videoHeight)
-        val minDistance = modes.minOfOrNull { resolutionDistanceSquared(it, targetWidth, targetHeight) } ?: return modes
-        return modes.filter { resolutionDistanceSquared(it, targetWidth, targetHeight) == minDistance }
+        val minDistance = flooredModes.minOfOrNull { resolutionDistanceSquared(it, targetWidth, targetHeight) } ?: return flooredModes
+        return flooredModes.filter { resolutionDistanceSquared(it, targetWidth, targetHeight) == minDistance }
     }
 
     suspend fun matchFrameRateAndWait(
@@ -469,12 +475,39 @@ object FrameRateUtils {
         return null
     }
 
+    /** Hard deadline after which a stuck extractor probe is force-released. */
+    private const val EXTRACTOR_PROBE_HARD_DEADLINE_MS = 6_000L
+
     private fun detectFrameRateWithExtractor(
         context: Context,
         sourceUrl: String,
         headers: Map<String, String>
     ): FrameRateDetection? {
         val extractor = MediaExtractor()
+        // MediaExtractor.setDataSource() is a blocking native call
+        // that cooperative withTimeoutOrNull cancellation cannot interrupt. On a
+        // non-faststart MP4 (moov atom at the tail) it reads toward end-of-file
+        // and can block indefinitely (runtime-confirmed >=109 s on 0.7.12-beta -
+        // "AFR on hangs, AFR off starts cleanly"). Releasing the extractor from a
+        // watchdog thread aborts the native open, making the probe budget real.
+        val probeFinished = java.util.concurrent.atomic.AtomicBoolean(false)
+        val watchdog = Thread({
+            try {
+                Thread.sleep(EXTRACTOR_PROBE_HARD_DEADLINE_MS)
+            } catch (_: InterruptedException) {
+                return@Thread
+            }
+            if (!probeFinished.get()) {
+                Log.w(TAG, "AFR extractor probe exceeded ${EXTRACTOR_PROBE_HARD_DEADLINE_MS} ms; force-releasing extractor")
+                try {
+                    extractor.release()
+                } catch (_: Throwable) {
+                }
+            }
+        }, "afr-probe-watchdog").apply {
+            isDaemon = true
+            start()
+        }
         return try {
             val uri = Uri.parse(sourceUrl)
             when (uri.scheme?.lowercase()) {
@@ -557,6 +590,8 @@ object FrameRateUtils {
             Log.w(TAG, "Frame rate probe failed: ${e.message}")
             null
         } finally {
+            probeFinished.set(true)
+            watchdog.interrupt()
             try {
                 extractor.release()
             } catch (_: Exception) {

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -2990,6 +2990,18 @@ public class MatroskaExtractor implements Extractor {
             rotationDegrees = 270;
           }
         }
+        // Surface the container-declared frame rate. Matroska's TrackEntry
+        // DefaultDuration is nanoseconds per frame for fixed-rate video; media3
+        // parses it into defaultSampleDurationNs but never feeds
+        // Format.frameRate, so MKV - unlike MP4, whose BoxParser sets it - could
+        // never trigger the track-format AFR path on ExoPlayer. The bounds
+        // reject malformed values and still-image tracks.
+        if (defaultSampleDurationNs > 0) {
+          float declaredFrameRate = 1_000_000_000f / defaultSampleDurationNs;
+          if (declaredFrameRate >= 5f && declaredFrameRate <= 121f) {
+            formatBuilder.setFrameRate(declaredFrameRate);
+          }
+        }
         formatBuilder
             .setWidth(width)
             .setHeight(height)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -437,6 +437,11 @@ class PlayerRuntimeController(
     internal var pendingMpvHardRestartOnNextAttach: Boolean = false
     internal var delayMpvResumeSeekUntilVideoTrack: Boolean = false
     internal var mpvDelayStartAfterAfrSwitch: Boolean = false
+    // Exo counterpart of mpvDelayStartAfterAfrSwitch: set when the AFR preflight
+    // actually changed the display mode, consumed by initializePlayer to hold
+    // playback start briefly so the (tunneled) pipeline does not begin inside
+    // the mode transition.
+    internal var exoDelayStartAfterAfrSwitch: Boolean = false
     internal var pauseOverlayJob: Job? = null
     internal val pauseOverlayDelayMs = 5000L
     internal val seekProgressSyncDebounceMs = 700L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -442,6 +442,19 @@ class PlayerRuntimeController(
     // playback start briefly so the (tunneled) pipeline does not begin inside
     // the mode transition.
     internal var exoDelayStartAfterAfrSwitch: Boolean = false
+    // Track-format AFR: frame rate taken from ExoPlayer's reported track format
+    // between prepare and first frame, replacing the MediaExtractor probe on the
+    // ExoPlayer engine path. trackAfrAttemptedForCurrentStream gates one attempt
+    // per stream; afrTrackSwitchInFlight holds playback start while a track-driven
+    // display-mode switch settles; afrModeAppliedPreStart records that the
+    // cache-hit preflight already applied a mode so the track path stands down.
+    internal var trackAfrAttemptedForCurrentStream: Boolean = false
+    @Volatile internal var afrTrackSwitchInFlight: Boolean = false
+    internal var afrModeAppliedPreStart: Boolean = false
+    // Per-stream generation stamp for the track-AFR coroutine. An old
+    // stream's coroutine reaching its finally block must not collapse the new
+    // stream's start-hold; incremented at every per-stream AFR reset.
+    @Volatile internal var afrTrackGeneration: Int = 0
     internal var pauseOverlayJob: Job? = null
     internal val pauseOverlayDelayMs = 5000L
     internal val seekProgressSyncDebounceMs = 700L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -20,6 +20,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
     resolutionMatchingEnabled: Boolean
 ) {
     mpvDelayStartAfterAfrSwitch = false
+    exoDelayStartAfterAfrSwitch = false
 
     if (frameRateMatchingMode == FrameRateMatchingMode.OFF) {
         _uiState.update {
@@ -98,6 +99,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
                 val switchedDisplayMode = initialDisplayModeId != null &&
                     initialDisplayModeId != result.appliedMode.modeId
                 mpvDelayStartAfterAfrSwitch = switchedDisplayMode
+                exoDelayStartAfterAfrSwitch = switchedDisplayMode
 
                 _uiState.update {
                     it.copy(
@@ -184,6 +186,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
             val switchedDisplayMode = initialDisplayModeId != null &&
                 initialDisplayModeId != result.appliedMode.modeId
             mpvDelayStartAfterAfrSwitch = switchedDisplayMode
+            exoDelayStartAfterAfrSwitch = switchedDisplayMode
 
             _uiState.update {
                 it.copy(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -100,17 +100,26 @@ internal suspend fun PlayerRuntimeController.runAfrExoPreflightIfEnabled(
 
     // 2. NextLib (primary) on cache miss — bounded, no extractor fallback.
     if (detection == null) {
-        // Mark the probe in flight so track-format AFR stands down while NextLib runs.
-        _uiState.update { it.copy(afrProbeRunning = true) }
-        val streamHeaders = headers.filterKeys { !it.equals("Range", ignoreCase = true) }
-        // Bounded on an abandonable thread: a stuck native build() cannot hold
-        // start past the budget (a cooperative timeout around withContext(IO)
-        // could not — the native call ignores cancellation).
-        detection = probeNextLibBounded(url, streamHeaders, AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS)
-        _uiState.update { it.copy(afrProbeRunning = false) }
         detectionSource = "NextLib"
-        if (detection != null) {
-            FrameRateUtils.cacheFrameRate(url, headers, detection)
+        // Mark the probe in flight so track-format AFR stands down while NextLib
+        // runs. try/finally + NonCancellable so a cancellation mid-probe (the
+        // 15 s absolute deadline, or a stream/episode switch) cannot leave the
+        // flag stuck true — a stuck flag blocks every later preflight AND
+        // AfrTrack via the afrProbeRunning guard.
+        _uiState.update { it.copy(afrProbeRunning = true) }
+        try {
+            val streamHeaders = headers.filterKeys { !it.equals("Range", ignoreCase = true) }
+            // Bounded on an abandonable thread: a stuck native build() cannot hold
+            // start past the budget (a cooperative timeout around withContext(IO)
+            // could not — the native call ignores cancellation).
+            detection = probeNextLibBounded(url, streamHeaders, AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS)
+            if (detection != null) {
+                FrameRateUtils.cacheFrameRate(url, headers, detection)
+            }
+        } finally {
+            withContext(NonCancellable) {
+                _uiState.update { it.copy(afrProbeRunning = false) }
+            }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.util.Log
 import com.nuvio.tv.core.player.FrameRateUtils
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.update
@@ -14,16 +15,54 @@ private const val AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS = 6000L
 private const val AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS = 4000L
 
 /**
- * ExoPlayer engine path: cache-only preflight.
- *
- * Applies a display-mode switch before prepare() ONLY when a cached detection
- * exists (instant). No NextLib probe, no MediaExtractor probe — on a cache miss
- * the frame rate comes from ExoPlayer's own track format after prepare (see
- * PlayerRuntimeControllerAfrTrack.kt), so the blocking-native-probe hang on
- * non-faststart MP4s is structurally impossible on this path. The full probing
- * preflight below remains in use for the MPV engine only.
+ * Runs the NextLib probe on an abandonable daemon thread so that a stuck native
+ * build() cannot hold playback start past [timeoutMs]. NextLib exposes no handle
+ * to interrupt an in-progress build (the MediaInfo only exists once build()
+ * returns, unlike MediaExtractor which the extractor watchdog release()s
+ * mid-setDataSource), so on timeout the coroutine returns via a cancellable
+ * await and the worker thread is abandoned — it ends when FFmpeg's network op
+ * completes or fails. NextLib stays the primary detector; this only bounds how
+ * long start waits for it.
  */
-internal suspend fun PlayerRuntimeController.runAfrCachePreflightIfEnabled(
+private suspend fun PlayerRuntimeController.probeNextLibBounded(
+    url: String,
+    headers: Map<String, String>,
+    timeoutMs: Long
+): FrameRateUtils.FrameRateDetection? {
+    val result = CompletableDeferred<FrameRateUtils.FrameRateDetection?>()
+    Thread({
+        val detection = try {
+            FrameRateUtils.detectFrameRateFromNextLib(context = context, sourceUrl = url, headers = headers)
+        } catch (t: Throwable) {
+            Log.w(PlayerRuntimeController.TAG, "AFR ExoPlayer preflight: NextLib probe threw: ${t.message}")
+            null
+        }
+        result.complete(detection)
+    }, "afr-nextlib-probe").apply {
+        isDaemon = true
+        start()
+    }
+    return withTimeoutOrNull(timeoutMs) { result.await() }
+}
+
+/**
+ * ExoPlayer engine path: NextLib-primary preflight, track-format fallback.
+ *
+ * Detection order:
+ *   1. cached detection (instant), else
+ *   2. NextLib (io.github.anilbeesetti.nextlib.mediainfo) — the primary, most
+ *      reliable FPS source; hard-bounded by AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS (an
+ *      abandonable probe thread, see probeNextLibBounded) and, in Initialization,
+ *      by the absolute preflight deadline, so it cannot hold start hostage.
+ *   3. on NextLib miss/timeout: NO blocking MediaExtractor fallback — that
+ *      native setDataSource() is the ≥109 s non-faststart-MP4 hang. Instead this
+ *      returns and the frame rate is taken from ExoPlayer's own track format
+ *      after prepare() (see PlayerRuntimeControllerAfrTrack.kt): a non-blocking
+ *      fallback, not a replacement for NextLib.
+ *
+ * The blocking extractor probe remains only in runAfrPreflightIfEnabled (MPV).
+ */
+internal suspend fun PlayerRuntimeController.runAfrExoPreflightIfEnabled(
     url: String,
     headers: Map<String, String>,
     frameRateMatchingMode: FrameRateMatchingMode,
@@ -46,32 +85,57 @@ internal suspend fun PlayerRuntimeController.runAfrCachePreflightIfEnabled(
 
     val activity = currentHostActivity()
     if (activity == null) {
-        Log.w(PlayerRuntimeController.TAG, "AFR cache preflight skipped: host activity unavailable")
+        Log.w(PlayerRuntimeController.TAG, "AFR ExoPlayer preflight skipped: host activity unavailable")
         return
     }
 
     if (_uiState.value.afrProbeRunning || _uiState.value.detectedFrameRateSource != null) {
-        Log.d(PlayerRuntimeController.TAG, "AFR cache preflight: already running or completed, skipping")
+        Log.d(PlayerRuntimeController.TAG, "AFR ExoPlayer preflight: already running or completed, skipping")
         return
     }
 
-    val cached = FrameRateUtils.getCachedFrameRate(url, headers) ?: run {
-        Log.d(PlayerRuntimeController.TAG, "AFR cache preflight: miss; deferring to track-format AFR after prepare")
+    // 1. Cache.
+    var detection = FrameRateUtils.getCachedFrameRate(url, headers)
+    var detectionSource = "cache"
+
+    // 2. NextLib (primary) on cache miss — bounded, no extractor fallback.
+    if (detection == null) {
+        // Mark the probe in flight so track-format AFR stands down while NextLib runs.
+        _uiState.update { it.copy(afrProbeRunning = true) }
+        val streamHeaders = headers.filterKeys { !it.equals("Range", ignoreCase = true) }
+        // Bounded on an abandonable thread: a stuck native build() cannot hold
+        // start past the budget (a cooperative timeout around withContext(IO)
+        // could not — the native call ignores cancellation).
+        detection = probeNextLibBounded(url, streamHeaders, AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS)
+        _uiState.update { it.copy(afrProbeRunning = false) }
+        detectionSource = "NextLib"
+        if (detection != null) {
+            FrameRateUtils.cacheFrameRate(url, headers, detection)
+        }
+    }
+
+    // 3. No detection → defer to track-format AFR after prepare (non-blocking fallback).
+    if (detection == null) {
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "AFR ExoPlayer preflight: NextLib miss/timeout after ${AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS}ms; deferring to track-format AFR after prepare"
+        )
         return
     }
 
-    Log.d(PlayerRuntimeController.TAG, "AFR cache preflight: cache hit! Using cached FPS=${cached.snapped}")
+    // 4. Apply the pre-prepare display-mode switch from the primary detection.
+    Log.d(PlayerRuntimeController.TAG, "AFR ExoPlayer preflight: $detectionSource FPS=${detection.snapped}; applying pre-prepare switch")
     _uiState.update {
         it.copy(
-            detectedFrameRateRaw = cached.raw,
-            detectedFrameRate = cached.snapped,
+            detectedFrameRateRaw = detection.raw,
+            detectedFrameRate = detection.snapped,
             detectedFrameRateSource = FrameRateSource.PROBE
         )
     }
-    val prefer23976ProbeBias = cached.raw in 23.95f..23.999f
+    val prefer23976ProbeBias = detection.raw in 23.95f..23.999f
     val targetFrameRate = FrameRateUtils.refineFrameRateForDisplay(
         activity = activity,
-        detectedFps = cached.snapped,
+        detectedFps = detection.snapped,
         prefer23976Near24 = prefer23976ProbeBias
     )
     val initialDisplayModeId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -85,8 +149,8 @@ internal suspend fun PlayerRuntimeController.runAfrCachePreflightIfEnabled(
     val result = FrameRateUtils.matchFrameRateAndWait(
         activity = activity,
         frameRate = targetFrameRate,
-        videoWidth = cached.videoWidth,
-        videoHeight = cached.videoHeight,
+        videoWidth = detection.videoWidth,
+        videoHeight = detection.videoHeight,
         resolutionMatchingEnabled = resolutionMatchingEnabled
     )
 
@@ -95,8 +159,7 @@ internal suspend fun PlayerRuntimeController.runAfrCachePreflightIfEnabled(
             initialDisplayModeId != result.appliedMode.modeId
         mpvDelayStartAfterAfrSwitch = switchedDisplayMode
         exoDelayStartAfterAfrSwitch = switchedDisplayMode
-        // Track-format AFR stands down when the cache path already ran a
-        // mode selection for this stream (whether or not the mode changed).
+        // Track-format AFR stands down: the preflight already ran a mode selection.
         afrModeAppliedPreStart = true
 
         _uiState.update {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -13,6 +13,105 @@ import kotlinx.coroutines.withContext
 private const val AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS = 6000L
 private const val AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS = 4000L
 
+/**
+ * ExoPlayer engine path: cache-only preflight.
+ *
+ * Applies a display-mode switch before prepare() ONLY when a cached detection
+ * exists (instant). No NextLib probe, no MediaExtractor probe — on a cache miss
+ * the frame rate comes from ExoPlayer's own track format after prepare (see
+ * PlayerRuntimeControllerAfrTrack.kt), so the blocking-native-probe hang on
+ * non-faststart MP4s is structurally impossible on this path. The full probing
+ * preflight below remains in use for the MPV engine only.
+ */
+internal suspend fun PlayerRuntimeController.runAfrCachePreflightIfEnabled(
+    url: String,
+    headers: Map<String, String>,
+    frameRateMatchingMode: FrameRateMatchingMode,
+    resolutionMatchingEnabled: Boolean
+) {
+    mpvDelayStartAfterAfrSwitch = false
+    exoDelayStartAfterAfrSwitch = false
+
+    if (frameRateMatchingMode == FrameRateMatchingMode.OFF) {
+        _uiState.update {
+            it.copy(
+                detectedFrameRateRaw = 0f,
+                detectedFrameRate = 0f,
+                detectedFrameRateSource = null,
+                afrProbeRunning = false
+            )
+        }
+        return
+    }
+
+    val activity = currentHostActivity()
+    if (activity == null) {
+        Log.w(PlayerRuntimeController.TAG, "AFR cache preflight skipped: host activity unavailable")
+        return
+    }
+
+    if (_uiState.value.afrProbeRunning || _uiState.value.detectedFrameRateSource != null) {
+        Log.d(PlayerRuntimeController.TAG, "AFR cache preflight: already running or completed, skipping")
+        return
+    }
+
+    val cached = FrameRateUtils.getCachedFrameRate(url, headers) ?: run {
+        Log.d(PlayerRuntimeController.TAG, "AFR cache preflight: miss; deferring to track-format AFR after prepare")
+        return
+    }
+
+    Log.d(PlayerRuntimeController.TAG, "AFR cache preflight: cache hit! Using cached FPS=${cached.snapped}")
+    _uiState.update {
+        it.copy(
+            detectedFrameRateRaw = cached.raw,
+            detectedFrameRate = cached.snapped,
+            detectedFrameRateSource = FrameRateSource.PROBE
+        )
+    }
+    val prefer23976ProbeBias = cached.raw in 23.95f..23.999f
+    val targetFrameRate = FrameRateUtils.refineFrameRateForDisplay(
+        activity = activity,
+        detectedFps = cached.snapped,
+        prefer23976Near24 = prefer23976ProbeBias
+    )
+    val initialDisplayModeId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        withContext(Dispatchers.Main) {
+            activity.window?.decorView?.display?.mode?.modeId
+        }
+    } else {
+        null
+    }
+
+    val result = FrameRateUtils.matchFrameRateAndWait(
+        activity = activity,
+        frameRate = targetFrameRate,
+        videoWidth = cached.videoWidth,
+        videoHeight = cached.videoHeight,
+        resolutionMatchingEnabled = resolutionMatchingEnabled
+    )
+
+    if (result != null) {
+        val switchedDisplayMode = initialDisplayModeId != null &&
+            initialDisplayModeId != result.appliedMode.modeId
+        mpvDelayStartAfterAfrSwitch = switchedDisplayMode
+        exoDelayStartAfterAfrSwitch = switchedDisplayMode
+        // Track-format AFR stands down when the cache path already ran a
+        // mode selection for this stream (whether or not the mode changed).
+        afrModeAppliedPreStart = true
+
+        _uiState.update {
+            it.copy(
+                displayModeInfo = DisplayModeInfo(
+                    width = result.appliedMode.physicalWidth,
+                    height = result.appliedMode.physicalHeight,
+                    refreshRate = result.appliedMode.refreshRate
+                ),
+                showDisplayModeInfo = true
+            )
+        }
+    }
+}
+
 internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
     url: String,
     headers: Map<String, String>,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrTrack.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrTrack.kt
@@ -1,0 +1,174 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package com.nuvio.tv.ui.screens.player
+
+import android.os.Build
+import android.util.Log
+import androidx.media3.common.Format
+import com.nuvio.tv.core.player.FrameRateUtils
+import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+// Absolute ceiling on the whole track-AFR step (mode switch wait + settle
+// hold). Timer-released, never event-gated — cannot deadlock startup.
+// 8 s covers the worst case (~4 s mode-switch wait + 2 s settle hold)
+// with margin; 7 s could clip a slow HDMI mode change mid-settle.
+private const val TRACK_AFR_ABSOLUTE_DEADLINE_MS = 8_000L
+
+// Settle hold after a real display-mode switch, mirroring
+// AFR_EXO_SETTLE_HOLD_MS on the preflight path (community
+// 0.7.14 QMS stutter report): don't start the A/V pipeline inside the mode
+// transition.
+private const val TRACK_AFR_SETTLE_HOLD_MS = 2_000L
+
+/**
+ * Track-format AFR: frame-rate matching driven by ExoPlayer's reported track
+ * format instead of a MediaExtractor/NextLib network probe.
+ *
+ * Called from the tracks-changed handler the moment the selected video
+ * format's frameRate is known — which is during preparation, before the first
+ * frame renders. ExoPlayer has already parsed the container (including
+ * moov-at-end MP4s, which its range-seeking handles and the blocking
+ * MediaExtractor probe did not), so the value is free and always available at
+ * exactly the right moment.
+ *
+ * Start gating: on the normal path the player is built with playWhenReady
+ * already true (0.7.14 removed the start-paused-until-first-frame gate), so
+ * arming the gate also pauses the player for the switch window — a paused
+ * ExoPlayer still renders the first frame and still reaches STATE_READY.
+ * While a track-driven switch is in flight the start sites stand down
+ * (afrTrackSwitchInFlight); when the switch settles,
+ * resumePlaybackAfterTrackAfrIfHeld() starts playback if the first frame
+ * arrived during the hold, otherwise the normal onRenderedFirstFrame /
+ * tunneled READY path starts it with the gate now open. If the deadline
+ * expires the finally block releases the gate regardless; the 12 s
+ * first-frame watchdog is a second, longer net and cannot fire inside the
+ * 8 s gate window.
+ */
+internal fun PlayerRuntimeController.maybeRunTrackFormatAfr(rawFps: Float, format: Format) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+    if (currentInternalPlayerEngine != InternalPlayerEngine.EXOPLAYER) return
+    if (trackAfrAttemptedForCurrentStream) return
+    if (afrModeAppliedPreStart) return
+    if (rawFps <= 0f) return
+    if (_uiState.value.frameRateMatchingMode == FrameRateMatchingMode.OFF) return
+    if (_uiState.value.afrProbeRunning) return
+    // Too late: playback is already running. A mid-playback mode switch is the
+    // known black-screen/stutter risk this design avoids; skip rather than
+    // switch under a live pipeline.
+    if (hasRenderedFirstFrame && _exoPlayer?.isPlaying == true) {
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "Track AFR: playback already running, skipping display-mode switch (fps=$rawFps)"
+        )
+        trackAfrAttemptedForCurrentStream = true
+        return
+    }
+    val activity = currentHostActivity()
+    if (activity == null) {
+        Log.w(PlayerRuntimeController.TAG, "Track AFR skipped: host activity unavailable")
+        return
+    }
+
+    trackAfrAttemptedForCurrentStream = true
+    afrTrackSwitchInFlight = true
+    // Engage the gate for real: playWhenReady is true from player build on
+    // the normal path, so without this the player auto-starts at STATE_READY
+    // and the stand-down at the start sites gates nothing. The guards above
+    // ensure playback is not already running; setting an already-false value
+    // is a no-op on the paused/startPaused flows.
+    _exoPlayer?.playWhenReady = false
+    // stamp this attempt with the current stream's generation; the
+    // finally block stands down if a per-stream reset happened meanwhile.
+    val startGeneration = afrTrackGeneration
+
+    scope.launch {
+        try {
+            withTimeoutOrNull(TRACK_AFR_ABSOLUTE_DEADLINE_MS) {
+                val playerSettings = playerSettingsDataStore.playerSettings.first()
+                val snapped = FrameRateUtils.snapToStandardRate(rawFps)
+                val prefer23976TrackBias = rawFps in 23.95f..23.999f
+                val targetFrameRate = FrameRateUtils.refineFrameRateForDisplay(
+                    activity = activity,
+                    detectedFps = snapped,
+                    prefer23976Near24 = prefer23976TrackBias
+                )
+                val initialDisplayModeId = withContext(Dispatchers.Main) {
+                    activity.window?.decorView?.display?.mode?.modeId
+                }
+
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "Track AFR: raw=$rawFps snapped=$snapped target=$targetFrameRate " +
+                        "size=${format.width}x${format.height}"
+                )
+
+                val result = FrameRateUtils.matchFrameRateAndWait(
+                    activity = activity,
+                    frameRate = targetFrameRate,
+                    videoWidth = format.width.takeIf { it > 0 },
+                    videoHeight = format.height.takeIf { it > 0 },
+                    resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                )
+
+                if (result != null) {
+                    val switchedDisplayMode = initialDisplayModeId != null &&
+                        initialDisplayModeId != result.appliedMode.modeId
+                    _uiState.update {
+                        it.copy(
+                            displayModeInfo = DisplayModeInfo(
+                                width = result.appliedMode.physicalWidth,
+                                height = result.appliedMode.physicalHeight,
+                                refreshRate = result.appliedMode.refreshRate
+                            ),
+                            showDisplayModeInfo = true
+                        )
+                    }
+                    if (switchedDisplayMode) {
+                        Log.d(
+                            PlayerRuntimeController.TAG,
+                            "Track AFR: display mode switched; holding playback start ${TRACK_AFR_SETTLE_HOLD_MS}ms"
+                        )
+                        delay(TRACK_AFR_SETTLE_HOLD_MS)
+                    }
+                }
+            } ?: Log.w(
+                PlayerRuntimeController.TAG,
+                "Track AFR exceeded absolute deadline (${TRACK_AFR_ABSOLUTE_DEADLINE_MS}ms); releasing start gate"
+            )
+        } finally {
+            // act only if this coroutine still belongs to the current
+            // stream — an old stream's finally otherwise collapses the new
+            // stream's start-hold (and could start held playback early).
+            if (afrTrackGeneration == startGeneration) {
+                afrTrackSwitchInFlight = false
+                resumePlaybackAfterTrackAfrIfHeld()
+            }
+        }
+    }
+}
+
+/**
+ * If the first frame rendered (or tunneled READY fired) while the track-AFR
+ * gate held playback paused, start playback now with the same guards the
+ * normal start sites use. If the frame hasn't arrived yet, do nothing — the
+ * normal onRenderedFirstFrame / tunneled READY path starts playback, its gate
+ * now open.
+ */
+internal fun PlayerRuntimeController.resumePlaybackAfterTrackAfrIfHeld() {
+    val player = _exoPlayer ?: return
+    if (!hasRenderedFirstFrame) return
+    if (userPausedManually) return
+    if (isReleasingPlayer) return
+    if (player.playWhenReady) return
+    Log.d(PlayerRuntimeController.TAG, "Track AFR: settle complete; starting held playback")
+    player.playWhenReady = true
+    player.play()
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -286,11 +286,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                         resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
                     )
                 } else {
-                    // Track-format AFR (ExoPlayer): cache-only, instant. On a
-                    // cache miss the frame rate comes from ExoPlayer's reported
-                    // track format after prepare — no MediaExtractor/NextLib
-                    // network probe on this path at all.
-                    runAfrCachePreflightIfEnabled(
+                    // ExoPlayer: NextLib-primary preflight (cache -> NextLib),
+                    // then track-format AFR after prepare as a non-blocking
+                    // fallback on a NextLib miss. No blocking MediaExtractor
+                    // fallback on this path (that was the non-faststart hang).
+                    runAfrExoPreflightIfEnabled(
                         url = url,
                         headers = headers,
                         frameRateMatchingMode = playerSettings.frameRateMatchingMode,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -162,6 +162,9 @@ private fun PlayerRuntimeController.disposeExoPlayerBeforeRebuild() {
     playbackSpeedAwareAudioSink = null
 }
 
+// AFR settle hold duration (Exo parity with mpvDelayStartAfterAfrSwitch).
+private const val AFR_EXO_SETTLE_HOLD_MS = 2_000L
+
 @androidx.annotation.OptIn(UnstableApi::class)
 internal fun PlayerRuntimeController.initializePlayer(
     url: String,
@@ -974,7 +977,30 @@ internal fun PlayerRuntimeController.initializePlayer(
                 // Exception: tunneled playback bypasses the normal video
                 // rendering pipeline so onRenderedFirstFrame() never fires.
                 // In that case we fall back to starting on STATE_READY.
-                playWhenReady = !startPaused && !userPausedManually
+                // AFR settle hold (community 0.7.14 QMS stutter reports): when
+                // the preflight actually changed the display mode,
+                // hold playback start ~2 s so the (tunneled) A/V pipeline does
+                // not begin inside the mode transition. On QMS-capable chains
+                // the seamless switch reports complete almost instantly, so the
+                // immediate start that replaced 0.7.13's first-frame gate can
+                // otherwise start the hardware clock mid-transition and latch
+                // bad frame pacing for the whole title. Timer-released, never
+                // event-gated - cannot deadlock startup; no-switch starts are
+                // unaffected.
+                val holdForAfrSettle =
+                    exoDelayStartAfterAfrSwitch && !startPaused && !userPausedManually
+                exoDelayStartAfterAfrSwitch = false
+                playWhenReady = !startPaused && !userPausedManually && !holdForAfrSettle
+                if (holdForAfrSettle) {
+                    val heldPlayer = this
+                    scope.launch {
+                        kotlinx.coroutines.delay(AFR_EXO_SETTLE_HOLD_MS)
+                        if (_exoPlayer === heldPlayer && !userPausedManually && !isReleasingPlayer) {
+                            heldPlayer.playWhenReady = true
+                            heldPlayer.play()
+                        }
+                    }
+                }
                 prepare()
 
                 addListener(object : Player.Listener {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -163,7 +163,7 @@ private fun PlayerRuntimeController.disposeExoPlayerBeforeRebuild() {
 }
 
 // AFR settle hold duration (Exo parity with mpvDelayStartAfterAfrSwitch).
-private const val AFR_EXO_SETTLE_HOLD_MS = 2_000L
+internal const val AFR_EXO_SETTLE_HOLD_MS = 2_000L
 
 @androidx.annotation.OptIn(UnstableApi::class)
 internal fun PlayerRuntimeController.initializePlayer(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -90,7 +90,25 @@ import androidx.media3.common.Tracks
 
 private const val STARTUP_SUBTITLE_PREFETCH_TIMEOUT_MS = 20_000L
 private const val MPV_AFR_SETTLE_DELAY_MS = 2_000L
+// Absolute cap on how long playback start may wait for the AFR
+// preflight. In-probe timeouts (NextLib 6s + extractor 4s budgets) are advisory
+// against blocked native calls; the extractor now also has a force-release
+// watchdog. This is the final backstop.
+private const val AFR_PREFLIGHT_ABSOLUTE_DEADLINE_MS = 15_000L
 private const val AUDIO_DELAY_REFRESH_DEBOUNCE_MS = 120L
+
+/**
+ * With Nuvio's own AFR off, leave media3's built-in
+ * Surface.setFrameRate path on ONLY_IF_SEAMLESS so displays/firmware that
+ * support seamless switching still get a free, blackout-less refresh match.
+ * With Nuvio AFR on, keep it OFF so the two mechanisms don't fight.
+ */
+private fun nuvioFrameRateStrategy(mode: FrameRateMatchingMode): Int =
+    if (mode == FrameRateMatchingMode.OFF) {
+        C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS
+    } else {
+        C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF
+    }
 private const val PLAYER_RELEASE_TIMEOUT_MS = 3000L
 private const val PLAYER_REBUILD_SETTLE_DELAY_MS = 120L
 private const val ADAPTIVE_QUALITY_INCREASE_MIN_DURATION_MS = 2_000
@@ -259,7 +277,14 @@ internal fun PlayerRuntimeController.initializePlayer(
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
                 mpvInitializationInProgress = true
                 try {
-                    afrJob.await()
+                    // Never let the probe hold playback hostage -
+                    // the in-probe timeouts are advisory against blocked native
+                    // calls, so back them with an absolute deadline here.
+                    withTimeoutOrNull(AFR_PREFLIGHT_ABSOLUTE_DEADLINE_MS) { afrJob.await() }
+                        ?: run {
+                            Log.w(PlayerRuntimeController.TAG, "AFR preflight exceeded absolute deadline; starting playback without it")
+                            afrJob.cancel()
+                        }
                     if (mpvDelayStartAfterAfrSwitch) {
                         Log.d(PlayerRuntimeController.TAG, "AFR display mode switched; delaying MPV start by ${MPV_AFR_SETTLE_DELAY_MS}ms")
                         delay(MPV_AFR_SETTLE_DELAY_MS)
@@ -563,7 +588,12 @@ internal fun PlayerRuntimeController.initializePlayer(
             isVc1TrackSelectionBypassActiveForCurrentPlayback = vc1TrackSelectionBypassActive
 
             val startupSubtitlePreparation = prepareStreamStartSubtitles(playerSettings)
-            afrJob.await()
+            // Absolute deadline (see MPV path above).
+            withTimeoutOrNull(AFR_PREFLIGHT_ABSOLUTE_DEADLINE_MS) { afrJob.await() }
+                ?: run {
+                    Log.w(PlayerRuntimeController.TAG, "AFR preflight exceeded absolute deadline; starting playback without it")
+                    afrJob.cancel()
+                }
 
             // ── Libass Setup (From 0.5.7-beta/Left) ──
             requestedUseLibassByUser = playerSettings.useLibass
@@ -837,7 +867,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
                     .setReleaseTimeoutMs(PLAYER_RELEASE_TIMEOUT_MS)
-                    .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
+                    .setVideoChangeFrameRateStrategy(nuvioFrameRateStrategy(playerSettings.frameRateMatchingMode))
                     .build()
             }
 
@@ -852,7 +882,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(playerDataSourceFactory, effectiveExtractorsFactory))
                     .setReleaseTimeoutMs(PLAYER_RELEASE_TIMEOUT_MS)
-                    .setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
+                    .setVideoChangeFrameRateStrategy(nuvioFrameRateStrategy(playerSettings.frameRateMatchingMode))
                     .buildWithAssSupportCompat(
                         context = context,
                         renderType = libassRenderType,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -209,6 +209,13 @@ internal fun PlayerRuntimeController.initializePlayer(
             hasTriedDv7HevcFallback = false
             forceDv7ToHevc = false
             mpvDelayStartAfterAfrSwitch = false
+            // Track-format AFR: fresh stream, fresh state. Bump the generation
+            // first so an in-flight track-AFR coroutine from the previous
+            // stream stands down in its finally.
+            afrTrackGeneration++
+            trackAfrAttemptedForCurrentStream = false
+            afrTrackSwitchInFlight = false
+            afrModeAppliedPreStart = false
             playerInitializationStartedAtMs = System.currentTimeMillis()
             // Reset per playback; only the ExoPlayer custom-buffer path sets a real value.
             effectiveBackBufferDurationMs = 0
@@ -270,12 +277,26 @@ internal fun PlayerRuntimeController.initializePlayer(
             )
 
             val afrJob = async {
-                runAfrPreflightIfEnabled(
-                    url = url,
-                    headers = headers,
-                    frameRateMatchingMode = playerSettings.frameRateMatchingMode,
-                    resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
-                )
+                if (effectiveInternalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
+                    // MPV has no track-format path; keep the full probing preflight.
+                    runAfrPreflightIfEnabled(
+                        url = url,
+                        headers = headers,
+                        frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                        resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                    )
+                } else {
+                    // Track-format AFR (ExoPlayer): cache-only, instant. On a
+                    // cache miss the frame rate comes from ExoPlayer's reported
+                    // track format after prepare — no MediaExtractor/NextLib
+                    // network probe on this path at all.
+                    runAfrCachePreflightIfEnabled(
+                        url = url,
+                        headers = headers,
+                        frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                        resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                    )
+                }
             }
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
                 mpvInitializationInProgress = true
@@ -1106,7 +1127,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                                     if (_uiState.value.postPlayDismissedForCurrentEpisode) {
                                         _uiState.update { it.copy(postPlayDismissedForCurrentEpisode = false) }
                                     }
-                                    if (!startPaused && !userPausedManually) {
+                                    // Same track-AFR settle gate as
+                                    // onRenderedFirstFrame() (hasRenderedFirstFrame
+                                    // was just set above, so the held-start resume
+                                    // path applies here too).
+                                    if (!startPaused && !userPausedManually && !afrTrackSwitchInFlight) {
                                         playWhenReady = true
                                         play()
                                     }
@@ -1122,7 +1147,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                                     }
                                 }
                                 // Non-tunneled: playback will start in onRenderedFirstFrame().
-                            } else if (!userPausedManually && hasRenderedFirstFrame) {
+                            } else if (!userPausedManually && hasRenderedFirstFrame && !afrTrackSwitchInFlight) {
+                                // A rebuffer inside the track-AFR settle window
+                                // must not restart playback mid-switch; the gate
+                                // release resumes it (hasRenderedFirstFrame is
+                                // already true on this branch).
                                 play()
                             }
                             tryApplyPendingResumeProgress(this@apply)
@@ -1225,7 +1254,10 @@ internal fun PlayerRuntimeController.initializePlayer(
                         updateAudioControlAvailability()
                         // Start playback now that the first video frame is
                         // visible: audio and video begin in sync.
-                        if (!startPaused && !userPausedManually) {
+                        // While a track-format AFR switch is settling, hold
+                        // the start; resumePlaybackAfterTrackAfrIfHeld() starts
+                        // playback when the gate releases (deadline-bounded).
+                        if (!startPaused && !userPausedManually && !afrTrackSwitchInFlight) {
                             playWhenReady = true
                             play()
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -779,8 +779,8 @@ internal fun PlayerRuntimeController.switchToSourceStream(
             try {
                 val playerSettings = playerSettingsDataStore.playerSettings.first()
                 // Track-format AFR: this branch is ExoPlayer-only (_exoPlayer
-                // scope), so use the cache-only preflight; the new stream's
-                // track format drives the switch on a cache miss.
+                // scope), so use the cache + NextLib preflight; on a NextLib miss
+                // the new stream's track format drives the switch after prepare.
                 // Bump the generation first so an in-flight track-AFR
                 // coroutine from the previous stream stands down.
                 afrTrackGeneration++
@@ -804,8 +804,27 @@ internal fun PlayerRuntimeController.switchToSourceStream(
                         audioDelayUsProvider = audioDelayUs::get
                     )
                 )
-                player.playWhenReady = true
+                // Honour the AFR settle hold on a source switch too: if the
+                // preflight changed the display mode, hold playback ~2 s so the
+                // A/V pipeline doesn't start inside the mode transition — the
+                // same QMS-stutter guard the fresh-init path applies. Timer-
+                // released and guarded; also clears exoDelayStartAfterAfrSwitch,
+                // which the init consume-site would otherwise never see on this
+                // path.
+                val holdForAfrSettle = exoDelayStartAfterAfrSwitch && !userPausedManually
+                exoDelayStartAfterAfrSwitch = false
+                player.playWhenReady = !holdForAfrSettle
                 player.prepare()
+                if (holdForAfrSettle) {
+                    val heldPlayer = player
+                    scope.launch {
+                        kotlinx.coroutines.delay(AFR_EXO_SETTLE_HOLD_MS)
+                        if (_exoPlayer === heldPlayer && !userPausedManually && !isReleasingPlayer) {
+                            heldPlayer.playWhenReady = true
+                            heldPlayer.play()
+                        }
+                    }
+                }
             } catch (e: Exception) {
                 _uiState.update { it.copy(error = e.message ?: context.getString(com.nuvio.tv.R.string.player_error_play_stream_failed)) }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -787,7 +787,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(
                 trackAfrAttemptedForCurrentStream = false
                 afrTrackSwitchInFlight = false
                 afrModeAppliedPreStart = false
-                runAfrCachePreflightIfEnabled(
+                runAfrExoPreflightIfEnabled(
                     url = url,
                     headers = newHeaders,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -759,7 +759,16 @@ internal fun PlayerRuntimeController.switchToSourceStream(
             showSourcesPanel = false,
             isLoadingSourceStreams = false,
             sourceStreamsError = null,
-            isTorrentStream = false
+            isTorrentStream = false,
+            // Reset detection state on a source switch so the
+            // preflight for the new stream isn't a guaranteed no-op. Without
+            // this, detectedFrameRateSource stays set (the TRACK path populates
+            // it during normal playback) and the skip-guard in the preflight
+            // silently kept the previous stream's refresh rate - mixed-frame-
+            // rate series (25 fps HDTV next to 23.976 WEB-DL) never re-matched.
+            detectedFrameRate = 0f,
+            detectedFrameRateRaw = 0f,
+            detectedFrameRateSource = null
         )
     }
     showStreamSourceIndicator(stream)
@@ -1317,6 +1326,12 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
             postPlayMode = null,
             postPlayDismissedForCurrentEpisode = true,
             playbackEnded = false,
+            // Next-episode switches never re-evaluated AFR -
+            // the previous episode's TRACK detection made the preflight guard a
+            // guaranteed no-op. Reset so each episode re-matches.
+            detectedFrameRate = 0f,
+            detectedFrameRateRaw = 0f,
+            detectedFrameRateSource = null,
         )
     }
     showStreamSourceIndicator(stream)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -760,7 +760,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(
             isLoadingSourceStreams = false,
             sourceStreamsError = null,
             isTorrentStream = false,
-            // Reset detection state on a source switch so the
+            // reset detection state on a source switch so the
             // preflight for the new stream isn't a guaranteed no-op. Without
             // this, detectedFrameRateSource stays set (the TRACK path populates
             // it during normal playback) and the skip-guard in the preflight
@@ -778,7 +778,16 @@ internal fun PlayerRuntimeController.switchToSourceStream(
         scope.launch {
             try {
                 val playerSettings = playerSettingsDataStore.playerSettings.first()
-                runAfrPreflightIfEnabled(
+                // Track-format AFR: this branch is ExoPlayer-only (_exoPlayer
+                // scope), so use the cache-only preflight; the new stream's
+                // track format drives the switch on a cache miss.
+                // Bump the generation first so an in-flight track-AFR
+                // coroutine from the previous stream stands down.
+                afrTrackGeneration++
+                trackAfrAttemptedForCurrentStream = false
+                afrTrackSwitchInFlight = false
+                afrModeAppliedPreStart = false
+                runAfrCachePreflightIfEnabled(
                     url = url,
                     headers = newHeaders,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
@@ -1326,7 +1335,7 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
             postPlayMode = null,
             postPlayDismissedForCurrentEpisode = true,
             playbackEnded = false,
-            // Next-episode switches never re-evaluated AFR -
+            // next-episode switches never re-evaluated AFR -
             // the previous episode's TRACK detection made the preflight guard a
             // guaranteed no-op. Reset so each episode re-matches.
             detectedFrameRate = 0f,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -85,6 +85,10 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
                                 detectedFrameRateSource = FrameRateSource.TRACK
                             )
                         }
+                        // Track-format AFR: drive the display-mode switch from
+                        // the format ExoPlayer just reported (self-gating; see
+                        // PlayerRuntimeControllerAfrTrack.kt).
+                        maybeRunTrackFormatAfr(rawFps = raw, format = format)
                     }
                     // Extract video codec, resolution, and bitrate for stream info
                     currentVideoCodec = CustomDefaultTrackNameProvider.formatNameFromMime(format.sampleMimeType)


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="1:1-1:11;0-10">Summary</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="3:1-3:1381;12-1392">Fixes frame-rate matching (AFR) on the ExoPlayer engine and restores MKV frame-rate matching. Critical bug: with AFR enabled, playback can hang indefinitely (≥109 s confirmed) on MP4s with the moov atom at the tail. On the ExoPlayer path the AFR preflight runs NextLib (primary) and then, on a NextLib miss, a blocking native <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaExtractor.setDataSource()</code> fallback that a cooperative timeout cannot interrupt — that fallback is the hang. The fix removes <strong>only</strong> the blocking extractor fallback from the ExoPlayer path while keeping <strong>NextLib as the primary, most-reliable FPS detector</strong>, bounded by a 6 s budget and a 15 s absolute deadline so it can never hold start hostage. On a NextLib miss the rate now comes from ExoPlayer's own track format after prepare — a non-blocking fallback, not a replacement for NextLib. It also fixes the surrounding state-reset and start-gate bugs. It also adds MKV frame-rate declaration from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code> (which makes that track-format fallback cover MKV, where <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format.frameRate</code> is otherwise missing), a 2 s settle-hold after a real mode switch, and a seamless-when-off refresh match. It is the frame-rate-matching counterpart to #2544 (which fixes playback throughput on the same non-faststart MP4 class) — disjoint subsystems, no shared files. 9 files, +522/−22. Per-item detail below.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="5:1-5:11;1394-1404">PR type</h2>

<ul class="contains-task-list" data-sourcepos="7:1-8:23;1406-1464">
<li class="task-list-item" data-sourcepos="7:1-7:36;1406-1441"><input disabled="" type="checkbox"> Translation/localization only</li>
<li class="task-list-item" data-sourcepos="8:1-8:23;1442-1464"><input disabled="" type="checkbox" checked=""> Critical bug fix</li>
</ul>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="10:1-10:7;1466-1472">Why</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="12:1-12:887;1474-2360">Load-bearing reason is a critical bug: AFR-on hangs playback start indefinitely on non-faststart MP4s — the blocking <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaExtractor.setDataSource()</code> fallback reads toward the tail moov and a cooperative timeout can't interrupt it, making the feature unusable on affected content. The fix removes only that blocking extractor fallback from the ExoPlayer path, keeps NextLib as the primary detector (bounded), and uses ExoPlayer's track format as a non-blocking fallback on a NextLib miss. Bundled with maintainer approval: MKV frame-rate matching (upstream matched only MP4, so MKV never switched refresh); a 2 s settle hold after a real mode switch (fixes a QMS frame-pacing regression from 0.7.14); per-stream AFR state reset (mixed-rate series never re-matched); and a 720p resolution-matching floor (an SD title could drop the whole HDMI output — UI included — to a 480p/576p mode).</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="14:1-14:21;2362-2382">Issue or approval</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="16:1-16:123;2384-2506"> Tracking issue: #___</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="18:1-18:22;2508-2529">Reproduction steps</h2>

<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3" data-sourcepos="20:1-22:120;2531-2821">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="20:1-20:61;2531-2591">Enable frame-rate matching (AFR) on the ExoPlayer engine.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="21:1-21:110;2592-2701">Play an MP4 whose moov atom is at the end of the file (non-faststart), sourced over a higher-latency link.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="22:1-22:120;2702-2821">Observe playback does not start (confirmed ≥109 s). Disable AFR and replay the same file — playback starts normally.</li>
</ol>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="24:1-24:114;2823-2936">Secondary: play a fixed-rate MKV; before this change the display refresh does not switch to match, after it does.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="26:1-26:24;2938-2961">UI / behavior impact</h2>

<ul class="contains-task-list" data-sourcepos="28:1-33:55;2963-3226">
<li class="task-list-item" data-sourcepos="28:1-28:19;2963-2981"><input disabled="" type="checkbox" checked=""> No UI change</li>
<li class="task-list-item" data-sourcepos="29:1-29:25;2982-3006"><input disabled="" type="checkbox"> No behavior change</li>
<li class="task-list-item" data-sourcepos="30:1-30:53;3007-3059"><input disabled="" type="checkbox"> UI changed only to fix a documented glitch/bug</li>
<li class="task-list-item" data-sourcepos="31:1-31:63;3060-3122"><input disabled="" type="checkbox"> Behavior changed only to fix a documented bug/regression</li>
<li class="task-list-item" data-sourcepos="32:1-32:49;3123-3171"><input disabled="" type="checkbox"> UI change has explicit maintainer approval</li>
<li class="task-list-item" data-sourcepos="33:1-33:55;3172-3226"><input disabled="" type="checkbox" checked=""> Behavior change has explicit maintainer approval</li>
</ul>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="35:1-35:16;3228-3243">Policy check</h2>

<ul class="contains-task-list" data-sourcepos="37:1-43:44;3245-3785">
<li class="task-list-item" data-sourcepos="37:1-37:52;3245-3296"><input disabled="" type="checkbox" checked=""> I have read and understood <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">CONTRIBUTING.md</code>.</li>
<li class="task-list-item" data-sourcepos="38:1-38:95;3297-3391"><input disabled="" type="checkbox" checked=""> This PR fits the current PR policy: localization/translation only or a critical bug fix.</li>
<li class="task-list-item" data-sourcepos="39:1-39:91;3392-3482"><input disabled="" type="checkbox" checked=""> This PR does not add features, UI changes, refactors, or other non-critical changes.</li>
<li class="task-list-item" data-sourcepos="40:1-40:59;3483-3541"><input disabled="" type="checkbox" checked=""> This PR is small, focused, and limited to one issue.</li>
<li class="task-list-item" data-sourcepos="41:1-41:94;3542-3635"><input disabled="" type="checkbox" checked=""> This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.</li>
<li class="task-list-item" data-sourcepos="42:1-42:106;3636-3741"><input disabled="" type="checkbox" checked=""> This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.</li>
<li class="task-list-item" data-sourcepos="43:1-43:44;3742-3785"><input disabled="" type="checkbox" checked=""> I listed the testing performed below.</li>
</ul>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="45:1-45:20;3787-3806">Scope boundaries</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="47:1-47:417;3808-4224">Intentionally not changed: MKVs without <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code> (start unmatched, as before — uncommon in mkvmerge output) and AVI (no vendored extractor; stock <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">AviExtractor</code> sets no rate); both would be covered by a later sample-PTS estimator. The MPV engine path is untouched (keeps the existing probing preflight). No cosmetic/UI polish, no dependency or architecture changes, nothing outside the AFR/frame-rate scope.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="49:1-49:11;4226-4236">Testing</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="51:1-51:221;4238-4458">On-device (Amlogic S905X4, Android 14), ExoPlayer engine, this branch built and installed. Detection read from the player log; display mode from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dumpsys SurfaceFlinger</code> (ground truth). Idle mode 2160p59.94 in each case.</p>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="53:1-55:572;4460-5860">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="53:1-53:327;4460-4786"><strong>NextLib hit (primary) — 1080p DV MKV, 23.976, remote debrid link:</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">AFR ExoPlayer preflight: NextLib FPS=23.976025; applying pre-prepare switch</code>, and no <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Track AFR:</code> line — the track-format fallback correctly stood down. Display 59.94 → 23.98 Hz, clean start, no hang. Confirms NextLib drives the switch when it resolves.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="54:1-54:502;4787-5288"><strong>NextLib miss → track-format fallback — 2160p DV WEB-DL MKV, 23.976, remote debrid link:</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">NextLib miss/timeout after 6000ms; deferring to track-format AFR after prepare</code>, then <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Track AFR: raw=23.976 snapped=23.976025 target=23.976025</code>, a 2 s settle hold, then start. Display 59.94 → 23.98 Hz. NextLib bounded at its 6 s budget; ~13 s to first frame, no hang. This MKV's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format.frameRate</code> is populated only by the vendored extractor's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code> (item 9), so the match exercises that path.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="55:1-55:572;5289-5860"><strong>NextLib miss → track-format fallback — 1080p H.264 MP4:</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">NextLib miss/timeout after 6000ms; deferring to track-format</code>, then <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Track AFR: raw=23.999855 snapped=24.0 target=24.0</code> (correct snap to 24.0). Display 59.94 → 24.00 Hz. The file showed the scatter-read signature (long container parse, rebuffering) of the class the old blocking <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaExtractor</code> preflight hung on; here the preflight cost only its 6 s NextLib budget and playback started with no ≥109 s hang. (Residual rebuffering on such files is a data-source concern handled separately in #2544, not AFR.)</li>
</ul>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="57:1-57:98;5862-5959">Not exercised: MKV without <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code>, and AVI — both out of scope (see Scope boundaries).</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="59:1-59:23;5961-5983">Screenshots / Video</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="61:1-61:17;5985-6001">Not a UI change.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="63:1-63:20;6003-6022">Breaking changes</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="65:1-65:160;6024-6183">None. The AFR-off refresh-match behaviour change is documented under UI / behavior impact and in the summary; it changes no config, schema, or public contract.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="67:1-67:17;6185-6201">Linked issues</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="69:1-69:11;6203-6213">Fixes #___</p>

<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="73:1-73:22;6220-6241">Detailed changelog</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="75:1-76:482;6243-6802"><strong>1. Preflight probe budgets are now real, and can never hold start hostage</strong>
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaExtractor.setDataSource()</code> is a blocking native call that cooperative <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">withTimeoutOrNull</code> cancellation cannot interrupt. On a non-faststart MP4 (moov atom at the tail) it reads toward end-of-file and can block playback start indefinitely (runtime-confirmed ≥109 s — "AFR on hangs, AFR off starts cleanly"). A watchdog thread now force-releases a stuck extractor after 6 s, and the whole preflight wait is additionally capped at an absolute 15 s deadline on both engine paths.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="78:1-79:242;6804-7113"><strong>2. AFR detection state resets on source-switch and next-episode</strong>
The previous stream's detection left the preflight skip-guard a guaranteed no-op, so a mixed-frame-rate series (25 fps HDTV next to 23.976 WEB-DL) never re-matched after the first title. State now resets on stream switch and episode advance.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="81:1-82:435;7115-7605"><strong>3. Seamless refresh match even with the feature OFF</strong>
With frame-rate matching <strong>off</strong>, the player is now built with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS</code> instead of <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">OFF</code>, so displays that support seamless switching still get a free refresh match. With it <strong>on</strong>, the strategy stays <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">OFF</code> so the two mechanisms don't fight. <em>(Behaviour note: this is a deliberate change to the AFR-off path — capable displays will now seamlessly match refresh even when the toggle is off.)</em></p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="84:1-85:226;7607-7875"><strong>4. Resolution matching floored at 720p</strong>
"Nearest resolution" with no lower bound let an SD file drop the whole HDMI output — UI included — to a 480p/576p mode on devices that expose them. Candidate modes are now floored at 720p; the 4K↔1080p use case is unaffected.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="87:1-88:796;7877-8736"><strong>5. Settle hold after a real display-mode switch (ExoPlayer)</strong>
0.7.13 started ExoPlayer paused and released play on first frame, which incidentally gave the display a settle window after the AFR switch and kept the tunneled AudioTrack clock out of the transition. 0.7.14 (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">9c9b0bb5</code>) removed that gate, so playback and the tunneled hardware clock now start the instant the switch reports complete. On QMS chains that report lands near-instantly and overlaps playback start, which can latch bad frame pacing for the entire title (community 0.7.14 stutter reports on QMS-capable displays). This adds a 2 s settle hold, gated only to starts where the initial mode id differs from the applied mode id, timer-released, and stale-player / user-pause guarded — mirroring the existing MPV <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">mpvDelayStartAfterAfrSwitch</code> behaviour. No-switch starts keep the fast path.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="90:1-91:23;8738-8857"><strong>6. NextLib-primary preflight + track-format fallback (ExoPlayer); blocking extractor removed</strong>
On the ExoPlayer path:</p>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="92:1-94:801;8858-10881">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="92:1-92:501;8858-9358"><strong>Preflight = cache → NextLib.</strong> A cached detection is used instantly; on a cache miss, NextLib (the primary, most-reliable FPS source) runs, hard-bounded by a 6 s budget — it runs on an abandonable probe thread so a stuck native <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">build()</code> can't hold start past the budget — with the 15 s absolute preflight deadline in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Initialization</code> as a second net. If it resolves a rate, the display-mode switch is applied before <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">prepare()</code>. NextLib remains the primary detector — this PR does not remove it.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="93:1-93:722;9359-10080"><strong>Track-format fallback (no blocking probe).</strong> On a NextLib miss/timeout the path does <strong>not</strong> call the blocking <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaExtractor.setDataSource()</code> — that native call, reading to the tail moov and un-interruptible by a cooperative timeout, is the ≥109 s non-faststart hang. Instead it returns and the rate is taken from the video <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format</code> ExoPlayer reports in the tracks-changed handler — available during preparation, before the first frame, because ExoPlayer's range-seeking has already parsed the container (moov-at-end MP4s included). This is a fallback for NextLib, not a replacement. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format.frameRate</code> is missing for MKV until item 9 populates it from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code>, which is what extends this fallback to MKV.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="94:1-94:801;10081-10881"><strong>Shared switch machinery.</strong> Arming any switch (NextLib pre-prepare or track-format post-prepare) pauses the player for the switch window (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">playWhenReady</code> is true from build since 0.7.14, so it would otherwise auto-start at <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">STATE_READY</code> mid-switch — see item 7); a paused ExoPlayer still renders the first frame and reaches <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">STATE_READY</code>. The start sites (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">onRenderedFirstFrame</code>, tunneled <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">STATE_READY</code>, post-rebuffer READY) stand down while the switch settles (2 s hold after a real mode change), and a timer-released 8 s ceiling guarantees the gate can never deadlock startup — the existing 12 s first-frame watchdog is a second, longer net. A per-stream generation stamp keeps a previous stream's in-flight coroutine from collapsing the next stream's start-hold on fast stream/episode switches.</li>
</ul>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="96:1-97:413;10883-11345"><strong>7. Start-gate fix (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">playWhenReady</code> dead gate)</strong>
Because 0.7.14 builds the player with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">playWhenReady = true</code>, the pre-existing "stand down at the start sites" logic gated nothing — the player auto-started at <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">STATE_READY</code> regardless. The track-AFR path now engages the gate for real (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">playWhenReady = false</code> for the switch window, under guards that ensure playback isn't already running), which is what makes the settle hold effective on the normal start path.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="99:1-100:539;11347-11940"><strong>8. Swap the Matroska extractor before the DV guard</strong>
The vendored <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dvmkv</code> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MatroskaExtractor</code> is what declares a video <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format</code> frame rate from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">TrackEntry</code> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code> (item 9). That swap was gated behind the Dolby Vision feature guard, so on a plain (non-DV) MKV the stock extractor ran and no frame rate was ever declared. The unconditional Matroska swap is moved above that guard. On an inactive DV config the transformer's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">shouldTransform()</code> returns false, so non-DV HEVC samples still stream through the stock write path with no added work — only the extractor identity changes.</p>

<blockquote class="ml-2 border-l-4 border-[hsl(var(--border-300)/0.1)] pl-4 text-text-300" data-sourcepos="102:1-102:413;11942-12354">
<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="102:3-102:413;11944-12354"><strong>Overlap with #2558:</strong> this is the same one-hunk hoist carried by the audio PR (#2558) as change F1, where it makes the DTS-HD MA / DTS:X first-sample sniff reachable. The executable change is identical; whichever PR merges first satisfies the other, and the second can drop its copy on rebase. This PR carries it so MKV frame-rate coverage is complete standalone rather than depending on #2558's merge order.</p>

</blockquote>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="104:1-105:567;12356-12975"><strong>9. Declare MKV frame rate from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code></strong>
MP4's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">BoxParser</code> sets <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format.frameRate</code>, so track-format AFR fires for MP4. Matroska never set it: media3 parses <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">TrackEntry</code> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code> into <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">defaultSampleDurationNs</code> but never feeds the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format</code>, so MKV silently missed frame-rate matching on the ExoPlayer engine. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DefaultDuration</code> is nanoseconds per frame for fixed-rate video; its reciprocal is the fps (e.g. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">41708333</code> ns → 23.976 Hz). Bounds (5–121 Hz) reject malformed values and still-image tracks. The rate is known at prepare time, so MKV then rides the same gate/settle/deadline machinery as MP4.</p>

<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" data-sourcepos="107:1-107:56;12977-13032">Why remove the extractor fallback (and not NextLib)</h3>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="109:1-109:426;13034-13459">NextLib stays the primary detector — it reads real stream metadata (FFmpeg <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaInfo</code>) and is more reliable than <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Format.frameRate</code>, particularly for MKV. The problem was the <em>fallback</em> that ran when NextLib returned nothing: a blocking <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MediaExtractor.setDataSource()</code> that reads toward the tail moov and, being an un-interruptible native call, hangs playback start (≥109 s confirmed) — a cooperative timeout can't stop it.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="111:1-111:210;13461-13670">NextLib does miss on some remote (debrid) links: across four cold on-device opens, its header read hit its 6 s budget on <strong>3 of 4</strong> (including a <strong>1080p</strong> title) — path/proxy latency dominates, not resolution:</p>

<div class="overflow-x-auto w-full px-2 mb-6" data-sourcepos="113:1-118:31;13672-13854">
Content | NextLib result
-- | --
2160p hybrid remux | 6 s timeout
2160p DV WEB-DL | 6 s timeout
1080p H.264 WEB-DL | success (~2.8 s)
1080p WEB-DL | 6 s timeout

</div>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="120:1-120:374;13856-14229">On those misses the old path fell through to the blocking extractor (the hang). Replacing that fallback with the container-declared rate from ExoPlayer's own track format — free, non-blocking, and always present at prepare time — gives a fast safety net without a second network probe, while NextLib remains primary and its misses are the only case the track format covers.</p>

<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" data-sourcepos="122:1-122:35;14231-14265">Relationship to other open PRs</h3>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="124:1-125:142;14267-15001">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="124:1-124:593;14267-14859"><strong>#2544</strong> (MP4 chunk-session data source, its issue #2543): this PR is the frame-rate-matching fix for the non-faststart MP4 file class that #2544 deferred in its scope boundaries. Disjoint subsystems — #2544 fixes playback <em>throughput</em> (chunk re-download across seek reopens → rebuffering) in ExoPlayer's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ParallelRangeDataSource</code>; this PR fixes the AFR <em>preflight</em> hang (Android <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">android.media.MediaExtractor</code> blocking on the tail moov) and adds the frame-rate matching itself. No shared files. The two compose: #2544 makes non-faststart MP4s play smoothly, this makes them match refresh.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="125:1-125:142;14860-15001"><strong>#2558</strong> (audio): shares the Matroska-swap hoist (item 8) as change F1 — same executable hunk, different rationale. Independent otherwise.</li></ul><!--EndFragment-->
</body>
</html>