### PR TITLE
fix: collection folder hero videos ignore the "Play Trailer Muted" setting (always muted)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -721,8 +721,8 @@ fun ModernHomeContent(
             val shouldPlayHeroTrailerState = remember(shouldPlayCatalogHeroTrailerState, shouldPlayCollectionHeroVideoState) {
                 derivedStateOf { shouldPlayCatalogHeroTrailerState.value || shouldPlayCollectionHeroVideoState.value }
             }
-            val heroMediaMutedState = remember(shouldPlayCollectionHeroVideoState, uiState.focusedPosterBackdropTrailerMuted) {
-                derivedStateOf { shouldPlayCollectionHeroVideoState.value || uiState.focusedPosterBackdropTrailerMuted }
+            val heroMediaMutedState = remember(uiState.focusedPosterBackdropTrailerMuted) {
+                derivedStateOf { uiState.focusedPosterBackdropTrailerMuted }
             }
             var heroTrailerFirstFrameRendered by remember { mutableStateOf(false) }
             LaunchedEffect(heroMediaDataState.value.third) {


### PR DESCRIPTION
## Summary

Collection folder hero videos (`heroVideoUrl`) were always played muted: the mute flag was hard-coded in `ModernHomeContent.kt`, ignoring the user's "Play Trailer Muted" preference even for MP4 files with a valid audio track. This PR removes the hard-coded mute so collection hero videos follow the same existing user setting as catalog hero trailers. Default behavior is unchanged ("Play Trailer Muted" defaults to on, so collection hero videos stay muted out of the box).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`heroMediaMutedState` was derived as `shouldPlayCollectionHeroVideoState.value || uiState.focusedPosterBackdropTrailerMuted`. The first term forces `trailerMuted = true` whenever a collection hero video plays, regardless of the user preference. Downstream (`ModernHeroSceneState.trailerMuted` → `ModernHomeHero` → `TrailerPlayer`), the player applies `player.volume = if (muted) 0f else 1f`, so the video is always silent. Users who configure a custom hero video for a collection folder and turn off "Play Trailer Muted" expect to hear its audio, exactly like catalog trailers. This is the only code path forcing the mute: all other uses of `shouldPlayCollectionHeroVideoState` handle URL/playback-key selection and end-of-playback, not audio.

## Issue or approval

Fixes #2623

## Reproduction steps

1. Edit a collection folder and set a hero video URL pointing to an MP4 with a valid audio track (e.g. AAC).
2. In Settings → Layout, enable trailer autoplay and uncheck "Play Trailer Muted".
3. On the home screen, focus the collection folder and wait for the hero video to start.
4. Expected: the video plays with audio, like catalog hero trailers. Actual: the video is always silent.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No new setting is added: collection hero videos reuse the existing "Play Trailer Muted" preference, which defaults to muted, so out-of-the-box behavior is unchanged. If a dedicated setting for collection hero video audio is preferred instead, I'm happy to rework it that way.
- The conditions deciding *when* a collection hero video plays (`shouldPlayCollectionHeroVideoState`) are untouched: playback still stops on scroll, sidebar expansion, or focus loss — the `TrailerPlayer` leaves the composition and `TrailerPlayerPool.stop()` is called, so no audio lingers after unfocus.
- No UI polish or other behavior tweaks are included; the diff is limited to two lines in `ModernHomeContent.kt`.

## Testing

- `./gradlew :app:compileFullDebugKotlin` passes (fullDebug variant).
- Verified the full audio code path by inspection: `heroMediaMutedState` is the only source of `ModernHeroSceneState.trailerMuted`, which `TrailerPlayer` applies as `player.volume = if (muted) 0f else 1f`; no other code path forces the mute for collection hero videos (the only other use of `shouldPlayCollectionHeroVideoState` handles end-of-playback).
- Verified stop-on-unfocus is unaffected: when the folder loses focus or scrolling starts, `shouldPlayCollectionHeroVideoState` turns false, the `TrailerPlayer` leaves the composition and `TrailerPlayerPool.stop()` runs (`playWhenReady = false` + `stop()` + `clearMediaItems()`), so no audio can linger.
- Default behavior is unchanged by construction: "Play Trailer Muted" defaults to true, so collection hero videos stay muted unless the user opts in to trailer audio. Manual device test (Ugoos AM9 PRO, Android 14) planned; will report results on this PR.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2623
