### PR TITLE
fix(subtitles): apply font size/position when subtitle track becomes active in ExoPlayer (#2599)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -97,6 +97,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.common.Tracks
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import androidx.tv.material3.Border
@@ -1433,7 +1434,7 @@ private fun ExoPlayerSurface(
                 }
             }
 
-            override fun onTracksChanged(trackGroups: androidx.media3.common.TrackGroups, trackSelections: androidx.media3.common.TrackSelectionArray) {
+            override fun onTracksChanged(tracks: Tracks) {
                 // Re-apply subtitle style when tracks change so style is applied
                 // even when subtitles are enabled after initial player setup.
                 playerView.post {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1369,6 +1369,7 @@ private fun ExoPlayerSurface(
 ) {
     val context = LocalContext.current
     val latestAspectMode by rememberUpdatedState(aspectMode)
+    val latestSubtitleStyle by rememberUpdatedState(subtitleStyle)
     val playerView = remember(context, player) {
         PlayerView(context).apply {
             useController = false
@@ -1429,6 +1430,14 @@ private fun ExoPlayerSurface(
                         videoHeight = size.height,
                         frameRate = fps
                     )
+                }
+            }
+
+            override fun onTracksChanged(trackGroups: androidx.media3.common.TrackGroups, trackSelections: androidx.media3.common.TrackSelectionArray) {
+                // Re-apply subtitle style when tracks change so style is applied
+                // even when subtitles are enabled after initial player setup.
+                playerView.post {
+                    playerView.applySubtitleStyleIfNeeded(latestSubtitleStyle)
                 }
             }
         }
@@ -1502,8 +1511,14 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
     if (getTag(R.id.player_view_subtitle_style_tag) == subtitleStyle) {
         return
     }
+    val subView = subtitleView
+    if (subView == null) {
+        // SubtitleView not yet available (no track selected yet). Don't set the
+        // tag so that when subtitles become active the style is re-applied.
+        return
+    }
     setTag(R.id.player_view_subtitle_style_tag, subtitleStyle)
-    subtitleView?.apply {
+    subView.apply {
         val baseFontSize = 24f
         val scaledFontSize = baseFontSize * (subtitleStyle.size / 100f)
         setFixedTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, scaledFontSize)


### PR DESCRIPTION
## Summary

The subtitle font size and position settings (configured in Settings > Subtitles) were not applied when using the ExoPlayer engine — they only worked when using MPV. Users could change the values and see them update in settings, but the actual subtitle rendering did not change.

The root cause is in `PlayerView.applySubtitleStyleIfNeeded()` in `PlayerScreen.kt`:
1. The function sets a deduplication tag (`player_view_subtitle_style_tag`) **before** checking if `subtitleView` is null
2. If `subtitleView` is null (which happens when no subtitle track is active yet), the style application is silently skipped
3. However, the tag is already set, so the next call sees the same style and returns early — the style is never applied even when subtitles become active later

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only

## Why

Subtitle font size and position are core accessibility features. Users with vision needs rely on larger subtitles, and the settings being silently ignored on the default engine (ExoPlayer) is a significant accessibility regression.

## Issue or approval

Fixes #2599

## Reproduction steps

1. Open Settings > Subtitles
2. Change font size to 200% and position to a different value
3. Play any video with subtitles using the default ExoPlayer engine
4. **Before fix**: Subtitles render at default size/position — settings are ignored
5. **After fix**: Subtitles render at the configured size/position

## UI / behavior impact

- [x] Subtitle font size and vertical position now correctly apply when using ExoPlayer (previously only worked with MPV engine)

## Policy check

- [x] No user-facing strings were added or modified
- [x] No new permissions are required
- [x] No analytics events were added or modified
- [x] No network calls were added or modified
- [x] No database migrations were added
- [x] The change is backward-compatible with existing saved data
- [x] All existing unit and integration tests pass
- [x] The fix does not introduce any dependency changes

## Scope boundaries

- Only modifies `PlayerScreen.kt`:
  - `applySubtitleStyleIfNeeded()`: returns early without setting the tag if `subtitleView` is null
  - `ExoPlayerSurface()`: adds `onTracksChanged` listener to re-apply style when tracks change
  - Adds `latestSubtitleStyle` via `rememberUpdatedState` for track-changed callback
- No changes to any settings, data, or configuration files.

## Testing

The fix ensures that:
1. When `subtitleView` is null, the deduplication tag is NOT set, so the style will be re-applied when subtitles become available
2. When tracks change (e.g. user selects a subtitle track), `onTracksChanged` fires and re-applies the style
3. The existing `LaunchedEffect(playerView, subtitleStyle)` continues to handle style changes from settings

## Screenshots / Video

Not a UI layout change — shows corrected subtitle rendering behavior

## Breaking changes

None. The fix only changes when the subtitle style is applied, not what is applied. Existing behavior with MPV is unchanged.

## Linked issues

Fixes #2599
