### PR TITLE
Fix external player auto next handoffs, binge group continuity, and finale detection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -869,7 +869,8 @@ class MainActivity : ComponentActivity() {
                             backdropUrl = ov.backdrop,
                             logoUrl = ov.logo,
                             title = ov.title,
-                            message = stringResource(R.string.external_auto_next_loading),
+                            message = ov.message ?: stringResource(R.string.external_auto_next_loading),
+                            progress = ov.progress,
                             modifier = Modifier.fillMaxSize()
                         )
                     }
@@ -947,6 +948,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onStop() {
+        externalPlaybackTracker.onExternalPlayerCoveredApp()
         super.onStop()
         startupSyncService.stopPeriodicSurfacePulls()
         // App going to background (e.g. user returning to the launcher): reconcile the

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
@@ -33,8 +33,8 @@ internal object ExternalAutoNextPolicy {
     ): Boolean = chainAborted && nowMs - lastAutoNextEmitMs < continuationWindowMs
 
     /**
-     * Whether the auto-advance loader may be raised. Only for a series/tv episode that hasn't been
-     * aborted, released on settle, or already raised. Season may be null (absolute-numbered content).
+     * Whether the auto-advance loader may be raised. Only for a series/tv episode that has not been
+     * aborted, explicitly released, or already raised. Season may be null (absolute-numbered content).
      */
     fun shouldRaiseLoader(
         episode: Int?,
@@ -44,10 +44,12 @@ internal object ExternalAutoNextPolicy {
         overlaySuppressed: Boolean,
         alreadyShowing: Boolean,
         autoNextEnabled: Boolean? = null,
-        hasNextEpisode: Boolean? = null
+        hasNextEpisode: Boolean? = null,
+        allowUnknownNextEpisode: Boolean = false
     ): Boolean {
         if (cancelled || chainAborted || overlaySuppressed || alreadyShowing) return false
-        if (autoNextEnabled == false || hasNextEpisode != true) return false
+        if (autoNextEnabled == false || hasNextEpisode == false) return false
+        if (hasNextEpisode == null && !allowUnknownNextEpisode) return false
         return isSeriesEpisode(episode, contentType)
     }
 
@@ -69,14 +71,22 @@ internal object ExternalAutoNextPolicy {
     fun isPlayableNextEpisode(available: Boolean?, hasAired: Boolean): Boolean =
         available != false && hasAired
 
-    fun shouldDelayLoaderRelease(
+    fun shouldHoldLoaderOnSettle(
         overlayShowing: Boolean,
         handoffActive: Boolean,
-        hasConfirmedNextEpisode: Boolean
-    ): Boolean = overlayShowing && handoffActive && hasConfirmedNextEpisode
+        mayHaveNextEpisode: Boolean,
+        forceRelease: Boolean
+    ): Boolean = overlayShowing && handoffActive && mayHaveNextEpisode && !forceRelease
 
     fun shouldIgnoreLoaderRelease(externalPlaybackActive: Boolean): Boolean =
         externalPlaybackActive
+
+    fun shouldCancelPendingAutoLaunch(
+        autoLaunch: Boolean,
+        autoNextNavigationPending: Boolean,
+        cancelled: Boolean,
+        chainAborted: Boolean
+    ): Boolean = autoLaunch && autoNextNavigationPending && (cancelled || chainAborted)
 
     private fun isSeriesEpisode(episode: Int?, contentType: String): Boolean =
         episode != null && contentType.lowercase() in SERIES_TYPES

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
@@ -42,9 +42,12 @@ internal object ExternalAutoNextPolicy {
         cancelled: Boolean,
         chainAborted: Boolean,
         overlaySuppressed: Boolean,
-        alreadyShowing: Boolean
+        alreadyShowing: Boolean,
+        autoNextEnabled: Boolean? = null,
+        hasNextEpisode: Boolean? = null
     ): Boolean {
         if (cancelled || chainAborted || overlaySuppressed || alreadyShowing) return false
+        if (autoNextEnabled == false || hasNextEpisode != true) return false
         return isSeriesEpisode(episode, contentType)
     }
 
@@ -61,6 +64,16 @@ internal object ExternalAutoNextPolicy {
         if (cancelled || chainAborted) return false
         return isSeriesEpisode(episode, contentType)
     }
+
+    /** External players can only advance to an episode that is both published and available. */
+    fun isPlayableNextEpisode(available: Boolean?, hasAired: Boolean): Boolean =
+        available != false && hasAired
+
+    fun shouldDelayLoaderRelease(
+        overlayShowing: Boolean,
+        handoffActive: Boolean,
+        hasConfirmedNextEpisode: Boolean
+    ): Boolean = overlayShowing && handoffActive && hasConfirmedNextEpisode
 
     private fun isSeriesEpisode(episode: Int?, contentType: String): Boolean =
         episode != null && contentType.lowercase() in SERIES_TYPES

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalAutoNextPolicy.kt
@@ -75,6 +75,9 @@ internal object ExternalAutoNextPolicy {
         hasConfirmedNextEpisode: Boolean
     ): Boolean = overlayShowing && handoffActive && hasConfirmedNextEpisode
 
+    fun shouldIgnoreLoaderRelease(externalPlaybackActive: Boolean): Boolean =
+        externalPlaybackActive
+
     private fun isSeriesEpisode(episode: Int?, contentType: String): Boolean =
         episode != null && contentType.lowercase() in SERIES_TYPES
 }

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -97,13 +97,56 @@ data class ExternalAutoNextEpisode(
 data class ExternalAutoNextOverlay(
     val backdrop: String?,
     val logo: String?,
-    val title: String?
+    val title: String?,
+    val message: String? = null,
+    val progress: Float? = null
 )
 
-private data class ExternalNextEpisodeLookup(
+data class ExternalNextEpisodeSnapshot(
     val metadataResolved: Boolean,
-    val nextVideo: Video?
-)
+    val nextVideoId: String? = null,
+    val nextSeason: Int? = null,
+    val nextEpisode: Int? = null
+) {
+    val hasNextEpisode: Boolean?
+        get() = if (!metadataResolved) null else nextVideoId != null && nextEpisode != null
+
+    companion object {
+        val Unknown = ExternalNextEpisodeSnapshot(metadataResolved = false)
+        val NoPlayableNextEpisode = ExternalNextEpisodeSnapshot(metadataResolved = true)
+    }
+}
+
+internal fun resolveExternalNextEpisodeSnapshot(
+    videos: List<Video>,
+    currentSeason: Int?,
+    currentEpisode: Int?
+): ExternalNextEpisodeSnapshot {
+    if (currentEpisode == null) return ExternalNextEpisodeSnapshot.Unknown
+    val currentExists = videos.any { video ->
+        video.episode == currentEpisode && (currentSeason == null || video.season == currentSeason)
+    }
+    if (!currentExists) return ExternalNextEpisodeSnapshot.Unknown
+
+    val nextVideo = PlayerNextEpisodeRules.resolveNextEpisode(
+        videos = videos,
+        currentSeason = currentSeason,
+        currentEpisode = currentEpisode
+    ) ?: return ExternalNextEpisodeSnapshot.NoPlayableNextEpisode
+    val nextEpisode = nextVideo.episode ?: return ExternalNextEpisodeSnapshot.Unknown
+    val isPlayable = ExternalAutoNextPolicy.isPlayableNextEpisode(
+        available = nextVideo.available,
+        hasAired = PlayerNextEpisodeRules.hasEpisodeAired(nextVideo.released)
+    )
+    if (!isPlayable) return ExternalNextEpisodeSnapshot.NoPlayableNextEpisode
+
+    return ExternalNextEpisodeSnapshot(
+        metadataResolved = true,
+        nextVideoId = nextVideo.id,
+        nextSeason = nextVideo.season,
+        nextEpisode = nextEpisode
+    )
+}
 
 /**
  * Application-scoped singleton that tracks external player playback.
@@ -133,10 +176,8 @@ class ExternalPlaybackTracker @Inject constructor(
     companion object {
         private const val TAG = "ExtPlaybackTracker"
         private const val AUTO_NEXT_TAG = "ExtAutoNext"
-        /** Max time the auto-advance loader stays up if the next player never launches. */
-        private const val AUTO_NEXT_OVERLAY_TIMEOUT_MS = 10_000L
-        /** Lets a confirmed handoff cross the old Stream screen without a one-frame source flash. */
-        private const val AUTO_NEXT_SETTLE_RELEASE_GRACE_MS = 1_500L
+        /** Longer than StreamScreen's 60 second hard timeout, so it owns launch failures. */
+        private const val AUTO_NEXT_OVERLAY_TIMEOUT_MS = 65_000L
         /** Max time to wait for series meta when resolving the next episode. */
         private const val META_FETCH_TIMEOUT_MS = 15_000L
         /** Retry a failed background lookup while the current episode is still playing. */
@@ -158,7 +199,6 @@ class ExternalPlaybackTracker @Inject constructor(
     // The in-flight auto-next resolution (meta fetch -> emit next episode). Held so the user can
     // cancel it by backing out of the "Loading next episode" loader before it navigates.
     private var autoNextJob: Job? = null
-    private var autoNextOverlayReleaseJob: Job? = null
     // Set when the user backs out of the loader; blocks the loader from re-raising and auto-next
     // from firing for the current return (e.g. while VLC's duration backfill is still running).
     // Reset on each new launch in startTracking.
@@ -171,13 +211,16 @@ class ExternalPlaybackTracker @Inject constructor(
     // Using a time window instead of a sticky flag means the abort can never get permanently stuck
     // if a continuation never actually launches (e.g. user backed out before it auto-played).
     private var lastAutoNextEmitMs = 0L
+    // True from next-episode navigation until external playback covers Nuvio or the handoff ends.
+    // This distinguishes a cancellable continuation from an unrelated direct auto-play launch.
+    private var autoNextNavigationPending = false
     // Set when the loader is released on a routine screen settle, so a later onStart can't re-raise a
     // loader that no longer has a job behind it (which would leave it stuck). Reset on a fresh launch.
     private var autoNextOverlaySuppressed = false
     // Resolve the successor while the current episode is playing. Besides making auto-next
     // immediate on return, this lets us avoid showing a loader after a known series finale.
     private var nextEpisodePrefetchJob: Job? = null
-    private var nextEpisodeLookup: ExternalNextEpisodeLookup? = null
+    private var nextEpisodeSnapshot: ExternalNextEpisodeSnapshot = ExternalNextEpisodeSnapshot.Unknown
     private var autoNextEnabledForPendingLaunch: Boolean? = null
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
@@ -220,37 +263,41 @@ class ExternalPlaybackTracker @Inject constructor(
     /**
      * Called before launching an external player. Stores metadata and starts keep-alive service.
      */
-    fun startTracking(metadata: ExternalPlaybackMetadata, autoLaunch: Boolean = false) {
-        autoNextOverlayReleaseJob?.cancel()
-        autoNextOverlayReleaseJob = null
+    fun startTracking(
+        metadata: ExternalPlaybackMetadata,
+        autoLaunch: Boolean = false,
+        nextEpisodeSnapshot: ExternalNextEpisodeSnapshot? = null,
+        autoNextEnabled: Boolean? = null
+    ) {
         // A manual stream choice supersedes any completion handoff still resolving for the
         // previous player session. Auto-launched continuations keep their handoff alive.
         if (!autoLaunch) {
             autoNextJob?.cancel()
             autoNextJob = null
+            autoNextNavigationPending = false
         }
         pendingMetadata = metadata
         isAutoLaunch = autoLaunch
-        // Fresh launch — allow the auto-next loader / advance again.
-        autoNextCancelled = false
         // A manual launch is always fresh; only an auto-launch within the window is a continuation
         // that keeps a user's abort in effect (so one Back press stops a runaway chain).
-        if (ExternalAutoNextPolicy.shouldResetChainAbort(
+        val shouldResetAbort = !autoNextNavigationPending &&
+            ExternalAutoNextPolicy.shouldResetChainAbort(
                 autoLaunch = autoLaunch,
                 nowMs = System.currentTimeMillis(),
                 lastAutoNextEmitMs = lastAutoNextEmitMs,
                 continuationWindowMs = CONTINUATION_WINDOW_MS
-            )) {
+            )
+        if (shouldResetAbort) {
+            autoNextCancelled = false
             autoNextChainAborted = false
         }
         autoNextOverlaySuppressed = false
         nextEpisodePrefetchJob?.cancel()
-        nextEpisodeLookup = null
-        autoNextEnabledForPendingLaunch = null
-        // Next player is launching and will cover the screen — drop the loader.
-        _autoNextOverlay.value = null
+        this.nextEpisodeSnapshot = nextEpisodeSnapshot ?: ExternalNextEpisodeSnapshot.Unknown
+        autoNextEnabledForPendingLaunch = autoNextEnabled
         // Persist so progress-save + auto-next survive the player killing our process.
         persistMetadata(metadata)
+        persistAutoNextState(this.nextEpisodeSnapshot, autoNextEnabled)
         startNextEpisodePrefetch(metadata)
 
         // Keep the process alive while the external player is foregrounded. Some boxes
@@ -286,14 +333,30 @@ class ExternalPlaybackTracker @Inject constructor(
         resumePositionMs: Long = 0L,
         subtitles: List<SubtitleInput>? = null,
         autoLaunch: Boolean = false,
+        nextEpisodeSnapshot: ExternalNextEpisodeSnapshot? = null,
         context: Context
-    ) {
-        startTracking(metadata, autoLaunch = autoLaunch)
+    ): Boolean {
+        if (shouldCancelPendingAutoLaunch(autoLaunch)) {
+            Log.d(AUTO_NEXT_TAG, "auto launch cancelled before tracker setup")
+            return false
+        }
+        val autoNextEnabled = playerSettingsDataStore.playerSettings.first()
+            .streamAutoPlayNextEpisodeEnabled
+        if (shouldCancelPendingAutoLaunch(autoLaunch)) {
+            Log.d(AUTO_NEXT_TAG, "auto launch cancelled while reading player settings")
+            return false
+        }
+        startTracking(
+            metadata = metadata,
+            autoLaunch = autoLaunch,
+            nextEpisodeSnapshot = nextEpisodeSnapshot,
+            autoNextEnabled = autoNextEnabled
+        )
 
         // Resolve resume position (if not given) and intro/outro skip segments off the main
         // thread, then launch. Skip resolution is bounded so it never stalls the launch for long
         // and is cached, so an auto-next chain pays it only once.
-        coroutineScope {
+        val launched = coroutineScope {
             val positionDeferred = async {
                 if (resumePositionMs > 0L) resumePositionMs else getResumePosition(metadata)
             }
@@ -302,10 +365,26 @@ class ExternalPlaybackTracker @Inject constructor(
             }
             val position = positionDeferred.await()
             val skipSegmentsJson = skipSegmentsDeferred.await()
-            withContext(Dispatchers.Main.immediate) {
-                doLaunch(url, title, headers, position, subtitles, skipSegmentsJson, context)
+            if (shouldCancelPendingAutoLaunch(autoLaunch)) {
+                Log.d(AUTO_NEXT_TAG, "auto launch cancelled during player preparation")
+                false
+            } else {
+                withContext(Dispatchers.Main.immediate) {
+                    doLaunch(url, title, headers, position, subtitles, skipSegmentsJson, context)
+                }
             }
         }
+        if (!launched) {
+            if (shouldCancelPendingAutoLaunch(autoLaunch)) {
+                Log.d(AUTO_NEXT_TAG, "cancelled auto launch cleaned up before external intent")
+            } else {
+                Log.w(TAG, "External player launch failed")
+            }
+            releaseAutoNextOverlay(forceRelease = true)
+            clearPersistedMetadata()
+            stopTracking()
+        }
+        return launched
     }
 
     /**
@@ -367,7 +446,7 @@ class ExternalPlaybackTracker @Inject constructor(
         subtitles: List<SubtitleInput>?,
         skipSegmentsJson: String?,
         context: Context
-    ) {
+    ): Boolean {
 
         val input = ExternalPlayerInput(
             url = url,
@@ -380,7 +459,7 @@ class ExternalPlaybackTracker @Inject constructor(
 
         if (ZidooPlayerMonitor.isZidooDevice()) {
             // Zidoo doesn't return ActivityResult - use fire-and-forget
-            ExternalPlayerLauncher.launch(
+            return ExternalPlayerLauncher.launch(
                 context = context,
                 url = url,
                 title = title,
@@ -393,8 +472,9 @@ class ExternalPlaybackTracker @Inject constructor(
             // Use Activity-level launcher for ActivityResult
             val launcher = activityLauncher
             if (launcher != null) {
-                try {
+                return try {
                     launcher.launch(input)
+                    true
                 } catch (e: Exception) {
                     Log.w(TAG, "ActivityResultLauncher failed, falling back to fire-and-forget", e)
                     ExternalPlayerLauncher.launch(
@@ -409,7 +489,7 @@ class ExternalPlaybackTracker @Inject constructor(
                 }
             } else {
                 Log.w(TAG, "No activityLauncher registered, using fire-and-forget")
-                ExternalPlayerLauncher.launch(
+                return ExternalPlayerLauncher.launch(
                     context = context,
                     url = url,
                     title = title,
@@ -438,6 +518,8 @@ class ExternalPlaybackTracker @Inject constructor(
         }
         if (pendingMetadata == null) {
             Log.d(TAG, "onActivityResult recovered metadata from disk (process was recreated)")
+            nextEpisodeSnapshot = loadPersistedNextEpisodeSnapshot()
+            autoNextEnabledForPendingLaunch = loadPersistedAutoNextEnabled()
         }
 
         if (result == null) {
@@ -449,9 +531,11 @@ class ExternalPlaybackTracker @Inject constructor(
             return
         }
 
-        // Raise the loader here too (covers the process-recreated case, where onStart had no
-        // in-memory metadata). Kept for a completion; dismissed below otherwise.
-        raiseAutoNextOverlay(metadata)
+        // Covers process recreation, where onStart could not use in-memory state. At this point
+        // the result is available, so only a completion may claim the transition loader.
+        if (isPlaybackCompleted(result)) {
+            raiseAutoNextOverlay(metadata, allowUnknownNextEpisode = true)
+        }
 
         Log.d(TAG, "External player returned: pos=${result.positionMs}ms, dur=${result.durationMs}ms, endedByUser=${result.endedByUser}")
 
@@ -580,6 +664,42 @@ class ExternalPlaybackTracker @Inject constructor(
             .apply()
     }
 
+    private fun persistAutoNextState(
+        snapshot: ExternalNextEpisodeSnapshot,
+        autoNextEnabled: Boolean?
+    ) {
+        persistedPrefs.edit()
+            .putBoolean("autoNextEnabledPresent", autoNextEnabled != null)
+            .putBoolean("autoNextEnabled", autoNextEnabled == true)
+            .putBoolean("nextEpisodeSnapshotPresent", true)
+            .putBoolean("nextEpisodeMetadataResolved", snapshot.metadataResolved)
+            .putString("nextEpisodeVideoId", snapshot.nextVideoId)
+            .putInt("nextEpisodeSeason", snapshot.nextSeason ?: Int.MIN_VALUE)
+            .putInt("nextEpisodeNumber", snapshot.nextEpisode ?: Int.MIN_VALUE)
+            .apply()
+    }
+
+    private fun loadPersistedAutoNextEnabled(): Boolean? {
+        val p = persistedPrefs
+        if (!p.getBoolean("autoNextEnabledPresent", false)) return null
+        return p.getBoolean("autoNextEnabled", false)
+    }
+
+    private fun loadPersistedNextEpisodeSnapshot(): ExternalNextEpisodeSnapshot {
+        val p = persistedPrefs
+        if (!p.getBoolean("nextEpisodeSnapshotPresent", false)) {
+            return ExternalNextEpisodeSnapshot.Unknown
+        }
+        return ExternalNextEpisodeSnapshot(
+            metadataResolved = p.getBoolean("nextEpisodeMetadataResolved", false),
+            nextVideoId = p.getString("nextEpisodeVideoId", null),
+            nextSeason = p.getInt("nextEpisodeSeason", Int.MIN_VALUE)
+                .takeIf { it != Int.MIN_VALUE },
+            nextEpisode = p.getInt("nextEpisodeNumber", Int.MIN_VALUE)
+                .takeIf { it != Int.MIN_VALUE }
+        )
+    }
+
     private fun loadPersistedMetadata(): ExternalPlaybackMetadata? {
         val p = persistedPrefs
         val contentId = p.getString("contentId", null) ?: return null
@@ -617,20 +737,39 @@ class ExternalPlaybackTracker @Inject constructor(
         }
 
         nextEpisodePrefetchJob = scope.launch {
-            val enabled = playerSettingsDataStore.playerSettings.first()
-                .streamAutoPlayNextEpisodeEnabled
+            val enabled = autoNextEnabledForPendingLaunch
+                ?: playerSettingsDataStore.playerSettings.first()
+                    .streamAutoPlayNextEpisodeEnabled
             autoNextEnabledForPendingLaunch = enabled
+            persistAutoNextState(nextEpisodeSnapshot, enabled)
             if (!enabled) return@launch
 
             repeat(NEXT_EPISODE_PREFETCH_ATTEMPTS) { attempt ->
-                val lookup = resolveNextEpisodeLookup(metadata)
-                nextEpisodeLookup = lookup
-                if (lookup.metadataResolved) {
-                    val next = lookup.nextVideo
-                    if (next == null) {
-                        Log.d(AUTO_NEXT_TAG, "Prefetch confirmed no next episode after S${metadata.season}E${metadata.episode}")
+                val refreshedSnapshot = resolveNextEpisodeSnapshot(metadata)
+                if (refreshedSnapshot.metadataResolved) {
+                    // Keep a playable successor captured from the screen's complete episode list
+                    // if a background addon refresh returns a thinner list with no successor.
+                    val keepLoadedSuccessor = nextEpisodeSnapshot.hasNextEpisode == true &&
+                        refreshedSnapshot.hasNextEpisode == false
+                    if (!keepLoadedSuccessor) {
+                        nextEpisodeSnapshot = refreshedSnapshot
+                        persistAutoNextState(refreshedSnapshot, enabled)
+                    }
+                    if (refreshedSnapshot.hasNextEpisode == false) {
+                        Log.d(
+                            AUTO_NEXT_TAG,
+                            if (keepLoadedSuccessor) {
+                                "Prefetch returned no successor; retaining loaded episode snapshot"
+                            } else {
+                                "Prefetch confirmed no next episode after S${metadata.season}E${metadata.episode}"
+                            }
+                        )
                     } else {
-                        Log.d(AUTO_NEXT_TAG, "Prefetched next episode S${next.season}E${next.episode} videoId=${next.id}")
+                        Log.d(
+                            AUTO_NEXT_TAG,
+                            "Prefetched next episode S${refreshedSnapshot.nextSeason}" +
+                                "E${refreshedSnapshot.nextEpisode} videoId=${refreshedSnapshot.nextVideoId}"
+                        )
                     }
                     return@launch
                 }
@@ -647,30 +786,20 @@ class ExternalPlaybackTracker @Inject constructor(
         }
     }
 
-    private suspend fun resolveNextEpisodeLookup(metadata: ExternalPlaybackMetadata): ExternalNextEpisodeLookup {
+    private suspend fun resolveNextEpisodeSnapshot(
+        metadata: ExternalPlaybackMetadata
+    ): ExternalNextEpisodeSnapshot {
         val result = withTimeoutOrNull(META_FETCH_TIMEOUT_MS) {
             metaRepository
                 .getMetaFromAllAddons(type = metadata.contentType, id = metadata.contentId)
                 .first { it !is NetworkResult.Loading }
         }
         val meta = (result as? NetworkResult.Success)?.data
-            ?: return ExternalNextEpisodeLookup(metadataResolved = false, nextVideo = null)
-        val episode = metadata.episode
-            ?: return ExternalNextEpisodeLookup(metadataResolved = true, nextVideo = null)
-        val nextVideo = PlayerNextEpisodeRules.resolveNextEpisode(
-                videos = meta.videos,
-                currentSeason = metadata.season,
-                currentEpisode = episode
-            )
-            ?.takeIf { candidate ->
-                ExternalAutoNextPolicy.isPlayableNextEpisode(
-                    available = candidate.available,
-                    hasAired = PlayerNextEpisodeRules.hasEpisodeAired(candidate.released)
-                )
-            }
-        return ExternalNextEpisodeLookup(
-            metadataResolved = true,
-            nextVideo = nextVideo
+            ?: return ExternalNextEpisodeSnapshot.Unknown
+        return resolveExternalNextEpisodeSnapshot(
+            videos = meta.videos,
+            currentSeason = metadata.season,
+            currentEpisode = metadata.episode
         )
     }
 
@@ -707,9 +836,8 @@ class ExternalPlaybackTracker @Inject constructor(
             return
         }
 
-        // Build the loader now, but do not display it until a playable successor is confirmed.
-        // An optimistic loader causes a visible flash when returning from a series finale.
-        val overlay = ExternalAutoNextOverlay(
+        // Reuse the overlay raised in onStart so ownership remains stable through navigation.
+        val overlay = _autoNextOverlay.value ?: ExternalAutoNextOverlay(
             backdrop = metadata.backdrop ?: metadata.poster,
             logo = metadata.logo,
             title = metadata.contentName
@@ -721,37 +849,44 @@ class ExternalPlaybackTracker @Inject constructor(
         autoNextJob?.cancel()
         autoNextJob = scope.launch {
             // Gate exactly like the internal path does.
-            val autoPlayNextEnabled = playerSettingsDataStore.playerSettings.first()
-                .streamAutoPlayNextEpisodeEnabled
+            val autoPlayNextEnabled = autoNextEnabledForPendingLaunch
+                ?: playerSettingsDataStore.playerSettings.first()
+                    .streamAutoPlayNextEpisodeEnabled
             if (!autoPlayNextEnabled) {
                 Log.d(AUTO_NEXT_TAG, "Auto-play next episode is OFF; skipping auto-advance")
                 dismissOverlayIfCurrent()
                 return@launch
             }
 
-            // Prefer the lookup started when playback launched. If it was still in flight, wait
-            // for it here; after a process recreation or a failed prefetch, retry once now.
-            nextEpisodePrefetchJob?.let { prefetchJob ->
-                withTimeoutOrNull(NEXT_EPISODE_PREFETCH_RETURN_WAIT_MS) { prefetchJob.join() }
-                if (prefetchJob.isActive) prefetchJob.cancel()
+            // A snapshot from the already loaded episode list is immediately authoritative. If
+            // that was unavailable, briefly join the background refresh before resolving here.
+            if (!nextEpisodeSnapshot.metadataResolved) {
+                nextEpisodePrefetchJob?.let { prefetchJob ->
+                    withTimeoutOrNull(NEXT_EPISODE_PREFETCH_RETURN_WAIT_MS) { prefetchJob.join() }
+                    if (prefetchJob.isActive) prefetchJob.cancel()
+                }
             }
-            val lookup = nextEpisodeLookup
-                ?.takeIf { it.metadataResolved }
-                ?: resolveNextEpisodeLookup(metadata)
-            if (!lookup.metadataResolved) {
+            val resolvedSnapshot = nextEpisodeSnapshot.takeIf { it.metadataResolved }
+                ?: resolveNextEpisodeSnapshot(metadata).also { refreshed ->
+                    if (refreshed.metadataResolved) {
+                        nextEpisodeSnapshot = refreshed
+                        persistAutoNextState(refreshed, autoPlayNextEnabled)
+                    }
+                }
+            if (!resolvedSnapshot.metadataResolved) {
                 Log.d(AUTO_NEXT_TAG, "Could not load series meta for ${metadata.contentId} (timeout or error); skipping")
                 dismissOverlayIfCurrent()
                 return@launch
             }
 
-            val nextVideo = lookup.nextVideo
-            val nextEpisode = nextVideo?.episode
-            if (nextVideo == null || nextEpisode == null) {
+            val nextVideoId = resolvedSnapshot.nextVideoId
+            val nextEpisode = resolvedSnapshot.nextEpisode
+            if (nextVideoId == null || nextEpisode == null) {
                 Log.d(AUTO_NEXT_TAG, "No next episode after S${season}E${episode} for ${metadata.contentId}")
                 dismissOverlayIfCurrent()
                 return@launch
             }
-            val nextSeason = nextVideo.season
+            val nextSeason = resolvedSnapshot.nextSeason
 
             val shouldShowLoader = ExternalAutoNextPolicy.shouldRaiseLoader(
                 episode = episode,
@@ -767,13 +902,14 @@ class ExternalPlaybackTracker @Inject constructor(
 
             Log.d(
                 AUTO_NEXT_TAG,
-                "Next episode resolved: S${nextSeason}E${nextEpisode} videoId=${nextVideo.id} " +
+                "Next episode resolved: S${nextSeason}E${nextEpisode} videoId=$nextVideoId " +
                     "(from S${season}E${episode}, content=${metadata.contentId})"
             )
 
             // Mark the time of this emit so the resulting launch is recognised as a chain
             // continuation (and a user abort survives it).
             lastAutoNextEmitMs = System.currentTimeMillis()
+            autoNextNavigationPending = true
             _autoPlayNext.emit(
                 ExternalAutoNextEpisode(
                     contentId = metadata.contentId,
@@ -783,16 +919,17 @@ class ExternalPlaybackTracker @Inject constructor(
                     backdrop = metadata.backdrop,
                     logo = metadata.logo,
                     year = metadata.year,
-                    nextVideoId = nextVideo.id,
+                    nextVideoId = nextVideoId,
                     nextSeason = nextSeason,
                     nextEpisode = nextEpisode
                 )
             )
 
-            // Safety net: normally cleared when the next player launches, but in Manual
-            // mode the Stream screen waits for the user, so don't leave the loader stuck.
+            // StreamScreen explicitly releases on manual fallback. This is only a final guard
+            // beyond its 60 second source-resolution timeout.
             delay(AUTO_NEXT_OVERLAY_TIMEOUT_MS)
             Log.d(AUTO_NEXT_TAG, "safety-net timeout -> clearing loader")
+            autoNextNavigationPending = false
             // Clear unconditionally: the identity-guarded variant left a stale overlay stuck when a
             // re-raise had replaced the object this job captured.
             _autoNextOverlay.value = null
@@ -815,40 +952,56 @@ class ExternalPlaybackTracker @Inject constructor(
         autoNextChainAborted = true
         autoNextJob?.cancel()
         autoNextJob = null
-        autoNextOverlayReleaseJob?.cancel()
-        autoNextOverlayReleaseJob = null
         _autoNextOverlay.value = null
     }
 
-    /** Hide the loader when the Stream screen settles without aborting the chain. A confirmed,
-     *  active handoff gets a short grace period so the old source screen cannot flash between the
-     *  external player and the next launch. Manual mode still reveals its source list promptly. */
-    fun releaseAutoNextOverlay() {
-        if (ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(isTracking)) {
+    /** Hide the loader when Stream settles. A possible active handoff retains ownership until the
+     * next external player covers Nuvio. Explicit manual fallback and launch failures force it off. */
+    fun releaseAutoNextOverlay(forceRelease: Boolean = false) {
+        if (!forceRelease && ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(isTracking)) {
             Log.d(AUTO_NEXT_TAG, "releaseAutoNextOverlay ignored while external player is active")
             return
         }
         val overlayShowing = _autoNextOverlay.value != null
-        val delayRelease = ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+        val holdLoader = ExternalAutoNextPolicy.shouldHoldLoaderOnSettle(
             overlayShowing = overlayShowing,
             handoffActive = autoNextJob?.isActive == true,
-            hasConfirmedNextEpisode = nextEpisodeLookup?.nextVideo != null
+            mayHaveNextEpisode = nextEpisodeSnapshot.hasNextEpisode != false,
+            forceRelease = forceRelease
         )
         Log.d(
             AUTO_NEXT_TAG,
-            "releaseAutoNextOverlay (settle) overlayWasShowing=$overlayShowing delayRelease=$delayRelease"
+            "releaseAutoNextOverlay (settle) overlayWasShowing=$overlayShowing " +
+                "holdLoader=$holdLoader forceRelease=$forceRelease"
         )
-        if (delayRelease) {
-            autoNextOverlayReleaseJob?.cancel()
-            autoNextOverlayReleaseJob = scope.launch {
-                delay(AUTO_NEXT_SETTLE_RELEASE_GRACE_MS)
-                autoNextOverlaySuppressed = true
-                _autoNextOverlay.value = null
-                Log.d(AUTO_NEXT_TAG, "settle grace expired -> clearing loader")
-            }
-            return
+        if (holdLoader) return
+        if (forceRelease || !autoNextCancelled) {
+            autoNextNavigationPending = false
         }
         autoNextOverlaySuppressed = true
+        _autoNextOverlay.value = null
+    }
+
+    /** Forward StreamScreen's detailed launch stage into the continuous root overlay. Null
+     * messages retain the previous stage so intermediate state cleanup cannot flash generic text. */
+    fun updateAutoNextOverlayStatus(message: String?, progress: Float?) {
+        val current = _autoNextOverlay.value ?: return
+        val updated = current.copy(
+            message = message?.takeIf { it.isNotBlank() } ?: current.message,
+            progress = progress
+        )
+        if (updated == current) return
+        _autoNextOverlay.value = updated
+        Log.d(AUTO_NEXT_TAG, "loader status message=${updated.message} progress=${updated.progress}")
+    }
+
+    /** The launched external player now owns the display, so the Nuvio transition cover can end. */
+    fun onExternalPlayerCoveredApp() {
+        if (!isTracking) return
+        Log.d(AUTO_NEXT_TAG, "external player covered app -> clearing transition loader")
+        autoNextJob?.cancel()
+        autoNextJob = null
+        autoNextNavigationPending = false
         _autoNextOverlay.value = null
     }
 
@@ -867,22 +1020,34 @@ class ExternalPlaybackTracker @Inject constructor(
      *  the next launch is treated as fresh (re-enabling auto-next). */
     fun consumeAbortedAutoNextContinuation() {
         lastAutoNextEmitMs = 0L
+        autoNextNavigationPending = false
     }
+
+    private fun shouldCancelPendingAutoLaunch(autoLaunch: Boolean): Boolean =
+        ExternalAutoNextPolicy.shouldCancelPendingAutoLaunch(
+            autoLaunch = autoLaunch,
+            autoNextNavigationPending = autoNextNavigationPending,
+            cancelled = autoNextCancelled,
+            chainAborted = autoNextChainAborted
+        )
 
     /** Raise the loader the instant we return (from MainActivity.onStart, before the result is
      *  parsed and the window repaints) so there's no episode-list flash. No-op for non-episodes;
      *  idempotent. Kept for a completion, dismissed by onActivityResult otherwise. */
     fun raiseAutoNextOverlayOnReturn() {
-        raiseAutoNextOverlay(pendingMetadata ?: return)
+        val metadata = pendingMetadata ?: loadPersistedMetadata() ?: return
+        if (pendingMetadata == null) {
+            nextEpisodeSnapshot = loadPersistedNextEpisodeSnapshot()
+            autoNextEnabledForPendingLaunch = loadPersistedAutoNextEnabled()
+        }
+        raiseAutoNextOverlay(metadata, allowUnknownNextEpisode = true)
     }
 
-    private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
-        val lookup = nextEpisodeLookup
-        val hasNextEpisode = when {
-            lookup?.metadataResolved != true -> null
-            lookup.nextVideo != null -> true
-            else -> false
-        }
+    private fun raiseAutoNextOverlay(
+        metadata: ExternalPlaybackMetadata,
+        allowUnknownNextEpisode: Boolean = false
+    ) {
+        val hasNextEpisode = nextEpisodeSnapshot.hasNextEpisode
         val shouldRaise = ExternalAutoNextPolicy.shouldRaiseLoader(
             episode = metadata.episode,
             contentType = metadata.contentType,
@@ -891,7 +1056,8 @@ class ExternalPlaybackTracker @Inject constructor(
             overlaySuppressed = autoNextOverlaySuppressed,
             alreadyShowing = _autoNextOverlay.value != null,
             autoNextEnabled = autoNextEnabledForPendingLaunch,
-            hasNextEpisode = hasNextEpisode
+            hasNextEpisode = hasNextEpisode,
+            allowUnknownNextEpisode = allowUnknownNextEpisode
         )
         if (!shouldRaise) {
             if (hasNextEpisode == false) {

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
+import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
@@ -99,6 +100,11 @@ data class ExternalAutoNextOverlay(
     val title: String?
 )
 
+private data class ExternalNextEpisodeLookup(
+    val metadataResolved: Boolean,
+    val nextVideo: Video?
+)
+
 /**
  * Application-scoped singleton that tracks external player playback.
  *
@@ -129,6 +135,8 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val AUTO_NEXT_TAG = "ExtAutoNext"
         /** Max time the auto-advance loader stays up if the next player never launches. */
         private const val AUTO_NEXT_OVERLAY_TIMEOUT_MS = 10_000L
+        /** Lets a confirmed handoff cross the old Stream screen without a one-frame source flash. */
+        private const val AUTO_NEXT_SETTLE_RELEASE_GRACE_MS = 1_500L
         /** Max time to wait for series meta when resolving the next episode. */
         private const val META_FETCH_TIMEOUT_MS = 15_000L
         /** A "completed" playback shorter than this is treated as a debrid cache-sync placeholder
@@ -145,6 +153,7 @@ class ExternalPlaybackTracker @Inject constructor(
     // The in-flight auto-next resolution (meta fetch -> emit next episode). Held so the user can
     // cancel it by backing out of the "Loading next episode" loader before it navigates.
     private var autoNextJob: Job? = null
+    private var autoNextOverlayReleaseJob: Job? = null
     // Set when the user backs out of the loader; blocks the loader from re-raising and auto-next
     // from firing for the current return (e.g. while VLC's duration backfill is still running).
     // Reset on each new launch in startTracking.
@@ -160,6 +169,11 @@ class ExternalPlaybackTracker @Inject constructor(
     // Set when the loader is released on a routine screen settle, so a later onStart can't re-raise a
     // loader that no longer has a job behind it (which would leave it stuck). Reset on a fresh launch.
     private var autoNextOverlaySuppressed = false
+    // Resolve the successor while the current episode is playing. Besides making auto-next
+    // immediate on return, this lets us avoid showing a loader after a known series finale.
+    private var nextEpisodePrefetchJob: Job? = null
+    private var nextEpisodeLookup: ExternalNextEpisodeLookup? = null
+    private var autoNextEnabledForPendingLaunch: Boolean? = null
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
     // the next episode's Stream route. replay = 1 so the event still reaches the
@@ -202,6 +216,14 @@ class ExternalPlaybackTracker @Inject constructor(
      * Called before launching an external player. Stores metadata and starts keep-alive service.
      */
     fun startTracking(metadata: ExternalPlaybackMetadata, autoLaunch: Boolean = false) {
+        autoNextOverlayReleaseJob?.cancel()
+        autoNextOverlayReleaseJob = null
+        // A manual stream choice supersedes any completion handoff still resolving for the
+        // previous player session. Auto-launched continuations keep their handoff alive.
+        if (!autoLaunch) {
+            autoNextJob?.cancel()
+            autoNextJob = null
+        }
         pendingMetadata = metadata
         isAutoLaunch = autoLaunch
         // Fresh launch — allow the auto-next loader / advance again.
@@ -217,10 +239,14 @@ class ExternalPlaybackTracker @Inject constructor(
             autoNextChainAborted = false
         }
         autoNextOverlaySuppressed = false
+        nextEpisodePrefetchJob?.cancel()
+        nextEpisodeLookup = null
+        autoNextEnabledForPendingLaunch = null
         // Next player is launching and will cover the screen — drop the loader.
         _autoNextOverlay.value = null
         // Persist so progress-save + auto-next survive the player killing our process.
         persistMetadata(metadata)
+        startNextEpisodePrefetch(metadata)
 
         // Keep the process alive while the external player is foregrounded. Some boxes
         // (e.g. NVIDIA Shield) otherwise kill it, dropping tracking state. Started while
@@ -575,6 +601,62 @@ class ExternalPlaybackTracker @Inject constructor(
 
     // ===================== Completion + auto-next =====================
 
+    private fun startNextEpisodePrefetch(metadata: ExternalPlaybackMetadata) {
+        if (!ExternalAutoNextPolicy.shouldAttemptAdvance(
+                episode = metadata.episode,
+                contentType = metadata.contentType,
+                cancelled = false,
+                chainAborted = false
+            )) {
+            return
+        }
+
+        nextEpisodePrefetchJob = scope.launch {
+            val enabled = playerSettingsDataStore.playerSettings.first()
+                .streamAutoPlayNextEpisodeEnabled
+            autoNextEnabledForPendingLaunch = enabled
+            if (!enabled) return@launch
+
+            nextEpisodeLookup = resolveNextEpisodeLookup(metadata)
+            val lookup = nextEpisodeLookup
+            if (lookup?.metadataResolved == true) {
+                val next = lookup.nextVideo
+                if (next == null) {
+                    Log.d(AUTO_NEXT_TAG, "Prefetch confirmed no next episode after S${metadata.season}E${metadata.episode}")
+                } else {
+                    Log.d(AUTO_NEXT_TAG, "Prefetched next episode S${next.season}E${next.episode} videoId=${next.id}")
+                }
+            }
+        }
+    }
+
+    private suspend fun resolveNextEpisodeLookup(metadata: ExternalPlaybackMetadata): ExternalNextEpisodeLookup {
+        val result = withTimeoutOrNull(META_FETCH_TIMEOUT_MS) {
+            metaRepository
+                .getMetaFromAllAddons(type = metadata.contentType, id = metadata.contentId)
+                .first { it !is NetworkResult.Loading }
+        }
+        val meta = (result as? NetworkResult.Success)?.data
+            ?: return ExternalNextEpisodeLookup(metadataResolved = false, nextVideo = null)
+        val episode = metadata.episode
+            ?: return ExternalNextEpisodeLookup(metadataResolved = true, nextVideo = null)
+        val nextVideo = PlayerNextEpisodeRules.resolveNextEpisode(
+                videos = meta.videos,
+                currentSeason = metadata.season,
+                currentEpisode = episode
+            )
+            ?.takeIf { candidate ->
+                ExternalAutoNextPolicy.isPlayableNextEpisode(
+                    available = candidate.available,
+                    hasAired = PlayerNextEpisodeRules.hasEpisodeAired(candidate.released)
+                )
+            }
+        return ExternalNextEpisodeLookup(
+            metadataResolved = true,
+            nextVideo = nextVideo
+        )
+    }
+
     // True on a natural end (end_by != "user"), or for players without end_by once the
     // position reaches COMPLETED_THRESHOLD (90%).
     private fun isPlaybackCompleted(result: ExternalPlayerResult): Boolean {
@@ -608,13 +690,13 @@ class ExternalPlaybackTracker @Inject constructor(
             return
         }
 
-        // Show the loader before the async work below so it covers the cold-start window.
+        // Build the loader now, but do not display it until a playable successor is confirmed.
+        // An optimistic loader causes a visible flash when returning from a series finale.
         val overlay = ExternalAutoNextOverlay(
             backdrop = metadata.backdrop ?: metadata.poster,
             logo = metadata.logo,
             title = metadata.contentName
         )
-        _autoNextOverlay.value = overlay
         fun dismissOverlayIfCurrent() {
             if (_autoNextOverlay.value === overlay) _autoNextOverlay.value = null
         }
@@ -630,25 +712,21 @@ class ExternalPlaybackTracker @Inject constructor(
                 return@launch
             }
 
-            // Bounded so a hung addon flow (never emits non-Loading) can't suspend here
-            // forever and leave the loader up — withTimeoutOrNull returns null on timeout.
-            val result = withTimeoutOrNull(META_FETCH_TIMEOUT_MS) {
-                metaRepository
-                    .getMetaFromAllAddons(type = metadata.contentType, id = metadata.contentId)
-                    .first { it !is NetworkResult.Loading }
+            // Prefer the lookup started when playback launched. If it was still in flight, wait
+            // for it here; after a process recreation or a failed prefetch, retry once now.
+            nextEpisodePrefetchJob?.let { prefetchJob ->
+                withTimeoutOrNull(META_FETCH_TIMEOUT_MS) { prefetchJob.join() }
             }
-            val meta = (result as? NetworkResult.Success)?.data
-            if (meta == null) {
+            val lookup = nextEpisodeLookup
+                ?.takeIf { it.metadataResolved }
+                ?: resolveNextEpisodeLookup(metadata)
+            if (!lookup.metadataResolved) {
                 Log.d(AUTO_NEXT_TAG, "Could not load series meta for ${metadata.contentId} (timeout or error); skipping")
                 dismissOverlayIfCurrent()
                 return@launch
             }
 
-            val nextVideo = PlayerNextEpisodeRules.resolveNextEpisode(
-                videos = meta.videos,
-                currentSeason = season,
-                currentEpisode = episode
-            )
+            val nextVideo = lookup.nextVideo
             val nextEpisode = nextVideo?.episode
             if (nextVideo == null || nextEpisode == null) {
                 Log.d(AUTO_NEXT_TAG, "No next episode after S${season}E${episode} for ${metadata.contentId}")
@@ -656,6 +734,18 @@ class ExternalPlaybackTracker @Inject constructor(
                 return@launch
             }
             val nextSeason = nextVideo.season
+
+            val shouldShowLoader = ExternalAutoNextPolicy.shouldRaiseLoader(
+                episode = episode,
+                contentType = metadata.contentType,
+                cancelled = autoNextCancelled,
+                chainAborted = autoNextChainAborted,
+                overlaySuppressed = autoNextOverlaySuppressed,
+                alreadyShowing = _autoNextOverlay.value != null,
+                autoNextEnabled = true,
+                hasNextEpisode = true
+            )
+            if (shouldShowLoader) _autoNextOverlay.value = overlay
 
             Log.d(
                 AUTO_NEXT_TAG,
@@ -707,17 +797,36 @@ class ExternalPlaybackTracker @Inject constructor(
         autoNextChainAborted = true
         autoNextJob?.cancel()
         autoNextJob = null
+        autoNextOverlayReleaseJob?.cancel()
+        autoNextOverlayReleaseJob = null
         _autoNextOverlay.value = null
     }
 
-    /** Hide the loader overlay when the Stream screen settles, without aborting the chain, so a
-     *  routine return to the screen never suppresses the next auto-advance. Suppresses re-raising so
-     *  a later onStart can't bring back a loader that no longer has a job behind it. */
+    /** Hide the loader when the Stream screen settles without aborting the chain. A confirmed,
+     *  active handoff gets a short grace period so the old source screen cannot flash between the
+     *  external player and the next launch. Manual mode still reveals its source list promptly. */
     fun releaseAutoNextOverlay() {
-        Log.d(AUTO_NEXT_TAG, "releaseAutoNextOverlay (settle) overlayWasShowing=${_autoNextOverlay.value != null}")
+        val overlayShowing = _autoNextOverlay.value != null
+        val delayRelease = ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+            overlayShowing = overlayShowing,
+            handoffActive = autoNextJob?.isActive == true,
+            hasConfirmedNextEpisode = nextEpisodeLookup?.nextVideo != null
+        )
+        Log.d(
+            AUTO_NEXT_TAG,
+            "releaseAutoNextOverlay (settle) overlayWasShowing=$overlayShowing delayRelease=$delayRelease"
+        )
+        if (delayRelease) {
+            autoNextOverlayReleaseJob?.cancel()
+            autoNextOverlayReleaseJob = scope.launch {
+                delay(AUTO_NEXT_SETTLE_RELEASE_GRACE_MS)
+                autoNextOverlaySuppressed = true
+                _autoNextOverlay.value = null
+                Log.d(AUTO_NEXT_TAG, "settle grace expired -> clearing loader")
+            }
+            return
+        }
         autoNextOverlaySuppressed = true
-        autoNextJob?.cancel()
-        autoNextJob = null
         _autoNextOverlay.value = null
     }
 
@@ -746,15 +855,28 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private fun raiseAutoNextOverlay(metadata: ExternalPlaybackMetadata) {
+        val lookup = nextEpisodeLookup
+        val hasNextEpisode = when {
+            lookup?.metadataResolved != true -> null
+            lookup.nextVideo != null -> true
+            else -> false
+        }
         val shouldRaise = ExternalAutoNextPolicy.shouldRaiseLoader(
             episode = metadata.episode,
             contentType = metadata.contentType,
             cancelled = autoNextCancelled,
             chainAborted = autoNextChainAborted,
             overlaySuppressed = autoNextOverlaySuppressed,
-            alreadyShowing = _autoNextOverlay.value != null
+            alreadyShowing = _autoNextOverlay.value != null,
+            autoNextEnabled = autoNextEnabledForPendingLaunch,
+            hasNextEpisode = hasNextEpisode
         )
-        if (!shouldRaise) return
+        if (!shouldRaise) {
+            if (hasNextEpisode == false) {
+                Log.d(AUTO_NEXT_TAG, "loader skipped for known final episode ${metadata.videoId}")
+            }
+            return
+        }
         _autoNextOverlay.value = ExternalAutoNextOverlay(
             backdrop = metadata.backdrop ?: metadata.poster,
             logo = metadata.logo,

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -139,6 +139,11 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val AUTO_NEXT_SETTLE_RELEASE_GRACE_MS = 1_500L
         /** Max time to wait for series meta when resolving the next episode. */
         private const val META_FETCH_TIMEOUT_MS = 15_000L
+        /** Retry a failed background lookup while the current episode is still playing. */
+        private const val NEXT_EPISODE_PREFETCH_ATTEMPTS = 3
+        private const val NEXT_EPISODE_PREFETCH_RETRY_DELAY_MS = 5_000L
+        /** Do not let a retrying prefetch hold the completion handoff for the full retry window. */
+        private const val NEXT_EPISODE_PREFETCH_RETURN_WAIT_MS = 1_000L
         /** A "completed" playback shorter than this is treated as a debrid cache-sync placeholder
          *  (e.g. Comet's few-second clip), not a real episode: not marked watched, no auto-advance. */
         private const val MIN_REAL_PLAYBACK_DURATION_MS = 30_000L
@@ -617,14 +622,26 @@ class ExternalPlaybackTracker @Inject constructor(
             autoNextEnabledForPendingLaunch = enabled
             if (!enabled) return@launch
 
-            nextEpisodeLookup = resolveNextEpisodeLookup(metadata)
-            val lookup = nextEpisodeLookup
-            if (lookup?.metadataResolved == true) {
-                val next = lookup.nextVideo
-                if (next == null) {
-                    Log.d(AUTO_NEXT_TAG, "Prefetch confirmed no next episode after S${metadata.season}E${metadata.episode}")
-                } else {
-                    Log.d(AUTO_NEXT_TAG, "Prefetched next episode S${next.season}E${next.episode} videoId=${next.id}")
+            repeat(NEXT_EPISODE_PREFETCH_ATTEMPTS) { attempt ->
+                val lookup = resolveNextEpisodeLookup(metadata)
+                nextEpisodeLookup = lookup
+                if (lookup.metadataResolved) {
+                    val next = lookup.nextVideo
+                    if (next == null) {
+                        Log.d(AUTO_NEXT_TAG, "Prefetch confirmed no next episode after S${metadata.season}E${metadata.episode}")
+                    } else {
+                        Log.d(AUTO_NEXT_TAG, "Prefetched next episode S${next.season}E${next.episode} videoId=${next.id}")
+                    }
+                    return@launch
+                }
+
+                val attemptNumber = attempt + 1
+                Log.d(
+                    AUTO_NEXT_TAG,
+                    "Next episode prefetch attempt $attemptNumber/$NEXT_EPISODE_PREFETCH_ATTEMPTS failed"
+                )
+                if (attemptNumber < NEXT_EPISODE_PREFETCH_ATTEMPTS) {
+                    delay(NEXT_EPISODE_PREFETCH_RETRY_DELAY_MS)
                 }
             }
         }
@@ -715,7 +732,8 @@ class ExternalPlaybackTracker @Inject constructor(
             // Prefer the lookup started when playback launched. If it was still in flight, wait
             // for it here; after a process recreation or a failed prefetch, retry once now.
             nextEpisodePrefetchJob?.let { prefetchJob ->
-                withTimeoutOrNull(META_FETCH_TIMEOUT_MS) { prefetchJob.join() }
+                withTimeoutOrNull(NEXT_EPISODE_PREFETCH_RETURN_WAIT_MS) { prefetchJob.join() }
+                if (prefetchJob.isActive) prefetchJob.cancel()
             }
             val lookup = nextEpisodeLookup
                 ?.takeIf { it.metadataResolved }
@@ -806,6 +824,10 @@ class ExternalPlaybackTracker @Inject constructor(
      *  active handoff gets a short grace period so the old source screen cannot flash between the
      *  external player and the next launch. Manual mode still reveals its source list promptly. */
     fun releaseAutoNextOverlay() {
+        if (ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(isTracking)) {
+            Log.d(AUTO_NEXT_TAG, "releaseAutoNextOverlay ignored while external player is active")
+            return
+        }
         val overlayShowing = _autoNextOverlay.value != null
         val delayRelease = ExternalAutoNextPolicy.shouldDelayLoaderRelease(
             overlayShowing = overlayShowing,

--- a/app/src/main/java/com/nuvio/tv/data/local/BingeGroupCacheDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/BingeGroupCacheDataStore.kt
@@ -35,6 +35,17 @@ class BingeGroupCacheDataStore @Inject constructor(
         }
     }
 
+    suspend fun replace(contentId: String, bingeGroup: String?) {
+        store().edit { prefs ->
+            val value = bingeGroup?.takeIf { it.isNotBlank() }
+            if (value == null) {
+                prefs.remove(prefKey(contentId))
+            } else {
+                prefs[prefKey(contentId)] = value
+            }
+        }
+    }
+
     suspend fun get(contentId: String): String? {
         return store().data.first()[prefKey(contentId)]
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
@@ -21,9 +21,9 @@ internal fun PlayerRuntimeController.startInitialPlaybackIfNeeded() {
     // (from CW, Details, or next-episode) can reuse the same source group.
     val bg = navigationArgs.bingeGroup
     val cid = contentId
-    if (bg != null && cid != null) {
+    if (cid != null) {
         scope.launch(kotlinx.coroutines.NonCancellable) {
-            bingeGroupCacheDataStore.save(cid, bg)
+            bingeGroupCacheDataStore.replace(cid, bg)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -535,9 +535,9 @@ private fun PlayerRuntimeController.applyStreamMetadata(stream: Stream) {
     // (from CW, Details, or next-episode) can reuse the same source group.
     val bg = stream.behaviorHints?.bingeGroup
     val cid = contentId
-    if (bg != null && cid != null) {
+    if (cid != null) {
         scope.launch(kotlinx.coroutines.NonCancellable) {
-            bingeGroupCacheDataStore.save(cid, bg)
+            bingeGroupCacheDataStore.replace(cid, bg)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -231,6 +231,15 @@ class PlayerViewModel @Inject constructor(
                 headers = controller.getCurrentHeaders(),
                 resumePositionMs = resumePositionMs,
                 subtitles = cachedSubtitles,
+                nextEpisodeSnapshot = controller.metaVideos
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { videos ->
+                        com.nuvio.tv.core.player.resolveExternalNextEpisodeSnapshot(
+                            videos = videos,
+                            currentSeason = metadata.season,
+                            currentEpisode = metadata.episode
+                        )
+                    },
                 context = activityContext
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicy.kt
@@ -1,0 +1,21 @@
+package com.nuvio.tv.ui.screens.stream
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+
+internal object DirectAutoPlayWatchdogPolicy {
+    suspend fun awaitForeground(hostInForeground: StateFlow<Boolean>) {
+        hostInForeground.first { it }
+    }
+
+    fun shouldTearDownResolvedTarget(
+        resolvedAutoPlayTarget: Boolean,
+        hostInForeground: Boolean,
+        showDirectAutoPlayOverlay: Boolean,
+        externalPlayerOverlayVisible: Boolean
+    ): Boolean {
+        return resolvedAutoPlayTarget &&
+            hostInForeground &&
+            (showDirectAutoPlayOverlay || externalPlayerOverlayVisible)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -335,10 +335,10 @@ fun StreamScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.onEvent(StreamScreenEvent.OnResume)
                 // Always dismiss overlay and stop tracking on resume
                 // covers both ActivityResult path and fire-and-forget path.
                 viewModel.stopExternalPlayerTracking()
+                viewModel.onEvent(StreamScreenEvent.OnResume)
                 if (pendingRestoreOnResume) {
                     restoreFocusedStream = true
                     pendingRestoreOnResume = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -280,7 +280,10 @@ fun StreamScreen(
     // mask this screen (whether it auto-launches a player or shows the manual list).
     LaunchedEffect(uiState.isLoading) {
         if (!uiState.isLoading) {
-            viewModel.dismissExternalAutoNextOverlay()
+            viewModel.dismissExternalAutoNextOverlay(
+                forceRelease = !uiState.isDirectAutoPlayFlow ||
+                    playerPreference != PlayerPreference.EXTERNAL
+            )
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -28,6 +28,7 @@ import com.nuvio.tv.data.local.BingeGroupCacheDataStore
 import com.nuvio.tv.domain.model.AddonStreams
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Stream
+import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.model.StreamDebridCacheState
 import com.nuvio.tv.domain.model.enabledAddons
@@ -107,6 +108,7 @@ class StreamScreenViewModel @Inject constructor(
     private var streamBadgePresentationJob: Job? = null
     private var streamBadgePresentationRequestId = 0L
     private var badgedAddonNames: Set<String> = emptySet()
+    private var playbackMetaVideos: List<Video>? = null
 
     private val embeddedStreamGroupName: String by lazy {
         context.getString(R.string.stream_embedded_group)
@@ -226,6 +228,14 @@ class StreamScreenViewModel @Inject constructor(
     }
 
     init {
+        viewModelScope.launch {
+            _uiState
+                .map { state -> state.directAutoPlayMessage to state.directAutoPlayProgress }
+                .distinctUntilChanged()
+                .collectLatest { (message, progress) ->
+                    externalPlaybackTracker.updateAutoNextOverlayStatus(message, progress)
+                }
+        }
         if (manualSelection) {
             // Returning from a playback error: keep the user on stream selection.
             autoPlayHandledForSession = true
@@ -754,7 +764,7 @@ class StreamScreenViewModel @Inject constructor(
                             directAutoPlayMessage = null
                         )
                     }
-                    externalPlaybackTracker.releaseAutoNextOverlay()
+                    externalPlaybackTracker.releaseAutoNextOverlay(forceRelease = true)
                 }
             }
 
@@ -849,7 +859,7 @@ class StreamScreenViewModel @Inject constructor(
                                 directAutoPlayMessage = null
                             )
                         }
-                        externalPlaybackTracker.releaseAutoNextOverlay()
+                        externalPlaybackTracker.releaseAutoNextOverlay(forceRelease = true)
                         streamLoadInner.cancel()
                         markRemainingSourceChipsAsError()
                     }
@@ -1046,8 +1056,6 @@ class StreamScreenViewModel @Inject constructor(
 
     private fun loadMissingMetaDetailsIfNeeded() {
         val requiresMetadataLookup = genres.isNullOrBlank() || year.isNullOrBlank() || runtime == null
-        if (!requiresMetadataLookup) return
-
         val metaId = contentId ?: videoId.substringBefore(":")
         if (metaId.isBlank() || contentType.isBlank()) return
 
@@ -1058,6 +1066,8 @@ class StreamScreenViewModel @Inject constructor(
             if (result !is NetworkResult.Success) return@launch
 
             val meta = result.data
+            playbackMetaVideos = meta.videos
+            if (!requiresMetadataLookup) return@launch
             val metaGenres = meta.genres.takeIf { it.isNotEmpty() }?.joinToString(" • ")
             val metaYear = meta.releaseInfo
                 ?.substringBefore("-")
@@ -1234,8 +1244,8 @@ class StreamScreenViewModel @Inject constructor(
 
     /** Release the MainActivity auto-next loader once this Stream screen has settled. Hides the
      *  overlay only; it must not abort the chain, or a fast settle would suppress the next advance. */
-    fun dismissExternalAutoNextOverlay() {
-        externalPlaybackTracker.releaseAutoNextOverlay()
+    fun dismissExternalAutoNextOverlay(forceRelease: Boolean = false) {
+        externalPlaybackTracker.releaseAutoNextOverlay(forceRelease = forceRelease)
     }
 
     /** Set to true when external player is launched, reset on stop. */
@@ -1551,6 +1561,7 @@ class StreamScreenViewModel @Inject constructor(
                         )
                     )
                 }
+                externalPlaybackTracker.releaseAutoNextOverlay(forceRelease = true)
                 return
             } finally {
                 call?.cancel()
@@ -1606,7 +1617,7 @@ class StreamScreenViewModel @Inject constructor(
         // protects against spurious ON_RESUME after the player intent is sent.
         externalPlayerLaunchTimeMs = System.currentTimeMillis()
 
-        externalPlaybackTracker.launchPlayer(
+        val launched = externalPlaybackTracker.launchPlayer(
             metadata = metadata,
             url = playUrl,
             title = metadata.buildPlayerTitle(),
@@ -1614,8 +1625,27 @@ class StreamScreenViewModel @Inject constructor(
             resumePositionMs = resumePositionMs,
             subtitles = subtitleInputs,
             autoLaunch = autoLaunch,
+            nextEpisodeSnapshot = playbackMetaVideos?.let { videos ->
+                com.nuvio.tv.core.player.resolveExternalNextEpisodeSnapshot(
+                    videos = videos,
+                    currentSeason = metadata.season,
+                    currentEpisode = metadata.episode
+                )
+            },
             context = context
         )
+        if (!launched) {
+            externalPlayerLaunched = false
+            externalPlayerLaunchTimeMs = 0L
+            updateUiStateIfChanged {
+                it.copy(
+                    showDirectAutoPlayOverlay = false,
+                    externalPlayerOverlayVisible = false,
+                    directAutoPlayMessage = null,
+                    directAutoPlayProgress = null
+                )
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -104,7 +104,6 @@ class StreamScreenViewModel @Inject constructor(
     private var resumeBaselineStreams: List<AddonStreams>? = null
     private var sourceChipErrorDismissJob: Job? = null
     private var pendingCacheSaveJob: Job? = null
-    private var pendingBingeGroupSaveJob: Job? = null
     private var streamBadgePresentationJob: Job? = null
     private var streamBadgePresentationRequestId = 0L
     private var badgedAddonNames: Set<String> = emptySet()
@@ -282,7 +281,7 @@ class StreamScreenViewModel @Inject constructor(
             StreamScreenEvent.OnRetry -> loadStreams()
             StreamScreenEvent.OnBackPress -> { /* Handle in screen */ }
             StreamScreenEvent.OnResume -> {
-                hostInForeground = true
+                hostInForeground.value = true
                 // If loading was cancelled (e.g. user went to player) and
                 // hasn't completed yet, resume it. The baseline snapshot
                 // captured at cancel time keeps existing results visible
@@ -819,8 +818,17 @@ class StreamScreenViewModel @Inject constructor(
                 // gated on !resolvedAutoPlayTarget. Only stuck if still foregrounded: a
                 // healthy external launch backgrounds us and keeps the VM alive behind
                 // the player for the whole episode.
-                val phantomStuck = resolvedAutoPlayTarget && hostInForeground &&
+                val hasResolvedOverlay = resolvedAutoPlayTarget &&
                     (_uiState.value.showDirectAutoPlayOverlay || _uiState.value.externalPlayerOverlayVisible)
+                if (hasResolvedOverlay) {
+                    DirectAutoPlayWatchdogPolicy.awaitForeground(hostInForeground)
+                }
+                val phantomStuck = DirectAutoPlayWatchdogPolicy.shouldTearDownResolvedTarget(
+                    resolvedAutoPlayTarget = resolvedAutoPlayTarget,
+                    hostInForeground = hostInForeground.value,
+                    showDirectAutoPlayOverlay = _uiState.value.showDirectAutoPlayOverlay,
+                    externalPlayerOverlayVisible = _uiState.value.externalPlayerOverlayVisible
+                )
                 if ((directAutoPlayFlowEnabledForSession && !resolvedAutoPlayTarget) || phantomStuck) {
                     Log.w(TAG, "Direct autoplay hard timeout reached; falling back to manual selection")
                     lastSuccessData?.let {
@@ -1236,11 +1244,10 @@ class StreamScreenViewModel @Inject constructor(
 
     // Foreground gate for the stuck-loader timeout; healthy external playback
     // backgrounds us (ON_STOP). True at init since the screen starts visible.
-    @Volatile
-    private var hostInForeground = true
+    private val hostInForeground = MutableStateFlow(true)
 
     fun onHostStopped() {
-        hostInForeground = false
+        hostInForeground.value = false
     }
     private var externalOverlayHideJob: kotlinx.coroutines.Job? = null
 
@@ -1350,30 +1357,16 @@ class StreamScreenViewModel @Inject constructor(
                 )
             }
         }
-        // Persist binge group per-content for cross-episode reuse (independent of URL).
-        val bg = playbackInfo.bingeGroup
-        val cid = playbackInfo.contentId
-        if (bg != null && !cid.isNullOrBlank()) {
-            // Drop any pending save so a backed-out pick can't land last and overwrite
-            // the group actually chosen.
-            pendingBingeGroupSaveJob?.cancel()
-            pendingBingeGroupSaveJob = viewModelScope.launch {
-                bingeGroupCacheDataStore.save(cid, bg)
-            }
-        }
-
         return playbackInfo
     }
 
     suspend fun awaitStreamLinkCacheSave() {
         pendingCacheSaveJob?.join()
-        pendingBingeGroupSaveJob?.join()
     }
 
     private suspend fun persistBingeGroupForPlayback(playbackInfo: StreamPlaybackInfo) {
-        val bg = playbackInfo.bingeGroup ?: return
         val cid = playbackInfo.contentId?.takeIf { it.isNotBlank() } ?: return
-        bingeGroupCacheDataStore.save(cid, bg)
+        bingeGroupCacheDataStore.replace(cid, playbackInfo.bingeGroup)
     }
 
     override fun onCleared() {
@@ -1431,8 +1424,7 @@ class StreamScreenViewModel @Inject constructor(
             )
         }
 
-        // The launched stream's group is the final write, ahead of any pending save.
-        pendingBingeGroupSaveJob?.cancel()
+        // Persist only the stream that actually launches. A missing group clears stale reuse state.
         persistBingeGroupForPlayback(playbackInfo)
 
         var playUrl = url

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
@@ -1,6 +1,9 @@
 package com.nuvio.tv.core.player
 
+import com.nuvio.tv.domain.model.Video
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -101,6 +104,18 @@ class ExternalAutoNextPolicyTest {
     }
 
     @Test
+    fun `completion may raise loader while next episode lookup is unknown`() {
+        assertTrue(
+            raise(
+                episode = 3,
+                type = "series",
+                hasNextEpisode = null,
+                allowUnknownNextEpisode = true
+            )
+        )
+    }
+
+    @Test
     fun `loader does not raise when auto-next is disabled`() {
         assertFalse(raise(episode = 3, type = "series", autoNextEnabled = false))
     }
@@ -145,34 +160,124 @@ class ExternalAutoNextPolicyTest {
     }
 
     @Test
-    fun `confirmed active handoff delays settle release`() {
+    fun `possible active handoff holds loader until player covers app`() {
         assertTrue(
-            ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+            ExternalAutoNextPolicy.shouldHoldLoaderOnSettle(
                 overlayShowing = true,
                 handoffActive = true,
-                hasConfirmedNextEpisode = true
+                mayHaveNextEpisode = true,
+                forceRelease = false
             )
         )
         assertFalse(
-            ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+            ExternalAutoNextPolicy.shouldHoldLoaderOnSettle(
                 overlayShowing = true,
                 handoffActive = true,
-                hasConfirmedNextEpisode = false
+                mayHaveNextEpisode = false,
+                forceRelease = false
             )
         )
         assertFalse(
-            ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+            ExternalAutoNextPolicy.shouldHoldLoaderOnSettle(
                 overlayShowing = true,
                 handoffActive = false,
-                hasConfirmedNextEpisode = true
+                mayHaveNextEpisode = true,
+                forceRelease = false
             )
         )
+        assertFalse(
+            ExternalAutoNextPolicy.shouldHoldLoaderOnSettle(
+                overlayShowing = true,
+                handoffActive = true,
+                mayHaveNextEpisode = true,
+                forceRelease = true
+            )
+        )
+    }
+
+    @Test
+    fun `loaded episode list snapshots a playable successor`() {
+        val snapshot = resolveExternalNextEpisodeSnapshot(
+            videos = listOf(video(1), video(2)),
+            currentSeason = 1,
+            currentEpisode = 1
+        )
+
+        assertTrue(snapshot.metadataResolved)
+        assertEquals("episode-2", snapshot.nextVideoId)
+        assertEquals(1, snapshot.nextSeason)
+        assertEquals(2, snapshot.nextEpisode)
+    }
+
+    @Test
+    fun `loaded episode list confirms a finale without a loader`() {
+        val snapshot = resolveExternalNextEpisodeSnapshot(
+            videos = listOf(video(12)),
+            currentSeason = 1,
+            currentEpisode = 12
+        )
+
+        assertTrue(snapshot.metadataResolved)
+        assertFalse(snapshot.hasNextEpisode == true)
+        assertNull(snapshot.nextVideoId)
+    }
+
+    @Test
+    fun `missing current episode keeps snapshot unknown`() {
+        val snapshot = resolveExternalNextEpisodeSnapshot(
+            videos = listOf(video(4)),
+            currentSeason = 1,
+            currentEpisode = 3
+        )
+
+        assertFalse(snapshot.metadataResolved)
+        assertNull(snapshot.hasNextEpisode)
+    }
+
+    @Test
+    fun `unavailable successor is confirmed not playable`() {
+        val snapshot = resolveExternalNextEpisodeSnapshot(
+            videos = listOf(video(1), video(2, available = false)),
+            currentSeason = 1,
+            currentEpisode = 1
+        )
+
+        assertTrue(snapshot.metadataResolved)
+        assertFalse(snapshot.hasNextEpisode == true)
     }
 
     @Test
     fun `settle release is ignored while external playback is active`() {
         assertTrue(ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(externalPlaybackActive = true))
         assertFalse(ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(externalPlaybackActive = false))
+    }
+
+    @Test
+    fun `back cancellation blocks only the pending auto next launch`() {
+        assertTrue(
+            ExternalAutoNextPolicy.shouldCancelPendingAutoLaunch(
+                autoLaunch = true,
+                autoNextNavigationPending = true,
+                cancelled = true,
+                chainAborted = true
+            )
+        )
+        assertFalse(
+            ExternalAutoNextPolicy.shouldCancelPendingAutoLaunch(
+                autoLaunch = false,
+                autoNextNavigationPending = true,
+                cancelled = true,
+                chainAborted = true
+            )
+        )
+        assertFalse(
+            ExternalAutoNextPolicy.shouldCancelPendingAutoLaunch(
+                autoLaunch = true,
+                autoNextNavigationPending = false,
+                cancelled = true,
+                chainAborted = true
+            )
+        )
     }
 
     private fun raise(
@@ -183,7 +288,8 @@ class ExternalAutoNextPolicyTest {
         overlaySuppressed: Boolean = false,
         alreadyShowing: Boolean = false,
         autoNextEnabled: Boolean? = null,
-        hasNextEpisode: Boolean? = true
+        hasNextEpisode: Boolean? = true,
+        allowUnknownNextEpisode: Boolean = false
     ) = ExternalAutoNextPolicy.shouldRaiseLoader(
         episode = episode,
         contentType = type,
@@ -192,6 +298,18 @@ class ExternalAutoNextPolicyTest {
         overlaySuppressed = overlaySuppressed,
         alreadyShowing = alreadyShowing,
         autoNextEnabled = autoNextEnabled,
-        hasNextEpisode = hasNextEpisode
+        hasNextEpisode = hasNextEpisode,
+        allowUnknownNextEpisode = allowUnknownNextEpisode
+    )
+
+    private fun video(episode: Int, available: Boolean? = true) = Video(
+        id = "episode-$episode",
+        title = "Episode $episode",
+        released = "2020-01-01",
+        thumbnail = null,
+        season = 1,
+        episode = episode,
+        overview = null,
+        available = available
     )
 }

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
@@ -91,6 +91,21 @@ class ExternalAutoNextPolicyTest {
     }
 
     @Test
+    fun `loader does not raise when prefetch confirms a series finale`() {
+        assertFalse(raise(episode = 12, type = "series", hasNextEpisode = false))
+    }
+
+    @Test
+    fun `loader does not raise before next episode lookup completes`() {
+        assertFalse(raise(episode = 12, type = "series", hasNextEpisode = null))
+    }
+
+    @Test
+    fun `loader does not raise when auto-next is disabled`() {
+        assertFalse(raise(episode = 3, type = "series", autoNextEnabled = false))
+    }
+
+    @Test
     fun `loader does not raise for movies or non-series content`() {
         assertFalse(raise(episode = null, type = "movie"))
         assertFalse(raise(episode = 3, type = "movie"))
@@ -121,19 +136,56 @@ class ExternalAutoNextPolicyTest {
         )
     }
 
+    @Test
+    fun `next episode must be available and aired`() {
+        assertTrue(ExternalAutoNextPolicy.isPlayableNextEpisode(available = true, hasAired = true))
+        assertTrue(ExternalAutoNextPolicy.isPlayableNextEpisode(available = null, hasAired = true))
+        assertFalse(ExternalAutoNextPolicy.isPlayableNextEpisode(available = false, hasAired = true))
+        assertFalse(ExternalAutoNextPolicy.isPlayableNextEpisode(available = true, hasAired = false))
+    }
+
+    @Test
+    fun `confirmed active handoff delays settle release`() {
+        assertTrue(
+            ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+                overlayShowing = true,
+                handoffActive = true,
+                hasConfirmedNextEpisode = true
+            )
+        )
+        assertFalse(
+            ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+                overlayShowing = true,
+                handoffActive = true,
+                hasConfirmedNextEpisode = false
+            )
+        )
+        assertFalse(
+            ExternalAutoNextPolicy.shouldDelayLoaderRelease(
+                overlayShowing = true,
+                handoffActive = false,
+                hasConfirmedNextEpisode = true
+            )
+        )
+    }
+
     private fun raise(
         episode: Int?,
         type: String,
         cancelled: Boolean = false,
         chainAborted: Boolean = false,
         overlaySuppressed: Boolean = false,
-        alreadyShowing: Boolean = false
+        alreadyShowing: Boolean = false,
+        autoNextEnabled: Boolean? = null,
+        hasNextEpisode: Boolean? = true
     ) = ExternalAutoNextPolicy.shouldRaiseLoader(
         episode = episode,
         contentType = type,
         cancelled = cancelled,
         chainAborted = chainAborted,
         overlaySuppressed = overlaySuppressed,
-        alreadyShowing = alreadyShowing
+        alreadyShowing = alreadyShowing,
+        autoNextEnabled = autoNextEnabled,
+        hasNextEpisode = hasNextEpisode
     )
 }

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalAutoNextPolicyTest.kt
@@ -169,6 +169,12 @@ class ExternalAutoNextPolicyTest {
         )
     }
 
+    @Test
+    fun `settle release is ignored while external playback is active`() {
+        assertTrue(ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(externalPlaybackActive = true))
+        assertFalse(ExternalAutoNextPolicy.shouldIgnoreLoaderRelease(externalPlaybackActive = false))
+    }
+
     private fun raise(
         episode: Int?,
         type: String,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/stream/DirectAutoPlayWatchdogPolicyTest.kt
@@ -1,0 +1,49 @@
+package com.nuvio.tv.ui.screens.stream
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DirectAutoPlayWatchdogPolicyTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `watchdog waits until host returns to foreground`() = runTest {
+        val foreground = MutableStateFlow(false)
+        val waiter = async {
+            DirectAutoPlayWatchdogPolicy.awaitForeground(foreground)
+        }
+
+        runCurrent()
+        assertFalse(waiter.isCompleted)
+
+        foreground.value = true
+        runCurrent()
+
+        assertTrue(waiter.isCompleted)
+    }
+
+    @Test
+    fun `resolved visible overlay is torn down only in foreground`() {
+        assertTrue(
+            DirectAutoPlayWatchdogPolicy.shouldTearDownResolvedTarget(
+                resolvedAutoPlayTarget = true,
+                hostInForeground = true,
+                showDirectAutoPlayOverlay = true,
+                externalPlayerOverlayVisible = false
+            )
+        )
+        assertFalse(
+            DirectAutoPlayWatchdogPolicy.shouldTearDownResolvedTarget(
+                resolvedAutoPlayTarget = true,
+                hostInForeground = false,
+                showDirectAutoPlayOverlay = true,
+                externalPlayerOverlayVisible = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

This fixes a regression in external player auto next completion. Nuvio now captures the next episode decision from the episode metadata already loaded by the player or Stream screen, then refreshes it in the background without discarding a known playable successor.

A confirmed finale, including episode 12 of 12 and any other final available episode, returns without presenting an auto next loader or attempting another launch. Unavailable and unaired episodes are excluded. When the episode list is genuinely unavailable, the existing metadata lookup remains as a fallback.

The transition loader now remains under one owner from the moment Nuvio returns to the foreground until the next external player covers the app. Its message and progress follow the active Stream loading stage, including source discovery, subtitle loading, and intro or outro lookup. Stream settlement cannot briefly expose the episode or source screen during an active handoff.

The binge group still belongs only to the stream that actually launched. If that group is unavailable for the next episode, normal autoplay selection remains the fallback. Back cancellation is checked before tracker setup, after settings are read, during launch preparation, and immediately before the external player intent, so cancelling cannot launch the pending continuation later.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Several lifecycle races affected the same external player completion path. The background metadata prefetch could fail or return a thinner episode list even though the current screen had already loaded a valid successor. Stream settlement callbacks could release the transition loader before navigation and source resolution finished. A cancelled continuation could also finish asynchronous launch preparation and open the external player after the user had backed out.

Together these races could return the user to the previous episode source selection, reuse an abandoned binge group, show a loader after a final episode, expose the episode or source screen between players, lose detailed loading status, or launch a continuation after cancellation.

The completed stream now owns the handoff state. A loaded episode snapshot supplies the strongest available successor or finale decision, the root transition loader keeps ownership until external playback covers Nuvio, and cancellation remains authoritative through the final launch boundary.

## Issue or approval

Fixes #2638

## Reproduction steps

1. Enable auto play next episode and select an external player.
2. Launch an episode from one binge group, back out, then launch another group and finish the episode naturally.
3. Confirm the next episode uses the group that actually launched or falls back to normal autoplay selection when that group is unavailable.
4. Observe the transition through episode navigation, source discovery, subtitle loading, and intro or outro lookup.
5. Repeat with episode 12 of 12 or another final available episode.
6. During a pending next episode transition, press Back and confirm no external player opens afterward.

Before this fix, the next episode could return to source selection, reuse an abandoned group, briefly expose Nuvio between players, lose loading details, or launch after cancellation. A finale could also show the loader before returning.

After this fix, the launched stream owns its binge group, a playable successor is validated before continuation, the loader remains continuous until the next player covers Nuvio, and confirmed finales return without another handoff.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR changes only external player auto next completion, transition loader ownership and status, cancellation, finale detection, and binge group continuity for launched streams. It does not change internal playback, stream ranking, sync, Continue Watching, episode dates, dependencies, or public data contracts.

## Testing

Focused unit tests passed:

`./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.player.ExternalAutoNextPolicyTest --tests com.nuvio.tv.ui.screens.stream.DirectAutoPlayWatchdogPolicyTest --tests com.nuvio.tv.ui.screens.player.PlayerNextEpisodeRulesTest`

The app compiled successfully. A final `assembleFullDebug` run in the PR worktree reached signing and stopped only because the private local `nuviotv.jks` file is not present in that worktree. The same source changes were built into the combined debug APK, installed on an NVIDIA Shield TV 2019 running Android 11, and exercised there.

Manual Shield validation covered a full episode completion with successful auto next, continuous detailed loader status, binge group reuse, normal selection fallback, manual cancellation, and final episode return. Valid next episodes launched without exposing the episode or source screen. Back cancellation did not launch a delayed continuation. Episode 12 of 12 and other confirmed finales returned without attempting another episode.

## Screenshots / Video

No new interface is introduced. The existing transition loader remains visible continuously and reports the current loading stage.

## Breaking changes

None.

## Linked issues

Fixes #2638
