### PR TITLE
fix(player): allow Sync Line focus when Skip Intro is visible (#2714)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -156,6 +156,7 @@ fun PlayerScreen(
     var restoreStreamInfoFocus by remember { mutableStateOf(false) }
     val nextEpisodeFocusRequester = remember { FocusRequester() }
     var subtitleDelayAutoSyncFocused by remember { mutableStateOf(false) }
+    val subtitleDelaySyncLineFocusRequester = remember { FocusRequester() }
     var subtitleTimingConsumeNextConfirmKeyUp by remember { mutableStateOf(false) }
     var reportCodeVisible by remember { mutableStateOf(false) }
     var exitDispatched by remember { mutableStateOf(false) }
@@ -837,7 +838,11 @@ fun PlayerScreen(
             onFocused = { viewModel.scheduleHideControls() },
             focusRequester = skipIntroFocusRequester,
             downFocusRequester = if (uiState.showControls) progressBarFocusRequester else null,
-            upFocusRequester = null,
+            upFocusRequester = if (uiState.showSubtitleDelayOverlay || uiState.showSubtitleTimingDialog) {
+                subtitleDelaySyncLineFocusRequester
+            } else {
+                null
+            },
             onHideControls = {
                 if (uiState.showControls) viewModel.hideControls()
                 else viewModel.onEvent(PlayerEvent.OnToggleControls)
@@ -1067,6 +1072,8 @@ fun PlayerScreen(
                 subtitleDelayMs = uiState.subtitleDelayMs,
                 isAutoSyncButtonFocused = subtitleDelayAutoSyncFocused,
                 isSliderFocused = !subtitleDelayAutoSyncFocused,
+                syncLineFocusRequester = subtitleDelaySyncLineFocusRequester,
+                onSyncLineFocused = { subtitleDelayAutoSyncFocused = true },
                 onOpenSyncByLine = {
                     subtitleDelayAutoSyncFocused = false
                     subtitleTimingConsumeNextConfirmKeyUp = true
@@ -2517,7 +2524,9 @@ private fun SubtitleDelayOverlay(
     subtitleDelayMs: Int,
     isAutoSyncButtonFocused: Boolean,
     isSliderFocused: Boolean,
-    onOpenSyncByLine: () -> Unit
+    onOpenSyncByLine: () -> Unit,
+    syncLineFocusRequester: FocusRequester,
+    onSyncLineFocused: () -> Unit = {}
 ) {
     val fraction = ((subtitleDelayMs - SUBTITLE_DELAY_MIN_MS).toFloat() /
         (SUBTITLE_DELAY_MAX_MS - SUBTITLE_DELAY_MIN_MS).toFloat()).coerceIn(0f, 1f)
@@ -2597,6 +2606,13 @@ private fun SubtitleDelayOverlay(
 
         Card(
             onClick = onOpenSyncByLine,
+            modifier = Modifier
+                .focusRequester(syncLineFocusRequester)
+                .onFocusChanged { focusState ->
+                    if (focusState.isFocused) {
+                        onSyncLineFocused()
+                    }
+                },
             colors = CardDefaults.colors(
                 containerColor = if (isAutoSyncButtonFocused) {
                     Color.White.copy(alpha = 0.22f)


### PR DESCRIPTION
## Summary

When the subtitle delay overlay was open and the Skip Intro/Recap button was also visible at the bottom-left, pressing D-Pad UP from Skip Intro called `onHideControls` instead of navigating focus to the Sync Line button. Focus was trapped on Skip Intro.

## PR type

- [x] Critical bug fix

## Problem

The Skip Intro button's `onPreviewKeyEvent` handler intercepted D-Pad UP with `upFocusRequester = null`, falling through to the `onHideControls` callback which toggles controls. When the subtitle delay overlay was visible, this prevented focus from ever reaching the Sync Line button.

The Sync Line button inside the `SubtitleDelayOverlay` (rendered at TopCenter) was unreachable from the bottom-left Skip Intro button.

## Root cause

In `PlayerScreen.kt`, the Skip Intro button was always created with `upFocusRequester = null`. Its `onPreviewKeyEvent` handler processes UP as:
1. If `upFocusRequester` is set → navigate there
2. Else if `onHideControls` exists → call it (toggle controls)
3. Else → let Compose handle it

Step 2 always fired when the subtitle overlay was open, consuming the key event before the subtitle overlay's key handler could process it.

## Fix

1. Added `subtitleDelaySyncLineFocusRequester` FocusRequester
2. Pass it as `upFocusRequester` to Skip Intro when `showSubtitleDelayOverlay` or `showSubtitleTimingDialog` is true
3. The Sync Line Card in `SubtitleDelayOverlay` accepts Compose focus and syncs the `subtitleDelayAutoSyncFocused` state

This routes D-Pad UP from Skip Intro directly to the Sync Line card, bypassing the `onHideControls` fallback entirely.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`
- [x] This PR fits the current PR policy: critical bug fix
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes
- [x] This PR is small, focused, and limited to one issue
- [x] This PR includes a linked issue and reproduction steps

## Testing

Static analysis of the focus flow:
1. Subtitle delay overlay visible + Skip Intro visible
2. D-Pad UP from Skip Intro → `upFocusRequester` is `subtitleDelaySyncLineFocusRequester` (non-null)
3. `onPreviewKeyEvent` routes to Sync Line Card via `requestFocus()`
4. Sync Line Card's `onFocusChanged` fires, sets `subtitleDelayAutoSyncFocused = true`
5. ENTER on Sync Line Card → opens subtitle timing dialog

Device test not possible from this environment. Smoke test:
1. Play content with a skip interval (intro/recap)
2. Open subtitle delay overlay while Skip Intro is visible
3. Press D-Pad UP from Skip Intro → focus should move to Sync Line
4. Press ENTER → subtitle timing dialog opens

## Linked issues

Fixes #2714