### PR TITLE
fix(player): seeking forward resets playback to beginning (#2545)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1327,7 +1327,7 @@ internal fun PlayerRuntimeController.initializePlayer(
 
                         val responseCode = (error.cause as? androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException)?.responseCode
                         if (responseCode == 416 && !hasRetriedCurrentStreamAfter416) {
-                            retryCurrentStreamFromStartAfter416()
+                            retryCurrentStreamFromStartAfter416(currentPosition)
                             return
                         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -607,11 +607,17 @@ internal fun PlayerRuntimeController.clearPendingInitialResumePosition() {
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(UnstableApi::class)
-internal fun PlayerRuntimeController.retryCurrentStreamFromStartAfter416() {
+internal fun PlayerRuntimeController.retryCurrentStreamFromStartAfter416(fromPositionMs: Long) {
     if (hasRetriedCurrentStreamAfter416) return
     hasRetriedCurrentStreamAfter416 = true
-    pendingResumeProgress = null
-    scheduleDeferredPlayerReinitialize(fromPositionMs = 0L, clearResumeProgress = true)
+    // Preserve the current position instead of resetting to the beginning.
+    // A 416 (Range Not Satisfiable) often happens when seeking forward beyond
+    // what the server's current response can serve. Restarting from position 0
+    // loses all playback progress and forces the user to re-seek.
+    // Keep pendingResumeProgress intact so the resume logic can re-apply it
+    // after reinitialization, complementing fromPositionMs.
+    val safePosition = fromPositionMs.takeIf { it > 0L } ?: 0L
+    scheduleDeferredPlayerReinitialize(fromPositionMs = safePosition, clearResumeProgress = false)
 }
 
 @androidx.annotation.OptIn(UnstableApi::class)


### PR DESCRIPTION
## Summary

When seeking forward during playback, if the server responds with HTTP 416 (Range Not Satisfiable), the player reinitializes from position 0 instead of preserving the current playback position.

## PR type

- [x] Critical bug fix

## Why

Seeking forward consistently resets the video/episode back to 0:00 (the very start). This happens every time a forward seek triggers a 416 from the streaming server.

In `PlayerRuntimeControllerInitialization.kt` line ~1329, when ExoPlayer encounters an `InvalidResponseCodeException` with responseCode 416, the handler calls `retryCurrentStreamFromStartAfter416()` which:
1. Clears `pendingResumeProgress` (null)
2. Calls `scheduleDeferredPlayerReinitialize(fromPositionMs = 0L, clearResumeProgress = true)`

This forces the player to restart from the beginning, discarding all playback progress.

A 416 error commonly occurs when seeking forward beyond what the server's current buffered range can serve — the server rejects the new byte-range request. The correct behavior is to reinitialize at the position the user was at (or wanted to reach), not from position 0.

## Issue or approval

Fixes #2545

## Reproduction steps

1. Play a torrent/stream source in the internal ExoPlayer
2. Seek forward (especially beyond the currently buffered range)
3. Observe: playback resets to 0:00 instead of resuming at the seeked position
4. This happens consistently when the server returns HTTP 416

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

- `PlayerRuntimeControllerObservers.kt` — `retryCurrentStreamFromStartAfter416()` signature + body: uses `fromPositionMs` (clamped to >= 0) instead of hardcoded `0L`
- `PlayerRuntimeControllerInitialization.kt` — call site passes `currentPosition` to `retryCurrentStreamFromStartAfter416(currentPosition)`
- No changes to error handling for other HTTP codes, player initialization, or UI behavior

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL

**Static analysis / code path verification:**

1. User seeks forward -> ExoPlayer sends new byte-range request to server
2. Server returns 416 -> `onPlayerError` fires
3. Error handler extracts `responseCode == 416` from `InvalidResponseCodeException`
4. Calls `retryCurrentStreamFromStartAfter416(currentPosition)`
5. `scheduleDeferredPlayerReinitialize(fromPositionMs = currentPosition, clearResumeProgress = false)`
6. Player reinitializes -> `pendingSeekPosition = currentPosition` (set in `scheduleDeferredPlayerReinitialize`)
7. On `STATE_READY` -> `seekTo(pendingSeekPosition)` -> playback resumes at correct position

**Note on test failure:** `StreamAutoPlaySelectorTest` has 1 pre-existing failure on upstream `dev` (binge group in MANUAL mode expects null but real behavior returns a match). This is NOT caused by our change — same test fails on clean `dev` checkout. PR #2766 addresses this separately.

**Device smoke test needed:**
1. Play a torrent/stream source where forward seeking triggers a 416
2. Seek forward
3. Verify playback resumes at the seeked position, NOT from 0:00
4. Verify no regression on normal seek behavior (seek backward, seek to specific position)

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2545
