### PR TITLE
feat(ui): Scroll long cast names and Continue Watching titles on focus

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -400,6 +400,9 @@ fun ContinueWatchingCard(
         }
     }
     var usesFallbackImage by remember { mutableStateOf(false) }
+    // Tracked so long titles only marquee while the card is focused.
+    var isFocused by remember { mutableStateOf(false) }
+    val marqueeState = rememberSyncedMarqueeState(focused = isFocused)
     // Reset fallback state when the item changes
     LaunchedEffect(imageModel) { usesFallbackImage = false }
 
@@ -484,7 +487,8 @@ fun ContinueWatchingCard(
                     return@onPreviewKeyEvent true
                 }
                 false
-            },
+            }
+            .onFocusChanged { isFocused = it.isFocused },
         shape = CardDefaults.shape(shape = CwCardShape),
         colors = CardDefaults.colors(
             containerColor = Color.Transparent,
@@ -578,22 +582,22 @@ fun ContinueWatchingCard(
                         )
                     }
 
-                    Text(
+                    // Title and episode title share one clock: same speed, each waits at its own end
+                    // until the longer one finishes, then both restart together.
+                    SyncedMarqueeText(
                         text = titleText,
+                        state = marqueeState,
                         style = MaterialTheme.typography.titleSmall,
                         color = NuvioTheme.colors.TextPrimary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
                     )
 
                     // Episode title if available
                     episodeTitle?.let { title ->
-                        Text(
+                        SyncedMarqueeText(
                             text = title,
+                            state = marqueeState,
                             style = MaterialTheme.typography.bodySmall,
                             color = NuvioTheme.extendedColors.textSecondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
                         )
                     }
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/FocusMarqueeText.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/FocusMarqueeText.kt
@@ -1,14 +1,38 @@
 package com.nuvio.tv.ui.components
 
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Text
+import kotlin.math.min
+import kotlinx.coroutines.delay
 
 // Compose's default marquee velocity (MarqueeDefaults.Velocity) is 30.dp/s, which at our title font
 // is only ~3.5 characters/second. Screen-reading research on horizontally scrolling text shows
@@ -24,6 +48,204 @@ private val MarqueeVelocity = 45.dp
  * Scrolling only happens while [focused] and when the text actually overflows (Compose's
  * [basicMarquee] is a no-op when it already fits).
  */
+/**
+ * Multi-line variant: normally wraps to [maxLines] and ellipsizes, exactly as before. Only when
+ * [focused] AND the text still doesn't fit in [maxLines] does it switch to a single scrolling line.
+ *
+ * The wrapped text stays in the layout (drawn transparent) while scrolling, so it keeps reserving
+ * its full height and nothing below it shifts when the marquee kicks in.
+ */
+@Composable
+fun FocusMarqueeMultilineText(
+    text: String,
+    focused: Boolean,
+    style: TextStyle,
+    maxLines: Int,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+) {
+    var overflowed by remember(text, maxLines) { mutableStateOf(false) }
+    val scrolling = focused && overflowed
+
+    Box(modifier) {
+        // No minLines: a short name must still take only the lines it needs, otherwise everything
+        // below it (the character label) gets pushed down. The wrapped text stays in the layout even
+        // while scrolling, so it keeps reserving exactly its own height and nothing shifts.
+        Text(
+            text = text,
+            style = style,
+            color = if (scrolling) Color.Transparent else color,
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = textAlign,
+            onTextLayout = { overflowed = it.hasVisualOverflow },
+        )
+        if (scrolling) {
+            Text(
+                text = text,
+                modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE, velocity = MarqueeVelocity),
+                style = style,
+                color = color,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Clip,
+                textAlign = textAlign,
+            )
+        }
+    }
+}
+
+private const val SyncedMarqueeStartDelayMs = 900L
+private const val SyncedMarqueeEndPauseMs = 900L
+
+/**
+ * Shared clock for a group of [SyncedMarqueeText]s (a card's title and episode title).
+ *
+ * Independent marquees drift apart when the two lines differ in length. Here every line moves at the
+ * same speed off one clock; a line that reaches the end of its own text holds there until the
+ * longest line finishes, then the whole group snaps back to the start and begins again together.
+ */
+@Stable
+class SyncedMarqueeState internal constructor() {
+    /** Full rotation distance per line: its text width plus the trailing gap. */
+    internal val distances = mutableStateMapOf<Any, Float>()
+    internal var travelledPx by mutableFloatStateOf(0f)
+    internal var focused by mutableStateOf(false)
+    internal var running by mutableStateOf(false)
+    internal val maxDistancePx: Float
+        get() = distances.values.maxOrNull() ?: 0f
+}
+
+@Composable
+fun rememberSyncedMarqueeState(focused: Boolean, velocity: Dp = MarqueeVelocity): SyncedMarqueeState {
+    val state = remember { SyncedMarqueeState() }
+    val velocityPx = with(LocalDensity.current) { velocity.toPx() }
+    SideEffect { state.focused = focused }
+
+    val maxDistance = state.maxDistancePx
+    LaunchedEffect(focused, maxDistance, velocityPx) {
+        state.travelledPx = 0f
+        state.running = false
+        if (!focused || maxDistance <= 0f || velocityPx <= 0f) return@LaunchedEffect
+        state.running = true
+        // Driven from real frame timestamps rather than a tween: tween durations are multiplied by
+        // the system "Animator duration scale" (0.5x on this device made it run at double speed),
+        // whereas frame-time integration always moves at the true velocity, like basicMarquee does.
+        while (true) {
+            delay(SyncedMarqueeStartDelayMs)
+            var travelled = 0f
+            var lastFrameNanos = 0L
+            while (travelled < maxDistance) {
+                withFrameNanos { now ->
+                    if (lastFrameNanos != 0L) {
+                        val deltaSeconds = (now - lastFrameNanos) / 1_000_000_000f
+                        travelled = (travelled + velocityPx * deltaSeconds).coerceAtMost(maxDistance)
+                        state.travelledPx = travelled
+                    }
+                    lastFrameNanos = now
+                }
+            }
+            delay(SyncedMarqueeEndPauseMs)
+            state.travelledPx = 0f
+        }
+    }
+    return state
+}
+
+/**
+ * Single line that scrolls in lockstep with the rest of its [state] group. At rest it is an ordinary
+ * ellipsized line; only while the group is focused does it lay out at full width and scroll.
+ */
+@Composable
+fun SyncedMarqueeText(
+    text: String,
+    state: SyncedMarqueeState,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+) {
+    val slot = remember { Any() }
+    val density = LocalDensity.current
+    var containerWidth by remember { mutableIntStateOf(0) }
+    var textWidth by remember(text) { mutableIntStateOf(0) }
+
+    val expanded = state.focused
+    val overflows = textWidth > containerWidth && containerWidth > 0
+    // Gap between the text and its trailing copy, matching basicMarquee's default feel.
+    val gapPx = containerWidth / 3f
+    // A full rotation carries the whole text plus the gap past the window, so the trailing copy
+    // lands exactly where the original started.
+    val distance = if (overflows) textWidth + gapPx else 0f
+
+    LaunchedEffect(slot, distance, expanded) {
+        state.distances[slot] = if (expanded) distance else 0f
+    }
+    DisposableEffect(slot) { onDispose { state.distances.remove(slot) } }
+
+    Box(
+        modifier = modifier
+            .clipToBounds()
+            .onSizeChanged { containerWidth = it.width }
+    ) {
+        if (expanded && overflows) {
+            // Two copies separated by the gap, translated as one. Once travelled reaches this
+            // line's distance the copy sits exactly where the original began, so a line that
+            // finishes early simply rests at the start position until the longest line catches up.
+            Row(
+                modifier = Modifier
+                    .wrapContentWidth(align = Alignment.Start, unbounded = true)
+                    .graphicsLayer { translationX = -min(state.travelledPx, distance) },
+                horizontalArrangement = Arrangement.spacedBy(with(density) { gapPx.toDp() })
+            ) {
+                MarqueeLine(text, style, color) { textWidth = it }
+                MarqueeLine(text, style, color)
+            }
+        } else if (expanded) {
+            // Focused but not yet known to overflow: lay out unbounded purely to learn the true
+            // text width. If it turns out to fit, this looks identical to the resting line.
+            Text(
+                text = text,
+                modifier = Modifier.wrapContentWidth(align = Alignment.Start, unbounded = true),
+                style = style,
+                color = color,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Clip,
+                onTextLayout = { textWidth = it.size.width },
+            )
+        } else {
+            // At rest: an ordinary ellipsized line, unchanged from before.
+            Text(
+                text = text,
+                style = style,
+                color = color,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MarqueeLine(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    onWidth: ((Int) -> Unit)? = null,
+) {
+    Text(
+        text = text,
+        style = style,
+        color = color,
+        maxLines = 1,
+        softWrap = false,
+        overflow = TextOverflow.Clip,
+        onTextLayout = { onWidth?.invoke(it.size.width) },
+    )
+}
+
 @Composable
 fun FocusMarqueeText(
     text: String,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CastSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CastSection.kt
@@ -2,6 +2,8 @@ package com.nuvio.tv.ui.screens.detail
 
 import com.nuvio.tv.ui.theme.NuvioTheme
 import com.nuvio.tv.domain.model.CardDepthSurface
+import com.nuvio.tv.ui.components.FocusMarqueeMultilineText
+import com.nuvio.tv.ui.components.FocusMarqueeText
 import com.nuvio.tv.ui.components.LocalCardDepthStyle
 import com.nuvio.tv.ui.components.nuvioCardDepth
 
@@ -353,12 +355,12 @@ private fun CastMemberItem(
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        Text(
+        FocusMarqueeMultilineText(
             text = member.name,
+            focused = isFocused,
             style = nameStyle,
-            color = NuvioTheme.colors.TextSecondary,
             maxLines = 2,
-            overflow = TextOverflow.Ellipsis
+            color = NuvioTheme.colors.TextSecondary,
         )
 
         val character = member.character
@@ -370,12 +372,11 @@ private fun CastMemberItem(
                 else -> character
             }
             Spacer(modifier = Modifier.height(NuvioTheme.spacing.xs))
-            Text(
+            FocusMarqueeText(
                 text = displayCharacter,
+                focused = isFocused,
                 style = characterStyle,
                 color = NuvioTheme.colors.TextTertiary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
             )
         }
     }


### PR DESCRIPTION
## Summary

Extends the existing focus-only marquee (from #2359) to two places it never covered. Everything still scrolls **only while focused** and ellipsizes at rest, exactly like the current behaviour.

**1. Cast row.** Character names are a single ellipsized line and now scroll on focus. Actor names keep their two-line wrap and only scroll when they **still** overflow after wrapping, so short names are untouched. The wrapped text stays in the layout drawn transparent while scrolling, so it keeps reserving its own height and the character label underneath does not move.

**2. Continue Watching cards.** The show title and the episode title now scroll on focus. Because those two lines are usually different lengths, scrolling them independently makes them drift apart and become hard to follow, so they share one clock:

- Both start together, at the same speed.
- Each completes a **full rotation** with a trailing copy following it, so the text wraps around rather than stopping once its tail is exposed.
- A line that finishes its rotation early lands back at its start position and **waits** there.
- When the longest line finishes, both pause and start again together.

This works in either direction, whether the title or the episode name is the longer one.

## Animation timing (worth knowing)

The scroll is driven from **real frame timestamps**, not a `tween`. Compose `tween` durations are multiplied by the system **Animator duration scale**, so on a device with that set to 0.5x the marquee ran at exactly double speed. Integrating position from frame deltas keeps a true velocity regardless of that setting, which is also how `basicMarquee` behaves. Speed matches the existing 45 dp/s used elsewhere.

## PR type

<!-- Presentational change extending existing behaviour; not localization, and not a critical bug fix. -->
- [ ] Translation/localization only
- [ ] Critical bug fix

## Why

Long cast names, especially on anime and foreign titles, are cut off with no way to read them, and the same is true of long show/episode titles on Continue Watching cards. The app already solves this for other cards with a focus marquee; these surfaces were simply never wired up. The shared clock exists because two independently scrolling lines on the same card are harder to read than one.

## Issue or approval

Fixes #2722

## Reproduction steps

N/A, not a bug fix. To see the change:

1. Open a title with a long cast list (anime works well) and focus a cast member whose name or character is cut off. The character name scrolls; the actor name scrolls only if it still overflows after wrapping to two lines. Nothing below shifts.
2. Go to Continue Watching and focus a card where both the show title and episode title are long. Both scroll together at the same speed, each completes a full rotation, the shorter one waits at its start position, then both restart together.
3. Move focus away: both revert to plain ellipsized lines and stop.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Purely presentational: text that was previously unreadable when truncated can now be read on focus. Resting appearance is unchanged.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue and testing notes.
- [x] I listed the testing performed below.

This extends an existing UI behaviour rather than fixing a critical bug, so the policy boxes that assert otherwise are left unchecked rather than overclaimed.

## Scope boundaries

- Only the cast row and the Continue Watching card are wired up. No other card, row or screen changes.
- Resting appearance is unchanged everywhere: still a single ellipsized line (and still a two-line wrap for actor names).
- Nothing animates unless the item is focused and the text actually overflows.
- `FocusMarqueeText` itself is unchanged; the multi-line and synced variants are additive.
- Multi-line descriptions still do not scroll, consistent with #2359.
- No changes to focus handling, navigation, layout metrics, or the data behind these cards.

## Testing

- `./gradlew :app:compileFullDebugKotlin` and `./gradlew :app:assembleFullDebug` pass.
- `./gradlew :app:testFullDebugUnitTest` compared against a stashed baseline: identical failures with and without this change (pre-existing/environment-dependent tests), so nothing new is broken by it.
- Installed and manually verified on an NVIDIA Shield:
  - Cast: long character names scroll on focus; long actor names scroll only when still overflowing after wrapping; the character label below stays put; short names behave as before.
  - Continue Watching: title and episode title start together, hold the same speed, each completes a full rotation, the shorter line waits at its start, then both restart together.
  - Verified in both directions (longer title vs longer episode name).
  - Unfocusing stops the scroll and restores the ellipsis.
- Scroll speed verified by instrumenting cycle start/end timestamps on device, which is how the animator-duration-scale interaction above was found and fixed.

## Screenshots / Video

**Demo (cast names scrolling on focus):**

https://github.com/user-attachments/assets/1798f177-ad7a-42e1-b121-f5be8cb56547

**Demo (Continue Watching title and episode title scrolling in step):**

https://github.com/user-attachments/assets/49b057e4-b12b-4bd2-8d53-693bf79d3af9

## Breaking changes

None. Purely presentational.

## Linked issues

Fixes #2722

