### PR TITLE
fix(addons): make Refresh Addons perform a complete synchronized refresh

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/AddonRefreshModels.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/AddonRefreshModels.kt
@@ -1,0 +1,25 @@
+package com.nuvio.tv.core.sync
+
+data class RemoteAddonEntry(
+    val url: String,
+    val name: String?,
+    val enabled: Boolean
+)
+
+data class RemoteAddonSnapshot(
+    val profileId: Int,
+    val addons: List<RemoteAddonEntry>
+)
+
+data class AddonRefreshSummary(
+    val profileId: Int,
+    val addonCount: Int,
+    val refreshedManifestCount: Int,
+    val failedManifestCount: Int
+) {
+    val completedFully: Boolean
+        get() = failedManifestCount == 0
+}
+
+class AddonRefreshConflictException :
+    IllegalStateException("Addons changed while the refresh was running")

--- a/app/src/main/java/com/nuvio/tv/core/sync/AddonSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/AddonSyncService.kt
@@ -26,6 +26,15 @@ class AddonSyncService @Inject constructor(
     private val profileManager: ProfileManager,
     private val syncClientIdentity: SyncClientIdentity
 ) {
+    fun effectiveAddonProfileId(): Int {
+        val activeProfile = profileManager.activeProfile
+        return when {
+            activeProfile == null -> profileManager.activeProfileId.value
+            !activeProfile.isPrimary && activeProfile.usesPrimaryAddons -> 1
+            else -> activeProfile.id
+        }
+    }
+
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
         return try {
             block()
@@ -86,47 +95,65 @@ class AddonSyncService @Inject constructor(
         }
     }
 
-    suspend fun getRemoteAddonUrls(): Result<List<String>> = withContext(Dispatchers.IO) {
-        try {
-            val effectiveUserId = authManager.getEffectiveUserId(fallbackToOwnIdOnFailure = false)
-                ?: return@withContext Result.failure(
-                    IllegalStateException("Unable to resolve sync owner for addon sync")
-                )
+    suspend fun getRemoteAddonSnapshot(profileId: Int): Result<RemoteAddonSnapshot> =
+        withContext(Dispatchers.IO) {
+            try {
+                val effectiveUserId = authManager.getEffectiveUserId(fallbackToOwnIdOnFailure = false)
+                    ?: return@withContext Result.failure(
+                        IllegalStateException("Unable to resolve sync owner for addon sync")
+                    )
 
-            val activeProfile = profileManager.activeProfile
-            val profileId = if (activeProfile != null && !activeProfile.isPrimary && activeProfile.usesPrimaryAddons) 1
-                            else profileManager.activeProfileId.value
-
-            val remoteAddons = withJwtRefreshRetry {
-                postgrest.from("addons")
-                    .select { filter {
-                        eq("user_id", effectiveUserId)
-                        eq("profile_id", profileId)
-                    } }
-                    .decodeList<SupabaseAddon>()
-            }
-
-            val nameMap = mutableMapOf<String, String>()
-            val enabledMap = mutableMapOf<String, Boolean>()
-            remoteAddons.forEach { addon ->
-                val canonicalUrl = canonicalizeUrl(addon.url)
-                if (!addon.name.isNullOrBlank()) {
-                    nameMap[canonicalUrl] = addon.name
+                val remoteAddons = withJwtRefreshRetry {
+                    postgrest.from("addons")
+                        .select { filter {
+                            eq("user_id", effectiveUserId)
+                            eq("profile_id", profileId)
+                        } }
+                        .decodeList<SupabaseAddon>()
                 }
-                enabledMap[canonicalUrl] = addon.enabled
-            }
-            if (remoteAddons.isNotEmpty()) {
-                addonPreferences.setUserSetNames(nameMap)
-                addonPreferences.setAddonEnabledStates(enabledMap)
-            }
 
-            Result.success(
-                remoteAddons
-                .sortedBy { it.sortOrder }
-                .map { it.url }
-            )
+                Result.success(
+                    RemoteAddonSnapshot(
+                        profileId = profileId,
+                        addons = remoteAddons
+                            .sortedBy { it.sortOrder }
+                            .map { addon ->
+                                RemoteAddonEntry(
+                                    url = canonicalizeUrl(addon.url),
+                                    name = addon.name?.takeIf { it.isNotBlank() },
+                                    enabled = addon.enabled
+                                )
+                            }
+                            .filter { it.url.isNotBlank() }
+                            .distinctBy { it.url.lowercase() }
+                    )
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to get remote addons for profile $profileId", e)
+                Result.failure(e)
+            }
+        }
+
+    suspend fun getRemoteAddonUrls(): Result<List<String>> {
+        val profileId = effectiveAddonProfileId()
+        val snapshot = getRemoteAddonSnapshot(profileId).getOrElse {
+            return Result.failure(it)
+        }
+
+        return try {
+            if (snapshot.addons.isNotEmpty()) {
+                addonPreferences.setUserSetNames(
+                    snapshot.addons.mapNotNull { addon ->
+                        addon.name?.let { addon.url to it }
+                    }.toMap()
+                )
+                addonPreferences.setAddonEnabledStates(
+                    snapshot.addons.associate { it.url to it.enabled }
+                )
+            }
+            Result.success(snapshot.addons.map { it.url })
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to get remote addon URLs", e)
+            Log.e(TAG, "Failed to get remote addon URLs for profile $profileId", e)
             Result.failure(e)
         }
     }

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -15,7 +15,9 @@ import com.nuvio.tv.data.repository.WatchProgressRepositoryImpl
 import com.nuvio.tv.domain.model.AuthState
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -24,6 +26,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -72,6 +76,9 @@ class StartupSyncService @Inject constructor(
     private var pendingResyncKey: String? = null
     @Volatile
     private var pendingResyncIncludesProfileSettings: Boolean = false
+    private val addonPullMutex = Mutex()
+    private val manualAddonRefreshJobLock = Any()
+    private var manualAddonRefreshJob: Deferred<Result<AddonRefreshSummary>>? = null
 
     init {
         scope.launch {
@@ -172,29 +179,53 @@ class StartupSyncService @Inject constructor(
         }
     }
 
-    fun requestAddonSyncNow() {
-        val profileId = profileManager.activeProfileId.value
-        Log.d(TAG, "Manual addon sync enqueued for profile $profileId")
-        scope.launch {
-            Log.d(TAG, "Manual addon sync starting for profile $profileId")
-
-            addonRepository.isSyncingFromRemote = true
-            try {
-                val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
-
-                addonRepository.reconcileWithRemoteAddonUrls(
-                    remoteUrls = remoteAddonUrls,
-                    removeMissingLocal = true
-                )
-
-                Log.d(TAG, "Manual addon sync pulled ${remoteAddonUrls.size} addons for profile $profileId")
-            } catch (e: Exception) {
-                Log.e(TAG, "Manual addon sync failed for profile $profileId", e)
-            } finally {
-                addonRepository.isSyncingFromRemote = false
+    fun requestAddonRefreshNow(): Deferred<Result<AddonRefreshSummary>> =
+        synchronized(manualAddonRefreshJobLock) {
+            manualAddonRefreshJob?.takeIf { it.isActive } ?: scope.async(
+                start = CoroutineStart.LAZY
+            ) {
+                performAddonRefresh()
+            }.also { job ->
+                manualAddonRefreshJob = job
+                job.invokeOnCompletion {
+                    synchronized(manualAddonRefreshJobLock) {
+                        if (manualAddonRefreshJob === job) {
+                            manualAddonRefreshJob = null
+                        }
+                    }
+                }
+                job.start()
             }
         }
-    }
+
+    private suspend fun performAddonRefresh(): Result<AddonRefreshSummary> =
+        addonPullMutex.withLock {
+            val profileId = addonSyncService.effectiveAddonProfileId()
+            val localMutationRevision = addonRepository.currentLocalMutationRevision()
+            Log.d(TAG, "Manual addon refresh starting for profile $profileId")
+            addonRepository.isSyncingFromRemote = true
+            try {
+                val snapshot = addonSyncService.getRemoteAddonSnapshot(profileId).getOrElse { throw it }
+                val summary = addonRepository.applyRemoteAddonSnapshot(
+                    snapshot = snapshot,
+                    expectedLocalMutationRevision = localMutationRevision
+                )
+                Log.d(
+                    TAG,
+                    "Manual addon refresh completed profile=$profileId addons=${summary.addonCount} " +
+                        "manifests=${summary.refreshedManifestCount} failed=${summary.failedManifestCount}"
+                )
+                Result.success(summary)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Manual addon refresh failed for profile $profileId", e)
+                Result.failure(e)
+            } finally {
+                addonRepository.isSyncingFromRemote = false
+                addonRepository.flushPendingSync()
+            }
+        }
 
     fun requestRealtimeSurfacePull(profileId: Int, surface: String) {
         if (!authManager.isAuthenticated) return
@@ -572,18 +603,21 @@ class StartupSyncService @Inject constructor(
             }
 
             val addonJob = async {
-                addonRepository.isSyncingFromRemote = true
-                try {
-                    val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
-                    addonRepository.reconcileWithRemoteAddonUrls(
-                        remoteUrls = remoteAddonUrls,
-                        removeMissingLocal = true
-                    )
-                    Log.d(TAG, "Pulled ${remoteAddonUrls.size} addons from remote for profile $profileId")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to pull addons from remote, keeping local cache", e)
-                } finally {
-                    addonRepository.isSyncingFromRemote = false
+                addonPullMutex.withLock {
+                    addonRepository.isSyncingFromRemote = true
+                    try {
+                        val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
+                        addonRepository.reconcileWithRemoteAddonUrls(
+                            remoteUrls = remoteAddonUrls,
+                            removeMissingLocal = true
+                        )
+                        Log.d(TAG, "Pulled ${remoteAddonUrls.size} addons from remote for profile $profileId")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to pull addons from remote, keeping local cache", e)
+                    } finally {
+                        addonRepository.isSyncingFromRemote = false
+                        addonRepository.flushPendingSync()
+                    }
                 }
             }
 
@@ -664,21 +698,23 @@ class StartupSyncService @Inject constructor(
         }
     }
 
-    private suspend fun pullRealtimeAddons(profileId: Int) {
-        addonRepository.isSyncingFromRemote = true
-        try {
-            val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
-            addonRepository.reconcileWithRemoteAddonUrls(
-                remoteUrls = remoteAddonUrls,
-                removeMissingLocal = true
-            )
-            Log.d(TAG, "Realtime addons pull reconciled ${remoteAddonUrls.size} addons for profile $profileId")
-        } catch (e: Exception) {
-            Log.e(TAG, "Realtime addons pull failed profile=$profileId", e)
-        } finally {
-            addonRepository.isSyncingFromRemote = false
+    private suspend fun pullRealtimeAddons(profileId: Int) =
+        addonPullMutex.withLock {
+            addonRepository.isSyncingFromRemote = true
+            try {
+                val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
+                addonRepository.reconcileWithRemoteAddonUrls(
+                    remoteUrls = remoteAddonUrls,
+                    removeMissingLocal = true
+                )
+                Log.d(TAG, "Realtime addons pull reconciled ${remoteAddonUrls.size} addons for profile $profileId")
+            } catch (e: Exception) {
+                Log.e(TAG, "Realtime addons pull failed profile=$profileId", e)
+            } finally {
+                addonRepository.isSyncingFromRemote = false
+                addonRepository.flushPendingSync()
+            }
         }
-    }
 
     private suspend fun pullWatchedItemsDelta(
         profileId: Int,

--- a/app/src/main/java/com/nuvio/tv/data/local/AddonPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/AddonPreferences.kt
@@ -162,6 +162,44 @@ class AddonPreferences @Inject constructor(
         }
     }
 
+    suspend fun getInstalledAddonUrls(profileId: Int): List<String> {
+        val preferences = store(profileId).data.first()
+        return getCurrentList(preferences)
+    }
+
+    suspend fun replaceFromRemote(
+        profileId: Int,
+        orderedUrls: List<String>,
+        names: Map<String, String>,
+        enabledStates: Map<String, Boolean>
+    ) {
+        store(profileId).edit { preferences ->
+            val canonicalUrls = orderedUrls
+                .map(::canonicalizeUrl)
+                .filter { it.isNotBlank() }
+                .distinctBy { it.lowercase() }
+            val canonicalNames = names.entries.associate { (url, name) ->
+                canonicalizeUrl(url).lowercase() to name
+            }
+            val canonicalEnabledStates = enabledStates.entries.associate { (url, enabled) ->
+                canonicalizeUrl(url).lowercase() to enabled
+            }
+
+            preferences[orderedUrlsKey] = gson.toJson(canonicalUrls)
+            preferences[userSetNamesKey] = gson.toJson(
+                canonicalUrls.mapNotNull { url ->
+                    canonicalNames[url.lowercase()]?.let { url to it }
+                }.toMap()
+            )
+            preferences[addonEnabledStatesKey] = gson.toJson(
+                canonicalUrls.associateWith { url ->
+                    canonicalEnabledStates[url.lowercase()] ?: true
+                }
+            )
+            preferences.remove(legacyUrlsKey)
+        }
+    }
+
     private fun getCurrentList(preferences: Preferences): List<String> {
         val json = preferences[orderedUrlsKey]
         return if (json != null) {

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -30,8 +31,20 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.sync.AddonSyncService
+import com.nuvio.tv.core.sync.AddonRefreshConflictException
+import com.nuvio.tv.core.sync.AddonRefreshSummary
+import com.nuvio.tv.core.sync.RemoteAddonSnapshot
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 class AddonRepositoryImpl @Inject constructor(
     private val api: AddonApi,
@@ -48,11 +61,18 @@ class AddonRepositoryImpl @Inject constructor(
         private const val LEGACY_MANIFEST_CACHE_KEY = "manifests"
         private const val MANIFEST_SUFFIX = "/manifest.json"
         private const val MANIFEST_CACHE_TTL_MS = 6 * 60 * 60 * 1000L 
+        private const val MANUAL_MANIFEST_REFRESH_TIMEOUT_MS = 15_000L
+        private const val MANUAL_MANIFEST_REFRESH_TOTAL_TIMEOUT_MS = 30_000L
+        private const val MANUAL_MANIFEST_REFRESH_CONCURRENCY = 6
     }
 
     private val syncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var syncJob: Job? = null
+    @Volatile
     var isSyncingFromRemote = false
+    private val remoteSyncPending = AtomicBoolean(false)
+    private val localMutationMutex = Mutex()
+    private val localMutationRevision = AtomicLong(0L)
 
     private fun canonicalizeUrl(url: String): String {
         val trimmed = url.trim().trimEnd('/')
@@ -73,6 +93,7 @@ class AddonRepositoryImpl @Inject constructor(
 
     private fun triggerRemoteSync() {
         if (isSyncingFromRemote) {
+            remoteSyncPending.set(true)
             Log.d(TAG, "triggerRemoteSync: skipped (syncing from remote)")
             return
         }
@@ -89,17 +110,21 @@ class AddonRepositoryImpl @Inject constructor(
         }
     }
 
+    fun flushPendingSync() {
+        if (!remoteSyncPending.compareAndSet(true, false)) return
+        triggerRemoteSync()
+    }
+
     private val gson = Gson()
     private val manifestCache = mutableMapOf<String, Addon>()
     private val manifestCacheLock = Any()
     private val manifestCacheRevision = MutableStateFlow(0L)
+    private val _refreshRevision = MutableStateFlow(0L)
+    override val refreshRevision: StateFlow<Long> = _refreshRevision
     @Volatile
     private var lastManifestRefreshTime = 0L
     private var manifestRefreshJob: Job? = null
-
-    init {
-        syncScope.launch { loadManifestCacheFromDisk() }
-    }
+    private val diskCacheJob: Job = syncScope.launch { loadManifestCacheFromDisk() }
 
     private fun isCacheStale(): Boolean =
         System.currentTimeMillis() - lastManifestRefreshTime > MANIFEST_CACHE_TTL_MS
@@ -109,7 +134,7 @@ class AddonRepositoryImpl @Inject constructor(
         manifestRefreshJob = syncScope.launch {
             val refreshed = urls.map { url ->
                 async {
-                    fetchAddon(url)
+                    fetchAddon(url, forceRefresh = true)
                 }
             }.awaitAll()
             val anyUpdated = refreshed.any { it is NetworkResult.Success }
@@ -166,6 +191,8 @@ class AddonRepositoryImpl @Inject constructor(
                     return@flow
                 }
 
+                diskCacheJob.join()
+
                 val enabledByUrl = enabledStates.mapKeys { (url, _) -> canonicalizeUrl(url) }
                 val cached = urls.mapNotNull { url ->
                     val canonical = canonicalizeUrl(url)
@@ -193,7 +220,7 @@ class AddonRepositoryImpl @Inject constructor(
                                         ?.copy(enabled = false)
                                         ?: placeholderAddon(canonical, userNames, enabled = false)
                                 }
-                                (getCachedManifest(canonical) ?: when (val result = fetchAddon(url)) {
+                                (getCachedManifest(canonical) ?: when (val result = fetchAddon(url, forceRefresh = true)) {
                                     is NetworkResult.Success -> result.data
                                     else -> null
                                 })?.copy(enabled = enabled)
@@ -212,7 +239,7 @@ class AddonRepositoryImpl @Inject constructor(
             }.flowOn(Dispatchers.IO)
         }
 
-    override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> {
+    override suspend fun fetchAddon(baseUrl: String, forceRefresh: Boolean): NetworkResult<Addon> {
         val cleanBaseUrl = canonicalizeUrl(baseUrl)
         val queryStart = cleanBaseUrl.indexOf('?')
         val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
@@ -237,28 +264,40 @@ class AddonRepositoryImpl @Inject constructor(
 
     override suspend fun addAddon(url: String) {
         val cleanUrl = canonicalizeUrl(url)
-        preferences.addAddon(cleanUrl)
+        localMutationMutex.withLock {
+            preferences.addAddon(cleanUrl)
+            localMutationRevision.incrementAndGet()
+        }
         triggerRemoteSync()
     }
 
     override suspend fun removeAddon(url: String) {
         val cleanUrl = canonicalizeUrl(url)
-        if (removeCachedManifest(cleanUrl)) {
-            persistManifestCacheToDisk()
-            bumpManifestCacheRevision()
+        localMutationMutex.withLock {
+            if (removeCachedManifest(cleanUrl)) {
+                persistManifestCacheToDisk()
+                bumpManifestCacheRevision()
+            }
+            preferences.removeAddon(cleanUrl)
+            localMutationRevision.incrementAndGet()
         }
-        preferences.removeAddon(cleanUrl)
         triggerRemoteSync()
     }
 
     override suspend fun setAddonOrder(urls: List<String>) {
-        preferences.setAddonOrder(urls)
+        localMutationMutex.withLock {
+            preferences.setAddonOrder(urls)
+            localMutationRevision.incrementAndGet()
+        }
         triggerRemoteSync()
     }
 
     override suspend fun setAddonEnabled(url: String, enabled: Boolean) {
         val cleanUrl = canonicalizeUrl(url)
-        preferences.setAddonEnabled(cleanUrl, enabled)
+        localMutationMutex.withLock {
+            preferences.setAddonEnabled(cleanUrl, enabled)
+            localMutationRevision.incrementAndGet()
+        }
         if (enabled && getCachedManifest(cleanUrl) == null) {
             fetchAddon(cleanUrl)
         }
@@ -322,6 +361,86 @@ class AddonRepositoryImpl @Inject constructor(
         if (finalList != currentCanonical) {
             preferences.setAddonOrder(finalList)
         }
+    }
+
+    fun currentLocalMutationRevision(): Long = localMutationRevision.get()
+
+    suspend fun applyRemoteAddonSnapshot(
+        snapshot: RemoteAddonSnapshot,
+        expectedLocalMutationRevision: Long? = null
+    ): AddonRefreshSummary {
+        diskCacheJob.join()
+        val remoteUrls = snapshot.addons.map { canonicalizeUrl(it.url) }
+        val remoteSet = remoteUrls.map(::normalizeUrl).toSet()
+
+        localMutationMutex.withLock {
+            if (expectedLocalMutationRevision != null &&
+                localMutationRevision.get() != expectedLocalMutationRevision
+            ) {
+                throw AddonRefreshConflictException()
+            }
+
+            val initialLocalUrls = preferences.getInstalledAddonUrls(snapshot.profileId)
+            preferences.replaceFromRemote(
+                profileId = snapshot.profileId,
+                orderedUrls = remoteUrls,
+                names = snapshot.addons.mapNotNull { addon ->
+                    addon.name?.let { addon.url to it }
+                }.toMap(),
+                enabledStates = snapshot.addons.associate { it.url to it.enabled }
+            )
+
+            val removedAny = initialLocalUrls
+                .filter { normalizeUrl(it) !in remoteSet }
+                .map(::canonicalizeUrl)
+                .fold(false) { removed, url -> removeCachedManifest(url) || removed }
+            if (removedAny) {
+                persistManifestCacheToDisk()
+                bumpManifestCacheRevision()
+            }
+        }
+
+        val enabledUrls = snapshot.addons
+            .filter { it.enabled }
+            .map { canonicalizeUrl(it.url) }
+        val semaphore = Semaphore(MANUAL_MANIFEST_REFRESH_CONCURRENCY)
+        val refreshedCounter = AtomicInteger(0)
+        withTimeoutOrNull(MANUAL_MANIFEST_REFRESH_TOTAL_TIMEOUT_MS) {
+            coroutineScope {
+                enabledUrls.map { url ->
+                    async {
+                        semaphore.withPermit {
+                            val result = try {
+                                withTimeoutOrNull(MANUAL_MANIFEST_REFRESH_TIMEOUT_MS) {
+                                    fetchAddon(url, forceRefresh = true)
+                                } ?: NetworkResult.Error("Manifest refresh timed out")
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                Log.w(TAG, "Manual manifest refresh failed for $url", e)
+                                NetworkResult.Error(e.message ?: "Manifest refresh failed")
+                            }
+                            if (result is NetworkResult.Success) {
+                                refreshedCounter.incrementAndGet()
+                            }
+                        }
+                    }
+                }.awaitAll()
+            }
+        }
+        val refreshedCount = refreshedCounter.get()
+        val failedCount = enabledUrls.size - refreshedCount
+        if (enabledUrls.isNotEmpty() && failedCount == 0) {
+            lastManifestRefreshTime = System.currentTimeMillis()
+        }
+        _refreshRevision.value = _refreshRevision.value + 1
+
+        return AddonRefreshSummary(
+            profileId = snapshot.profileId,
+            addonCount = snapshot.addons.size,
+            refreshedManifestCount = refreshedCount,
+            failedManifestCount = failedCount
+        )
     }
 
     private fun placeholderAddon(

--- a/app/src/main/java/com/nuvio/tv/domain/repository/AddonRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/AddonRepository.kt
@@ -3,10 +3,12 @@ package com.nuvio.tv.domain.repository
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.domain.model.Addon
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface AddonRepository {
+    val refreshRevision: StateFlow<Long>
     fun getInstalledAddons(): Flow<List<Addon>>
-    suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon>
+    suspend fun fetchAddon(baseUrl: String, forceRefresh: Boolean = false): NetworkResult<Addon>
     suspend fun addAddon(url: String)
     suspend fun removeAddon(url: String)
     suspend fun setAddonOrder(urls: List<String>)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -716,12 +716,16 @@ class AccountViewModel @Inject constructor(
             pluginManager.flushPendingSync()
 
             addonRepository.isSyncingFromRemote = true
-            val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
-            addonRepository.reconcileWithRemoteAddonUrls(
-                remoteUrls = remoteAddonUrls,
-                removeMissingLocal = true
-            )
-            addonRepository.isSyncingFromRemote = false
+            try {
+                val remoteAddonUrls = addonSyncService.getRemoteAddonUrls().getOrElse { throw it }
+                addonRepository.reconcileWithRemoteAddonUrls(
+                    remoteUrls = remoteAddonUrls,
+                    removeMissingLocal = true
+                )
+            } finally {
+                addonRepository.isSyncingFromRemote = false
+                addonRepository.flushPendingSync()
+            }
 
             val isTraktConnected = traktAuthDataStore.isEffectivelyAuthenticated.first()
             val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
@@ -169,17 +169,7 @@ fun AddonManagerScreen(
     BackHandler { onBackPress() }
 
     val defaultRefreshAddonsSubtitle = stringResource(R.string.addon_refresh_default_subtitle)
-    val refreshedAddonsSubtitle = stringResource(R.string.addon_refresh_done_subtitle)
-    var refreshAddonsSubtitle by remember(defaultRefreshAddonsSubtitle) {
-        mutableStateOf(defaultRefreshAddonsSubtitle)
-    }
-
-    LaunchedEffect(refreshAddonsSubtitle) {
-        if (refreshAddonsSubtitle != defaultRefreshAddonsSubtitle) {
-            delay(5_000)
-            refreshAddonsSubtitle = defaultRefreshAddonsSubtitle
-        }
-    }
+    val refreshAddonsSubtitle = uiState.addonRefreshSubtitle ?: defaultRefreshAddonsSubtitle
 
     // When isEditing changes to true, focus the text field and show keyboard
     LaunchedEffect(isEditing) {
@@ -410,10 +400,9 @@ fun AddonManagerScreen(
             item {
                 RefreshAddonsEntryCard(
                     subtitle = refreshAddonsSubtitle,
-                    onClick = {
-                        viewModel.requestAddonSyncNow()
-                        refreshAddonsSubtitle = refreshedAddonsSubtitle
-                    },
+                    onClick = viewModel::requestAddonSyncNow,
+                    enabled = !uiState.isRefreshingAddons,
+                    isError = uiState.addonRefreshFailed,
                     modifier = Modifier.focusProperties {
                         down = firstAddonToggleFocusRequester
                     }
@@ -754,12 +743,15 @@ private fun CollectionsEntryCard(onClick: () -> Unit) {
 private fun RefreshAddonsEntryCard(
     subtitle: String,
     onClick: () -> Unit,
+    enabled: Boolean,
+    isError: Boolean,
     modifier: Modifier = Modifier
 ) {
     var isFocused by remember { mutableStateOf(false) }
 
     Surface(
         onClick = onClick,
+        enabled = enabled,
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { isFocused = it.isFocused },
@@ -800,7 +792,7 @@ private fun RefreshAddonsEntryCard(
                     Text(
                         text = subtitle,
                         style = MaterialTheme.typography.bodySmall,
-                        color = NuvioTheme.colors.TextSecondary
+                        color = if (isError) NuvioTheme.colors.Error else NuvioTheme.colors.TextSecondary
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerUiState.kt
@@ -11,6 +11,9 @@ data class AddonManagerUiState(
     val error: String? = null,
     val transientMessage: String? = null,
     val transientMessageIsError: Boolean = false,
+    val isRefreshingAddons: Boolean = false,
+    val addonRefreshSubtitle: String? = null,
+    val addonRefreshFailed: Boolean = false,
     // QR mode
     val isQrModeActive: Boolean = false,
     val qrCodeBitmap: Bitmap? = null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerViewModel.kt
@@ -99,6 +99,7 @@ class AddonManagerViewModel @Inject constructor(
     private var disabledHomeCatalogKeys: Set<String> = emptySet()
     private var followAddonsOrderEnabled: Boolean = false
     private var currentCollections: List<Collection> = emptyList()
+    private var addonRefreshMessageJob: kotlinx.coroutines.Job? = null
 
     init {
         observeInstalledAddons()
@@ -108,7 +109,46 @@ class AddonManagerViewModel @Inject constructor(
     }
 
     fun requestAddonSyncNow() {
-        startupSyncService.requestAddonSyncNow()
+        if (_uiState.value.isRefreshingAddons) return
+
+        addonRefreshMessageJob?.cancel()
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isRefreshingAddons = true,
+                    addonRefreshSubtitle = context.getString(R.string.addon_refresh_in_progress_subtitle),
+                    addonRefreshFailed = false
+                )
+            }
+
+            val result = startupSyncService.requestAddonRefreshNow().await()
+            val summary = result.getOrNull()
+            val failed = result.isFailure
+            val subtitle = when {
+                result.exceptionOrNull() is com.nuvio.tv.core.sync.AddonRefreshConflictException ->
+                    context.getString(R.string.addon_refresh_conflict_subtitle)
+                failed -> context.getString(R.string.addon_refresh_failed_subtitle)
+                summary != null && !summary.completedFully -> context.getString(
+                    R.string.addon_refresh_partial_subtitle,
+                    summary.failedManifestCount
+                )
+                else -> context.getString(R.string.addon_refresh_done_subtitle)
+            }
+            _uiState.update {
+                it.copy(
+                    isRefreshingAddons = false,
+                    addonRefreshSubtitle = subtitle,
+                    addonRefreshFailed = failed || summary?.completedFully == false
+                )
+            }
+
+            addonRefreshMessageJob = viewModelScope.launch {
+                delay(if (failed) 8_000L else 5_000L)
+                _uiState.update {
+                    it.copy(addonRefreshSubtitle = null, addonRefreshFailed = false)
+                }
+            }
+        }
     }
 
     private fun loadLogoBytes() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -128,12 +128,20 @@ internal fun HomeViewModel.observeTmdbSettingsPipeline() {
 @OptIn(FlowPreview::class)
 internal fun HomeViewModel.observeInstalledAddonsPipeline() {
     viewModelScope.launch {
-        addonRepository.getInstalledAddons()
+        var previousRefreshRevision: Long? = null
+        combine(
+            addonRepository.getInstalledAddons(),
+            addonRepository.refreshRevision
+        ) { installedAddons, refreshRevision ->
+            installedAddons to refreshRevision
+        }
             .distinctUntilChanged()
-            .collectLatest { installedAddons ->
+            .collectLatest { (installedAddons, refreshRevision) ->
                 val addons = installedAddons.enabledAddons()
                 addonsCache = addons
-                loadAllCatalogsPipeline(addons)
+                val forceReload = previousRefreshRevision?.let { it != refreshRevision } == true
+                previousRefreshRevision = refreshRevision
+                loadAllCatalogsPipeline(addons, forceReload = forceReload)
             }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1430,6 +1430,10 @@
     <string name="addon_refresh_action">Refresh Addons</string>
     <string name="addon_refresh_default_subtitle">Pull latest addon changes for current profile</string>
     <string name="addon_refresh_done_subtitle">Addons refreshed just now</string>
+    <string name="addon_refresh_in_progress_subtitle">Refreshing profile and addon manifests…</string>
+    <string name="addon_refresh_failed_subtitle">Refresh failed. Existing addons were kept.</string>
+    <string name="addon_refresh_conflict_subtitle">Addons changed during refresh. Run refresh again.</string>
+    <string name="addon_refresh_partial_subtitle">Profile refreshed, but %1$d addon manifests could not be updated.</string>
     <string name="addon_pending_collections_updated">Collections updated</string>
     <string name="addon_pending_collections_replace">%1$d collection(s) will replace current collections</string>
     <string name="addon_confirm_total_addons">Total addons: %1$d</string>

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonRepositoryRefreshTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonRepositoryRefreshTest.kt
@@ -1,0 +1,187 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.nuvio.tv.core.auth.AuthManager
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.core.sync.AddonRefreshConflictException
+import com.nuvio.tv.core.sync.AddonSyncService
+import com.nuvio.tv.core.sync.RemoteAddonEntry
+import com.nuvio.tv.core.sync.RemoteAddonSnapshot
+import com.nuvio.tv.data.local.AddonPreferences
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.AddonManifestDto
+import com.nuvio.tv.domain.model.AuthState
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.fail
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+class AddonRepositoryRefreshTest {
+
+    private val api = mockk<AddonApi>()
+    private val preferences = mockk<AddonPreferences>()
+    private val addonSyncService = mockk<AddonSyncService>()
+    private val authManager = mockk<AuthManager>()
+    private val context = mockk<Context>(relaxed = true)
+    private val sharedPreferences = mockk<SharedPreferences>(relaxed = true)
+
+    private lateinit var repository: AddonRepositoryImpl
+
+    @Before
+    fun setUp() {
+        every { context.getSharedPreferences(any(), any()) } returns sharedPreferences
+        every { sharedPreferences.contains(any()) } returns false
+        every { sharedPreferences.getString(any(), any()) } returns null
+        every { authManager.isAuthenticated } returns false
+        every { authManager.authState } returns MutableStateFlow(AuthState.SignedOut)
+        repository = AddonRepositoryImpl(
+            api = api,
+            preferences = preferences,
+            addonSyncService = addonSyncService,
+            authManager = authManager,
+            context = context
+        )
+    }
+
+    @Test
+    fun `successful empty remote snapshot clears the explicit profile`() = runTest {
+        coEvery { preferences.getInstalledAddonUrls(1) } returns listOf(TEST_URL)
+        coJustRun {
+            preferences.replaceFromRemote(
+                profileId = 1,
+                orderedUrls = emptyList(),
+                names = emptyMap(),
+                enabledStates = emptyMap()
+            )
+        }
+
+        val summary = repository.applyRemoteAddonSnapshot(
+            RemoteAddonSnapshot(profileId = 1, addons = emptyList())
+        )
+
+        assertEquals(0, summary.addonCount)
+        assertTrue(summary.completedFully)
+        assertEquals(1L, repository.refreshRevision.value)
+        coVerify(exactly = 1) {
+            preferences.replaceFromRemote(
+                profileId = 1,
+                orderedUrls = emptyList(),
+                names = emptyMap(),
+                enabledStates = emptyMap()
+            )
+        }
+        coVerify(exactly = 0) { api.getManifest(any()) }
+    }
+
+    @Test
+    fun `manual refresh fetches an unchanged addon URL again`() = runTest {
+        coEvery { preferences.getInstalledAddonUrls(1) } returns listOf(TEST_URL)
+        coJustRun {
+            preferences.replaceFromRemote(
+                profileId = 1,
+                orderedUrls = listOf(TEST_URL),
+                names = emptyMap(),
+                enabledStates = mapOf(TEST_URL to true)
+            )
+        }
+        coEvery { api.getManifest(any()) } returnsMany listOf(
+            Response.success(manifest(name = "Old name")),
+            Response.success(manifest(name = "New name"))
+        )
+
+        assertTrue(repository.fetchAddon(TEST_URL) is NetworkResult.Success)
+        val summary = repository.applyRemoteAddonSnapshot(
+            RemoteAddonSnapshot(
+                profileId = 1,
+                addons = listOf(RemoteAddonEntry(TEST_URL, null, enabled = true))
+            )
+        )
+
+        assertEquals(1, summary.refreshedManifestCount)
+        assertEquals(0, summary.failedManifestCount)
+        assertEquals(1L, repository.refreshRevision.value)
+        coVerify(exactly = 2) { api.getManifest("$TEST_URL/manifest.json") }
+    }
+
+    @Test
+    fun `manifest failure reports partial refresh after applying cloud snapshot`() = runTest {
+        coEvery { preferences.getInstalledAddonUrls(2) } returns emptyList()
+        coJustRun {
+            preferences.replaceFromRemote(
+                profileId = 2,
+                orderedUrls = listOf(TEST_URL),
+                names = mapOf(TEST_URL to "Custom"),
+                enabledStates = mapOf(TEST_URL to true)
+            )
+        }
+        coEvery { api.getManifest(any()) } throws IllegalStateException("offline")
+
+        val summary = repository.applyRemoteAddonSnapshot(
+            RemoteAddonSnapshot(
+                profileId = 2,
+                addons = listOf(RemoteAddonEntry(TEST_URL, "Custom", enabled = true))
+            )
+        )
+
+        assertEquals(1, summary.addonCount)
+        assertEquals(0, summary.refreshedManifestCount)
+        assertEquals(1, summary.failedManifestCount)
+        assertFalse(summary.completedFully)
+        assertEquals(1L, repository.refreshRevision.value)
+        coVerify(exactly = 1) {
+            preferences.replaceFromRemote(
+                profileId = 2,
+                orderedUrls = listOf(TEST_URL),
+                names = mapOf(TEST_URL to "Custom"),
+                enabledStates = mapOf(TEST_URL to true)
+            )
+        }
+    }
+
+    @Test
+    fun `newer local mutation is not overwritten by an in flight refresh`() = runTest {
+        val expectedRevision = repository.currentLocalMutationRevision()
+        coJustRun { preferences.addAddon(TEST_URL) }
+        repository.addAddon(TEST_URL)
+
+        try {
+            repository.applyRemoteAddonSnapshot(
+                snapshot = RemoteAddonSnapshot(profileId = 1, addons = emptyList()),
+                expectedLocalMutationRevision = expectedRevision
+            )
+            fail("Expected AddonRefreshConflictException")
+        } catch (_: AddonRefreshConflictException) {
+            // Expected: the remote snapshot must not replace the newer local edit.
+        }
+
+        coVerify(exactly = 0) {
+            preferences.replaceFromRemote(
+                profileId = any(),
+                orderedUrls = any(),
+                names = any(),
+                enabledStates = any()
+            )
+        }
+    }
+
+    private fun manifest(name: String) = AddonManifestDto(
+        id = "com.example.addon",
+        name = name,
+        version = "1.0.0"
+    )
+
+    private companion object {
+        const val TEST_URL = "https://example.com/addon"
+    }
+}


### PR DESCRIPTION
## Summary

Refresh Addons now performs one complete synchronization operation and reports the result only after profile data, manifests, and Home invalidation have been processed.

**Refresh Addons now:**

* Waits for the actual result before reporting success.
* Prevents simultaneous refresh requests.
* Captures the effective profile, including inherited primary addons.
* Atomically updates URLs, names, order, and enabled states.
* Distinguishes a successful empty profile from a network failure.
* Force fetches enabled addon manifests, including unchanged URLs.
* Limits manifest work to six concurrent requests and 30 seconds total.
* Reports partial failures instead of falsely claiming success.
* Forces Home catalogs to reload after refresh.
* Flushes local addon changes made while synchronization was running.
* Refresh now continues even if you leave the Addons screen.
* Repeated refresh requests share one running operation.
* Startup, realtime, and manual addon pulls are serialized.
* Disk manifest cache finishes loading before refreshed manifests are applied.
* The effective profile is captured consistently.
* Local addon edits made during a cloud request cannot be overwritten.
* Pending local cloud pushes now flush after startup, realtime, manual, and account pulls.
* Existing startup synchronization behavior remains scoped as before.
* Home catalogs reload even when the refreshed manifest compares equal.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The existing Refresh Addons action started synchronization but did not wait for its result. It could report success while cloud work was still running, apply only addon URLs instead of the complete remote profile state, and conflate a failed request with a successful empty profile.

Startup, realtime, account, and manual pulls could run independently. That allowed an older cloud response to overwrite a newer local addon edit or leave a pending local push unflushed. Manifest refreshes also relied on normal cache behavior, so unchanged URLs and same version manifests could remain stale, and Home could skip its reload when the resulting addon list compared equal.

This restores the intended behavior of the existing action. A refresh now has one service owned lifecycle, one captured effective profile, conflict protection for local edits, bounded manifest work, accurate result states, and explicit Home invalidation.

## Issue or approval

Fixes #2738.

Addresses the existing Refresh Addons expectations in #575 and the manual same URL manifest refresh case in #2466. It also resolves the stale remote addon name behavior reported in #892 and #396.

## Reproduction steps

1. Sign in with Nuvio Sync.
2. Change an addon URL, name, order, enabled state, or manifest content remotely.
3. Open Addons and select **Refresh Addons**.
4. Leave the Addons screen while the request is running, or trigger another synchronization path.
5. Return to Addons and Home.
6. Before this fix, success could appear before completion, profile fields or manifests could remain stale, and Home could retain old catalogs.
7. With this fix, the running refresh is shared and survives navigation, the complete effective profile is applied, enabled manifests are fetched again, and Home reloads after the result.

To reproduce the failure path, make the Nuvio Sync request unavailable and select **Refresh Addons**. Before this fix, failure could be indistinguishable from an empty profile or silent success. After this fix, existing addon state is preserved and the failure is reported.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The existing Refresh Addons row is disabled while work is active and its subtitle now reports running, complete, partial, conflict, or failed results. No layout or navigation is changed.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR changes only the existing addon synchronization and manual refresh path. It does not add scheduled refresh, change addon catalog TTL rules, change VPN or backend reachability, alter startup synchronization scope, or bundle Mobile parity. Mobile parity is implemented separately in NuvioMedia/NuvioMobile#1613.

The repository contract and disk cache ordering are aligned with #2734 so the changes can be rebased cleanly regardless of merge order.

## Testing

* Added repository tests for complete remote snapshot application, successful empty profiles, manifest failure summaries, and protection against newer local mutations.
* Passed focused Full Debug unit tests for `AddonRepositoryRefreshTest`, `AddonManagementAccessTest`, and `HomeCatalogSyncSupportTest`.
* Passed Full Debug Kotlin compilation.
* Passed Full Debug assembly and lint.
* Passed `git diff --check`.
* Installed the Full Debug ARM64 APK over the existing debug app on an NVIDIA Shield TV running Android 11.
* The repository's broader test suite still contains preexisting failures outside this refresh flow; the focused refresh tests pass.

## Screenshots / Video

No layout or design change. The existing row only displays accurate synchronization state and result text.

## Breaking changes

None.

## Linked issues

Fixes #2738.

Addresses #575, #2466, #892, and #396.

Related reports outside this PR: #1877 remains a VPN or backend reachability problem, while #2189 remains an automatic catalog TTL problem. This PR only makes network failures truthful and forces Home to reload after an explicit refresh.

Mobile parity: NuvioMedia/NuvioMobile#1613, tracked by NuvioMedia/NuvioMobile#1612.
