### PR TITLE
Fix vertical fast scroll in classic mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +77,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.screens.home.ModernHomeContent
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalTvMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
@@ -511,6 +513,7 @@ private fun RowsContent(
     val rowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
     val focusedItemByRow = remember { mutableStateMapOf<String, Int>() }
     val currentFocusedRowKey = remember { mutableStateOf(focusState.focusedRowKey) }
+    val folderScope = rememberCoroutineScope()
 
     DisposableEffect(Unit) {
         onDispose {
@@ -607,13 +610,25 @@ private fun RowsContent(
                     fun requesterForKey(k: String?): FocusRequester? = when {
                         k == null -> null
                         rowEntryFocusRequesters.containsKey(k) -> rowEntryFocusRequesters[k]
-                        else -> null
+                        else -> {
+                            val baseKey = k.substringBeforeLast('_')
+                            rowEntryFocusRequesters[baseKey]
+                        }
                     }
                     val requester = if (target == null) null
                     else requesterForKey(target.key as? String)
                         ?: visibleItems.firstNotNullOfOrNull { requesterForKey(it.key as? String) }
 
-                    runCatching { requester?.requestFocus() }
+                    requester?.let { req ->
+                        folderScope.launch {
+                            repeat(6) {
+                                val ok = runCatching { req.requestFocus(); true }
+                                    .getOrDefault(false)
+                                if (ok) return@launch
+                                withFrameNanos { }
+                            }
+                        }
+                    }
                     null
                 },
             ),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -24,11 +24,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -133,6 +135,7 @@ fun ClassicHomeContent(
     // This spreads the composition work and prevents frame spikes when a new row scrolls in.
     val nestedPrefetchStrategy = remember { LazyListPrefetchStrategy(nestedPrefetchItemCount = 2) }
 
+    val scope = rememberCoroutineScope()
     val columnListState = rememberLazyListState(
         initialFirstVisibleItemIndex = focusState.verticalScrollIndex,
         initialFirstVisibleItemScrollOffset = focusState.verticalScrollOffset,
@@ -403,14 +406,26 @@ fun ClassicHomeContent(
                         k == null -> null
                         k == "hero_carousel" -> heroFocusRequester
                         rowEntryFocusRequesters.containsKey(k) -> rowEntryFocusRequesters[k]
-                        else -> null
+                        else -> {
+                            val baseKey = k.substringBeforeLast('_')
+                            rowEntryFocusRequesters[baseKey]
+                        }
                     }
                     val requester = if (target == null) null
                     else requesterForKey(target.key as? String)
                         ?: visibleItems.firstNotNullOfOrNull { requesterForKey(it.key as? String) }
 
-                    runCatching { requester?.requestFocus() }
-                    null // Classic uses imperative requestFocus for now
+                    requester?.let { req ->
+                        scope.launch {
+                            repeat(6) {
+                                val ok = runCatching { req.requestFocus(); true }
+                                    .getOrDefault(false)
+                                if (ok) return@launch
+                                withFrameNanos { }
+                            }
+                        }
+                    }
+                    null // Classic uses imperative requestFocus
                 },
             ),
         contentPadding = PaddingValues(top = if (heroVisible) NuvioTheme.spacing.none else NuvioTheme.spacing.xl, bottom = NuvioTheme.spacing.xl),


### PR DESCRIPTION
## Summary

Fix focus landing after fast scroll in Classic home. After LazyColumn keys were changed to `"${stableKey}_$index"` format (to fix duplicate key crashes), `requesterForKey` stopped matching row entry focus requesters (keyed by bare `stableKey`). Focus ended up null after every fast scroll, leaving it in an undefined position.

## PR type

- [x] Critical bug fix

## Why

Holding DPAD up/down in Classic home to fast scroll leaves focus in the wrong place when released. The user sees a different item than where focus actually lands, making navigation broken. Modern home is unaffected because it uses state-driven focus recovery.

## Issue or approval

Fixes focus loss regression introduced when LazyColumn keys were suffixed with `_$index` to prevent duplicate key crashes.

## Reproduction steps

1. Open app in Classic home presentation
2. Navigate to any catalog row
3. Hold DPAD_DOWN for 2-3 seconds to trigger fast scroll
4. Release DPAD_DOWN
5. Observe focus lands on a row that is NOT the one visible at the top of viewport
6. Compare with Modern home where focus correctly lands on the visible row

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `resolveVerticalLanding` logic in ClassicHomeContent and FolderDetailScreen changed.
- No changes to Modern home, DpadFastScrollModifier, or CatalogRowSection.
- No UI polish or extra behavior tweaks.

## Testing

- Tested with hero visible and hidden.
- Tested FolderDetailScreen fast scroll.
- Verified Modern home still works correctly (no regression).
- Verified single-step DPAD navigation unaffected.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Focus loss regression from LazyColumn key format change (`stableKey` -> `stableKey_index`).
