### PR TITLE
feat(home): show selected MDBList ratings in heroes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/MDBListRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MDBListRepository.kt
@@ -173,6 +173,43 @@ class MDBListRepository @Inject constructor(
         return deferred.await()
     }
 
+    suspend fun getRatingsForItem(
+        itemId: String,
+        itemType: String
+    ): MDBListRatingsResult? {
+        val normalizedType = normalizeMediaType(itemType)
+        val meta = Meta(
+            id = itemId,
+            type = if (normalizedType == "show") {
+                com.nuvio.tv.domain.model.ContentType.SERIES
+            } else {
+                com.nuvio.tv.domain.model.ContentType.MOVIE
+            },
+            name = itemId,
+            poster = null,
+            posterShape = com.nuvio.tv.domain.model.PosterShape.POSTER,
+            background = null,
+            logo = null,
+            description = null,
+            releaseInfo = null,
+            imdbRating = null,
+            genres = emptyList(),
+            runtime = null,
+            director = emptyList(),
+            cast = emptyList(),
+            videos = emptyList(),
+            country = null,
+            awards = null,
+            language = null,
+            links = emptyList()
+        )
+        return getRatingsForMeta(
+            meta = meta,
+            fallbackItemId = itemId,
+            fallbackItemType = itemType
+        )
+    }
+
     private suspend fun fetchRatings(
         imdbId: String,
         mediaType: String,

--- a/app/src/main/java/com/nuvio/tv/ui/components/CompactMdbListRatingsRow.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CompactMdbListRatingsRow.kt
@@ -1,0 +1,161 @@
+package com.nuvio.tv.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.MDBListRatings
+import java.util.Locale
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun CompactMdbListRatingsRow(
+    ratings: MDBListRatings,
+    modifier: Modifier = Modifier,
+    textColor: Color = Color.White.copy(alpha = 0.82f),
+    textStyle: TextStyle = MaterialTheme.typography.labelMedium,
+    logoSize: Dp = 22.dp,
+    itemSpacing: Dp = 12.dp,
+    wrap: Boolean = false,
+    lineSpacing: Dp = 6.dp
+) {
+    val context = LocalContext.current
+    val rawItems = remember(ratings) {
+        listOf(
+            Triple("trakt", R.raw.mdblist_trakt, ratings.trakt),
+            Triple("imdb", R.raw.imdb_logo_2016, ratings.imdb),
+            Triple("tmdb", R.raw.mdblist_tmdb, ratings.tmdb),
+            Triple("letterboxd", R.raw.mdblist_letterboxd, ratings.letterboxd),
+            Triple("mal", R.raw.mdblist_mal, ratings.mal),
+            Triple("tomatoes", R.raw.mdblist_tomatoes, ratings.tomatoes)
+        ).filter { it.third != null }
+    }
+
+    val content: @Composable () -> Unit = {
+        rawItems.forEach { (provider, logoRes, rating) ->
+            val resolvedRating = rating ?: return@forEach
+            RatingItem(
+                provider = provider,
+                rating = resolvedRating,
+                logo = {
+                    val model = remember(context, logoRes, logoSize) {
+                        ImageRequest.Builder(context)
+                            .data(logoRes)
+                            .build()
+                    }
+                    AsyncImage(
+                        model = model,
+                        contentDescription = null,
+                        modifier = Modifier.size(logoSize),
+                        contentScale = ContentScale.Fit
+                    )
+                },
+                textColor = textColor,
+                textStyle = textStyle
+            )
+        }
+
+        ratings.audience?.let { rating ->
+            RatingItem(
+                provider = "audience",
+                rating = rating,
+                logo = {
+                    Image(
+                        painter = painterResource(id = R.drawable.mdblist_audience),
+                        contentDescription = null,
+                        modifier = Modifier.size(logoSize)
+                    )
+                },
+                textColor = textColor,
+                textStyle = textStyle
+            )
+        }
+
+        ratings.metacritic?.let { rating ->
+            RatingItem(
+                provider = "metacritic",
+                rating = rating,
+                logo = {
+                    Image(
+                        painter = painterResource(id = R.drawable.mdblist_metacritic),
+                        contentDescription = null,
+                        modifier = Modifier.size(logoSize)
+                    )
+                },
+                textColor = textColor,
+                textStyle = textStyle
+            )
+        }
+    }
+
+    if (wrap) {
+        FlowRow(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+            verticalArrangement = Arrangement.spacedBy(lineSpacing)
+        ) {
+            content()
+        }
+    } else {
+        Row(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun RatingItem(
+    provider: String,
+    rating: Double,
+    logo: @Composable () -> Unit,
+    textColor: Color,
+    textStyle: TextStyle
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        logo()
+        Text(
+            text = formatRating(provider, rating),
+            style = textStyle,
+            color = textColor,
+            maxLines = 1
+        )
+    }
+}
+
+private fun formatRating(provider: String, rating: Double): String {
+    return when (provider) {
+        "imdb", "tmdb", "letterboxd" -> String.format(Locale.US, "%.1f", rating)
+        else -> {
+            if (rating % 1.0 == 0.0) {
+                rating.toInt().toString()
+            } else {
+                String.format(Locale.US, "%.1f", rating)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/components/HeroCarousel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/HeroCarousel.kt
@@ -62,7 +62,9 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.MDBListRatings
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.ui.screens.home.homeItemStatusKey
 import com.nuvio.tv.ui.util.LocalRecompositionHighlighterEnabled
 import kotlinx.coroutines.delay
 
@@ -75,7 +77,9 @@ fun HeroCarousel(
     items: StableList<MetaPreview>,
     onItemClick: (MetaPreview) -> Unit,
     onItemFocus: (MetaPreview) -> Unit = {},
+    onMdbListRatingRequest: (MetaPreview) -> Unit = {},
     focusRequester: FocusRequester? = null,
+    mdbListRatings: Map<String, MDBListRatings> = emptyMap(),
     fullWidth: Dp = Dp.Unspecified,
     modifier: Modifier = Modifier
 ) {
@@ -83,6 +87,7 @@ fun HeroCarousel(
 
     val currentOnItemClick by rememberUpdatedState(onItemClick)
     val currentOnItemFocus by rememberUpdatedState(onItemFocus)
+    val currentOnMdbListRatingRequest by rememberUpdatedState(onMdbListRatingRequest)
     var activeIndex by remember { mutableIntStateOf(0) }
     var isFocused by remember { mutableStateOf(false) }
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
@@ -90,6 +95,11 @@ fun HeroCarousel(
     LaunchedEffect(activeIndex, isFocused) {
         if (!isFocused) return@LaunchedEffect
         items.getOrNull(activeIndex)?.let { currentOnItemFocus(it) }
+    }
+
+    val activeItem = items.getOrNull(activeIndex)
+    LaunchedEffect(activeItem?.id, activeItem?.apiType) {
+        activeItem?.let { currentOnMdbListRatingRequest(it) }
     }
 
     // Auto-advance when not focused — delay first advance to 20s so initial GPU load settles
@@ -152,7 +162,12 @@ fun HeroCarousel(
             label = "heroSlide"
         ) { index ->
             val item = items.getOrNull(index) ?: return@Crossfade
-            HeroCarouselSlide(item = item)
+            HeroCarouselSlide(
+                item = item,
+                mdbListRatings = mdbListRatings[
+                    homeItemStatusKey(item.id, item.apiType)
+                ]
+            )
         }
 
         // Indicator dots — optimized to minimize recompositions and layout passes
@@ -195,7 +210,8 @@ fun HeroCarousel(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun HeroCarouselSlide(
-    item: MetaPreview
+    item: MetaPreview,
+    mdbListRatings: MDBListRatings?
 ) {
     val highlighterEnabled = LocalRecompositionHighlighterEnabled.current
     val context = LocalContext.current
@@ -226,6 +242,15 @@ private fun HeroCarouselSlide(
     }
     var logoLoadFailed by remember(item.logo) { mutableStateOf(false) }
     val showLogo = !item.logo.isNullOrBlank() && !logoLoadFailed
+    val heroRatings = remember(mdbListRatings, item.imdbRating) {
+        mdbListRatings?.let { ratings ->
+            if (ratings.imdb == null) {
+                ratings.copy(imdb = item.imdbRating?.toDouble())
+            } else {
+                ratings
+            }
+        }?.takeUnless { it.isEmpty() }
+    }
 
     val bgColor = NuvioTheme.colors.Background
     val bottomGradient = remember(bgColor) {
@@ -307,27 +332,37 @@ private fun HeroCarouselSlide(
 
             Spacer(modifier = Modifier.height(NuvioTheme.spacing.sm))
 
-            // Meta info row: IMDB rating + year + genres
+            // Meta info row: selected MDBList providers (or the built-in IMDb rating) + year.
             Row(
-                horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                item.imdbRating?.let { rating ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xs)
-                    ) {
-                        ImdbRatingSourceLabel(
-                            logoModifier = Modifier.size(30.dp),
-                            textStyle = MaterialTheme.typography.labelLarge,
-                            textColor = Color.White.copy(alpha = 0.8f)
-                        )
-                        val ratingText = remember(rating) { String.format("%.1f", rating) }
-                        Text(
-                            text = ratingText,
-                            style = MaterialTheme.typography.labelLarge,
-                            color = Color.White.copy(alpha = 0.8f)
-                        )
+                if (heroRatings != null) {
+                    CompactMdbListRatingsRow(
+                        ratings = heroRatings,
+                        textColor = Color.White.copy(alpha = 0.82f),
+                        textStyle = MaterialTheme.typography.labelMedium,
+                        logoSize = 18.dp,
+                        itemSpacing = 8.dp
+                    )
+                } else {
+                    item.imdbRating?.let { rating ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xs)
+                        ) {
+                            ImdbRatingSourceLabel(
+                                logoModifier = Modifier.size(30.dp),
+                                textStyle = MaterialTheme.typography.labelLarge,
+                                textColor = Color.White.copy(alpha = 0.82f)
+                            )
+                            val ratingText = remember(rating) { String.format("%.1f", rating) }
+                            Text(
+                                text = ratingText,
+                                style = MaterialTheme.typography.labelLarge,
+                                color = Color.White.copy(alpha = 0.82f)
+                            )
+                        }
                     }
                 }
 
@@ -337,10 +372,20 @@ private fun HeroCarouselSlide(
                     }?.trim()?.takeIf { it.isNotEmpty() }
                 }
                 releaseYear?.let { year ->
+                    if (heroRatings != null || item.imdbRating != null) {
+                        Box(
+                            modifier = Modifier
+                                .size(NuvioTheme.spacing.xs)
+                                .clip(RoundedCornerShape(percent = 50))
+                                .background(Color.White.copy(alpha = 0.6f))
+                        )
+                    }
                     Text(
                         text = year,
                         style = MaterialTheme.typography.labelLarge,
-                        color = Color.White.copy(alpha = 0.8f)
+                        color = Color.White.copy(alpha = 0.8f),
+                        maxLines = 1,
+                        softWrap = false
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -90,6 +90,7 @@ fun ClassicHomeContent(
     onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     onRequestTrailerPreview: (MetaPreview) -> Unit,
     onItemFocus: (MetaPreview) -> Unit = {},
+    onMdbListRatingFocus: (String, String) -> Unit = { _, _ -> },
     catalogSeeAllLabel: String? = null,
     onSaveFocusState: (Int, Int, String?, Map<String, String>, Map<String, Int>, Int, Int) -> Unit,
     scrollToTopTrigger: Int = 0,
@@ -435,6 +436,7 @@ fun ClassicHomeContent(
             item(key = "hero_carousel", contentType = "hero") {
                 HeroCarousel(
                     items = uiState.heroItems.asStable(),
+                    mdbListRatings = uiState.heroMdbListRatings,
                     focusRequester = if (shouldRequestInitialFocus) heroFocusRequester else null,
                     modifier = Modifier.onFocusChanged {
                         if (it.hasFocus && uiState.classicFocusGradientEnabled) {
@@ -442,6 +444,9 @@ fun ClassicHomeContent(
                         }
                     },
                     onItemFocus = handleHeroFocus,
+                    onMdbListRatingRequest = { item ->
+                        onMdbListRatingFocus(item.id, item.apiType)
+                    },
                     onItemClick = { item ->
                         onNavigateToDetail(
                             item.id,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -102,6 +102,7 @@ fun GridHomeContent(
     onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
     onItemFocus: (com.nuvio.tv.domain.model.MetaPreview) -> Unit = {},
+    onMdbListRatingFocus: (String, String) -> Unit = { _, _ -> },
     catalogSeeAllLabel: String? = null,
     onSaveGridFocusState: (Int, Int, String?) -> Unit,
     scrollToTopTrigger: Int = 0
@@ -383,6 +384,10 @@ fun GridHomeContent(
                         is GridItem.Hero -> {
                             HeroCarousel(
                                 items = gridItem.items.asStable(),
+                                mdbListRatings = uiState.heroMdbListRatings,
+                                onMdbListRatingRequest = { item ->
+                                    onMdbListRatingFocus(item.id, item.apiType)
+                                },
                                 focusRequester = if (shouldRequestInitialFocus) heroFocusRequester else null,
                                 onItemClick = remember(onNavigateToDetail) {
                                     { item ->
@@ -537,6 +542,10 @@ fun GridHomeContent(
                     is GridItem.Hero -> {
                         HeroCarousel(
                             items = gridItem.items.asStable(),
+                            mdbListRatings = uiState.heroMdbListRatings,
+                            onMdbListRatingRequest = { item ->
+                                onMdbListRatingFocus(item.id, item.apiType)
+                            },
                             focusRequester = if (shouldRequestInitialFocus) heroFocusRequester else null,
                             onItemClick = remember(onNavigateToDetail) {
                                 { item ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -501,6 +501,9 @@ private fun ClassicHomeRoute(
         onItemFocus = { item ->
             viewModel.onItemFocus(item)
         },
+        onMdbListRatingFocus = { itemId, itemType ->
+            viewModel.onMdbListRatingFocus(itemId, itemType)
+        },
         onSaveFocusState = { vi, vo, rk, ikm, m, ri, ii ->
             viewModel.saveFocusState(vi, vo, rk, ikm, m, ri, ii)
         },
@@ -549,6 +552,11 @@ private fun GridHomeRoute(
         onItemFocus = remember(viewModel) {
             { item ->
                 viewModel.onItemFocus(item)
+            }
+        },
+        onMdbListRatingFocus = remember(viewModel) {
+            { itemId, itemType ->
+                viewModel.onMdbListRatingFocus(itemId, itemType)
             }
         },
         onSaveGridFocusState = remember(viewModel) {
@@ -603,6 +611,11 @@ private fun ModernHomeRoute(
             viewModel.preloadAdjacentItem(item)
         }
     }
+    val requestMdbListRating = remember(viewModel) {
+        { itemId: String, itemType: String ->
+            viewModel.onMdbListRatingFocus(itemId, itemType)
+        }
+    }
     ModernHomeContent(
         uiState = uiState,
         focusState = focusState,
@@ -627,6 +640,7 @@ private fun ModernHomeRoute(
         onItemFocus = remember(viewModel) {
             { item -> viewModel.onItemFocus(item) }
         },
+        onMdbListRatingFocus = requestMdbListRating,
         onPreloadAdjacentItem = preloadAdjacentItem,
         onSaveFocusState = saveModernFocusState,
         onRequestLazyCatalogLoad = remember(viewModel) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.LibrarySourceMode
+import com.nuvio.tv.domain.model.MDBListRatings
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.WatchProgress
 
@@ -25,6 +26,7 @@ data class HomeUiState(
     val modernLandscapePostersEnabled: Boolean = false,
     val modernHeroFullScreenBackdropEnabled: Boolean = false,
     val heroItems: List<MetaPreview> = emptyList(),
+    val heroMdbListRatings: Map<String, MDBListRatings> = emptyMap(),
     val heroCatalogKeys: List<String> = emptyList(),
     val heroSectionEnabled: Boolean = true,
     val modernHomePresentation: ModernHomePresentationState = ModernHomePresentationState(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -40,6 +40,7 @@ import com.nuvio.tv.domain.repository.WatchProgressRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -187,6 +188,8 @@ class HomeViewModel @Inject constructor(
     internal var trailerPreviewJob: Job? = null
     internal var currentTmdbSettings: TmdbSettings = TmdbSettings()
     internal var currentMdbListSettings: MDBListSettings = MDBListSettings()
+    internal var heroMdbListRatingsJob: Job? = null
+    internal var activeHeroMdbListRatingTarget: Pair<String, String>? = null
     internal var heroEnrichmentJob: Job? = null
     internal var lastHeroEnrichmentSignature: String? = null
     internal var lastHeroEnrichedItems: List<MetaPreview> = emptyList()
@@ -471,7 +474,42 @@ class HomeViewModel @Inject constructor(
         apiType = apiType
     )
 
-    fun onItemFocus(item: MetaPreview) = onItemFocusPipeline(item)
+    fun onItemFocus(item: MetaPreview) {
+        requestHeroMdbListRatings(item.id, item.apiType)
+        onItemFocusPipeline(item)
+    }
+
+    fun onMdbListRatingFocus(itemId: String, itemType: String) {
+        requestHeroMdbListRatings(itemId, itemType)
+    }
+
+    private fun requestHeroMdbListRatings(itemId: String, itemType: String) {
+        activeHeroMdbListRatingTarget = itemId to itemType
+        val ratingKey = homeItemStatusKey(itemId, itemType)
+        if (_uiState.value.heroMdbListRatings.containsKey(ratingKey)) return
+
+        heroMdbListRatingsJob?.cancel()
+        heroMdbListRatingsJob = viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            delay(EXTERNAL_META_PREFETCH_FOCUS_DEBOUNCE_MS)
+            val result = try {
+                mdbListRepository.getRatingsForItem(itemId, itemType)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                null
+            }
+            val ratings = result?.ratings?.takeUnless { it.isEmpty() } ?: return@launch
+            _uiState.update { state ->
+                if (state.heroMdbListRatings[ratingKey] == ratings) {
+                    state
+                } else {
+                    state.copy(
+                        heroMdbListRatings = state.heroMdbListRatings + (ratingKey to ratings)
+                    )
+                }
+            }
+        }
+    }
 
     fun preloadAdjacentItem(item: MetaPreview) = preloadAdjacentItemPipeline(item)
 
@@ -490,7 +528,17 @@ class HomeViewModel @Inject constructor(
             mdbListSettingsDataStore.settings
                 .distinctUntilChanged()
                 .collectLatest { settings ->
+                    val changed = currentMdbListSettings != settings
                     currentMdbListSettings = settings
+                    if (changed) {
+                        heroMdbListRatingsJob?.cancel()
+                        _uiState.update { it.copy(heroMdbListRatings = emptyMap()) }
+                        if (settings.enabled && settings.apiKey.isNotBlank()) {
+                            activeHeroMdbListRatingTarget?.let { (itemId, itemType) ->
+                                requestHeroMdbListRatings(itemId, itemType)
+                            }
+                        }
+                    }
                 }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -110,6 +110,7 @@ fun ModernHomeContent(
     onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     onNavigateToFolderDetail: (String, String) -> Unit = { _, _ -> },
     onItemFocus: (MetaPreview) -> Unit = {},
+    onMdbListRatingFocus: (String, String) -> Unit = { _, _ -> },
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
     onSaveFocusState: (Int, Int, String?, Map<String, String>, Map<String, Int>, Int, Int) -> Unit,
     scrollToTopTrigger: Int = 0,
@@ -158,6 +159,10 @@ fun ModernHomeContent(
             Box(modifier = Modifier.fillMaxSize()) {
                 com.nuvio.tv.ui.components.HeroCarousel(
                     items = uiState.heroItems.asStable(),
+                    mdbListRatings = uiState.heroMdbListRatings,
+                    onMdbListRatingRequest = { item ->
+                        onMdbListRatingFocus(item.id, item.apiType)
+                    },
                     onItemClick = { item ->
                         onNavigateToDetail(item.id, item.apiType, "")
                     },
@@ -577,11 +582,49 @@ fun ModernHomeContent(
                     row?.items?.getOrNull(clampedIdx)
                 }
             }
+            val activeContinueWatchingRatingTarget by remember(activeCarouselItemState) {
+                derivedStateOf {
+                    val payload = activeCarouselItemState.value?.payload as? ModernPayload.ContinueWatching
+                        ?: return@derivedStateOf null
+                    when (val item = payload.item) {
+                        is ContinueWatchingItem.InProgress ->
+                            item.progress.contentId to item.progress.contentType
+                        is ContinueWatchingItem.NextUp ->
+                            item.info.contentId to item.info.contentType
+                    }
+                }
+            }
+            LaunchedEffect(activeContinueWatchingRatingTarget) {
+                activeContinueWatchingRatingTarget?.let { (itemId, itemType) ->
+                    onMdbListRatingFocus(itemId, itemType)
+                }
+            }
 
-            val resolvedHeroState = remember(activeCarouselItemState, enrichedPreviews, enrichingItemId, heroItem, uiState.heroEnrichmentEnabled, failedEnrichmentIds) {
+            val resolvedHeroState = remember(
+                activeCarouselItemState,
+                enrichedPreviews,
+                enrichingItemId,
+                heroItem,
+                uiState.heroEnrichmentEnabled,
+                uiState.heroMdbListRatings,
+                failedEnrichmentIds
+            ) {
                 derivedStateOf {
                     val activeCarouselItem = activeCarouselItemState.value
                     val activeItemId = activeCarouselItem?.metaPreview?.id
+                    val activeRatingTarget = activeItemId?.let { id ->
+                        id to activeCarouselItem?.metaPreview?.apiType.orEmpty()
+                    } ?: when (
+                        val payload = activeCarouselItem?.payload as? ModernPayload.ContinueWatching
+                    ) {
+                        null -> null
+                        else -> when (val item = payload.item) {
+                            is ContinueWatchingItem.InProgress ->
+                                item.progress.contentId to item.progress.contentType
+                            is ContinueWatchingItem.NextUp ->
+                                item.info.contentId to item.info.contentType
+                        }
+                    }
                     val enrichmentActive = enrichingItemId != null && enrichingItemId == activeItemId
                     
                     val enrichedItem = activeItemId?.let { enrichedPreviews[it] }
@@ -616,6 +659,13 @@ fun ModernHomeContent(
                         enrichedHero != null -> enrichedHero
                         else -> activeCarouselItem.heroPreview
                     }
+                    val resolvedHeroWithRatings = resolvedHero?.copy(
+                        mdbListRatings = activeRatingTarget?.let { (itemId, itemType) ->
+                            uiState.heroMdbListRatings[
+                                homeItemStatusKey(itemId, itemType)
+                            ]
+                        }
+                    )
                     
                     // Only use the real enrichmentActive flag from the ViewModel.
                     // Additionally, if enrichment is enabled but no enriched data exists yet
@@ -634,13 +684,13 @@ fun ModernHomeContent(
                     }
                     
                     val heroBackdrop = firstNonBlank(
-                        resolvedHero?.backdrop,
-                        resolvedHero?.imageUrl,
-                        resolvedHero?.poster,
+                        resolvedHeroWithRatings?.backdrop,
+                        resolvedHeroWithRatings?.imageUrl,
+                        resolvedHeroWithRatings?.poster,
                         activeRowFallbackBackdrop
                     )
-                    
-                    Triple(heroBackdrop, resolvedHero, effectiveEnrichmentActive)
+
+                    Triple(heroBackdrop, resolvedHeroWithRatings, effectiveEnrichmentActive)
                 }
             }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -59,6 +59,7 @@ import coil3.request.transitionFactory
 import com.nuvio.tv.R
 import kotlinx.coroutines.delay
 import com.nuvio.tv.ui.components.ImdbRatingSourceLabel
+import com.nuvio.tv.ui.components.CompactMdbListRatingsRow
 import com.nuvio.tv.ui.components.TrailerPlayer
 import androidx.compose.ui.res.stringResource
 
@@ -439,10 +440,23 @@ private fun HeroTitleContent(
         val statusBadge = secondaryMeta.status
         val secondaryDetails = secondaryMeta.details
         val hasSecondaryBadge = ageRatingBadge != null || statusBadge != null
-        val showImdbInPrimary = !preview.isSeries && !hasSecondaryBadge && !preview.imdbText.isNullOrBlank()
-        val showImdbInPrimaryWithHighlight = showImdbInPrimary && secondaryHighlightText == null
-        val showImdbInSecondary = !preview.imdbText.isNullOrBlank() &&
-            (preview.isSeries || hasSecondaryBadge || secondaryHighlightText != null)
+        val heroRatings = remember(preview.mdbListRatings, preview.imdbText) {
+            preview.mdbListRatings?.let { ratings ->
+                if (ratings.imdb == null) {
+                    ratings.copy(imdb = preview.imdbText?.toDoubleOrNull())
+                } else {
+                    ratings
+                }
+            }?.takeUnless { it.isEmpty() }
+        }
+        val usePrimaryImdbSlot =
+            !preview.isSeries && !hasSecondaryBadge && secondaryHighlightText == null
+        val showImdbInPrimaryWithHighlight = heroRatings == null &&
+            usePrimaryImdbSlot &&
+            !preview.imdbText.isNullOrBlank()
+        val showImdbInSecondary = heroRatings == null &&
+            !preview.imdbText.isNullOrBlank() &&
+            !usePrimaryImdbSlot
 
         Row(
             modifier = Modifier.fillMaxWidth().graphicsLayer { alpha = metaAlpha },
@@ -521,7 +535,27 @@ private fun HeroTitleContent(
             }
         }
 
-        if (secondaryHighlightText != null || ageRatingBadge != null || showImdbInSecondary || statusBadge != null || secondaryDetails.isNotEmpty()) {
+        heroRatings?.let { ratings ->
+            CompactMdbListRatingsRow(
+                ratings = ratings,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer { alpha = metaAlpha },
+                textColor = NuvioTheme.colors.TextSecondary,
+                textStyle = labelMedium,
+                logoSize = 16.dp,
+                itemSpacing = 8.dp,
+                wrap = true
+            )
+        }
+
+        if (
+            secondaryHighlightText != null ||
+            ageRatingBadge != null ||
+            showImdbInSecondary ||
+            statusBadge != null ||
+            secondaryDetails.isNotEmpty()
+        ) {
             Row(
                 modifier = Modifier.fillMaxWidth().graphicsLayer { alpha = metaAlpha },
                 verticalAlignment = Alignment.CenterVertically,
@@ -537,7 +571,10 @@ private fun HeroTitleContent(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
-                if (secondaryHighlightText != null && (hasSecondaryBadge || showImdbInSecondary || secondaryDetails.isNotEmpty())) {
+                if (
+                    secondaryHighlightText != null &&
+                    (hasSecondaryBadge || showImdbInSecondary || secondaryDetails.isNotEmpty())
+                ) {
                     HeroMetaDivider(metaScale)
                 }
                 if (ageRatingBadge != null && statusBadge != null) {
@@ -563,7 +600,10 @@ private fun HeroTitleContent(
                         )
                     }
                 }
-                if ((ageRatingBadge != null || statusBadge != null) && (showImdbInSecondary || secondaryDetails.isNotEmpty())) {
+                if (
+                    (ageRatingBadge != null || statusBadge != null) &&
+                    (showImdbInSecondary || secondaryDetails.isNotEmpty())
+                ) {
                     HeroMetaDivider(metaScale)
                 }
                 if (showImdbInSecondary) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -15,6 +15,7 @@ import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import com.nuvio.tv.ui.util.localizedContentType
 import com.nuvio.tv.ui.util.computeAirDateBadgeText
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.MDBListRatings
 import com.nuvio.tv.R
 import com.nuvio.tv.ui.components.formatContinueWatchingProgressLabel
 import com.nuvio.tv.ui.util.StableList
@@ -62,7 +63,8 @@ data class HeroPreview(
      *  even after navigation away and back. */
     val frozenBackdropUrl: String? = null,
     /** Same idea for the logo URL. */
-    val frozenLogoUrl: String? = null
+    val frozenLogoUrl: String? = null,
+    val mdbListRatings: MDBListRatings? = null
 )
 
 @Immutable


### PR DESCRIPTION
## Summary

Shows the user selected MDBList rating providers in home heroes across Classic, Grid, and Modern layouts.

The implementation:

* Resolves ratings only for the active hero item
* Reuses the existing MDBList repository cache and in flight request deduplication
* Debounces focus changes and cancels stale hero requests
* Clears displayed hero ratings when MDBList settings change
* Keys cached UI results by content type and item ID
* Preserves the existing IMDb hero presentation when MDBList is unavailable
* Places Modern ratings on a dedicated row between primary metadata and age or status badges
* Wraps complete Modern provider entries instead of clipping them

## PR type

* [ ] Translation/localization only
* [ ] Critical bug fix

Feature request implementation pending maintainer approval in #2821.

## Why

MDBList already lets users choose rating providers, but those selections currently appear on detail surfaces while home heroes continue to show only the built in IMDb value. This makes the integration feel incomplete and can show a different IMDb value between Home and Details.

The hero now reflects the enabled MDBList providers while retaining the current IMDb path as a safe fallback.

## Issue or approval

Closes #2821. Broader MDBList integration is tracked in #2812. The older report #130 documents the missing hero behavior. Maintainer approval is still pending.

## Reproduction steps

1. Configure MDBList with an API key and enable multiple rating providers.
2. Return to Home using Classic, Grid, or Modern layout.
3. Focus or wait for a hero item to become active.
4. Observe that only the built in IMDb rating is shown before this change.
5. With this change, confirm the enabled MDBList provider logos and values appear.
6. Disable MDBList or remove its API key and confirm the existing IMDb hero presentation remains available.
7. In Modern, enable enough providers to exceed one line and confirm complete provider entries wrap without clipping above the age and status row.

## UI / behavior impact

* [ ] No UI change
* [ ] No behavior change
* [ ] UI changed only to fix a documented glitch/bug
* [ ] Behavior changed only to fix a documented bug/regression
* [ ] UI change has explicit maintainer approval
* [ ] Behavior change has explicit maintainer approval

This extends the existing MDBList rating selection to home heroes and performs a focused cached request for the active hero.

## Policy check

* [x] I have read and understood `CONTRIBUTING.md`.
* [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
* [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
* [x] This PR is small, focused, and limited to one issue.
* [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
* [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
* [x] I listed the testing performed below.

## Scope boundaries

This PR does not change MDBList provider settings, detail ratings, API contracts, metadata enrichment, artwork quality, or non hero cards. It adds no dependencies. It does not include the high resolution TMDB artwork setting.

## Testing

* `:app:compileFullDebugKotlin`
* Manually verified on NVIDIA Shield TV using Classic, Grid, and Modern layouts.
* Verified multiple enabled providers, Modern overflow wrapping, age and status row placement, year separation, settings refresh, and IMDb fallback behavior.

## Screenshots / Video

The [hero rating examples](https://github.com/NuvioMedia/NuvioTV/pull/2823#issuecomment-5127950430) show Classic and Grid plus the dedicated Modern ratings row.

## Breaking changes

None. MDBList disabled and failure states retain the existing IMDb behavior.

## Linked issues

Closes #2821. Related to #2812. Historical context: #130.