### PR TITLE
Fix cached stream reuse after external player startup failure

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackRecoveryPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackRecoveryPolicy.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.core.player
+
+/** Conservative rules for recovering from an external player that never started playback. */
+internal object ExternalPlaybackRecoveryPolicy {
+    const val QUICK_RETURN_WINDOW_MS = 15_000L
+
+    fun shouldInvalidateCachedLink(
+        hasUsableResult: Boolean,
+        externalPlayerCoveredApp: Boolean,
+        launchStartedAtMs: Long,
+        returnedAtMs: Long,
+        quickReturnWindowMs: Long = QUICK_RETURN_WINDOW_MS
+    ): Boolean {
+        if (hasUsableResult || !externalPlayerCoveredApp || launchStartedAtMs <= 0L) return false
+        if (returnedAtMs < launchStartedAtMs || quickReturnWindowMs < 0L) return false
+        return returnedAtMs - launchStartedAtMs <= quickReturnWindowMs
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -1,9 +1,11 @@
 package com.nuvio.tv.core.player
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
+import com.nuvio.tv.data.local.StreamLinkCacheDataStore
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.repository.MetaRepository
@@ -171,6 +173,7 @@ class ExternalPlaybackTracker @Inject constructor(
     private val traktAuthService: TraktAuthService,
     private val metaRepository: MetaRepository,
     private val playerSettingsDataStore: PlayerSettingsDataStore,
+    private val streamLinkCacheDataStore: StreamLinkCacheDataStore,
     private val skipIntroRepository: SkipIntroRepository
 ) {
     companion object {
@@ -222,6 +225,8 @@ class ExternalPlaybackTracker @Inject constructor(
     private var nextEpisodePrefetchJob: Job? = null
     private var nextEpisodeSnapshot: ExternalNextEpisodeSnapshot = ExternalNextEpisodeSnapshot.Unknown
     private var autoNextEnabledForPendingLaunch: Boolean? = null
+    private var activityResultLaunchStartedAtMs = 0L
+    private var externalPlayerCoveredApp = false
 
     // Fires on external-episode completion; collected by MainActivity to navigate to
     // the next episode's Stream route. replay = 1 so the event still reaches the
@@ -278,6 +283,8 @@ class ExternalPlaybackTracker @Inject constructor(
         }
         pendingMetadata = metadata
         isAutoLaunch = autoLaunch
+        activityResultLaunchStartedAtMs = 0L
+        externalPlayerCoveredApp = false
         // A manual launch is always fresh; only an auto-launch within the window is a continuation
         // that keeps a user's abort in effect (so one Back press stops a runaway chain).
         val shouldResetAbort = !autoNextNavigationPending &&
@@ -473,9 +480,13 @@ class ExternalPlaybackTracker @Inject constructor(
             val launcher = activityLauncher
             if (launcher != null) {
                 return try {
+                    activityResultLaunchStartedAtMs = SystemClock.elapsedRealtime()
+                    externalPlayerCoveredApp = false
                     launcher.launch(input)
                     true
                 } catch (e: Exception) {
+                    activityResultLaunchStartedAtMs = 0L
+                    externalPlayerCoveredApp = false
                     Log.w(TAG, "ActivityResultLauncher failed, falling back to fire-and-forget", e)
                     ExternalPlayerLauncher.launch(
                         context = context,
@@ -512,6 +523,8 @@ class ExternalPlaybackTracker @Inject constructor(
         val metadata = pendingMetadata ?: loadPersistedMetadata()
         if (metadata == null) {
             Log.d(TAG, "onActivityResult but no pending metadata (in-memory or persisted)")
+            activityResultLaunchStartedAtMs = 0L
+            externalPlayerCoveredApp = false
             clearPersistedMetadata()
             stopTracking()
             return
@@ -524,12 +537,26 @@ class ExternalPlaybackTracker @Inject constructor(
 
         if (result == null) {
             Log.d(TAG, "External player returned no progress data")
+            val shouldInvalidateCachedLink = ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = false,
+                externalPlayerCoveredApp = externalPlayerCoveredApp,
+                launchStartedAtMs = activityResultLaunchStartedAtMs,
+                returnedAtMs = SystemClock.elapsedRealtime()
+            )
+            activityResultLaunchStartedAtMs = 0L
+            externalPlayerCoveredApp = false
             _autoNextOverlay.value = null
             clearPersistedMetadata()
             // On Zidoo, the monitor job handles progress - don't stop it prematurely.
             if (!ZidooPlayerMonitor.isZidooDevice()) stopTracking()
+            if (shouldInvalidateCachedLink) {
+                invalidateFailedStreamLink(metadata)
+            }
             return
         }
+
+        activityResultLaunchStartedAtMs = 0L
+        externalPlayerCoveredApp = false
 
         // Covers process recreation, where onStart could not use in-memory state. At this point
         // the result is available, so only a completion may claim the transition loader.
@@ -998,11 +1025,27 @@ class ExternalPlaybackTracker @Inject constructor(
     /** The launched external player now owns the display, so the Nuvio transition cover can end. */
     fun onExternalPlayerCoveredApp() {
         if (!isTracking) return
+        if (activityResultLaunchStartedAtMs > 0L) {
+            externalPlayerCoveredApp = true
+        }
         Log.d(AUTO_NEXT_TAG, "external player covered app -> clearing transition loader")
         autoNextJob?.cancel()
         autoNextJob = null
         autoNextNavigationPending = false
         _autoNextOverlay.value = null
+    }
+
+    private fun invalidateFailedStreamLink(metadata: ExternalPlaybackMetadata) {
+        val contentKey = "${metadata.contentType.lowercase()}|${metadata.videoId}"
+        val invalidation = streamLinkCacheDataStore.invalidate(contentKey)
+        scope.launch {
+            runCatching {
+                streamLinkCacheDataStore.removeInvalidated(contentKey, invalidation)
+            }.onFailure { error ->
+                Log.w(TAG, "Could not remove failed stream link for ${metadata.videoId}", error)
+            }
+            Log.w(TAG, "External player returned before playback; invalidated link for ${metadata.videoId}")
+        }
     }
 
     /** The next-episode auto-play was navigated to but the user has aborted the chain — the Stream

--- a/app/src/main/java/com/nuvio/tv/data/local/StreamLinkCacheDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/StreamLinkCacheDataStore.kt
@@ -5,9 +5,13 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.json.JSONArray
 import org.json.JSONObject
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,7 +38,11 @@ class StreamLinkCacheDataStore @Inject constructor(
 ) {
     companion object {
         private const val FEATURE = "stream_link_cache"
+        private const val CACHE_LOCK_COUNT = 32
     }
+
+    private val invalidations = StreamLinkCacheInvalidations()
+    private val cacheLocks = Array(CACHE_LOCK_COUNT) { Mutex() }
 
     private fun store(profileId: Int = profileManager.activeProfileId.value) =
         factory.get(profileId, FEATURE)
@@ -54,6 +62,7 @@ class StreamLinkCacheDataStore @Inject constructor(
         contentLanguage: String? = null,
         year: String? = null
     ) {
+        val invalidationAtStart = invalidations.current(contentKey)
         val payload = JSONObject().apply {
             put("url", url)
             put("streamName", streamName)
@@ -70,68 +79,92 @@ class StreamLinkCacheDataStore @Inject constructor(
             year?.let { put("year", it) }
         }.toString()
 
-        store().edit { prefs ->
-            prefs[cachePrefKey(contentKey)] = payload
+        cacheLock(contentKey).withLock {
+            store().edit { prefs ->
+                prefs[cachePrefKey(contentKey)] = payload
+            }
+            invalidationAtStart?.let { invalidations.clearIfCurrent(contentKey, it) }
         }
     }
 
     suspend fun getValid(contentKey: String, maxAgeMs: Long): CachedStreamLink? {
         if (maxAgeMs <= 0L) return null
+        if (invalidations.isInvalidated(contentKey)) return null
 
-        val key = cachePrefKey(contentKey)
-        val raw = store().data.first()[key] ?: return null
+        return cacheLock(contentKey).withLock {
+            if (invalidations.isInvalidated(contentKey)) return@withLock null
 
-        val parsed = runCatching {
-            val json = JSONObject(raw)
-            val cachedAtMs = json.optLong("cachedAtMs", 0L)
-            val age = System.currentTimeMillis() - cachedAtMs
-            if (cachedAtMs <= 0L || age > maxAgeMs) return@runCatching null
+            val key = cachePrefKey(contentKey)
+            val raw = store().data.first()[key] ?: return@withLock null
 
-            val headersJson = json.optJSONObject("headers")
-            val headers = buildMap {
-                headersJson?.keys()?.forEach { headerKey ->
-                    put(headerKey, headersJson.optString(headerKey, ""))
+            val parsed = runCatching {
+                val json = JSONObject(raw)
+                val cachedAtMs = json.optLong("cachedAtMs", 0L)
+                val age = System.currentTimeMillis() - cachedAtMs
+                if (cachedAtMs <= 0L || age > maxAgeMs) return@runCatching null
+
+                val headersJson = json.optJSONObject("headers")
+                val headers = buildMap {
+                    headersJson?.keys()?.forEach { headerKey ->
+                        put(headerKey, headersJson.optString(headerKey, ""))
+                    }
+                }.filterValues { it.isNotEmpty() }
+
+                val url = json.optString("url", "")
+                val streamName = json.optString("streamName", "")
+                val infoHash = json.optString("infoHash", "").ifBlank { null }
+                // Accept entry if it has either a real URL (HTTP stream) or an
+                // infoHash (torrent stream — URL is re-resolved on each playback).
+                if (streamName.isBlank() || (url.isBlank() && infoHash == null)) return@runCatching null
+
+                val sourcesJson = json.optJSONArray("sources")
+                val sources = sourcesJson?.let { arr ->
+                    (0 until arr.length()).mapNotNull { i ->
+                        arr.optString(i).takeIf { it.isNotEmpty() }
+                    }
+                }?.takeIf { it.isNotEmpty() }
+
+                CachedStreamLink(
+                    url = url,
+                    streamName = streamName,
+                    headers = headers,
+                    cachedAtMs = cachedAtMs,
+                    filename = json.optString("filename", "").ifBlank { null },
+                    videoHash = json.optString("videoHash", "").ifBlank { null },
+                    videoSize = json.optLong("videoSize", -1L).takeIf { it >= 0L },
+                    infoHash = infoHash,
+                    fileIdx = if (json.has("fileIdx")) json.optInt("fileIdx", -1).takeIf { it >= 0 } else null,
+                    sources = sources,
+                    bingeGroup = json.optString("bingeGroup", "").ifBlank { null },
+                    contentLanguage = json.optString("contentLanguage", "").ifBlank { null },
+                    year = json.optString("year", "").ifBlank { null }
+                )
+            }.getOrNull()
+
+            if (parsed == null) {
+                store().edit { mutablePrefs ->
+                    mutablePrefs.remove(key)
                 }
-            }.filterValues { it.isNotEmpty() }
+            }
 
-            val url = json.optString("url", "")
-            val streamName = json.optString("streamName", "")
-            val infoHash = json.optString("infoHash", "").ifBlank { null }
-            // Accept entry if it has either a real URL (HTTP stream) or an
-            // infoHash (torrent stream — URL is re-resolved on each playback).
-            if (streamName.isBlank() || (url.isBlank() && infoHash == null)) return@runCatching null
+            parsed
+        }
+    }
 
-            val sourcesJson = json.optJSONArray("sources")
-            val sources = sourcesJson?.let { arr ->
-                (0 until arr.length()).mapNotNull { i ->
-                    arr.optString(i).takeIf { it.isNotEmpty() }
-                }
-            }?.takeIf { it.isNotEmpty() }
+    fun invalidate(contentKey: String): Long = invalidations.invalidate(contentKey)
 
-            CachedStreamLink(
-                url = url,
-                streamName = streamName,
-                headers = headers,
-                cachedAtMs = cachedAtMs,
-                filename = json.optString("filename", "").ifBlank { null },
-                videoHash = json.optString("videoHash", "").ifBlank { null },
-                videoSize = json.optLong("videoSize", -1L).takeIf { it >= 0L },
-                infoHash = infoHash,
-                fileIdx = if (json.has("fileIdx")) json.optInt("fileIdx", -1).takeIf { it >= 0 } else null,
-                sources = sources,
-                bingeGroup = json.optString("bingeGroup", "").ifBlank { null },
-                contentLanguage = json.optString("contentLanguage", "").ifBlank { null },
-                year = json.optString("year", "").ifBlank { null }
-            )
-        }.getOrNull()
-
-        if (parsed == null) {
-            store().edit { mutablePrefs ->
-                mutablePrefs.remove(key)
+    suspend fun removeInvalidated(contentKey: String, invalidation: Long) {
+        cacheLock(contentKey).withLock {
+            if (invalidations.current(contentKey) != invalidation) return@withLock
+            store().edit { prefs ->
+                prefs.remove(cachePrefKey(contentKey))
             }
         }
+    }
 
-        return parsed
+    private fun cacheLock(contentKey: String): Mutex {
+        val index = (contentKey.hashCode() and Int.MAX_VALUE) % cacheLocks.size
+        return cacheLocks[index]
     }
 
     private fun cachePrefKey(contentKey: String): Preferences.Key<String> {
@@ -140,4 +173,22 @@ class StreamLinkCacheDataStore @Inject constructor(
             .joinToString("") { "%02x".format(it) }
         return stringPreferencesKey("stream_link_$digest")
     }
+}
+
+internal class StreamLinkCacheInvalidations {
+    private val sequence = AtomicLong(0L)
+    private val entries = ConcurrentHashMap<String, Long>()
+
+    fun invalidate(contentKey: String): Long {
+        val token = sequence.incrementAndGet()
+        entries[contentKey] = token
+        return token
+    }
+
+    fun current(contentKey: String): Long? = entries[contentKey]
+
+    fun isInvalidated(contentKey: String): Boolean = entries.containsKey(contentKey)
+
+    fun clearIfCurrent(contentKey: String, token: Long): Boolean =
+        entries.remove(contentKey, token)
 }

--- a/app/src/test/java/com/nuvio/tv/core/player/ExternalPlaybackRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/ExternalPlaybackRecoveryPolicyTest.kt
@@ -1,0 +1,79 @@
+package com.nuvio.tv.core.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExternalPlaybackRecoveryPolicyTest {
+    @Test
+    fun `refreshes when covered player quickly returns without a usable result`() {
+        assertTrue(
+            ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = false,
+                externalPlayerCoveredApp = true,
+                launchStartedAtMs = 1_000L,
+                returnedAtMs = 12_000L
+            )
+        )
+    }
+
+    @Test
+    fun `does not refresh a normal result`() {
+        assertFalse(
+            ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = true,
+                externalPlayerCoveredApp = true,
+                launchStartedAtMs = 1_000L,
+                returnedAtMs = 2_000L
+            )
+        )
+    }
+
+    @Test
+    fun `does not refresh when the player never covered the app`() {
+        assertFalse(
+            ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = false,
+                externalPlayerCoveredApp = false,
+                launchStartedAtMs = 1_000L,
+                returnedAtMs = 2_000L
+            )
+        )
+    }
+
+    @Test
+    fun `does not refresh a long playback from a player without result support`() {
+        assertFalse(
+            ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = false,
+                externalPlayerCoveredApp = true,
+                launchStartedAtMs = 1_000L,
+                returnedAtMs = 16_001L
+            )
+        )
+    }
+
+    @Test
+    fun `does not refresh a recovered process without an in memory launch time`() {
+        assertFalse(
+            ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = false,
+                externalPlayerCoveredApp = true,
+                launchStartedAtMs = 0L,
+                returnedAtMs = 2_000L
+            )
+        )
+    }
+
+    @Test
+    fun `includes the exact quick return boundary`() {
+        assertTrue(
+            ExternalPlaybackRecoveryPolicy.shouldInvalidateCachedLink(
+                hasUsableResult = false,
+                externalPlayerCoveredApp = true,
+                launchStartedAtMs = 1_000L,
+                returnedAtMs = 16_000L
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/local/StreamLinkCacheInvalidationsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/StreamLinkCacheInvalidationsTest.kt
@@ -1,0 +1,36 @@
+package com.nuvio.tv.data.local
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamLinkCacheInvalidationsTest {
+    private val invalidations = StreamLinkCacheInvalidations()
+
+    @Test
+    fun `invalidation blocks the matching content key only`() {
+        invalidations.invalidate("series|episode-1")
+
+        assertTrue(invalidations.isInvalidated("series|episode-1"))
+        assertFalse(invalidations.isInvalidated("series|episode-2"))
+    }
+
+    @Test
+    fun `fresh save clears its observed invalidation`() {
+        val token = invalidations.invalidate("series|episode-1")
+
+        assertTrue(invalidations.clearIfCurrent("series|episode-1", token))
+        assertFalse(invalidations.isInvalidated("series|episode-1"))
+    }
+
+    @Test
+    fun `older save cannot clear a newer invalidation`() {
+        val oldToken = invalidations.invalidate("series|episode-1")
+        val newToken = invalidations.invalidate("series|episode-1")
+
+        assertNotEquals(oldToken, newToken)
+        assertFalse(invalidations.clearIfCurrent("series|episode-1", oldToken))
+        assertTrue(invalidations.isInvalidated("series|episode-1"))
+    }
+}


### PR DESCRIPTION
## Summary

External player launches that return quickly without usable playback data now invalidate only the failed content item's cached stream link. The next normal playback attempt requests fresh stream results and then follows the existing binge group and autoplay selection rules.

The recovery is intentionally conservative. It requires an Activity Result launch, confirmation that the external player covered Nuvio, no usable result, and a return within 15 seconds. Content scoped invalidation tokens and cache locks prevent an older pending save from restoring the failed link or an older cleanup from deleting a newly fetched link.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When an external player returned before playback started, the result path cleared tracking state but left the attempted stream link cached. A normal retry from the episode card could therefore select the same failed link again until the playback state was refreshed.

The cache write and removal paths are asynchronous, so a simple delete could race with an existing save or a newly fetched result. The added generation token and content key locking keep invalidation immediate while ensuring only the matching failed entry is removed.

## Issue or approval

Fixes #2668

## Reproduction steps

1. Enable an external player and cached stream link reuse.
2. Open an episode from its episode card with the normal OK action.
3. Let the external player launch with a stream that fails before playback begins and returns to Nuvio within a few seconds without position or duration data.
4. Press OK on the same episode card again without opening source selection manually.
5. Before this fix, Nuvio can reuse the same failed cached stream.
6. After this fix, the normal retry requests fresh stream results and applies the existing selection rules.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This changes only recovery after an Activity Result based external player launch returns without usable data within 15 seconds after covering Nuvio. It does not retry automatically, navigate to source selection, or change watch progress, watched state, binge group ownership, finale detection, auto next, or the stream selection timeout.

Fire and forget launches, Zidoo monitoring, process recreated sessions without an in memory launch time, normal playback results, and longer external playback sessions remain unchanged. The cache coordination changes are limited to ordering invalidation, save, read, and removal for the affected content key.

## Testing

- Ran `.\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.core.player.ExternalPlaybackRecoveryPolicyTest" --tests "com.nuvio.tv.core.player.ExternalAutoNextPolicyTest" --tests "com.nuvio.tv.data.local.StreamLinkCacheInvalidationsTest"`.
- All 34 focused tests passed: 6 recovery policy tests, 25 existing external auto next policy tests, and 3 cache invalidation tests.
- Built the full debug APK successfully.
- Installed the debug APK with `adb install -r` on an NVIDIA Shield Android TV running Android 11, preserving existing app data.
- Confirmed normal external player launch still works. The original transient failed stream could not be forced reliably after it cleared.
- Ran `git diff --check` successfully.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2668