### PR TITLE
feat(simkl): use native anime[] envelope for anime history and list writes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationBodies.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationBodies.kt
@@ -33,8 +33,13 @@ fun buildSimklListMutationBody(
         SimklListMutationRequestDto(
             movies = requestItems.filter { (item, _) -> item.kind == TrackingMediaKind.MOVIE }
                 .map { it.second },
-            shows = requestItems.filter { (item, _) -> item.kind != TrackingMediaKind.MOVIE }
-                .map { it.second }
+            // Anime uses its own native envelope, mirroring the scrobble path
+            // (buildSimklScrobbleBody). See the Simkl anime guide, Path B.
+            anime = requestItems.filter { (item, _) -> item.kind == TrackingMediaKind.ANIME }
+                .map { it.second },
+            shows = requestItems.filter { (item, _) ->
+                item.kind != TrackingMediaKind.MOVIE && item.kind != TrackingMediaKind.ANIME
+            }.map { it.second }
         )
     )
 }
@@ -91,11 +96,24 @@ private fun buildHistoryRequest(
                 includeWatchedAt = includeWatchedAt
             )
         }
-    val shows = items.filter { item -> item.media.kind != TrackingMediaKind.MOVIE }
+    // Series groups split by envelope. Anime that has no TV-style (seasonal)
+    // coordinates uses the native anime envelope (flat absolute episodes),
+    // consistent with buildSimklScrobbleBody; seasonal anime stays in shows[]
+    // with use_tvdb_anime_seasons so Simkl cross-maps TVDB coordinates.
+    val seriesGroups = items.filter { item -> item.media.kind != TrackingMediaKind.MOVIE }
         .groupBy { item -> item.media.stableKey }
         .values
-        .map { matchingItems -> buildShowHistoryItem(matchingItems, includeWatchedAt) }
-    return SimklHistoryMutationRequestDto(movies = movies, shows = shows)
+        .map { matchingItems -> matchingItems to buildShowHistoryItem(matchingItems, includeWatchedAt) }
+    val anime = seriesGroups.filter { (group, _) -> usesNativeAnimeEnvelope(group) }
+        .map { it.second }
+    val shows = seriesGroups.filterNot { (group, _) -> usesNativeAnimeEnvelope(group) }
+        .map { it.second }
+    return SimklHistoryMutationRequestDto(movies = movies, shows = shows, anime = anime)
+}
+
+private fun usesNativeAnimeEnvelope(group: List<TrackingHistoryItem>): Boolean {
+    if (group.first().media.kind != TrackingMediaKind.ANIME) return false
+    return group.all { item -> item.media.episode?.season == null }
 }
 
 private fun buildShowHistoryItem(
@@ -230,7 +248,8 @@ private val SimklMutationJson = Json { encodeDefaults = false; explicitNulls = f
 @Serializable
 private data class SimklListMutationRequestDto(
     val movies: List<SimklListItemDto> = emptyList(),
-    val shows: List<SimklListItemDto> = emptyList()
+    val shows: List<SimklListItemDto> = emptyList(),
+    val anime: List<SimklListItemDto> = emptyList()
 )
 
 @Serializable
@@ -244,7 +263,8 @@ private data class SimklListItemDto(
 @Serializable
 private data class SimklHistoryMutationRequestDto(
     val movies: List<SimklHistoryItemDto> = emptyList(),
-    val shows: List<SimklHistoryItemDto> = emptyList()
+    val shows: List<SimklHistoryItemDto> = emptyList(),
+    val anime: List<SimklHistoryItemDto> = emptyList()
 )
 
 @Serializable

--- a/app/src/test/java/com/nuvio/tv/data/simkl/SimklAnimeContractVectorsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/simkl/SimklAnimeContractVectorsTest.kt
@@ -1,0 +1,155 @@
+package com.nuvio.tv.data.simkl
+
+import com.nuvio.tv.core.tracking.TrackingEpisode
+import com.nuvio.tv.core.tracking.TrackingExternalIds
+import com.nuvio.tv.core.tracking.TrackingHistoryItem
+import com.nuvio.tv.core.tracking.TrackingListStatus
+import com.nuvio.tv.core.tracking.TrackingMediaKind
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import com.nuvio.tv.core.tracking.TrackingScrobbleEvent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Golden contract vectors for Simkl anime writes, derived from the Simkl anime
+ * guide (https://api.simkl.org/guides/anime) Path A / Path B. These pin the
+ * envelope and payload shape the mutation builders must produce, so history,
+ * list, and scrobble writes stay consistent with each other and with the guide.
+ */
+class SimklAnimeContractVectorsTest {
+
+    // Path B (native): anime with anime-native ids + a flat/absolute episode
+    // goes in the anime[] envelope with a flat episode and no season key.
+    @Test
+    fun `history native cour-split anime uses anime envelope with flat episode`() {
+        val body = buildSimklHistoryMutationBody(
+            listOf(TrackingHistoryItem(nativeAnime(TrackingEpisode(number = 4)), WATCHED_AT))
+        ).obj()
+
+        assertNull(body["shows"])
+        val entry = body.getValue("anime").jsonArray.single().jsonObject
+        assertNull(entry["use_tvdb_anime_seasons"])
+        val episode = entry.getValue("episodes").jsonArray.single().jsonObject
+        assertEquals(4, episode.getValue("number").jsonPrimitive.content.toInt())
+        assertNull(episode["season"])
+        assertEquals(16498L, entry.ids().getValue("mal").jsonPrimitive.content.toLong())
+    }
+
+    // Path A (hybrid): anime with TMDB/TVDB identity and seasonal coordinates
+    // goes in shows[] with use_tvdb_anime_seasons so Simkl cross-maps TVDB.
+    @Test
+    fun `history seasonal anime uses shows envelope with tvdb cross-mapping flag`() {
+        val body = buildSimklHistoryMutationBody(
+            listOf(TrackingHistoryItem(hybridAnime(TrackingEpisode(season = 3, number = 13)), WATCHED_AT))
+        ).obj()
+
+        assertNull(body["anime"])
+        val entry = body.getValue("shows").jsonArray.single().jsonObject
+        assertTrue(entry.getValue("use_tvdb_anime_seasons").jsonPrimitive.content.toBoolean())
+        val season = entry.getValue("seasons").jsonArray.single().jsonObject
+        assertEquals(3, season.getValue("number").jsonPrimitive.content.toInt())
+        assertEquals(1429L, entry.ids().getValue("tmdb").jsonPrimitive.content.toLong())
+    }
+
+    @Test
+    fun `history movie uses movies envelope`() {
+        val body = buildSimklHistoryMutationBody(
+            listOf(TrackingHistoryItem(movie(), WATCHED_AT))
+        ).obj()
+
+        assertNull(body["shows"])
+        assertNull(body["anime"])
+        assertEquals(1, body.getValue("movies").jsonArray.size)
+    }
+
+    @Test
+    fun `history non-anime show uses shows envelope without flag`() {
+        val body = buildSimklHistoryMutationBody(
+            listOf(TrackingHistoryItem(show(TrackingEpisode(season = 2, number = 1)), WATCHED_AT))
+        ).obj()
+
+        val entry = body.getValue("shows").jsonArray.single().jsonObject
+        assertNull(entry["use_tvdb_anime_seasons"])
+    }
+
+    @Test
+    fun `list mutation routes anime to anime envelope`() {
+        val body = buildSimklListMutationBody(
+            listOf(movie(), nativeAnime(), show()),
+            TrackingListStatus.PLAN_TO_WATCH
+        ).obj()
+
+        assertEquals(1, body.getValue("movies").jsonArray.size)
+        assertEquals(1, body.getValue("anime").jsonArray.size)
+        assertEquals(1, body.getValue("shows").jsonArray.size)
+    }
+
+    @Test
+    fun `scrobble native anime uses anime wrapper without season`() {
+        val body = buildSimklScrobbleBody(
+            TrackingScrobbleEvent(nativeAnime(TrackingEpisode(number = 4)), 80.0)
+        ).obj()
+
+        assertTrue("anime" in body)
+        assertNull(body["show"])
+        assertNull(body.getValue("episode").jsonObject["season"])
+    }
+
+    @Test
+    fun `scrobble seasonal anime uses show wrapper`() {
+        val body = buildSimklScrobbleBody(
+            TrackingScrobbleEvent(hybridAnime(TrackingEpisode(season = 3, number = 13)), 80.0)
+        ).obj()
+
+        assertTrue("show" in body)
+        assertNull(body["anime"])
+    }
+
+    // -- fixtures --------------------------------------------------------
+
+    private fun movie() = TrackingMediaReference(
+        kind = TrackingMediaKind.MOVIE,
+        title = "Inception",
+        year = 2010,
+        ids = TrackingExternalIds(simkl = 53536, imdb = "tt1375666", tmdb = 27205)
+    )
+
+    private fun show(episode: TrackingEpisode? = null) = TrackingMediaReference(
+        kind = TrackingMediaKind.SHOW,
+        title = "Breaking Bad",
+        year = 2008,
+        ids = TrackingExternalIds(simkl = 46639, imdb = "tt0903747", tvdb = "81189"),
+        episode = episode
+    )
+
+    private fun nativeAnime(episode: TrackingEpisode? = null) = TrackingMediaReference(
+        kind = TrackingMediaKind.ANIME,
+        title = "Attack on Titan",
+        year = 2013,
+        ids = TrackingExternalIds(simkl = 39687, mal = 16498, anidb = 9541),
+        episode = episode
+    )
+
+    private fun hybridAnime(episode: TrackingEpisode? = null) = TrackingMediaReference(
+        kind = TrackingMediaKind.ANIME,
+        title = "Attack on Titan",
+        year = 2013,
+        ids = TrackingExternalIds(simkl = 39687, tmdb = 1429, tvdb = "267440"),
+        episode = episode
+    )
+
+    private fun JsonObject.ids(): JsonObject = getValue("ids").jsonObject
+
+    private fun String.obj(): JsonObject = Json.parseToJsonElement(this).jsonObject
+
+    private companion object {
+        const val WATCHED_AT = 1_700_000_000_000L
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/simkl/SimklMutationServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/simkl/SimklMutationServiceTest.kt
@@ -32,7 +32,8 @@ class SimklMutationServiceTest {
 
         assertNull(body["to"])
         val movie = body.getValue("movies").jsonArray.single().jsonObject
-        val anime = body.getValue("shows").jsonArray.single().jsonObject
+        val anime = body.getValue("anime").jsonArray.single().jsonObject
+        assertNull(body["shows"])
         assertEquals("plantowatch", movie.getValue("to").jsonPrimitive.content)
         assertEquals("plantowatch", anime.getValue("to").jsonPrimitive.content)
         assertEquals(53536L, movie.getValue("ids").jsonObject.getValue("simkl").jsonPrimitive.content.toLong())
@@ -68,16 +69,23 @@ class SimklMutationServiceTest {
     }
 
     @Test
-    fun `anime history uses tvdb mapping flag only for seasonal coordinates`() {
+    fun `anime history uses native envelope for flat episodes and tvdb hybrid for seasonal`() {
+        // Seasonal anime keeps the TVDB cross-mapping (Path A) in shows[].
         val seasonal = buildSimklHistoryMutationBody(
             listOf(TrackingHistoryItem(anime(TrackingEpisode(2, 4)), 1_700_000_000_000L))
         ).asObject().getValue("shows").jsonArray.single().jsonObject
         assertTrue(seasonal.getValue("use_tvdb_anime_seasons").jsonPrimitive.content.toBoolean())
 
-        val flat = buildSimklHistoryMutationBody(
+        // Flat (absolute) anime uses the native anime[] envelope (Path B),
+        // consistent with buildSimklScrobbleBody.
+        val flatBody = buildSimklHistoryMutationBody(
             listOf(TrackingHistoryItem(anime(TrackingEpisode(number = 4)), 1_700_000_000_000L))
-        ).asObject().getValue("shows").jsonArray.single().jsonObject
+        ).asObject()
+        assertNull(flatBody["shows"])
+        val flat = flatBody.getValue("anime").jsonArray.single().jsonObject
         assertNull(flat["use_tvdb_anime_seasons"])
+        assertEquals(4, flat.getValue("episodes").jsonArray.single().jsonObject
+            .getValue("number").jsonPrimitive.content.toInt())
 
         val regularShow = buildSimklHistoryMutationBody(
             listOf(TrackingHistoryItem(show(TrackingEpisode(2, 4)), 1_700_000_000_000L))
@@ -86,10 +94,10 @@ class SimklMutationServiceTest {
     }
 
     @Test
-    fun `anime removal uses shows and excludes watch fields`() {
+    fun `anime removal uses native envelope for flat and shows for seasonal`() {
         val item = buildSimklHistoryRemovalBody(
             listOf(anime(TrackingEpisode(number = 4)))
-        ).asObject().getValue("shows").jsonArray.single().jsonObject
+        ).asObject().getValue("anime").jsonArray.single().jsonObject
 
         assertNull(item["watched_at"])
         assertNull(item["status"])


### PR DESCRIPTION
## What

Route anime **history** and **list** writes through Simkl's native `anime[]` envelope, making them consistent with the scrobble path and the [Simkl anime guide](https://api.simkl.org/guides/anime).

## Why

`buildSimklScrobbleBody` already does the right thing: flat/absolute anime → the native `anime` wrapper (Path B), seasonal anime → `show` with TVDB cross-mapping (Path A). But `buildHistoryRequest` and `buildSimklListMutationBody` sent **all** anime through `shows[]`. So a native-id anime (`mal`/`anilist`/`anidb`/`kitsu` with a flat absolute episode, and frequently no TMDB/TVDB) was written as a show — the exact case the guide routes through `anime[]`.

## Change

- `SimklMutationBodies.kt`:
  - History: series groups with no seasonal coordinates → `anime[]` (flat episodes); seasonal anime stays in `shows[]` with `use_tvdb_anime_seasons` (unchanged). The split mirrors the scrobble predicate exactly.
  - List: anime → `anime[]`; movies/shows unchanged.
  - `buildShowHistoryItem` is reused untouched — it already emits the flat, flagless DTO for flat episodes.
- No read-path change: the response parser already sums `not_found` across all keys and maps `"anime" -> ANIME`.
- Updated the three affected assertions in `SimklMutationServiceTest`.
- Added `SimklAnimeContractVectorsTest` — golden vectors pinning the Path A/B envelope + payload shapes across history, list, and scrobble.

## Verification note (please read)

I authored this in an environment where I **could not run the Android/Gradle build locally**, so I have not executed the unit tests against this branch. The change is small, reuses existing helpers, and mirrors the already-tested scrobble logic, but please let CI (or a local `:app:testDebugUnitTest --tests "*Simkl*"`) confirm before merging. One item worth validating against a live Simkl account: that a native-only anime (e.g. `mal` id + flat episode) is accepted under `anime[]` for `/sync/history` as the guide describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
