### PR TITLE
fix(ui): card depth lower corners in Continue Watching section (#2656)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -498,18 +498,20 @@ fun ContinueWatchingCard(
         ),
         scale = CardDefaults.scale(focusedScale = 1f)
     ) {
-        Column {
+        Column(
+            modifier = Modifier
+                .nuvioCardDepth(
+                    shape = CwCardShape,
+                    surface = CardDepthSurface.CONTINUE_WATCHING,
+                    style = cardDepthStyle
+                )
+        ) {
             // Thumbnail with progress overlay
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(imageHeight)
                     .clip(CwClipShape)
-                    .nuvioCardDepth(
-                        shape = CwClipShape,
-                        surface = CardDepthSurface.CONTINUE_WATCHING,
-                        style = cardDepthStyle
-                    )
             ) {
                 // Background image with size hints for efficient decoding
                 if (effectiveImageModel.isNullOrBlank()) {


### PR DESCRIPTION
## Summary

The card depth effect (edge glow) now renders with fully rounded corners on Continue Watching cards, matching the behavior of poster cards elsewhere on the home screen.

## PR type

- [x] Critical bug fix

## Problem

With **Edge glow** enabled and **Edge coverage** set to anything other than "Top only" (e.g. "Half" or "Full Outline"), the lower two corners of Continue Watching cards displayed sharp 90° angles in the glow border, while every other card on the home screen had consistently rounded edges.

## Root cause

The `nuvioCardDepth` modifier was applied to the **thumbnail Box** inside the Continue Watching card, using `CwClipShape`:

```kotlin
private val CwClipShape = RoundedCornerShape(topStart = NuvioTheme.spacing.md, topEnd = NuvioTheme.spacing.md)
```

This shape only has top corners rounded (bottom corners = 0dp). The `border()` drawn by `cardDepthVisual` followed this shape, producing rectangular bottom corners.

Meanwhile, the actual **card shape** (`CwCardShape`) has all 4 corners rounded:
```kotlin
private val CwCardShape = RoundedCornerShape(NuvioTheme.radii.md)
```

## Fix

Move `nuvioCardDepth` from the thumbnail Box to the outer Column wrapper and pass `CwCardShape` (all 4 corners rounded). The edge glow now follows the same outline as the card itself.

The thumbnail Box retains its `.clip(CwClipShape)` for image clipping — only the depth effect border moves up one level.

## Changed files

- `ContinueWatchingSection.kt` — moved `nuvioCardDepth` from thumbnail Box to Column wrapper, changed shape from `CwClipShape` to `CwCardShape` (+8, -6 lines)

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL

**Static analysis:**

1. `CwCardShape` = `RoundedCornerShape(NuvioTheme.radii.md)` → all 4 corners rounded equally
2. `nuvioCardDepth(shape = CwCardShape, ...)` → `border()` now draws with all 4 corners rounded
3. The Card wrapping already clips content to `CwCardShape`, so the border stays within bounds
4. The thumbnail image still clips to `CwClipShape` (top-only rounded) — no visual change to the image corner treatment
5. The sheen overlay (top 22% of height) now covers 22% of the full card height (thumbnail + text) — visually consistent with poster card behavior

**Device smoke test needed:**
1. Enable "Edge glow" in settings
2. Set "Edge coverage" to "Half" or "Full Outline"
3. Navigate to Continue Watching section on Home
4. Observe: lower corners of the glow should now be rounded, matching other poster cards

## Linked issues

Fixes #2656