### PR TITLE
Accelerate scrubbing while remote keys are held

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -977,10 +977,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             showControlsTemporarily()
         }
         PlayerEvent.OnSeekForward -> {
-            onEvent(PlayerEvent.OnSeekBy(deltaMs = 10_000L))
+            onEvent(PlayerEvent.OnSeekBy(deltaMs = PlayerScrubRates.STEP_SHORT_MS))
         }
         PlayerEvent.OnSeekBackward -> {
-            onEvent(PlayerEvent.OnSeekBy(deltaMs = -10_000L))
+            onEvent(PlayerEvent.OnSeekBy(deltaMs = -PlayerScrubRates.STEP_SHORT_MS))
         }
         is PlayerEvent.OnSeekBy -> {
             pendingPreviewSeekPosition = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -621,14 +621,12 @@ fun PlayerScreen(
                         KeyEvent.KEYCODE_DPAD_LEFT,
                         KeyEvent.KEYCODE_DPAD_RIGHT -> {
                             if (!uiState.showControls) {
-                                val repeatCount = keyEvent.nativeKeyEvent.repeatCount
-                                val stepMs = when {
-                                    repeatCount >= 8 -> 30_000L
-                                    repeatCount >= 3 -> 20_000L
-                                    else -> 10_000L
-                                }
-                                val isLeft = keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_LEFT
-                                val deltaMs = if (isLeft) -stepMs else stepMs
+                                val isLeft =
+                                    keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_LEFT
+                                val deltaMs = PlayerScrubRates.deltaMsForKeyRepeat(
+                                    repeatCount = keyEvent.nativeKeyEvent.repeatCount,
+                                    forward = !isLeft
+                                )
                                 viewModel.onEvent(PlayerEvent.OnPreviewSeekBy(deltaMs))
                                 true
                             } else {
@@ -681,11 +679,25 @@ fun PlayerScreen(
                             true
                         }
                         KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> {
-                            viewModel.onEvent(PlayerEvent.OnSeekForward)
+                            viewModel.onEvent(
+                                PlayerEvent.OnSeekBy(
+                                    PlayerScrubRates.deltaMsForKeyRepeat(
+                                        repeatCount = keyEvent.nativeKeyEvent.repeatCount,
+                                        forward = true
+                                    )
+                                )
+                            )
                             true
                         }
                         KeyEvent.KEYCODE_MEDIA_REWIND -> {
-                            viewModel.onEvent(PlayerEvent.OnSeekBackward)
+                            viewModel.onEvent(
+                                PlayerEvent.OnSeekBy(
+                                    PlayerScrubRates.deltaMsForKeyRepeat(
+                                        repeatCount = keyEvent.nativeKeyEvent.repeatCount,
+                                        forward = false
+                                    )
+                                )
+                            )
                             true
                         }
                         else -> false
@@ -2247,11 +2259,21 @@ private fun ProgressBar(
                             }
                         }
                         KeyEvent.KEYCODE_DPAD_LEFT -> {
-                            onSeekPreview(-10_000L)
+                            onSeekPreview(
+                                PlayerScrubRates.deltaMsForKeyRepeat(
+                                    repeatCount = keyEvent.nativeKeyEvent.repeatCount,
+                                    forward = false
+                                )
+                            )
                             true
                         }
                         KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                            onSeekPreview(10_000L)
+                            onSeekPreview(
+                                PlayerScrubRates.deltaMsForKeyRepeat(
+                                    repeatCount = keyEvent.nativeKeyEvent.repeatCount,
+                                    forward = true
+                                )
+                            )
                             true
                         }
                         else -> false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScrubRates.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScrubRates.kt
@@ -1,0 +1,40 @@
+package com.nuvio.tv.ui.screens.player
+
+/**
+ * Scrub / seek step sizes for remote D-pad and media keys.
+ *
+ * Android TV remotes fire repeated ACTION_DOWN events while a direction
+ * key is held (`KeyEvent.repeatCount` increases). Mapping that count to
+ * progressively larger steps makes long holds scrub faster without changing
+ * the feel of a single tap.
+ */
+object PlayerScrubRates {
+    const val STEP_SHORT_MS = 10_000L
+    const val STEP_MEDIUM_MS = 20_000L
+    const val STEP_LONG_MS = 30_000L
+    const val STEP_VERY_LONG_MS = 60_000L
+
+    private const val MEDIUM_REPEAT_THRESHOLD = 3
+    private const val LONG_REPEAT_THRESHOLD = 8
+    private const val VERY_LONG_REPEAT_THRESHOLD = 15
+
+    /**
+     * Returns the seek delta magnitude (always positive) for the given key
+     * repeat count. Callers apply the sign for forward / backward.
+     */
+    fun stepMsForKeyRepeat(repeatCount: Int): Long {
+        val count = repeatCount.coerceAtLeast(0)
+        return when {
+            count >= VERY_LONG_REPEAT_THRESHOLD -> STEP_VERY_LONG_MS
+            count >= LONG_REPEAT_THRESHOLD -> STEP_LONG_MS
+            count >= MEDIUM_REPEAT_THRESHOLD -> STEP_MEDIUM_MS
+            else -> STEP_SHORT_MS
+        }
+    }
+
+    /** Signed delta for a left/rewind (negative) or right/forward (positive) scrub. */
+    fun deltaMsForKeyRepeat(repeatCount: Int, forward: Boolean): Long {
+        val step = stepMsForKeyRepeat(repeatCount)
+        return if (forward) step else -step
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerScrubRatesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerScrubRatesTest.kt
@@ -1,0 +1,30 @@
+package com.nuvio.tv.ui.screens.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlayerScrubRatesTest {
+
+    @Test
+    fun stepMsForKeyRepeat_rampsWithHold() {
+        assertEquals(PlayerScrubRates.STEP_SHORT_MS, PlayerScrubRates.stepMsForKeyRepeat(0))
+        assertEquals(PlayerScrubRates.STEP_SHORT_MS, PlayerScrubRates.stepMsForKeyRepeat(2))
+        assertEquals(PlayerScrubRates.STEP_MEDIUM_MS, PlayerScrubRates.stepMsForKeyRepeat(3))
+        assertEquals(PlayerScrubRates.STEP_MEDIUM_MS, PlayerScrubRates.stepMsForKeyRepeat(7))
+        assertEquals(PlayerScrubRates.STEP_LONG_MS, PlayerScrubRates.stepMsForKeyRepeat(8))
+        assertEquals(PlayerScrubRates.STEP_LONG_MS, PlayerScrubRates.stepMsForKeyRepeat(14))
+        assertEquals(PlayerScrubRates.STEP_VERY_LONG_MS, PlayerScrubRates.stepMsForKeyRepeat(15))
+        assertEquals(PlayerScrubRates.STEP_VERY_LONG_MS, PlayerScrubRates.stepMsForKeyRepeat(100))
+    }
+
+    @Test
+    fun deltaMsForKeyRepeat_appliesDirection() {
+        assertEquals(-PlayerScrubRates.STEP_SHORT_MS, PlayerScrubRates.deltaMsForKeyRepeat(0, forward = false))
+        assertEquals(PlayerScrubRates.STEP_LONG_MS, PlayerScrubRates.deltaMsForKeyRepeat(8, forward = true))
+    }
+
+    @Test
+    fun stepMsForKeyRepeat_clampsNegativeRepeatCount() {
+        assertEquals(PlayerScrubRates.STEP_SHORT_MS, PlayerScrubRates.stepMsForKeyRepeat(-1))
+    }
+}


### PR DESCRIPTION
## Summary
- Centralize seek step sizes in `PlayerScrubRates` so hold-to-scrub acceleration is consistent across controls.
- Apply ramped steps (10s → 20s → 30s → 60s by key `repeatCount`) to hidden-controls D-pad scrub, focused progress bar L/R, and media FF/RW.
- Keep single-tap seek at 10s; add unit coverage for the ramp thresholds.

## Test plan
- [ ] On Android TV, tap D-pad left/right with controls hidden — still seeks ±10s
- [ ] Hold D-pad left/right with controls hidden — scrub steps increase (20s / 30s / 60s)
- [ ] Focus progress bar and hold L/R — same acceleration
- [ ] Hold media FF/RW — same acceleration
- [ ] Run `PlayerScrubRatesTest`