### PR TITLE
feat(library): Search the cloud library and move Refresh in line with the Saved/Cloud tabs

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -285,6 +285,29 @@ fun LibraryScreen(
                 onSelected = { mode ->
                     viewMode = mode
                     expandedPicker = null
+                },
+                // Refresh belongs to the cloud view only, pinned right in line with the tabs.
+                trailing = if (viewMode == LibraryViewMode.Cloud) {
+                    {
+                        Button(
+                            onClick = viewModel::refreshCloudLibrary,
+                            enabled = !uiState.cloudLibrary.isRefreshing,
+                            colors = ButtonDefaults.colors(
+                                containerColor = NuvioTheme.colors.BackgroundCard,
+                                contentColor = NuvioTheme.colors.TextPrimary
+                            )
+                        ) {
+                            Text(
+                                if (uiState.cloudLibrary.isRefreshing) {
+                                    stringResource(R.string.library_syncing_btn)
+                                } else {
+                                    stringResource(R.string.cloud_library_refresh)
+                                }
+                            )
+                        }
+                    }
+                } else {
+                    null
                 }
             )
         }
@@ -411,9 +434,9 @@ fun LibraryScreen(
             }
 
             item(span = { GridItemSpan(maxLineSpan) }) {
-                CloudLibraryActionsRow(
-                    isRefreshing = uiState.cloudLibrary.isRefreshing,
-                    onRefresh = viewModel::refreshCloudLibrary
+                CloudLibrarySearchRow(
+                    query = uiState.cloudSearchQuery,
+                    onQueryChange = viewModel::onCloudSearchQueryChange
                 )
             }
 
@@ -561,31 +584,37 @@ fun LibraryScreen(
 private fun LibraryViewModeRow(
     selectedMode: LibraryViewMode,
     primaryFocusRequester: FocusRequester,
-    onSelected: (LibraryViewMode) -> Unit
+    onSelected: (LibraryViewMode) -> Unit,
+    /** Optional action pinned to the right of the tabs (used for the cloud refresh button). */
+    trailing: (@Composable () -> Unit)? = null
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
     ) {
-        LibraryViewMode.entries.forEachIndexed { index, mode ->
-            val selected = mode == selectedMode
-            Button(
-                onClick = { onSelected(mode) },
-                modifier = Modifier
-                    .then(if (index == 0) Modifier.focusRequester(primaryFocusRequester) else Modifier),
-                colors = ButtonDefaults.colors(
-                    containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
-                    contentColor = NuvioTheme.colors.TextPrimary
-                )
-            ) {
-                Text(
-                    text = when (mode) {
-                        LibraryViewMode.Saved -> stringResource(R.string.library_source_saved)
-                        LibraryViewMode.Cloud -> stringResource(R.string.library_source_cloud)
-                    }
-                )
+        Row(horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)) {
+            LibraryViewMode.entries.forEachIndexed { index, mode ->
+                val selected = mode == selectedMode
+                Button(
+                    onClick = { onSelected(mode) },
+                    modifier = Modifier
+                        .then(if (index == 0) Modifier.focusRequester(primaryFocusRequester) else Modifier),
+                    colors = ButtonDefaults.colors(
+                        containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
+                        contentColor = NuvioTheme.colors.TextPrimary
+                    )
+                ) {
+                    Text(
+                        text = when (mode) {
+                            LibraryViewMode.Saved -> stringResource(R.string.library_source_saved)
+                            LibraryViewMode.Cloud -> stringResource(R.string.library_source_cloud)
+                        }
+                    )
+                }
             }
         }
+        trailing?.invoke()
     }
 }
 
@@ -651,25 +680,85 @@ private fun CloudLibraryItemType.localizedLabel(): String =
         CloudLibraryItemType.File -> stringResource(R.string.cloud_library_type_files)
     }
 
+private fun isCloudSearchSelectKey(keyCode: Int): Boolean {
+    return keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
+        keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
+        keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
+}
+
+/**
+ * Free-text filter over the already-loaded cloud library. Purely local: it never triggers a
+ * provider request, it just narrows [LibraryUiState.visibleCloudItems]. Filtering is applied on
+ * every keystroke, so results narrow live as you type.
+ *
+ * Follows the same D-pad text-entry pattern as the list editor dialog: the field stays read-only
+ * until SELECT is pressed, so arrow keys keep navigating the grid instead of moving a caret.
+ */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun CloudLibraryActionsRow(
-    isRefreshing: Boolean,
-    onRefresh: () -> Unit
+private fun CloudLibrarySearchRow(
+    query: String,
+    onQueryChange: (String) -> Unit
 ) {
+    var editing by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
+        horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
     ) {
-        Button(
-            onClick = onRefresh,
-            enabled = !isRefreshing,
-            colors = ButtonDefaults.colors(
-                containerColor = NuvioTheme.colors.BackgroundCard,
-                contentColor = NuvioTheme.colors.TextPrimary
+        androidx.compose.material3.OutlinedTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            modifier = Modifier
+                .weight(1f)
+                .onFocusChanged { if (!it.isFocused) editing = false }
+                .onPreviewKeyEvent { event ->
+                    val native = event.nativeKeyEvent
+                    if (native.action == AndroidKeyEvent.ACTION_DOWN && isCloudSearchSelectKey(native.keyCode)) {
+                        editing = true
+                        keyboardController?.show()
+                    }
+                    false
+                },
+            readOnly = !editing,
+            singleLine = true,
+            maxLines = 1,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    editing = false
+                    keyboardController?.hide()
+                }
+            ),
+            label = { androidx.compose.material3.Text(stringResource(R.string.cloud_library_search_label)) },
+            colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                focusedTextColor = NuvioTheme.colors.TextPrimary,
+                unfocusedTextColor = NuvioTheme.colors.TextPrimary,
+                focusedContainerColor = NuvioTheme.colors.BackgroundCard,
+                unfocusedContainerColor = NuvioTheme.colors.BackgroundCard,
+                focusedBorderColor = NuvioTheme.colors.FocusRing,
+                unfocusedBorderColor = NuvioTheme.colors.Border,
+                focusedLabelColor = NuvioTheme.colors.TextSecondary,
+                unfocusedLabelColor = NuvioTheme.colors.TextTertiary,
+                cursorColor = NuvioTheme.colors.FocusRing
             )
-        ) {
-            Text(if (isRefreshing) stringResource(R.string.library_syncing_btn) else stringResource(R.string.cloud_library_refresh))
+        )
+
+        if (query.isNotEmpty()) {
+            Button(
+                onClick = {
+                    onQueryChange("")
+                    editing = false
+                },
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioTheme.colors.BackgroundCard,
+                    contentColor = NuvioTheme.colors.TextPrimary
+                )
+            ) {
+                Text(stringResource(R.string.cloud_library_search_clear))
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -100,6 +100,8 @@ data class LibraryUiState(
     val availableCloudTypes: List<FilterOption> = emptyList(),
     val selectedCloudProviderId: String? = null,
     val selectedCloudType: CloudLibraryItemType? = null,
+    /** Free-text filter applied to the cloud library only. Never queries addons or the saved list. */
+    val cloudSearchQuery: String = "",
     val resolvingCloudFileKey: String? = null,
     val cloudLibrarySettingsVersion: Long = 0L,
     val listTabs: List<LibraryListTab> = emptyList(),
@@ -244,6 +246,12 @@ class LibraryViewModel @Inject constructor(
     fun onSelectCloudProvider(providerId: String?) {
         _uiState.update { current ->
             current.copy(selectedCloudProviderId = providerId).withVisibleCloudItems()
+        }
+    }
+
+    fun onCloudSearchQueryChange(query: String) {
+        _uiState.update { current ->
+            current.copy(cloudSearchQuery = query).withVisibleCloudItems()
         }
     }
 
@@ -854,7 +862,16 @@ class LibraryViewModel @Inject constructor(
         } else {
             providerFiltered
         }
-        val visible = typeFiltered
+        // Matches the item name or any of its file names, so a release title or a filename both work.
+        val query = cloudSearchQuery.trim()
+        val visible = if (query.isEmpty()) {
+            typeFiltered
+        } else {
+            typeFiltered.filter { item ->
+                item.name.contains(query, ignoreCase = true) ||
+                    item.files.any { file -> file.name.contains(query, ignoreCase = true) }
+            }
+        }
         val providerCounts = allCloudItems
             .groupBy { it.providerId to it.providerName }
             .map { (provider, items) -> FilterOption(key = provider.first, label = provider.second, count = items.size) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1780,6 +1780,8 @@
     <string name="cloud_library_playable_file_count">%1$d playable files</string>
     <string name="cloud_library_provider_all">All</string>
     <string name="cloud_library_refresh">Refresh cloud library</string>
+    <string name="cloud_library_search_clear">Clear search</string>
+    <string name="cloud_library_search_label">Search cloud library</string>
     <string name="cloud_library_select_provider">Select provider</string>
     <string name="cloud_library_select_type">Select type</string>
     <string name="cloud_library_status_ready">Ready to play</string>


### PR DESCRIPTION
## Summary

Two changes to Library → Cloud:

**1. Search the cloud library.** The cloud view only had provider and type dropdowns, so finding a specific release in a large account meant scrolling the entire list, even though the item names and file names are already loaded on the client. Adds a search field that filters the loaded cloud library only:

- Purely local. It never triggers a provider request, it just narrows `visibleCloudItems`.
- Matches the item name **or any of its file names**, since the useful identifier is often in the filename rather than the item title.
- Stacks on top of the existing provider/type filters.
- Narrows on every keystroke.
- A Clear button appears once there is text.
- Text entry follows the same D-pad pattern as the list editor dialog: the field stays read-only until SELECT opens the keyboard, so arrow keys keep navigating the grid instead of moving a caret.

**2. Refresh cloud library moved in line with the tabs.** It previously sat in its own row between the filter dropdowns and the item grid, where D-pad navigation did not reliably route to it, so it could not be pressed. It now sits at the top right in line with the Saved/Cloud tabs and only renders while the Cloud view is selected. Being adjacent to the focusable tabs also makes it reachable again.

## PR type

<!-- Adds a filter to an existing screen and relocates an existing control; not localization, and only the unreachable Refresh button is strictly a bug. -->
- [ ] Translation/localization only
- [ ] Critical bug fix

## Why

Once a debrid account has a large cached library, the provider/type filters are not enough to find a specific release, and everything needed to filter it is already in memory. The Refresh button relocation fixes a control that could not be reached with a remote, and puts it with the other view-level controls rather than in the middle of the content flow.

## Issue or approval

Fixes #2721

## Reproduction steps

For the Refresh button (the bug half):

1. Open Library and switch to the Cloud tab.
2. Try to reach "Refresh cloud library" with the D-pad.
3. Before this change focus does not land on it, so it cannot be pressed. After, it sits beside the Saved/Cloud tabs and is reachable.

For the search (the new filter):

1. Open Library → Cloud with a connected provider that has several cached items.
2. Press SELECT on the search field to open the keyboard and type part of a title, or part of a filename.
3. The list narrows as you type, combined with whatever provider/type filters are set.
4. Clear the field to restore the full list.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

Maintainer approved. The Refresh relocation additionally fixes a control that could not be reached with a remote.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: maintainer approved change.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

This is a maintainer approved change rather than a pure bug fix, so the box asserting no UI/feature change is left unchecked rather than overclaimed.

## Scope boundaries

- Cloud view only. The Saved view, its filters, sorting, list tabs and genre/year pickers are untouched.
- The search is a client-side filter over already-loaded items. No provider API, request, refresh or caching behaviour is changed.
- Filtering runs through the existing `withVisibleCloudItems()` path, so provider/type counts and validation behave exactly as before.
- The Refresh button's action is unchanged; only its placement and visibility condition changed. The now-unused `CloudLibraryActionsRow` was removed rather than left dead.
- No changes to playback, file resolution or the cloud item cards themselves.

## Testing

- `./gradlew :app:compileFullDebugKotlin` and `./gradlew :app:assembleFullDebug` pass.
- `./gradlew :app:testFullDebugUnitTest` compared against a stashed baseline: identical failures with and without this change (pre-existing/environment-dependent tests), so nothing new is broken by it.
- Installed and manually verified on an NVIDIA Shield with a Torbox account:
  - Refresh is reachable with the D-pad from the tabs and triggers a refresh; it is absent in the Saved view.
  - Typing narrows the grid live; matches hit both release titles and filenames.
  - Search combines correctly with the provider and type dropdowns.
  - Clear restores the full list; leaving and re-entering Cloud behaves normally.
  - Arrow keys still navigate the grid while the search field is focused but not in edit mode.

## Screenshots / Video

**Demo (searching the cloud library, with Refresh in line with the Saved/Cloud tabs):**

https://github.com/user-attachments/assets/9d190275-8345-4618-a046-c46be43150ca

## Breaking changes

None.

## Linked issues

Fixes #2721


