### PR TITLE
fix(home): Hero section uses wrong localized month form for release dates (#2508)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -633,7 +633,13 @@ internal fun extractYearText(type: ContentType, releaseInfo: String?, released: 
                         cachedDateFormatLocale = locale
                     }
                 }
-                java.time.format.DateTimeFormatter.ofPattern(pattern, locale).format(it)
+                // Use SimpleDateFormat (not DateTimeFormatter) to match the Details
+                // page formatting. DateTimeFormatter.ofPattern interprets MMMM as
+                // the standalone month form in some locales (e.g. Polish "czerwiec"
+                // instead of the genitive "czerwca" used in full dates), while
+                // SimpleDateFormat uses the inflected form expected in date context.
+                java.text.SimpleDateFormat(pattern, locale)
+                    .format(java.util.Date(it.atStartOfDay(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli()))
             }
         if (full != null) return full
     }


### PR DESCRIPTION
## Summary

The Hero section in Modern Home displays release dates with the wrong grammatical month form in some locales (e.g. Polish standalone "czerwiec" instead of genitive "czerwca"). The Details page already formats the same date correctly.

## PR type

- [x] Critical bug fix

## Why

In languages with distinct standalone vs. inflected month forms (Polish, Czech, Russian, etc.), the Hero section shows the standalone form:
- **Hero (wrong):** "25 czerwiec 2026" (standalone — as if listing the month name)
- **Details (correct):** "25 czerwca 2026" (genitive — correct for a full date)

Both screens call `android.text.format.DateFormat.getBestDateTimePattern(locale, "dMMMMy")` to get the locale-appropriate pattern. The pattern contains `MMMM` (full month name).

However, the two screens use **different formatters** with the same pattern:
- **Details page** (`HeroSection.kt` line 651): `java.text.SimpleDateFormat(pattern, locale)` — uses the inflected month form (legacy Java behavior)
- **Hero section** (`ModernHomeModels.kt` line 636): `java.time.format.DateTimeFormatter.ofPattern(pattern, locale)` — uses the standalone month form (`TextStyle.FULL_STANDALONE`) in some locales

`DateTimeFormatter` interprets `MMMM` as standalone by default in the ICU library for Slavic locales, while `SimpleDateFormat` uses the inflected form.

## Issue or approval

Fixes #2508

## Reproduction steps

1. Set device locale to Polish (or Czech, Russian, etc.)
2. Open a movie with a release date (e.g. June 25, 2026) in the Hero section on the Modern Home screen
3. Observe the month form: "25 czerwiec 2026" (standalone form — wrong)
4. Navigate to the Details page for the same movie
5. Observe the same date formatted as "25 czerwca 2026" (genitive form — correct)

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `ModernHomeModels.kt` — `extractYearText()` formatter changed from `DateTimeFormatter` to `SimpleDateFormat`
- No changes to the Details page (`HeroSection.kt`) — it already uses the correct formatter
- No changes to caching, layout, or other behavior

## Testing

**Compilation verified:** `./gradlew :app:compileFullDebugKotlin` — BUILD SUCCESSFUL

**Static analysis:**
1. `extractYearText()` now uses `SimpleDateFormat` with `getBestDateTimePattern(locale, "dMMMMy")`
2. This is identical to the Details page `HeroSection.kt` line 651 approach
3. Both screens will now produce the same localized date string for the same input
4. Caching behavior preserved (pattern is still cached by locale)

**Device test needed:**
1. Set device locale to Polish
2. Open a movie with a release date (e.g. June 25, 2026)
3. Verify Hero section shows "25 czerwca 2026" (genitive form)
4. Verify Details page shows the same format
5. Confirm both screens now match

## Screenshots / Video

Before/after comparison requires a Polish locale device setup. The change affects only the month form text (standalone vs genitive), not layout or structure.

## Breaking changes

None.

## Linked issues

Fixes #2508
