### PR TITLE
fix: collection folder hero videos are over-zoomed by the YouTube trailer overscan

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -739,6 +739,7 @@ fun ModernHomeContent(
             val liveHeroSceneState = remember(
                 resolvedHeroState,
                 shouldPlayHeroTrailerState,
+                shouldPlayCollectionHeroVideoState,
                 heroMediaDataState,
                 heroMediaMutedState,
                 fullScreenBackdrop
@@ -757,6 +758,13 @@ fun ModernHomeContent(
                         trailerAudioUrl = heroMediaAudioUrl,
                         trailerPlaybackKey = heroMediaPlaybackKey,
                         trailerMuted = heroMediaMutedState.value,
+                        // Collection hero videos are clean MP4 files; the overscan zoom only
+                        // exists to hide the black borders of YouTube trailer streams.
+                        trailerOverscanZoom = if (shouldPlayCollectionHeroVideoState.value) {
+                            1f
+                        } else {
+                            MODERN_TRAILER_OVERSCAN_ZOOM
+                        },
                         fullScreenBackdrop = fullScreenBackdrop
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -89,6 +89,7 @@ internal fun ModernHeroScene(
         heroTrailerAudioUrl = { state().trailerAudioUrl },
         heroTrailerPlaybackKey = { state().trailerPlaybackKey },
         muted = { state().trailerMuted },
+        trailerOverscanZoom = { state().trailerOverscanZoom },
         onTrailerEnded = onTrailerEnded,
         onFirstFrameRendered = onFirstFrameRendered,
         modifier = modifier,
@@ -112,6 +113,7 @@ internal fun ModernHeroMediaLayer(
     heroTrailerAudioUrl: () -> String?,
     heroTrailerPlaybackKey: () -> String?,
     muted: () -> Boolean,
+    trailerOverscanZoom: () -> Float,
     onTrailerEnded: () -> Unit,
     onFirstFrameRendered: () -> Unit,
     modifier: Modifier,
@@ -176,6 +178,7 @@ internal fun ModernHeroMediaLayer(
             val playbackKeyVal = heroTrailerPlaybackKey()
             val audioUrlVal = heroTrailerAudioUrl()
             val mutedVal = muted()
+            val overscanZoomVal = trailerOverscanZoom()
             key(playbackKeyVal ?: trailerUrlVal) {
                 TrailerPlayer(
                     trailerUrl = trailerUrlVal,
@@ -185,7 +188,7 @@ internal fun ModernHeroMediaLayer(
                     onFirstFrameRendered = onFirstFrameRendered,
                     muted = mutedVal,
                     cropToFill = true,
-                    overscanZoom = MODERN_TRAILER_OVERSCAN_ZOOM,
+                    overscanZoom = overscanZoomVal,
                     modifier = Modifier
                         .fillMaxSize()
                         .graphicsLayer {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -161,6 +161,7 @@ internal data class ModernHeroSceneState(
     val trailerAudioUrl: String?,
     val trailerPlaybackKey: String?,
     val trailerMuted: Boolean,
+    val trailerOverscanZoom: Float,
     val fullScreenBackdrop: Boolean
 )
 


### PR DESCRIPTION
## Summary

Collection folder hero videos (`heroVideoUrl`) were rendered with the +35% overscan zoom (`MODERN_TRAILER_OVERSCAN_ZOOM = 1.35f`) that exists to hide the black borders of YouTube trailer streams. Collection hero videos are clean MP4 files without borders, so the extra zoom cropped away a large part of the frame. This PR propagates the existing collection-video signal to the hero player and uses `overscanZoom = 1f` for collection hero videos, keeping `1.35f` for YouTube trailers and `cropToFill = true` (fill the hero container) in both cases.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`ModernHomeHero.kt` unconditionally passed `overscanZoom = MODERN_TRAILER_OVERSCAN_ZOOM` to the hero `TrailerPlayer`. That overscan is a workaround for YouTube trailer streams, which carry black borders; applying it to clean user-provided MP4 files over-zooms the image so much that a significant part of the frame is lost, making the collection hero video feature look broken. `ModernHomeContent.kt` already knows whether the hero is playing a collection video (`shouldPlayCollectionHeroVideoState`), so the fix is to carry that information through `ModernHeroSceneState` (new `trailerOverscanZoom` field, computed next to the other hero media fields) down to the `TrailerPlayer` call. The card trailer player (`ModernHomeRows.kt`) is untouched: it only ever plays YouTube catalog trailers (collection folders render GIFs there), so its overscan remains correct. The hero `TrailerPlayer` call also serves the full-screen backdrop mode, so both hero layouts are covered by the same change.

## Issue or approval

Fixes #2625

## Reproduction steps

1. Edit a collection folder and set a hero video URL pointing to a clean 16:9 MP4 (no black borders).
2. On the home screen, focus the collection folder and wait for the hero video to start playing.
3. Compare the rendered video with the source file.
4. Expected: the video fills the hero container without extra zoom. Actual: the video is scaled up by an extra 35% and heavily cropped on every side.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- YouTube trailer rendering is unchanged: catalog hero trailers and expanded-card trailers keep the 1.35f overscan, and `cropToFill = true` stays on for all hero media.
- `TrailerPlayer.kt` is untouched — its `overscanZoom` parameter already defaults to no zoom; only the value passed by the hero changes.
- No settings, strings, or other UI are added or modified.

## Testing

- `./gradlew :app:compileFullDebugKotlin` passes (fullDebug variant).
- Verified by inspection that the hero `TrailerPlayer` call in `ModernHomeHero.kt` is the only place collection hero videos are rendered (the card player in `ModernHomeRows.kt` only receives YouTube catalog trailer URLs; collection folders render GIFs on cards), and that the same call serves both the standard hero and the full-screen backdrop mode.
- The new `ModernHeroSceneState.trailerOverscanZoom` field has no default value, so the compiler guarantees every construction site sets it (there is exactly one).

## Screenshots / Video

No screenshots attached: the change removes the extra 35% zoom on collection folder hero videos in the home hero (about a third of the frame was cropped away before). Happy to provide before/after captures on request.

## Breaking changes

None.

## Linked issues

Fixes #2625
