### PR TITLE
feat(search): Live search while typing, parity from Mobile/Desktop

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/SearchHistoryDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/SearchHistoryDataStore.kt
@@ -41,7 +41,15 @@ class SearchHistoryDataStore @Inject constructor(
         val current = recentSearches.first()
         val updated = buildList {
             add(normalized)
-            addAll(current.filterNot { it.equals(normalized, ignoreCase = true) })
+            addAll(
+                current.filterNot { existing ->
+                    existing.equals(normalized, ignoreCase = true) ||
+                        // Live search saves each query the user pauses on, and on a remote every
+                        // prefix of a word is one of those. Collapse them into the query actually
+                        // landed on instead of listing "f", "fr", "fri" alongside "frieren".
+                        normalized.startsWith(existing, ignoreCase = true)
+                }
+            )
         }.take(maxItems.coerceAtLeast(1))
 
         store().edit { prefs ->

--- a/app/src/main/java/com/nuvio/tv/ui/components/SearchSkeletonRow.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/SearchSkeletonRow.kt
@@ -1,0 +1,100 @@
+package com.nuvio.tv.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.nuvio.tv.ui.theme.NuvioTheme
+
+private val SKELETON_TITLE_WIDTH = 180.dp
+private val SKELETON_TITLE_HEIGHT = 24.dp
+private val SKELETON_SUBTITLE_WIDTH = 90.dp
+private val SKELETON_SUBTITLE_HEIGHT = 12.dp
+private val SKELETON_BAR_CORNER_RADIUS = 6.dp
+private const val SKELETON_POSTER_COUNT = 8
+
+/**
+ * Loading stand-in for a search result row, drawn from scratch rather than by handing a fabricated
+ * [com.nuvio.tv.domain.model.CatalogRow] to the real row: a row built from blank names still renders
+ * its header decorations, which shows up as a stray " - Movie" and "from " with nothing after them.
+ *
+ * Mirrors the two header lines this screen actually has, a catalog title and the addon name, so the
+ * layout does not shift when the real rows arrive.
+ */
+@Composable
+fun SearchSkeletonRow(
+    posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
+    showAddonName: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    val shimmerOffsetState = rememberPlaceholderShimmerOffsetState(label = "searchSkeletonShimmer")
+
+    Column(modifier = modifier) {
+        Column(
+            modifier = Modifier.padding(
+                start = NuvioTheme.spacing.xxxl,
+                end = NuvioTheme.spacing.xxxl,
+                bottom = NuvioTheme.spacing.md
+            ),
+            verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xs)
+        ) {
+            SkeletonBar(
+                width = SKELETON_TITLE_WIDTH,
+                height = SKELETON_TITLE_HEIGHT,
+                shimmerOffsetState = shimmerOffsetState
+            )
+            if (showAddonName) {
+                SkeletonBar(
+                    width = SKELETON_SUBTITLE_WIDTH,
+                    height = SKELETON_SUBTITLE_HEIGHT,
+                    shimmerOffsetState = shimmerOffsetState
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.padding(horizontal = NuvioTheme.spacing.xxxl),
+            horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
+        ) {
+            repeat(SKELETON_POSTER_COUNT) {
+                Box(
+                    modifier = Modifier
+                        .width(posterCardStyle.width)
+                        .height(posterCardStyle.height)
+                        .clip(RoundedCornerShape(posterCardStyle.cornerRadius))
+                        .placeholderCardShimmer(
+                            shimmerOffsetState = shimmerOffsetState,
+                            backgroundColor = NuvioTheme.colors.SurfaceVariant
+                        )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SkeletonBar(
+    width: Dp,
+    height: Dp,
+    shimmerOffsetState: androidx.compose.runtime.State<Float>
+) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(SKELETON_BAR_CORNER_RADIUS))
+            .placeholderCardShimmer(
+                shimmerOffsetState = shimmerOffsetState,
+                backgroundColor = NuvioTheme.colors.SurfaceVariant
+            )
+    )
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -93,6 +93,7 @@ import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Text
 import com.nuvio.tv.ui.components.CatalogRowSection
+import com.nuvio.tv.ui.components.SearchSkeletonRow
 import com.nuvio.tv.ui.components.EmptyScreenState
 import com.nuvio.tv.ui.components.ErrorState
 import com.nuvio.tv.ui.components.LoadingIndicator
@@ -108,6 +109,9 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
+
+/** Skeleton rows shown while a search is pending, matching the two mobile renders. */
+private const val SEARCH_SKELETON_ROW_COUNT = 2
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -614,19 +618,18 @@ fun SearchScreen(
                         }
                     }
 
-                    uiState.isSearching && uiState.catalogRows.isEmpty() -> {
-                        // Placeholder shimmer rows are emitted by the ViewModel,
-                        // so this branch only fires if search targets haven't
-                        // been resolved yet (very brief).
-                        item {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 80.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                LoadingIndicator()
-                            }
+                    // Nothing to show yet, either still waiting on the debounce or on the first
+                    // responses. Mobile renders skeleton rows for both, so this does too. Unlike
+                    // mobile it only applies with an empty screen: mobile swaps results out for
+                    // skeletons on every keystroke, which on a remote reads as flicker because each
+                    // letter outlasts the debounce, so existing results are kept instead.
+                    (hasPendingUnsubmittedQuery || uiState.isSearching) && visibleCatalogRows.isEmpty() -> {
+                        items(SEARCH_SKELETON_ROW_COUNT) {
+                            SearchSkeletonRow(
+                                posterCardStyle = posterCardStyle,
+                                showAddonName = uiState.catalogAddonNameEnabled,
+                                modifier = Modifier.padding(bottom = 24.dp)
+                            )
                         }
                     }
 
@@ -736,6 +739,17 @@ fun SearchScreen(
                                     )
                                 }
                             )
+                        }
+
+                        // Results are up but more catalogs are still answering, as on mobile.
+                        if (uiState.isSearching || hasPendingUnsubmittedQuery) {
+                            item(key = "search_loading_more") {
+                                SearchSkeletonRow(
+                                    posterCardStyle = posterCardStyle,
+                                    showAddonName = uiState.catalogAddonNameEnabled,
+                                    modifier = Modifier.padding(bottom = 24.dp)
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.focusGroup
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
@@ -579,18 +580,9 @@ fun SearchScreen(
                     )
                 }
 
-                if ((trimmedSubmittedQuery.length < 2 || hasPendingUnsubmittedQuery) && !showRecentSearches) {
-                    item {
-                        Text(
-                            text = stringResource(R.string.search_keyboard_hint),
-                            style = androidx.tv.material3.MaterialTheme.typography.bodySmall,
-                            color = NuvioTheme.colors.TextSecondary,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 52.dp)
-                        )
-                    }
-                }
+                // The "press Done to search" hint is gone: search now runs as you type, so the
+                // instruction is wrong, and it was re-appearing on every keystroke. Neither the
+                // mobile nor the desktop client shows an equivalent message.
 
                 when {
                     trimmedSubmittedQuery.length < 2 && !hasPendingUnsubmittedQuery -> {
@@ -1069,5 +1061,33 @@ private fun SearchInputField(
                 cursorColor = NuvioTheme.colors.FocusRing
             )
         )
+
+        // Clear button, requested in review. Placed beside the field rather than as a trailing
+        // icon so it is reachable with the D-pad, matching the voice button's treatment.
+        if (query.isNotEmpty()) {
+            var isClearButtonFocused by remember { mutableStateOf(false) }
+            Spacer(modifier = Modifier.width(NuvioTheme.spacing.md))
+            IconButton(
+                onClick = { onQueryChanged("") },
+                modifier = Modifier
+                    .onFocusChanged { isClearButtonFocused = it.isFocused }
+                    .size(NuvioTheme.spacing.huge)
+                    .border(
+                        width = if (isClearButtonFocused) NuvioTheme.spacing.xxs else NuvioTheme.spacing.hairline,
+                        color = if (isClearButtonFocused) NuvioTheme.colors.FocusRing else NuvioTheme.colors.Border,
+                        shape = RoundedCornerShape(NuvioTheme.radii.md)
+                    )
+                    .background(
+                        color = NuvioTheme.colors.BackgroundCard,
+                        shape = RoundedCornerShape(NuvioTheme.radii.md)
+                    )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.cd_clear_search),
+                    tint = NuvioTheme.colors.TextPrimary
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -74,6 +74,8 @@ class SearchViewModel @Inject constructor(
     private var catalogRowsUpdateJob: Job? = null
     private var suggestionJob: Job? = null
     private var liveSearchJob: Job? = null
+    private var lastRequestKey: String? = null
+    private var lastCompletedRequestKey: String? = null
     private var hasRenderedFirstCatalog = false
     private var pendingCatalogResponses = 0
     private var revealBatchAfterNextDiscoverFetch = false
@@ -90,8 +92,6 @@ class SearchViewModel @Inject constructor(
          */
         const val LIVE_SEARCH_DEBOUNCE_MS = 350L
 
-        /** Shimmer rows shown while a typed query is still waiting to run, as on mobile. */
-        const val PENDING_PLACEHOLDER_ROWS = 2
         const val MAX_SUGGESTIONS = 8
         const val MAX_RECENT_SEARCHES = 8
     }
@@ -196,70 +196,26 @@ class SearchViewModel @Inject constructor(
             is SearchEvent.SelectDiscoverCatalog -> selectDiscoverCatalog(event.catalogKey)
             is SearchEvent.SelectDiscoverGenre -> selectDiscoverGenre(event.genre)
             SearchEvent.LoadNextDiscoverResults -> loadNextDiscoverResults()
-            SearchEvent.Retry -> performSearch(uiState.value.submittedQuery.ifBlank { uiState.value.query })
+            SearchEvent.Retry -> {
+                // An explicit retry must refetch even though nothing about the request changed.
+                lastRequestKey = null
+                lastCompletedRequestKey = null
+                performSearch(uiState.value.submittedQuery.ifBlank { uiState.value.query })
+            }
         }
     }
-
-    /**
-     * Generic shimmer rows for the window between a keystroke and the search running. The real
-     * per-catalog placeholders replace these once the search targets are resolved; both use the
-     * same `__placeholder_` item convention that [CatalogRowSection] renders as shimmer.
-     */
-    private fun pendingSearchPlaceholderRows(): List<CatalogRow> =
-        (0 until PENDING_PLACEHOLDER_ROWS).map { rowIndex ->
-            val key = "pending_search_$rowIndex"
-            CatalogRow(
-                addonId = key,
-                addonName = " ",
-                addonBaseUrl = "",
-                catalogId = key,
-                catalogName = " ",
-                type = ContentType.fromString("movie"),
-                rawType = "movie",
-                items = (0 until 8).map { i ->
-                    MetaPreview(
-                        id = "__placeholder_${key}_$i",
-                        type = ContentType.fromString("movie"),
-                        rawType = "movie",
-                        name = " ",
-                        poster = "placeholder://empty",
-                        posterShape = PosterShape.POSTER,
-                        background = null,
-                        logo = null,
-                        description = null,
-                        releaseInfo = " ",
-                        imdbRating = null,
-                        genres = emptyList()
-                    )
-                },
-                isLoading = true,
-                hasMore = false,
-                currentPage = 0,
-                supportsSkip = false,
-                skipStep = 0,
-                extraArgs = emptyMap()
-            )
-        }
 
     private fun onQueryChanged(query: String) {
         _uiState.update {
             val trimmedInput = query.trim()
-            val submitted = it.submittedQuery.trim()
             it.copy(
                 query = query,
                 error = null,
                 isSearching = false,
-                // Keep whatever is on screen while a keystroke is still waiting to run. Swapping to
-                // an empty list flashed the no-results state on every letter, and swapping to
-                // shimmer flashed a different row set instead: on a remote each letter outlasts the
-                // debounce, so every one of those swaps was a visible rebuild. Only the first query
-                // of a session, with nothing to keep, gets the shimmer rows mobile shows.
-                catalogRows = when {
-                    trimmedInput == submitted -> it.catalogRows
-                    trimmedInput.length < 2 -> emptyList()
-                    it.catalogRows.isEmpty() -> pendingSearchPlaceholderRows()
-                    else -> it.catalogRows
-                }
+                // Keep whatever is on screen while a keystroke waits to run. Clearing here flashed
+                // the no-results state on every letter, because on a remote each letter outlasts the
+                // debounce. The screen renders skeleton rows for this window instead.
+                catalogRows = if (trimmedInput.length < 2) emptyList() else it.catalogRows
             )
         }
 
@@ -276,6 +232,11 @@ class SearchViewModel @Inject constructor(
                 kotlinx.coroutines.delay(LIVE_SEARCH_DEBOUNCE_MS)
                 performSearch(query)
             }
+        } else {
+            // Emptying the field has to retire the submitted query too. Leaving it set kept the
+            // screen in its results state with nothing to show, instead of falling back to recent
+            // searches, until the screen was rebuilt by navigating away and back.
+            performSearch(query)
         }
 
         fetchSuggestions(trimmed)
@@ -368,6 +329,34 @@ class SearchViewModel @Inject constructor(
         }
     }
 
+    private fun resetCatalogAccumulator() {
+        catalogsMap.clear()
+        catalogOrder.clear()
+        hasRenderedFirstCatalog = false
+        pendingCatalogResponses = 0
+    }
+
+    /**
+     * Identifies a search by everything that changes what it would return: the query, the released
+     * filter, and the exact set of catalogs it would hit. Enabling an addon or flipping the filter
+     * changes the key, so those still refetch.
+     */
+    private fun buildRequestKey(
+        query: String,
+        searchTargets: List<Pair<Addon, CatalogDescriptor>>
+    ): String = buildString {
+        append(query.lowercase())
+        append('|')
+        append(hideUnreleasedContent)
+        append('|')
+        append(
+            searchTargets.joinToString(separator = "|") { (addon, catalog) ->
+                "${addon.baseUrl}:${catalog.apiType}:${catalog.id}"
+            }
+        )
+    }
+
+
     private fun performSearch(rawQuery: String) {
         val query = rawQuery.trim()
         suggestionJob?.cancel()
@@ -379,17 +368,13 @@ class SearchViewModel @Inject constructor(
             )
         }
 
-        // Cancel any in-flight work from the previous query.
-        activeSearchJobs.forEach { it.cancel() }
-        activeSearchJobs = emptyList()
-        catalogRowsUpdateJob?.cancel()
-
-        catalogsMap.clear()
-        catalogOrder.clear()
-        hasRenderedFirstCatalog = false
-        pendingCatalogResponses = 0
-
         if (query.length < 2) {
+            activeSearchJobs.forEach { it.cancel() }
+            activeSearchJobs = emptyList()
+            catalogRowsUpdateJob?.cancel()
+            resetCatalogAccumulator()
+            lastRequestKey = null
+            lastCompletedRequestKey = null
             _uiState.update {
                 it.copy(
                     isSearching = false,
@@ -402,10 +387,6 @@ class SearchViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            // Rows are left alone here. Clearing them produced an empty frame between the old
-            // results and the placeholders below, which is the flash this screen used to show.
-            _uiState.update { it.copy(isSearching = true, error = null) }
-
             val addons = try {
                 addonRepository.getInstalledAddons().first().enabledAddons()
             } catch (e: Exception) {
@@ -413,9 +394,28 @@ class SearchViewModel @Inject constructor(
                 return@launch
             }
 
-            _uiState.update { it.copy(installedAddons = addons) }
-
             val searchTargets = buildSearchTargets(addons)
+
+            // Same query against the same catalogs, and that run either finished or is still
+            // arriving, so there is nothing new to fetch. Without this, pressing Done after live
+            // search had already run the query tore the rows down and refetched everything, and
+            // deleting a letter then retyping it did the same. A run that was cancelled part way
+            // is deliberately not counted, so it gets to finish rather than staying half filled.
+            val requestKey = buildRequestKey(query, searchTargets)
+            val alreadySatisfied = requestKey == lastRequestKey &&
+                (requestKey == lastCompletedRequestKey || activeSearchJobs.any { it.isActive })
+            if (alreadySatisfied) return@launch
+            lastRequestKey = requestKey
+
+            // Committed to a new run: drop the previous query's work and accumulated rows.
+            activeSearchJobs.forEach { it.cancel() }
+            activeSearchJobs = emptyList()
+            catalogRowsUpdateJob?.cancel()
+            resetCatalogAccumulator()
+
+            // Rows are left alone here. Clearing them produced an empty frame between the old
+            // results and the placeholders below, which is the flash this screen used to show.
+            _uiState.update { it.copy(isSearching = true, error = null, installedAddons = addons) }
 
             if (searchTargets.isEmpty()) {
                 _uiState.update {
@@ -509,6 +509,7 @@ class SearchViewModel @Inject constructor(
                     // Cancellations are expected when query changes.
                 } finally {
                     if (uiState.value.submittedQuery.trim() == query) {
+                        lastCompletedRequestKey = requestKey
                         _uiState.update { it.copy(isSearching = false) }
                         // Remembered once it has actually returned something, so backing out still
                         // saves what you typed while typos that match nothing never get recorded.
@@ -933,14 +934,23 @@ class SearchViewModel @Inject constructor(
     private fun buildSearchTargets(addons: List<Addon>): List<Pair<Addon, CatalogDescriptor>> {
         val allSearchTargets = addons.flatMap { addon ->
             addon.catalogs
-                .filter { catalog ->
-                    catalog.supportsExtra("search")
-                }
+                .filter { catalog -> catalog.isSearchable() }
                 .map { catalog -> addon to catalog }
         }
 
         return allSearchTargets
     }
+
+    /**
+     * A catalog is only searchable if a search is all it needs. One that also requires something we
+     * cannot supply, a mandatory genre for instance, answers with an error or nothing at all, so
+     * querying it just costs a request per keystroke and leaves a row that never fills in.
+     */
+    private fun CatalogDescriptor.isSearchable(): Boolean =
+        supportsExtra("search") &&
+            extra.none { property ->
+                property.isRequired && !property.name.equals("search", ignoreCase = true)
+            }
 
     private fun catalogKey(addonId: String, addonBaseUrl: String, type: String, catalogId: String): String {
         return catalogRowStableKey(addonId, addonBaseUrl, type, catalogId)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -73,6 +73,7 @@ class SearchViewModel @Inject constructor(
     private var discoverJob: Job? = null
     private var catalogRowsUpdateJob: Job? = null
     private var suggestionJob: Job? = null
+    private var liveSearchJob: Job? = null
     private var hasRenderedFirstCatalog = false
     private var pendingCatalogResponses = 0
     private var revealBatchAfterNextDiscoverFetch = false
@@ -82,6 +83,12 @@ class SearchViewModel @Inject constructor(
         const val DISCOVER_INITIAL_LIMIT = 100
         const val DISCOVER_SHOW_MORE_BATCH = 50
         const val SUGGESTION_DEBOUNCE_MS = 150L
+
+        /**
+         * Live search fires while typing, but each run fans out to every enabled addon catalog, so
+         * it waits longer than the suggestion debounce to avoid a request storm per keystroke.
+         */
+        const val LIVE_SEARCH_DEBOUNCE_MS = 400L
         const val MAX_SUGGESTIONS = 8
         const val MAX_RECENT_SEARCHES = 8
     }
@@ -202,11 +209,23 @@ class SearchViewModel @Inject constructor(
             )
         }
 
-        // Search is explicit on submit only; stop any in-flight requests while editing.
+        // Drop in-flight requests for the previous keystroke before scheduling the next run.
         activeSearchJobs.forEach { it.cancel() }
         activeSearchJobs = emptyList()
 
-        fetchSuggestions(query.trim())
+        // Live search: results follow what you type, like mobile. Debounced because each run hits
+        // every enabled addon catalog. History is only written on an explicit submit, so typing
+        // "harry" doesn't leave "h", "ha", "har"... in recent searches.
+        liveSearchJob?.cancel()
+        val trimmed = query.trim()
+        if (trimmed.length >= 2) {
+            liveSearchJob = viewModelScope.launch {
+                kotlinx.coroutines.delay(LIVE_SEARCH_DEBOUNCE_MS)
+                performSearch(query, saveToHistory = false)
+            }
+        }
+
+        fetchSuggestions(trimmed)
     }
 
     private fun fetchSuggestions(query: String) {
@@ -285,7 +304,9 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun submitSearch() {
-        performSearch(_uiState.value.query)
+        // An explicit submit supersedes any debounced live run and is what gets remembered.
+        liveSearchJob?.cancel()
+        performSearch(_uiState.value.query, saveToHistory = true)
     }
 
     private fun clearRecentSearches() {
@@ -294,7 +315,7 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun performSearch(rawQuery: String) {
+    private fun performSearch(rawQuery: String, saveToHistory: Boolean = true) {
         val query = rawQuery.trim()
         suggestionJob?.cancel()
         _uiState.update {
@@ -305,7 +326,7 @@ class SearchViewModel @Inject constructor(
             )
         }
 
-        if (query.length >= 2) {
+        if (saveToHistory && query.length >= 2) {
             viewModelScope.launch {
                 searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -88,7 +88,10 @@ class SearchViewModel @Inject constructor(
          * Live search fires while typing, but each run fans out to every enabled addon catalog, so
          * it waits longer than the suggestion debounce to avoid a request storm per keystroke.
          */
-        const val LIVE_SEARCH_DEBOUNCE_MS = 400L
+        const val LIVE_SEARCH_DEBOUNCE_MS = 350L
+
+        /** Shimmer rows shown while a typed query is still waiting to run, as on mobile. */
+        const val PENDING_PLACEHOLDER_ROWS = 2
         const val MAX_SUGGESTIONS = 8
         const val MAX_RECENT_SEARCHES = 8
     }
@@ -197,6 +200,47 @@ class SearchViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Generic shimmer rows for the window between a keystroke and the search running. The real
+     * per-catalog placeholders replace these once the search targets are resolved; both use the
+     * same `__placeholder_` item convention that [CatalogRowSection] renders as shimmer.
+     */
+    private fun pendingSearchPlaceholderRows(): List<CatalogRow> =
+        (0 until PENDING_PLACEHOLDER_ROWS).map { rowIndex ->
+            val key = "pending_search_$rowIndex"
+            CatalogRow(
+                addonId = key,
+                addonName = " ",
+                addonBaseUrl = "",
+                catalogId = key,
+                catalogName = " ",
+                type = ContentType.fromString("movie"),
+                rawType = "movie",
+                items = (0 until 8).map { i ->
+                    MetaPreview(
+                        id = "__placeholder_${key}_$i",
+                        type = ContentType.fromString("movie"),
+                        rawType = "movie",
+                        name = " ",
+                        poster = "placeholder://empty",
+                        posterShape = PosterShape.POSTER,
+                        background = null,
+                        logo = null,
+                        description = null,
+                        releaseInfo = " ",
+                        imdbRating = null,
+                        genres = emptyList()
+                    )
+                },
+                isLoading = true,
+                hasMore = false,
+                currentPage = 0,
+                supportsSkip = false,
+                skipStep = 0,
+                extraArgs = emptyMap()
+            )
+        }
+
     private fun onQueryChanged(query: String) {
         _uiState.update {
             val trimmedInput = query.trim()
@@ -205,7 +249,17 @@ class SearchViewModel @Inject constructor(
                 query = query,
                 error = null,
                 isSearching = false,
-                catalogRows = if (trimmedInput == submitted) it.catalogRows else emptyList()
+                // Keep whatever is on screen while a keystroke is still waiting to run. Swapping to
+                // an empty list flashed the no-results state on every letter, and swapping to
+                // shimmer flashed a different row set instead: on a remote each letter outlasts the
+                // debounce, so every one of those swaps was a visible rebuild. Only the first query
+                // of a session, with nothing to keep, gets the shimmer rows mobile shows.
+                catalogRows = when {
+                    trimmedInput == submitted -> it.catalogRows
+                    trimmedInput.length < 2 -> emptyList()
+                    it.catalogRows.isEmpty() -> pendingSearchPlaceholderRows()
+                    else -> it.catalogRows
+                }
             )
         }
 
@@ -214,14 +268,13 @@ class SearchViewModel @Inject constructor(
         activeSearchJobs = emptyList()
 
         // Live search: results follow what you type, like mobile. Debounced because each run hits
-        // every enabled addon catalog. History is only written on an explicit submit, so typing
-        // "harry" doesn't leave "h", "ha", "har"... in recent searches.
+        // every enabled addon catalog.
         liveSearchJob?.cancel()
         val trimmed = query.trim()
         if (trimmed.length >= 2) {
             liveSearchJob = viewModelScope.launch {
                 kotlinx.coroutines.delay(LIVE_SEARCH_DEBOUNCE_MS)
-                performSearch(query, saveToHistory = false)
+                performSearch(query)
             }
         }
 
@@ -304,9 +357,9 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun submitSearch() {
-        // An explicit submit supersedes any debounced live run and is what gets remembered.
+        // An explicit submit just skips the remaining debounce; the live run would land anyway.
         liveSearchJob?.cancel()
-        performSearch(_uiState.value.query, saveToHistory = true)
+        performSearch(_uiState.value.query)
     }
 
     private fun clearRecentSearches() {
@@ -315,7 +368,7 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun performSearch(rawQuery: String, saveToHistory: Boolean = true) {
+    private fun performSearch(rawQuery: String) {
         val query = rawQuery.trim()
         suggestionJob?.cancel()
         _uiState.update {
@@ -324,12 +377,6 @@ class SearchViewModel @Inject constructor(
                 query = rawQuery,
                 suggestions = emptyList()
             )
-        }
-
-        if (saveToHistory && query.length >= 2) {
-            viewModelScope.launch {
-                searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
-            }
         }
 
         // Cancel any in-flight work from the previous query.
@@ -355,7 +402,9 @@ class SearchViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            _uiState.update { it.copy(isSearching = true, error = null, catalogRows = emptyList()) }
+            // Rows are left alone here. Clearing them produced an empty frame between the old
+            // results and the placeholders below, which is the flash this screen used to show.
+            _uiState.update { it.copy(isSearching = true, error = null) }
 
             val addons = try {
                 addonRepository.getInstalledAddons().first().enabledAddons()
@@ -434,7 +483,15 @@ class SearchViewModel @Inject constructor(
                     extraArgs = emptyMap()
                 )
             }
-            _uiState.update { it.copy(catalogRows = placeholderRows) }
+            // Only shimmer when there is nothing real to look at. If the previous query's results
+            // are still up, they stay until this query's results replace them, so refining a search
+            // is a single swap rather than results -> shimmer -> results on every letter.
+            _uiState.update { state ->
+                val showingRealRows = state.catalogRows.any { row ->
+                    row.items.firstOrNull()?.id?.startsWith("__placeholder_") != true
+                }
+                if (showingRealRows) state else state.copy(catalogRows = placeholderRows)
+            }
 
             val jobs = searchTargets.map { (addon, catalog) ->
                 viewModelScope.launch {
@@ -453,6 +510,13 @@ class SearchViewModel @Inject constructor(
                 } finally {
                     if (uiState.value.submittedQuery.trim() == query) {
                         _uiState.update { it.copy(isSearching = false) }
+                        // Remembered once it has actually returned something, so backing out still
+                        // saves what you typed while typos that match nothing never get recorded.
+                        if (catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
+                            viewModelScope.launch {
+                                searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2118,6 +2118,7 @@
     <string name="cd_trakt_qr">Trakt activation QR</string>
     <string name="cd_imdb">IMDb</string>
     <string name="cd_open_discover">Open discover</string>
+    <string name="cd_clear_search">Clear search</string>
     <string name="cd_voice_search">Voice search</string>
     <string name="cd_donation_qr">Donation QR code</string>
     <string name="cd_contributor_qr">Contributor support QR code</string>


### PR DESCRIPTION
> **Platform parity.** Mobile and desktop both already search as you type. TV is the only client that requires an explicit submit, so this brings it in line rather than introducing new behaviour.

## Summary

Search now runs **as you type**, matching mobile and desktop, instead of only running when the query is explicitly submitted.

Previously `onQueryChanged` fetched suggestions and then actively cancelled any in-flight search ("Search is explicit on submit only"), so no results appeared until you pressed Done. On a remote that confirm step is the slowest part of searching, and it made TV behave differently from mobile/desktop for the same action.

Now the query kicks off a debounced search once it reaches 2 characters. Pressing Done still searches immediately and supersedes any pending run.

**Debounce.** A search fans out to **every enabled addon catalog**, so this is deliberately debounced at 350ms, matching mobile, and longer than the existing 150ms suggestion debounce, to avoid a request storm per keystroke. Each keystroke also cancels the previous in-flight run, so only the latest query is ever resolving.

**Loading state.** The window between a keystroke and results arriving shows skeleton rows rather than the empty/no-results state, the same way mobile does while a typed query is waiting to run. `SearchSkeletonRow` is a dedicated composable picked by screen state, mirroring mobile's `HomeSkeletonRow`, rather than a fabricated `CatalogRow`: a row built from blank names still draws its header decorations, which showed up as a stray " - Movie" and "from " with nothing after them. Skeletons appear when there is nothing real on screen, and a trailing one is appended while further catalogs are still answering. Unlike mobile, results already on screen are kept while a new query settles instead of being swapped out per keystroke: on a remote every letter outlasts the debounce, so that swap reads as flicker.

**Clear button.** The field can now be emptied with a D-pad reachable clear button beside the voice button, instead of holding down delete. With search running live, clearing is a normal part of the flow rather than a rare action.

**Fetching.** A search is identified by the query, the released-content filter and the exact set of catalogs it would hit, and an identical request that already finished or is still arriving is not refetched. Previously, pressing Done after live search had already run that query tore the rows down and refetched everything, and deleting a letter then retyping it did the same. Mobile has had this guard in `SearchRepository`; TV had none. A run cancelled part way is deliberately not counted as satisfied, so it re-runs rather than staying half filled, and Retry always refetches.

**Searchable catalogs.** A catalog that needs a search plus something else that cannot be supplied, a mandatory genre for instance, is no longer queried. It answered with an error or nothing, so it cost one request per keystroke per addon and left a row that never filled in. This matches mobile's `supportsSearch` rule, which requires a search extra and no other required extras.

**Search history.** Queries are recorded once they actually return results, rather than only on an explicit submit, so typing something and backing out still remembers it while typos that match nothing never get saved. Saving also drops any existing entry that is a prefix of the new one, so "f", "fr", "fri" collapse into "frieren" as you type. That prefix rule is TV specific rather than mobile parity: mobile only de-duplicates exact matches, and gets away with it because phone typing outruns the debounce, whereas on a remote every prefix settles long enough to be recorded.

Clearing the field also retires the submitted query. Leaving it set kept the screen in its results state with nothing to show, instead of falling back to recent searches, until the screen was rebuilt by navigating away and back.

**Removed hint.** The "Press Done on the keyboard to search" hint is dropped. It no longer describes how the screen works, and neither mobile nor desktop has an equivalent.

## PR type

<!-- Platform parity with mobile and desktop, so neither box applies: it is not localization, and not a critical bug fix. -->
- [ ] Translation/localization only
- [ ] Critical bug fix

## Why

Mobile and desktop already narrow results while typing, so TV requiring an explicit submit makes the same interaction behave differently depending on which client you pick up. Searching on a remote is also slow enough without an extra confirm step. This is a parity change, not a new capability.

## Issue or approval

Fixes #2720

## Reproduction steps

N/A, not a bug fix. To see the change:

1. Open Search.
2. Start typing a title (at least 2 characters).
3. Shimmer rows appear while the query settles, then results populate on their own, without pressing Done.
4. Keep typing to refine: the previous results stay up until the new ones land, rather than flashing between states.
5. Press Done at any point: it searches immediately.
6. Back out without pressing Done, then reopen Search: the query you typed is in recent searches, listed once rather than as every prefix you passed through.
7. Press the clear button beside the voice button to empty the field.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

UI changes are the shimmer loading rows, the clear button, and the removal of the now-inaccurate keyboard hint. Behaviour changes are when the search runs and when history is written.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: maintainer approved change.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue and testing notes.
- [x] I listed the testing performed below.

This is platform parity rather than a critical bug fix, so the box asserting no UI or feature change is left unchecked rather than overclaimed.

## Scope boundaries

- `SearchViewModel`: the debounce constant, the live search job, request de-duplication, the searchable-catalog rule, and when history is written.
- `SearchScreen`: the clear button, skeleton rows chosen by screen state, and removal of the keyboard hint block.
- `SearchSkeletonRow`: new, and used only by this screen.
- `CatalogRowSection` is untouched. The loading rows no longer pass through it as fabricated data, so it did not need to learn about them.
- `SearchHistoryDataStore`: prefix collapse on save. Normalization, deduplication and the cap on stored entries are unchanged.
- The suggestion path, the search request/fan-out logic, result rendering, catalog ordering and the Discover path are all unchanged.
- No change to what a search returns, only to when it is triggered and how the wait is presented.

## Testing

- `./gradlew :app:compileFullDebugKotlin`, `./gradlew :app:assembleFullDebug` and `./gradlew :app:lintFullDebug` pass.
- `./gradlew :app:testFullDebugUnitTest`: failures are confined to the same pre-existing, environment-dependent classes (media3, player, tmdb, trakt, datastore, poster options) with and without this change. Nothing in search or search history fails.
- Installed and manually verified on an NVIDIA Shield:
  - Typing at least 2 characters populates results without pressing Done.
  - Pausing mid-word does not fire a request per keystroke; only the settled query resolves.
  - Shimmer appears for the first query of a session; refining an existing search swaps straight from the old results to the new ones without flashing.
  - Pressing Done still searches immediately.
  - Typing a title and backing out without submitting leaves that query in recent searches.
  - Recent searches show the settled query, not the prefixes typed along the way, and a typo that returned nothing is not recorded.
  - The clear button is reachable with the D-pad and empties the field.
  - Clearing back under 2 characters stops results without leaving a stale in-flight search.
  - Pressing the clear button returns to recent searches rather than an empty results view.
  - Pressing Done after live search has already run the query does not refetch or rebuild the rows.
  - Deleting a character and retyping it does not refetch.
  - Retry still refetches after a failed search.

## Screenshots / Video

**Demo (results narrowing while typing):**

https://github.com/user-attachments/assets/24f59191-10ad-4146-be1b-50f12f13739f

## Breaking changes

None.

## Linked issues

Fixes #2720

