### PR TITLE
fix: capture profile ID at event-time to prevent cross-profile contamination

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -174,9 +174,10 @@ class StartupSyncService @Inject constructor(
     }
 
     fun requestAddonSyncNow() {
+        val profileId = profileManager.activeProfileId.value
+        Log.d(TAG, "Manual addon sync enqueued for profile $profileId")
         scope.launch {
-            val profileId = profileManager.activeProfileId.value
-            Log.d(TAG, "Manual addon sync requested for profile $profileId")
+            Log.d(TAG, "Manual addon sync starting for profile $profileId")
 
             addonRepository.isSyncingFromRemote = true
             try {
@@ -189,7 +190,7 @@ class StartupSyncService @Inject constructor(
 
                 Log.d(TAG, "Manual addon sync pulled ${remoteAddonUrls.size} addons for profile $profileId")
             } catch (e: Exception) {
-                Log.e(TAG, "Manual addon sync failed", e)
+                Log.e(TAG, "Manual addon sync failed for profile $profileId", e)
             } finally {
                 addonRepository.isSyncingFromRemote = false
             }

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -531,7 +531,7 @@ class StartupSyncService @Inject constructor(
                 }
         }
 
-        traktCredentialSyncService.pullFromRemote()
+        traktCredentialSyncService.pullFromRemote(profileId = profileId)
             .onSuccess { applied ->
                 Log.d(TAG, "Trakt credential pull completed for profile $profileId (applied=$applied)")
             }

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -211,7 +211,7 @@ class StartupSyncService @Inject constructor(
                 "plugins" -> pullRealtimePlugins(profileId)
                 "library" -> pullRealtimeLibrary(profileId)
                 "watch_progress" -> {
-                    watchProgressSyncService.restoreLastPushTimestamp()
+                    watchProgressSyncService.restoreLastPushTimestamp(profileId)
                     syncWatchProgressDelta(
                         profileId = profileId,
                         pushUnsynced = false,
@@ -219,7 +219,7 @@ class StartupSyncService @Inject constructor(
                     )
                 }
                 "watched_items" -> {
-                    watchedItemsSyncService.restoreLastPushTimestamp()
+                    watchedItemsSyncService.restoreLastPushTimestamp(profileId)
                     pullWatchedItemsDelta(
                         profileId = profileId,
                         traktMode = traktAuthDataStore.isEffectivelyAuthenticated.first(),
@@ -274,8 +274,8 @@ class StartupSyncService @Inject constructor(
         val profileId = profileManager.activeProfileId.value
         val isTraktConnected = traktAuthDataStore.isEffectivelyAuthenticated.first()
         val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
-        watchProgressSyncService.restoreLastPushTimestamp()
-        watchedItemsSyncService.restoreLastPushTimestamp()
+        watchProgressSyncService.restoreLastPushTimestamp(profileId)
+        watchedItemsSyncService.restoreLastPushTimestamp(profileId)
         Log.d(
             TAG,
             "Periodic watch state pull: profile=$profileId isTraktConnected=$isTraktConnected shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
@@ -424,8 +424,8 @@ class StartupSyncService @Inject constructor(
 
             val isTraktConnected = traktAuthDataStore.isEffectivelyAuthenticated.first()
             val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
-            watchProgressSyncService.restoreLastPushTimestamp()
-            watchedItemsSyncService.restoreLastPushTimestamp()
+            watchProgressSyncService.restoreLastPushTimestamp(profileId)
+            watchedItemsSyncService.restoreLastPushTimestamp(profileId)
             Log.d(
                 TAG,
                 "Watch progress sync: isTraktConnected=$isTraktConnected shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
@@ -475,8 +475,8 @@ class StartupSyncService @Inject constructor(
             pullBroadRemoteData(profileId, includeProfileSettings)
             val isTraktConnected = traktAuthDataStore.isEffectivelyAuthenticated.first()
             val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
-            watchProgressSyncService.restoreLastPushTimestamp()
-            watchedItemsSyncService.restoreLastPushTimestamp()
+            watchProgressSyncService.restoreLastPushTimestamp(profileId)
+            watchedItemsSyncService.restoreLastPushTimestamp(profileId)
             Log.d(
                 TAG,
                 "Warm watch progress sync: isTraktConnected=$isTraktConnected shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
@@ -719,7 +719,7 @@ class StartupSyncService @Inject constructor(
                 } else {
                     Log.d(TAG, "Detected unsynced watched items, pushing to remote")
                 }
-                watchedItemsSyncService.pushToRemote()
+                watchedItemsSyncService.pushToRemote(profileId)
             }
         } catch (e: Exception) {
             if (traktMode) {
@@ -759,7 +759,7 @@ class StartupSyncService @Inject constructor(
                 } else {
                     Log.d(TAG, "Detected unsynced watched items after snapshot, pushing to remote")
                 }
-                watchedItemsSyncService.pushToRemote()
+                watchedItemsSyncService.pushToRemote(profileId)
             }
         } catch (e: Exception) {
             if (traktMode) {

--- a/app/src/main/java/com/nuvio/tv/core/sync/TraktCredentialSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/TraktCredentialSyncService.kt
@@ -47,11 +47,27 @@ class TraktCredentialSyncService @Inject constructor(
         }
     }
 
+    /**
+     * Push the current profile's Trakt credentials to the remote.
+     * Captures the profile ID and auth state at call-time so both
+     * the state and the profile_id sent to the RPC are consistent.
+     */
     suspend fun pushCurrentToRemote(): Result<Unit> {
-        return pushStateToRemote(traktAuthDataStore.getCurrentState())
+        val profileId = profileManager.activeProfileId.value
+        val state = traktAuthDataStore.getCurrentState(profileId)
+        return pushStateToRemote(state, profileId)
     }
 
-    suspend fun pushStateToRemote(state: TraktAuthState): Result<Unit> = withContext(Dispatchers.IO) {
+    /**
+     * Push a specific Trakt auth state to the remote for a given profile.
+     * @param state The Trakt auth state to push
+     * @param profileId The profile to associate the credentials with. Must be
+     *   captured at call-time to prevent race conditions on profile switch.
+     */
+    suspend fun pushStateToRemote(
+        state: TraktAuthState,
+        profileId: Int = profileManager.activeProfileId.value
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         mutex.withLock {
             try {
                 if (!authManager.isAuthenticated || !state.isAuthenticated) {
@@ -59,7 +75,6 @@ class TraktCredentialSyncService @Inject constructor(
                 }
 
                 val credentialJson = state.toCredentialJson() ?: return@withLock Result.success(Unit)
-                val profileId = profileManager.activeProfileId.value
                 val params = buildJsonObject {
                     put("p_profile_id", profileId)
                     put("p_credentials", buildJsonArray {
@@ -84,14 +99,15 @@ class TraktCredentialSyncService @Inject constructor(
         }
     }
 
-    suspend fun pullFromRemote(): Result<Boolean> = withContext(Dispatchers.IO) {
+    suspend fun pullFromRemote(
+        profileId: Int = profileManager.activeProfileId.value
+    ): Result<Boolean> = withContext(Dispatchers.IO) {
         mutex.withLock {
             try {
                 if (!authManager.isAuthenticated) {
                     return@withLock Result.success(false)
                 }
 
-                val profileId = profileManager.activeProfileId.value
                 val params = buildJsonObject {
                     put("p_profile_id", profileId)
                 }
@@ -105,12 +121,12 @@ class TraktCredentialSyncService @Inject constructor(
 
                 val remoteState = traktCredential.credentialJson.toTraktAuthState()
                     ?: return@withLock Result.success(false)
-                val localState = traktAuthDataStore.getCurrentState()
+                val localState = traktAuthDataStore.getCurrentState(profileId)
                 if (localState.syncSignature() == remoteState.syncSignature()) {
                     return@withLock Result.success(false)
                 }
 
-                traktAuthDataStore.saveSyncedAuthState(remoteState)
+                traktAuthDataStore.saveSyncedAuthState(remoteState, profileId = profileId)
                 Log.d(TRAKT_CREDENTIAL_TAG, "Pulled Trakt credentials for profile $profileId")
                 Result.success(true)
             } catch (e: Exception) {

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
@@ -64,17 +64,17 @@ class WatchProgressSyncService @Inject constructor(
         private set
 
     /** Called after a successful push to record the sync point. */
-    fun markPushSucceeded() {
+    fun markPushSucceeded(profileId: Int = profileManager.activeProfileId.value) {
         val now = System.currentTimeMillis()
         lastSuccessfulPushMs = now
         scope.launch {
-            watchProgressPreferences.setLastSuccessfulPushMs(now)
+            watchProgressPreferences.setLastSuccessfulPushMs(now, profileId)
         }
     }
 
     /** Restores persisted push timestamp on startup. */
-    suspend fun restoreLastPushTimestamp() {
-        lastSuccessfulPushMs = watchProgressPreferences.getLastSuccessfulPushMs()
+    suspend fun restoreLastPushTimestamp(profileId: Int = profileManager.activeProfileId.value) {
+        lastSuccessfulPushMs = watchProgressPreferences.getLastSuccessfulPushMs(profileId)
     }
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
         return try {
@@ -197,7 +197,7 @@ class WatchProgressSyncService @Inject constructor(
             }
 
             Log.d(TAG, "Pushed ${entries.size} watch progress entries to remote for profile $profileId")
-            markPushSucceeded()
+            markPushSucceeded(profileId)
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to push watch progress to remote", e)
@@ -240,7 +240,7 @@ class WatchProgressSyncService @Inject constructor(
             }
 
             Log.d(TAG, "Pushed single watch progress entry to remote for profile $profileId (key=$key)")
-            markPushSucceeded()
+            markPushSucceeded(profileId)
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to push single watch progress to remote", e)

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
@@ -382,10 +382,10 @@ class WatchedItemsSyncService @Inject constructor(
     suspend fun deleteFromRemote(
         contentId: String,
         season: Int?,
-        episode: Int?
+        episode: Int?,
+        profileId: Int = profileManager.activeProfileId.value
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            val profileId = profileManager.activeProfileId.value
             val params = buildJsonObject {
                 put("p_profile_id", profileId)
                 put("p_keys", buildJsonArray {
@@ -411,12 +411,12 @@ class WatchedItemsSyncService @Inject constructor(
 
     suspend fun deleteFromRemoteBatch(
         contentId: String,
-        episodes: List<Pair<Int, Int>>
+        episodes: List<Pair<Int, Int>>,
+        profileId: Int = profileManager.activeProfileId.value
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             if (episodes.isEmpty()) return@withContext Result.success(Unit)
 
-            val profileId = profileManager.activeProfileId.value
             val params = buildJsonObject {
                 put("p_profile_id", profileId)
                 put("p_keys", buildJsonArray {

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
@@ -60,16 +60,16 @@ class WatchedItemsSyncService @Inject constructor(
     var lastSuccessfulPushMs: Long = 0L
         private set
 
-    fun markPushSucceeded() {
+    fun markPushSucceeded(profileId: Int = profileManager.activeProfileId.value) {
         val now = System.currentTimeMillis()
         lastSuccessfulPushMs = now
         CoroutineScope(Dispatchers.IO).launch {
-            watchedItemsPreferences.setLastSuccessfulPushMs(now)
+            watchedItemsPreferences.setLastSuccessfulPushMs(now, profileId)
         }
     }
 
-    suspend fun restoreLastPushTimestamp() {
-        lastSuccessfulPushMs = watchedItemsPreferences.getLastSuccessfulPushMs()
+    suspend fun restoreLastPushTimestamp(profileId: Int = profileManager.activeProfileId.value) {
+        lastSuccessfulPushMs = watchedItemsPreferences.getLastSuccessfulPushMs(profileId)
     }
 
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
@@ -119,11 +119,11 @@ class WatchedItemsSyncService @Inject constructor(
         }
     }
 
-    suspend fun pushToRemote(): Result<Unit> = withContext(Dispatchers.IO) {
+    suspend fun pushToRemote(profileId: Int = profileManager.activeProfileId.value): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val items = watchedItemsPreferences.getAllItems()
             Log.d(TAG, "pushToRemote: ${items.size} watched items to push")
-            pushItemsToRemote(items, updateLastSuccessfulPush = true)
+            pushItemsToRemote(items, updateLastSuccessfulPush = true, profileId = profileId)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to push watched items to remote", e)
             Result.failure(e)
@@ -162,7 +162,7 @@ class WatchedItemsSyncService @Inject constructor(
 
             Log.d(TAG, "Pushed ${items.size} watched items to remote for profile $profileId")
             if (updateLastSuccessfulPush) {
-                markPushSucceeded()
+                markPushSucceeded(profileId)
             }
             Result.success(Unit)
         } catch (e: Exception) {

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
@@ -132,12 +132,12 @@ class WatchedItemsSyncService @Inject constructor(
 
     suspend fun pushItemsToRemote(
         items: Collection<WatchedItem>,
-        updateLastSuccessfulPush: Boolean = false
+        updateLastSuccessfulPush: Boolean = false,
+        profileId: Int = profileManager.activeProfileId.value
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             if (items.isEmpty()) return@withContext Result.success(Unit)
             Log.d(TAG, "pushItemsToRemote: ${items.size} watched items to push")
-            val profileId = profileManager.activeProfileId.value
             val params = buildJsonObject {
                 put("p_items", buildJsonArray {
                     items.forEach { item ->

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktAuthDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktAuthDataStore.kt
@@ -91,9 +91,11 @@ class TraktAuthDataStore @Inject constructor(
 
     val isEffectivelyAuthenticated: Flow<Boolean> = isAuthenticated
 
-    /** Direct read of auth state for the current active profile, bypassing flatMapLatest. */
-    suspend fun getCurrentState(): TraktAuthState {
-        val prefs = store().data.first()
+    /** Direct read of auth state for the given profile, bypassing flatMapLatest. */
+    suspend fun getCurrentState(
+        profileId: Int = profileManager.activeProfileId.value
+    ): TraktAuthState {
+        val prefs = store(profileId).data.first()
         return TraktAuthState(
             accessToken = prefs[accessTokenKey],
             refreshToken = prefs[refreshTokenKey],
@@ -135,8 +137,11 @@ class TraktAuthDataStore @Inject constructor(
         }
     }
 
-    suspend fun saveSyncedAuthState(state: TraktAuthState) {
-        store().edit { preferences ->
+    suspend fun saveSyncedAuthState(
+        state: TraktAuthState,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             if (!state.isAuthenticated) {
                 preferences.remove(accessTokenKey)
                 preferences.remove(refreshTokenKey)

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -264,13 +264,16 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Mark content as completed
      */
-    suspend fun markAsCompleted(progress: WatchProgress) {
+    suspend fun markAsCompleted(
+        progress: WatchProgress,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         // If the incoming duration is a dummy sentinel (≤ 1ms), check for an
         // existing local entry with a real duration from prior playback.
         // This creates a proper completed entry that syncs correctly cross-device.
         val effectiveDuration = if (progress.duration <= 1L) {
             val key = createKey(progress)
-            val existing = getAllRawEntries()[key]
+            val existing = getAllRawEntries(profileId)[key]
             existing?.duration?.takeIf { it > 1L } ?: progress.duration
         } else {
             progress.duration
@@ -287,9 +290,12 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Mark multiple items as completed in a single DataStore transaction.
      */
-    suspend fun markAsCompletedBatch(progressList: List<WatchProgress>) {
+    suspend fun markAsCompletedBatch(
+        progressList: List<WatchProgress>,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         if (progressList.isEmpty()) return
-        val rawEntries = getAllRawEntries()
+        val rawEntries = getAllRawEntries(profileId)
         val now = System.currentTimeMillis()
         val completed = progressList.map { progress ->
             val effectiveDuration = if (progress.duration <= 1L) {

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -40,13 +40,13 @@ class WatchProgressPreferences @Inject constructor(
     private val deltaInitializedKey = booleanPreferencesKey("watch_progress_delta_initialized")
 
     /** Persisted timestamp of the last successful push to remote. */
-    suspend fun getLastSuccessfulPushMs(): Long {
-        val prefs = store().data.first()
+    suspend fun getLastSuccessfulPushMs(profileId: Int = profileManager.activeProfileId.value): Long {
+        val prefs = store(profileId).data.first()
         return prefs[lastSuccessfulPushMsKey] ?: 0L
     }
 
-    suspend fun setLastSuccessfulPushMs(timestampMs: Long) {
-        store().edit { prefs ->
+    suspend fun setLastSuccessfulPushMs(timestampMs: Long, profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { prefs ->
             prefs[lastSuccessfulPushMsKey] = timestampMs
         }
     }
@@ -147,8 +147,8 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Get watch progress for a specific content item
      */
-    fun getProgress(contentId: String): Flow<WatchProgress?> {
-        return store().data.map { preferences ->
+    fun getProgress(contentId: String, profileId: Int = profileManager.activeProfileId.value): Flow<WatchProgress?> {
+        return store(profileId).data.map { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json)
             // Try direct key first (movies), then find latest episode entry (series).
@@ -161,8 +161,8 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Get watch progress for a specific episode
      */
-    fun getEpisodeProgress(contentId: String, season: Int, episode: Int): Flow<WatchProgress?> {
-        return store().data.map { preferences ->
+    fun getEpisodeProgress(contentId: String, season: Int, episode: Int, profileId: Int = profileManager.activeProfileId.value): Flow<WatchProgress?> {
+        return store(profileId).data.map { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json)
             map.values.find { 
@@ -174,8 +174,8 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Get all episode progress for a series
      */
-    fun getAllEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> {
-        return store().data.map { preferences ->
+    fun getAllEpisodeProgress(contentId: String, profileId: Int = profileManager.activeProfileId.value): Flow<Map<Pair<Int, Int>, WatchProgress>> {
+        return store(profileId).data.map { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json)
             map.values
@@ -468,8 +468,8 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Clear all watch progress
      */
-    suspend fun clearAll() {
-        store().edit { preferences ->
+    suspend fun clearAll(profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { preferences ->
             preferences.remove(watchProgressKey)
             preferences.remove(deltaCursorKey)
             preferences.remove(deltaInitializedKey)
@@ -480,9 +480,10 @@ class WatchProgressPreferences @Inject constructor(
      * Clear all watch progress entries EXCEPT those with non-Trakt-compatible IDs
      */
     suspend fun clearAllPreservingNonTraktIds(
-        isNonTraktId: (String) -> Boolean
+        isNonTraktId: (String) -> Boolean,
+        profileId: Int = profileManager.activeProfileId.value
     ) {
-        store().edit { preferences ->
+        store(profileId).edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json)
             val preserved = map.filter { (_, progress) -> isNonTraktId(progress.contentId) }

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -480,8 +480,8 @@ class WatchProgressPreferences @Inject constructor(
      * Clear all watch progress entries EXCEPT those with non-Trakt-compatible IDs
      */
     suspend fun clearAllPreservingNonTraktIds(
-        isNonTraktId: (String) -> Boolean,
-        profileId: Int = profileManager.activeProfileId.value
+        profileId: Int = profileManager.activeProfileId.value,
+        isNonTraktId: (String) -> Boolean
     ) {
         store(profileId).edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -187,8 +187,11 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Save or update watch progress
      */
-    suspend fun saveProgress(progress: WatchProgress) {
-        store().edit { preferences ->
+    suspend fun saveProgress(
+        progress: WatchProgress,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json).toMutableMap()
             upsertProgressEntries(map, listOf(progress))
@@ -198,9 +201,12 @@ class WatchProgressPreferences @Inject constructor(
         }
     }
 
-    suspend fun saveProgressBatch(progressList: List<WatchProgress>) {
+    suspend fun saveProgressBatch(
+        progressList: List<WatchProgress>,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         if (progressList.isEmpty()) return
-        store().edit { preferences ->
+        store(profileId).edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json).toMutableMap()
             upsertProgressEntries(map, progressList)
@@ -212,8 +218,13 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Remove watch progress for a specific item
      */
-    suspend fun removeProgress(contentId: String, season: Int? = null, episode: Int? = null) {
-        store().edit { preferences ->
+    suspend fun removeProgress(
+        contentId: String,
+        season: Int? = null,
+        episode: Int? = null,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json).toMutableMap()
 
@@ -247,9 +258,13 @@ class WatchProgressPreferences @Inject constructor(
     /**
      * Remove watch progress for multiple episodes in a single DataStore transaction.
      */
-    suspend fun removeProgressBatch(contentId: String, episodes: List<Pair<Int, Int>>) {
+    suspend fun removeProgressBatch(
+        contentId: String,
+        episodes: List<Pair<Int, Int>>,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         if (episodes.isEmpty()) return
-        store().edit { preferences ->
+        store(profileId).edit { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
             val map = parseProgressMap(json).toMutableMap()
             for ((season, episode) in episodes) {
@@ -284,7 +299,7 @@ class WatchProgressPreferences @Inject constructor(
             duration = effectiveDuration,
             lastWatched = System.currentTimeMillis()
         )
-        saveProgress(completedProgress)
+        saveProgress(completedProgress, profileId = profileId)
     }
 
     /**
@@ -310,7 +325,7 @@ class WatchProgressPreferences @Inject constructor(
                 lastWatched = now
             )
         }
-        saveProgressBatch(completed)
+        saveProgressBatch(completed, profileId = profileId)
     }
 
     /**

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -99,8 +99,11 @@ class WatchedItemsPreferences @Inject constructor(
         }
     }
 
-    suspend fun markAsWatched(item: WatchedItem) {
-        store().edit { preferences ->
+    suspend fun markAsWatched(
+        item: WatchedItem,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val filtered = current.filterNot { json ->
                 runCatching {
@@ -115,9 +118,12 @@ class WatchedItemsPreferences @Inject constructor(
         }
     }
 
-    suspend fun markAsWatchedBatch(items: List<WatchedItem>) {
+    suspend fun markAsWatchedBatch(
+        items: List<WatchedItem>,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         if (items.isEmpty()) return
-        store().edit { preferences ->
+        store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val newKeys = items.map { Triple(it.contentId, it.season, it.episode) }.toSet()
             val filtered = current.filterNot { json ->

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -36,13 +36,13 @@ class WatchedItemsPreferences @Inject constructor(
     private val deltaCursorKey = longPreferencesKey("watched_items_delta_cursor")
     private val deltaInitializedKey = booleanPreferencesKey("watched_items_delta_initialized")
 
-    suspend fun getLastSuccessfulPushMs(): Long {
-        val prefs = store().data.first()
+    suspend fun getLastSuccessfulPushMs(profileId: Int = profileManager.activeProfileId.value): Long {
+        val prefs = store(profileId).data.first()
         return prefs[lastSuccessfulPushMsKey] ?: 0L
     }
 
-    suspend fun setLastSuccessfulPushMs(timestampMs: Long) {
-        store().edit { prefs ->
+    suspend fun setLastSuccessfulPushMs(timestampMs: Long, profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { prefs ->
             prefs[lastSuccessfulPushMsKey] = timestampMs
         }
     }
@@ -182,8 +182,8 @@ class WatchedItemsPreferences @Inject constructor(
         return allItems.first()
     }
 
-    suspend fun mergeRemoteItems(remoteItems: List<WatchedItem>) {
-        store().edit { preferences ->
+    suspend fun mergeRemoteItems(remoteItems: List<WatchedItem>, profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val localItems = current.mapNotNull { json ->
                 runCatching { gson.fromJson(json, WatchedItem::class.java) }.getOrNull()
@@ -275,8 +275,8 @@ class WatchedItemsPreferences @Inject constructor(
         return preservedLocalItems
     }
 
-    suspend fun clearAll() {
-        store().edit { preferences ->
+    suspend fun clearAll(profileId: Int = profileManager.activeProfileId.value) {
+        store(profileId).edit { preferences ->
             preferences.remove(watchedItemsKey)
             preferences.remove(deltaCursorKey)
             preferences.remove(deltaInitializedKey)

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -137,8 +137,13 @@ class WatchedItemsPreferences @Inject constructor(
         }
     }
 
-    suspend fun unmarkAsWatched(contentId: String, season: Int? = null, episode: Int? = null) {
-        store().edit { preferences ->
+    suspend fun unmarkAsWatched(
+        contentId: String,
+        season: Int? = null,
+        episode: Int? = null,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
+        store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val filtered = current.filterNot { json ->
                 runCatching {
@@ -153,10 +158,14 @@ class WatchedItemsPreferences @Inject constructor(
         }
     }
 
-    suspend fun unmarkAsWatchedBatch(contentId: String, episodes: List<Pair<Int, Int>>) {
+    suspend fun unmarkAsWatchedBatch(
+        contentId: String,
+        episodes: List<Pair<Int, Int>>,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         if (episodes.isEmpty()) return
         val removeKeys = episodes.map { (s, e) -> Triple(contentId, s, e) }.toSet()
-        store().edit { preferences ->
+        store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val filtered = current.filterNot { json ->
                 runCatching {

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -51,11 +51,11 @@ class WatchedSeriesStateHolder @Inject constructor(
     private var revalidateAfterMap: Map<String, Long> = emptyMap()
     private var loaded = false
 
-    private fun store() = factory.get(profileManager.activeProfileId.value, FEATURE)
+    private fun store(profileId: Int = profileManager.activeProfileId.value) = factory.get(profileId, FEATURE)
 
-    suspend fun loadFromDisk() {
+    suspend fun loadFromDisk(profileId: Int = profileManager.activeProfileId.value) {
         if (loaded) return
-        val prefs = store().data.first()
+        val prefs = store(profileId).data.first()
         val persisted = prefs[KEY] ?: emptySet()
         val resetVersion = prefs[VALIDATION_RESET_KEY] ?: 0
         if (resetVersion < VALIDATION_RESET_VERSION) {
@@ -75,8 +75,9 @@ class WatchedSeriesStateHolder @Inject constructor(
 
     fun update(ids: Set<String>) {
         _fullyWatchedSeriesIds.value = ids
+        val profileId = profileManager.activeProfileId.value
         scope.launch {
-            store().edit { prefs -> prefs[KEY] = ids }
+            store(profileId).edit { prefs -> prefs[KEY] = ids }
         }
     }
 
@@ -89,7 +90,8 @@ class WatchedSeriesStateHolder @Inject constructor(
     fun updateWithValidation(
         ids: Set<String>,
         validatedIds: Set<String>,
-        revalidateAt: Map<String, Long> = emptyMap()
+        revalidateAt: Map<String, Long> = emptyMap(),
+        profileId: Int = profileManager.activeProfileId.value
     ) {
         val idsChanged = _fullyWatchedSeriesIds.value != ids
         _fullyWatchedSeriesIds.value = ids
@@ -117,7 +119,7 @@ class WatchedSeriesStateHolder @Inject constructor(
         revalidateAfterMap = updated
         if (idsChanged || deadlinesChanged) {
             scope.launch {
-                store().edit { prefs ->
+                store(profileId).edit { prefs ->
                     prefs[KEY] = ids
                     prefs[REVALIDATE_KEY] = gson.toJson(updated)
                 }
@@ -144,10 +146,10 @@ class WatchedSeriesStateHolder @Inject constructor(
      * Clears all revalidation deadlines, forcing every series to be re-evaluated
      * on the next CW pipeline cycle. Called when the user manually clears the CW cache.
      */
-    fun clearValidationState() {
+    fun clearValidationState(profileId: Int = profileManager.activeProfileId.value) {
         revalidateAfterMap = emptyMap()
         scope.launch {
-            store().edit { prefs -> prefs.remove(REVALIDATE_KEY) }
+            store(profileId).edit { prefs -> prefs.remove(REVALIDATE_KEY) }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -222,6 +222,12 @@ class TraktProgressService @Inject constructor(
     @Volatile
     private var metadataWarmupScheduled: Boolean = false
     private val episodeProgressActivityVersion = AtomicLong(0L)
+    /** Monotonically increasing generation counter. Incremented on every profile
+     *  switch via [resetProfileScopedState]. Captured at the start of
+     *  [refreshRemoteSnapshot] and checked before writing to shared state —
+     *  prevents stale results from cancelled-but-still-running async work
+     *  from overwriting the new profile's data. */
+    private val refreshGeneration = AtomicLong(0L)
     private val mappingSemaphore = Semaphore(MAPPING_CONCURRENCY)
 
     private val playbackCacheTtlMs = 30_000L
@@ -317,6 +323,7 @@ class TraktProgressService @Inject constructor(
         refreshIntervalMs = baseRefreshIntervalMs
         consecutiveRefreshFailures = 0
         episodeProgressActivityVersion.set(0L)
+        refreshGeneration.incrementAndGet()
 
         cacheMutex.withLock {
             episodeVideoIdCache.clear()
@@ -1036,6 +1043,14 @@ class TraktProgressService @Inject constructor(
             return
         }
 
+        // Capture the generation at the start of the refresh. If the profile
+        // switches while this refresh is in-flight (collectLatest cancellation
+        // does NOT cancel in-flight HTTP), the generation will have been
+        // incremented by resetProfileScopedState. Before writing to shared
+        // state, we check the generation — stale results from a cancelled
+        // but still-running refresh are silently discarded.
+        val generation = refreshGeneration.get()
+
         supervisorScope {
             val hiddenDeferred = async { runCatching { ensureHiddenProgressShows(force = force) } }
 
@@ -1074,6 +1089,13 @@ class TraktProgressService @Inject constructor(
                 if (!hasLoadedRemoteProgress.value) {
                     throw IOException("Progress snapshot fetch failed before initial load")
                 }
+                return@supervisorScope
+            }
+
+            // Guard: if the profile switched mid-refresh, discard stale data.
+            // The generation was incremented by resetProfileScopedState().
+            if (refreshGeneration.get() != generation) {
+                trace("refreshRemoteSnapshot: discarding stale snapshot (generation changed)")
                 return@supervisorScope
             }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -835,7 +835,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 }
         }
         if (authManager.isAuthenticated && !useTraktProgress) {
-            watchedItemsSyncService.deleteFromRemote(contentId, season, episode)
+            watchedItemsSyncService.deleteFromRemote(contentId, season, episode, profileId = profileId)
                 .onFailure { error ->
                     Log.w(TAG, "removeFromHistory watched item remote delete failed", error)
                 }
@@ -880,7 +880,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     }
             }
             if (authManager.isAuthenticated) {
-                watchedItemsSyncService.deleteFromRemoteBatch(contentId, episodes)
+                watchedItemsSyncService.deleteFromRemoteBatch(contentId, episodes, profileId = profileId)
                     .onFailure { error ->
                         Log.w(TAG, "removeFromHistoryBatch watched item remote delete failed", error)
                     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -117,7 +117,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun triggerWatchedItemsSync(items: Collection<WatchedItem>) {
+    private fun triggerWatchedItemsSync(
+        items: Collection<WatchedItem>,
+        profileId: Int = profileManager.activeProfileId.value
+    ) {
         if (items.isEmpty()) return
         if (isSyncingFromRemote) return
         if (!hasCompletedInitialWatchedItemsPull) return
@@ -709,9 +712,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
             watchProgressPreferences.saveProgress(progress)
             if (progress.isCompleted()) {
                 val watchedItem = progress.toWatchedItem()
-                watchedItemsPreferences.markAsWatched(watchedItem)
+                watchedItemsPreferences.markAsWatched(watchedItem, profileId = profileId)
                 if (syncRemote && authManager.isAuthenticated) {
-                    triggerWatchedItemsSync(listOf(watchedItem))
+                    triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
                 }
             }
             // Mirror to Nuvio Sync so data is ready if user switches source later.
@@ -738,15 +741,16 @@ class WatchProgressRepositoryImpl @Inject constructor(
 
         if (progress.isCompleted()) {
             val watchedItem = progress.toWatchedItem()
-            watchedItemsPreferences.markAsWatched(watchedItem)
+            watchedItemsPreferences.markAsWatched(watchedItem, profileId = profileId)
             if (syncRemote && authManager.isAuthenticated) {
-                triggerWatchedItemsSync(listOf(watchedItem))
+                triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
             }
         }
     }
 
     override suspend fun saveProgressBatch(progressList: List<WatchProgress>, syncRemote: Boolean) {
         if (progressList.isEmpty()) return
+        val profileId = profileManager.activeProfileId.value
         if (shouldUseTraktProgress()) {
             if (syncRemote) {
                 progressList.forEach { progress ->
@@ -771,9 +775,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
             .filter { it.isCompleted() }
             .map { progress -> progress.toWatchedItem() }
         if (completedWatchedItems.isNotEmpty()) {
-            watchedItemsPreferences.markAsWatchedBatch(completedWatchedItems)
+            watchedItemsPreferences.markAsWatchedBatch(completedWatchedItems, profileId = profileId)
             if (syncRemote && authManager.isAuthenticated) {
-                triggerWatchedItemsSync(completedWatchedItems)
+                triggerWatchedItemsSync(completedWatchedItems, profileId = profileId)
             }
         }
     }
@@ -883,6 +887,12 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markAsCompleted(progress: WatchProgress, syncRemoteToTrakt: Boolean) {
+        // Capture the profile ID at event-time so all downstream operations
+        // write to the correct profile's DataStore even if the user switches
+        // profiles during an async gap (e.g. launch(NonCancellable) in the
+        // player's saveWatchProgressInternal).
+        val profileId = profileManager.activeProfileId.value
+
         // Clear any CW dismiss keys for this series so it reappears in Continue Watching.
         if (progress.contentType.equals("series", ignoreCase = true) ||
             progress.contentType.equals("tv", ignoreCase = true)) {
@@ -902,9 +912,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
             optimisticContinueWatchingUpdates.tryEmit(completed)
             traktProgressService.applyOptimisticProgress(completed)
             // Save to local stores first so Nuvio Sync has the data even if Trakt fails.
-            watchProgressPreferences.markAsCompleted(progress)
+            watchProgressPreferences.markAsCompleted(progress, profileId = profileId)
             val watchedItem = progress.toWatchedItem(watchedAt = now)
-            watchedItemsPreferences.markAsWatched(watchedItem)
+            watchedItemsPreferences.markAsWatched(watchedItem, profileId = profileId)
             runCatching {
                 if (syncRemoteToTrakt) {
                     traktProgressService.markAsWatched(
@@ -923,12 +933,12 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
             // Mirror to Nuvio Sync so data is ready if user switches source later.
             triggerRemoteSync()
-            triggerWatchedItemsSync(listOf(watchedItem))
+            triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
             return
         }
-        watchProgressPreferences.markAsCompleted(progress)
+        watchProgressPreferences.markAsCompleted(progress, profileId = profileId)
         val watchedItem = progress.toWatchedItem()
-        watchedItemsPreferences.markAsWatched(watchedItem)
+        watchedItemsPreferences.markAsWatched(watchedItem, profileId = profileId)
         if (hasEffectiveTraktConnection && syncRemoteToTrakt) {
             val now = System.currentTimeMillis()
             val duration = progress.duration.takeIf { it > 0L } ?: 1L
@@ -950,11 +960,15 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
         }
         triggerRemoteSync()
-        triggerWatchedItemsSync(listOf(watchedItem))
+        triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
     }
 
     override suspend fun markAsCompletedBatch(progressList: List<WatchProgress>) {
         if (progressList.isEmpty()) return
+        // Capture the profile ID at event-time so all downstream operations
+        // write to the correct profile's DataStore even if the user switches
+        // profiles during any asynchronous gap.
+        val profileId = profileManager.activeProfileId.value
         val firstProgress = progressList.first()
         // Clear CW dismiss keys once for the series
         if (firstProgress.contentType.equals("series", ignoreCase = true) ||
@@ -990,19 +1004,19 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 throw it
             }
             // Also save locally for offline access
-            watchProgressPreferences.markAsCompletedBatch(progressList)
+            watchProgressPreferences.markAsCompletedBatch(progressList, profileId = profileId)
             val watchedItems = progressList.map { progress -> progress.toWatchedItem(watchedAt = now) }
-            watchedItemsPreferences.markAsWatchedBatch(watchedItems)
+            watchedItemsPreferences.markAsWatchedBatch(watchedItems, profileId = profileId)
             // Mirror to Nuvio Sync so data is ready if user switches source later.
             triggerRemoteSync()
-            triggerWatchedItemsSync(watchedItems)
+            triggerWatchedItemsSync(watchedItems, profileId = profileId)
             return
         }
 
         // Nuvio sync is primary — batch local save first
-        watchProgressPreferences.markAsCompletedBatch(progressList)
+        watchProgressPreferences.markAsCompletedBatch(progressList, profileId = profileId)
         val watchedItems = progressList.map { progress -> progress.toWatchedItem(watchedAt = now) }
-        watchedItemsPreferences.markAsWatchedBatch(watchedItems)
+        watchedItemsPreferences.markAsWatchedBatch(watchedItems, profileId = profileId)
 
         // Mirror to Trakt if connected (same as single markAsCompleted)
         if (hasEffectiveTraktConnection) {
@@ -1015,7 +1029,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
         }
 
         triggerRemoteSync()
-        triggerWatchedItemsSync(watchedItems)
+        triggerWatchedItemsSync(watchedItems, profileId = profileId)
     }
 
     private fun WatchProgress.toWatchedItem(watchedAt: Long = System.currentTimeMillis()): WatchedItem =

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -140,7 +140,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
             if (batch.isEmpty()) return@launch
             withContext(NonCancellable) {
-                watchedItemsSyncService.pushItemsToRemote(batch)
+                watchedItemsSyncService.pushItemsToRemote(batch, profileId = profileId)
             }
         }
     }
@@ -709,7 +709,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             } else {
                 traktProgressService.updateOptimisticProgressQuietly(progress)
             }
-            watchProgressPreferences.saveProgress(progress)
+            watchProgressPreferences.saveProgress(progress, profileId = profileId)
             if (progress.isCompleted()) {
                 val watchedItem = progress.toWatchedItem()
                 watchedItemsPreferences.markAsWatched(watchedItem, profileId = profileId)
@@ -728,7 +728,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
             return
         }
-        watchProgressPreferences.saveProgress(progress)
+        watchProgressPreferences.saveProgress(progress, profileId = profileId)
 
         if (syncRemote && authManager.isAuthenticated) {
             syncScope.launch(NonCancellable) {
@@ -757,7 +757,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     traktProgressService.applyOptimisticProgress(progress)
                 }
             }
-            watchProgressPreferences.saveProgressBatch(progressList)
+            watchProgressPreferences.saveProgressBatch(progressList, profileId = profileId)
             // Mirror to Nuvio Sync so data is ready if user switches source later.
             if (syncRemote && authManager.isAuthenticated) {
                 triggerRemoteSync()
@@ -765,7 +765,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             return
         }
 
-        watchProgressPreferences.saveProgressBatch(progressList)
+        watchProgressPreferences.saveProgressBatch(progressList, profileId = profileId)
 
         if (syncRemote && authManager.isAuthenticated) {
             triggerRemoteSync()
@@ -783,9 +783,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun removeProgress(contentId: String, season: Int?, episode: Int?) {
+        val profileId = profileManager.activeProfileId.value
         val useTraktProgress = shouldUseTraktProgress()
         val hasEffectiveTraktConnection = hasEffectiveTraktConnection()
-        val remoteDeleteKeys = resolveRemoteDeleteKeys(contentId, season, episode)
+        val remoteDeleteKeys = resolveRemoteDeleteKeys(contentId, season, episode, profileId = profileId)
         if (hasEffectiveTraktConnection) {
             traktProgressService.applyOptimisticRemoval(contentId, season, episode)
             traktProgressService.removeProgress(contentId, season, episode)
@@ -812,9 +813,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun removeFromHistory(contentId: String, videoId: String?, season: Int?, episode: Int?) {
+        val profileId = profileManager.activeProfileId.value
         val useTraktProgress = shouldUseTraktProgress()
         val remoteDeleteKeys = if (!useTraktProgress) {
-            resolveRemoteDeleteKeys(contentId, season, episode)
+            resolveRemoteDeleteKeys(contentId, season, episode, profileId = profileId)
         } else {
             emptyList()
         }
@@ -822,7 +824,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             traktProgressService.removeFromHistory(contentId, videoId, season, episode)
         }
         watchProgressPreferences.removeProgress(contentId, season, episode)
-        watchedItemsPreferences.unmarkAsWatched(contentId, season, episode)
+        watchedItemsPreferences.unmarkAsWatched(contentId, season, episode, profileId = profileId)
         if (useTraktProgress) {
             return
         }
@@ -847,12 +849,13 @@ class WatchProgressRepositoryImpl @Inject constructor(
         episodes: List<Pair<Int, Int>>
     ) {
         if (episodes.isEmpty()) return
+        val profileId = profileManager.activeProfileId.value
         val useTraktProgress = shouldUseTraktProgress()
         val hasEffectiveTraktConnection = hasEffectiveTraktConnection()
 
         // Batch local removes (single DataStore transaction each)
         watchProgressPreferences.removeProgressBatch(contentId, episodes)
-        watchedItemsPreferences.unmarkAsWatchedBatch(contentId, episodes)
+        watchedItemsPreferences.unmarkAsWatchedBatch(contentId, episodes, profileId = profileId)
 
         // Batch Trakt remove (single API call)
         if (hasEffectiveTraktConnection) {
@@ -1126,9 +1129,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
     private suspend fun resolveRemoteDeleteKeys(
         contentId: String,
         season: Int?,
-        episode: Int?
+        episode: Int?,
+        profileId: Int = profileManager.activeProfileId.value
     ): List<String> {
-        val rawEntries = watchProgressPreferences.getAllRawEntries()
+        val rawEntries = watchProgressPreferences.getAllRawEntries(profileId)
         val keys = if (season != null && episode != null) {
             listOf("${contentId}_s${season}e${episode}", contentId)
         } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -697,7 +697,7 @@ class AccountViewModel @Inject constructor(
         addonSyncService.pushToRemote()
         watchProgressSyncService.pushToRemote(profileId)
         librarySyncService.pushToRemote()
-        watchedItemsSyncService.pushToRemote()
+        watchedItemsSyncService.pushToRemote(profileId)
     }
 
     private suspend fun pullRemoteData(): Result<Unit> {
@@ -725,8 +725,8 @@ class AccountViewModel @Inject constructor(
 
             val isTraktConnected = traktAuthDataStore.isEffectivelyAuthenticated.first()
             val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
-            watchProgressSyncService.restoreLastPushTimestamp()
-            watchedItemsSyncService.restoreLastPushTimestamp()
+            watchProgressSyncService.restoreLastPushTimestamp(profileId)
+            watchedItemsSyncService.restoreLastPushTimestamp(profileId)
             Log.d(
                 "AccountViewModel",
                 "pullRemoteData: isTraktConnected=$isTraktConnected shouldUseSupabaseWatchProgressSync=$shouldUseSupabaseWatchProgressSync"
@@ -760,7 +760,7 @@ class AccountViewModel @Inject constructor(
                 Log.d("AccountViewModel", "pullRemoteData: watched items sync applied ${watchedItemsResult.upsertedItems} upserts and ${watchedItemsResult.deletedItems} deletes (snapshot=${watchedItemsResult.usedSnapshot})")
                 if (watchedItemsResult.preservedLocalItems) {
                     Log.d("AccountViewModel", "pullRemoteData: detected unsynced watched items, pushing")
-                    watchedItemsSyncService.pushToRemote()
+                    watchedItemsSyncService.pushToRemote(profileId)
                 }
             } else if (shouldUseSupabaseWatchProgressSync) {
                 watchProgressRepository.isSyncingFromRemote = true
@@ -774,7 +774,7 @@ class AccountViewModel @Inject constructor(
                 Log.d("AccountViewModel", "pullRemoteData: watched items sync applied ${watchedItemsResult.upsertedItems} upserts and ${watchedItemsResult.deletedItems} deletes in Trakt mode (snapshot=${watchedItemsResult.usedSnapshot})")
                 if (watchedItemsResult.preservedLocalItems) {
                     Log.d("AccountViewModel", "pullRemoteData: detected unsynced watched items in Trakt mode, pushing")
-                    watchedItemsSyncService.pushToRemote()
+                    watchedItemsSyncService.pushToRemote(profileId)
                 }
             }
             return Result.success(Unit)


### PR DESCRIPTION
## Summary

Fixes a critical multi-profile isolation bug where watched history and Continue Watching data from one profile could contaminate another profile's data.

**Root cause:** Several methods in the watch-progress pipeline read profileManager.activeProfileId.value lazily after async gaps (coroutine launches, withContext(Dispatchers.IO), delay). When the user switches profiles during one of these gaps, the stale coroutine writes data to the wrong profile.

Additionally, TraktCredentialSyncService.pushCurrentToRemote could push one profile's Trakt credentials under another profile's ID, and TraktProgressService.refreshRemoteSnapshot had no guard against cancelled-but-still-running async HTTP writes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Multiple-profile support shipped without proper isolation in watched-history and Trakt credential sync paths. Users with two profiles each connected to a different Trakt account would see the main profile's history contaminated with items watched on Profile 2.

3 race conditions were identified and fixed:

1. WatchProgressRepositoryImpl.markAsCompleted called from the player's launch(NonCancellable) coroutine never captured profileId at event time. A profile switch before execution caused watched items to be written to the wrong profile.

2. TraktCredentialSyncService.pushCurrentToRemote read auth state via getCurrentState (profile X) then relit profileManager.activeProfileId.value inside withContext(Dispatchers.IO) (profile Y), pushing credentials under the wrong profile_id.

3. TraktProgressService.refreshRemoteSnapshot collectLatest cancelled the coroutine on profile switch, but child async HTTP requests continued executing and wrote stale data to remoteProgress.value.

## Issue or approval

Fixes multi-profile isolation regression.

## Reproduction steps

1. Create two profiles, each connected to a different Trakt account
2. Watch content to completion on Profile 2
3. Switch to Profile 1
4. Profile 1's watched history now contains items from Profile 2

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR is small, focused, and limited to one issue.
- [x] I listed the testing performed below.

## Scope boundaries

Only modifies profile-ID capture and propagation. All new parameters default to profileManager.activeProfileId.value for backward compatibility.

## Testing

Verified all callers compile with new optional profileId parameters. Code review by two independent sub-agents. TraktProgressService refresh guarded by a generation counter.

## Breaking changes

None.

## Linked issues

No linked issue.