### PR TITLE
fix(player): add FFmpeg software audio decode to recovery ladder

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1321,6 +1321,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                                 retryCurrentStreamWithSafeAudioFallback(currentPosition)
                                 return
                             }
+                            if (!hasTriedAudioPcmFallback) {
+                                hasTriedAudioPcmFallback = true
+                                retryCurrentStreamWithSafeAudioFallback(currentPosition)
+                                return
+                            }
                             if (!isAudioDisabledForCurrentPlayback) {
                                 audioDisabledForcedStreamUrls.add(currentStreamUrl)
                                 retryCurrentStreamWithAudioDisabled(currentPosition)
@@ -1339,6 +1344,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                                 retryCurrentStreamWithSafeAudioFallback(currentPosition)
                                 return
                             }
+                            if (!hasTriedAudioPcmFallback) {
+                                hasTriedAudioPcmFallback = true
+                                retryCurrentStreamWithSafeAudioFallback(currentPosition)
+                                return
+                            }
                             if (!isAudioDisabledForCurrentPlayback) {
                                 audioDisabledForcedStreamUrls.add(currentStreamUrl)
                                 retryCurrentStreamWithAudioDisabled(currentPosition)
@@ -1349,6 +1359,11 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (error.isStuckPlayingNoProgress()) {
                             if (!isSafeAudioModeActiveForCurrentPlayback) {
                                 safeAudioForcedStreamUrls.add(currentStreamUrl)
+                                retryCurrentStreamWithSafeAudioFallback(currentPosition)
+                                return
+                            }
+                            if (!hasTriedAudioPcmFallback) {
+                                hasTriedAudioPcmFallback = true
                                 retryCurrentStreamWithSafeAudioFallback(currentPosition)
                                 return
                             }


### PR DESCRIPTION
## Summary

Adds FFmpeg software audio decoding as a recovery step between SafeAudio and AudioDisabled in the ExoPlayer recovery ladder. When hardware audio decode fails and the safe-audio retry doesn't help, the player now tries FFmpeg-based software audio decoding before falling back to audio-disabled mode.

The fix sets `hasTriedAudioPcmFallback = true` in all three recovery paths (DECODING_FAILED, AudioTrack failure, StuckPlayingNoProgress), triggering the existing `effectiveDecoderPriority` path that switches to `EXTENSION_RENDERER_MODE_PREFER` — which is audio-only FFmpeg decode, matching the behavior of the "Prefer hardware" decoder setting.

## Why

The recovery ladder previously went straight from safe-audio to audio-disabled. The FFmpeg fallback existed in `effectiveDecoderPriority` but was never triggered from the recovery retry logic — `hasTriedAudioPcmFallback` was only set via the PCM audio detection path, not from recovery retries.

## Scope

- FFmpeg audio decode step only — no engine switch to libmpv
- No new settings or UI
- Recovery ladder only: DECODING_FAILED, AudioTrack failure, StuckPlaying paths
- 3 lines added per path

## Testing

- [x] Code compiles
- [x] Existing unit tests pass
- Device testing: play TrueHD/DTS-HD MA stream, verify audio recovers via FFmpeg after decode failure

Fixes #2608