### PR TITLE
Fix for shimmer rows loosing focus

### DIFF
--- a/app/src/main/java/com/nuvio/tv/domain/model/CatalogRow.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/CatalogRow.kt
@@ -35,8 +35,8 @@ fun CatalogRow.legacyKey(): String {
     return catalogRowLegacyKey(addonId, apiType, catalogId)
 }
 
-fun CatalogRow.stableItemKey(index: Int, item: MetaPreview): String {
-    return "${stableKey()}_${item.apiType}_${item.id}_$index"
+fun CatalogRow.stableItemKey(index: Int): String {
+    return "${stableKey()}_$index"
 }
 
 fun catalogRowStableKey(

--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -105,7 +105,7 @@ fun CatalogRowSection(
     listState: LazyListState = rememberLazyListState(initialFirstVisibleItemIndex = initialScrollIndex)
 ) {
     fun rowItemFocusKey(index: Int, item: MetaPreview): String {
-        return catalogRow.stableItemKey(index, item)
+        return catalogRow.stableItemKey(index)
     }
 
     val seeAllCardShape = RoundedCornerShape(posterCardStyle.cornerRadius)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -218,7 +218,7 @@ fun CatalogSeeAllScreen(
                 ) {
                     itemsIndexed(
                         items = catalogRow.items,
-                        key = { index, item -> catalogRow.stableItemKey(index, item) }
+                        key = { index, item -> catalogRow.stableItemKey(index) }
                     ) { index, item ->
                         val isWatched = if (isSearchMode) {
                             val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -191,7 +191,7 @@ fun ClassicHomeContent(
             when (row) {
                 is HomeRow.Catalog -> row.row.stableKey()
                 is HomeRow.CollectionRow -> "collection_${row.collection.id}"
-                is HomeRow.PlaceholderCatalog -> row.catalogKey
+                is HomeRow.PlaceholderCatalog -> row.stableCatalogKey
             }
         }
     }
@@ -437,7 +437,7 @@ fun ClassicHomeContent(
                     when (row) {
                         is HomeRow.Catalog -> row.row.stableKey()
                         is HomeRow.CollectionRow -> "collection_${row.collection.id}"
-                        is HomeRow.PlaceholderCatalog -> row.catalogKey
+                        is HomeRow.PlaceholderCatalog -> row.stableCatalogKey
                     }
                 }
                 val cwDownRequester = firstRowKey?.let { rowEntryFocusRequesters.getOrPut(it) { FocusRequester() } }
@@ -509,7 +509,7 @@ fun ClassicHomeContent(
                         "${r.stableKey()}_$index"
                     }
                     is HomeRow.CollectionRow -> "collection_${item.collection.id}"
-                    is HomeRow.PlaceholderCatalog -> "${item.catalogKey}_$index"
+                    is HomeRow.PlaceholderCatalog -> "${item.stableCatalogKey}_$index"
                 }
             },
             contentType = { _, item ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -124,6 +124,7 @@ sealed class HomeRow {
     @Immutable
     data class PlaceholderCatalog(
         val catalogKey: String,
+        val stableCatalogKey: String,
         val addonId: String,
         val addonName: String,
         val addonBaseUrl: String,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -9,6 +9,7 @@ import com.nuvio.tv.domain.model.CatalogDescriptor
 import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.Collection
 import com.nuvio.tv.domain.model.HomeLayout
+import com.nuvio.tv.domain.model.catalogRowStableKey
 import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.domain.model.legacyKey
 import com.nuvio.tv.domain.model.mergeCatalogPage
@@ -721,6 +722,12 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                         if (currentLayout == HomeLayout.MODERN) {
                             add(HomeRow.PlaceholderCatalog(
                                 catalogKey = placeholder.catalogKey,
+                                stableCatalogKey = catalogRowStableKey(
+                                    placeholder.addonId,
+                                    placeholder.addonBaseUrl,
+                                    placeholder.apiType,
+                                    placeholder.catalogId
+                                ),
                                 addonId = placeholder.addonId,
                                 addonName = placeholder.addonName,
                                 addonBaseUrl = placeholder.addonBaseUrl,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
@@ -136,7 +136,7 @@ internal fun buildModernHomePresentation(
                                     cachedItem.showFullReleaseDate == input.showFullReleaseDate
                                 ) {
                                     cachedItem.carouselItem.let { cached ->
-                                        val stableItemKey = row.stableItemKey(itemIndex, item)
+                                        val stableItemKey = row.stableItemKey(itemIndex)
                                         if (cached.key == stableItemKey) cached
                                         else cached.copy(key = stableItemKey)
                                     }
@@ -150,7 +150,7 @@ internal fun buildModernHomePresentation(
                                         strTypeSeries = strTypeSeries,
                                         showFullReleaseDate = input.showFullReleaseDate,
                                         previousCachedItem = cachedItem?.carouselItem
-                                    ).copy(key = row.stableItemKey(itemIndex, item))
+                                    ).copy(key = row.stableItemKey(itemIndex))
                                     rowItemCache[cacheKey] = CachedCarouselItem(
                                         source = item,
                                         useLandscapePosters = input.useLandscapePosters,
@@ -222,11 +222,12 @@ internal fun buildModernHomePresentation(
                         return@forEachIndexed
                     }
                     renderedCatalogRows++
+                    val stableRowKey = homeRow.stableCatalogKey
                     val fakeItemCount = 8
                     val fakeItems = (0 until fakeItemCount).map { i ->
                         val fakeId = "__placeholder_${homeRow.catalogKey}_$i"
                         ModernCarouselItem(
-                            key = "${homeRow.catalogKey}_$i",
+                            key = "${stableRowKey}_$i",
                             title = "",
                             subtitle = null,
                             // Dummy URL triggers shimmer instead of MonochromePosterPlaceholder
@@ -254,7 +255,7 @@ internal fun buildModernHomePresentation(
                         homeRow.catalogName.replaceFirstChar { it.uppercase() }
                     }
                     val placeholderRow = HeroCarouselRow(
-                        key = homeRow.catalogKey,
+                        key = stableRowKey,
                         title = placeholderTitle,
                         globalRowIndex = index,
                         catalogId = homeRow.catalogId,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
@@ -227,7 +227,8 @@ internal fun ModernHomeRowsList(
             for (idx in firstVisible.coerceAtLeast(0)..(lastVisible + prefetchAheadForLazy)) {
                 val row = rows.list.getOrNull(idx) ?: continue
                 if (row.isLoading && row.items.list.firstOrNull()?.imageUrl == "placeholder://empty") {
-                    latestOnRequestLazyCatalogLoad.value(row.key)
+                    val legacyKey = "${row.addonId}_${row.apiType}_${row.catalogId}"
+                    latestOnRequestLazyCatalogLoad.value(legacyKey)
                 }
             }
         }
@@ -249,7 +250,8 @@ internal fun ModernHomeRowsList(
                 for (idx in firstVisible.coerceAtLeast(0)..(lastVisible + 1)) {
                     val row = rows.list.getOrNull(idx) ?: continue
                     if (row.isLoading && row.items.list.firstOrNull()?.imageUrl == "placeholder://empty") {
-                        latestOnRequestLazyCatalogLoad.value(row.key)
+                        val legacyKey = "${row.addonId}_${row.apiType}_${row.catalogId}"
+                        latestOnRequestLazyCatalogLoad.value(legacyKey)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fix focus loss when shimmer placeholder items transition to real catalog items on the home screen. Commit 0a36607 introduced content-based Compose keys (`stableKey_apiType_id_index`) which caused shimmer and real items at the same position to have different keys, breaking focus stability.

This PR makes item keys purely positional (`stableKey_index`), so both shimmer and real items at position 0 resolve to the same key, e.g. `addonId_-123456_42_movie_popularCatalog_0`. Compose treats them as the same element and focus is preserved.

## PR type

- [x] Critical bug fix

## Why

After 0a36607, shimmer items get a key like `addonId_-123456_42_movie_popularCatalog_movie___placeholder_xyz_0_0` while the replacing real item gets `addonId_-123456_42_movie_popularCatalog_movie_tt1234567_0`. Compose sees them as different elements and drops focus.

Now both get `addonId_-123456_42_movie_popularCatalog_0` - same key regardless of item content.

## Issue or approval

Regression introduced in 0a36607 ("Fix duplicate catalog Compose keys").

## Reproduction steps

1. Open the app on a TV/emulator with D-pad navigation
2. Focus any catalog row that loads lazily (scroll down to trigger lazy load)
3. Observe focus jumps away when shimmer items are replaced by real data
4. Expected: focus stays on the same positional item after data loads

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change the row-level `stableKey()` logic (baseUrl hash) introduced in 0a36607 - that fix for duplicate row keys remains intact.
- Lazy catalog load callback still uses the legacy key format internally.

## Testing

- Verified build compiles cleanly (`compileFullDebugKotlin`)
- Tested on emulator TCL Android TV: focus stays on the first item when shimmer→real transition happens on Modern and Classic layouts
- Verified lazy catalog loading still triggers correctly when scrolling to placeholder rows

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Regression from 0a36607.
