### PR TITLE
fix(home): show full release date for TMDB collection movies (#2516)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -622,7 +622,12 @@ private var cachedDateFormatPattern: String? = null
 internal fun extractYearText(type: ContentType, releaseInfo: String?, released: String?, showFullDate: Boolean = true): String? {
     if (showFullDate && type == ContentType.MOVIE) {
         val full = released
-            ?.let { runCatching { java.time.OffsetDateTime.parse(it).toLocalDate() }.getOrNull() }
+            ?.let {
+                // Try OffsetDateTime first (addon format: "2024-03-15T00:00:00.000Z"),
+                // then LocalDate (TMDB collection format: "2024-03-15"). (#2516)
+                runCatching { java.time.OffsetDateTime.parse(it).toLocalDate() }.getOrNull()
+                    ?: runCatching { java.time.LocalDate.parse(it) }.getOrNull()
+            }
             ?.let {
                 val locale = java.util.Locale.getDefault()
                 val pattern = if (locale == cachedDateFormatLocale && cachedDateFormatPattern != null) {


### PR DESCRIPTION
## Summary

Movies inside FOLLOW_LAYOUT collections with TMDB sources now display the full localized release date (e.g. "15 March 2024") instead of just the year ("2024").

## PR type

- [x] Critical bug fix

## Problem

In the Modern Home layout, movies shown in catalog rows display a full localized release date (from the `released` field). The same movies shown inside a TMDB-sourced collection display only the year.

## Root cause

`extractYearText()` in `ModernHomeModels.kt` parses the `released` field using `OffsetDateTime.parse()`:

```kotlin
runCatching { java.time.OffsetDateTime.parse(it).toLocalDate() }.getOrNull()
```

This works for Stremio addon data where `released` is an ISO datetime with timezone offset (`"2024-03-15T00:00:00.000Z"`).

However, TMDB collection sources (`TmdbCollectionSourceResolver.kt`) provide `released` as a plain date string (`"2024-03-15"`). `OffsetDateTime.parse("2024-03-15")` throws a parse exception because there's no timezone offset, so `getOrNull()` returns null.

The function then falls through to `extractYearOrRange(releaseInfo)`, but `releaseInfo` was already truncated to 4 characters (year only) by the collection source resolver:
```kotlin
releaseInfo = it.releaseDate?.take(4),
```

Result: only the year is displayed.

## Fix

Add `LocalDate.parse()` as a fallback in `extractYearText()`:

```kotlin
runCatching { java.time.OffsetDateTime.parse(it).toLocalDate() }.getOrNull()
    ?: runCatching { java.time.LocalDate.parse(it) }.getOrNull()
```

This handles both formats:
- Addon ISO datetime → `OffsetDateTime.parse()` succeeds
- TMDB plain date → `OffsetDateTime.parse()` fails, `LocalDate.parse()` succeeds

Both paths produce a `LocalDate` that gets formatted as a full localized date string.

## Changed files

- `ModernHomeModels.kt` — 1 expression change in `extractYearText()` (+6, -1 lines)

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL

**Static analysis / logic verification:**

Given `released = "2024-03-15"`:
1. `OffsetDateTime.parse("2024-03-15")` → throws DateTimeParseException → `getOrNull()` = null
2. `LocalDate.parse("2024-03-15")` → succeeds → returns `LocalDate(2024, 3, 15)`
3. `DateTimeFormatter.ofPattern(bestPattern, locale).format(localDate)` → e.g. "15 March 2024" (locale-dependent)

Given `released = "2024-03-15T00:00:00.000Z"`:
1. `OffsetDateTime.parse(...)` → succeeds → `.toLocalDate()` → `LocalDate(2024, 3, 15)`
2. Fallback not reached

Both paths produce the correct full date.

**Device smoke test needed:**
1. Create a TMDB-sourced collection with movies
2. Set collection to FOLLOW_LAYOUT with Modern Home layout
3. Navigate to the collection
4. Observe: movies should display full release date, not just year

## Linked issues

Fixes #2516