### PR TITLE
fix: Language normalization for Latin American Spanish trailers in TMDB

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -461,15 +461,22 @@ internal fun normalizeTmdbTrailerLanguage(language: String?): String {
         ?.takeIf { it.isNotBlank() }
         ?: return TMDB_TRAILER_FALLBACK_LANGUAGE
 
-    if (normalized.contains('-')) {
+    val formatted = if (normalized.contains('-')) {
         val parts = normalized.split("-", limit = 2)
         val locale = parts[0].lowercase()
         val region = parts.getOrNull(1)?.uppercase()?.takeIf { it.isNotBlank() }
-        return if (region != null) "$locale-$region" else locale
+        if (region != null) "$locale-$region" else locale
+    } else {
+        normalized.lowercase()
     }
 
-    if (normalized.equals("en", ignoreCase = true)) return TMDB_TRAILER_FALLBACK_LANGUAGE
-    return normalized.lowercase()
+    if (formatted == "en") return TMDB_TRAILER_FALLBACK_LANGUAGE
+
+    // Map codes unsupported by TMDB to their closest equivalent
+    return when (formatted) {
+        "es-419" -> "es-MX"
+        else -> formatted
+    }
 }
 
 internal fun normalizeTmdbMediaType(type: String?): String? {


### PR DESCRIPTION
## Summary

Changed TrailerService.kt
Added mapping for unsupported es-419 region tag.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

Currently, when the app language is set to Latin American Spanish (`es-419`), the video fetch request sends `include_video_language=es-419` to the TMDB API. 

However, **TMDB does not support numeric region codes (`419`) for videos**.

When this happens, TMDB's API automatically falls back to the base language tag `es`, which de-facto serves **Spain Spanish (`es-ES`)** content. 

By adding a map to `es-MX` in `TrailerService.kt`, we align the app's regional setting with TMDB's tagging standard, ensuring users actually get Latin American Spanish trailers instead of Spain Spanish ones.

## Issue or approval

Fixes #2705 

## Reproduction steps

1. Go to **TMDB Enrichment > Language** and select Latin American Spanish (`es-419`).
2. Open any movie or TV show detail page.
3. Watch the trailer or inspect the API request.
4. Notice that the trailer loaded from YouTube corresponds to the Spanish (Spain) dubbed/subtitled version.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

The scope is strictly limited to fix TMDB trailer language normalization logic in TrailerService.kt. It does not introduce extra UI polish or unrelated behavior tweaks.

## Testing

Manually tested in 4k tv emulator with android 16

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #2705
