### PR TITLE
fix(home): expand collection hero video into full hero area (#2683)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -729,8 +729,19 @@ fun ModernHomeContent(
                 heroTrailerFirstFrameRendered = false
             }
 
-            val isTrailerPlayingFullscreenState = remember(fullScreenBackdrop, shouldPlayCatalogHeroTrailerState) {
-                derivedStateOf { fullScreenBackdrop && shouldPlayCatalogHeroTrailerState.value && heroTrailerFirstFrameRendered }
+            // Collection hero videos should trigger the same fullscreen layout
+            // and content fade as catalog trailers — otherwise the video plays
+            // "behind" the collection cards instead of expanding into the hero area (#2683).
+            val isTrailerPlayingFullscreenState = remember(
+                fullScreenBackdrop,
+                shouldPlayCatalogHeroTrailerState,
+                shouldPlayCollectionHeroVideoState
+            ) {
+                derivedStateOf {
+                    fullScreenBackdrop &&
+                        (shouldPlayCatalogHeroTrailerState.value || shouldPlayCollectionHeroVideoState.value) &&
+                        heroTrailerFirstFrameRendered
+                }
             }
             BackHandler(enabled = isTrailerPlayingFullscreenState.value) {
                 focusedCatalogSelection.value = null
@@ -908,6 +919,7 @@ fun ModernHomeContent(
 
             val fullScreenBackdropUpdated by rememberUpdatedState(fullScreenBackdrop)
             val shouldPlayCatalogHeroTrailerUpdated by rememberUpdatedState(shouldPlayCatalogHeroTrailerState.value)
+            val shouldPlayCollectionHeroVideoUpdated by rememberUpdatedState(shouldPlayCollectionHeroVideoState.value)
             val heroTrailerFirstFrameRenderedUpdated by rememberUpdatedState(heroTrailerFirstFrameRendered)
 
             val onTrailerEndedLambda = remember {
@@ -931,13 +943,15 @@ fun ModernHomeContent(
                 onFirstFrameRendered = onFirstFrameRenderedLambda
             )
 
+            // Fade content rows when ANY hero media (catalog trailer or collection
+            // hero video) is playing in fullscreen — not just catalog trailers.
             val trailerContentAlphaState = animateFloatAsState(
-                targetValue = if (fullScreenBackdropUpdated && shouldPlayCatalogHeroTrailerUpdated && heroTrailerFirstFrameRenderedUpdated) 0f else 1f,
+                targetValue = if (fullScreenBackdropUpdated && (shouldPlayCatalogHeroTrailerUpdated || shouldPlayCollectionHeroVideoUpdated) && heroTrailerFirstFrameRenderedUpdated) 0f else 1f,
                 animationSpec = tween(durationMillis = 480),
                 label = "trailerContentFade"
             )
 
-            val shouldPlayTrailerLambda = remember { { shouldPlayCatalogHeroTrailerUpdated } }
+            val shouldPlayTrailerLambda = remember { { shouldPlayCatalogHeroTrailerUpdated || shouldPlayCollectionHeroVideoUpdated } }
             val heroTrailerRenderedLambda = remember { { heroTrailerFirstFrameRenderedUpdated } }
 
             val heroMetadataModifier = remember(rowHorizontalPadding, rowsViewportHeight) {


### PR DESCRIPTION
## Summary

Collection folder hero videos now expand into the full hero area (with content-row fade and title-block style transitions) exactly like catalog trailers do.

## PR type

- [x] Critical bug fix

## Problem

When a Collection folder has a `heroVideoUrl`, the video plays in the `TrailerPlayer` but:
1. The content rows do **not** fade out — they remain at full opacity on top of the video
2. The hero title block does **not** transition to its "trailer playing" style
3. The `BackHandler` does **not** fire for returning from the fullscreen state

The result is the video playing "behind" the collection cards/folders instead of expanding into the full hero area like normal catalog trailer playback.

## Root cause

Three expressions in `ModernHomeContent.kt` control the fullscreen expansion, content-row fade, and title-block style. All three only check `shouldPlayCatalogHeroTrailerState` (catalog item trailers) and ignore `shouldPlayCollectionHeroVideoState`:

1. `isTrailerPlayingFullscreenState` — gates the `BackHandler` and indicates fullscreen state
2. `trailerContentAlphaState` — animates content row alpha to 0 when a trailer plays fullscreen
3. `shouldPlayTrailerLambda` — read by `HeroTitleBlock.trailerPlaying` to switch text style

Note: `shouldPlayHeroTrailerState` (the OR of both conditions) was already used to create the `TrailerPlayer` — the video **did** play. But the surrounding layout never reacted because the fullscreen/fade/style expressions were not included.

## Fix

Include `shouldPlayCollectionHeroVideoState` in all three expressions:

```kotlin
// Before
derivedStateOf { fullScreenBackdrop && shouldPlayCatalogHeroTrailerState.value && heroTrailerFirstFrameRendered }

// After
derivedStateOf {
    fullScreenBackdrop &&
        (shouldPlayCatalogHeroTrailerState.value || shouldPlayCollectionHeroVideoState.value) &&
        heroTrailerFirstFrameRendered
}
```

Same pattern for `trailerContentAlphaState` and `shouldPlayTrailerLambda`.

Added `shouldPlayCollectionHeroVideoUpdated` via `rememberUpdatedState` to keep lambda reads consistent with the existing `shouldPlayCatalogHeroTrailerUpdated` pattern.

## Changed files

- `ModernHomeContent.kt` — 3 expression changes + 1 new `rememberUpdatedState` declaration (+18, -4 lines)

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL (only pre-existing warnings)

**Static analysis / code path verification:**

1. User navigates to a Collection page with hero video URL configured
2. Focus lands on a collection folder card → `focusedCatalogSelection` is set with `ModernPayload.CollectionFolder`
3. `collectionHeroVideoUrl` resolves from the payload
4. `shouldPlayCollectionHeroVideoState` becomes true (scroll stopped, sidebar closed, URL not blank, not ended)
5. **Before fix:** `isTrailerPlayingFullscreenState` remained false, `trailerContentAlphaState` stayed at 1f, `shouldPlayTrailerLambda` returned false
6. **After fix:** all three include the collection condition → `isTrailerPlayingFullscreenState` becomes true, alpha animates to 0, title block enters trailer style, BackHandler activates

**Device smoke test needed:**
1. Create a Collection with a folder that has a `heroVideoUrl` (mp4)
2. Navigate to the collection page (Modern layout, Full Screen Backdrop enabled)
3. Focus on the folder card
4. Observe: video should expand into the full hero area, content rows should fade, Back should dismiss

## Linked issues

Fixes #2683