### PR TITLE
fix: prevent CW leak when profiles have different Trakt states

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ContinueWatchingEnrichmentCache.kt
@@ -191,6 +191,8 @@ class ContinueWatchingEnrichmentCache @Inject constructor(
             try {
                 nextUpFile().delete()
                 inProgressFile().delete()
+                lastNextUpHash = 0
+                lastInProgressHash = 0
                 Log.d(TAG, "Cleared CW enrichment cache for profile ${profileManager.activeProfileId.value}")
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to clear CW enrichment cache: ${e.message}")

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -79,6 +79,7 @@ class WatchProgressPreferences @Inject constructor(
      */
     @Volatile private var cachedProgressJson: String? = null
     @Volatile private var cachedProgressResult: List<WatchProgress>? = null
+    @Volatile private var cachedProfileId: Int = -1
 
     val allProgress: Flow<List<WatchProgress>> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { preferences ->
@@ -86,7 +87,7 @@ class WatchProgressPreferences @Inject constructor(
 
             // Fast path: if JSON hasn't changed, return cached result immediately.
             val cached = cachedProgressResult
-            if (json == cachedProgressJson && cached != null) {
+            if (json == cachedProgressJson && cached != null && cachedProfileId == pid) {
                 return@map cached
             }
 
@@ -109,6 +110,7 @@ class WatchProgressPreferences @Inject constructor(
             val result = latestByContent.sortedByDescending { it.lastWatched }
 
             // Cache for next emission
+            cachedProfileId = pid
             cachedProgressJson = json
             cachedProgressResult = result
             result
@@ -117,13 +119,14 @@ class WatchProgressPreferences @Inject constructor(
 
     @Volatile private var cachedRawProgressJson: String? = null
     @Volatile private var cachedRawProgressResult: List<WatchProgress>? = null
+    @Volatile private var cachedRawProfileId: Int = -1
 
     val allRawProgress: Flow<List<WatchProgress>> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { preferences ->
             val json = preferences[watchProgressKey] ?: "{}"
 
             val cached = cachedRawProgressResult
-            if (json == cachedRawProgressJson && cached != null) {
+            if (json == cachedRawProgressJson && cached != null && cachedRawProfileId == pid) {
                 return@map cached
             }
 
@@ -131,6 +134,7 @@ class WatchProgressPreferences @Inject constructor(
                 .values
                 .sortedByDescending { it.lastWatched }
 
+            cachedRawProfileId = pid
             cachedRawProgressJson = json
             cachedRawProgressResult = result
             result

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -49,12 +49,13 @@ class WatchedSeriesStateHolder @Inject constructor(
     /** Per-series revalidation deadline (contentId → epochMs when re-check is needed). */
     @Volatile
     private var revalidateAfterMap: Map<String, Long> = emptyMap()
-    private var loaded = false
+    @Volatile
+    private var loadedForProfileId: Int? = null
 
     private fun store(profileId: Int = profileManager.activeProfileId.value) = factory.get(profileId, FEATURE)
 
     suspend fun loadFromDisk(profileId: Int = profileManager.activeProfileId.value) {
-        if (loaded) return
+        if (loadedForProfileId == profileId) return
         val prefs = store(profileId).data.first()
         val persisted = prefs[KEY] ?: emptySet()
         val resetVersion = prefs[VALIDATION_RESET_KEY] ?: 0
@@ -70,7 +71,7 @@ class WatchedSeriesStateHolder @Inject constructor(
         if (_fullyWatchedSeriesIds.value.isEmpty() && persisted.isNotEmpty()) {
             _fullyWatchedSeriesIds.value = persisted
         }
-        loaded = true
+        loadedForProfileId = profileId
     }
 
     fun update(ids: Set<String>) {

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedSeriesStateHolder.kt
@@ -82,6 +82,12 @@ class WatchedSeriesStateHolder @Inject constructor(
         }
     }
 
+    /** Clear in-memory state only — does NOT touch DataStore on disk. */
+    fun clearInMemory() {
+        _fullyWatchedSeriesIds.value = emptySet()
+        revalidateAfterMap = emptyMap()
+    }
+
     /**
      * Update badge IDs and mark the given series as freshly validated.
      * [revalidateAt] allows setting per-series deadlines (e.g. upcoming season premiere).

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -101,13 +101,10 @@ class WatchProgressRepositoryImpl @Inject constructor(
     private val inFlightMetadataKeys = mutableSetOf<String>()
     private val metadataHydrationLimit = 30
 
-    private fun triggerRemoteSync() {
+    private fun triggerRemoteSync(profileId: Int = profileManager.activeProfileId.value) {
         if (isSyncingFromRemote) return
         if (!hasCompletedInitialPull) return
         if (!authManager.isAuthenticated) return
-        // Capture profile ID now so the delayed push targets the correct profile
-        // even if the user switches profiles during the debounce window.
-        val profileId = profileManager.activeProfileId.value
         syncJob?.cancel()
         syncJob = syncScope.launch {
             delay(2000)
@@ -310,28 +307,41 @@ class WatchProgressRepositoryImpl @Inject constructor(
         get() = useTraktProgressFlow()
             .flatMapLatest { useTraktProgress ->
                 if (useTraktProgress) {
+                    // Capture the profile ID at subscription time so any stale Trakt
+                    // emissions that arrive during the 300ms debounce on profile switch
+                    // are dropped instead of leaking into the new profile's CW list.
+                    val subscriptionProfileId = profileManager.activeProfileId.value
                     // Merge Trakt remote progress with local-only entries that use
                     // non-Trakt-compatible IDs (kitsu:, mal:, anilist:, etc.).
                     // Trakt will never return these IDs, so they must come from local storage.
-                    combine(
-                        traktAllProgressFlow(),
-                        watchProgressPreferences.allProgress
-                    ) { traktItems, localItems ->
-                        val localNonTraktItems = localItems.filter { !isTraktCompatibleId(it.contentId) }
-                        if (localNonTraktItems.isEmpty()) {
-                            traktItems
-                        } else {
-                            val traktKeys = traktItems.map { progressKey(it) }.toSet()
-                            val merged = traktItems.toMutableList()
-                            localNonTraktItems.forEach { localItem ->
-                                val key = progressKey(localItem)
-                                if (key !in traktKeys) {
-                                    merged.add(localItem)
+                    profileManager.activeProfileId
+                        .map { it == subscriptionProfileId }
+                        .distinctUntilChanged()
+                        .flatMapLatest { sameProfile ->
+                            if (!sameProfile) {
+                                flowOf(emptyList())
+                            } else {
+                                combine(
+                                    traktAllProgressFlow(),
+                                    watchProgressPreferences.allProgress
+                                ) { traktItems, localItems ->
+                                    val localNonTraktItems = localItems.filter { !isTraktCompatibleId(it.contentId) }
+                                    if (localNonTraktItems.isEmpty()) {
+                                        traktItems
+                                    } else {
+                                        val traktKeys = traktItems.map { progressKey(it) }.toSet()
+                                        val merged = traktItems.toMutableList()
+                                        localNonTraktItems.forEach { localItem ->
+                                            val key = progressKey(localItem)
+                                            if (key !in traktKeys) {
+                                                merged.add(localItem)
+                                            }
+                                        }
+                                        merged.sortedByDescending { it.lastWatched }
+                                    }
                                 }
                             }
-                            merged.sortedByDescending { it.lastWatched }
                         }
-                    }
                 } else {
                     watchProgressPreferences.allProgress
                         .onEach { items ->
@@ -760,7 +770,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             watchProgressPreferences.saveProgressBatch(progressList, profileId = profileId)
             // Mirror to Nuvio Sync so data is ready if user switches source later.
             if (syncRemote && authManager.isAuthenticated) {
-                triggerRemoteSync()
+                triggerRemoteSync(profileId = profileId)
             }
             return
         }
@@ -768,7 +778,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
         watchProgressPreferences.saveProgressBatch(progressList, profileId = profileId)
 
         if (syncRemote && authManager.isAuthenticated) {
-            triggerRemoteSync()
+            triggerRemoteSync(profileId = profileId)
         }
 
         val completedWatchedItems = progressList
@@ -809,7 +819,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     Log.w(TAG, "removeProgress remote delete failed; relying on push sync", error)
                 }
         }
-        triggerRemoteSync()
+        triggerRemoteSync(profileId = profileId)
     }
 
     override suspend fun removeFromHistory(contentId: String, videoId: String?, season: Int?, episode: Int?) {
@@ -840,7 +850,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     Log.w(TAG, "removeFromHistory watched item remote delete failed", error)
                 }
         }
-        triggerRemoteSync()
+        triggerRemoteSync(profileId = profileId)
     }
 
     override suspend fun removeFromHistoryBatch(
@@ -885,7 +895,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                         Log.w(TAG, "removeFromHistoryBatch watched item remote delete failed", error)
                     }
             }
-            triggerRemoteSync()
+            triggerRemoteSync(profileId = profileId)
         }
     }
 
@@ -935,7 +945,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 throw it
             }
             // Mirror to Nuvio Sync so data is ready if user switches source later.
-            triggerRemoteSync()
+            triggerRemoteSync(profileId = profileId)
             triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
             return
         }
@@ -962,7 +972,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 Log.w(TAG, "Failed to mirror completed state to Trakt", error)
             }
         }
-        triggerRemoteSync()
+        triggerRemoteSync(profileId = profileId)
         triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
     }
 
@@ -1011,7 +1021,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             val watchedItems = progressList.map { progress -> progress.toWatchedItem(watchedAt = now) }
             watchedItemsPreferences.markAsWatchedBatch(watchedItems, profileId = profileId)
             // Mirror to Nuvio Sync so data is ready if user switches source later.
-            triggerRemoteSync()
+            triggerRemoteSync(profileId = profileId)
             triggerWatchedItemsSync(watchedItems, profileId = profileId)
             return
         }
@@ -1031,7 +1041,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
             }
         }
 
-        triggerRemoteSync()
+        triggerRemoteSync(profileId = profileId)
         triggerWatchedItemsSync(watchedItems, profileId = profileId)
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -335,7 +335,7 @@ class HomeViewModel @Inject constructor(
                     cwEnrichedInProgressOverlay.clear()
                     cwLastBadgeEpisodeKeys = emptySet()
                     _uiState.update {
-                        it.copy(layoutPreferencesReady = false)
+                        it.copy(layoutPreferencesReady = false, continueWatchingItems = emptyList())
                     }
                     clearFocusState()
                     _gridFocusState.value = HomeScreenFocusState()
@@ -344,6 +344,7 @@ class HomeViewModel @Inject constructor(
                     loadContinueWatching()
                     // Clear watched badges so they don't leak between profiles.
                     watchedSeriesStateHolder.update(emptySet())
+                    watchedSeriesStateHolder.loadFromDisk(profileId = newId)
                     _movieWatchedStatus.value = emptyMap()
                     _pendingWatchedBatch.value = emptyMap()
                     _uiState.update { it.copy(movieWatchedStatus = emptyMap()) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -343,7 +343,7 @@ class HomeViewModel @Inject constructor(
                     _initialCwResolved.value = false
                     loadContinueWatching()
                     // Clear watched badges so they don't leak between profiles.
-                    watchedSeriesStateHolder.update(emptySet())
+                    watchedSeriesStateHolder.clearInMemory()
                     watchedSeriesStateHolder.loadFromDisk(profileId = newId)
                     _movieWatchedStatus.value = emptyMap()
                     _pendingWatchedBatch.value = emptyMap()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1152,7 +1152,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val enrichStartMs = SystemClock.elapsedRealtime()
                 val changed = enrichVisibleContinueWatchingItems(
                     finalItems = normalItems,
-                    debug = debug
+                    debug = debug,
+                    pipelineProfileId = pipelineProfileId
                 )
                 debug.recordEnrichmentComplete(
                     elapsedMs = SystemClock.elapsedRealtime() - enrichStartMs,
@@ -1508,7 +1509,8 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
 
 private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
     finalItems: List<ContinueWatchingItem>,
-    debug: CwDebugSession? = null
+    debug: CwDebugSession? = null,
+    pipelineProfileId: Int
 ): Boolean = coroutineScope {
     if (finalItems.isEmpty()) return@coroutineScope false
 
@@ -1573,7 +1575,8 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
     }
     persistLocalContinueWatchingMetadata(
         originalItems = finalItems,
-        enrichedItems = sortedEnrichedItems
+        enrichedItems = sortedEnrichedItems,
+        pipelineProfileId = pipelineProfileId
     )
     true
 }
@@ -2389,7 +2392,8 @@ private fun buildNextUpSeedCacheKey(
 
 private fun HomeViewModel.persistLocalContinueWatchingMetadata(
     originalItems: List<ContinueWatchingItem>,
-    enrichedItems: List<ContinueWatchingItem>
+    enrichedItems: List<ContinueWatchingItem>,
+    pipelineProfileId: Int
 ) {
     val localItems = enrichedItems.indices.mapNotNull { index ->
         val original = originalItems.getOrNull(index) as? ContinueWatchingItem.InProgress ?: return@mapNotNull null
@@ -2464,6 +2468,7 @@ private fun HomeViewModel.persistLocalContinueWatchingMetadata(
     }
 
     viewModelScope.launch(Dispatchers.IO) {
+        if (profileManager.activeProfileId.value != pipelineProfileId) return@launch
         if (nextUpSnapshot.isNotEmpty()) {
             runCatching { cwEnrichmentCache.saveNextUpSnapshot(nextUpSnapshot, force = true) }
         }


### PR DESCRIPTION
## Summary

Follow-up to PR #2587 (`fix/profile-isolation`, merge `eaf2d90`).
When Profile 1 has Trakt connected and Profile 2 doesn't,
Continue Watching items from Profile 1 leak into Profile 2.

## Root Cause

`useTraktProgressFlow()` has a **300ms debounce on false transitions**. When switching from Profile 1 (Trakt) to Profile 2 (no Trakt):

1. `traktAuthDataStore.isEffectivelyAuthenticated` emits false for Profile 2
2. `useTraktProgressFlow()` debounces this for 300ms
3. During those 300ms, the CW pipeline still operates in Trakt mode
4. `traktAllProgressFlow()` still emits Profile 1's cached Trakt data
5. `watchProgressPreferences.allProgress`'s inner `flatMapLatest` on `activeProfileId` has **already** switched to Profile 2's (empty) DataStore
6. The `combine` merges Profile 1's Trakt items + Profile 2's empty local → returns Profile 1's Trakt items
7. These items get rendered in the UI and persisted to Profile 2's enrichment cache files

## Fixes

### Critical

**Fix 1 — Profile guard in allProgress combine** (`WatchProgressRepositoryImpl.kt`)
Wraps the Trakt combine with `activeProfileId.map{it==subscriptionProfileId}.distinctUntilChanged().flatMapLatest` so stale Trakt emissions during the 300ms debounce are dropped immediately.

**Fix 5 — Profile switch handler** (`HomeViewModel.kt`, `WatchedSeriesStateHolder.kt`)
Clears `continueWatchingItems = emptyList()` immediately on switch. Added `clearInMemory()` to `WatchedSeriesStateHolder` that zeros in-memory badges without touching DataStore on disk, replacing the original `update(emptySet())` which wrote `emptySet()` to the **new** profile's persisted badge store (since `activeProfileId.value` was already `newId`). Followed by `loadFromDisk(profileId = newId)` to load the destination profile's real badges.

**Fix 7 — Guard enrichment cache writes against profile-switch race** (`HomeViewModelContinueWatching.kt`)
`persistLocalContinueWatchingMetadata` (lines 2468/2471 in the original) had no profile-identity guard. A Profile 1 pipeline that completes enrichment after the profile switch would write Profile 1's items into Profile 2's enrichment cache files (`nextup_2.json` / `inprogress_2.json`) — and with `force=true` even bypassing the throttle. Added `pipelineProfileId` plumbing through `enrichVisibleContinueWatchingItems` → `persistLocalContinueWatchingMetadata`, with a guard that skips the IO write if `activeProfileId` has changed since pipeline start. This also fixes the no-Trakt bleed report (Discord).

### Supporting

**Fix 2** — Profile-keyed cache in WatchProgressPreferences (`cachedProfileId` / `cachedRawProfileId`)

**Fix 3** — Reset throttle hashes (`lastNextUpHash`, `lastInProgressHash`) in `ContinueWatchingEnrichmentCache.clearAll()`

**Fix 4** — Per-profile loaded state (`WatchedSeriesStateHolder.kt`): `loaded: Boolean` → `loadedForProfileId: Int?`. Each profile now loads its own fully-watched series IDs independently, preventing stale badge state.

**Fix 6** — `triggerRemoteSync` accepts explicit `profileId` parameter (removed lazy re-read). All 9 call sites updated.