### PR TITLE
feat(sync): add multi-ID mapping (IMDB, TMDB, TVDB, MAL, Simkl, Kitsu) support to watched items sync

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchedItemsSyncService.kt
@@ -150,6 +150,11 @@ class WatchedItemsSyncService @Inject constructor(
                             if (item.episode != null) put("episode", item.episode)
                             else put("episode", JsonPrimitive(null as Int?))
                             put("watched_at", item.watchedAt)
+                            if (item.ids != null && item.ids.isNotEmpty()) {
+                                put("ids", buildJsonObject {
+                                    item.ids.forEach { (k, v) -> put(k, v) }
+                                })
+                            }
                         }
                     }
                 })
@@ -203,9 +208,11 @@ class WatchedItemsSyncService @Inject constructor(
                         title = entry.title,
                         season = entry.season,
                         episode = entry.episode,
-                        watchedAt = entry.watchedAt
+                        watchedAt = entry.watchedAt,
+                        ids = entry.ids
                     )
                 })
+
 
                 if (remote.size < WATCHED_ITEMS_PAGE_SIZE) break
                 page++

--- a/app/src/main/java/com/nuvio/tv/data/remote/supabase/SupabaseModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/supabase/SupabaseModels.kt
@@ -140,7 +140,8 @@ data class SupabaseWatchedItem(
     val season: Int? = null,
     val episode: Int? = null,
     @SerialName("watched_at") val watchedAt: Long,
-    @SerialName("profile_id") val profileId: Int = 1
+    @SerialName("profile_id") val profileId: Int = 1,
+    val ids: Map<String, String>? = null
 )
 
 @Serializable
@@ -152,8 +153,10 @@ data class SupabaseWatchedItemEvent(
     val title: String = "",
     val season: Int? = null,
     val episode: Int? = null,
-    @SerialName("watched_at") val watchedAt: Long
+    @SerialName("watched_at") val watchedAt: Long,
+    val ids: Map<String, String>? = null
 )
+
 
 @Serializable
 data class SupabaseProfile(

--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchedItem.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchedItem.kt
@@ -6,5 +6,7 @@ data class WatchedItem(
     val title: String,
     val season: Int? = null,
     val episode: Int? = null,
-    val watchedAt: Long
+    val watchedAt: Long,
+    val ids: Map<String, String>? = null
 )
+


### PR DESCRIPTION
### Overview

This PR adds multi-ID mapping support to `WatchedItem`, `SupabaseWatchedItem`, and `WatchedItemsSyncService` for watched items synchronization.

### Motivation & Background

Currently, watched items sync accepts a single `content_id` string. When syncing watched history across external platforms and bridges (such as Trakt, Simkl, MyAnimeList, and external importers), items may have different IDs across TVDB, TMDB, IMDB, MAL, Kitsu, AniDB, and Simkl.

By passing pre-resolved `ids` maps directly in `sync_push_watched_items` RPC payloads and `WatchedItem`:
1. **Eliminates Runtime Resolution Bottlenecks**: Avoids unnecessary external API calls (e.g. MDBList/TMDB) during sync.
2. **Instant Cross-Platform Matching**: Ensures anime and TV shows with differing TMDB vs MAL IDs match accurately across Nuvio, MAL, and Stremio without rate-limit issues.
3. **Non-Breaking Backwards Compatibility**: Optional `ids` map field; falls back to `content_id` when omitted.

### Changes Made

- **`WatchedItem.kt`**: Added optional `ids: Map<String, String>? = null` field.
- **`SupabaseModels.kt`**: Added `ids` map field to `SupabaseWatchedItem` and `SupabaseWatchedItemEvent`.
- **`WatchedItemsSyncService.kt`**: Updated `pushItemsToRemote` to serialize `ids` into the `p_items` JSON RPC array, and `pullFromRemote` to decode and populate `ids`.

### Server-side companion required

Heads-up that this is the **client half** of a two-part change. For the `ids` map to actually persist and round-trip, the Supabase side needs a matching change:

- an `ids` (jsonb) column on the `watched_items` table,
- `sync_push_watched_items` updated to persist it,
- the pull query/view updated to return it.

Without that, the client will send `ids` in `p_items` but the server will drop it and always return `null` on pull. Happy to align the payload shape to whatever you prefer server-side. Canonical keys I'm sending: `imdb, tmdb, tvdb, mal, kitsu, anidb, simkl`.

### Considerations

- Something to enrich the anime mappings: https://github.com/Goldenfreddy0703/Otaku-Mappings/blob/main/README.md
- Additionally, providing a public endpoint or csv/json upload would simplify the use of watched items sync as well.
