### PR TITLE
fix(player): remove 1s rewind after long pause to prevent A/V desync (#2760)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -104,7 +104,6 @@ class PlayerRuntimeController(
         internal const val STALL_WATCHDOG_POLL_INTERVAL_MS = 1_000L
         internal const val MAX_TIMEOUT_RECOVERY_ATTEMPTS = 2
         internal const val ADDON_SUBTITLE_TRACK_ID_PREFIX = "nuvio-addon-sub:"
-        internal const val LONG_PAUSE_THRESHOLD_MS = 300_000L // 5 minutes
     }
 
     internal data class PendingAudioSelection(
@@ -353,7 +352,6 @@ class PlayerRuntimeController(
     internal var metaCountry: String? = null
     internal var nextEpisodeVideo: Video? = null
     internal var userPausedManually = false
-    internal var pauseStartTimeMs: Long = 0L
 
     internal var isInBackground: Boolean = false
     internal var pendingBackgroundCrashRecovery: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -217,7 +217,6 @@ internal fun PlayerRuntimeController.pauseForLifecycle() {
         _uiState.update { it.copy(isPlaying = false) }
         return
     }
-    pauseStartTimeMs = System.currentTimeMillis()
     _exoPlayer?.let { player ->
         // Disable automatic audio focus handling so ExoPlayer can't
         // re-acquire focus and set playWhenReady=true behind our back.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1101,18 +1101,11 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
                 _exoPlayer?.let { player ->
                     if (player.isPlaying) {
                         userPausedManually = true
-                        pauseStartTimeMs = System.currentTimeMillis()
                         player.pause()
                         schedulePauseOverlay()
                     } else {
                         userPausedManually = false
                         cancelPauseOverlay()
-                        val pausedDuration = System.currentTimeMillis() - pauseStartTimeMs
-                        if (pauseStartTimeMs > 0L && pausedDuration > PlayerRuntimeController.LONG_PAUSE_THRESHOLD_MS) {
-                            val pos = player.currentPosition
-                            player.seekTo((pos - 1000L).coerceAtLeast(0L))
-                        }
-                        pauseStartTimeMs = 0L
                         player.play()
                     }
                 }


### PR DESCRIPTION
## Summary

Removes the artificial 1-second rewind (`seekTo(pos - 1000)`) that runs when resuming ExoPlayer after a pause longer than 5 minutes. That seek can force catch-up playback and leave hardware-decoded audio 1–2s behind video.

## PR type

- [x] Critical bug fix

## Why

On long-pause resume, `PlayerRuntimeControllerPlaybackEvents` rewound 1s before `play()`. Reporter (#2760) still sees the desync on current builds with **Audio decoder priority = Prefer device**; the same stream stays in sync with **Prefer app (FFmpeg)**. That matches a hardware-decoder path that is sensitive to seek-induced catch-up, not a general “player is always broken” issue.

Resume at the current position instead. Stall-watchdog recovery and other pause/resume paths are unchanged. Dead `LONG_PAUSE_THRESHOLD_MS` / `pauseStartTimeMs` are removed with the seek.

## Issue or approval

Fixes #2760

## Reproduction steps

1. Internal player, **Audio decoder priority = Prefer device** (not FFmpeg-only)
2. Play any stream on a device similar to Shield 2019 Pro
3. Pause ≥ 5 minutes (TV on)
4. Press play
5. Before (dev): brief ~3x catch-up then audio ~1–2s late (skip seek re-syncs)
6. After: resume at current position without the artificial 1s rewind

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only removes the long-pause 1s rewind + dead timestamp/threshold fields.
- Does not change stall watchdog, buffer engine, or audio decoder priority settings.
- Does not address Android screensaver restart (separate issue if still open).
- Related #2680 (default back-buffer for manual 1s seeks) is left as-is; it still helps user-initiated rewinds.

## Testing

- `./gradlew :app:compileFullDebugKotlin` — **passed** on rebased `upstream/dev`
- Static check: no remaining `LONG_PAUSE_THRESHOLD_MS` / `pauseStartTimeMs` / `seekTo(pos - 1000)` paths; `STALL_WATCHDOG_*` unchanged
- **Not device-verified here** (no Android device/emulator in this environment). Needs Shield/TV check with Prefer device + pause ≥ 5 min. PR fullDebug APK from Actions is the right artifact for that.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. Long-pause resume no longer rewinds 1s; playback continues from the paused position.

## Linked issues

Fixes #2760