### PR TITLE
Fix: Improve DV Profile 5 Handling with Always Strip DV enabled

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionMatroskaTransformer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/DolbyVisionMatroskaTransformer.kt
@@ -37,6 +37,36 @@ internal class DolbyVisionMatroskaTransformer(
     // Reused across samples; grows to the largest frame once.
     private val scratch = ExposedByteArrayOutputStream(64 * 1024)
 
+    // Cached per-stream once resolved. SEI carrying mastering-display/CLL info
+    // is typically only sent on keyframes, so we keep checking each sample
+    // until we find it or hit the detection window, rather than deciding off
+    // just the first frame.
+    private var dv5StripDecision: Boolean? = null
+    private var dv5DetectionSamplesChecked = 0
+
+    private fun shouldStripDv5Rpu(
+        sample: ByteArray,
+        sampleLength: Int,
+        nalUnitLengthFieldLength: Int
+    ): Boolean {
+        dv5StripDecision?.let { return it }
+        val detected = HevcDvRpuStripper.containsHdr10StaticMetadataSei(
+            sample, sampleLength, nalUnitLengthFieldLength
+        )
+        if (detected) {
+            dv5StripDecision = true
+            android.util.Log.i("DVStrip", "DV5_STRIP_DECISION: hdr10StaticSeiPresent=true -> STRIP")
+            return true
+        }
+        dv5DetectionSamplesChecked++
+        if (dv5DetectionSamplesChecked >= DV5_DETECTION_SAMPLE_LIMIT) {
+            dv5StripDecision = false
+            android.util.Log.i("DVStrip", "DV5_STRIP_DECISION: hdr10StaticSeiPresent=false after $dv5DetectionSamplesChecked samples -> SKIP")
+            return false
+        }
+        return false
+    }
+
     // Reuses the package-private ExposedByteArrayOutputStream from HevcDvRpuStripper.kt
 
     override fun onDolbyVisionBlockAdditionalData(
@@ -85,7 +115,9 @@ internal class DolbyVisionMatroskaTransformer(
 
         if (stripRpuOnly) {
             if (profile == 5) {
-                return stripHdr10PlusIfEnabled(sample, sampleLength, nalUnitLengthFieldLength) ?: sample
+                if (!shouldStripDv5Rpu(sample, sampleLength, nalUnitLengthFieldLength)) {
+                    return stripHdr10PlusIfEnabled(sample, sampleLength, nalUnitLengthFieldLength) ?: sample
+                }
             }
             // Use the shared ExposedByteArrayOutputStream scratch buffer to avoid GC allocations on every frame
             val changed = HevcDvRpuStripper.stripRpuLengthDelimited(
@@ -363,5 +395,6 @@ internal class DolbyVisionMatroskaTransformer(
     private companion object {
         const val NAL_TYPE_UNSPEC62 = 62
         const val NAL_TYPE_UNSPEC63 = 63
+        const val DV5_DETECTION_SAMPLE_LIMIT = 15
     }
 }

--- a/app/src/main/java/com/nuvio/tv/core/player/HevcDvRpuStripper.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/HevcDvRpuStripper.kt
@@ -65,6 +65,57 @@ internal object HevcDvRpuStripper {
         return changed
     }
 
+    private fun readLengthField(
+        data: ByteArray,
+        offset: Int,
+        lengthBytes: Int
+    ): Int {
+        var value = 0
+        for (i in 0 until lengthBytes) {
+            value = (value shl 8) or (data[offset + i].toInt() and 0xFF)
+        }
+        return value
+    }
+
+    private const val NAL_TYPE_PREFIX_SEI = 39
+    private const val SEI_PAYLOAD_TYPE_MASTERING_DISPLAY = 137
+    private const val SEI_PAYLOAD_TYPE_CONTENT_LIGHT_LEVEL = 144
+
+    /**
+     * Scans for a Prefix SEI NAL (type 39) whose first payload is Mastering
+     * Display Colour Volume (137) or Content Light Level Info (144) — i.e. the
+     * base layer carries its own real HDR10 static metadata, independent of the
+     * DV RPU. This is the actual discriminator between DV5 sources whose base
+     * layer is directly viewable (safe to strip RPU) vs. ones that are only
+     * valid via the DV reshaping curve (unsafe to strip). Every DV5 frame has
+     * an RPU regardless — that's not a useful signal on its own.
+     */
+    fun containsHdr10StaticMetadataSei(
+        sample: ByteArray,
+        sampleLength: Int,
+        nalUnitLengthFieldLength: Int
+    ): Boolean {
+        if (nalUnitLengthFieldLength !in 1..4) return false
+        var offset = 0
+        var found = false
+        while (offset + nalUnitLengthFieldLength <= sampleLength) {
+            val nalSize = readLengthField(sample, offset, nalUnitLengthFieldLength)
+            offset += nalUnitLengthFieldLength
+            if (nalSize <= 0 || offset + nalSize > sampleLength) break
+            val nalType = (sample[offset].toInt() ushr 1) and 0x3F
+            if (nalType == NAL_TYPE_PREFIX_SEI && nalSize >= 3) {
+                // payload_type is a single byte here since 137/144 < 0xFF
+                // (no 0xFF continuation prefix needed at these values).
+                val payloadType = sample[offset + 2].toInt() and 0xFF
+                if (payloadType == SEI_PAYLOAD_TYPE_MASTERING_DISPLAY ||
+                    payloadType == SEI_PAYLOAD_TYPE_CONTENT_LIGHT_LEVEL) {
+                    found = true
+                }
+            }
+            offset += nalSize
+        }
+        return found
+    }
     /**
      * Rewrites a length-delimited (MP4/fMP4) sample, removing any NAL unit
      * whose type is 62 (DV RPU). Returns the rewritten bytes, or null if


### PR DESCRIPTION
## Summary
<!-- What changed in this PR? -->
Fixes incorrect color rendering (green/purple tint) on certain Dolby Vision Profile 5 files when "Always Strip DV" is enabled. Previously, DV RPU stripping was unconditionally skipped for all Profile 5 sources. Some DV5 sources carry standalone HDR10 static metadata (Mastering Display Colour Volume / Content Light Level SEI) in their base layer and are safe to strip, while others rely entirely on the RPU reshaping curve and must not be stripped. This PR detects HDR10 static metadata SEI in the base layer and only strips DV5 RPU when it's present.

## PR type
<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix
<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why
<!-- Why this change is needed. Explain the critical bug or localization update. -->
Playback of affected DV5 files produced a green/purple tint when "Always Strip DV" was enabled, because the RPU stripper unconditionally skipped all Profile 5 sources regardless of whether their base layer was valid HDR10 on its own. Files without this metadata rely on the RPU and must not be stripped, or they show the same tint.

## Issue or approval
<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
Fixes #2657 

## Reproduction steps
<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->
1. Enable "Always Strip DV" in player settings.
2. Play a DV5 MKV whose HEVC base layer carries Mastering Display Colour Volume / Content Light Level SEI (e.g. `The.Testaments.S01E03...DV.HDR.H265...mkv`).
3. Observe green/purple tint — RPU stripped from a base layer that lacked valid standalone HDR10 grading handling.
4. With this fix, the same file plays correctly, and a DV5 file without this SEI (e.g. `Running.Point.S01E01...DV.H265...mkv`) continues to play correctly as before.

## UI / behavior impact
<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.
> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries
<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
Only touches DV5 RPU-strip gating in `DolbyVisionMatroskaTransformer.kt` and adds a detection helper in `HevcDvRpuStripper.kt`. Does not change DV7 handling, DV8.1 conversion, or non-"Always Strip DV" playback paths.

## Testing
<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->
Manually tested on Fire TV Stick 4K with "Always Strip DV" enabled:
- DV5 file with HDR10 static metadata SEI present: previously showed green/purple tint, now plays with correct color (RPU stripped, decoded as plain HEVC).
- DV5 file without HDR10 static metadata SEI: continues to play correctly via native DV decoder (RPU preserved, no regression).
- Confirmed via logcat (`DVStrip` tag) that the strip decision resolves correctly per file (`STRIP` vs `SKIP`) and is not carried over between different files in the same session.

## Screenshots / Video
<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
Not a UI change.

## Breaking changes
<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.

## Linked issues
<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
Fixes #2657 