### PR TITLE
Simkl anime - ID isolation, per-episode removal, videoId watched resolution

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProvider.kt
@@ -29,6 +29,7 @@ interface TrackingProgressProvider {
     ): Flow<Boolean>
     suspend fun watchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>>
     suspend fun showIdSiblings(): Map<String, Set<String>>
+    fun isWatchedByVideoId(videoId: String, episode: Int): Boolean = false
     suspend fun refresh(intent: TrackingRefreshIntent)
     suspend fun removeProgress(contentId: String, season: Int?, episode: Int?)
     fun applyOptimisticProgress(progress: WatchProgress, quiet: Boolean)

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -568,6 +568,11 @@ class WatchProgressRepositoryImpl @Inject constructor(
         return activeProgressProvider()?.showIdSiblings().orEmpty()
     }
 
+    override fun isWatchedByVideoId(videoId: String, episode: Int): Boolean {
+        val providerId = activeProgressProviderId ?: return false
+        return trackingProgressProviders.provider(providerId)?.isWatchedByVideoId(videoId, episode) ?: false
+    }
+
     override fun isWatched(contentId: String, videoId: String?, season: Int?, episode: Int?): Flow<Boolean> {
         return activeProgressProviderFlow()
             .flatMapLatest { provider ->
@@ -709,34 +714,35 @@ class WatchProgressRepositoryImpl @Inject constructor(
     override suspend fun removeFromHistoryBatch(
         contentId: String,
         videoId: String?,
-        episodes: List<Pair<Int, Int>>
+        episodes: List<Triple<Int, Int, String?>>
     ) {
         if (episodes.isEmpty()) return
         val profileId = profileManager.activeProfileId.value
-        watchProgressPreferences.removeProgressBatch(contentId, episodes)
-        watchedItemsPreferences.unmarkAsWatchedBatch(contentId, episodes, profileId = profileId)
+        val episodePairs = episodes.map { (season, episode, _) -> season to episode }
+        watchProgressPreferences.removeProgressBatch(contentId, episodePairs)
+        watchedItemsPreferences.unmarkAsWatchedBatch(contentId, episodePairs, profileId = profileId)
         connectedProgressProviders().forEach { provider ->
-            episodes.forEach { (season, episode) ->
+            episodes.forEach { (season, episode, _) ->
                 provider.applyOptimisticRemoval(contentId, season, episode)
             }
         }
-        val media = episodes.map { (season, episode) ->
+        val media = episodes.map { (season, episode, epVideoId) ->
             buildTrackingMediaReference(
                 contentType = "series",
                 parentMetaId = contentId,
-                videoId = videoId,
+                videoId = epVideoId ?: videoId,
                 seasonNumber = season,
                 episodeNumber = episode
             )
         }
         broadcastHistoryRemoval(profileId, media)
-        val remoteDeleteKeys = episodes.map { (season, episode) ->
+        val remoteDeleteKeys = episodes.map { (season, episode, _) ->
             "${contentId}_s${season}e${episode}"
         } + contentId
         if (authManager.isAuthenticated) {
             watchProgressSyncService.deleteFromRemote(remoteDeleteKeys.distinct())
                 .onFailure { error -> Log.w(TAG, "removeFromHistoryBatch remote delete failed", error) }
-            watchedItemsSyncService.deleteFromRemoteBatch(contentId, episodes, profileId = profileId)
+            watchedItemsSyncService.deleteFromRemoteBatch(contentId, episodePairs, profileId = profileId)
                 .onFailure { error ->
                     Log.w(TAG, "removeFromHistoryBatch watched item remote delete failed", error)
                 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
@@ -301,18 +301,20 @@ fun TrackingMediaReference.resolveAnimeEpisodeForSimkl(): TrackingMediaReference
     val parsed = parseSimklAnimeVideoId(videoId) ?: return this
     val videoEpisodeNumber = parsed.episodeNumber ?: return this
 
-    // Override IDs: anime-specific ID from videoId takes priority
+    // Override IDs: use ONLY the anime-specific ID from videoId.
+    // Clear all other IDs to prevent Simkl from matching a wrong entry
+    // (e.g. shared anidb/anilist IDs from the enriched parent entry).
     val videoIds = parseTrackingExternalIds("${parsed.prefix}:${parsed.id}")
     val overriddenIds = TrackingExternalIds(
-        imdb = ids.imdb,
-        tmdb = ids.tmdb,
-        tvdb = ids.tvdb,
-        trakt = ids.trakt,
-        simkl = ids.simkl,
-        mal = videoIds.mal ?: ids.mal,
-        anidb = videoIds.anidb ?: ids.anidb,
-        anilist = videoIds.anilist ?: ids.anilist,
-        kitsu = videoIds.kitsu ?: ids.kitsu
+        imdb = null,
+        tmdb = null,
+        tvdb = null,
+        trakt = null,
+        simkl = null,
+        mal = videoIds.mal,
+        anidb = videoIds.anidb,
+        anilist = videoIds.anilist,
+        kitsu = videoIds.kitsu
     )
 
     // Override episode: use absolute number from videoId, drop season

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingHistoryWriter.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingHistoryWriter.kt
@@ -39,6 +39,10 @@ class SimklTrackingHistoryWriter @Inject constructor(
         if (profileId != profileManager.activeProfileId.value) return TrackingMutationResult(0)
         syncRepository.ensureLoaded()
         val snapshot = syncRepository.state.value.snapshot
-        return service.removeFromHistory(items.map(snapshot::enrichMediaReference))
+        return service.removeFromHistory(
+            items.map { ref ->
+                snapshot.enrichMediaReference(ref).resolveAnimeEpisodeForSimkl()
+            }
+        )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingProgressProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingProgressProvider.kt
@@ -181,6 +181,9 @@ class SimklTrackingProgressProvider @Inject constructor(
     override fun isHiddenFromProgress(contentId: String): Boolean =
         syncRepository.state.value.snapshot.isHiddenFromContinueWatching(contentId)
 
+    override fun isWatchedByVideoId(videoId: String, episode: Int): Boolean =
+        checkWatchedByVideoId(syncRepository.state.value.snapshot, videoId, episode)
+
     override suspend fun prepareNextUpSeed(progress: WatchProgress): WatchProgress = progress
 }
 
@@ -271,7 +274,7 @@ private fun isWatchedInSnapshot(
     // 3. Anime video ID resolution: parse anime-specific ID and episode from videoId,
     //    find the corresponding Simkl entry, and check watched status directly.
     if (videoId != null && episode != null) {
-        if (isWatchedByVideoId(snapshot, videoId, episode)) return true
+        if (checkWatchedByVideoId(snapshot, videoId, episode)) return true
     }
 
     return false
@@ -296,7 +299,7 @@ private fun SimklSyncSnapshot.resolveCanonicalContentId(contentId: String): Stri
  * - Split season (multiple MAL per season): "mal:11759:3" → entry mal:11759, episode 3
  * - Franchise parent with child MAL IDs per season
  */
-private fun isWatchedByVideoId(
+internal fun checkWatchedByVideoId(
     snapshot: SimklSyncSnapshot,
     videoId: String,
     episode: Int

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -82,6 +82,8 @@ interface WatchProgressRepository {
      */
     suspend fun getShowIdSiblings(): Map<String, Set<String>>
 
+    fun isWatchedByVideoId(videoId: String, episode: Int): Boolean = false
+
     /**
      * Save or update watch progress
      */
@@ -113,7 +115,7 @@ interface WatchProgressRepository {
     suspend fun removeFromHistoryBatch(
         contentId: String,
         videoId: String?,
-        episodes: List<Pair<Int, Int>>
+        episodes: List<Triple<Int, Int, String?>>
     )
     
     /**

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -492,11 +492,10 @@ class PosterOptionsController @Inject constructor(
             return
         }
 
-        val episodePairs = episodes.map { it.season!! to it.episode!! }
         watchProgressRepository.removeFromHistoryBatch(
             contentId = item.id,
             videoId = item.imdbId,
-            episodes = episodePairs
+            episodes = episodes.map { Triple(it.season!!, it.episode!!, it.id) }
         )
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -142,6 +142,7 @@ class MetaDetailsViewModel @Inject constructor(
      *  updated to [Meta.id] once meta loads (typically an IMDB ID like "tt0396375").
      *  This ensures progress is read from the same key it was written under. */
     private val _effectiveContentId = MutableStateFlow(itemId)
+    private val _optimisticMarks = mutableSetOf<Pair<Int, Int>>()
 
     init {
         posterOptions.bind(viewModelScope)
@@ -491,7 +492,27 @@ class MetaDetailsViewModel @Inject constructor(
         if (itemType.lowercase() == "movie") return
         viewModelScope.launch {
             _effectiveContentId.flatMapLatest { cid ->
-                watchedItemsPreferences.getWatchedEpisodesForContent(cid)
+                combine(
+                    watchedItemsPreferences.getWatchedEpisodesForContent(cid),
+                    watchProgressRepository.getAllEpisodeProgress(cid),
+                    _uiState.map { it.meta?.videos }.distinctUntilChanged(),
+                ) { localWatched, progressMap, videos ->
+                    val fromProgress = progressMap.filterValues { it.isCompleted() }.keys
+                    val merged = (localWatched + fromProgress).toMutableSet()
+                    if (videos.isNullOrEmpty()) return@combine merged
+                    for (video in videos) {
+                        val s = video.season ?: continue
+                        val e = video.episode ?: continue
+                        val key = s to e
+                        val watchedByVideoId = watchProgressRepository.isWatchedByVideoId(video.id, e)
+                        if (watchedByVideoId && key !in merged) {
+                            merged += key
+                        } else if (!watchedByVideoId && key in merged && key !in fromProgress && key !in _optimisticMarks) {
+                            merged -= key
+                        }
+                    }
+                    merged as Set<Pair<Int, Int>>
+                }
             }
                 .distinctUntilChanged()
                 .collectLatest { watchedSet ->
@@ -2087,9 +2108,11 @@ class MetaDetailsViewModel @Inject constructor(
                 || _uiState.value.watchedEpisodes.contains(season to episode)
             runCatching {
                 if (isWatched) {
+                    _optimisticMarks -= season to episode
                     watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = video.id, season = season, episode = episode)
                     showMessage(localizedContext.getString(R.string.detail_episode_marked_unwatched))
                 } else {
+                    _optimisticMarks += season to episode
                     watchProgressRepository.markAsCompleted(buildCompletedEpisodeProgress(meta, video))
                     showMessage(localizedContext.getString(R.string.detail_episode_marked_watched))
                 }
@@ -2191,11 +2214,11 @@ class MetaDetailsViewModel @Inject constructor(
             }
 
             runCatching {
-                val episodePairs = watched.map { it.season!! to it.episode!! }
+                val episodeTriples = watched.map { Triple(it.season!!, it.episode!!, it.id) }
                 watchProgressRepository.removeFromHistoryBatch(
                     contentId = _effectiveContentId.value,
                     videoId = resolveFallbackVideoId(),
-                    episodes = episodePairs
+                    episodes = episodeTriples
                 )
             }.onFailure { error ->
                 Log.w(TAG, "Failed to batch unmark season $season: ${error.message}")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelLibraryActions.kt
@@ -439,11 +439,10 @@ private suspend fun HomeViewModel.unmarkSeriesWatched(item: MetaPreview) {
         return
     }
 
-    val episodePairs = episodes.map { it.season!! to it.episode!! }
     watchProgressRepository.removeFromHistoryBatch(
         contentId = item.id,
         videoId = item.imdbId,
-        episodes = episodePairs
+        episodes = episodes.map { Triple(it.season!!, it.episode!!, it.id) }
     )
     fullyWatchedSeriesIds.updateWithValidation(
         fullyWatchedSeriesIds.fullyWatchedSeriesIds.value - item.id,


### PR DESCRIPTION
## Summary

Follow-up fixes to https://github.com/NuvioMedia/NuvioTV/pull/2751 for Simkl anime tracking. Fixes wrong IDs in write path, broken episode removal, and missing watched checkmarks when entering anime via MAL content ID.

## PR type

- [x] Reproducible bug fix

## Why

Four issues found during real-device testing:

1. **Shared IDs routing all episodes to one entry:** After enrichment, shared anidb/anilist/kitsu IDs caused Simkl to match all episodes to one entry in batch writes. Fix: only send the single ID from the videoId prefix, clear everything else.

2. **Single unmark not resolving:** removeFromHistory didn't apply resolveAnimeEpisodeForSimkl. Simkl couldn't match the request -> deleted 0 episodes.

3. **Bulk unmark broken for anime:** removeFromHistoryBatch used one shared videoId for all episodes. Fix: changed signature to `List<Triple<Int, Int, String?>>` carrying per-episode videoId.

4. **Watched checkmarks missing under MAL:** When entering Bleach via `mal:60636` or Re:Zero via `mal:61316`, episodes stored under canonical IMDB weren't shown as watched. The existing local-storage-only approach couldn't resolve cross-ID watched state. Fix: `observeWatchedEpisodes` now combines local storage + episodeProgress + videoId fallback from Simkl snapshot. Snapshot is source of truth - stale local entries not confirmed by the provider are removed.

## Issue or approval

No linked issue - follow-up to https://github.com/NuvioMedia/NuvioTV/pull/2751

## Reproduction steps

**Bugs 1-3:**
1. Open Re:Zero via MAL, bulk mark S1+S2 -> all go to one entry
2. Single unmark -> Simkl returns deleted:0
3. "Mark season unwatched" -> nothing happens

**Bug 4:**
1. Open Bleach via `mal:60636` -> S17E14-26 not shown as watched (missing TVDB mapping)
2. Open Re:Zero via `mal:61316` -> no episodes shown as watched (entry not in snapshot)
3. Mark ep under MAL, unmark under IMDB -> MAL still shows it watched (stale local)

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Changes:
- SimklMediaProjections: resolveAnimeEpisodeForSimkl clears all shared IDs
- SimklTrackingHistoryWriter: removeFromHistory applies resolveAnimeEpisodeForSimkl
- WatchProgressRepository: removeFromHistoryBatch takes `List<Triple<Int, Int, String?>>` (per-episode videoId)
- TrackingProgressProvider: new `isWatchedByVideoId(videoId, episode)` interface method (default false)
- SimklTrackingProgressProvider: overrides isWatchedByVideoId via snapshot lookup
- WatchProgressRepository: delegates isWatchedByVideoId to active provider
- MetaDetailsViewModel: observeWatchedEpisodes combines local + episodeProgress + videoId fallback, removes stale entries not confirmed by provider
- MetaDetailsViewModel, HomeViewModelLibraryActions, PosterOptionsController: pass video.id in removal Triple

Trakt unaffected (default false for isWatchedByVideoId). No UI component changes.

## Testing

- Verified on device: bulk mark Re:Zero S1+S2 -> correct MAL IDs per season
- Verified on device: single unmark -> Simkl returns deleted:1
- Verified on device: "Mark season unwatched" -> works correctly
- Verified on device: Bleach via MAL -> all S17 episodes shown as watched (including 13 without TVDB mapping)
- Verified on device: Re:Zero S4 via MAL -> episodes from previous seasons shown as watched
- Verified on device: unmark under IMDB propagates to MAL view (stale local entry removed)
- Verified on device: unmark under MAL propagates to IMDB and CW

## Screenshots / Video

Not a UI change.

## Breaking changes

`removeFromHistoryBatch` signature changed from `List<Pair<Int, Int>>` to `List<Triple<Int, Int, String?>>`. All callers updated.

## Linked issues

Follow-up to https://github.com/NuvioMedia/NuvioTV/pull/2751
