### PR TITLE
fix(audio): stabilise passthrough on Android TV (disable focus handli…

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -872,7 +872,13 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setUsage(C.USAGE_MEDIA)
                     .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
                     .build()
-                setAudioAttributes(audioAttributes, true)
+                // On Android TV, disable audio focus handling so transient focus/volume
+                // events can't force passthrough (Atmos/TrueHD/DTS-HD) to decode to PCM.
+                // Keep focus handling on phones/tablets, where ducking/pausing for calls
+                // and other apps' audio matters. (NuvioTV runs on both form factors.)
+                val handleAudioFocus = !context.packageManager
+                    .hasSystemFeature(android.content.pm.PackageManager.FEATURE_LEANBACK)
+                setAudioAttributes(audioAttributes, handleAudioFocus)
                 setPlaybackSpeed(_uiState.value.playbackSpeed)
                 if (applyPcmFallbackOnStartup) {
                     pendingAudioPcmFallbackRebuild = false
@@ -1914,7 +1920,28 @@ private class SubtitleOffsetRenderersFactory(
         enableFloatOutput: Boolean,
         enableAudioTrackPlaybackParams: Boolean
     ): AudioSink {
-        val builder = DefaultAudioSink.Builder(context)
+        // On Android TV, pin audio capabilities so background audio-device changes
+        // (e.g. a Bluetooth remote idling then reinitialising) can't make the sink
+        // renegotiate and drop passthrough to PCM. On phones/tablets, keep the live
+        // AudioCapabilitiesReceiver — headphone/Bluetooth/routing changes are common
+        // there and must be handled dynamically. (NuvioTV runs on both form factors.)
+        val isTelevision =
+            context.packageManager.hasSystemFeature(android.content.pm.PackageManager.FEATURE_LEANBACK)
+        val builder = (if (isTelevision) {
+            // No Context => no live AudioCapabilitiesReceiver. Probe capabilities once
+            // (with the MEDIA/MOVIE attributes playback uses) and pin them, as Kodi/VLC
+            // do. Trade-off: no adaptation if the output device genuinely changes
+            // mid-playback, and a cold AVR wake-up may be probed before it reports
+            // passthrough (recovers on the next play).
+            val probeAttributes = AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                .build()
+            DefaultAudioSink.Builder()
+                .setAudioCapabilities(AudioCapabilities.getCapabilities(context, probeAttributes, null))
+        } else {
+            DefaultAudioSink.Builder(context)
+        })
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
             .setAudioProcessors(arrayOf(gainAudioProcessor))


### PR DESCRIPTION
## Summary
On the Android TV form factor only, keeps compressed-audio passthrough (Dolby Atmos/TrueHD, DTS-HD/DTS:X) from silently falling back to PCM mid-playback. Two independent causes are addressed: (1) ExoPlayer audio-focus handling is disabled so focus-driven ducking can't force a bitstream to PCM, and (2) audio capabilities are probed once at playback start and pinned, so a background audio-device change can't trigger a mid-playback renegotiation to PCM. Both are guarded behind `hasSystemFeature(FEATURE_LEANBACK)` — phones/tablets are unchanged.

## PR type
<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why
Passthrough dropping to PCM breaks lossless/object audio (Atmos/TrueHD/DTS-HD/DTS:X) — the AV receiver/soundbar re-locks to stereo PCM and the user loses the format entirely, mid-playback, with no indication. Two distinct triggers cause it on Android TV boxes:
1. **Focus ducking:** with `handleAudioFocus=true`, a transient audio-focus/volume event triggers ducking, which applies a software volume multiplier. That can't be applied to a compressed bitstream, so `DefaultAudioSink` falls back to PCM decoding.
2. **Capability renegotiation:** the live `AudioCapabilitiesReceiver` re-queries device audio capabilities on any audio-device change — including a Bluetooth remote (near-universal on TV boxes) idling to save battery and then reinitialising. If the HAL transiently reports capabilities without the passthrough encoding during that transition, `DefaultAudioSink` renegotiates the track and drops passthrough to PCM.

Kodi and VLC avoid both on Android by not handling audio focus and not subscribing to device-change events; this PR brings the same behaviour to NuvioTV's TV form factor while leaving mobile untouched (where focus handling and dynamic device adaptation are required).

## Issue or approval
No linked issue — reporting/reproduction was via the Discord community rather than a filed GitHub issue. Happy to open a tracking issue if preferred before review.

## Reproduction steps
1. Android TV box outputting bitstream passthrough to an AVR/soundbar (e.g. a title with Dolby TrueHD, Dolby Digital Plus, or DTS-HD MA), with an AVR that displays the active codec.
2. Start playback and confirm the AVR shows the compressed format (e.g. "Dolby TrueHD" / "DTS-HD MA").
3. Trigger either path:
   - **Focus:** let another app produce a transient sound / focus change, or a system audio event fire.
   - **Capability change:** leave the Bluetooth remote idle for a few minutes so it enters low-power/standby and then reinitialises (e.g. on the next button press).
4. Observe the AVR switch from the compressed format to "PCM 2.0" and the audio degrade, without stopping playback.
With this change (on a TV device), passthrough is retained through both events.

## UI / behavior impact
<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
- Guarded to the Android TV

## Testing
- **Ugoos AM6B+** Confirmed passthrough (DTS-HD MA / TrueHD) is retained through the Bluetooth-remote idle/reinitialise cycle that previously dropped it to PCM.
- Built via `./gradlew assembleFullRelease` (armeabi-v7a); installed and verified on the above.