### PR TITLE
fix(trakt): auto-refresh token when opening settings screen (#2687)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TraktViewModel.kt
@@ -84,6 +84,10 @@ class TraktViewModel @Inject constructor(
         }
         observeSettings()
         observeAuthState()
+        // Auto-refresh Trakt token on settings open to prevent expiry (#2687)
+        viewModelScope.launch {
+            traktAuthService.refreshTokenIfNeeded(force = false)
+        }
     }
 
     fun onContinueWatchingDaysCapSelected(days: Int) {


### PR DESCRIPTION
## Summary

The Trakt OAuth access token expires after 24 hours. Previously it was only refreshed when an authorized API request triggered the refresh flow via `executeAuthorizedRequest`. If no requests were made for over 24 hours, the token stayed expired and the settings screen showed "0s remaining" — requiring a manual re-login.

Now `TraktViewModel.init` calls `refreshTokenIfNeeded(force=false)` when the settings screen opens. This proactively refreshes the token if it's within 60 seconds of expiry (the `refreshLeewaySeconds`), keeping the session alive without requiring manual intervention.

## PR type

- [x] Critical bug fix

## Why

Token refresh was only reactive (triggered by authorized API calls returning 401, or by `getValidAccessToken` during request preparation). There was no proactive refresh mechanism. When no API calls happened for more than 24 hours, the token expired silently and the user would see "0s remaining" in settings without knowing why.

## Issue or approval

Fixes #2687

## Reproduction steps

1. Authenticate with Trakt in NuvioTV
2. Close the app and do not open it for over 24 hours
3. Open Settings -> Trakt
4. Observe: the token shows "0s remaining" and needs manual re-login
5. With fix: the token auto-refreshes on opening settings, no manual intervention needed

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `TraktViewModel.kt` — added `refreshTokenIfNeeded(force=false)` call in `init` block
- `TraktAuthService.kt` unchanged — existing `refreshTokenIfNeeded` and `tokenRefreshMutex` are reused
- No changes to API request path, OAuth flow, or UI elements

## Testing

**Static analysis:**

1. `TraktViewModel.init` -> launches coroutine -> calls `refreshTokenIfNeeded(force=false)`
2. `refreshTokenIfNeeded` -> acquires `tokenRefreshMutex` -> checks `isTokenExpiredOrExpiring`
3. If expired -> calls Trakt API `/oauth/token` with refresh_token grant -> stores new token
4. `TraktAuthDataStore` update triggers `observeAuthState` -> `applyAuthState` -> UI updates
5. `force=false` ensures no unnecessary refresh for a still-valid token

**Device smoke test:**
1. Authenticate with Trakt
2. Wait >24 hours (or mock the expiry clock)
3. Open Settings -> Trakt
4. Token should auto-refresh without manual re-login

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2687
