### PR TITLE
fix(player): restore ExoPlayer aspect modes broken by fixed-size surface buffers (#2761)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerAspectScaleUtils.kt
@@ -131,6 +131,15 @@ internal fun applyExoAspectMode(playerView: PlayerView, mode: AspectMode) {
 
     applyAspectScale(targetView, mode, viewAspect, videoAspect)
     centerTargetInPlayer(playerView, targetView)
+    (surfaceView as? SurfaceView)?.let { surface ->
+        val videoSize = playerView.player?.videoSize
+        applySurfaceBufferSizing(
+            surfaceView = surface,
+            mode = mode,
+            videoWidth = videoSize?.width ?: 0,
+            videoHeight = videoSize?.height ?: 0
+        )
+    }
 }
 
 internal fun applyAspectMode(playerView: PlayerView, mode: AspectMode) {
@@ -225,14 +234,16 @@ internal fun configureHardwareSurfaceOverlay(
     playerView: PlayerView,
     videoWidth: Int,
     videoHeight: Int,
-    frameRate: Float = 0f
+    frameRate: Float = 0f,
+    aspectMode: AspectMode
 ) {
     val targetView = resolveVideoSurfaceView(playerView) as? SurfaceView ?: return
-    if (videoWidth > 0 && videoHeight > 0) {
-        runCatching {
-            targetView.holder.setFixedSize(videoWidth, videoHeight)
-        }
-    }
+    applySurfaceBufferSizing(
+        surfaceView = targetView,
+        mode = aspectMode,
+        videoWidth = videoWidth,
+        videoHeight = videoHeight
+    )
     runCatching {
         targetView.setZOrderMediaOverlay(false)
     }
@@ -247,6 +258,26 @@ internal fun configureHardwareSurfaceOverlay(
                     )
                 }
             }
+        }
+    }
+}
+
+private fun applySurfaceBufferSizing(
+    surfaceView: SurfaceView,
+    mode: AspectMode,
+    videoWidth: Int,
+    videoHeight: Int
+) {
+    // A fixed-size buffer is only safe while the surface stays inside the screen:
+    // once an aspect mode scales it past the screen edges, the composer squeezes the
+    // full buffer into the clipped window and distorts the picture (#2761).
+    if (mode == AspectMode.ORIGINAL && videoWidth > 0 && videoHeight > 0) {
+        runCatching {
+            surfaceView.holder.setFixedSize(videoWidth, videoHeight)
+        }
+    } else {
+        runCatching {
+            surfaceView.holder.setSizeFromLayout()
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1420,7 +1420,8 @@ private fun ExoPlayerSurface(
                         playerView = playerView,
                         videoWidth = videoSize.width,
                         videoHeight = videoSize.height,
-                        frameRate = fps
+                        frameRate = fps,
+                        aspectMode = latestAspectMode
                     )
                 }
             }
@@ -1434,7 +1435,8 @@ private fun ExoPlayerSurface(
                         playerView = playerView,
                         videoWidth = size.width,
                         videoHeight = size.height,
-                        frameRate = fps
+                        frameRate = fps,
+                        aspectMode = latestAspectMode
                     )
                 }
             }
@@ -1448,7 +1450,8 @@ private fun ExoPlayerSurface(
                 playerView = playerView,
                 videoWidth = size.width,
                 videoHeight = size.height,
-                frameRate = fps
+                frameRate = fps,
+                aspectMode = latestAspectMode
             )
         }
         onDispose {


### PR DESCRIPTION
## Summary

Fixes ExoPlayer aspect modes rendering as stretched video since 0.7.20. `SurfaceHolder.setFixedSize()` is now applied only in the default (`ORIGINAL`/Fit) aspect mode; every scaled mode (Crop, Stretch, zooms) switches the surface back to `setSizeFromLayout()`.

Root cause: 0.7.20 introduced `configureHardwareSurfaceOverlay()` (244379f3, PR #2719), which pins the video SurfaceView buffer to the video dimensions via `setFixedSize()` to engage the TV HWC/VPU scaler. When an aspect mode scales the surface past the screen edges (Crop scales `exo_content_frame` uniformly beyond the display bounds), the surface window gets clipped to the screen, and the composer then squeezes the entire fixed-size buffer into that clipped window. The result: Crop looks identical to Stretch (distorted picture). This matches the report exactly — broken on ExoPlayer, "Always", first reported the day 0.7.20 shipped, on an AMLogic-based box (Mi Box S), and 244379f3 is the only display/surface change between 0.7.19 and 0.7.20.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Aspect ratio control is broken for ExoPlayer users on 0.7.20: Crop (and the zoom modes) distort the picture instead of cropping, with no workaround other than switching the whole engine to Libmpv.

## Issue or approval

Fixes #2761

## Reproduction steps

1. Set the internal player engine to ExoPlayer (0.7.20).
2. Play any title whose aspect ratio differs from the screen (e.g. a 2.35:1 movie on a 16:9 TV).
3. Cycle the aspect ratio to **Crop**.
4. Observe the picture is stretched/distorted (identical to Stretch) instead of cropped with correct proportions.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- The HWC overlay optimization from #2719 is intentionally kept for the default `ORIGINAL` mode (the surface never overflows the screen there, so the fixed-size buffer is safe), and `setZOrderMediaOverlay()` / `Surface.setFrameRate()` are untouched in all modes.
- The Libmpv part of #2761 (subtitles scaling together with the video on aspect change) is a separate, pre-existing issue in the mpv surface scaling path and is not addressed here to keep this PR minimal.

## Testing

- Bisected the regression: `git log 0.7.19-beta..0.7.20-beta` shows 244379f3 is the only display/surface change between the last good and first bad release; the fix restores the exact pre-0.7.20 surface sizing (`setSizeFromLayout`) for all scaled modes.
- Verified every `configureHardwareSurfaceOverlay()` call site passes the current aspect mode, and that `applyExoAspectMode()` now re-syncs buffer sizing when the user cycles modes mid-playback (both directions: entering and leaving `ORIGINAL`).
- **Reproduced and verified on an Android TV emulator** (android-tv arm64 system image, Android 14 / API 34, 1920×1080), matching the reporter's Android 14 TV device:
  - Content: Tears of Steel 720p (1280×534, true 2.40:1 — open movie, CC-BY), served from a local Stremio addon; internal player on **ExoPlayer** (Media3 1.8.0 confirmed via logcat).
  - **Before (dev @ be335045, same code as 0.7.20):** Fit renders correctly letterboxed; switching to **Crop** fills the screen by vertically stretching the picture (identical to Stretch) instead of cropping — logcat confirms `Aspect mode toggled: ORIGINAL -> FULL_SCREEN (Crop)` while the frame is visibly distorted.
  - **After (this fix):** Crop fills the screen with a uniform zoom (sides cropped, proportions correct). Cycled through all 7 modes — Stretch still stretches (its intended behavior), Slight/Cinema Zoom, Vertical/Horizontal stretch, and Fit all behave as designed.
  - `assembleFullDebug` builds cleanly on both branches.

## Screenshots / Video

All from the same 2.40:1 test video on the internal ExoPlayer:

**1. Before — Fit: correct letterbox (baseline)**
<img width="1920" height="1080" alt="1-before-fit-correct" src="https://github.com/user-attachments/assets/3f8dc1ee-6cbc-4033-899f-7db85e25901e" />

**2. Before — Crop (OSD label visible): picture vertically stretched — the bug**
<img width="1920" height="1080" alt="2-before-crop-BUG-stretched" src="https://github.com/user-attachments/assets/777b4599-52a8-4e09-9c79-b88023fecc12" />

**3. After — Crop: full-screen uniform crop, correct proportions**
<img width="1920" height="1080" alt="3-after-crop-FIXED" src="https://github.com/user-attachments/assets/0c187245-f34f-4d70-aacb-7b48923fb616" />

**4. After — Stretch: still stretches (intended behavior preserved)**
<img width="1920" height="1080" alt="4-after-stretch-intended" src="https://github.com/user-attachments/assets/3e624d4b-0956-447f-9856-b0b09ead0767" />

**5. After — Fit: still correct**
<img width="1920" height="1080" alt="5-after-fit-correct" src="https://github.com/user-attachments/assets/5851299e-47c1-44fe-9c9a-e0fb06b46950" />

## Breaking changes

None.

## Linked issues

Fixes #2761

