### PR TITLE
Fix duplicate fetch response header values

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/FetchResponseHeaders.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/FetchResponseHeaders.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.core.plugin
+
+import okhttp3.Headers
+
+private const val MAX_FETCH_HEADER_VALUE_CHARS = 8 * 1024
+private const val FETCH_TRUNCATION_SUFFIX = "\n...[truncated]"
+
+internal fun Headers.toPluginResponseHeaders(): Map<String, String> =
+    toMultimap().mapKeys { (name, _) -> name.lowercase() }.mapValues { (_, values) ->
+        truncateString(values.joinToString(","), MAX_FETCH_HEADER_VALUE_CHARS)
+    }
+
+internal fun truncateString(value: String, maxChars: Int): String {
+    if (value.length <= maxChars) return value
+    val end = maxChars - FETCH_TRUNCATION_SUFFIX.length
+    if (end <= 0) return FETCH_TRUNCATION_SUFFIX.take(maxChars)
+    return value.substring(0, end) + FETCH_TRUNCATION_SUFFIX
+}

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
@@ -40,9 +40,6 @@ private const val TAG = "PluginRuntime"
 private const val PLUGIN_TIMEOUT_MS = 60_000L
 private const val MAX_FETCH_RESPONSE_BYTES = 1024 * 1024
 private const val MAX_FETCH_BODY_CHARS = 1024 * 1024
-private const val MAX_FETCH_HEADER_VALUE_CHARS = 8 * 1024
-private const val FETCH_TRUNCATION_SUFFIX = "\n...[truncated]"
-
 @Singleton
 class PluginRuntime @Inject constructor() {
 
@@ -588,10 +585,7 @@ class PluginRuntime @Inject constructor() {
 
                     val charset = bodyContentType?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
                     val responseBody = decodeBodyToSafeString(decodedRead.bytes, charset)
-                    val responseHeaders = mutableMapOf<String, String>()
-                    httpResponse.headers.forEach { (name, value) ->
-                        responseHeaders[name.lowercase()] = truncateString(value, MAX_FETCH_HEADER_VALUE_CHARS)
-                    }
+                    val responseHeaders = httpResponse.headers.toPluginResponseHeaders()
 
                     val result = mapOf(
                         "ok" to httpResponse.isSuccessful,
@@ -626,13 +620,6 @@ class PluginRuntime @Inject constructor() {
         val bytes: ByteArray,
         val truncated: Boolean
     )
-
-    private fun truncateString(value: String, maxChars: Int): String {
-        if (value.length <= maxChars) return value
-        val end = maxChars - FETCH_TRUNCATION_SUFFIX.length
-        if (end <= 0) return FETCH_TRUNCATION_SUFFIX.take(maxChars)
-        return value.substring(0, end) + FETCH_TRUNCATION_SUFFIX
-    }
 
     private fun decodeBodyToSafeString(bytes: ByteArray, charset: java.nio.charset.Charset): String {
         val decoded = try {

--- a/app/src/testFull/java/com/nuvio/tv/core/plugin/FetchResponseHeadersTest.kt
+++ b/app/src/testFull/java/com/nuvio/tv/core/plugin/FetchResponseHeadersTest.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.core.plugin
+
+import okhttp3.Headers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FetchResponseHeadersTest {
+
+    @Test
+    fun `response headers preserve duplicate values`() {
+        val headers = Headers.Builder()
+            .add("X-Test", "Hello")
+            .add("X-Test", "World")
+            .build()
+
+        assertEquals("Hello,World", headers.toPluginResponseHeaders()["x-test"])
+    }
+}


### PR DESCRIPTION
## Summary

Preserve every value for duplicate fetch response headers by grouping OkHttp headers before serializing them to plugin JavaScript. Adds a focused regression test for the reported `X-Test: Hello` and `X-Test: World` case.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The existing mutable map assignment overwrites earlier values when a response repeats a header name. Plugins therefore receive only the final value through `response.headers.get()`, which breaks fetch behavior for servers that return duplicate headers.

## Issue or approval

Fixes #2691

## Reproduction steps

1. Run a plugin that fetches `https://httpbin.org/response-headers?X-Test=Hello&X-Test=World`.
2. Read `response.headers.get('X-Test')`.
3. Before this fix, only `World` is returned. After this fix, the value is `Hello,World`.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to full-flavor plugin fetch response-header serialization. No request behavior, UI, dependencies, architecture, or unrelated plugin behavior changed.

## Testing

- Added `FetchResponseHeadersTest`, covering duplicate header names and the lowercase key used by the JavaScript fetch shim.
- Ran the test against the pre-fix conversion as a negative control; it failed with the reported lost-value behavior.
- Compiled the production helper and regression test in a JVM Gradle harness using the repository's Kotlin 2.0.21 and OkHttp 4.12.0 versions; the fixed conversion passes.
- Upstream GitHub Actions built the `fullDebug` APK successfully: https://github.com/NuvioMedia/NuvioTV/actions/runs/29801489130

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2691
