### PR TITLE
fix(tmdb): use AIO Metadata IMDb aliases for enrichment

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
@@ -199,36 +199,51 @@ class TmdbService @Inject constructor(
      * 
      * @param videoId The video ID (can be IMDB or TMDB format)
      * @param mediaType The media type
+     * @param fallbackImdbId An addon-provided IMDB alias for non-TMDB IDs such as MAL or Kitsu
      * @return The TMDB ID as a string, or null if conversion failed
      */
-    suspend fun ensureTmdbId(videoId: String, mediaType: String): String? {
-        // Check if it's already a TMDB ID (numeric or prefixed)
-        val cleanId = videoId
+    suspend fun ensureTmdbId(
+        videoId: String,
+        mediaType: String,
+        fallbackImdbId: String? = null
+    ): String? {
+        val normalizedType = normalizeMediaType(mediaType)
+        val candidates = listOfNotNull(videoId, fallbackImdbId)
+            .mapNotNull(::normalizeTmdbLookupCandidate)
+            .distinct()
+        var supportedCandidateSeen = false
+
+        for (candidate in candidates) {
+            if (candidate.startsWith("tt", ignoreCase = true)) {
+                supportedCandidateSeen = true
+                imdbToTmdb(candidate, normalizedType)?.let { return it.toString() }
+                continue
+            }
+
+            if (candidate.all(Char::isDigit)) {
+                return candidate
+            }
+        }
+
+        if (!supportedCandidateSeen) {
+            Log.w(TAG, "Unknown video ID format: $videoId")
+        }
+        return null
+    }
+
+    private fun normalizeTmdbLookupCandidate(rawId: String): String? {
+        val cleanId = rawId
+            .trim()
             .removePrefix("tmdb:")
             .removePrefix("movie:")
             .removePrefix("series:")
 
-        // Stremio-style series ids can look like: tt1234567:season:episode
-        // Plugins/TMDB lookup need the base external id only.
-        val idPart = cleanId
+        // Stremio-style series ids can look like: tt1234567:season:episode.
+        return cleanId
             .substringBefore(':')
             .substringBefore('/')
             .trim()
-        
-        // If it's an IMDB ID, convert it
-        if (idPart.startsWith("tt")) {
-            val tmdbId = imdbToTmdb(idPart, normalizeMediaType(mediaType))
-            return tmdbId?.toString()
-        }
-        
-        // If it looks like a numeric ID, assume it's already a TMDB ID
-        if (idPart.all { it.isDigit() }) {
-            return idPart
-        }
-        
-        // Unknown format
-        Log.w(TAG, "Unknown video ID format: $videoId")
-        return null
+            .takeIf(String::isNotBlank)
     }
     
     /**

--- a/app/src/main/java/com/nuvio/tv/data/repository/MDBListRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MDBListRepository.kt
@@ -261,6 +261,7 @@ class MDBListRepository @Inject constructor(
         fallbackItemType: String,
         mediaType: String
     ): String? {
+        meta.imdbId?.takeIf { it.startsWith("tt") }?.let { return it }
         extractImdbId(meta.id)?.let { return it }
         extractImdbId(fallbackItemId)?.let { return it }
 
@@ -275,7 +276,8 @@ class MDBListRepository @Inject constructor(
         }
 
         val lookupType = if (fallbackItemType.isNotBlank()) fallbackItemType else mediaType
-        val converted = tmdbService.ensureTmdbId(meta.id, lookupType)?.toIntOrNull()?.let { tmdbNumericId ->
+        val converted = tmdbService.ensureTmdbId(meta.id, lookupType, meta.imdbId)
+            ?.toIntOrNull()?.let { tmdbNumericId ->
             tmdbService.tmdbToImdb(tmdbNumericId, lookupType)
         }
         return converted?.takeIf { it.startsWith("tt") }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -1099,7 +1099,9 @@ class FolderDetailViewModel @Inject constructor(
 
             var enrichment: com.nuvio.tv.core.tmdb.TmdbEnrichment? = null
             if (tmdbEnabled) {
-                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                val tmdbId = runCatching {
+                    tmdbService.ensureTmdbId(item.id, item.apiType, item.imdbId)
+                }.getOrNull()
                 if (tmdbId != null) {
                     enrichment = runCatching {
                         tmdbMetadataService.fetchEnrichment(
@@ -1270,8 +1272,15 @@ class FolderDetailViewModel @Inject constructor(
         if (!trailerPreviewLoadingIds.add(itemId)) return
 
         val requestVersion = trailerPreviewRequestVersion
+        val fallbackImdbId = _uiState.value.tabs
+            .firstNotNullOfOrNull { tab ->
+                tab.catalogRow?.items?.firstOrNull { it.id == itemId }
+            }
+            ?.imdbId
         viewModelScope.launch {
-            val tmdbId = runCatching { tmdbService.ensureTmdbId(itemId, apiType) }.getOrNull()
+            val tmdbId = runCatching {
+                tmdbService.ensureTmdbId(itemId, apiType, fallbackImdbId)
+            }.getOrNull()
             val trailerSource = trailerService.getTrailerPlaybackSource(
                 title = title,
                 year = extractYear(releaseInfo),
@@ -1373,7 +1382,9 @@ class FolderDetailViewModel @Inject constructor(
             try {
                 var tmdbEnriched = false
                 if (tmdbEnabled) {
-                    val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                    val tmdbId = runCatching {
+                        tmdbService.ensureTmdbId(item.id, item.apiType, item.imdbId)
+                    }.getOrNull()
                     if (tmdbId != null) {
                         val enrichment = runCatching {
                             tmdbMetadataService.fetchEnrichment(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1065,8 +1065,8 @@ class MetaDetailsViewModel @Inject constructor(
                     val settings = tmdbSettingsDataStore.settings.first()
                     val tmdbContentType = resolveTmdbContentType(meta)
                     val tmdbLookupType = tmdbContentType.toApiString()
-                    val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
-                        ?: tmdbService.ensureTmdbId(itemId, itemType)
+                    val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType, meta.imdbId)
+                        ?: tmdbService.ensureTmdbId(itemId, itemType, meta.imdbId)
                     if (tmdbId.isNullOrBlank()) {
                         _uiState.update { it.copy(moreLikeThis = emptyList(), moreLikeThisSource = null) }
                         return@launch
@@ -1205,10 +1205,12 @@ class MetaDetailsViewModel @Inject constructor(
                 }
 
                 val tmdbLookupType = tmdbContentType.toApiString()
-                val tmdbIdString = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
-                    ?: tmdbService.ensureTmdbId(itemId, itemType)
+                val tmdbIdString = tmdbService.ensureTmdbId(meta.id, tmdbLookupType, meta.imdbId)
+                    ?: tmdbService.ensureTmdbId(itemId, itemType, meta.imdbId)
                 val tmdbId = tmdbIdString?.toIntOrNull()
-                val imdbId = extractImdbId(meta.id) ?: extractImdbId(itemId)
+                val imdbId = meta.imdbId?.takeIf { it.startsWith("tt") }
+                    ?: extractImdbId(meta.id)
+                    ?: extractImdbId(itemId)
 
                 if (tmdbId == null && imdbId == null) {
                     _uiState.update { state ->
@@ -1266,8 +1268,8 @@ class MetaDetailsViewModel @Inject constructor(
 
         val tmdbContentType = resolveTmdbContentType(meta)
         val tmdbLookupType = tmdbContentType.toApiString()
-        val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
-            ?: tmdbService.ensureTmdbId(itemId, itemType)
+        val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType, meta.imdbId)
+            ?: tmdbService.ensureTmdbId(itemId, itemType, meta.imdbId)
             ?: return meta
 
         val isSeries = meta.apiType in listOf("series", "tv")
@@ -2368,7 +2370,7 @@ class MetaDetailsViewModel @Inject constructor(
             }
 
             val tmdbId = try {
-                tmdbService.ensureTmdbId(meta.id, meta.apiType)
+                tmdbService.ensureTmdbId(meta.id, meta.apiType, meta.imdbId)
             } catch (_: Exception) {
                 null
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -88,7 +88,8 @@ internal data class CwMetaSummary(
     val imdbRating: Float?,
     val language: String?,
     val country: String?,
-    val videos: List<CwVideoSummary>
+    val videos: List<CwVideoSummary>,
+    val imdbId: String? = null
 ) {
     fun watchableEpisodes(): List<CwVideoSummary> {
         val candidates = videos.filter { it.season != null && it.episode != null && (it.season ?: 0) > 0 }
@@ -172,6 +173,7 @@ private fun Meta.toCwSummary(): CwMetaSummary = CwMetaSummary(
     genres = genres,
     releaseInfo = releaseInfo,
     imdbRating = imdbRating,
+    imdbId = imdbId,
     language = language,
     country = country,
     videos = videos.map { v ->
@@ -2904,6 +2906,7 @@ private suspend fun HomeViewModel.resolveTmdbIdForNextUp(
     val candidates = buildList {
         add(progress.contentId)
         add(meta.id)
+        meta.imdbId?.let(::add)
         add(progress.videoId)
         if (progress.contentId.startsWith("trakt:")) add(progress.contentId.substringAfter(':'))
         if (meta.id.startsWith("trakt:")) add(meta.id.substringAfter(':'))
@@ -2913,7 +2916,7 @@ private suspend fun HomeViewModel.resolveTmdbIdForNextUp(
         .distinct()
 
     for (candidate in candidates) {
-        tmdbService.ensureTmdbId(candidate, progress.contentType)?.let {
+        tmdbService.ensureTmdbId(candidate, progress.contentType, meta.imdbId)?.let {
             synchronized(cwTmdbIdCache) {
                 cwTmdbIdCache[cacheKey] = it
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -335,7 +335,8 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(item: MetaPreview) {
         title = item.name,
         releaseInfo = item.releaseInfo,
         apiType = item.apiType,
-        fallbackYtId = item.trailerYtIds.firstOrNull()
+        fallbackYtId = item.trailerYtIds.firstOrNull(),
+        fallbackImdbId = item.imdbId
     )
 }
 
@@ -344,7 +345,8 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
     title: String,
     releaseInfo: String?,
     apiType: String,
-    fallbackYtId: String? = null
+    fallbackYtId: String? = null,
+    fallbackImdbId: String? = null
 ) {
     if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled) return
     if (startupGracePeriodActive) return
@@ -372,7 +374,7 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
             }
 
             val tmdbId = try {
-                tmdbService.ensureTmdbId(itemId, apiType)
+                tmdbService.ensureTmdbId(itemId, apiType, fallbackImdbId)
             } catch (_: Exception) {
                 null
             }
@@ -485,7 +487,9 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
             var tmdbEnriched = false
 
             if (tmdbEnabledForCurrentLayout) {
-                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                val tmdbId = runCatching {
+                    tmdbService.ensureTmdbId(item.id, item.apiType, item.imdbId)
+                }.getOrNull()
 
                 val enrichmentDeferred = if (tmdbId != null) async {
                     runCatching {
@@ -578,7 +582,9 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
         try {
             var tmdbEnriched = false
             if (tmdbEnabledForCurrentLayout) {
-                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                val tmdbId = runCatching {
+                    tmdbService.ensureTmdbId(item.id, item.apiType, item.imdbId)
+                }.getOrNull()
                 val enrichment = if (tmdbId != null) runCatching {
                     tmdbMetadataService.fetchEnrichment(
                         tmdbId = tmdbId,
@@ -833,7 +839,8 @@ internal suspend fun HomeViewModel.enrichHeroItemsPipeline(
             async(Dispatchers.IO) {
                 try {
                     val tmdbDeferred = async {
-                        val tmdbId = tmdbService.ensureTmdbId(item.id, item.apiType) ?: return@async null
+                        val tmdbId = tmdbService.ensureTmdbId(item.id, item.apiType, item.imdbId)
+                            ?: return@async null
                         tmdbId.toIntOrNull()?.let { numericId ->
                             runCatching { tmdbService.tmdbToImdb(numericId, item.apiType) }
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -184,6 +184,7 @@ class PlayerRuntimeController(
     internal var currentAddonLogo: String? = navigationArgs.addonLogo
     internal var currentStreamDescription: String? = navigationArgs.streamDescription
     internal var contentLanguage: String? = navigationArgs.contentLanguage
+    internal var metaImdbId: String? = null
     internal var currentVideoCodec: String? = null
     internal var currentVideoWidth: Int? = null
     internal var currentVideoHeight: Int? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -23,6 +23,9 @@ internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?
         ) {
             is NetworkResult.Success -> {
                 applyMetaDetails(result.data)
+                if (!result.data.imdbId.isNullOrBlank()) {
+                    enrichDescriptionFromTmdb(id, type, result.data.imdbId)
+                }
             }
             is NetworkResult.Error -> {
             }
@@ -37,6 +40,7 @@ internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?
 }
 
 internal fun PlayerRuntimeController.applyMetaDetails(meta: Meta) {
+    metaImdbId = meta.imdbId
     metaVideos = meta.videos
     metaGenres = meta.genres
     metaCountry = meta.country
@@ -81,16 +85,22 @@ internal fun PlayerRuntimeController.updateEpisodeDescription() {
 
     // Re-enrich from TMDB for the new episode.
     scope.launch {
-        enrichDescriptionFromTmdb(contentId, contentType)
+        enrichDescriptionFromTmdb(contentId, contentType, metaImdbId)
     }
 }
 
-private suspend fun PlayerRuntimeController.enrichDescriptionFromTmdb(id: String?, type: String?) {
+private suspend fun PlayerRuntimeController.enrichDescriptionFromTmdb(
+    id: String?,
+    type: String?,
+    fallbackImdbId: String? = null
+) {
     if (id.isNullOrBlank() || type.isNullOrBlank()) return
     val settings = tmdbSettingsDataStore.settings.first()
     if (!settings.enabled || !settings.useBasicInfo) return
 
-    val tmdbId = runCatching { tmdbService.ensureTmdbId(id, type) }.getOrNull() ?: return
+    val tmdbId = runCatching {
+        tmdbService.ensureTmdbId(id, type, fallbackImdbId)
+    }.getOrNull() ?: return
     val contentType = when (type.lowercase()) {
         "series", "tv" -> ContentType.SERIES
         else -> ContentType.MOVIE

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbServiceTest.kt
@@ -1,0 +1,104 @@
+package com.nuvio.tv.core.tmdb
+
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TmdbFindResponse
+import com.nuvio.tv.data.remote.api.TmdbFindResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import retrofit2.Response
+
+class TmdbServiceTest {
+
+    @Test
+    fun `anime id uses addon imdb id for tmdb lookup`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery {
+            api.findByExternalId(
+                externalId = "tt28254942",
+                apiKey = any(),
+                externalSource = "imdb_id"
+            )
+        } returns Response.success(
+            TmdbFindResponse(tvResults = listOf(TmdbFindResult(id = 228234)))
+        )
+
+        val service = TmdbService(api)
+
+        assertEquals(
+            "228234",
+            service.ensureTmdbId(
+                videoId = "mal:49894",
+                mediaType = "series",
+                fallbackImdbId = "tt28254942"
+            )
+        )
+        coVerify(exactly = 1) {
+            api.findByExternalId("tt28254942", any(), "imdb_id")
+        }
+    }
+
+    @Test
+    fun `numeric tmdb id takes precedence over fallback imdb id`() = runTest {
+        val api = mockk<TmdbApi>()
+        val service = TmdbService(api)
+
+        assertEquals(
+            "228234",
+            service.ensureTmdbId(
+                videoId = "tmdb:228234",
+                mediaType = "series",
+                fallbackImdbId = "tt28254942"
+            )
+        )
+        coVerify(exactly = 0) {
+            api.findByExternalId(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `primary imdb id remains authoritative over fallback imdb id`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery {
+            api.findByExternalId(
+                externalId = "tt0133093",
+                apiKey = any(),
+                externalSource = "imdb_id"
+            )
+        } returns Response.success(
+            TmdbFindResponse(movieResults = listOf(TmdbFindResult(id = 603)))
+        )
+
+        val service = TmdbService(api)
+
+        assertEquals(
+            "603",
+            service.ensureTmdbId(
+                videoId = "tt0133093",
+                mediaType = "movie",
+                fallbackImdbId = "tt28254942"
+            )
+        )
+        coVerify(exactly = 1) {
+            api.findByExternalId("tt0133093", any(), "imdb_id")
+        }
+        coVerify(exactly = 0) {
+            api.findByExternalId("tt28254942", any(), "imdb_id")
+        }
+    }
+
+    @Test
+    fun `unsupported id without imdb fallback remains unresolved`() = runTest {
+        val api = mockk<TmdbApi>()
+        val service = TmdbService(api)
+
+        assertNull(service.ensureTmdbId("mal:51097", "series"))
+        coVerify(exactly = 0) {
+            api.findByExternalId(any(), any(), any())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a guarded compatibility fallback for addon metadata that includes a custom `imdb_id` field.

AIO Metadata can use a MAL or Kitsu ID as the primary content ID while also returning an IMDb alias through this nonstandard field. Nuvio already parses that alias, but its TMDB lookup paths previously ignored it and attempted to resolve only the unsupported `mal:` or `kitsu:` ID.

When the custom alias is present, Nuvio now uses it for existing TMDB, trailer, MDBList, Home, Continue Watching, collection, details, and player metadata lookups. The original addon content ID remains unchanged.

This is not a universal MAL or Kitsu mapping solution. The official Stremio addon SDK does not define `imdb_id` on a meta object, so spec compliant addons that provide only a MAL or Kitsu ID remain on the existing unsupported path. Addons without the custom alias are unaffected.

The release date behavior from #2641 is unchanged. Precise addon timestamps remain authoritative while TMDB release dates are disabled. Users who enable TMDB release dates retain the existing midnight UTC parsing, availability filtering, and cache invalidation behavior.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

AIO Metadata already supplied the IMDb identifier required by TMDB, and Nuvio already accepted it in `MetaDto`, but the identifier was discarded before enrichment. The lookup then received the MAL or Kitsu primary ID, logged it as unsupported, and returned no enrichment despite having a usable alias in the same response.

The fallback is deliberately conditional. Existing IMDb and numeric TMDB primary IDs remain authoritative. The custom alias is consulted only when the primary ID cannot be resolved directly, and no new external mapping service or addon assumption is introduced.

## Issue or approval

Fixes #2742

## Reproduction steps

1. Enable TMDB enrichment.
2. Open an AIO Metadata anime whose primary content ID is MAL or Kitsu and whose meta response includes the custom `imdb_id` alias.
3. Inspect details, Home presentation, Continue Watching, trailers, collections, or player metadata.
4. Before this fix, Nuvio attempts to resolve the MAL or Kitsu ID and enrichment remains missing.
5. After this fix, Nuvio uses the available IMDb alias for enrichment while preserving the original addon content ID.
6. Repeat with metadata that does not contain `imdb_id`. Existing behavior remains unchanged.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- This is compatibility behavior for AIO Metadata and any other addon that exposes the same custom `imdb_id` field.
- It does not claim or implement general MAL or Kitsu to IMDb or TMDB resolution.
- The official Stremio meta contract is unchanged and no custom field is required.
- Addons without an IMDb alias continue through their existing lookup paths.
- Addon primary IDs are never replaced.
- Existing IMDb and numeric TMDB IDs remain authoritative.
- Metadata precedence, release date selection, episode availability, settings, UI, stream resolution, and external player behavior are unchanged.
- No additional API or mapping dependency is introduced.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.core.tmdb.TmdbServiceTest" --tests "com.nuvio.tv.core.tmdb.EpisodeReleaseDateParserTest"`
- `./gradlew :app:assembleFullDebug`
- Installed the full debug build on an NVIDIA Shield TV 2019 running Android 11.
- Verified AIO Metadata content with a MAL primary ID and custom IMDb alias resolves through IMDb to TMDB.
- Verified existing IMDb and numeric TMDB IDs remain authoritative.
- Verified unsupported IDs without an IMDb alias remain unresolved.
- Verified the original MAL or Kitsu content ID is preserved.
- Verified the #2641 release date parser tests still pass.

The broader full debug unit test task still contains an unrelated date sensitive Continue Watching assertion that hard codes July 12, 2026 and now evaluates against the current date. The focused TMDB and release date compatibility tests pass.

## Screenshots / Video

No UI layout change. These screenshots show the metadata behavior before and after the compatibility fallback.

### Before

<img width="3840" height="2160" alt="BeforeAndroidTV" src="https://github.com/user-attachments/assets/745b9e75-0b3b-4028-9b19-4fc97a3929a3" />

### After

<img width="2688" height="1512" alt="AfterAndroidTV" src="https://github.com/user-attachments/assets/0ed644c4-e90f-4e5c-a41a-455901e47bf3" />

## Breaking changes

None.

## Linked issues

Fixes #2742

Related release date behavior: #2641

Mobile parity: NuvioMedia/NuvioMobile#1614, NuvioMedia/NuvioMobile#1615
