### PR TITLE
fix(ui): focus currently selected option when dropdown menus open (#2507)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -1109,6 +1109,16 @@ private fun LibraryDropdownPicker(
     var isFocused by remember { mutableStateOf(false) }
     var anchorSize by remember { mutableStateOf(IntSize.Zero) }
     var focusedOptionValue by remember(expanded) { mutableStateOf<String?>(null) }
+    val selectedItemFocusRequester = remember { FocusRequester() }
+
+    // When the dropdown opens, request focus on the currently selected item
+    // so the user can navigate from the correct position (#2507).
+    LaunchedEffect(expanded) {
+        if (expanded && selectedValue != null) {
+            kotlinx.coroutines.delay(50)
+            try { selectedItemFocusRequester.requestFocus() } catch (_: Exception) {}
+        }
+    }
 
     Box(modifier = modifier) {
         Card(
@@ -1200,6 +1210,7 @@ private fun LibraryDropdownPicker(
 
                 DropdownMenuItem(
                     modifier = Modifier
+                        .then(if (isSelected) Modifier.focusRequester(selectedItemFocusRequester) else Modifier)
                         .padding(horizontal = 6.dp, vertical = NuvioTheme.spacing.xxs)
                         .background(
                             color = itemBackgroundColor,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -294,6 +294,16 @@ private fun DiscoverDropdownPicker(
     var isFocused by remember { mutableStateOf(false) }
     var anchorSize by remember { mutableStateOf(IntSize.Zero) }
     var focusedOptionValue by remember(expanded) { mutableStateOf<String?>(null) }
+    val selectedItemFocusRequester = remember { FocusRequester() }
+
+    // When the dropdown opens, request focus on the currently selected item
+    // so the user can navigate from the correct position (#2507).
+    LaunchedEffect(expanded) {
+        if (expanded && selectedValue != null) {
+            kotlinx.coroutines.delay(50)
+            try { selectedItemFocusRequester.requestFocus() } catch (_: Exception) {}
+        }
+    }
 
     Box(modifier = modifier) {
         Card(
@@ -392,6 +402,7 @@ private fun DiscoverDropdownPicker(
 
                 DropdownMenuItem(
                     modifier = Modifier
+                        .then(if (isSelected) Modifier.focusRequester(selectedItemFocusRequester) else Modifier)
                         .padding(horizontal = 6.dp, vertical = NuvioTheme.spacing.xxs)
                         .background(
                             color = itemBackgroundColor,


### PR DESCRIPTION
## Summary

Dropdown menus in the Library and Discover tabs now open with focus on the currently selected option instead of always starting at the first item.

## PR type

- [x] Critical bug fix

## Problem

When opening any dropdown filter (Type, Sort, Genre in Library; filters in Discover), focus always landed on the first item regardless of which option was currently selected. This forced users to scroll from the top every time, making filter navigation tedious — especially for long genre lists.

Additionally, for long lists, closing and reopening the dropdown caused focus to drift approximately two items higher each time until reaching the beginning.

## Root cause

Neither `LibraryDropdownPicker` nor `DiscoverDropdownPicker` contained any logic to request focus on the selected item when the menu expanded. The default Material3 `DropdownMenu` behavior places focus on the first focusable child.

## Fix

In both dropdown composables:
1. Added a `FocusRequester` instance
2. Applied `.focusRequester(selectedItemFocusRequester)` to the `DropdownMenuItem` modifier of the currently selected option
3. Added a `LaunchedEffect(expanded)` that requests focus on the selected item with a 50ms delay (allowing the Popup composition to materialize)

The `try/catch` around `requestFocus()` guards against the rare case where the composable is disposed before the delay completes.

## Changed files

- `LibraryScreen.kt` → `LibraryDropdownPicker` (+11 lines)
- `SearchDiscoverSection.kt` → `DiscoverDropdownPicker` (+11 lines)

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL

**Static analysis:**

1. `FocusRequester` attached only to the item where `option.value == selectedValue`
2. `LaunchedEffect(expanded)` fires when `expanded` changes to `true`
3. 50ms delay allows the Popup + DropdownMenuContent to compose and measure before focus transfer
4. `try/catch` prevents crash if composition is torn down during the delay
5. No changes to selection logic, colors, or item layout

**Device smoke test needed:**
1. Open Library → tap any filter dropdown (Type, Sort, Genre)
2. Select an option other than the first
3. Close the dropdown, then reopen it
4. Observe: focus should land on the previously selected option, not the first item
5. Repeat with Discover tab filters

## Linked issues

Fixes #2507