### PR TITLE
fix(library): use most recent watch timestamp for Continue Watching sort order (#2811)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktProgressService.kt
@@ -1532,7 +1532,7 @@ class TraktProgressService @Inject constructor(
         val contentId = normalizeContentId(show.ids)
         if (contentId.isBlank()) return null
 
-        val furthestEpisode = item.seasons.orEmpty()
+        val episodeTriples = item.seasons.orEmpty()
             .asSequence()
             .filter { season -> (season.number ?: 0) > 0 }
             .flatMap { season ->
@@ -1549,25 +1549,28 @@ class TraktProgressService @Inject constructor(
                         )
                     }
             }
-            .maxWithOrNull(
-                if (useFurthestEpisode) {
-                    compareBy<Triple<Int, Int, Long>>(
-                        { it.first },
-                        { it.second },
-                        { it.third }
-                    )
-                } else {
-                    compareBy<Triple<Int, Int, Long>>(
-                        { it.third },
-                        { it.first },
-                        { it.second }
-                    )
-                }
-            ) ?: return null
+            .toList()
+
+        val furthestEpisode = episodeTriples.maxWithOrNull(
+            if (useFurthestEpisode) {
+                compareBy<Triple<Int, Int, Long>>(
+                    { it.first },
+                    { it.second },
+                    { it.third }
+                )
+            } else {
+                compareBy<Triple<Int, Int, Long>>(
+                    { it.third },
+                    { it.first },
+                    { it.second }
+                )
+            }
+        ) ?: return null
 
         val season = furthestEpisode.first
         val episode = furthestEpisode.second
-        val lastWatched = furthestEpisode.third.takeIf { it > 0L }
+        val mostRecentWatched = episodeTriples.maxOf { it.third }
+        val lastWatched = mostRecentWatched.takeIf { it > 0L }
             ?: parseIsoToMillis(item.lastWatchedAt)
 
         return WatchProgress(


### PR DESCRIPTION
## Summary
When `useFurthestEpisode=true`, Continue Watching sorting incorrectly uses the furthest episode's `lastWatched` timestamp instead of the most recently watched episode's timestamp. This causes series to not move to the top when a user watches a new episode in an earlier season.

## PR type
- [x] Critical bug fix

## Why
If a user watched S5E10 a month ago and watches S1E1 today, the WatchProgress gets `lastWatched = (S5E10 timestamp, 1 month ago)`. Continue Watching sorts based on the old timestamp — the series doesn't move to the top.

## Issue or approval
Fixes #2811

## Reproduction steps
1. Have a show with watched episodes across different seasons
2. Watch an episode in an earlier season (e.g. S1E1)
3. The Continue Watching row sorts this show based on the furthest episode's old timestamp rather than today's watch

## UI / behavior impact
- [x] Bug fix — sorting order of Continue Watching now correctly uses the most recent watch timestamp

## Policy check
- [x] I have read the contributing guidelines and this PR follows them
- [x] The PR title follows the conventional commit format
- [x] The code change is minimal and focused on the described issue
- [x] No new dependencies are introduced
- [x] The change is backward compatible
- [x] The PR does not modify unrelated files
- [x] The PR does not introduce any localization issues

## Scope boundaries
- Only `mapWatchedShowSeed` in `TraktProgressService.kt` is modified
- No locale files, test files, or unrelated code are touched

## Testing
Manual verification: the fix computes `mostRecentWatched` as `episodeTriples.maxOf { it.third }` before falling back to `item.lastWatchedAt`. Existing compilation ensures type safety.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #2811