### PR TITLE
Fix watched badge on still-airing series and new episodes disappearing from Continue Watching

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -37,7 +37,9 @@ class WatchedSeriesStateHolder @Inject constructor(
         private val KEY = stringSetPreferencesKey("fully_watched_ids")
         private val REVALIDATE_KEY = stringPreferencesKey("revalidate_after")
         private val VALIDATION_RESET_KEY = intPreferencesKey("validation_reset_version")
-        private const val VALIDATION_RESET_VERSION = 1
+        // v2: re-validate every series once so shows that are still airing drop the
+        // premature "completed" badge they were given while caught up on aired episodes.
+        private const val VALIDATION_RESET_VERSION = 2
         private const val DEFAULT_TTL_MS = 7L * 24 * 60 * 60 * 1000 // 7 days
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -35,6 +35,7 @@ class WatchedSeriesStateHolder @Inject constructor(
     companion object {
         private const val FEATURE = "watched_series_cache"
         private val KEY = stringSetPreferencesKey("fully_watched_ids")
+        private val MANUAL_KEY = stringSetPreferencesKey("manually_marked_ids")
         private val REVALIDATE_KEY = stringPreferencesKey("revalidate_after")
         private val VALIDATION_RESET_KEY = intPreferencesKey("validation_reset_version")
         // v2: re-validate every series once so shows that are still airing drop the
@@ -48,6 +49,16 @@ class WatchedSeriesStateHolder @Inject constructor(
     private val _fullyWatchedSeriesIds = MutableStateFlow<Set<String>>(emptySet())
     val fullyWatchedSeriesIds: StateFlow<Set<String>> = _fullyWatchedSeriesIds.asStateFlow()
 
+    /**
+     * Series the user marked watched by hand. Derived badge evaluation must leave these alone:
+     * a still-airing series never earns the badge on its own, but saying so explicitly is a
+     * deliberate choice and outranks what the episode counts imply.
+     */
+    @Volatile
+    private var manuallyMarkedIds: Set<String> = emptySet()
+
+    fun isManuallyMarked(contentId: String): Boolean = contentId in manuallyMarkedIds
+
     /** Per-series revalidation deadline (contentId → epochMs when re-check is needed). */
     @Volatile
     private var revalidateAfterMap: Map<String, Long> = emptyMap()
@@ -59,6 +70,7 @@ class WatchedSeriesStateHolder @Inject constructor(
         if (loaded) return
         val prefs = store(profileId).data.first()
         val persisted = prefs[KEY] ?: emptySet()
+        manuallyMarkedIds = prefs[MANUAL_KEY] ?: emptySet()
         val resetVersion = prefs[VALIDATION_RESET_KEY] ?: 0
         if (resetVersion < VALIDATION_RESET_VERSION) {
             revalidateAfterMap = emptyMap()
@@ -80,6 +92,21 @@ class WatchedSeriesStateHolder @Inject constructor(
         val profileId = profileManager.activeProfileId.value
         scope.launch {
             store(profileId).edit { prefs -> prefs[KEY] = ids }
+        }
+    }
+
+    /**
+     * Record that the user marked these series watched by hand, so derived evaluation stops
+     * second-guessing the badge. [marked] false clears the override again.
+     */
+    @Synchronized
+    fun setManuallyMarked(ids: Set<String>, marked: Boolean) {
+        val updated = if (marked) manuallyMarkedIds + ids else manuallyMarkedIds - ids
+        if (updated == manuallyMarkedIds) return
+        manuallyMarkedIds = updated
+        val profileId = profileManager.activeProfileId.value
+        scope.launch {
+            store(profileId).edit { prefs -> prefs[MANUAL_KEY] = updated }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
@@ -85,6 +85,17 @@ data class Meta(
             .filter { it.season !in unavailableSeasons }
             .filter { it.available != false && !isFutureRelease(it.released) }
     }
+
+    /** Total episode entries (season > 0) the meta knows about, aired or not. */
+    fun totalEpisodeCount(): Int =
+        videos.count { it.season != null && it.episode != null && (it.season ?: 0) > 0 }
+
+    /**
+     * True when the series lists more episodes than are currently watchable, i.e. it still has
+     * episodes that have not aired yet. Such a series is still airing, so it must never be
+     * treated as "completed" even when every aired episode has been watched.
+     */
+    fun hasUpcomingEpisodes(): Boolean = totalEpisodeCount() > watchableEpisodes().size
 }
 
 /**

--- a/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
@@ -94,8 +94,12 @@ data class Meta(
      * True when the series lists more episodes than are currently watchable, i.e. it still has
      * episodes that have not aired yet. Such a series is still airing, so it must never be
      * treated as "completed" even when every aired episode has been watched.
+     *
+     * Pass [watchableCount] when [watchableEpisodes] was already computed: it parses a date per
+     * video, and callers on the main thread should not pay for that twice.
      */
-    fun hasUpcomingEpisodes(): Boolean = totalEpisodeCount() > watchableEpisodes().size
+    fun hasUpcomingEpisodes(watchableCount: Int = watchableEpisodes().size): Boolean =
+        totalEpisodeCount() > watchableCount
 }
 
 /**

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -386,6 +386,9 @@ class PosterOptionsController @Inject constructor(
     }
 
     private suspend fun markSeriesWatched(item: MetaPreview) {
+        // Marking by hand only covers aired episodes, which is indistinguishable from simply
+        // being caught up. Record the intent so badge evaluation does not strip it back off.
+        watchedSeriesStateHolder.setManuallyMarked(setOf(item.id), marked = true)
         val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
         if (episodes.isEmpty()) {
             watchProgressRepository.markAsCompleted(buildCompletedMovieProgress(item))
@@ -414,6 +417,7 @@ class PosterOptionsController @Inject constructor(
     }
 
     private suspend fun unmarkSeriesWatched(item: MetaPreview) {
+        watchedSeriesStateHolder.setManuallyMarked(setOf(item.id), marked = false)
         val episodes = fetchSeriesEpisodes(item).filter { it.season != null && it.episode != null && it.season != 0 }
         if (episodes.isEmpty()) {
             watchProgressRepository.removeFromHistory(item.id, videoId = item.imdbId)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1555,7 +1555,13 @@ class MetaDetailsViewModel @Inject constructor(
             meta.id.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
             itemId.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
         }
-        val updated = if (allWatched) current + allIds else current - allIds
+        // Watching every aired episode is not completion while the series is still releasing,
+        // so an airing show must not earn the badge here either.
+        val updated = if (allWatched && !meta.hasUpcomingEpisodes()) {
+            current + allIds
+        } else {
+            current - allIds
+        }
         if (updated != current) {
             watchedSeriesStateHolder.updateWithValidation(updated, allIds)
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1555,6 +1555,14 @@ class MetaDetailsViewModel @Inject constructor(
             meta.id.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
             itemId.takeIf { it.isNotBlank() && it != contentId }?.let { add(it) }
         }
+
+        if (watchedSeriesStateHolder.isManuallyMarked(contentId)) {
+            // Honour the user's own call while it still holds. Once they unwatch an episode the
+            // claim no longer does, so drop the override and let the derived rules take over.
+            if (allWatched) return
+            watchedSeriesStateHolder.setManuallyMarked(allIds, marked = false)
+        }
+
         // Watching every aired episode is not completion while the series is still releasing,
         // so an airing show must not earn the badge here either.
         val updated = if (allWatched && !meta.hasUpcomingEpisodes(episodes.size)) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1557,7 +1557,7 @@ class MetaDetailsViewModel @Inject constructor(
         }
         // Watching every aired episode is not completion while the series is still releasing,
         // so an airing show must not earn the badge here either.
-        val updated = if (allWatched && !meta.hasUpcomingEpisodes()) {
+        val updated = if (allWatched && !meta.hasUpcomingEpisodes(episodes.size)) {
             current + allIds
         } else {
             current - allIds

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -203,6 +203,8 @@ class HomeViewModel @Inject constructor(
     internal val cwBadgeEpisodeCache = Collections.synchronizedMap(mutableMapOf<String, Set<Pair<Int, Int>>?>())
     /** Per-series earliest upcoming season release date (epochMs) for smart TTL scheduling. */
     internal val cwBadgeNextSeasonMs = ConcurrentHashMap<String, Long>()
+    /** contentId → whether the series still has unaired/upcoming episodes (i.e. it is still airing). */
+    internal val cwBadgeHasUpcoming = ConcurrentHashMap<String, Boolean>()
     /** Snapshot of watchedShowEpisodes keys from the last badge evaluation cycle. */
     @Volatile
     internal var cwLastBadgeEpisodeKeys: Set<String> = emptySet()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -1035,6 +1035,12 @@ private fun HomeViewModel.reconcileFullyWatchedFromLocalItems(
     val cacheResolvedIds = mutableSetOf<String>()
     val cacheResolvedFullyWatched = buildSet {
         seriesContentIds.forEach { contentId ->
+            // Marked watched by hand: leave the badge exactly as the user set it.
+            if (fullyWatchedSeriesIds.isManuallyMarked(contentId)) {
+                if (contentId in fullyWatched) add(contentId)
+                cacheResolvedIds.add(contentId)
+                return@forEach
+            }
             val requiredEpisodes = synchronized(cwBadgeEpisodeCache) {
                 cwBadgeEpisodeCache["series:$contentId"] ?: cwBadgeEpisodeCache["tv:$contentId"]
             } ?: return@forEach

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -1040,7 +1040,14 @@ private fun HomeViewModel.reconcileFullyWatchedFromLocalItems(
             } ?: return@forEach
             cacheResolvedIds.add(contentId)
             val watchedEpisodes = watchedEpisodesByContentId[contentId].orEmpty()
-            if (requiredEpisodes.isNotEmpty() && requiredEpisodes.all { it in watchedEpisodes }) {
+            // Having watched every aired episode is not completion while the series is still
+            // releasing. Only badge when we positively know nothing is upcoming; absent means
+            // unknown, so fail safe and leave it unbadged.
+            val stillAiring = cwBadgeHasUpcoming[contentId] != false
+            if (requiredEpisodes.isNotEmpty() &&
+                requiredEpisodes.all { it in watchedEpisodes } &&
+                !stillAiring
+            ) {
                 add(contentId)
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -147,6 +147,18 @@ internal data class CwMetaSummary(
             }
             .minOrNull()
     }
+
+    /** Total episode entries (season > 0) the meta knows about, aired or not. */
+    fun totalEpisodeCount(): Int =
+        videos.count { it.season != null && it.episode != null && (it.season ?: 0) > 0 }
+
+    /**
+     * True when the series lists more episodes than are currently watchable, i.e. it still
+     * has episodes that have not aired/released yet (future-dated OR flagged unavailable).
+     * Such a series is still airing, so it must never be treated as "completed" even when
+     * every aired episode has been watched.
+     */
+    fun hasUpcomingEpisodes(): Boolean = totalEpisodeCount() > watchableEpisodes().size
 }
 
 internal data class CwVideoSummary(
@@ -1695,6 +1707,10 @@ private suspend fun HomeViewModel.buildNextUpItem(
                     cwBadgeEpisodeCache[cacheKey] = episodes
                 }
             }
+            // Must travel with the episode cache: publishBadgeUpdate reads this to decide
+            // "completed", and a missing entry would read as "not airing" and badge a series
+            // that is still releasing episodes.
+            cwBadgeHasUpcoming[progress.contentId] = cachedMeta.hasUpcomingEpisodes()
             cachedMeta.earliestUpcomingSeasonMs()?.let { ms ->
                 cwBadgeNextSeasonMs[progress.contentId] = ms
             }
@@ -2324,6 +2340,7 @@ private suspend fun HomeViewModel.resolveBadgeEpisodes(
         existingSummary.earliestUpcomingSeasonMs()?.let { ms ->
             cwBadgeNextSeasonMs[contentId] = ms
         }
+        cwBadgeHasUpcoming[contentId] = existingSummary.hasUpcomingEpisodes()
         synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = episodes }
         return episodes
     }
@@ -2358,6 +2375,7 @@ private suspend fun HomeViewModel.resolveBadgeEpisodes(
             summary.earliestUpcomingSeasonMs()?.let { ms ->
                 cwBadgeNextSeasonMs[contentId] = ms
             }
+            cwBadgeHasUpcoming[contentId] = summary.hasUpcomingEpisodes()
             synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = episodes }
             return episodes
         }
@@ -2578,6 +2596,7 @@ private fun HomeViewModel.publishBadgeUpdate(
     allWatchedEpisodes: Map<String, Set<Pair<Int, Int>>>
 ) {
     val validatedNotFullyWatched = mutableSetOf<String>()
+    val ongoingCaughtUp = mutableSetOf<String>()
     val updatedFullyWatched = allWatchedEpisodes.keys
         .filter { contentId ->
             val cacheKey = "series:$contentId"
@@ -2589,17 +2608,28 @@ private fun HomeViewModel.publishBadgeUpdate(
             val allWatched = airedEpisodes.all { it in watched }
             val fullyWatchedByCount = !allWatched &&
                 watched.size >= airedEpisodes.size
-            if (!allWatched && !fullyWatchedByCount && watched.isNotEmpty()) {
-                validatedNotFullyWatched.add(contentId)
+            val caughtUp = allWatched || fullyWatchedByCount
+            // A series still releasing episodes is not completed even when every aired one is
+            // watched. Absent means we never established that, so fail safe and leave it unbadged.
+            val stillAiring = cwBadgeHasUpcoming[contentId] != false
+            when {
+                caughtUp && stillAiring -> {
+                    ongoingCaughtUp.add(contentId)
+                    false
+                }
+                !caughtUp && watched.isNotEmpty() -> {
+                    validatedNotFullyWatched.add(contentId)
+                    false
+                }
+                else -> caughtUp
             }
-            allWatched || fullyWatchedByCount
         }
         .toSet()
-    // Expand IDs: for each fully-watched IMDB ID, also include the
-    // "tmdb:<id>" variant so catalogs that use TMDB IDs get the badge too.
-    val expandedFullyWatched = buildSet {
-        addAll(updatedFullyWatched)
-        for (contentId in updatedFullyWatched) {
+    // Expand IDs: for each ID, also include the "tmdb:<id>" variant so catalogs that use
+    // TMDB IDs get the same badge treatment.
+    fun expandTmdb(ids: Set<String>): Set<String> = buildSet {
+        addAll(ids)
+        for (contentId in ids) {
             if (contentId.startsWith("tt")) {
                 tmdbService.cachedTmdbId(contentId)?.let { tmdbId ->
                     add("tmdb:$tmdbId")
@@ -2607,25 +2637,25 @@ private fun HomeViewModel.publishBadgeUpdate(
             }
         }
     }
-    val expandedNotFullyWatched = buildSet {
-        addAll(validatedNotFullyWatched)
-        for (contentId in validatedNotFullyWatched) {
-            if (contentId.startsWith("tt")) {
-                tmdbService.cachedTmdbId(contentId)?.let { tmdbId ->
-                    add("tmdb:$tmdbId")
-                }
-            }
-        }
-    }
+    val expandedFullyWatched = expandTmdb(updatedFullyWatched)
+    val expandedNotFullyWatched = expandTmdb(validatedNotFullyWatched)
+    // Ongoing series caught up on every aired episode: removed from the badge set, but with a
+    // finite revalidation deadline so they can earn the badge once the show actually ends.
+    val expandedOngoing = expandTmdb(ongoingCaughtUp)
     val current = fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
-    val merged = (current - expandedNotFullyWatched) + expandedFullyWatched
-    val allValidatedIds = expandedFullyWatched + expandedNotFullyWatched
+    val merged = (current - expandedNotFullyWatched - expandedOngoing) + expandedFullyWatched
+    val allValidatedIds = expandedFullyWatched + expandedNotFullyWatched + expandedOngoing
     val revalidateAt = buildMap {
         for (contentId in expandedFullyWatched) {
             cwBadgeNextSeasonMs[contentId]?.let { put(contentId, it) }
         }
         for (contentId in expandedNotFullyWatched) {
             put(contentId, Long.MAX_VALUE)
+        }
+        // Ongoing shows re-check at the next known season premiere, otherwise fall back to the
+        // default TTL (via updateWithValidation) so an ended show is picked up within a week.
+        for (contentId in expandedOngoing) {
+            cwBadgeNextSeasonMs[contentId]?.let { put(contentId, it) }
         }
     }
     fullyWatchedSeriesIds.updateWithValidation(merged, allValidatedIds, revalidateAt)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2606,6 +2606,10 @@ private fun HomeViewModel.publishBadgeUpdate(
     val ongoingCaughtUp = mutableSetOf<String>()
     val updatedFullyWatched = allWatchedEpisodes.keys
         .filter { contentId ->
+            // The user marked this one watched by hand: that decision is theirs to reverse.
+            if (fullyWatchedSeriesIds.isManuallyMarked(contentId)) {
+                return@filter contentId in fullyWatchedSeriesIds.fullyWatchedSeriesIds.value
+            }
             val cacheKey = "series:$contentId"
             val airedEpisodes = synchronized(cwBadgeEpisodeCache) {
                 cwBadgeEpisodeCache[cacheKey] ?: cwBadgeEpisodeCache["tv:$contentId"]

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -157,8 +157,12 @@ internal data class CwMetaSummary(
      * has episodes that have not aired/released yet (future-dated OR flagged unavailable).
      * Such a series is still airing, so it must never be treated as "completed" even when
      * every aired episode has been watched.
+     *
+     * Pass [watchableCount] when [watchableEpisodes] was already computed: it parses a date per
+     * video, and there is no reason to pay for that twice.
      */
-    fun hasUpcomingEpisodes(): Boolean = totalEpisodeCount() > watchableEpisodes().size
+    fun hasUpcomingEpisodes(watchableCount: Int = watchableEpisodes().size): Boolean =
+        totalEpisodeCount() > watchableCount
 }
 
 internal data class CwVideoSummary(
@@ -1698,7 +1702,8 @@ private suspend fun HomeViewModel.buildNextUpItem(
                 ?: cwMetaCache["tv:${progress.contentId}"]
         }
         if (cachedMeta != null) {
-            val episodes = cachedMeta.watchableEpisodes()
+            val watchable = cachedMeta.watchableEpisodes()
+            val episodes = watchable
                 .mapNotNull { v -> v.season?.let { s -> v.episode?.let { e -> s to e } } }
                 .toSet()
             val cacheKey = "series:${progress.contentId}"
@@ -1710,7 +1715,7 @@ private suspend fun HomeViewModel.buildNextUpItem(
             // Must travel with the episode cache: publishBadgeUpdate reads this to decide
             // "completed", and a missing entry would read as "not airing" and badge a series
             // that is still releasing episodes.
-            cwBadgeHasUpcoming[progress.contentId] = cachedMeta.hasUpcomingEpisodes()
+            cwBadgeHasUpcoming[progress.contentId] = cachedMeta.hasUpcomingEpisodes(watchable.size)
             cachedMeta.earliestUpcomingSeasonMs()?.let { ms ->
                 cwBadgeNextSeasonMs[progress.contentId] = ms
             }
@@ -2334,13 +2339,14 @@ private suspend fun HomeViewModel.resolveBadgeEpisodes(
         cwMetaCache[cacheKey] ?: cwMetaCache["series:$contentId"] ?: cwMetaCache["tv:$contentId"]
     }
     if (existingSummary != null) {
-        val episodes = existingSummary.watchableEpisodes()
+        val watchable = existingSummary.watchableEpisodes()
+        val episodes = watchable
             .mapNotNull { v -> v.season?.let { s -> v.episode?.let { e -> s to e } } }
             .toSet()
         existingSummary.earliestUpcomingSeasonMs()?.let { ms ->
             cwBadgeNextSeasonMs[contentId] = ms
         }
-        cwBadgeHasUpcoming[contentId] = existingSummary.hasUpcomingEpisodes()
+        cwBadgeHasUpcoming[contentId] = existingSummary.hasUpcomingEpisodes(watchable.size)
         synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = episodes }
         return episodes
     }
@@ -2369,13 +2375,14 @@ private suspend fun HomeViewModel.resolveBadgeEpisodes(
             } ?: continue
             val meta = (result as? NetworkResult.Success<*>)?.data as? Meta ?: continue
             val summary = meta.toCwSummary()
-            val episodes = summary.watchableEpisodes()
+            val watchable = summary.watchableEpisodes()
+            val episodes = watchable
                 .mapNotNull { v -> v.season?.let { s -> v.episode?.let { e -> s to e } } }
                 .toSet()
             summary.earliestUpcomingSeasonMs()?.let { ms ->
                 cwBadgeNextSeasonMs[contentId] = ms
             }
-            cwBadgeHasUpcoming[contentId] = summary.hasUpcomingEpisodes()
+            cwBadgeHasUpcoming[contentId] = summary.hasUpcomingEpisodes(watchable.size)
             synchronized(cwBadgeEpisodeCache) { cwBadgeEpisodeCache[cacheKey] = episodes }
             return episodes
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
@@ -351,6 +351,9 @@ private suspend fun HomeViewModel.markSeriesWatched(item: MetaPreview) {
         )
     }
     watchProgressRepository.markAsCompletedBatch(progressList)
+    // Marking by hand only covers aired episodes, which is indistinguishable from simply being
+    // caught up. Record the intent so badge evaluation does not strip this back off again.
+    fullyWatchedSeriesIds.setManuallyMarked(setOf(item.id), marked = true)
     fullyWatchedSeriesIds.updateWithValidation(
         fullyWatchedSeriesIds.fullyWatchedSeriesIds.value + item.id,
         setOf(item.id)
@@ -370,6 +373,7 @@ private suspend fun HomeViewModel.unmarkSeriesWatched(item: MetaPreview) {
         videoId = item.imdbId,
         episodes = episodePairs
     )
+    fullyWatchedSeriesIds.setManuallyMarked(setOf(item.id), marked = false)
     fullyWatchedSeriesIds.updateWithValidation(
         fullyWatchedSeriesIds.fullyWatchedSeriesIds.value - item.id,
         setOf(item.id)


### PR DESCRIPTION
## Summary

A series was marked fully watched as soon as every aired episode had been watched, with no check for whether more episodes were still to come. Being caught up on an ongoing show was treated as having completed it.

This fixes both symptoms of that single cause: the completed checkmark showing on a series that is still airing, and a newly aired episode appearing in Continue Watching on launch and then vanishing when the row refreshes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Watched state is wrong in two user-visible ways for anyone following a currently airing series, which is the normal case for weekly shows.

Old behavior: a series was flagged fully watched when every aired episode had been watched.

Broken behavior: catching up on an airing series (for example 2 of 12 episodes released, both watched) marked it completed. The poster got the completed checkmark, and because the Continue Watching pipeline drops the next-up entry for any series carrying that flag, the next episode to air was removed from Continue Watching. It appeared on launch from the cached snapshot and then disappeared once the pipeline re-evaluated, so new episodes looked like they were flashing in and out.

New behavior: a series is only completed when it is positively known that nothing is upcoming, so an airing series keeps neither the checkmark nor the Continue Watching drop, and its new episodes stay in Continue Watching.

Completion was computed independently in three places, and all three had the same gap. The catalog reconcile runs on library and catalog load and re-added the flag that the Continue Watching pass had just removed, so fixing any one of them alone had no visible effect.

Manual marking: marking a series watched only marks its aired episodes, which leaves the watch data identical to simply being caught up. Derived evaluation cannot tell the two apart, so tightening it also stripped the badge straight back off after the user set it by hand on an airing series. For series the poster menu derives its mark/unmark state from that same badge, so losing it also removed the option to unmark, leaving the episodes watched with no way to undo it from the library. The series a user marks by hand are now recorded and left out of derived evaluation. The override is dropped again when the series is unmarked, or when the user unwatches an episode so the claim no longer holds.

## Issue or approval

Fixes #2631

## Reproduction steps

1. Pick a series that is currently airing and still has unaired episodes remaining (for example a weekly anime with 2 of 12 episodes released).
2. Watch every episode that has aired, so you are fully caught up.
3. Open the Library and look at that series' poster. The completed checkmark is shown even though the series is not finished.
4. Wait until the next episode airs, then relaunch the app.
5. Watch the Continue Watching row on the home screen. The newly aired episode appears, then disappears when the row refreshes.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed:

- No UI code, layout, or styling is touched. The completed badge component is unchanged and simply receives correct data.
- Marking a series watched by hand still applies the badge immediately, including while the series is airing. Keeping that working needed a change rather than no change, described under "Manual marking" below.
- The two Continue Watching call sites that only stamp a revalidation deadline are unchanged, since they do not add the flag.
- The existing `fullyWatchedByCount` heuristic for Trakt anime remapping is preserved rather than replaced.
- The Play button on the detail screen restarts an airing series at S1E1 once you are caught up, because no unwatched available episode remains. That is pre-existing and out of scope here.
- `app/src/test/java/com/nuvio/tv/core/trakt/TraktPublicListSourceResolverTest.kt` currently fails to compile on `dev` with an ambiguous `TraktCredentialSyncService` import. It reproduces on a clean checkout without these changes, so it is left alone rather than bundled into this fix.

The only structural change is a local `expandTmdb` helper in `publishBadgeUpdate`, which replaces two copies of an identical ID expansion block because the fix needs a third. It is required by the change rather than a drive-by cleanup.

## Testing

Tested on an NVIDIA Shield TV Pro (Android 11) against a real library of 29 watched series, built from source as `fullDebug` and installed over ADB.

- `./gradlew :app:assembleFullDebug` passes, which is what CI builds.
- Verified with instrumented logging (removed before this commit) that all 29 series resolved and every currently airing series was classified as still airing, while a genuinely finished series was not.
- Airing series with every aired episode watched (for example 2 of 12 released, both watched): the completed checkmark is gone from the Library poster.
- A genuinely finished and fully watched series: the completed checkmark is still shown, confirming the fix does not suppress legitimate badges.
- Opening the detail page of a caught-up airing series and returning to the Library: the checkmark stays gone. Before the detail screen was fixed, this round trip re-added it.
- Continue Watching: a series with a newly aired episode keeps that episode in the row instead of dropping it on refresh.
- Marking an airing series watched by hand from the library poster menu: the badge appears and stays, and "Unmark as watched" remains available on the poster so it can be undone without opening the series. Unmarking clears it again.
- Unwatching an episode of a hand-marked series from the detail screen drops the override, and the series returns to the derived rules.

The unit test task `:app:testFullDebugUnitTest` does not compile on `dev` for the pre-existing Trakt reason noted above, unrelated to these files.

## Screenshots / Video

No UI code, layout, or styling is modified. The only visible difference is the one being fixed: the existing completed checkmark no longer appears on series that are still airing, and a newly aired episode stays in Continue Watching instead of vanishing on refresh.

Recordings from an NVIDIA Shield TV Pro, each showing the behavior before and after the fix.

**New episode staying in Continue Watching**

https://github.com/user-attachments/assets/00c8e3ba-f6d1-4bec-ba6e-48c34425e0bc

**Watched badge no longer shown on a series that is still airing**

https://github.com/user-attachments/assets/01d1cf52-61ae-4c88-9a6d-0a83e40743de

https://github.com/user-attachments/assets/d549a67a-5f68-455c-9526-aec1fc5efc3d

## Breaking changes

None.

`VALIDATION_RESET_VERSION` is bumped from 1 to 2 so that badges already stored on disk are re-evaluated once after upgrade. Without it, existing incorrect badges would persist behind their revalidation deadline. This only forces one re-check of series that already have watch history and does not clear watch progress or change any stored schema.

## Linked issues

Fixes #2631


