### PR TITLE
fix(player): keep subtitles enabled after delay adjustment (#2710)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -299,6 +299,8 @@ class PlayerRuntimeController(
     internal var hidePlayerEngineSwitchInfoJob: Job? = null
     internal var hideSubtitleDelayOverlayJob: Job? = null
     internal var subtitleAutoSyncLoadJob: Job? = null
+    /** Cancels previous TEXT-track bounce jobs when subtitle delay is adjusted repeatedly. */
+    internal var subtitleTimingRefreshJob: Job? = null
     internal var nextEpisodeAutoPlayJob: Job? = null
     internal var debridResolveJob: Job? = null
     internal var stillWatchingPromptJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -43,6 +43,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     hidePlayerEngineSwitchInfoJob?.cancel()
     hideSubtitleDelayOverlayJob?.cancel()
     subtitleAutoSyncLoadJob?.cancel()
+    subtitleTimingRefreshJob?.cancel()
+    subtitleTimingRefreshJob = null
     playbackPreparationJob?.cancel()
     playbackPreparationJob = null
     traktMappingJob?.cancel()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -282,6 +282,12 @@ internal fun PlayerRuntimeController.disableSubtitles() {
 }
 
 internal fun PlayerRuntimeController.refreshActiveSubtitleTrackAfterTimingChange() {
+    // MPV applies delay via setSubtitleDelayMs; live Exo delay is applied by
+    // SubtitleOffsetRenderer. This path only exists to flush any cue already on
+    // screen under the previous offset. It must re-apply the active override
+    // after re-enabling TEXT - otherwise the track stays selected in UI but
+    // ExoPlayer has no TEXT override and subtitles disappear (issue #2710).
+    if (isUsingMpvEngine()) return
     val player = _exoPlayer ?: return
     val state = _uiState.value
     if (state.selectedAddonSubtitle == null && state.selectedSubtitleTrackIndex < 0) return
@@ -292,17 +298,41 @@ internal fun PlayerRuntimeController.refreshActiveSubtitleTrackAfterTimingChange
         .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
         .build()
 
-    scope.launch {
+    subtitleTimingRefreshJob?.cancel()
+    subtitleTimingRefreshJob = scope.launch {
         delay(90)
         if (_exoPlayer !== player) return@launch
         val latestState = _uiState.value
-        if (latestState.selectedAddonSubtitle == null && latestState.selectedSubtitleTrackIndex < 0) {
+        val latestAddon = latestState.selectedAddonSubtitle
+        val latestInternalIndex = latestState.selectedSubtitleTrackIndex
+        if (latestAddon == null && latestInternalIndex < 0) {
             return@launch
         }
+
+        // Re-enable TEXT, then restore the same selection override that was active
+        // before the bounce. setTrackTypeDisabled(false) alone is not enough when
+        // the previous selection was applied via TrackSelectionOverride.
         player.trackSelectionParameters = player.trackSelectionParameters
             .buildUpon()
             .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
             .build()
+
+        if (latestAddon != null) {
+            val trackId = buildAddonSubtitleTrackId(latestAddon)
+            val restored = applyAddonSubtitleOverride(trackId) ||
+                applyAddonSubtitleOverrideByLanguage(
+                    PlayerSubtitleUtils.normalizeLanguageCode(latestAddon.lang)
+                )
+            if (!restored) {
+                Log.w(
+                    PlayerRuntimeController.TAG,
+                    "refreshActiveSubtitleTrackAfterTimingChange: failed to restore addon " +
+                        "subtitle id=${latestAddon.id} lang=${latestAddon.lang}"
+                )
+            }
+        } else {
+            selectSubtitleTrack(latestInternalIndex)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix a regression where adjusting subtitle delay disables subtitles on the ExoPlayer path.

## PR type

- [x] Critical bug fix

## Why

When the user adjusts subtitle delay, the player temporarily disables `TRACK_TYPE_TEXT` to flush stale cues, then re-enables the track type after 90ms. Re-enabling alone does not restore a `TrackSelectionOverride`, so ExoPlayer ends up with text tracks enabled but none selected. UI still shows the previous subtitle as selected, but nothing is rendered.

## Issue or approval

Fixes #2710

## Reproduction steps

1. Play a video with internal ExoPlayer
2. Open OSD -> subtitles -> select a subtitle track (embedded or addon)
3. Open subtitle delay and adjust it
4. Observe: subtitles disappear after the adjustment

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No UI changes or layout changes
- No delay algorithm changes (`SubtitleOffsetRenderer` / MPV `setSubtitleDelayMs` unchanged)
- No track selection UX changes beyond restoring the previously active selection after the TEXT bounce

## Testing

Static code analysis / path walkthrough of the failure:

1. `adjustSubtitleDelay` always calls `refreshActiveSubtitleTrackAfterTimingChange()`
2. That function disabled TEXT, then only called `setTrackTypeDisabled(TEXT, false)`
3. Active selection on Exo is applied via `TrackSelectionOverride` in `selectSubtitleTrack` / `applyAddonSubtitleOverride`
4. After bounce, override was not re-applied -> no cues

Code changes verified:

- After re-enable, addon path restores override by track id, then language fallback
- Internal path calls `selectSubtitleTrack(latestInternalIndex)`
- Repeated delay adjustments cancel the previous bounce job (`subtitleTimingRefreshJob`)
- Job cancelled on `releasePlayer`
- MPV path short-circuits (already uses `setSubtitleDelayMs`)

Device/emulator runtime test not run from this environment (no Android SDK/device attached). Would appreciate a maintainer or user smoke test of:

1. Embedded subtitle + delay adjust
2. Addon SRT subtitle + delay adjust
3. Rapid repeated delay adjustments
4. MPV engine path still applies delay without side effects

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2710