### PR TITLE
Fix: Trakt Continue Watching Regression

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1762,8 +1762,11 @@ class TraktProgressService @Inject constructor(
         }
         val season = progress.season ?: return false
         val episode = progress.episode ?: return false
-        if (keys.any { it in fullyWatchedSeries }) return true
         val episodeKey = season to episode
+        if (keys.any { it in fullyWatchedSeries } &&
+            keys.any { key -> watchedEpisodes[key]?.contains(episodeKey) == true }) {
+            return true
+        }
         return keys.any { key -> watchedEpisodes[key]?.contains(episodeKey) == true }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1750,6 +1750,7 @@ class TraktProgressService @Inject constructor(
         watchedEpisodes: Map<String, Set<Pair<Int, Int>>>,
         fullyWatchedSeries: Set<String>
     ): Boolean {
+        if (progress.isInProgress()) return false
         val keys = progressLookupKeys(progress)
         if (progress.contentType.equals("movie", ignoreCase = true)) {
             return keys.any { it in watchedMovies }


### PR DESCRIPTION
## Summary
Fixes movies/episodes with watched history not appearing in Continue Watching. `isKnownWatchedPlayback()` suppressed any Trakt playback entry with prior watch history, without checking if it was still in progress.

Fixes new episodes of fully-watched series not appearing in Continue Watching automatically.

## PR type
<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix
<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why
Movies/episodes that had ever been marked watched on Trakt were being silently dropped from Continue Watching, even when actively being rewatched or freshly resumed in Nuvio. This makes resume/progress tracking broken for a large chunk of previously-watched content.

For ongoing series that were already fully watched, a newly released episode should appear in Continue Watching on its own. The show-level `fullyWatchedSeries` check was blocking this from happening.

## Issue or approval
Fixes regression introduced in commit b211f46. Reported Issue #2597.

## Reproduction steps
Bug 1
1. Mark a movie as watched on Trakt (or have prior watch history for it).
2. Start playing it again in Nuvio and stop partway through (in-progress playback saved to Trakt).
3. The movie does not appear in Continue Watching, despite valid in-progress playback data.

Bug 2
1. Watch every currently-released episode of an ongoing series.
2. The show gets added to `watchedSeriesStateHolder` as fully watched.
3. A new episode is released.
4. The new episode does not appear in Continue Watching, and the show remains excluded entirely.

## UI / behavior impact
<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.
> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries
Both fixes are contained entirely within `isKnownWatchedPlayback()` in `TraktProgressService.kt`. No UI polish, no refactors, no unrelated cache/logic changes.

## Testing
Manually verified on a Fire TV Stick 4K:
- Rewatched a previously-watched movie, stopped partway through, confirmed it now appears in Continue Watching.
- Confirmed previously-completed (not in-progress) entries are still correctly suppressed.
- On a series already marked fully watched, confirmed a newly released episode now appears in Continue Watching on its own.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Regression identified via code review of commit b211f46. Reported Issue #2597.