### PR TITLE
fix(player): resolve critical stuck external auto-next loader and unblock autoplay after backing out

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -187,12 +187,22 @@ class ExternalPlaybackTracker @Inject constructor(
         private const val MIN_REAL_PLAYBACK_DURATION_MS = 30_000L
         /** A launch within this of an auto-next emit counts as a chain continuation. */
         private const val CONTINUATION_WINDOW_MS = 12_000L
+        /** After returning to the app with a persisted (process-recreated) session, how long to
+         *  wait for the player's ActivityResult before treating the session as dead and clearing
+         *  the orphaned loader. A redelivered result arrives within ~1s of resume; if none comes
+         *  the external session died without ever returning, so the loader must not stay stuck. */
+        private const val STALE_RETURN_WATCHDOG_MS = 8_000L
         /** Upper bound on how long resolving skip segments may delay an external launch. */
         private const val SKIP_RESOLVE_TIMEOUT_MS = 4_000L
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var zidooMonitorJob: Job? = null
+    // Armed only when the loader is raised on return from a persisted (process-recreated) session,
+    // where onActivityResult may never fire because the external player killed us and left no
+    // pending result. If the result does not arrive within STALE_RETURN_WATCHDOG_MS the session is
+    // dead: clear the orphaned persisted copy and drop the loader so it can't get permanently stuck.
+    private var staleReturnWatchdogJob: Job? = null
     // The in-flight auto-next resolution (meta fetch -> emit next episode). Held so the user can
     // cancel it by backing out of the "Loading next episode" loader before it navigates.
     private var autoNextJob: Job? = null
@@ -272,6 +282,9 @@ class ExternalPlaybackTracker @Inject constructor(
             autoNextJob = null
             autoNextNavigationPending = false
         }
+        // A fresh launch supersedes any dead-session recovery still being watched for.
+        staleReturnWatchdogJob?.cancel()
+        staleReturnWatchdogJob = null
         pendingMetadata = metadata
         isAutoLaunch = autoLaunch
         // A manual launch is always fresh; only an auto-launch within the window is a continuation
@@ -503,6 +516,10 @@ class ExternalPlaybackTracker @Inject constructor(
     /** Entry point for the player's ActivityResult: recover metadata, backfill a missing
      *  duration if needed, save progress, and auto-advance on completion. */
     fun onActivityResult(result: ExternalPlayerResult?) {
+        // The result arrived, so this is a live session, not a dead one — stand down the watchdog
+        // before it can clear the persisted copy out from under the recovery below.
+        staleReturnWatchdogJob?.cancel()
+        staleReturnWatchdogJob = null
         // If the player killed our process, pendingMetadata is null after recreation —
         // fall back to the persisted copy so we still save progress and auto-advance.
         val metadata = pendingMetadata ?: loadPersistedMetadata()
@@ -946,6 +963,12 @@ class ExternalPlaybackTracker @Inject constructor(
         Log.d(AUTO_NEXT_TAG, "dismissAutoNextOverlay (user back) overlayWasShowing=${_autoNextOverlay.value != null}")
         autoNextCancelled = true
         autoNextChainAborted = true
+        // Backing out ends the pending handoff. Clear it so the non-windowed launch guard
+        // (shouldCancelPendingAutoLaunch) can't stay armed forever: with it stuck true, every later
+        // auto-launch was cancelled before startTracking could reset the abort, so a fresh re-click
+        // never auto-played. Cleared here, the in-flight continuation is still blocked by the
+        // windowed isAutoNextContinuationAborted check, while a later launch is treated as fresh.
+        autoNextNavigationPending = false
         autoNextJob?.cancel()
         autoNextJob = null
         _autoNextOverlay.value = null
@@ -1031,12 +1054,34 @@ class ExternalPlaybackTracker @Inject constructor(
      *  parsed and the window repaints) so there's no episode-list flash. No-op for non-episodes;
      *  idempotent. Kept for a completion, dismissed by onActivityResult otherwise. */
     fun raiseAutoNextOverlayOnReturn() {
+        val recoveredFromDisk = pendingMetadata == null
         val metadata = pendingMetadata ?: loadPersistedMetadata() ?: return
-        if (pendingMetadata == null) {
+        if (recoveredFromDisk) {
             nextEpisodeSnapshot = loadPersistedNextEpisodeSnapshot()
             autoNextEnabledForPendingLaunch = loadPersistedAutoNextEnabled()
         }
         raiseAutoNextOverlay(metadata, allowUnknownNextEpisode = true)
+        // In-process handoffs keep pendingMetadata, so onActivityResult is guaranteed to run and
+        // clear the loader. A disk-recovered session has no in-memory state: if the player killed us
+        // without leaving a redeliverable result, onActivityResult never fires and this loader would
+        // re-raise on every launch forever. Guard that dead case with a watchdog; a live redelivered
+        // result cancels it at the top of onActivityResult before it can fire.
+        if (recoveredFromDisk) armStaleReturnWatchdog()
+    }
+
+    private fun armStaleReturnWatchdog() {
+        staleReturnWatchdogJob?.cancel()
+        staleReturnWatchdogJob = scope.launch {
+            delay(STALE_RETURN_WATCHDOG_MS)
+            Log.d(
+                AUTO_NEXT_TAG,
+                "stale-return watchdog fired: no ActivityResult after recovery -> clearing dead session"
+            )
+            clearPersistedMetadata()
+            nextEpisodeSnapshot = ExternalNextEpisodeSnapshot.Unknown
+            autoNextEnabledForPendingLaunch = null
+            _autoNextOverlay.value = null
+        }
     }
 
     private fun raiseAutoNextOverlay(


### PR DESCRIPTION
## Summary

Fixes two related failures in the external player auto next flow. Both are isolated to `ExternalPlaybackTracker.kt`.

1. The "Loading next episode" loader could get stuck permanently. It is re-raised on every launch from the persisted `external_playback_pending` copy, and in the dead session case (the player kills our process and leaves no redeliverable result) `onActivityResult` never fires to clear it. Because it lives in persisted storage, the stuck loader survived clearing the app cache, force stopping the app, and restarting the device. The only way to clear it was wiping the app's data, which signs the user out and forces a fresh sign in. A stale return watchdog now arms only when the loader is raised from disk (a recovered session, `pendingMetadata == null`) and clears the orphaned copy and the loader if no result arrives within 8 seconds.

2. Backing out of the loader left `autoNextNavigationPending` set, which kept the non windowed launch guard armed forever, so every later auto launch was cancelled before `startTracking` could reset the abort and a re clicked episode never auto played. Clearing that flag on dismiss lets a fresh re click reach `startTracking`, while the in flight continuation stays blocked by the existing windowed abort check.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Both bugs break external player binge watching with no in app recovery.

The stuck loader is re-raised from the persisted copy on every `onStart` so the transition never flashes the episode list. That is correct for a live handoff, but when the external player kills our process and no Activity Result is redelivered, `onActivityResult` never runs to clear the persisted copy, so the loader is raised again on every launch. Because the trigger is in persisted storage it survived clearing the cache, force stopping, and a full device restart; the only recovery was clearing app data, which logs the user out and requires signing back in.

The blocked auto play happens because `dismissAutoNextOverlay()` set the abort flags but left `autoNextNavigationPending` true. Unlike the stream screen's `isAutoNextContinuationAborted()` guard, `shouldCancelPendingAutoLaunch` is not time windowed, so once that flag stuck true every later auto launch was cancelled in `launchPlayer` before `startTracking` could reset the abort. Re clicking the same episode then never auto played.

## Issue or approval

Fixes #2709

## Reproduction steps

Stuck loader:
1. Use an external player and start a series episode from Nuvio so auto next is armed.
2. During playback, have the external player kill Nuvio's process (reproducible on NVIDIA Shield; can be forced with `adb shell am force-stop` on the app while the player is foreground).
3. Return to Nuvio. The "Loading next episode" loader is raised from the persisted copy, and because no Activity Result is redelivered it stays up.
4. Before this fix, the loader survived clearing the app cache, force stopping, and restarting the device; the only recovery was clearing app data, which logs you out and forces a fresh sign in. After this fix, it clears itself within 8 seconds and does not re-raise on the next launch.

Blocked auto play after backing out:
1. During an external player auto next handoff, back out of the loader.
2. Re click the same episode.
3. Before this fix, it never auto plays ("auto launch cancelled before tracker setup" in logcat). After this fix, the fresh re click auto plays.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Limited to the external player auto next state machine in `ExternalPlaybackTracker.kt`. The stale return watchdog arms only on the disk recovered path (`pendingMetadata == null`), so a normal in process binge, where `pendingMetadata` stays non null at `onStart`, never triggers it. The dismiss change only clears `autoNextNavigationPending`; `lastAutoNextEmitMs` is left untouched so the in flight continuation is still blocked and backing out is preserved. No changes to progress saving, watched state, binge group ownership, finale detection, the continuation window, Zidoo monitoring, or fire and forget launches.

## Testing

- Reproduced the dead session state on an NVIDIA Shield: the loader raised from disk, the watchdog fired about 8 seconds later, the persisted copy was emptied, and the next launch was clean with no re-raise.
- Confirmed the watchdog only arms on the recovered from disk path, so normal in process auto next is unaffected.
- `:app:compileFullDebugKotlin` and the external auto next unit tests (`ExternalAutoNext*`) pass.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2709
