### PR TITLE
fix(collections): hide undated TMDB titles when Hide Unreleased Content is on (#2793)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/util/ReleaseInfoUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/core/util/ReleaseInfoUtils.kt
@@ -33,3 +33,11 @@ fun CatalogRow.filterReleasedItems(
     val filtered = items.filterNot { it.isUnreleased(today, clock) }
     return if (filtered.size == items.size) this else copy(items = filtered)
 }
+
+/**
+ * True when the item carries no release information at all. Only meaningful for
+ * sources where dates are authoritative (e.g. TMDB, where a movie without a
+ * release_date is unannounced); addon metadata often legitimately omits dates.
+ */
+fun MetaPreview.hasNoReleaseInfo(): Boolean =
+    released.isNullOrBlank() && releaseInfo.isNullOrBlank()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.R
 import com.nuvio.tv.core.build.AppFeaturePolicy
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.tmdb.TmdbCollectionSourceResolver
+import com.nuvio.tv.core.util.hasNoReleaseInfo
 import com.nuvio.tv.core.util.isUnreleased
 import com.nuvio.tv.core.trakt.TraktPublicListSourceResolver
 import com.nuvio.tv.data.trailer.TrailerService
@@ -907,7 +908,10 @@ class FolderDetailViewModel @Inject constructor(
                         _uiState.update { s ->
                             val tabs = s.tabs.toMutableList()
                             val currentRow = tabs.getOrNull(tabIndex)?.catalogRow
-                            val filteredData = result.data.filteredForRelease(s.hideUnreleasedContent)
+                            val filteredData = result.data.filteredForRelease(
+                                hideUnreleased = s.hideUnreleasedContent,
+                                treatMissingDateAsUnreleased = true
+                            )
                             val row = if (append && currentRow != null) {
                                 val existingIds = currentRow.items.map { "${it.apiType}:${it.id}" }.toHashSet()
                                 val newItems = filteredData.items.filter { "${it.apiType}:${it.id}" !in existingIds }
@@ -1536,10 +1540,21 @@ class FolderDetailViewModel @Inject constructor(
 
 }
 
-/** Drops unreleased items from a freshly-loaded row when the user toggle is on. */
-private fun CatalogRow.filteredForRelease(hideUnreleased: Boolean): CatalogRow {
+/**
+ * Drops unreleased items from a freshly-loaded row when the user toggle is on.
+ * [treatMissingDateAsUnreleased] additionally drops items that have no release
+ * information at all — used for TMDB-resolved rows, where a missing release date
+ * means the title is unannounced (#2793). Addon rows keep the lenient behavior
+ * because sparse addon metadata often omits dates for released content.
+ */
+private fun CatalogRow.filteredForRelease(
+    hideUnreleased: Boolean,
+    treatMissingDateAsUnreleased: Boolean = false
+): CatalogRow {
     if (!hideUnreleased) return this
     val today = java.time.LocalDate.now()
-    val filtered = items.filterNot { it.isUnreleased(today) }
+    val filtered = items.filterNot { item ->
+        item.isUnreleased(today) || (treatMissingDateAsUnreleased && item.hasNoReleaseInfo())
+    }
     return if (filtered.size == items.size) this else copy(items = filtered)
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -969,7 +969,10 @@ class FolderDetailViewModel @Inject constructor(
                         _uiState.update { s ->
                             val tabs = s.tabs.toMutableList()
                             val currentRow = tabs.getOrNull(tabIndex)?.catalogRow
-                            val filteredData = result.data.filteredForRelease(s.hideUnreleasedContent)
+                            val filteredData = result.data.filteredForRelease(
+                                hideUnreleased = s.hideUnreleasedContent,
+                                treatMissingDateAsUnreleased = true
+                            )
                             val row = if (append && currentRow != null) {
                                 val existingIds = currentRow.items.map { "${it.apiType}:${it.id}" }.toHashSet()
                                 val newItems = filteredData.items.filter { "${it.apiType}:${it.id}" !in existingIds }
@@ -1543,9 +1546,10 @@ class FolderDetailViewModel @Inject constructor(
 /**
  * Drops unreleased items from a freshly-loaded row when the user toggle is on.
  * [treatMissingDateAsUnreleased] additionally drops items that have no release
- * information at all — used for TMDB-resolved rows, where a missing release date
- * means the title is unannounced (#2793). Addon rows keep the lenient behavior
- * because sparse addon metadata often omits dates for released content.
+ * information at all — used for TMDB- and Trakt-resolved rows, where a missing
+ * release date means the title is unannounced (#2793). Addon rows keep the
+ * lenient behavior because sparse addon metadata often omits dates for
+ * released content.
  */
 private fun CatalogRow.filteredForRelease(
     hideUnreleased: Boolean,

--- a/app/src/test/java/com/nuvio/tv/core/util/ReleaseInfoUtilsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/util/ReleaseInfoUtilsTest.kt
@@ -52,7 +52,32 @@ class ReleaseInfoUtilsTest {
         )
     }
 
-    private fun preview(released: String): MetaPreview = MetaPreview(
+    // --- #2793: TMDB titles with no release information at all ---
+    // A TMDB collection can contain announced-but-undated titles (e.g.
+    // "Untitled Top Gun 3": release_date is empty on TMDB). Those map to
+    // released == null and releaseInfo == null, which the date-based
+    // isUnreleased() cannot flag — the strict TMDB collection path catches
+    // them via hasNoReleaseInfo() instead.
+
+    @Test
+    fun `undated item is not caught by date-based isUnreleased`() {
+        val item = preview(released = null)
+        assertFalse(item.isUnreleased(today = LocalDate.of(2026, 7, 28)))
+    }
+
+    @Test
+    fun `undated item is flagged by hasNoReleaseInfo`() {
+        assertTrue(preview(released = null).hasNoReleaseInfo())
+        assertTrue(preview(released = " ", releaseInfo = "").hasNoReleaseInfo())
+    }
+
+    @Test
+    fun `dated items are not flagged by hasNoReleaseInfo`() {
+        assertFalse(preview(released = "2022-05-27").hasNoReleaseInfo())
+        assertFalse(preview(released = null, releaseInfo = "2022").hasNoReleaseInfo())
+    }
+
+    private fun preview(released: String?, releaseInfo: String? = null): MetaPreview = MetaPreview(
         id = "tt1",
         type = ContentType.MOVIE,
         name = "Title",
@@ -61,7 +86,7 @@ class ReleaseInfoUtilsTest {
         background = null,
         logo = null,
         description = null,
-        releaseInfo = null,
+        releaseInfo = releaseInfo,
         imdbRating = null,
         genres = emptyList(),
         released = released,


### PR DESCRIPTION
## Summary

Fixes "Hide Unreleased Content" not hiding unannounced titles inside collections that use a TMDB source (#2793).

Root cause: the collection pipeline does apply the filter (`FolderDetailViewModel.filteredForRelease` runs for every TMDB tab load), but the filter itself cannot flag titles that have **no release information at all**. `MetaPreview.isUnreleased()` returns `false` when both `released` and `releaseInfo` are null — and that is exactly what TMDB returns for announced-but-undated titles. The reporter's example, "Untitled Top Gun 3" in collection 531330, has an empty `release_date` on TMDB, so it mapped to `released = null` / `releaseInfo = null` and sailed through the filter.

The fix adds a `hasNoReleaseInfo()` check that is applied to **TMDB- and Trakt-resolved collection rows**, where a missing release date authoritatively means "unannounced" (Trakt included at the reporter's request — same gap, same code shape). Addon-sourced rows keep the existing lenient behavior on purpose: sparse addon metadata often omits dates for perfectly released content, and hiding those would be a regression.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With "Hide Unreleased Content" enabled, unreleased/unannounced titles still show up inside TMDB-backed collections, contradicting the setting and the behavior everywhere else in the app. Previously reported in #2323 and auto-closed as stale; still reproducible on 0.7.20.

## Issue or approval

Fixes #2793

## Reproduction steps

1. Enable the "Hide Unreleased Content" setting.
2. Create a collection using a TMDB source with Collection ID 531330 (Top Gun Collection).
3. Open the collection.
4. "Untitled Top Gun 3" (no release date on TMDB) is still visible despite the setting.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Strict missing-date filtering applies to TMDB and Trakt collection source rows (`loadTmdbSourceForTab` / `loadTraktSourceForTab`, covering both the initial load and pagination for every source type). Trakt was added at the reporter's request since it shares the exact same gap; released Trakt content always carries a `year`, so undated items there are likewise unannounced titles.
- Addon catalog rows intentionally keep the lenient date-based filter — addon metadata frequently omits dates for released content, and hiding those would be a regression. If maintainers want stricter addon behavior too, that needs a product decision and is best handled separately.
- No changes to the home screen, search, or details pipelines — their existing `filterReleasedItems`/`isUnreleased` behavior is unchanged.

## Testing

- Verified the root cause against real TMDB data: collection 531330's third entry ("Untitled Top Gun 3") has an empty `release_date` on TMDB, which maps to `released = null` / `releaseInfo = null` — the exact shape `isUnreleased()` cannot flag.
- Added unit tests (`ReleaseInfoUtilsTest`): an undated item passes the date-based `isUnreleased()` check (documents the gap) and is flagged by the new `hasNoReleaseInfo()`; dated items (full date or year-only) are not flagged. Existing release-timestamp tests still pass.
- `:app:testFullDebugUnitTest` and `:app:compileFullDebugKotlin` pass locally.
- Note: my local debug build has no TMDB API key, so I could not click through the exact TMDB collection on-device. The CI debug APK from this PR is built with the repo's keys — the reproduction steps above should show "Untitled Top Gun 3" hidden with the setting enabled and visible with it disabled.

## Screenshots / Video

Not a UI change (list-content behavior fix). The bug's visual state is captured in the issue's screenshot; after the fix the undated title is simply absent from the collection when the setting is on.

## Breaking changes

None.

## Linked issues

Fixes #2793
