### PR TITLE
Feat/simkl anime tracking

### DIFF
--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -24,6 +24,7 @@ import com.nuvio.tv.core.sync.StartupSyncService
 import com.nuvio.tv.core.sync.androidtv.AndroidTvChannelSyncService
 import com.nuvio.tv.core.network.IPv4FirstDns
 import com.nuvio.tv.data.local.SentrySettingsDataStore
+import com.nuvio.tv.data.simkl.SimklAnimeIdPreferenceHolder
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.Cookie
 import okhttp3.CookieJar
@@ -39,6 +40,7 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
     @Inject lateinit var androidTvChannelSyncService: AndroidTvChannelSyncService
     @Inject lateinit var realtimeSyncInvalidationService: RealtimeSyncInvalidationService
     @Inject lateinit var sentrySettingsDataStore: SentrySettingsDataStore
+    @Inject lateinit var simklAnimeIdPreferenceHolder: SimklAnimeIdPreferenceHolder
 
     companion object {
         /**

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.data.simkl.SimklAnimeIdPreference
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -61,6 +62,7 @@ class TraktSettingsDataStore @Inject constructor(
     private val watchProgressSourceKey = stringPreferencesKey("watch_progress_source")
     private val librarySourceModeKey = stringPreferencesKey("library_source_mode")
     private val moreLikeThisSourceKey = stringPreferencesKey("more_like_this_source")
+    private val simklAnimeIdPreferenceKey = stringPreferencesKey("simkl_anime_id_preference")
 
     val continueWatchingDaysCap: Flow<Int> = profileManager.activeProfileId.flatMapLatest { pid ->
         factory.get(pid, FEATURE).data.map { prefs ->
@@ -190,6 +192,18 @@ class TraktSettingsDataStore @Inject constructor(
     suspend fun setMoreLikeThisSource(source: MoreLikeThisSourcePreference) {
         store().edit { prefs ->
             prefs[moreLikeThisSourceKey] = source.name
+        }
+    }
+
+    val simklAnimeIdPreference: Flow<SimklAnimeIdPreference> = profileManager.activeProfileId.flatMapLatest { pid ->
+        factory.get(pid, FEATURE).data.map { prefs ->
+            SimklAnimeIdPreference.fromStorage(prefs[simklAnimeIdPreferenceKey])
+        }
+    }
+
+    suspend fun setSimklAnimeIdPreference(preference: SimklAnimeIdPreference) {
+        store().edit { prefs ->
+            prefs[simklAnimeIdPreferenceKey] = preference.name
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklAnimeIdPreference.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklAnimeIdPreference.kt
@@ -1,0 +1,27 @@
+package com.nuvio.tv.data.simkl
+
+/**
+ * Determines which external ID is used as the canonical content ID for anime entries
+ * resolved through Simkl.
+ *
+ * By default (IMDB), anime entries that share the same IMDB ID get grouped together
+ * (e.g. multiple MAL seasons of one franchise). Choosing MAL or KITSU gives each season
+ * its own canonical ID so they appear as separate items in the library and watched state.
+ */
+enum class SimklAnimeIdPreference {
+    /** Use IMDB ID when available (groups multiple seasons under one ID). */
+    IMDB,
+
+    /** Prefer MyAnimeList ID — each MAL entry gets its own canonical ID. */
+    MAL,
+
+    /** Prefer Kitsu ID — each Kitsu entry gets its own canonical ID. */
+    KITSU;
+
+    companion object {
+        val DEFAULT = IMDB
+
+        fun fromStorage(value: String?): SimklAnimeIdPreference =
+            entries.firstOrNull { it.name == value } ?: DEFAULT
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklAnimeIdPreferenceHolder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklAnimeIdPreferenceHolder.kt
@@ -1,0 +1,35 @@
+package com.nuvio.tv.data.simkl
+
+import com.nuvio.tv.data.local.TraktSettingsDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds the current [SimklAnimeIdPreference] in memory so that projection functions
+ * (which run synchronously on snapshot data) can access the preference without suspending.
+ *
+ * Listens to the DataStore flow and updates [current] whenever it changes.
+ */
+@Singleton
+class SimklAnimeIdPreferenceHolder @Inject constructor(
+    settingsDataStore: TraktSettingsDataStore
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    init {
+        settingsDataStore.simklAnimeIdPreference
+            .onEach { preference -> current = preference }
+            .launchIn(scope)
+    }
+
+    companion object {
+        @Volatile
+        var current: SimklAnimeIdPreference = SimklAnimeIdPreference.DEFAULT
+            internal set
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklLibraryProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklLibraryProjection.kt
@@ -110,7 +110,7 @@ private fun SimklLibraryEntry.toLibraryEntry(
     val simklId = media.ids.simklIdValue()?.toLongOrNull()
     val entryType = when (mediaType) {
         SimklMediaType.MOVIES -> "movie"
-        SimklMediaType.ANIME -> "anime"
+        SimklMediaType.ANIME -> if (animeType == "movie") "movie" else "series"
         SimklMediaType.SHOWS -> "series"
     }
     return LibraryEntry(
@@ -139,3 +139,4 @@ private fun SimklLibraryEntry.toLibraryEntry(
         trackingSourceUrl = buildSimklSourceUrl(mediaType, media)
     )
 }
+

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
@@ -133,16 +133,38 @@ fun SimklMedia.toTrackingExternalIds(): TrackingExternalIds = TrackingExternalId
     kitsu = ids.idValue("kitsu")?.toLongOrNull()
 )
 
-fun SimklMedia.canonicalContentId(): String? = when {
-    !ids.idValue("imdb").isNullOrBlank() -> ids.idValue("imdb")
-    !ids.idValue("tmdb").isNullOrBlank() -> "tmdb:${ids.idValue("tmdb")}"
-    !ids.idValue("tvdb").isNullOrBlank() -> "tvdb:${ids.idValue("tvdb")}"
-    !ids.idValue("mal").isNullOrBlank() -> "mal:${ids.idValue("mal")}"
-    !ids.idValue("anidb").isNullOrBlank() -> "anidb:${ids.idValue("anidb")}"
-    !ids.idValue("anilist").isNullOrBlank() -> "anilist:${ids.idValue("anilist")}"
-    !ids.idValue("kitsu").isNullOrBlank() -> "kitsu:${ids.idValue("kitsu")}"
-    !ids.simklIdValue().isNullOrBlank() -> "simkl:${ids.simklIdValue()}"
-    else -> null
+fun SimklMedia.canonicalContentId(): String? =
+    canonicalContentId(SimklAnimeIdPreferenceHolder.current)
+
+/**
+ * Resolves the canonical content ID for this media entry.
+ * When the user prefers MAL or Kitsu, anime-specific IDs take priority over IMDB.
+ */
+fun SimklMedia.canonicalContentId(preference: SimklAnimeIdPreference): String? {
+    when (preference) {
+        SimklAnimeIdPreference.MAL -> {
+            ids.idValue("mal")?.takeIf(String::isNotBlank)?.let { return "mal:$it" }
+            ids.idValue("kitsu")?.takeIf(String::isNotBlank)?.let { return "kitsu:$it" }
+            ids.idValue("anidb")?.takeIf(String::isNotBlank)?.let { return "anidb:$it" }
+        }
+        SimklAnimeIdPreference.KITSU -> {
+            ids.idValue("kitsu")?.takeIf(String::isNotBlank)?.let { return "kitsu:$it" }
+            ids.idValue("mal")?.takeIf(String::isNotBlank)?.let { return "mal:$it" }
+            ids.idValue("anidb")?.takeIf(String::isNotBlank)?.let { return "anidb:$it" }
+        }
+        SimklAnimeIdPreference.IMDB -> Unit
+    }
+    return when {
+        !ids.idValue("imdb").isNullOrBlank() -> ids.idValue("imdb")
+        !ids.idValue("tmdb").isNullOrBlank() -> "tmdb:${ids.idValue("tmdb")}"
+        !ids.idValue("tvdb").isNullOrBlank() -> "tvdb:${ids.idValue("tvdb")}"
+        !ids.idValue("mal").isNullOrBlank() -> "mal:${ids.idValue("mal")}"
+        !ids.idValue("anidb").isNullOrBlank() -> "anidb:${ids.idValue("anidb")}"
+        !ids.idValue("anilist").isNullOrBlank() -> "anilist:${ids.idValue("anilist")}"
+        !ids.idValue("kitsu").isNullOrBlank() -> "kitsu:${ids.idValue("kitsu")}"
+        !ids.simklIdValue().isNullOrBlank() -> "simkl:${ids.simklIdValue()}"
+        else -> null
+    }
 }
 
 fun simklPosterUrl(path: String?): String? = path?.trim()?.trim('/')

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklSyncModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklSyncModels.kt
@@ -181,7 +181,8 @@ data class SimklSyncState(
     val snapshot: SimklSyncSnapshot = SimklSyncSnapshot(),
     val isLoading: Boolean = false,
     val hasLoaded: Boolean = false,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val projectionVersion: Long = 0L
 )
 
 fun Map<String, JsonElement>.idValue(key: String): String? =

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklSyncRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklSyncRepository.kt
@@ -182,6 +182,15 @@ class SimklSyncRepository @Inject constructor(
     private fun isCurrent(profileId: Int, generation: Long): Boolean =
         profileId == profileManager.activeProfileId.value && generation == profileGeneration
 
+    /**
+     * Bumps the projection version to force downstream collectors (CW, library, watched badges)
+     * to recompute their projections without re-fetching from the network.
+     */
+    fun invalidateProjections() {
+        val current = _state.value
+        _state.value = current.copy(projectionVersion = current.projectionVersion + 1L)
+    }
+
     private companion object {
         const val TAG = "SimklSync"
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.rememberUpdatedState
@@ -1314,10 +1313,9 @@ private fun MetaDetailsContent(
     }
     var activePeopleTab by rememberSaveable(meta.id) { mutableStateOf(initialPeopleTab) }
     var seasonOptionsDialogSeason by remember { mutableStateOf<Int?>(null) }
-    // Tracks whether the initial auto-scroll to the "next to play" episode has fired
-    // for each season.  Until it fires we must keep passing scrollToEpisodeId even if
-    // the user already focused an episode (which sets lastFocusedEpisodeIdBySeason).
-    val nextToWatchScrolledSeasons = remember(meta.id) { mutableStateMapOf<Int, Boolean>() }
+    // Tracks whether the initial auto-scroll to the "next to play" episode has fired.
+    // Once it fires, no more auto-scrolls happen for the lifetime of this detail screen.
+    var initialEpisodeScrollDone by remember(meta.id) { mutableStateOf(false) }
     val episodeFocusRequestersBySeason = remember(meta.id) { mutableMapOf<Int, MutableMap<String, FocusRequester>>() }
     val seasonEpisodeFocusRequesters = remember(selectedSeason, episodesForSeason) {
         val byEpisodeId = episodeFocusRequestersBySeason.getOrPut(selectedSeason) { mutableMapOf() }
@@ -1746,25 +1744,25 @@ private fun MetaDetailsContent(
                             },
                             scrollToEpisodeId = if (lastFocusedEpisodeIdBySeason[selectedSeason] != null) {
                                 null
-                            } else if (nextToWatchScrolledSeasons[selectedSeason] != true && pendingRestoreType != RestoreTarget.EPISODE) {
+                            } else if (!initialEpisodeScrollDone && pendingRestoreType != RestoreTarget.EPISODE) {
                                 val ntwId = nextToWatch?.nextVideoId
                                     ?: nextToWatch?.let { ntw -> episodesForSeason.firstOrNull { it.season == ntw.nextSeason && it.episode == ntw.nextEpisode }?.id }
                                 if (ntwId != null) {
                                     ntwId
                                 } else if (nextToWatch != null) {
                                     // nextToWatch resolved but target is in a different season — mark done and fall through.
-                                    nextToWatchScrolledSeasons[selectedSeason] = true
+                                    initialEpisodeScrollDone = true
                                     defaultSeriesVideo?.id?.takeIf { defaultId -> episodesForSeason.any { it.id == defaultId } }
                                 } else {
                                     // nextToWatch not yet calculated — emit null so LaunchedEffect waits.
                                     null
                                 }
-                            } else if (lastFocusedEpisodeIdBySeason[selectedSeason] == null && pendingRestoreType != RestoreTarget.EPISODE) {
-                                // nextToWatch scroll already done; fall back to default only if user hasn't focused anything yet.
+                            } else if (lastFocusedEpisodeIdBySeason[selectedSeason] == null && !initialEpisodeScrollDone && pendingRestoreType != RestoreTarget.EPISODE) {
+                                // Initial scroll not yet done; fall back to default only if user hasn't focused anything yet.
                                 defaultSeriesVideo?.id?.takeIf { defaultId -> episodesForSeason.any { it.id == defaultId } }
                             } else null,
                             onScrollToEpisodeHandled = {
-                                nextToWatchScrolledSeasons[selectedSeason] = true
+                                initialEpisodeScrollDone = true
                             }
                         )
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -143,6 +143,7 @@ class MetaDetailsViewModel @Inject constructor(
      *  This ensures progress is read from the same key it was written under. */
     private val _effectiveContentId = MutableStateFlow(itemId)
     private val _optimisticMarks = mutableSetOf<Pair<Int, Int>>()
+    private val _optimisticUnmarks = mutableSetOf<Pair<Int, Int>>()
 
     init {
         posterOptions.bind(viewModelScope)
@@ -499,13 +500,16 @@ class MetaDetailsViewModel @Inject constructor(
                 ) { localWatched, progressMap, videos ->
                     val fromProgress = progressMap.filterValues { it.isCompleted() }.keys
                     val merged = (localWatched + fromProgress).toMutableSet()
+                    // Remove optimistic unmarks — episodes the user just batch-unmarked
+                    // that may still linger in localWatched/fromProgress briefly.
+                    merged -= _optimisticUnmarks
                     if (videos.isNullOrEmpty()) return@combine merged
                     for (video in videos) {
                         val s = video.season ?: continue
                         val e = video.episode ?: continue
                         val key = s to e
                         val watchedByVideoId = watchProgressRepository.isWatchedByVideoId(video.id, e)
-                        if (watchedByVideoId && key !in merged) {
+                        if (watchedByVideoId && key !in merged && key !in _optimisticUnmarks) {
                             merged += key
                         } else if (!watchedByVideoId && key in merged && key !in fromProgress && key !in _optimisticMarks) {
                             merged -= key
@@ -648,7 +652,8 @@ class MetaDetailsViewModel @Inject constructor(
                             } else if (tryApplyTmdbFallbackMeta()) {
                                 Unit
                             } else {
-                                _uiState.update { it.copy(isLoading = false, error = result.message) }
+                                val errorMsg = buildMetaLoadErrorMessage(result.message, metaLookupId)
+                                _uiState.update { it.copy(isLoading = false, error = errorMsg) }
                             }
                         }
                         NetworkResult.Loading -> {
@@ -675,7 +680,8 @@ class MetaDetailsViewModel @Inject constructor(
                             is NetworkResult.Success -> applyMetaWithEnrichment(result.data)
                             is NetworkResult.Error -> {
                                 if (!tryApplyTmdbFallbackMeta()) {
-                                    _uiState.update { it.copy(isLoading = false, error = result.message) }
+                                    val errorMsg = buildMetaLoadErrorMessage(result.message, metaLookupId)
+                                    _uiState.update { it.copy(isLoading = false, error = errorMsg) }
                                 }
                             }
                             NetworkResult.Loading -> {
@@ -757,6 +763,11 @@ class MetaDetailsViewModel @Inject constructor(
         }
             ?.takeIf { it.isNotBlank() }
             ?: raw
+    }
+
+    private fun buildMetaLoadErrorMessage(originalMessage: String?, lookupId: String): String {
+        val base = originalMessage ?: "Failed to load metadata"
+        return "$base\n\nID: $lookupId"
     }
 
     private fun applyMeta(meta: Meta) {
@@ -2109,9 +2120,11 @@ class MetaDetailsViewModel @Inject constructor(
             runCatching {
                 if (isWatched) {
                     _optimisticMarks -= season to episode
+                    _optimisticUnmarks += season to episode
                     watchProgressRepository.removeFromHistory(_effectiveContentId.value, videoId = video.id, season = season, episode = episode)
                     showMessage(localizedContext.getString(R.string.detail_episode_marked_unwatched))
                 } else {
+                    _optimisticUnmarks -= season to episode
                     _optimisticMarks += season to episode
                     watchProgressRepository.markAsCompleted(buildCompletedEpisodeProgress(meta, video))
                     showMessage(localizedContext.getString(R.string.detail_episode_marked_watched))
@@ -2169,6 +2182,10 @@ class MetaDetailsViewModel @Inject constructor(
                 return@launch
             }
 
+            val optimisticKeys = unwatched.map { it.season!! to it.episode!! }.toSet()
+            _optimisticUnmarks -= optimisticKeys
+            _optimisticMarks += optimisticKeys
+
             val pendingKeys = unwatched.map { episodePendingKey(it) }.toSet()
             _uiState.update {
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKeys)
@@ -2208,6 +2225,10 @@ class MetaDetailsViewModel @Inject constructor(
                 showMessage(localizedContext.getString(R.string.detail_no_watched_episodes))
                 return@launch
             }
+
+            val optimisticKeys = watched.map { it.season!! to it.episode!! }.toSet()
+            _optimisticMarks -= optimisticKeys
+            _optimisticUnmarks += optimisticKeys
 
             val pendingKeys = watched.map { episodePendingKey(it) }.toSet()
             _uiState.update {
@@ -2260,6 +2281,10 @@ class MetaDetailsViewModel @Inject constructor(
                 return@launch
             }
 
+            val optimisticKeys = unwatched.map { it.season!! to it.episode!! }.toSet()
+            _optimisticUnmarks -= optimisticKeys
+            _optimisticMarks += optimisticKeys
+
             val pendingKeys = unwatched.map { episodePendingKey(it) }.toSet()
             _uiState.update {
                 it.copy(episodeWatchedPendingKeys = it.episodeWatchedPendingKeys + pendingKeys)
@@ -2300,6 +2325,10 @@ class MetaDetailsViewModel @Inject constructor(
                 showMessage(localizedContext.getString(R.string.detail_all_previous_seasons_watched))
                 return@launch
             }
+
+            val optimisticKeys = unwatched.map { it.season!! to it.episode!! }.toSet()
+            _optimisticUnmarks -= optimisticKeys
+            _optimisticMarks += optimisticKeys
 
             val pendingKeys = unwatched.map { episodePendingKey(it) }.toSet()
             _uiState.update {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsScreen.kt
@@ -33,6 +33,7 @@ import com.nuvio.tv.core.tracking.TrackingProviderId
 import com.nuvio.tv.data.local.MoreLikeThisSourcePreference
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressSource
+import com.nuvio.tv.data.simkl.SimklAnimeIdPreference
 import com.nuvio.tv.data.simkl.SimklConnectionMode
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.ui.components.NuvioDialog
@@ -64,13 +65,15 @@ fun TrackingSettingsScreen(
     var showWatchProgressDialog by remember { mutableStateOf(false) }
     var showDaysCapDialog by remember { mutableStateOf(false) }
     var showMoreLikeThisSourceDialog by remember { mutableStateOf(false) }
+    var showAnimeIdDialog by remember { mutableStateOf(false) }
 
     val hasOverlay = activeProvider != null ||
         disconnectProvider != null ||
         showLibrarySourceDialog ||
         showWatchProgressDialog ||
         showDaysCapDialog ||
-        showMoreLikeThisSourceDialog
+        showMoreLikeThisSourceDialog ||
+        showAnimeIdDialog
 
     BackHandler(enabled = !hasOverlay) {
         onBackPress()
@@ -174,6 +177,9 @@ fun TrackingSettingsScreen(
         onMoreLikeThisClick = {
             restoreFocusTarget = TrackingFocusTarget.MORE_LIKE_THIS
             showMoreLikeThisSourceDialog = true
+        },
+        onAnimeIdClick = {
+            showAnimeIdDialog = true
         }
     )
 
@@ -349,6 +355,35 @@ fun TrackingSettingsScreen(
             maxHeight = 320.dp
         )
     }
+
+    if (showAnimeIdDialog) {
+        SettingsSingleChoiceDialog(
+            title = stringResource(R.string.tracking_simkl_anime_id_title),
+            subtitle = stringResource(R.string.tracking_simkl_anime_id_subtitle),
+            options = listOf(
+                SettingsPickerOption(
+                    SimklAnimeIdPreference.IMDB,
+                    stringResource(R.string.tracking_simkl_anime_id_imdb)
+                ),
+                SettingsPickerOption(
+                    SimklAnimeIdPreference.MAL,
+                    stringResource(R.string.tracking_simkl_anime_id_mal)
+                ),
+                SettingsPickerOption(
+                    SimklAnimeIdPreference.KITSU,
+                    stringResource(R.string.tracking_simkl_anime_id_kitsu)
+                )
+            ),
+            selectedValue = trackingState.simklAnimeIdPreference,
+            onOptionSelected = { preference ->
+                trackingViewModel.selectSimklAnimeIdPreference(preference)
+                showAnimeIdDialog = false
+            },
+            onDismiss = { showAnimeIdDialog = false },
+            width = 620.dp,
+            maxHeight = 360.dp
+        )
+    }
 }
 
 @Composable
@@ -368,7 +403,8 @@ internal fun TrackingSettingsOverview(
     onWatchProgressClick: () -> Unit,
     onContinueWatchingWindowClick: () -> Unit,
     onCommentsChanged: (Boolean) -> Unit,
-    onMoreLikeThisClick: () -> Unit
+    onMoreLikeThisClick: () -> Unit,
+    onAnimeIdClick: () -> Unit
 ) {
     val listState = rememberLazyListState()
     val traktPresentation = traktConnectionPresentation(traktState)
@@ -456,45 +492,63 @@ internal fun TrackingSettingsOverview(
                             )
                         }
                     }
-                    item(key = "tracking_trakt_features") {
-                        SettingsGroupCard(
-                            title = stringResource(R.string.tracking_trakt_features_title),
-                            subtitle = stringResource(R.string.tracking_trakt_features_subtitle)
-                        ) {
-                            SettingsActionRow(
-                                title = stringResource(R.string.trakt_continue_watching_window),
-                                subtitle = if (traktConnected && !traktProgressActive) {
-                                    stringResource(R.string.tracking_trakt_progress_required)
-                                } else {
-                                    stringResource(R.string.trakt_continue_watching_subtitle)
-                                },
-                                value = continueWatchingWindowLabel(traktState.continueWatchingDaysCap),
-                                enabled = traktConnected && traktProgressActive,
-                                onClick = onContinueWatchingWindowClick,
-                                modifier = Modifier
-                                    .focusRequester(continueWatchingFocusRequester)
-                                    .testTag(TrackingSettingsTestTags.CONTINUE_WATCHING)
-                            )
-                            SettingsToggleRow(
-                                title = stringResource(R.string.trakt_comments_title),
-                                subtitle = stringResource(R.string.trakt_comments_subtitle),
-                                checked = traktState.showMetaComments,
-                                enabled = traktConnected,
-                                onToggle = {
-                                    onCommentsChanged(!traktState.showMetaComments)
-                                },
-                                modifier = Modifier.testTag(TrackingSettingsTestTags.COMMENTS)
-                            )
-                            SettingsActionRow(
-                                title = stringResource(R.string.trakt_more_like_this_source_title),
-                                subtitle = stringResource(R.string.trakt_more_like_this_source_subtitle),
-                                value = moreLikeThisSourceLabel(traktState.moreLikeThisSource),
-                                enabled = traktConnected,
-                                onClick = onMoreLikeThisClick,
-                                modifier = Modifier
-                                    .focusRequester(moreLikeThisFocusRequester)
-                                    .testTag(TrackingSettingsTestTags.MORE_LIKE_THIS)
-                            )
+                    if (traktConnected) {
+                        item(key = "tracking_trakt_features") {
+                            SettingsGroupCard(
+                                title = stringResource(R.string.tracking_trakt_features_title),
+                                subtitle = stringResource(R.string.tracking_trakt_features_subtitle)
+                            ) {
+                                SettingsActionRow(
+                                    title = stringResource(R.string.trakt_continue_watching_window),
+                                    subtitle = if (!traktProgressActive) {
+                                        stringResource(R.string.tracking_trakt_progress_required)
+                                    } else {
+                                        stringResource(R.string.trakt_continue_watching_subtitle)
+                                    },
+                                    value = continueWatchingWindowLabel(traktState.continueWatchingDaysCap),
+                                    enabled = traktProgressActive,
+                                    onClick = onContinueWatchingWindowClick,
+                                    modifier = Modifier
+                                        .focusRequester(continueWatchingFocusRequester)
+                                        .testTag(TrackingSettingsTestTags.CONTINUE_WATCHING)
+                                )
+                                SettingsToggleRow(
+                                    title = stringResource(R.string.trakt_comments_title),
+                                    subtitle = stringResource(R.string.trakt_comments_subtitle),
+                                    checked = traktState.showMetaComments,
+                                    enabled = true,
+                                    onToggle = {
+                                        onCommentsChanged(!traktState.showMetaComments)
+                                    },
+                                    modifier = Modifier.testTag(TrackingSettingsTestTags.COMMENTS)
+                                )
+                                SettingsActionRow(
+                                    title = stringResource(R.string.trakt_more_like_this_source_title),
+                                    subtitle = stringResource(R.string.trakt_more_like_this_source_subtitle),
+                                    value = moreLikeThisSourceLabel(traktState.moreLikeThisSource),
+                                    enabled = true,
+                                    onClick = onMoreLikeThisClick,
+                                    modifier = Modifier
+                                        .focusRequester(moreLikeThisFocusRequester)
+                                        .testTag(TrackingSettingsTestTags.MORE_LIKE_THIS)
+                                )
+                            }
+                        }
+                    }
+                    if (simklState.mode == SimklConnectionMode.CONNECTED) {
+                        item(key = "tracking_simkl_features") {
+                            SettingsGroupCard(
+                                title = stringResource(R.string.tracking_simkl_features_title),
+                                subtitle = stringResource(R.string.tracking_simkl_features_subtitle)
+                            ) {
+                                SettingsActionRow(
+                                    title = stringResource(R.string.tracking_simkl_anime_id_title),
+                                    subtitle = stringResource(R.string.tracking_simkl_anime_id_subtitle),
+                                    value = animeIdPreferenceLabel(trackingState.simklAnimeIdPreference),
+                                    onClick = onAnimeIdClick,
+                                    modifier = Modifier.testTag("tracking_simkl_anime_id")
+                                )
+                            }
                         }
                     }
                 }
@@ -595,6 +649,13 @@ private fun continueWatchingWindowLabel(days: Int): String {
     } else {
         stringResource(R.string.trakt_days_format, days)
     }
+}
+
+@Composable
+private fun animeIdPreferenceLabel(preference: SimklAnimeIdPreference): String = when (preference) {
+    SimklAnimeIdPreference.IMDB -> stringResource(R.string.tracking_simkl_anime_id_imdb)
+    SimklAnimeIdPreference.MAL -> stringResource(R.string.tracking_simkl_anime_id_mal)
+    SimklAnimeIdPreference.KITSU -> stringResource(R.string.tracking_simkl_anime_id_kitsu)
 }
 
 private enum class TrackingFocusTarget {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsViewModel.kt
@@ -9,8 +9,11 @@ import com.nuvio.tv.core.tracking.availableLibrarySourceModes
 import com.nuvio.tv.core.tracking.availableWatchProgressSources
 import com.nuvio.tv.core.tracking.effectiveTrackingSourceSelection
 import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressSource
+import com.nuvio.tv.data.simkl.SimklAnimeIdPreference
 import com.nuvio.tv.data.simkl.SimklAuthRepository
+import com.nuvio.tv.data.simkl.SimklSyncRepository
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -25,6 +28,7 @@ data class TrackingSettingsUiState(
     val watchProgressSource: WatchProgressSource = WatchProgressSource.NUVIO_SYNC,
     val librarySourceMode: LibrarySourceMode = LibrarySourceMode.LOCAL,
     val connectedProviderIds: Set<TrackingProviderId> = emptySet(),
+    val simklAnimeIdPreference: SimklAnimeIdPreference = SimklAnimeIdPreference.DEFAULT,
     val isReady: Boolean = false
 ) {
     val availableWatchProgressSources: List<WatchProgressSource>
@@ -37,6 +41,8 @@ data class TrackingSettingsUiState(
 @HiltViewModel
 class TrackingSettingsViewModel @Inject constructor(
     private val sourceController: TrackingSourceController,
+    private val settingsDataStore: TraktSettingsDataStore,
+    private val simklSyncRepository: SimklSyncRepository,
     traktAuthDataStore: TraktAuthDataStore,
     simklAuthRepository: SimklAuthRepository
 ) : ViewModel() {
@@ -49,8 +55,9 @@ class TrackingSettingsViewModel @Inject constructor(
                 sourceController.watchProgressSource,
                 sourceController.librarySourceMode,
                 traktAuthDataStore.state,
-                simklAuthRepository.state
-            ) { watchProgressSource, librarySourceMode, traktState, simklState ->
+                simklAuthRepository.state,
+                settingsDataStore.simklAnimeIdPreference
+            ) { watchProgressSource, librarySourceMode, traktState, simklState, animeIdPref ->
                 val connectedProviderIds = buildSet {
                     if (traktState.isAuthenticated) add(TrackingProviderId.TRAKT)
                     if (simklState.isAuthenticated) add(TrackingProviderId.SIMKL)
@@ -63,6 +70,7 @@ class TrackingSettingsViewModel @Inject constructor(
                     watchProgressSource = effective.watchProgressSource,
                     librarySourceMode = effective.librarySourceMode,
                     connectedProviderIds = connectedProviderIds,
+                    simklAnimeIdPreference = animeIdPref,
                     isReady = true
                 )
             }.collect { state ->
@@ -81,6 +89,13 @@ class TrackingSettingsViewModel @Inject constructor(
     fun selectLibrarySourceMode(mode: LibrarySourceMode) {
         viewModelScope.launch {
             sourceController.selectLibrarySourceMode(mode)
+        }
+    }
+
+    fun selectSimklAnimeIdPreference(preference: SimklAnimeIdPreference) {
+        viewModelScope.launch {
+            settingsDataStore.setSimklAnimeIdPreference(preference)
+            simklSyncRepository.invalidateProjections()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,6 +402,13 @@
     <string name="tracking_sources_subtitle">Choose where Nuvio reads your library and watch progress. Playback scrobbles to every connected service.</string>
     <string name="tracking_trakt_features_title">Trakt features</string>
     <string name="tracking_trakt_features_subtitle">Trakt-specific history, reviews, and recommendations</string>
+    <string name="tracking_simkl_features_title">Simkl features</string>
+    <string name="tracking_simkl_features_subtitle">Simkl-specific anime ID resolution settings</string>
+    <string name="tracking_simkl_anime_id_title">Anime ID preference</string>
+    <string name="tracking_simkl_anime_id_subtitle">Controls how anime series are identified. Choosing MAL or Kitsu gives each season its own entry instead of grouping under one IMDB ID.</string>
+    <string name="tracking_simkl_anime_id_imdb">Prefer IMDB</string>
+    <string name="tracking_simkl_anime_id_mal">Prefer MyAnimeList</string>
+    <string name="tracking_simkl_anime_id_kitsu">Prefer Kitsu</string>
     <string name="tracking_status_connected">Connected</string>
     <string name="tracking_status_disconnected">Not connected</string>
     <string name="tracking_status_waiting">Waiting for approval</string>


### PR DESCRIPTION
## Summary

Add user-facing setting for Simkl anime ID resolution preference. When set to MAL or Kitsu, each anime season gets its own canonical ID instead of grouping under a shared IMDB ID. This prevents incorrect watched badge cross-contamination between seasons and allows proper per-seasos library and cw entries (if user's meta addon support it).

Continuation of #2783.

This PR also hides Trakt/Simkl settings when they are not connected

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When Simkl resolves anime entries, multiple MAL seasons (e.g. Haikyuu S1, S2, S3) share a single IMDB ID. This causes:
- Watched badges follow IMDB id for all seasons (separate season entries are marked as watched if IMDB group is marked as watched)
- Separate season entries in Library (each anime season is always returned as separate entry) would direct user to an IMDB meta 

This setting lets users choose MAL or Kitsu as the primary ID resolver for anime, giving each season its own identity in Library and CW.

## Issue or approval

Continuation of #2783

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change default behavior (IMDB remains default)
- Does not affect non-anime content (movies/shows always use standard IMDB -> TMDB -> TVDB chain)
- Does not modify Trakt tracking logic
- Trakt features section now hidden when Trakt not connected (same pattern as Simkl features)

## Testing

- Physical TCL Adnroid TV
- Verified setting persists across app restart
- Verified CW rebuilds immediately after preference change (no restart needed)
- Verified anime seasons get separate canonical IDs when MAL selected
- Verified default (IMDB) behavior unchanged
- Verified Simkl features section hidden when Simkl disconnected
- Verified Trakt features section hidden when Trakt disconnected
- Build: ./gradlew app:compileFullDebugKotlin passes clean

## Screenshots / Video

Not a UI change (settings row follows existing pattern)

## Breaking changes

None. Default behavior (IMDB preference) is unchanged. Existing users see no difference unless they explicitly change the setting.

## Linked issues

Continuation of #2783
