### PR TITLE
Update upstream for Parental Guidance

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -323,7 +323,7 @@ object NetworkModule {
     @Named("parentalGuide")
     fun provideParentalGuideRetrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit =
         Retrofit.Builder()
-            .baseUrl("https://api.imdbapi.dev/")
+            .baseUrl("https://api.tiffara.com/")
             .client(okHttpClient)
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()


### PR DESCRIPTION
## Summary

Updated Parental Guidance upstream due to domain change. 

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [X] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

Due to a change in the upstream domain for the Parental Guidance api, this information was no longer being fetched and returned

## Issue or approval

Fixes #2614

## Reproduction steps

Open an item known to have parental guidance information (Shawshank Redemption as a test).

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This fix ix limited to the baseUrl for the Parental Guidance api

## Testing

Created a debug build with the fix applied and tested an item known to have parental guidance information (Shawshank Redemption as a test).

## Screenshots / Video

<img width="1920" height="1080" alt="IMG_2493" src="https://github.com/user-attachments/assets/03a53058-4d50-440e-b891-f57a89a2c3a5" />


## Breaking changes

None

## Linked issues

https://github.com/NuvioMedia/NuvioTV/issues/2614
