### PR TITLE
fix(continue-watching): add next episode to Continue Watching after current episode is marked watched (#2581)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -726,6 +726,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
                 if (syncRemote && authManager.isAuthenticated) {
                     triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
                 }
+                // Emit optimistic continue-watching update so the next episode
+                // appears on the home screen without requiring manual playback.
+                optimisticContinueWatchingUpdates.tryEmit(progress)
             }
             // Mirror to Nuvio Sync so data is ready if user switches source later.
             if (syncRemote && authManager.isAuthenticated) {
@@ -755,6 +758,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
             if (syncRemote && authManager.isAuthenticated) {
                 triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
             }
+            // Emit optimistic continue-watching update so the next episode
+            // appears on the home screen without requiring manual playback.
+            optimisticContinueWatchingUpdates.tryEmit(progress)
         }
     }
 


### PR DESCRIPTION
## Summary

When an episode is watched to completion (>= 90% watched) and the user exits playback, the episode is correctly marked as watched. However, the next episode of the series does not appear in the "Continue Watching" section on the home screen until the user manually starts playing it.

The root cause is that `saveProgress()` calls `markAsWatched()` when `progress.isCompleted()` but does not emit an optimistic continue-watching update. The home screen only picks up the next episode when a progress save with a non-zero position triggers the optimistic flow.

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only

## Why

Users expect the next episode to appear in Continue Watching immediately after finishing the previous one. Having to manually start the next episode to "seed" Continue Watching is a poor UX experience reported by multiple users.

## Issue or approval

Fixes #2581

## Reproduction steps

1. Open any TV series
2. Start playing an episode
3. Watch the episode until approximately 98% completion
4. Press the Back button to exit playback
5. Return to the home screen
6. **Before fix**: The next episode does NOT appear in "Continue Watching" — you must manually open and play it for a few seconds
7. **After fix**: The next episode appears in "Continue Watching" automatically

## UI / behavior impact

- [x] No visible UI changes — Continue Watching behavior is restored to the expected state: the next episode appears automatically after finishing the current one.

## Policy check

- [x] No user-facing strings were added or modified
- [x] No new permissions are required
- [x] No analytics events were added or modified
- [x] No network calls were added or modified
- [x] No database migrations were added
- [x] The change is backward-compatible with existing saved data
- [x] All existing unit and integration tests pass
- [x] The fix does not introduce any dependency changes

## Scope boundaries

- Only modifies `WatchProgressRepositoryImpl.saveProgress()` to emit an `optimisticContinueWatchingUpdates` event when an episode is marked as completed.
- No changes to the save path, UI components, or configuration files.
- The optimistic flow already exists and handles the home screen refresh — this fix simply triggers it on episode completion.

## Testing

The fix adds a single `tryEmit()` call to an existing `MutableSharedFlow` that the home screen already observes. The optimistic flow handler already knows how to resolve the next episode from a completed `WatchProgress` entry.

## Screenshots / Video

Not a UI change

## Breaking changes

None. The fix is purely additive: it triggers an existing flow that was not being triggered on episode completion.

## Linked issues

Fixes #2581
