### PR TITLE
fix(zidoo): recognize Z9X 8K model in isZidooDevice()

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ZidooPlayerMonitor.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ZidooPlayerMonitor.kt
@@ -60,7 +60,9 @@ object ZidooPlayerMonitor {
         val model = Build.MODEL?.lowercase() ?: ""
         return manufacturer.contains("zidoo") ||
             brand.contains("zidoo") ||
-            model.contains("zidoo")
+            model.contains("zidoo") ||
+            // Zidoo Z9X 8K reports Build.MODEL = "Z9X 8K" (no "zidoo" substring).
+            model.contains("z9x 8k")
     }
 
     /**


### PR DESCRIPTION
## Summary

`isZidooDevice()` substring-matched `Build.MANUFACTURER` / `BRAND` / `MODEL` against `"zidoo"`. The
Z9X 8K reports `Build.MODEL = "Z9X 8K"` — no `"zidoo"` substring — so detection failed and the whole
Zidoo tracking path (including the #2159 race fix) was skipped, and progress was never saved.

Adds a `model.contains("z9x 8k")` fallback.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Z9X 8K owners silently lose all watch progress after external playback. No user-side workaround.

## Issue or approval

Fixes #2155 — closed by #2159, but that fix never ran on this device, since detection fails upstream
of it. May warrant reopening.

## Reproduction steps

1. Install NuvioTV on a Zidoo Z9X 8K (firmware v1.3.05_G, Android 11).
2. Play anything via the external Zidoo player.
3. Exit partway, or play to completion.
4. Return to NuvioTV — no progress recorded.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

One condition added to `isZidooDevice()`; no other file touched. Existing `"zidoo"` checks unchanged,
so no other device is affected. Not included: a general REST-API probe fallback covering future
models automatically — happy to swap that in if maintainers prefer broader coverage.

## Testing

Physical Z9X 8K (firmware v1.3.05_G, Android 11) on my LAN.

Confirmed — `Build.MODEL` is exactly `"Z9X 8K"`, so the new condition matches. Device's Chrome UA:
`Mozilla/5.0 (Linux; Android 11; Z9X 8K) ...` (Android builds this from `Build.MODEL`). Corroborated
by the box's REST API (`/ZidooControlCenter/getModel` → `"model":"Z9X 8K"`).

Not confirmed — I could not sideload, and the firmware refuses adb network debugging, so I have not
run the patched app on-device or watched progress save end-to-end. Verified at the detection level
only; the rest is inferred from the path having been skipped entirely before. A maintainer with this
hardware could confirm quickly.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2155
