### PR TITLE
fix(player): improve HLS manifest path matching

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -598,7 +598,7 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
         }
 
         private val DELIMITED_M3U8_PATTERN = Regex("(^|[=/_.?&-])(m3u8|m3u)($|[=/_.?&-])")
-        private val PLAYLIST_HLS_PATTERN = Regex("/(playlist|hls|manifest|master)/(?!stream$|list$|info$|details$)[a-zA-Z0-9_-]+$")
+        private val PLAYLIST_HLS_PATTERN = Regex("/(playlist|hls|manifest|master|vs)/(?!stream$|list$|info$|details$)[a-zA-Z0-9_/-]+$")
         private val DELIMITED_MPD_PATTERN = Regex("(^|[=/_.?&-])mpd($|[=/_.?&-])")
         private val DELIMITED_SS_PATTERN = Regex("(^|[=/_.?&-])(ism|isml)($|[=/_.?&-])")
 


### PR DESCRIPTION
## Summary

This PR resolves a critical regression in HLS stream resolution where stream URLs containing `/vs/` or nested directories (such as season/episode paths like `/vs/tt11198330/s3/e01`) fail to resolve their MIME type, defaulting to an unknown type. This causes ExoPlayer to treat them as progressive container streams and crash on load.
Specifically, it:
1. Adds `vs` to the capture group inside `PLAYLIST_HLS_PATTERN` to recognize it as an HLS path endpoint.
2. Allows slash `/` characters in the path matching suffix to support nested directory structures under these stream endpoints.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. Since MIME type active probing was removed to avoid network blocking and start-up latency (commit [1d60da4382](https://github.com/tapframe/NuvioTV/commit/1d60da4382d3a8fa8ae7ccbd21fcf88dbc4d689a)), the player relies on static file/path extension inference.
2. Stream URLs from hosts like Vidmody use nested paths without a `.m3u8` file extension (e.g., `/vs/tt11198330/s3/e01`).
3. The previous regex `PLAYLIST_HLS_PATTERN` ended with `[a-zA-Z0-9_-]+$`, which did not match nested directories containing slashes (`/`), and did not include `vs` as a known playlist path keyword. Consequently, the stream MIME type resolved to `unknown`, defaulting to progressive media type in ExoPlayer and causing playback failures.

## Issue or approval

Reported on Discord

## Reproduction steps

1. Try to play a nested stream URL without a standard extension, for example: `https://example.com/vs/tt11198330/s3/e01` or `https://example.com/vs/tt34611082`.
2. The player will attempt to load the stream under ExoPlayer but will fail immediately, printing "Resolved stream mimeType=unknown".

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR is strictly limited to updating the regex in `PlayerMediaSourceFactory.kt` to allow slashes and match `vs` endpoints. It does not touch any player UI, buffering logic, or track selection code.

## Testing

1. Verified compile check via `.\gradlew.bat :app:compileFullDebugKotlin` successfully.
2. Simulated the regex matcher on target URLs: `https://example.com/vs/tt34611082` and `https://example.com/vs/tt11198330/s3/e01` to ensure they resolve to `MimeTypes.APPLICATION_M3U8` (HLS).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Reported on Discord
