### PR TITLE
fix(player): fix double buffer after first frame before duration

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -101,6 +101,13 @@ class PlayerRuntimeController(
         internal const val SWITCH_TRACE_ENABLED = false
         internal const val TRACK_FRAME_RATE_GRACE_MS = 1500L
         internal const val FIRST_FRAME_TIMEOUT_MS = 12_000L
+        /** Deadlock path: force playWhenReady when paused at READY without a first frame. */
+        internal const val FIRST_FRAME_DEADLOCK_TIMEOUT_MS = 3_500L
+        /**
+         * After first frame, wait this long for VOD duration before completing startup
+         * presentation. Progressive containers resolve duration via timeline after samples.
+         */
+        internal const val STARTUP_DURATION_GRACE_MS = 2_500L
         // Stall watchdog: re-seeks past the buffered edge if bufferedPosition stops
         // advancing during STATE_BUFFERING. Fires before OkHttp's readTimeout.
         internal const val STALL_WATCHDOG_THRESHOLD_MS = 15_000L
@@ -287,6 +294,12 @@ class PlayerRuntimeController(
     internal var progressJob: Job? = null
     internal var vodTelemetryJob: Job? = null
     internal var firstFrameWatchdogJob: Job? = null
+    internal var startupDurationWatchdogJob: Job? = null
+    /**
+     * True once startup loading is complete (first frame + VOD duration when required).
+     * Rebuffers before this are still part of initial prepare, not mid-playback rebuffers.
+     */
+    internal var startupPresentationComplete: Boolean = false
     internal var stallWatchdogJob: Job? = null
     internal var hideControlsJob: Job? = null
     internal var hideSeekOverlayJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -953,10 +953,12 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (playbackState == Player.STATE_BUFFERING || playbackState == Player.STATE_READY) {
                             mediaSourceFactory.unlockStartupPrefetch()
                         }
-                        val playerDuration = duration
-                        if (playerDuration > lastKnownDuration) { lastKnownDuration = playerDuration }
                         val isBuffering = playbackState == Player.STATE_BUFFERING
-                        updatePlaybackTimeline(duration = playerDuration.coerceAtLeast(0L))
+                        syncPlaybackTimelineFromPlayer(this@apply)
+                        // Metadata/duration often lands during READY/BUFFERING transitions.
+                        if (hasRenderedFirstFrame && !startupPresentationComplete) {
+                            maybeCompleteStartupPresentation(this@apply, "startup_state_$playbackState")
+                        }
                         _uiState.update {
                             it.copy(
                                 isBuffering = if (NuvioExoPlayerPerformanceHelper.shouldSuppressBufferingUi(
@@ -967,11 +969,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                         }
                         updateAudioControlAvailability()
 
-                        // Rebuffer telemetry: a rebuffer is STATE_BUFFERING entered
-                        // AFTER the first frame (initial startup buffering is excluded).
-                        // Accumulate time spent rebuffering; closed out on any non-buffering state.
+                        // Rebuffer telemetry: only count stalls after startup presentation is
+                        // complete (first frame + VOD duration). Earlier BUFFERING is still
+                        // initial prepare / metadata resolution.
                         if (playbackState == Player.STATE_BUFFERING) {
-                            if (hasRenderedFirstFrame && rebufferStartedAtMs == 0L) {
+                            if (startupPresentationComplete && rebufferStartedAtMs == 0L) {
                                 rebufferCount += 1
                                 rebufferStartedAtMs = SystemClock.elapsedRealtime()
                                 playbackAnalyticsDiagnostics.onRebufferStarted(this@apply, rebufferCount)
@@ -1054,16 +1056,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                                         playWhenReady = true
                                         play()
                                     }
-                                    finishLoadingDiagnostics("first_frame_ready")
                                     currentDiagnostics = recordFirstFrameDiagnostics(this@apply, currentDiagnostics, playerSettings)
-                                    _uiState.update {
-                                        it.copy(
-                                            showLoadingOverlay = false,
-                                            loadingMessage = null,
-                                            loadingProgress = if (it.loadingProgress != null) 1f else null,
-                                            showPlayerEngineSwitchInfo = false
-                                        )
-                                    }
+                                    maybeCompleteStartupPresentation(this@apply, "first_frame_ready_tunneled")
                                 }
                                 // Non-tunneled: playback will start in onRenderedFirstFrame().
                             } else if (!userPausedManually && hasRenderedFirstFrame) {
@@ -1085,10 +1079,15 @@ internal fun PlayerRuntimeController.initializePlayer(
                                 }
                                 _uiState.update { it.copy(pendingSeekPosition = null) }
                             }
-                            tryAutoSelectPreferredSubtitleFromAvailableTracks()
-                            if (!NuvioExoPlayerPerformanceHelper.shouldGuardTrackRebuild() || !hasRenderedFirstFrame) {
-                                trackSelectionParameters = trackSelectionParameters.buildUpon().build()
+                            // Defer track-affecting subtitle auto-select until startup is complete
+                            // so we do not force a second BUFFERING while duration is still unresolved.
+                            if (startupPresentationComplete) {
+                                tryAutoSelectPreferredSubtitleFromAvailableTracks()
                             }
+                            // Do not no-op rebuild trackSelectionParameters here. buildUpon().build()
+                            // creates a new instance and forces Media3 reselection → post-first-frame
+                            // rebuffer even when nothing changed (regression surface after playWhenReady
+                            // started true at prepare).
                             maybeScheduleFirstFrameWatchdog()
                         } else if (playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE) {
                             cancelFirstFrameWatchdog()
@@ -1159,6 +1158,19 @@ internal fun PlayerRuntimeController.initializePlayer(
                         }
                     }
 
+                    override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
+                        if (isReleasingPlayer) return
+                        syncPlaybackTimelineFromPlayer(this@apply)
+                        // Progressive containers often publish duration via Timeline after the
+                        // first decoded frame; complete startup once duration is known.
+                        if (hasRenderedFirstFrame && !startupPresentationComplete) {
+                            maybeCompleteStartupPresentation(this@apply, "timeline_duration_ready")
+                        }
+                        if (startupPresentationComplete) {
+                            tryAutoSelectPreferredSubtitleFromAvailableTracks()
+                        }
+                    }
+
                     override fun onRenderedFirstFrame() {
                         val isFirstFrame = !hasRenderedFirstFrame  // capture BEFORE flipping
                         hasRenderedFirstFrame = true
@@ -1175,20 +1187,15 @@ internal fun PlayerRuntimeController.initializePlayer(
                         }
                         refreshStableProgressResetGate()
                         cancelFirstFrameWatchdog()
-                        _uiState.update {
-                            it.copy(
-                                showLoadingOverlay = false,
-                                loadingMessage = null,
-                                loadingProgress = if (it.loadingProgress != null) 1f else null,
-                                loadingIssueReportVisible = false,
-                                loadingIssueElapsedMs = 0L,
-                                showPlayerEngineSwitchInfo = false
-                            )
-                        }
-                        finishLoadingDiagnostics("first_frame_rendered")
-
                         if (isFirstFrame) {
                             currentDiagnostics = recordFirstFrameDiagnostics(this@apply, currentDiagnostics, playerSettings)
+                        }
+                        // Do not dismiss loading solely on first frame: VOD duration may still
+                        // be TIME_UNSET while the extractor finishes seek-map/metadata. Completing
+                        // early produced "first frame then rebuffer until duration appears".
+                        maybeCompleteStartupPresentation(this@apply, "first_frame_rendered")
+                        if (startupPresentationComplete) {
+                            tryAutoSelectPreferredSubtitleFromAvailableTracks()
                         }
                     }
 
@@ -1837,6 +1844,7 @@ internal fun PlayerRuntimeController.buildStartupSubtitleConfigurations(startupS
 
 internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
     cancelFirstFrameWatchdog()
+    cancelStartupDurationWatchdog()
     cancelStallWatchdog()
     val preparingMessage = context.getString(R.string.player_loading_preparing)
     resetLoadingDiagnostics(
@@ -1845,6 +1853,8 @@ internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
         progress = null
     )
     hasRenderedFirstFrame = false
+    startupPresentationComplete = false
+    cancelStartupDurationWatchdog()
     hasMarkedCurrentEpisodeCompleted = false
     shouldEnforceAutoplayOnFirstReady = true
     userPausedManually = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -39,6 +39,8 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         view.setPaused(false)
         applyPendingMpvSeekIfNeeded(view)
         hasRenderedFirstFrame = false
+        startupPresentationComplete = false
+        cancelStartupDurationWatchdog()
         _uiState.update {
             it.copy(
                 isBuffering = true,
@@ -138,6 +140,8 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         applyPendingMpvSeekIfNeeded(view)
 
         hasRenderedFirstFrame = false
+        startupPresentationComplete = false
+        cancelStartupDurationWatchdog()
         _uiState.update {
             it.copy(
                 isBuffering = true,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -1,22 +1,23 @@
 package com.nuvio.tv.ui.screens.player
 
 import android.util.Log
-import com.nuvio.tv.core.player.OpenSubtitlesHasher
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import com.nuvio.tv.R
+import com.nuvio.tv.core.player.OpenSubtitlesHasher
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.domain.model.Subtitle
 import com.nuvio.tv.domain.model.enabledAddons
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.yield
 
 internal data class SubtitleFetchRequest(
@@ -661,9 +662,109 @@ internal fun PlayerRuntimeController.cancelFirstFrameWatchdog() {
     firstFrameWatchdogJob = null
 }
 
+internal fun PlayerRuntimeController.cancelStartupDurationWatchdog() {
+    startupDurationWatchdogJob?.cancel()
+    startupDurationWatchdogJob = null
+}
+
 internal fun PlayerRuntimeController.cancelStallWatchdog() {
     stallWatchdogJob?.cancel()
     stallWatchdogJob = null
+}
+
+/**
+ * Progressive/VOD duration is often delivered via Timeline after the first decoded
+ * frame. Treat live/dynamic items as duration-ready (they never get a fixed duration).
+ */
+internal fun Player.isStartupDurationReady(): Boolean {
+    if (isCurrentMediaItemLive || isCurrentMediaItemDynamic) return true
+    val d = duration
+    return d != C.TIME_UNSET && d > 0L
+}
+
+/**
+ * Sync playhead/duration from ExoPlayer without treating [C.TIME_UNSET] as 0, which
+ * previously wiped the scrubber duration during mid-startup BUFFERING ticks.
+ */
+internal fun PlayerRuntimeController.syncPlaybackTimelineFromPlayer(player: Player) {
+    val pos = player.currentPosition.coerceAtLeast(0L)
+    val buffered = player.bufferedPosition.coerceAtLeast(pos)
+    val d = player.duration
+    if (d != C.TIME_UNSET && d > 0L) {
+        if (d > lastKnownDuration) {
+            lastKnownDuration = d
+        }
+        updatePlaybackTimeline(
+            currentPosition = pos,
+            duration = d,
+            bufferedPosition = buffered
+        )
+    } else {
+        updatePlaybackTimeline(
+            currentPosition = pos,
+            bufferedPosition = buffered
+        )
+    }
+}
+
+/**
+ * Complete startup presentation only when first frame is rendered and VOD duration
+ * is known (or not applicable). Keeps the loading overlay up through metadata
+ * resolution so the post-first-frame "duration rebuffer" is not presented as a
+ * second mid-playback stall.
+ */
+internal fun PlayerRuntimeController.maybeCompleteStartupPresentation(
+    player: Player,
+    phase: String
+) {
+    if (!hasRenderedFirstFrame || startupPresentationComplete) return
+    syncPlaybackTimelineFromPlayer(player)
+
+    if (!player.isStartupDurationReady()) {
+        if (startupDurationWatchdogJob?.isActive != true) {
+            recordLoadingDiagnosticEvent(
+                phase = "awaiting_duration",
+                message = context.getString(R.string.player_loading_buffering),
+                detail = "first_frame_without_duration"
+            )
+            startupDurationWatchdogJob = scope.launch {
+                delay(PlayerRuntimeController.STARTUP_DURATION_GRACE_MS)
+                val live = _exoPlayer ?: return@launch
+                if (!hasRenderedFirstFrame || startupPresentationComplete) return@launch
+                Log.w(
+                    PlayerRuntimeController.TAG,
+                    "STARTUP_DURATION: grace elapsed without duration " +
+                        "(live=${live.isCurrentMediaItemLive} dynamic=${live.isCurrentMediaItemDynamic} " +
+                        "duration=${live.duration}); completing startup presentation"
+                )
+                completeStartupPresentation(live, "startup_duration_grace")
+            }
+        }
+        return
+    }
+
+    completeStartupPresentation(player, phase)
+}
+
+private fun PlayerRuntimeController.completeStartupPresentation(
+    player: Player,
+    phase: String
+) {
+    if (startupPresentationComplete) return
+    startupPresentationComplete = true
+    cancelStartupDurationWatchdog()
+    syncPlaybackTimelineFromPlayer(player)
+    _uiState.update {
+        it.copy(
+            showLoadingOverlay = false,
+            loadingMessage = null,
+            loadingProgress = if (it.loadingProgress != null) 1f else null,
+            loadingIssueReportVisible = false,
+            loadingIssueElapsedMs = 0L,
+            showPlayerEngineSwitchInfo = false
+        )
+    }
+    finishLoadingDiagnostics(phase)
 }
 
 /** Tiny skip past the buffered edge to force Media3 to cancel the in-flight Range request. */
@@ -749,22 +850,44 @@ internal fun PlayerRuntimeController.maybeScheduleStallWatchdog() {
 internal fun PlayerRuntimeController.maybeScheduleFirstFrameWatchdog() {
     if (hasRenderedFirstFrame || !currentStreamHasVideoTrack) return
     val player = _exoPlayer ?: return
-    if (player.playbackState != Player.STATE_READY) return
+
+    val isReadyAndPlaying = player.playbackState == Player.STATE_READY && player.playWhenReady
+    val isReadyAndDeadlocked =
+        player.playbackState == Player.STATE_READY && !player.playWhenReady && !userPausedManually
+    if (!isReadyAndPlaying && !isReadyAndDeadlocked) return
     if (firstFrameWatchdogJob?.isActive == true) return
 
     firstFrameWatchdogJob = scope.launch {
-        delay(PlayerRuntimeController.FIRST_FRAME_TIMEOUT_MS)
+        if (isReadyAndDeadlocked) {
+            // Devices that never render a frame while paused: force play after a short wait.
+            delay(PlayerRuntimeController.FIRST_FRAME_DEADLOCK_TIMEOUT_MS)
+            val livePlayer = _exoPlayer ?: return@launch
+            if (hasRenderedFirstFrame) return@launch
+            if (livePlayer.playbackState == Player.STATE_READY &&
+                !livePlayer.playWhenReady &&
+                !userPausedManually
+            ) {
+                Log.w(
+                    PlayerRuntimeController.TAG,
+                    "FIRST_FRAME_DEADLOCK_PREVENTION: STATE_READY paused without first frame; " +
+                        "forcing playWhenReady=true"
+                )
+                livePlayer.playWhenReady = true
+                livePlayer.play()
+            }
+            // Continue into the long-timeout codec fallbacks only if still stuck after force-play.
+            if (hasRenderedFirstFrame) return@launch
+            delay(
+                PlayerRuntimeController.FIRST_FRAME_TIMEOUT_MS -
+                    PlayerRuntimeController.FIRST_FRAME_DEADLOCK_TIMEOUT_MS
+            )
+        } else {
+            delay(PlayerRuntimeController.FIRST_FRAME_TIMEOUT_MS)
+        }
 
         val livePlayer = _exoPlayer ?: return@launch
         if (hasRenderedFirstFrame) return@launch
-        if (livePlayer.playbackState != Player.STATE_READY) return@launch
-
-        if (!livePlayer.playWhenReady && !userPausedManually) {
-            livePlayer.playWhenReady = true
-            livePlayer.play()
-            return@launch
-        }
-        if (!livePlayer.playWhenReady) return@launch
+        if (livePlayer.playbackState != Player.STATE_READY || !livePlayer.playWhenReady) return@launch
 
         val currentPosition = livePlayer.currentPosition
         if (isManualDv81Mode2ActiveForCurrentPlayback &&
@@ -796,7 +919,9 @@ private fun PlayerRuntimeController.scheduleDeferredPlayerReinitialize(
     clearResumeProgress: Boolean = false
 ) {
     cancelFirstFrameWatchdog()
+    cancelStartupDurationWatchdog()
     cancelStallWatchdog()
+    startupPresentationComplete = false
     if (clearResumeProgress) {
         pendingResumeProgress = null
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -178,7 +178,6 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                                         "currentPositionMs=$pos durationMs=$playerDuration engine=MPV " +
                                         "host=${currentStreamUrl.safePlaybackEventsHost()}"
                                 )
-                                finishLoadingDiagnostics("mpv_first_frame_ready")
                                 if (_uiState.value.postPlayDismissedForCurrentEpisode) {
                                     _uiState.update { it.copy(postPlayDismissedForCurrentEpisode = false) }
                                 }
@@ -192,16 +191,32 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                         currentPosition = displayPosition,
                         duration = playerDuration
                     )
+                    // Match Exo path: complete startup only when first frame and duration are ready.
+                    if (firstFrameReady && !startupPresentationComplete) {
+                        if (playerDuration > 0L) {
+                            startupPresentationComplete = true
+                            cancelStartupDurationWatchdog()
+                            finishLoadingDiagnostics("mpv_first_frame_ready")
+                        } else if (startupDurationWatchdogJob?.isActive != true) {
+                            startupDurationWatchdogJob = scope.launch {
+                                delay(PlayerRuntimeController.STARTUP_DURATION_GRACE_MS)
+                                if (!hasRenderedFirstFrame || startupPresentationComplete) return@launch
+                                startupPresentationComplete = true
+                                finishLoadingDiagnostics("mpv_startup_duration_grace")
+                            }
+                        }
+                    }
+                    val startupReady = startupPresentationComplete
                     val ended = playerDuration > 0L && pos >= (playerDuration - 500L)
                     val wasEnded = _uiState.value.playbackEnded
                     _uiState.update { state ->
                         state.copy(
                             isPlaying = playingNow,
-                            isBuffering = !firstFrameReady || cacheBuffering,
-                            showLoadingOverlay = if (state.loadingOverlayEnabled) !firstFrameReady else false,
+                            isBuffering = !startupReady || cacheBuffering,
+                            showLoadingOverlay = if (state.loadingOverlayEnabled) !startupReady else false,
                             // Snap the loading-logo fill to 100% once playback is
                             // ready so the logo finishes filling on dismissal.
-                            loadingProgress = if (firstFrameReady && state.loadingProgress != null) 1f else state.loadingProgress,
+                            loadingProgress = if (startupReady && state.loadingProgress != null) 1f else state.loadingProgress,
                             playbackEnded = ended
                         )
                     }
@@ -223,16 +238,27 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
 
             _exoPlayer?.let { player ->
                 val pos = player.currentPosition.coerceAtLeast(0L)
-                val playerDuration = player.duration
-                if (playerDuration > lastKnownDuration) {
-                    lastKnownDuration = playerDuration
-                }
                 val displayPosition = pendingPreviewSeekPosition ?: pos
-                updatePlaybackTimeline(
-                    currentPosition = displayPosition,
-                    duration = playerDuration.coerceAtLeast(0L),
-                    bufferedPosition = player.bufferedPosition.coerceAtLeast(displayPosition)
-                )
+                // Never coerce TIME_UNSET → 0; that wiped scrubber duration during startup.
+                val playerDuration = player.duration
+                if (playerDuration != androidx.media3.common.C.TIME_UNSET && playerDuration > 0L) {
+                    if (playerDuration > lastKnownDuration) {
+                        lastKnownDuration = playerDuration
+                    }
+                    updatePlaybackTimeline(
+                        currentPosition = displayPosition,
+                        duration = playerDuration,
+                        bufferedPosition = player.bufferedPosition.coerceAtLeast(displayPosition)
+                    )
+                } else {
+                    updatePlaybackTimeline(
+                        currentPosition = displayPosition,
+                        bufferedPosition = player.bufferedPosition.coerceAtLeast(displayPosition)
+                    )
+                }
+                if (hasRenderedFirstFrame && !startupPresentationComplete) {
+                    maybeCompleteStartupPresentation(player, "progress_duration_ready")
+                }
                 playbackAnalyticsDiagnostics.recordProgressSnapshot(
                     player = player,
                     hasRenderedFirstFrame = hasRenderedFirstFrame,
@@ -1367,6 +1393,8 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         PlayerEvent.OnRetry -> {
             hasRenderedFirstFrame = false
+            startupPresentationComplete = false
+            cancelStartupDurationWatchdog()
             hasRetriedCurrentStreamAfter416 = false
             playbackIssueReportRequestVersion.incrementAndGet()
             resetErrorRetryState()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -312,8 +312,17 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
         maybeScheduleFirstFrameWatchdog()
     } else {
         cancelFirstFrameWatchdog()
+        // Audio-only: there is no video first frame. Treat READY tracks as the
+        // startup sync point so loading does not wait forever for duration+frame.
+        val player = _exoPlayer
+        if (player != null && !hasRenderedFirstFrame && player.playbackState == Player.STATE_READY) {
+            hasRenderedFirstFrame = true
+            maybeCompleteStartupPresentation(player, "audio_only_ready")
+        }
     }
-    tryAutoSelectPreferredSubtitleFromAvailableTracks()
+    if (startupPresentationComplete) {
+        tryAutoSelectPreferredSubtitleFromAvailableTracks()
+    }
     maybeAdjustLibassPipelineForTracks(tracks)
 }
 


### PR DESCRIPTION
## Summary

Fixes the startup regression where playback showed a first frame, then rebuffered shortly after while duration was still missing on the scrubber.

Root causes addressed:
- Loading was dismissed on first frame alone, before progressive VOD duration/seek-map was ready
- First `STATE_READY` forced a no-op `trackSelectionParameters` rebuild that triggered Media3 reselection/rebuffer
- `TIME_UNSET` duration was coerced to `0`, wiping scrubber duration; no `onTimelineChanged` path to pick up late duration
- Subtitle auto-select and rebuffer telemetry ran before startup presentation was complete

## Changes

- Complete startup only after first frame **and** known VOD duration (live/dynamic exempt; 2.5s grace fallback)
- Add `onTimelineChanged` + safe duration sync that never writes `TIME_UNSET` as `0` 
- Remove no-op track rebuild on first READY
- Defer subtitle auto-select until startup presentation is complete
- Count REBUFFER only after startup presentation is complete
- Restore short first-frame deadlock force-play (3.5s) path

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Users reported: start stream -> black/load -> first frame -> play ~1s -> buffer again, with duration missing until the second buffer. Not network-bound (reproduced on small files). This was a startup pipeline regression, not a cosmetic spinner issue.

## Reproduction steps

1. Start any progressive VOD stream (especially extensionless / non-faststart / cold start)
2. Observe first video frame appear
3. Scrubber duration still missing / zero
4. Short rebuffer shortly after, then duration appears

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes reproduction steps and testing notes.

## Testing

- `./gradlew :app:compileFullDebugKotlin` passed
- Logic verified against player startup/duration/timeline paths

## Breaking changes

None.