### PR TITLE
fix(player): preserve Sources panel D-pad focus when a late addon reshuffles the list

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -198,6 +198,19 @@ internal fun StreamSourcesSidePanel(
                     val initialFocusStream = uiState.sourceFilteredStreams.getOrNull(currentStreamIndex)
                         ?: uiState.sourceFilteredStreams.firstOrNull()
 
+                    // Occurrence-counted keys: keying by list index made every key change
+                    // when a later addon's results reshuffled the list, disposing all rows
+                    // (including the focused one) and killing D-pad focus.
+                    val streamKeys = remember(uiState.sourceFilteredStreams) {
+                        val seen = mutableMapOf<String, Int>()
+                        uiState.sourceFilteredStreams.map { stream ->
+                            val base = stream.stableKey(0)
+                            val count = seen.getOrDefault(base, 0)
+                            seen[base] = count + 1
+                            stream.stableKey(count)
+                        }
+                    }
+
                     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
 
                     LazyColumn(
@@ -235,8 +248,8 @@ internal fun StreamSourcesSidePanel(
                                 }
                             }
                     ) {
-                        itemsIndexed(uiState.sourceFilteredStreams, key = { index, stream ->
-                            stream.stableKey(index)
+                        itemsIndexed(uiState.sourceFilteredStreams, key = { index, _ ->
+                            streamKeys[index]
                         }) { index, stream ->
                             StreamItem(
                                 stream = stream,


### PR DESCRIPTION
## Summary

The in-player Sources panel keyed its `LazyColumn` rows by `stableKey(index)`. When a slower, higher-priority addon's results arrived after the panel was already open, `orderAddonStreams` re-sorted the list and prepended the new streams, so every row's key changed. Compose disposed and recreated all rows — including the focused one — leaving the panel with a dead D-pad until the user backed out and reopened.

This keys each row by an **occurrence-counted** `stableKey` instead, so a row's key no longer depends on its position. Rows keep their identity across the reshuffle and focus is preserved. This matches `stableKey`'s own KDoc contract, where `occurrence` is documented as a duplicate-disambiguator, not a list index.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Regression-class focus bug reported and reproduced in #2612. On Android TV, opening the Sources panel during playback with 2+ addons where the higher-priority addon responds slower leaves the panel completely unnavigable on first open — no D-pad input registers at all, and the only recovery is Back + reopen. Source selection is a core playback flow, so this makes it look broken.

## Issue or approval

Fixes #2612

## Reproduction steps

1. Install 2+ addons where the higher-priority one responds slower (repro'd with AIOStreams + EasyNews; AIOStreams aggregates several providers so it responds a bit later and sorts above the already-shown results).
2. Start playing anything.
3. Open player controls, then Sources (cloud icon).
4. The list is usable for ~1–2s while only the fast addon's results show; the moment the slower higher-priority addon's results are inserted and the list reshuffles, focus dies.
5. Try to navigate with the D-pad: nothing registers. Only Back works. Reopening the panel works normally every time.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI changed only to fix a documented glitch/bug
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Touches only `StreamSourcesSidePanel.kt` (the in-player Sources panel), which is the exact surface reported in #2612.
- `StreamScreen.kt` uses the same `stableKey(index)` pattern and likely has the same latent issue, but it is intentionally left out of this PR to keep the change minimal and single-purpose. Happy to follow up on it separately, or fold it in here if you'd prefer.
- No UI polish, no refactors, no behavior changes beyond restoring focus survival.

## Testing

- Built the patched tree: `./gradlew :app:assembleFullDebug` — BUILD SUCCESSFUL.
- Installed the patched Full debug APK on the same device/addon setup as the report (Google TV Streamer 4K, Android 14, internal player, AIOStreams + EasyNews) and confirmed the fix: opening the Sources panel during playback now keeps D-pad focus through the AIOStreams reshuffle. Source selection works immediately on first open — no more backing out and reopening. Repeated the flow several times.
- Before the fix, reproduced the bug on the same device exactly as described in #2612: first Sources-panel open during playback goes focus-dead the instant the slower higher-priority addon's results reshuffle the list; in-panel Reload does **not** reproduce it (focus sits on the always-composed Reload header button during the re-fetch).
- Verified against `stableKey`'s definition: the key is built from addon + content identity + `occurrence`, with no list position, so occurrence-counted keys are position-independent and identical rows still get distinct keys.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2612
