### PR TITLE
fix: harden external-player binge autoplay

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
@@ -47,7 +47,7 @@ internal object ExternalAutoNextPolicy {
         hasNextEpisode: Boolean? = null
     ): Boolean {
         if (cancelled || chainAborted || overlaySuppressed || alreadyShowing) return false
-        if (autoNextEnabled == false || hasNextEpisode == false) return false
+        if (autoNextEnabled == false || hasNextEpisode != true) return false
         return isSeriesEpisode(episode, contentType)
     }
 

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
@@ -42,9 +42,12 @@ internal object ExternalAutoNextPolicy {
         cancelled: Boolean,
         chainAborted: Boolean,
         overlaySuppressed: Boolean,
-        alreadyShowing: Boolean
+        alreadyShowing: Boolean,
+        autoNextEnabled: Boolean? = null,
+        hasNextEpisode: Boolean? = null
     ): Boolean {
         if (cancelled || chainAborted || overlaySuppressed || alreadyShowing) return false
+        if (autoNextEnabled == false || hasNextEpisode == false) return false
         return isSeriesEpisode(episode, contentType)
     }
 
@@ -61,6 +64,10 @@ internal object ExternalAutoNextPolicy {
         if (cancelled || chainAborted) return false
         return isSeriesEpisode(episode, contentType)
     }
+
+    /** External players can only advance to an episode that is both published and available. */
+    fun isPlayableNextEpisode(available: Boolean?, hasAired: Boolean): Boolean =
+        available != false && hasAired
 
     private fun isSeriesEpisode(episode: Int?, contentType: String): Boolean =
         episode != null && contentType.lowercase() in SERIES_TYPES

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
+import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
@@ -99,6 +100,11 @@ data class ExternalAutoNextOverlay(
     val title: String?
 )
 
+private data class ExternalNextEpisodeLookup(
+    val metadataResolved: Boolean,
+    val nextVideo: Video?
+)
+
 /**
  * Application-scoped singleton that tracks external player playback.
  *
@@ -160,6 +166,11 @@ class ExternalPlaybackTracker @Inject constructor(
     // Set when the loader is released on a routine screen settle, so a later onStart can't re-raise a
     // loader that no longer has a job behind it (which would leave it stuck). Reset on a fresh launch.
     private var autoNextOverlaySuppressed = false
+    // Resolve the successor while the current episode is playing. Besides making auto-next
+    // immediate on return, this lets us avoid showing a loader after a known series finale.
+    private var nextEpisodePrefetchJob: Job? = null
+    private var nextEpisodeLookup: ExternalNextEpisodeLookup? = null
+    private var autoNextEnabledForPendingLaunch: Boolean? = null
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
     // the next episode's Stream route. replay = 1 so the event still reaches the
@@ -202,6 +213,12 @@ class ExternalPlaybackTracker @Inject constructor(
      * Called before launching an external player. Stores metadata and starts keep-alive service.
      */
     fun startTracking(metadata: ExternalPlaybackMetadata, autoLaunch: Boolean = false) {
+        // A manual stream choice supersedes any completion handoff still resolving for the
+        // previous player session. Auto-launched continuations keep their handoff alive.
+        if (!autoLaunch) {
+            autoNextJob?.cancel()
+            autoNextJob = null
+        }
         pendingMetadata = metadata
         isAutoLaunch = autoLaunch
         // Fresh launch — allow the auto-next loader / advance again.
@@ -217,10 +234,14 @@ class ExternalPlaybackTracker @Inject constructor(
             autoNextChainAborted = false
         }
         autoNextOverlaySuppressed = false
+        nextEpisodePrefetchJob?.cancel()
+        nextEpisodeLookup = null
+        autoNextEnabledForPendingLaunch = null
         // Next player is launching and will cover the screen — drop the loader.
         _autoNextOverlay.value = null
         // Persist so progress-save + auto-next survive the player killing our process.
         persistMetadata(metadata)
+        startNextEpisodePrefetch(metadata)
 
         // Keep the process alive while the external player is foregrounded. Some boxes
         // (e.g. NVIDIA Shield) otherwise kill it, dropping tracking state. Started while
@@ -575,6 +596,62 @@ class ExternalPlaybackTracker @Inject constructor(
 
     // ===================== Completion + auto-next =====================
 
+    private fun startNextEpisodePrefetch(metadata: ExternalPlaybackMetadata) {
+        if (!ExternalAutoNextPolicy.shouldAttemptAdvance(
+                episode = metadata.episode,
+                contentType = metadata.contentType,
+                cancelled = false,
+                chainAborted = false
+            )) {
+            return
+        }
+
+        nextEpisodePrefetchJob = scope.launch {
+            val enabled = playerSettingsDataStore.playerSettings.first()
+                .streamAutoPlayNextEpisodeEnabled
+            autoNextEnabledForPendingLaunch = enabled
+            if (!enabled) return@launch
+
+            nextEpisodeLookup = resolveNextEpisodeLookup(metadata)
+            val lookup = nextEpisodeLookup
+            if (lookup?.metadataResolved == true) {
+                val next = lookup.nextVideo
+                if (next == null) {
+                    Log.d(AUTO_NEXT_TAG, "Prefetch confirmed no next episode after S${metadata.season}E${metadata.episode}")
+                } else {
+                    Log.d(AUTO_NEXT_TAG, "Prefetched next episode S${next.season}E${next.episode} videoId=${next.id}")
+                }
+            }
+        }
+    }
+
+    private suspend fun resolveNextEpisodeLookup(metadata: ExternalPlaybackMetadata): ExternalNextEpisodeLookup {
+        val result = withTimeoutOrNull(META_FETCH_TIMEOUT_MS) {
+            metaRepository
+                .getMetaFromAllAddons(type = metadata.contentType, id = metadata.contentId)
+                .first { it !is NetworkResult.Loading }
+        }
+        val meta = (result as? NetworkResult.Success)?.data
+            ?: return ExternalNextEpisodeLookup(metadataResolved = false, nextVideo = null)
+        val episode = metadata.episode
+            ?: return ExternalNextEpisodeLookup(metadataResolved = true, nextVideo = null)
+        val nextVideo = PlayerNextEpisodeRules.resolveNextEpisode(
+                videos = meta.videos,
+                currentSeason = metadata.season,
+                currentEpisode = episode
+            )
+            ?.takeIf { candidate ->
+                ExternalAutoNextPolicy.isPlayableNextEpisode(
+                    available = candidate.available,
+                    hasAired = PlayerNextEpisodeRules.hasEpisodeAired(candidate.released)
+                )
+            }
+        return ExternalNextEpisodeLookup(
+            metadataResolved = true,
+            nextVideo = nextVideo
+        )
+    }
+
     // True on a natural end (end_by != "user"), or for players without end_by once the
     // position reaches COMPLETED_THRESHOLD (90%).
     private fun isPlaybackCompleted(result: ExternalPlayerResult): Boolean {
@@ -630,25 +707,21 @@ class ExternalPlaybackTracker @Inject constructor(
                 return@launch
             }
 
-            // Bounded so a hung addon flow (never emits non-Loading) can't suspend here
-            // forever and leave the loader up — withTimeoutOrNull returns null on timeout.
-            val result = withTimeoutOrNull(META_FETCH_TIMEOUT_MS) {
-                metaRepository
-                    .getMetaFromAllAddons(type = metadata.contentType, id = metadata.contentId)
-                    .first { it !is NetworkResult.Loading }
+            // Prefer the lookup started when playback launched. If it was still in flight, wait
+            // for it here; after a process recreation or a failed prefetch, retry once now.
+            nextEpisodePrefetchJob?.let { prefetchJob ->
+                withTimeoutOrNull(META_FETCH_TIMEOUT_MS) { prefetchJob.join() }
             }
-            val meta = (result as? NetworkResult.Success)?.data
-            if (meta == null) {
+            val lookup = nextEpisodeLookup
+                ?.takeIf { it.metadataResolved }
+                ?: resolveNextEpisodeLookup(metadata)
+            if (!lookup.metadataResolved) {
                 Log.d(AUTO_NEXT_TAG, "Could not load series meta for ${metadata.contentId} (timeout or error); skipping")
                 dismissOverlayIfCurrent()
                 return@launch
             }
 
-            val nextVideo = PlayerNextEpisodeRules.resolveNextEpisode(
-                videos = meta.videos,
-                currentSeason = season,
-                currentEpisode = episode
-            )
+            val nextVideo = lookup.nextVideo
             val nextEpisode = nextVideo?.episode
             if (nextVideo == null || nextEpisode == null) {
                 Log.d(AUTO_NEXT_TAG, "No next episode after S${season}E${episode} for ${metadata.contentId}")
@@ -716,8 +789,6 @@ class ExternalPlaybackTracker @Inject constructor(
     fun releaseAutoNextOverlay() {
         Log.d(AUTO_NEXT_TAG, "releaseAutoNextOverlay (settle) overlayWasShowing=${_autoNextOverlay.value != null}")
         autoNextOverlaySuppressed = true
-        autoNextJob?.cancel()
-        autoNextJob = null
         _autoNextOverlay.value = null
     }
 
@@ -746,15 +817,28 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
+        val lookup = nextEpisodeLookup
+        val hasNextEpisode = when {
+            lookup?.metadataResolved != true -> null
+            lookup.nextVideo != null -> true
+            else -> false
+        }
         val shouldRaise = ExternalAutoNextPolicy.shouldRaiseLoader(
             episode = metadata.episode,
             contentType = metadata.contentType,
             cancelled = autoNextCancelled,
             chainAborted = autoNextChainAborted,
             overlaySuppressed = autoNextOverlaySuppressed,
-            alreadyShowing = _autoNextOverlay.value != null
+            alreadyShowing = _autoNextOverlay.value != null,
+            autoNextEnabled = autoNextEnabledForPendingLaunch,
+            hasNextEpisode = hasNextEpisode
         )
-        if (!shouldRaise) return
+        if (!shouldRaise) {
+            if (hasNextEpisode == false) {
+                Log.d(AUTO_NEXT_TAG, "loader skipped for known final episode ${metadata.videoId}")
+            }
+            return
+        }
         _autoNextOverlay.value = ExternalAutoNextOverlay(
             backdrop = metadata.backdrop ?: metadata.poster,
             logo = metadata.logo,

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -685,13 +685,13 @@ class ExternalPlaybackTracker @Inject constructor(
             return
         }
 
-        // Show the loader before the async work below so it covers the cold-start window.
+        // Build the loader now, but do not display it until a playable successor is confirmed.
+        // An optimistic loader causes a visible flash when returning from a series finale.
         val overlay = ExternalAutoNextOverlay(
             backdrop = metadata.backdrop ?: metadata.poster,
             logo = metadata.logo,
             title = metadata.contentName
         )
-        _autoNextOverlay.value = overlay
         fun dismissOverlayIfCurrent() {
             if (_autoNextOverlay.value === overlay) _autoNextOverlay.value = null
         }
@@ -729,6 +729,18 @@ class ExternalPlaybackTracker @Inject constructor(
                 return@launch
             }
             val nextSeason = nextVideo.season
+
+            val shouldShowLoader = ExternalAutoNextPolicy.shouldRaiseLoader(
+                episode = episode,
+                contentType = metadata.contentType,
+                cancelled = autoNextCancelled,
+                chainAborted = autoNextChainAborted,
+                overlaySuppressed = autoNextOverlaySuppressed,
+                alreadyShowing = _autoNextOverlay.value != null,
+                autoNextEnabled = true,
+                hasNextEpisode = true
+            )
+            if (shouldShowLoader) _autoNextOverlay.value = overlay
 
             Log.d(
                 AUTO_NEXT_TAG,

--- a/app/src/main/java/com/nuvio/tv/data/local/BingeGroupCacheDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/BingeGroupCacheDataStore.kt
@@ -35,6 +35,17 @@ class BingeGroupCacheDataStore @Inject constructor(
         }
     }
 
+    suspend fun replace(contentId: String, bingeGroup: String?) {
+        store().edit { prefs ->
+            val value = bingeGroup?.takeIf { it.isNotBlank() }
+            if (value == null) {
+                prefs.remove(prefKey(contentId))
+            } else {
+                prefs[prefKey(contentId)] = value
+            }
+        }
+    }
+
     suspend fun get(contentId: String): String? {
         return store().data.first()[prefKey(contentId)]
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
@@ -21,9 +21,9 @@ internal fun PlayerRuntimeController.startInitialPlaybackIfNeeded() {
     // (from CW, Details, or next-episode) can reuse the same source group.
     val bg = navigationArgs.bingeGroup
     val cid = contentId
-    if (bg != null && cid != null) {
+    if (cid != null) {
         scope.launch(kotlinx.coroutines.NonCancellable) {
-            bingeGroupCacheDataStore.save(cid, bg)
+            bingeGroupCacheDataStore.replace(cid, bg)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -535,9 +535,9 @@ private fun PlayerRuntimeController.applyStreamMetadata(stream: Stream) {
     // (from CW, Details, or next-episode) can reuse the same source group.
     val bg = stream.behaviorHints?.bingeGroup
     val cid = contentId
-    if (bg != null && cid != null) {
+    if (cid != null) {
         scope.launch(kotlinx.coroutines.NonCancellable) {
-            bingeGroupCacheDataStore.save(cid, bg)
+            bingeGroupCacheDataStore.replace(cid, bg)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicy.kt
@@ -1,0 +1,21 @@
+package com.nuvio.tv.ui.screens.stream
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+
+internal object DirectAutoPlayWatchdogPolicy {
+    suspend fun awaitForeground(hostInForeground: StateFlow<Boolean>) {
+        hostInForeground.first { it }
+    }
+
+    fun shouldTearDownResolvedTarget(
+        resolvedAutoPlayTarget: Boolean,
+        hostInForeground: Boolean,
+        showDirectAutoPlayOverlay: Boolean,
+        externalPlayerOverlayVisible: Boolean
+    ): Boolean {
+        return resolvedAutoPlayTarget &&
+            hostInForeground &&
+            (showDirectAutoPlayOverlay || externalPlayerOverlayVisible)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -335,10 +335,10 @@ fun StreamScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.onEvent(StreamScreenEvent.OnResume)
                 // Always dismiss overlay and stop tracking on resume
                 // covers both ActivityResult path and fire-and-forget path.
                 viewModel.stopExternalPlayerTracking()
+                viewModel.onEvent(StreamScreenEvent.OnResume)
                 if (pendingRestoreOnResume) {
                     restoreFocusedStream = true
                     pendingRestoreOnResume = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -104,7 +104,6 @@ class StreamScreenViewModel @Inject constructor(
     private var resumeBaselineStreams: List<AddonStreams>? = null
     private var sourceChipErrorDismissJob: Job? = null
     private var pendingCacheSaveJob: Job? = null
-    private var pendingBingeGroupSaveJob: Job? = null
     private var streamBadgePresentationJob: Job? = null
     private var streamBadgePresentationRequestId = 0L
     private var badgedAddonNames: Set<String> = emptySet()
@@ -282,7 +281,7 @@ class StreamScreenViewModel @Inject constructor(
             StreamScreenEvent.OnRetry -> loadStreams()
             StreamScreenEvent.OnBackPress -> { /* Handle in screen */ }
             StreamScreenEvent.OnResume -> {
-                hostInForeground = true
+                hostInForeground.value = true
                 // If loading was cancelled (e.g. user went to player) and
                 // hasn't completed yet, resume it. The baseline snapshot
                 // captured at cancel time keeps existing results visible
@@ -819,8 +818,17 @@ class StreamScreenViewModel @Inject constructor(
                 // gated on !resolvedAutoPlayTarget. Only stuck if still foregrounded: a
                 // healthy external launch backgrounds us and keeps the VM alive behind
                 // the player for the whole episode.
-                val phantomStuck = resolvedAutoPlayTarget && hostInForeground &&
+                val hasResolvedOverlay = resolvedAutoPlayTarget &&
                     (_uiState.value.showDirectAutoPlayOverlay || _uiState.value.externalPlayerOverlayVisible)
+                if (hasResolvedOverlay) {
+                    DirectAutoPlayWatchdogPolicy.awaitForeground(hostInForeground)
+                }
+                val phantomStuck = DirectAutoPlayWatchdogPolicy.shouldTearDownResolvedTarget(
+                    resolvedAutoPlayTarget = resolvedAutoPlayTarget,
+                    hostInForeground = hostInForeground.value,
+                    showDirectAutoPlayOverlay = _uiState.value.showDirectAutoPlayOverlay,
+                    externalPlayerOverlayVisible = _uiState.value.externalPlayerOverlayVisible
+                )
                 if ((directAutoPlayFlowEnabledForSession && !resolvedAutoPlayTarget) || phantomStuck) {
                     Log.w(TAG, "Direct autoplay hard timeout reached; falling back to manual selection")
                     lastSuccessData?.let {
@@ -1236,11 +1244,10 @@ class StreamScreenViewModel @Inject constructor(
 
     // Foreground gate for the stuck-loader timeout; healthy external playback
     // backgrounds us (ON_STOP). True at init since the screen starts visible.
-    @Volatile
-    private var hostInForeground = true
+    private val hostInForeground = MutableStateFlow(true)
 
     fun onHostStopped() {
-        hostInForeground = false
+        hostInForeground.value = false
     }
     private var externalOverlayHideJob: kotlinx.coroutines.Job? = null
 
@@ -1350,30 +1357,16 @@ class StreamScreenViewModel @Inject constructor(
                 )
             }
         }
-        // Persist binge group per-content for cross-episode reuse (independent of URL).
-        val bg = playbackInfo.bingeGroup
-        val cid = playbackInfo.contentId
-        if (bg != null && !cid.isNullOrBlank()) {
-            // Drop any pending save so a backed-out pick can't land last and overwrite
-            // the group actually chosen.
-            pendingBingeGroupSaveJob?.cancel()
-            pendingBingeGroupSaveJob = viewModelScope.launch {
-                bingeGroupCacheDataStore.save(cid, bg)
-            }
-        }
-
         return playbackInfo
     }
 
     suspend fun awaitStreamLinkCacheSave() {
         pendingCacheSaveJob?.join()
-        pendingBingeGroupSaveJob?.join()
     }
 
     private suspend fun persistBingeGroupForPlayback(playbackInfo: StreamPlaybackInfo) {
-        val bg = playbackInfo.bingeGroup ?: return
         val cid = playbackInfo.contentId?.takeIf { it.isNotBlank() } ?: return
-        bingeGroupCacheDataStore.save(cid, bg)
+        bingeGroupCacheDataStore.replace(cid, playbackInfo.bingeGroup)
     }
 
     override fun onCleared() {
@@ -1431,8 +1424,7 @@ class StreamScreenViewModel @Inject constructor(
             )
         }
 
-        // The launched stream's group is the final write, ahead of any pending save.
-        pendingBingeGroupSaveJob?.cancel()
+        // Persist only the stream that actually launches. A missing group clears stale reuse state.
         persistBingeGroupForPlayback(playbackInfo)
 
         var playUrl = url

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
@@ -96,6 +96,11 @@ class ExternalAutoNextPolicyTest {
     }
 
     @Test
+    fun `loader does not raise before next episode lookup completes`() {
+        assertFalse(raise(episode = 12, type = "series", hasNextEpisode = null))
+    }
+
+    @Test
     fun `loader does not raise when auto-next is disabled`() {
         assertFalse(raise(episode = 3, type = "series", autoNextEnabled = false))
     }
@@ -147,7 +152,7 @@ class ExternalAutoNextPolicyTest {
         overlaySuppressed: Boolean = false,
         alreadyShowing: Boolean = false,
         autoNextEnabled: Boolean? = null,
-        hasNextEpisode: Boolean? = null
+        hasNextEpisode: Boolean? = true
     ) = ExternalAutoNextPolicy.shouldRaiseLoader(
         episode = episode,
         contentType = type,

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
@@ -91,6 +91,16 @@ class ExternalAutoNextPolicyTest {
     }
 
     @Test
+    fun `loader does not raise when prefetch confirms a series finale`() {
+        assertFalse(raise(episode = 12, type = "series", hasNextEpisode = false))
+    }
+
+    @Test
+    fun `loader does not raise when auto-next is disabled`() {
+        assertFalse(raise(episode = 3, type = "series", autoNextEnabled = false))
+    }
+
+    @Test
     fun `loader does not raise for movies or non-series content`() {
         assertFalse(raise(episode = null, type = "movie"))
         assertFalse(raise(episode = 3, type = "movie"))
@@ -121,19 +131,31 @@ class ExternalAutoNextPolicyTest {
         )
     }
 
+    @Test
+    fun `next episode must be available and aired`() {
+        assertTrue(ExternalAutoNextPolicy.isPlayableNextEpisode(available = true, hasAired = true))
+        assertTrue(ExternalAutoNextPolicy.isPlayableNextEpisode(available = null, hasAired = true))
+        assertFalse(ExternalAutoNextPolicy.isPlayableNextEpisode(available = false, hasAired = true))
+        assertFalse(ExternalAutoNextPolicy.isPlayableNextEpisode(available = true, hasAired = false))
+    }
+
     private fun raise(
         episode: Int?,
         type: String,
         cancelled: Boolean = false,
         chainAborted: Boolean = false,
         overlaySuppressed: Boolean = false,
-        alreadyShowing: Boolean = false
+        alreadyShowing: Boolean = false,
+        autoNextEnabled: Boolean? = null,
+        hasNextEpisode: Boolean? = null
     ) = ExternalAutoNextPolicy.shouldRaiseLoader(
         episode = episode,
         contentType = type,
         cancelled = cancelled,
         chainAborted = chainAborted,
         overlaySuppressed = overlaySuppressed,
-        alreadyShowing = alreadyShowing
+        alreadyShowing = alreadyShowing,
+        autoNextEnabled = autoNextEnabled,
+        hasNextEpisode = hasNextEpisode
     )
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicyTest.kt
@@ -1,0 +1,49 @@
+package com.nuvio.tv.ui.screens.stream
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DirectAutoPlayWatchdogPolicyTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `watchdog waits until host returns to foreground`() = runTest {
+        val foreground = MutableStateFlow(false)
+        val waiter = async {
+            DirectAutoPlayWatchdogPolicy.awaitForeground(foreground)
+        }
+
+        runCurrent()
+        assertFalse(waiter.isCompleted)
+
+        foreground.value = true
+        runCurrent()
+
+        assertTrue(waiter.isCompleted)
+    }
+
+    @Test
+    fun `resolved visible overlay is torn down only in foreground`() {
+        assertTrue(
+            DirectAutoPlayWatchdogPolicy.shouldTearDownResolvedTarget(
+                resolvedAutoPlayTarget = true,
+                hostInForeground = true,
+                showDirectAutoPlayOverlay = true,
+                externalPlayerOverlayVisible = false
+            )
+        )
+        assertFalse(
+            DirectAutoPlayWatchdogPolicy.shouldTearDownResolvedTarget(
+                resolvedAutoPlayTarget = true,
+                hostInForeground = false,
+                showDirectAutoPlayOverlay = true,
+                externalPlayerOverlayVisible = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- persist the manually selected binge group before direct autoplay launches
- keep the external-player completion handoff alive when the stream screen settles
- prefetch and validate the next episode, excluding unavailable or unaired entries
- suppress auto-next UI until a playable successor is confirmed
- harden the foreground watchdog so a covered external player is not mistaken for a failed launch

## Root cause
The regression combined two lifecycle races. Direct autoplay could launch before the selected binge group was persisted, and the returning stream screen canceled the external auto-next job during its normal loading-to-settled transition. Finale returns also raised an optimistic loader before metadata had confirmed a successor.

## Impact
External-player binge playback retains the selected source group, advances after natural completion, and returns quietly at a finale without attempting a nonexistent episode or flashing a loader.

## Validation
- `:app:testFullDebugUnitTest` focused on `ExternalAutoNextPolicyTest`, `PlayerNextEpisodeRulesTest`, and `DirectAutoPlayWatchdogPolicyTest`
- `:app:compileFullDebugKotlin`
- `:app:assembleFullDebug`
- Shield testing confirmed external auto-next and binge-group reuse; the final no-loader confirmation remains for this draft