### PR TITLE
fix(search): keep Fire TV keyboard open and match shimmer depth

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/SearchSkeletonRow.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/SearchSkeletonRow.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -13,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.nuvio.tv.domain.model.CardDepthSurface
 import com.nuvio.tv.ui.theme.NuvioTheme
 
 private val SKELETON_TITLE_WIDTH = 180.dp
@@ -37,6 +39,8 @@ fun SearchSkeletonRow(
     modifier: Modifier = Modifier
 ) {
     val shimmerOffsetState = rememberPlaceholderShimmerOffsetState(label = "searchSkeletonShimmer")
+    val cardDepthStyle = LocalCardDepthStyle.current
+    val cardShape = RoundedCornerShape(posterCardStyle.cornerRadius)
 
     Column(modifier = modifier) {
         Column(
@@ -70,12 +74,22 @@ fun SearchSkeletonRow(
                     modifier = Modifier
                         .width(posterCardStyle.width)
                         .height(posterCardStyle.height)
-                        .clip(RoundedCornerShape(posterCardStyle.cornerRadius))
-                        .placeholderCardShimmer(
-                            shimmerOffsetState = shimmerOffsetState,
-                            backgroundColor = NuvioTheme.colors.SurfaceVariant
+                        .clip(cardShape)
+                        .nuvioCardDepth(
+                            shape = cardShape,
+                            surface = CardDepthSurface.POSTERS,
+                            style = cardDepthStyle
                         )
-                )
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .placeholderCardShimmer(
+                                shimmerOffsetState = shimmerOffsetState,
+                                backgroundColor = NuvioTheme.colors.SurfaceVariant
+                            )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -158,7 +158,8 @@ fun SearchScreen(
             pendingFocusMoveToResultsQuery = recognized
             pendingFocusMoveSawSearching = false
             pendingFocusMoveHadExistingSearchRows =
-                uiState.submittedQuery.trim().length >= 2 && uiState.catalogRows.any { it.items.isNotEmpty() }
+                uiState.submittedQuery.trim().length >= MIN_SEARCH_QUERY_LENGTH &&
+                    uiState.catalogRows.any { it.items.isNotEmpty() }
         } else {
             Toast.makeText(context, strVoiceNoSpeech, Toast.LENGTH_SHORT).show()
         }
@@ -320,14 +321,20 @@ fun SearchScreen(
         searchRowFocusedItemIndex.keys.retainAll(visibleRowKeys)
     }
 
-    val isDiscoverMode = remember(uiState.discoverLocation, trimmedSubmittedQuery) {
-        uiState.discoverLocation == DiscoverLocation.IN_SEARCH && trimmedSubmittedQuery.isEmpty()
+    val isDiscoverMode = remember(uiState.discoverLocation, trimmedQuery, trimmedSubmittedQuery) {
+        shouldShowDiscoverInSearch(
+            discoverLocation = uiState.discoverLocation,
+            query = trimmedQuery,
+            submittedQuery = trimmedSubmittedQuery
+        )
     }
     LaunchedEffect(isDiscoverMode) {
         if (isDiscoverMode) viewModel.ensureDiscoverLoaded()
     }
     val hasPendingUnsubmittedQuery = remember(isDiscoverMode, trimmedQuery, trimmedSubmittedQuery) {
-        !isDiscoverMode && trimmedQuery.length >= 2 && trimmedQuery != trimmedSubmittedQuery
+        !isDiscoverMode &&
+            trimmedQuery.length >= MIN_SEARCH_QUERY_LENGTH &&
+            trimmedQuery != trimmedSubmittedQuery
     }
     val showRecentSearches = remember(
         trimmedQuery,
@@ -342,16 +349,22 @@ fun SearchScreen(
         trimmedSubmittedQuery,
         uiState.catalogRows
     ) {
-        if (isDiscoverMode) false else trimmedSubmittedQuery.length >= 2 && uiState.catalogRows.any { it.items.isNotEmpty() }
+        if (isDiscoverMode) {
+            false
+        } else {
+            trimmedSubmittedQuery.length >= MIN_SEARCH_QUERY_LENGTH &&
+                uiState.catalogRows.any { it.items.isNotEmpty() }
+        }
     }
     val submitCurrentQuery: (String) -> Unit = { submittedQuery ->
         viewModel.onEvent(SearchEvent.SubmitSearch)
         focusResults = false
-        if (submittedQuery.length >= 2) {
+        if (submittedQuery.length >= MIN_SEARCH_QUERY_LENGTH) {
             pendingFocusMoveToResultsQuery = submittedQuery
             pendingFocusMoveSawSearching = false
             pendingFocusMoveHadExistingSearchRows =
-                trimmedSubmittedQuery.length >= 2 && uiState.catalogRows.any { row -> row.items.isNotEmpty() }
+                trimmedSubmittedQuery.length >= MIN_SEARCH_QUERY_LENGTH &&
+                    uiState.catalogRows.any { row -> row.items.isNotEmpty() }
         } else {
             pendingFocusMoveToResultsQuery = null
             pendingFocusMoveSawSearching = false
@@ -361,7 +374,7 @@ fun SearchScreen(
     val handleQueryChanged: (String) -> Unit = { nextQuery ->
         val previousQuery = uiState.query.trim()
         val trimmedNextQuery = nextQuery.trim()
-        val selectedSuggestion = trimmedNextQuery.length >= 2 &&
+        val selectedSuggestion = trimmedNextQuery.length >= MIN_SEARCH_QUERY_LENGTH &&
             trimmedNextQuery != trimmedSubmittedQuery &&
             uiState.suggestions.any { it.equals(trimmedNextQuery, ignoreCase = true) } &&
             trimmedNextQuery.startsWith(previousQuery, ignoreCase = true) &&
@@ -491,12 +504,20 @@ fun SearchScreen(
             .fillMaxSize(),
         contentAlignment = Alignment.TopCenter
     ) {
-        if (isDiscoverMode) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = 10.dp)
-            ) {
+        val listState = rememberLazyListState()
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .recompositionHighlighter()
+                .dpadRepeatThrottle(),
+            state = listState,
+            contentPadding = PaddingValues(
+                top = if (isDiscoverMode) 10.dp else NuvioTheme.spacing.lg,
+                bottom = NuvioTheme.spacing.lg
+            ),
+            verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg)
+        ) {
+            item(key = "search_input") {
                 SearchInputField(
                     query = uiState.query,
                     canMoveToResults = canMoveToResults,
@@ -518,27 +539,24 @@ fun SearchScreen(
                     clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null,
                     isScreenActive = isScreenActive
                 )
+            }
 
-                Spacer(modifier = Modifier.height(NuvioTheme.spacing.md))
-
+            if (isDiscoverMode) {
                 if (showRecentSearches) {
-                    RecentSearchesSection(
-                        recentSearches = uiState.recentSearches,
-                        onSearchSelected = submitRecentSearch,
-                        onClearHistory = {
-                            viewModel.onEvent(SearchEvent.ClearRecentSearches)
-                        },
-                        onSectionFocusChanged = { focused -> isRecentSearchSectionFocused = focused },
-                        clearHistoryFocusRequester = recentClearHistoryFocusRequester,
-                        modifier = Modifier.padding(horizontal = 52.dp)
-                    )
+                    item(key = "recent_searches") {
+                        RecentSearchesSection(
+                            recentSearches = uiState.recentSearches,
+                            onSearchSelected = submitRecentSearch,
+                            onClearHistory = {
+                                viewModel.onEvent(SearchEvent.ClearRecentSearches)
+                            },
+                            onSectionFocusChanged = { focused -> isRecentSearchSectionFocused = focused },
+                            clearHistoryFocusRequester = recentClearHistoryFocusRequester,
+                            modifier = Modifier.padding(horizontal = 52.dp)
+                        )
+                    }
                 } else {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
+                    item(key = "search_start") {
                         EmptyScreenState(
                             title = stringResource(R.string.search_start_title),
                             subtitle = stringResource(R.string.search_start_subtitle),
@@ -546,50 +564,13 @@ fun SearchScreen(
                         )
                     }
                 }
-            }
-        } else {
-            val listState = rememberLazyListState()
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .recompositionHighlighter()
-                    .dpadRepeatThrottle(),
-                state = listState,
-                contentPadding = PaddingValues(vertical = NuvioTheme.spacing.lg),
-                verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg)
-            ) {
-                item {
-                    SearchInputField(
-                        query = uiState.query,
-                        canMoveToResults = canMoveToResults,
-                        voiceFocusRequester = if (isVoiceSearchAvailable) voiceFocusRequester else null,
-                        searchFocusRequester = searchFocusRequester,
-                        onSearchFieldFocusChanged = { focused -> isSearchFieldFocused = focused },
-                        onQueryChanged = handleQueryChanged,
-                        onSubmit = {
-                            submitCurrentQuery(uiState.query.trim())
-                        },
-                        showVoiceSearch = isVoiceSearchAvailable,
-                        isVoiceListening = isVoiceListening,
-                        voiceRmsLevel = voiceRmsLevel,
-                        onVoiceSearch = launchVoiceSearch,
-                        onMoveToResults = {
-                            focusResults = true
-                        },
-                        onOpenDiscover = onOpenDiscover,
-                        showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
-                        keyboardController = keyboardController,
-                        clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null,
-                        isScreenActive = isScreenActive
-                    )
-                }
-
+            } else {
                 // The "press Done to search" hint is gone: search now runs as you type, so the
                 // instruction is wrong, and it was re-appearing on every keystroke. Neither the
                 // mobile nor the desktop client shows an equivalent message.
 
                 when {
-                    trimmedSubmittedQuery.length < 2 && !hasPendingUnsubmittedQuery -> {
+                    trimmedSubmittedQuery.length < MIN_SEARCH_QUERY_LENGTH && !hasPendingUnsubmittedQuery -> {
                         item {
                             if (showRecentSearches) {
                                 RecentSearchesSection(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
@@ -6,6 +6,20 @@ import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.DiscoverLocation
 import com.nuvio.tv.domain.model.MetaPreview
 
+internal const val MIN_SEARCH_QUERY_LENGTH = 2
+
+internal fun submittedSearchQuery(rawQuery: String): String =
+    rawQuery.trim().takeIf { it.length >= MIN_SEARCH_QUERY_LENGTH }.orEmpty()
+
+internal fun shouldShowDiscoverInSearch(
+    discoverLocation: DiscoverLocation,
+    query: String,
+    submittedQuery: String
+): Boolean =
+    discoverLocation == DiscoverLocation.IN_SEARCH &&
+        query.trim().length < MIN_SEARCH_QUERY_LENGTH &&
+        submittedQuery.isBlank()
+
 @Immutable
 data class SearchUiState(
     val query: String = "",

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -215,7 +215,7 @@ class SearchViewModel @Inject constructor(
                 // Keep whatever is on screen while a keystroke waits to run. Clearing here flashed
                 // the no-results state on every letter, because on a remote each letter outlasts the
                 // debounce. The screen renders skeleton rows for this window instead.
-                catalogRows = if (trimmedInput.length < 2) emptyList() else it.catalogRows
+                catalogRows = if (trimmedInput.length < MIN_SEARCH_QUERY_LENGTH) emptyList() else it.catalogRows
             )
         }
 
@@ -227,7 +227,7 @@ class SearchViewModel @Inject constructor(
         // every enabled addon catalog.
         liveSearchJob?.cancel()
         val trimmed = query.trim()
-        if (trimmed.length >= 2) {
+        if (trimmed.length >= MIN_SEARCH_QUERY_LENGTH) {
             liveSearchJob = viewModelScope.launch {
                 kotlinx.coroutines.delay(LIVE_SEARCH_DEBOUNCE_MS)
                 performSearch(query)
@@ -245,7 +245,7 @@ class SearchViewModel @Inject constructor(
     private fun fetchSuggestions(query: String) {
         suggestionJob?.cancel()
 
-        if (query.length < 2) {
+        if (query.length < MIN_SEARCH_QUERY_LENGTH) {
             _uiState.update { it.copy(suggestions = emptyList()) }
             return
         }
@@ -362,13 +362,13 @@ class SearchViewModel @Inject constructor(
         suggestionJob?.cancel()
         _uiState.update {
             it.copy(
-                submittedQuery = query,
+                submittedQuery = submittedSearchQuery(query),
                 query = rawQuery,
                 suggestions = emptyList()
             )
         }
 
-        if (query.length < 2) {
+        if (query.length < MIN_SEARCH_QUERY_LENGTH) {
             activeSearchJobs.forEach { it.cancel() }
             activeSearchJobs = emptyList()
             catalogRowsUpdateJob?.cancel()

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchPresentationRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchPresentationRulesTest.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.ui.screens.search
+
+import com.nuvio.tv.domain.model.DiscoverLocation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchPresentationRulesTest {
+
+    @Test
+    fun `one character remains in discover without becoming a submitted search`() {
+        assertEquals("", submittedSearchQuery("a"))
+        assertTrue(
+            shouldShowDiscoverInSearch(
+                discoverLocation = DiscoverLocation.IN_SEARCH,
+                query = "a",
+                submittedQuery = ""
+            )
+        )
+    }
+
+    @Test
+    fun `minimum query leaves discover while live search is pending`() {
+        assertEquals("ab", submittedSearchQuery(" ab "))
+        assertFalse(
+            shouldShowDiscoverInSearch(
+                discoverLocation = DiscoverLocation.IN_SEARCH,
+                query = "ab",
+                submittedQuery = ""
+            )
+        )
+    }
+
+    @Test
+    fun `discover location off never enters discover mode`() {
+        assertFalse(
+            shouldShowDiscoverInSearch(
+                discoverLocation = DiscoverLocation.OFF,
+                query = "",
+                submittedQuery = ""
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

This follow up fixes two regressions in the live search experience introduced with #2723:

**Fire TV keyboard stability.** The search field now remains the same keyed item inside one stable `LazyColumn` while the screen moves between Discover, pending search, loading, results, and empty states. Fire TV no longer loses its input connection and closes the keyboard while a query is being typed.

**Search shimmer depth.** Search poster placeholders now use the same `LocalCardDepthStyle`, poster depth surface, clipping, and outer card structure as normal catalog placeholders. The shimmer therefore transitions into loaded cards without changing depth style.

The minimum search length is also defined once and applied consistently to presentation and submission state. A one character query cannot become a submitted search or prematurely leave Discover.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The live search screen rendered its input field in two different layout branches: a `Column` for Discover and a separate `LazyColumn` for search results. When live search changed modes, Compose disposed and recreated the text field. Android TV keyboards can survive that replacement, but Fire TV treats the lost input connection as completion and closes the keyboard, sometimes after the first character.

The dedicated search shimmer also drew bare clipped boxes and bypassed the poster depth modifier used by regular cards. When card depth was enabled, the loading placeholders and loaded results visibly used different surfaces.

Keeping one keyed input item preserves the active editor across every search state. Reusing the established poster depth path makes loading and loaded cards visually consistent.

## Issue or approval

Maintainer requested follow up to #2723. Both the Fire TV keyboard regression and shimmer depth mismatch were reported by @skoruppa after merge.

## Reproduction steps

1. On Fire TV, open Search and activate the text field.
2. Begin typing a title.
3. Before this fix, the keyboard can close as live search changes the screen from Discover to search content.
4. After this fix, continue typing slowly or quickly. The keyboard remains open while loading and results update.
5. Enable poster card depth and start a new search.
6. Before this fix, shimmer cards do not use the configured depth treatment.
7. After this fix, shimmer cards and loaded poster cards use the same depth style.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

The only visual change corrects the reported mismatch by applying the existing card depth style to search placeholders. No new design or feature is introduced.

## Scope boundaries

- Search screen only.
- Live search debounce, catalog fan out, result ordering, suggestions, history rules, and returned content are unchanged.
- The keyboard fix changes layout ownership only; it does not change when a valid query searches.
- The shimmer fix reuses the existing poster depth implementation and does not alter shimmer timing.
- Discover content and normal catalog cards are unchanged.
- No player, addon, profile, or storage behavior is touched.

## Testing

- `./gradlew :app:compileFullDebugKotlin`
- `./gradlew :app:assembleFullDebug`
- `./gradlew :app:testFullDebugUnitTest --tests 'com.nuvio.tv.ui.screens.search.SearchPresentationRulesTest'`
- Installed and manually verified on an NVIDIA Shield:
  - First character keeps the keyboard open.
  - Crossing the two character search threshold keeps the keyboard open.
  - Typing one character every 700 ms keeps the keyboard open while results update.
  - Deleting from results through two characters, one character, and empty keeps the keyboard open.
  - Done closes the keyboard normally and retains the query and results.
  - Clear returns to the expected empty or Discover state.
  - Search shimmer uses the configured poster depth and transitions consistently into loaded cards.
  - No crashes, ANRs, or input connection errors appeared in logcat.

## Screenshots / Video

No additional media. This follow up preserves the approved search UI and corrects its input lifecycle and existing card depth treatment.

## Breaking changes

None.

## Linked issues

Follow up to #2723.
