### PR TITLE
fix(mpv): pass resume start option as loadfile fifth argument

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -52,7 +52,7 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
             ?.let { String.format(Locale.US, "start=%.3f", it / 1000.0) }
         if (startOption != null && holder.surface?.isValid == true) {
             ensureSurfaceAttachedIfAlreadyAvailable()
-            mpv.command("loadfile", url, "replace", startOption)
+            loadFileWithOptions(url, startOption)
             hasQueuedInitialMedia = true
             pendingInitialMediaUrl = null
             pendingInitialStartOption = null
@@ -88,10 +88,19 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         pendingInitialMediaUrl = null
         pendingInitialStartOption = null
         if (startOption != null) {
-            mpv.command("loadfile", url, "replace", startOption)
+            loadFileWithOptions(url, startOption)
         } else {
             mpv.command("loadfile", url, "replace")
         }
+    }
+
+    /**
+     * mpv's `loadfile` signature is `<url> [<flags> [<index> [<options>]]]`, so the per-file option
+     * list belongs in the fifth argument. Passing it where `<index>` is expected makes mpv reject
+     * the whole command and stay idle, i.e. resuming at a position would never load the file.
+     */
+    private fun loadFileWithOptions(url: String, options: String) {
+        mpv.command("loadfile", url, "replace", LOADFILE_DEFAULT_INDEX, options)
     }
 
     fun setMediaUsingLoadfile(url: String, headers: Map<String, String>) {
@@ -640,6 +649,8 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "NuvioMpvSurfaceView"
+        /** `loadfile` insertion index; only meaningful for insert-at flags, -1 is mpv's default. */
+        private const val LOADFILE_DEFAULT_INDEX = "-1"
         private const val MPV_COVER_FALLBACK_SCALE = 1.15f
         private const val MPV_MAX_VOLUME_PERCENT = 400.0
         private const val ASPECT_RETRY_DELAY_MS = 120L


### PR DESCRIPTION
## Summary

MPV player fails to load media when resuming from a saved watch position. The `loadfile` command passes `start=` as the 4th argument, but mpv 0.38+ expects that slot to be an insertion index; the option list belongs in the 5th argument. mpv rejects the command and stays idle.

This change routes resume options through a dedicated helper that sends `-1` for index and `start=` in the options slot.

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only

## Why

When playback resumes from saved progress (`startPositionMs > 0`), `NuvioMpvSurfaceView.setMedia()` builds a `start=…` option and passes it to:

```
mpv.command("loadfile", url, "replace", startOption)
```

mpv's `loadfile` signature is:

```
loadfile <url> [<flags> [<index> [<options>]]]
```

The 4th parameter must be an integer index. mpv tries to parse `start=32.658` as that index, fails, and rejects the entire command:

```
The loadfile option must be an integer: start=32.658
Command loadfile: argument index can't be parsed: option parameter could not be parsed.
```

After that mpv emits `event: idle` and never loads the file. `time-pos`, `duration`, and track metadata stay unavailable; the UI looks stuck on loading/buffering even though AFR and other preflight steps may have succeeded.

Fresh playback (`startPositionMs == 0`) is unaffected because it uses the 3-argument form without `start=`.

## Issue or approval

No linked GitHub issue yet. Bug observed on device (Smart TV Pro, armv7l mpv build) while testing resume playback on a partially watched MKV stream after AFR preflight completed successfully.

Symptoms: player screen opens, AFR may detect frame rate and switch display mode, but MPV never starts — logcat shows the `loadfile` parse error above and repeated `mpv_get_property … was unavailable` polling.

## Reproduction steps

1. Enable MPV as the internal player.
2. Start an episode or movie and watch for ~30 seconds so watch progress is saved (> 0 ms).
3. Exit playback and reopen the same item (resume from saved position).
4. Observe MPV init in logcat: `loadfile` fails with `start=… must be an integer`, then `event: idle`.
5. Player UI stays on loading/buffering; no video, no audio, no tracks.

Workaround: clear watch progress or start from 0 — playback works because no `start=` option is sent.

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `NuvioMpvSurfaceView.kt` is changed.
- No changes to AFR preflight, ExoPlayer paths, or watch-progress storage.
- `setMediaUsingLoadfile()` and zero-start `loadfile` calls are untouched.
- No UI/layout changes.

## Testing

- Reproduced on Smart TV Pro (192.168.2.13): resume playback failed with `loadfile` index parse error in logcat before the fix.
- After fix: `loadfile` uses `replace`, `-1`, `start=…`; resume playback should load and seek correctly.
- Fresh start (`startPositionMs = 0`) still uses the existing 3-argument `loadfile` path.
- Suggested manual verify after install:
  1. Resume a partially watched title — video should start near saved position.
  2. Start a new title from the beginning — should still work.
  3. Confirm logcat no longer shows `The loadfile option must be an integer`.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

No linked issue — bug found during local MPV + AFR testing. Resume-from-progress failure caused by incorrect `loadfile` argument ordering against mpv 0.38+ API.
