### PR TITLE
fix(stream): keep scroll position per provider

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -61,6 +61,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -701,6 +703,8 @@ private fun RightStreamSection(
     var listHasFocus by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    val listStates = remember { mutableMapOf<String?, LazyListState>() }
+    val listState = listStates.getOrPut(selectedAddonFilter) { LazyListState() }
     val orderedAddonNames = remember(availableAddons, sourceChips) {
         buildList {
             addAll(availableAddons)
@@ -806,7 +810,8 @@ private fun RightStreamSection(
                             onAddonFilterSelected = { onAddonFilterSelectedGuarded(it) },
                             chipFocusRequesters = chipFocusRequesters,
                             orderedAddonNames = orderedAddonNames,
-                            onFocusChanged = { listHasFocus = it }
+                            onFocusChanged = { listHasFocus = it },
+                            listState = listState
                         )
                     }
                 }
@@ -1018,7 +1023,8 @@ private fun StreamsList(
     onAddonFilterSelected: (String?) -> Unit = {},
     chipFocusRequesters: List<FocusRequester> = emptyList(),
     orderedAddonNames: List<String> = emptyList(),
-    onFocusChanged: (Boolean) -> Unit = {}
+    onFocusChanged: (Boolean) -> Unit = {},
+    listState: LazyListState = rememberLazyListState()
 ) {
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val firstCardFocusRequester = remember { FocusRequester() }
@@ -1053,6 +1059,7 @@ private fun StreamsList(
     }
 
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxSize()
             .padding(NuvioTheme.spacing.lg)


### PR DESCRIPTION
## Summary

Each provider tab keeps its own scroll position now. `RightStreamSection` passes `StreamsList` a `LazyListState` keyed on `selectedAddonFilter`, instead of the list quietly making one for itself.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

All the provider tabs on the Sources screen share one scroll position, so switching tabs drops you at the last tab's offset instead of that provider's own. Full write-up and videos in #2538.

## Issue or approval

Fixes #2538

## Reproduction steps

1. Open a title with two providers installed and go to the Sources screen.
2. On the first provider's tab, scroll the list down to the bottom.
3. Switch to the second provider's tab.
4. The second provider's list opens scrolled to the position from the first tab.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Just the LazyListState ownership. Didn't touch ordering, filtering, the chips, or focus handling, and no styling moved. `StreamsList` still defaults to `rememberLazyListState()` so nothing else calling it notices.

## Testing

TCL C805 (G08_4K_GB), Android 14. 0.7.14-beta release APK, internal player, built on top of dev@7d735089.

Used two demo addons that just return numbered placeholder streams so the offset is obvious, 12 in Demo Alpha and 8 in Demo Beta. Scrolled Alpha down to 12, tabbed over to Beta, Beta came up at its own first stream. Went back to Alpha, still on 12. Did the same on a few other titles and provider combos and got the same thing every time. Focus order on the tabs and on the list is unchanged, and I didn't get stuck anywhere with the d-pad.

## Screenshots / Video

Before and after clips are both on #2538, recorded on the TCL.

## Breaking changes

None

## Linked issues

Fixes #2538
