### PR TITLE
Simkl anime - clear shared IDs, resolve removeFromHistory, per-episode videoId in batch removal

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
@@ -301,18 +301,20 @@ fun TrackingMediaReference.resolveAnimeEpisodeForSimkl(): TrackingMediaReference
     val parsed = parseSimklAnimeVideoId(videoId) ?: return this
     val videoEpisodeNumber = parsed.episodeNumber ?: return this
 
-    // Override IDs: anime-specific ID from videoId takes priority
+    // Override IDs: use ONLY the anime-specific ID from videoId.
+    // Clear all other IDs to prevent Simkl from matching a wrong entry
+    // (e.g. shared anidb/anilist IDs from the enriched parent entry).
     val videoIds = parseTrackingExternalIds("${parsed.prefix}:${parsed.id}")
     val overriddenIds = TrackingExternalIds(
-        imdb = ids.imdb,
-        tmdb = ids.tmdb,
-        tvdb = ids.tvdb,
-        trakt = ids.trakt,
-        simkl = ids.simkl,
-        mal = videoIds.mal ?: ids.mal,
-        anidb = videoIds.anidb ?: ids.anidb,
-        anilist = videoIds.anilist ?: ids.anilist,
-        kitsu = videoIds.kitsu ?: ids.kitsu
+        imdb = null,
+        tmdb = null,
+        tvdb = null,
+        trakt = null,
+        simkl = null,
+        mal = videoIds.mal,
+        anidb = videoIds.anidb,
+        anilist = videoIds.anilist,
+        kitsu = videoIds.kitsu
     )
 
     // Override episode: use absolute number from videoId, drop season

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingHistoryWriter.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingHistoryWriter.kt
@@ -39,6 +39,10 @@ class SimklTrackingHistoryWriter @Inject constructor(
         if (profileId != profileManager.activeProfileId.value) return TrackingMutationResult(0)
         syncRepository.ensureLoaded()
         val snapshot = syncRepository.state.value.snapshot
-        return service.removeFromHistory(items.map(snapshot::enrichMediaReference))
+        return service.removeFromHistory(
+            items.map { ref ->
+                snapshot.enrichMediaReference(ref).resolveAnimeEpisodeForSimkl()
+            }
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fix for resolveAnimeEpisodeForSimkl - clears all shared IDs when overriding from videoId, applies anime resolution to removeFromHistory, and fixes bulk removal to pass per-episode videoId.

Previously:
1. After enrichMediaReference added shared anidb/anilist/kitsu IDs from the parent entry, resolveAnimeEpisodeForSimkl kept them. Simkl matched everything to one entry via shared IDs.
2. removeFromHistory only did enrichMediaReference without resolveAnimeEpisodeForSimkl, so single unmark didn't resolve to the correct per-season MAL entry.
3. removeFromHistoryBatch used one shared videoId for ALL episodes. For anime with multiple MAL entries per season, this meant all episodes were sent with the wrong (or no) anime-specific videoId.

This is a follow-up to https://github.com/NuvioMedia/NuvioTV/pull/2741.

## PR type

- [x] Reproducible bug fix

## Why

Three issues found during testing on real anime:

1. **Shared IDs in batch writes:** Re:Zero has mal:31240 (S1), mal:39587 (S2 part 1), mal:42203 (S2 part 2). After enrichment they all had the same anidb/anilist/kitsu from the matched entry. Simkl used those shared IDs to route all episodes to one entry. Fix: only send the single ID from the videoId prefix, clear everything else.

2. **Single unmark not resolving:** removeFromHistory did enrichMediaReference but not resolveAnimeEpisodeForSimkl. So unmark sent enriched IDs (wrong entry) with TVDB season/episode. Simkl couldn't find it -> deleted 0 episodes.

3. **Bulk unmark broken for anime:** removeFromHistoryBatch took one shared `videoId: String?` for all episodes. For anime where S2E1 is `mal:39587:1` and S2E14 is `mal:42203:1`, they all got the same fallback IMDB videoId (useless for anime resolution). Fix: change signature to `episodes: List<Triple<Int, Int, String?>>` carrying per-episode videoId.

## Issue or approval

No linked issue - follow-up fix to https://github.com/NuvioMedia/NuvioTV/pull/2741 found during real-device testing.

## Reproduction steps

1. Open Re:Zero (`mal:42203`) in details
2. Bulk mark S1 + S2 episodes as watched -> all go to one wrong entry (shared IDs)
3. Try to unmark single episode -> Simkl returns `deleted: 0`
4. Try "Mark season unwatched" -> nothing happens (shared videoId, no per-episode resolution)

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Changes:
- SimklMediaProjections: resolveAnimeEpisodeForSimkl now sets overriddenIds with ONLY the videoId-parsed ID, all other fields null
- SimklTrackingHistoryWriter: removeFromHistory now calls resolveAnimeEpisodeForSimkl after enrichMediaReference
- WatchProgressRepository interface: removeFromHistoryBatch signature changed from `episodes: List<Pair<Int, Int>>` to `episodes: List<Triple<Int, Int, String?>>` (season, episode, videoId)
- WatchProgressRepositoryImpl: uses per-episode videoId in buildTrackingMediaReference
- MetaDetailsViewModel: passes `video.id` as third element in Triple
- HomeViewModelLibraryActions: same
- PosterOptionsController: same

Trakt unaffected (doesn't use resolveAnimeEpisodeForSimkl). addToHistory already had the resolve call and was working.

## Testing

- Verified on device: bulk mark S1+S2 of Re:Zero -> separate entries with correct MAL IDs
- Verified on device: single unmark -> Simkl returns `deleted: 1`
- Verified on device: "Mark season unwatched" -> Simkl correctly removes episodes from per-season MAL entries
- Existing SimklAnimeWatchedResolutionTest still passes

## Screenshots / Video

Not a UI change.

## Breaking changes

`removeFromHistoryBatch` signature changed from `List<Pair<Int, Int>>` to `List<Triple<Int, Int, String?>>`. All callers in the codebase updated. No external API affected.

## Linked issues

Follow-up to https://github.com/NuvioMedia/NuvioTV/pull/2741
