### PR TITLE
fix(player): allow focus on Report Issue in error overlay (#2571)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -2714,6 +2714,7 @@ private fun ErrorOverlay(
     onBack: () -> Unit
 ) {
     val exitFocusRequester = remember { FocusRequester() }
+    val reportFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
         exitFocusRequester.requestFocus()
@@ -2779,14 +2780,25 @@ private fun ErrorOverlay(
                         onClick = onReport,
                         isPrimary = false,
                         enabled = reportStatus != PlaybackIssueReportStatus.Sending &&
-                            reportStatus != PlaybackIssueReportStatus.Sent
+                            reportStatus != PlaybackIssueReportStatus.Sent,
+                        modifier = Modifier
+                            .focusRequester(reportFocusRequester)
+                            .focusProperties { right = exitFocusRequester }
                     )
                 }
                 DialogButton(
                     text = stringResource(R.string.player_go_back),
                     onClick = onBack,
                     isPrimary = true,
-                    modifier = Modifier.focusRequester(exitFocusRequester)
+                    modifier = Modifier
+                        .focusRequester(exitFocusRequester)
+                        .then(
+                            if (showReportAction) {
+                                Modifier.focusProperties { left = reportFocusRequester }
+                            } else {
+                                Modifier
+                            }
+                        )
                 )
             }
         }


### PR DESCRIPTION
## Summary

Fix focus/navigation bug in the playback error overlay where navigating LEFT from the 'Go Back' button to the 'Report Issue' button was broken for ~45 seconds after the overlay appeared. Added explicit focusProperties linking the two buttons and a FocusRequester for the Report Issue button.

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only

## Why

When a playback error occurs, the error overlay shows two buttons: 'Report Issue' (left) and 'Go Back' (right). Default focus is on 'Go Back', but pressing LEFT on the D-pad to reach 'Report Issue' did not work immediately. It only worked after ~45 seconds (coinciding with LOADING_ISSUE_REPORT_DELAY_MS = 45_000L in PlayerLoadingDiagnostics.kt, which triggered a recomposition that refreshed the focus tree), or by pressing DOWN then LEFT as a workaround.

The root cause: only the 'Go Back' button had a FocusRequester assigned (exitFocusRequester), and neither button had explicit focusProperties for left/right traversal. In Compose TV, when programmatic focus (FocusRequester.requestFocus()) is used on one child in a Row, the default sibling focus traversal can break because the focus system does not establish proper horizontal links between the two buttons.

## Issue or approval

Fixes #2571

## Reproduction steps

1. Trigger a playback error that shows the error overlay
2. Wait for the overlay to appear (default focus is on 'Go Back')
3. Press LEFT on the D-pad to navigate to 'Report Issue'
4. Observe that focus stays on 'Go Back' and does not move to 'Report Issue'
5. After ~40-45 seconds, pressing LEFT works (focus tree recomposition)
6. Alternative workaround: press DOWN then LEFT works immediately

## UI / behavior impact

- [x] Fixes a navigation/accessibility bug (D-pad left navigation now works immediately)
- [ ] Changes visual appearance
- [ ] Changes behavior/functionality
- [ ] Other (please describe)

## Policy check

- [x] This PR has a linked GitHub issue
- [x] Changes are minimal and focused on a single bug
- [x] No feature additions, UI polish, refactors, or drive-by cleanups
- [x] PR is against the dev branch
- [x] PR adheres to the project's freeze policy (critical bug fix only)
- [x] Commit message references the issue
- [x] All changes are in a single commit

## Scope boundaries

- Only modifies ErrorOverlay composable in PlayerScreen.kt
- Does NOT change any other overlays, focus logic, or timer behavior
- Does NOT change the 45-second LOADING_ISSUE_REPORT_DELAY_MS timer (that is a separate concern for the loading overlay, not the error overlay)
- Does NOT alter default focus behavior (Go Back still receives initial focus)
- Does NOT change any business logic, UI text, or visuals

## Testing

- Code review: explicit focusProperties linking matches the established pattern used throughout the codebase (e.g., skip-intro focus routing fix #2714)
- No unit tests exist for the ErrorOverlay composable (purely UI/composable, no test coverage for TV Compose focus behavior in this project)
- Build compiles (1 file changed, 14 insertions, 2 deletions)

## Screenshots / Video

Not a UI visual change / focus-only.

## Breaking changes

None.

## Linked issues

Fixes #2571