### PR TITLE
Simkl: expand watched badge to sibling IDs and TmdbEntityBrowse screen

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -2184,6 +2184,7 @@ class MetaDetailsViewModel @Inject constructor(
             _uiState.update {
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
             }
+            reevaluateSeriesWatchedBadge()
             showMessage(localizedContext.getString(R.string.detail_marked_episodes_watched, unwatched.size))
         }
     }
@@ -2227,6 +2228,7 @@ class MetaDetailsViewModel @Inject constructor(
             _uiState.update {
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
             }
+            reevaluateSeriesWatchedBadge()
             showMessage(localizedContext.getString(R.string.detail_marked_episodes_unwatched, watched.size))
         }
     }
@@ -2273,6 +2275,7 @@ class MetaDetailsViewModel @Inject constructor(
             _uiState.update {
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
             }
+            reevaluateSeriesWatchedBadge()
             showMessage(localizedContext.getString(R.string.detail_marked_previous_watched, unwatched.size))
         }
     }
@@ -2313,6 +2316,7 @@ class MetaDetailsViewModel @Inject constructor(
             _uiState.update {
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys - pendingKeys)
             }
+            reevaluateSeriesWatchedBadge()
             showMessage(localizedContext.getString(R.string.detail_marked_episodes_watched, unwatched.size))
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -205,6 +205,9 @@ class HomeViewModel @Inject constructor(
     /** Snapshot of watchedShowEpisodes keys from the last badge evaluation cycle. */
     @Volatile
     internal var cwLastBadgeEpisodeKeys: Set<String> = emptySet()
+    /** Cached show ID siblings from the last badge evaluation cycle (for anime ID expansion). */
+    @Volatile
+    internal var cwLastShowIdSiblings: Map<String, Set<String>> = emptyMap()
     internal val cwTmdbIdCache = Collections.synchronizedMap(mutableMapOf<String, String?>())
     internal val cwNextUpResolutionCache = Collections.synchronizedMap(mutableMapOf<String, NextUpResolution?>())
     internal val cwNextUpNegativeCacheTimestamps = ConcurrentHashMap<String, Long>()
@@ -334,6 +337,7 @@ class HomeViewModel @Inject constructor(
                     cwEnrichedNextUpOverlay.clear()
                     cwEnrichedInProgressOverlay.clear()
                     cwLastBadgeEpisodeKeys = emptySet()
+                    cwLastShowIdSiblings = emptyMap()
                     _uiState.update {
                         it.copy(layoutPreferencesReady = false, continueWatchingItems = emptyList())
                     }
@@ -386,6 +390,7 @@ class HomeViewModel @Inject constructor(
         cwEnrichedNextUpOverlay.clear()
         cwEnrichedInProgressOverlay.clear()
         cwLastBadgeEpisodeKeys = emptySet()
+        cwLastShowIdSiblings = emptyMap()
         watchedSeriesStateHolder.clearValidationState()
         _uiState.update { it.copy(continueWatchingItems = emptyList(), upcomingItems = emptyList()) }
         // Bump trigger so the pipeline's collectLatest restarts with fresh state.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -683,6 +683,7 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     cwLastBadgeEpisodeKeys = currentKeys.toSet()
 
                     val showIdSiblings = watchProgressRepository.getShowIdSiblings()
+                    cwLastShowIdSiblings = showIdSiblings
 
                     // Deduplicate IDs using Trakt's sibling mapping (IMDB ↔ TMDB from
                     // the same show). Resolve meta once per show, then cross-cache the
@@ -2731,12 +2732,20 @@ private fun HomeViewModel.publishBadgeUpdate(
         .toSet()
     // Expand IDs: for each fully-watched IMDB ID, also include the
     // "tmdb:<id>" variant so catalogs that use TMDB IDs get the badge too.
+    // Additionally expand with anime-tracker siblings (mal:, kitsu:, anidb:, anilist:)
+    // so catalogs using those IDs also show the badge.
+    val siblingMap = cwLastShowIdSiblings
     val expandedFullyWatched = buildSet {
         addAll(updatedFullyWatched)
         for (contentId in updatedFullyWatched) {
             if (contentId.startsWith("tt")) {
                 tmdbService.cachedTmdbId(contentId)?.let { tmdbId ->
                     add("tmdb:$tmdbId")
+                }
+            }
+            siblingMap[contentId]?.forEach { siblingId ->
+                if (siblingId != contentId && !siblingId.startsWith("__")) {
+                    add(siblingId)
                 }
             }
         }
@@ -2747,6 +2756,11 @@ private fun HomeViewModel.publishBadgeUpdate(
             if (contentId.startsWith("tt")) {
                 tmdbService.cachedTmdbId(contentId)?.let { tmdbId ->
                     add("tmdb:$tmdbId")
+                }
+            }
+            siblingMap[contentId]?.forEach { siblingId ->
+                if (siblingId != contentId && !siblingId.startsWith("__")) {
+                    add(siblingId)
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
@@ -92,6 +92,8 @@ fun TmdbEntityBrowseScreen(
     onNavigateToDetail: (itemId: String, itemType: String, addonBaseUrl: String?) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val watchedMovieIds by viewModel.watchedMovieIds.collectAsStateWithLifecycle()
+    val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsStateWithLifecycle()
     val screenMode = when (uiState) {
         TmdbEntityBrowseUiState.Loading -> 0
         is TmdbEntityBrowseUiState.Error -> 1
@@ -129,6 +131,8 @@ fun TmdbEntityBrowseScreen(
                     TmdbEntityBrowseContent(
                         data = successState.data,
                         sourceType = viewModel.sourceType,
+                        watchedMovieIds = watchedMovieIds,
+                        watchedSeriesIds = watchedSeriesIds,
                         onNavigateToDetail = onNavigateToDetail,
                         onItemLongPress = { item ->
                             viewModel.posterOptions.show(item, null)
@@ -157,6 +161,8 @@ fun TmdbEntityBrowseScreen(
 private fun TmdbEntityBrowseContent(
     data: TmdbEntityBrowseData,
     sourceType: String,
+    watchedMovieIds: Set<String>,
+    watchedSeriesIds: Set<String>,
     onNavigateToDetail: (itemId: String, itemType: String, addonBaseUrl: String?) -> Unit,
     onItemLongPress: (MetaPreview) -> Unit = {},
     onLoadMoreRail: (TmdbEntityMediaType, TmdbEntityRailType) -> Unit
@@ -265,6 +271,8 @@ private fun TmdbEntityBrowseContent(
                                     )
                                 },
                                 posterCardStyle = posterCardStyle,
+                                watchedMovieIds = watchedMovieIds,
+                                watchedSeriesIds = watchedSeriesIds,
                                 restoreItemId = pendingRestoreItemId,
                                 restoreFocusToken = restoreFocusToken,
                                 onInitialFocusHandled = { initialFocusRequested = true },
@@ -426,6 +434,8 @@ private fun EntityRailRow(
     rememberedFocusedIndex: Int,
     rowListState: LazyListState,
     posterCardStyle: PosterCardStyle,
+    watchedMovieIds: Set<String>,
+    watchedSeriesIds: Set<String>,
     restoreItemId: String?,
     restoreFocusToken: Int,
     onInitialFocusHandled: () -> Unit,
@@ -545,6 +555,11 @@ private fun EntityRailRow(
                     onLongPress = { onItemLongPress(item) },
                     posterCardStyle = posterCardStyle,
                     showLabel = true,
+                    isWatched = if (rail.mediaType == TmdbEntityMediaType.TV) {
+                        item.id in watchedSeriesIds
+                    } else {
+                        item.id in watchedMovieIds
+                    },
                     focusRequester = requester,
                     onFocused = {
                         onFocusedItemIndexChanged(itemIndex)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseViewModel.kt
@@ -26,6 +26,8 @@ class TmdbEntityBrowseViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val tmdbMetadataService: TmdbMetadataService,
     private val tmdbSettingsDataStore: TmdbSettingsDataStore,
+    private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
+    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
     val posterOptions: com.nuvio.tv.ui.components.posteroptions.PosterOptionsController,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -41,12 +43,20 @@ class TmdbEntityBrowseViewModel @Inject constructor(
     }
     val sourceType: String = savedStateHandle.get<String>("sourceType").orEmpty()
 
+    private val _watchedMovieIds = MutableStateFlow<Set<String>>(emptySet())
+    val watchedMovieIds: StateFlow<Set<String>> = _watchedMovieIds.asStateFlow()
+    val watchedSeriesIds: StateFlow<Set<String>> = watchedSeriesStateHolder.fullyWatchedSeriesIds
+
     private val _uiState = MutableStateFlow<TmdbEntityBrowseUiState>(TmdbEntityBrowseUiState.Loading)
     val uiState: StateFlow<TmdbEntityBrowseUiState> = _uiState.asStateFlow()
 
     init {
         posterOptions.bind(viewModelScope)
         load()
+        viewModelScope.launch {
+            watchProgressRepository.observeWatchedMovieIds()
+                .collect { ids -> _watchedMovieIds.value = ids }
+        }
     }
 
     fun retry() {


### PR DESCRIPTION
## Summary

Expand watched badge ID coverage so that fully-watched series are recognized under all known sibling IDs (MAL, Kitsu, AniDB, AniList, Simkl, TMDB, Trakt) and add watched badges to the TmdbEntityBrowse screen (network/company).

## PR type

- [x] Critical bug fix

## Why

When a series is marked fully watched under its IMDB ID, catalogs displaying the same series under a different ID (e.g. `mal:123`, `kitsu:456`, `tmdb:789`) did not show the watched badge. This is because `publishBadgeUpdate` only expanded IMDB -> TMDB, ignoring anime-tracker and other sibling IDs provided by the tracking provider's sibling map.

Additionally, the TmdbEntityBrowse screen (opened via network/station icon on detail page) had no watched badge support at all despite items using `tmdb:` IDs that are now present in `fullyWatchedSeriesIds`.

## Issue or approval

Continuation of https://github.com/NuvioMedia/NuvioTV/pull/2741

## Reproduction steps

1. Have anime tracked in Simkl (e.g. Attack on Titan under multiple MAL entries sharing one IMDB)
2. Mark all episodes as watched via Simkl
3. Navigate to a catalog that uses `mal:` or `kitsu:` IDs for that anime
4. Observe: no watched badge appears on the poster
5. Navigate to a network screen (e.g. click network icon on a series detail) -> no badges at all

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change how `fullyWatchedSeriesIds` is computed (aired vs watched comparison unchanged)
- Does not change ambiguous ID handling - `__ambiguous__` siblings are still excluded from expansion
- Does not affect the CW pipeline next-up logic
- TmdbEntityBrowse screen: only adds badge observation, no other UI/behavior changes

## Testing

- Built successfully with `compileFullDebugKotlin`
- SimklAnimeWatchedResolutionTest and SimklProjectionsTest pass
- Verified ambiguous ID filtering: when sibling map contains `__ambiguous__`, expansion is skipped
- Verified Trakt sibling map (IMDB<->TMDB<->Trakt) feeds into expansion
- Verified Simkl sibling map (IMDB<->TMDB<->MAL<->Kitsu<->AniDB<->AniList<->Simkl) feeds into expansion

## Screenshots / Video

Not a UI change - badges use existing GridContentCard check icon, just now appear in more contexts.

## Breaking changes

None.

## Linked issues

Continuation of https://github.com/NuvioMedia/NuvioTV/pull/2741
