### PR TITLE
fix(streams): reset scroll position when switching source tabs (#2538)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -1026,8 +1027,14 @@ private fun StreamsList(
     val firstCardFocusRequester = remember { FocusRequester() }
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     val restoreFocusRequester = remember { FocusRequester() }
+    val streamListState = rememberLazyListState()
     val firstStreamKey = streams.firstOrNull()?.let { first ->
         "${first.addonName}_${first.url ?: first.infoHash ?: first.ytId ?: "unknown"}"
+    }
+
+    // Reset scroll position to the top when the addon filter changes (#2538).
+    LaunchedEffect(selectedAddonFilter) {
+        streamListState.scrollToItem(0)
     }
 
     LaunchedEffect(requestInitialFocus, firstStreamKey) {
@@ -1055,6 +1062,7 @@ private fun StreamsList(
     }
 
     LazyColumn(
+        state = streamListState,
         modifier = Modifier
             .fillMaxSize()
             .padding(NuvioTheme.spacing.lg)


### PR DESCRIPTION
## Summary

The streams/sources list now scrolls back to the top when switching between addon filter tabs, instead of carrying the previous tab's scroll position.

## PR type

- [x] Critical bug fix

## Why

The Streams screen uses filter chips to switch between addon sources (e.g. Torrentio, MediaFusion). All tabs shared a single implicit `LazyColumn` scroll state. Scrolling down one provider's stream list and switching to another tab kept the same scroll offset, showing the second provider's list already scrolled far down (or showing empty space if it had fewer items).

`StreamsList` composable used the default `rememberLazyListState()` without explicit keying. Since the `LazyColumn` persists across tab switches (same composable, different items), the scroll state was never reset.

## Issue or approval

Fixes #2538

## Reproduction steps

1. Open a title with two or more installed source addons
2. On the first addon's tab, scroll the stream list down several items
3. Switch to the second addon's tab
4. Observe: the list is already scrolled down, showing empty space or the wrong items
5. Expected: list should start from the top for each addon

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `StreamScreen.kt` — `StreamsList` function: explicit `LazyListState` + scroll reset on filter change (+8 lines)
- No changes to the filter chip UI, stream item rendering, or data loading logic

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL

**Device smoke test needed:**
1. Open a title with two installed source addons
2. On the first addon's tab, scroll the stream list down
3. Switch to the second addon's tab using Left/Right
4. Observe: the list should start from the top, not carry the previous scroll position
5. Switch back to the first addon — list should also start from the top

## Screenshots / Video

Before/after comparison of scroll position reset. The fix addresses a visual glitch where an empty or wrong section of the list was visible after switching tabs.

## Breaking changes

None.

## Linked issues

Fixes #2538
