### PR TITLE
fix(player): prevent unexpected auto resume on transient lifecycle events when pause

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1137,6 +1137,9 @@ internal fun PlayerRuntimeController.initializePlayer(
                             tryShowParentalGuide()
                             emitScrobbleStart()
                         } else {
+                            if (!isInBackground) {
+                                userPausedManually = true
+                            }
                             if (userPausedManually) schedulePauseOverlay() else cancelPauseOverlay()
                             if (playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE) {
                                 stopProgressUpdates()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -271,7 +271,7 @@ internal fun PlayerRuntimeController.resumeForLifecycle() {
         }
     }
 
-    val shouldAutoResume = (wasPendingPause || (wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle)) && !userPausedManually
+    val shouldAutoResume = wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle && !userPausedManually
     wasPlayingBeforeLifecyclePause = false
     wasStoppedByLifecycle = false
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerLifecycleDebounceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerLifecycleDebounceTest.kt
@@ -16,7 +16,7 @@ class PlayerLifecycleDebounceTest {
     private val testScope = TestScope(testDispatcher)
 
     @Test
-    fun `transient pause within 400ms cancels pause job and should auto resume`() = testScope.runTest {
+    fun `transient pause within 400ms cancels pause job and should auto resume if playing`() = testScope.runTest {
         var wasPlayingBeforeLifecyclePause = false
         var wasStoppedByLifecycle = false
         var isInBackground = false
@@ -35,13 +35,36 @@ class PlayerLifecycleDebounceTest {
         testScheduler.advanceTimeBy(50L)
 
         // Simulate resumeForLifecycle
-        val wasPendingPause = isPendingPause
         isPendingPause = false // Job cancelled
 
-        val shouldAutoResume = (wasPendingPause || (wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle)) && !userPausedManually
+        val shouldAutoResume = wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle && !userPausedManually
 
-        assertTrue("Should auto resume after transient <400ms pause", shouldAutoResume)
+        assertTrue("Should auto resume after transient <400ms pause if playing", shouldAutoResume)
         assertFalse("App should not be marked as in background", isInBackground)
+    }
+
+    @Test
+    fun `transient pause within 400ms does NOT auto resume if already paused`() = testScope.runTest {
+        var wasPlayingBeforeLifecyclePause = false
+        var wasStoppedByLifecycle = false
+        var userPausedManually = false
+        var isPlaying = false
+
+        // Simulate pauseForLifecycle when player was already paused
+        val currentlyPlaying = isPlaying
+        if (currentlyPlaying && !userPausedManually) {
+            wasPlayingBeforeLifecyclePause = true
+        }
+
+        var isPendingPause = true
+
+        // Simulate ON_RESUME firing 50ms later
+        testScheduler.advanceTimeBy(50L)
+        isPendingPause = false
+
+        val shouldAutoResume = wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle && !userPausedManually
+
+        assertFalse("Should NOT auto resume after transient pause if already paused", shouldAutoResume)
     }
 
     @Test
@@ -69,8 +92,7 @@ class PlayerLifecycleDebounceTest {
         isPlaying = false
 
         // Simulate ON_RESUME firing later
-        val wasPendingPause = isPendingPause // false, already executed
-        val shouldAutoResume = (wasPendingPause || (wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle)) && !userPausedManually
+        val shouldAutoResume = wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle && !userPausedManually
 
         assertTrue("Should auto resume when returning from non-stopped overlay pause", shouldAutoResume)
         assertTrue("App was in background before resume", isInBackground)
@@ -91,8 +113,7 @@ class PlayerLifecycleDebounceTest {
         isPlaying = false
 
         // Simulate ON_RESUME when user re-opens app from Home screen
-        val wasPendingPause = false
-        val shouldAutoResume = (wasPendingPause || (wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle)) && !userPausedManually
+        val shouldAutoResume = wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle && !userPausedManually
 
         assertFalse("Should NOT auto resume when returning from ON_STOP home screen exit", shouldAutoResume)
     }
@@ -103,8 +124,7 @@ class PlayerLifecycleDebounceTest {
         var wasStoppedByLifecycle = false
         var userPausedManually = true
 
-        val wasPendingPause = true
-        val shouldAutoResume = (wasPendingPause || (wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle)) && !userPausedManually
+        val shouldAutoResume = wasPlayingBeforeLifecyclePause && !wasStoppedByLifecycle && !userPausedManually
 
         assertFalse("Should NOT auto resume when user paused manually", shouldAutoResume)
     }


### PR DESCRIPTION
## Summary

Fixes an unexpected playback auto-resume regression where pausing video caused it to automatically start playing again shortly after. This regression was introduced by PR #2718 (`6997f2b897`) which added debounced lifecycle auto-resume handling. The fix ensures `shouldAutoResume` ONLY triggers if playback was actively playing (`wasPlayingBeforeLifecyclePause`) prior to the lifecycle pause event, and sets `userPausedManually = true` when paused in the foreground.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

PR #2718 introduced debounced lifecycle pause/resume (`pendingLifecyclePauseJob`) to prevent MediaSession teardown during transient focus loss. However, `resumeForLifecycle()` evaluated `wasPendingPause` as an unconditional trigger for `shouldAutoResume`, causing paused videos to auto-resume whenever transient Android TV system lifecycle events occurred (such as TV recommendation updates or focus shifts).

## Issue or approval

#2718 (Fixes regression introduced in #2718)

## Reproduction steps

1. Play any video stream in Nuvio TV.
2. Pause playback via remote control or UI controls.
3. Wait for a background/transient system lifecycle event (e.g. recommendation update, focus shift, or overlay flash).
4. **Observed Behavior (before fix):** The player automatically resumes playback without user input.
5. **Expected Behavior:** The player remains paused.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited only to fixing the lifecycle auto-resume logic in `PlayerRuntimeControllerMpv.kt` and `PlayerRuntimeControllerInitialization.kt`. No UI elements or player controls were modified.

## Testing

- Executed unit test suite `PlayerLifecycleDebounceTest` covering transient pause/resume, already-paused transient events, and manual user pause handling (`.\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.PlayerLifecycleDebounceTest"`). All tests passed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

#2718
