### PR TITLE
fix(player): do not mark watched or auto-play next on short error streams (#2819)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -987,12 +987,22 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (playerDuration > lastKnownDuration) { lastKnownDuration = playerDuration }
                         val isBuffering = playbackState == Player.STATE_BUFFERING
                         updatePlaybackTimeline(duration = playerDuration.coerceAtLeast(0L))
+                        // Only mark playbackEnded for real finishes so PlayerScreen does not
+                        // dispatch next-episode navigation for short debrid/error placeholders.
+                        val naturalEnded = playbackState == Player.STATE_ENDED &&
+                            shouldTreatAsNaturalPlaybackCompletion(
+                                hasRenderedFirstFrame = hasRenderedFirstFrame,
+                                hasFatalError = !_uiState.value.error.isNullOrBlank(),
+                                durationMs = playerDuration.coerceAtLeast(0L).let { d ->
+                                    maxOf(d, lastKnownDuration)
+                                }
+                            )
                         _uiState.update {
                             it.copy(
                                 isBuffering = if (NuvioExoPlayerPerformanceHelper.shouldSuppressBufferingUi(
                                     suppressBufferingUiForSeek, seekBufferingUiDeferred, isBuffering
                                 )) false else isBuffering,
-                                playbackEnded = playbackState == Player.STATE_ENDED
+                                playbackEnded = naturalEnded
                             )
                         }
                         updateAudioControlAvailability()
@@ -1125,7 +1135,6 @@ internal fun PlayerRuntimeController.initializePlayer(
                         }
 
                         if (playbackState == Player.STATE_ENDED) {
-                            emitCompletionScrobbleStop(progressPercent = 99.5f)
                             // Re-persist diagnostics with the final rebuffer totals (the
                             // first-frame snapshot captured 0, since rebuffers accrue after).
                             Log.i(
@@ -1144,8 +1153,9 @@ internal fun PlayerRuntimeController.initializePlayer(
                                     runCatching { playerSettingsDataStore.setLastPlaybackDiagnostics(endDiagnostics) }
                                 }
                             }
-                            saveWatchProgress()
-                            resetPostPlayStateAfterPlaybackEnded()
+                            // Marks watched + auto-play next only for real episode finishes;
+                            // short debrid/error placeholders are ignored (see #2819).
+                            handleNaturalPlaybackEnded()
                         }
 
                         refreshStableProgressResetGate()
@@ -1434,13 +1444,18 @@ internal fun PlayerRuntimeController.initializePlayer(
                             }
                         }
 
+                        // Fatal error: stop any next-episode auto-play that may have been
+                        // armed by a short placeholder ENDED or residual post-play state.
+                        cancelNextEpisodeAutoPlayOnFatalError()
                         _uiState.update {
                             it.copy(
                                 error = detailedError,
                                 showLoadingOverlay = false,
                                 showPauseOverlay = false,
                                 loadingIssueReportVisible = false,
-                                loadingIssueElapsedMs = 0L
+                                loadingIssueElapsedMs = 0L,
+                                playbackEnded = false,
+                                postPlayMode = null
                             )
                         }
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -296,6 +296,10 @@ internal fun PlayerRuntimeController.resetPostPlayOverlayState(clearEpisode: Boo
 
 internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionMs: Long, durationMs: Long) {
     if (!hasRenderedFirstFrame) return
+    // Short debrid/error clips must never arm next-episode auto-play (see #2819).
+    val effectiveDurationEarly = durationMs.takeIf { it > 0L } ?: lastKnownDuration
+    if (isShortPlaceholderDuration(effectiveDurationEarly)) return
+    if (!_uiState.value.error.isNullOrBlank()) return
 
     val state = _uiState.value
     if (state.nextEpisode == null || nextEpisodeVideo == null) {
@@ -306,7 +310,7 @@ internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionM
     }
     if (state.postPlayMode != null || state.postPlayDismissedForCurrentEpisode) return
 
-    val effectiveDuration = durationMs.takeIf { it > 0L } ?: lastKnownDuration
+    val effectiveDuration = effectiveDurationEarly
     val shouldShow = PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
         positionMs = positionMs,
         durationMs = effectiveDuration,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -61,10 +61,13 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         ) {
             return@onFailure
         }
+        cancelNextEpisodeAutoPlayOnFatalError()
         _uiState.update { state ->
             state.copy(
                 error = detailedError,
-                showLoadingOverlay = false
+                showLoadingOverlay = false,
+                playbackEnded = false,
+                postPlayMode = null
             )
         }
     }
@@ -165,11 +168,14 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         ) {
             return@onFailure
         }
+        cancelNextEpisodeAutoPlayOnFatalError()
         _uiState.update {
             it.copy(
                 error = detailedError,
                 showLoadingOverlay = false,
-                isBuffering = false
+                isBuffering = false,
+                playbackEnded = false,
+                postPlayMode = null
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -146,6 +146,29 @@ internal fun shouldResetPostPlayStateAfterPlaybackEnded(
     return true
 }
 
+/**
+ * Whether an ENDED / near-end event should count as a real episode finish.
+ *
+ * Debrid cache-sync placeholders and unplayable source responses (e.g. RAR-only
+ * torrents, "service unavailable" error clips) often report a short duration and
+ * reach STATE_ENDED. Treating those as natural completion marks the episode watched
+ * and chains auto-play next through an entire season. Mirror the external-player
+ * guard in [com.nuvio.tv.core.player.ExternalPlaybackTracker].
+ */
+internal fun shouldTreatAsNaturalPlaybackCompletion(
+    hasRenderedFirstFrame: Boolean,
+    hasFatalError: Boolean,
+    durationMs: Long
+): Boolean {
+    if (hasFatalError) return false
+    if (!hasRenderedFirstFrame) return false
+    if (isShortPlaceholderDuration(durationMs)) return false
+    return true
+}
+
+/** Streams shorter than ~2:01 are treated as error/placeholder clips, not real episodes. */
+internal fun isShortPlaceholderDuration(duration: Long): Boolean = duration in 1..120_999L
+
 internal fun PlayerRuntimeController.startProgressUpdates() {
     progressJob?.cancel()
     progressJob = scope.launch {
@@ -192,7 +215,12 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                         currentPosition = displayPosition,
                         duration = playerDuration
                     )
-                    val ended = playerDuration > 0L && pos >= (playerDuration - 500L)
+                    val nearEnd = playerDuration > 0L && pos >= (playerDuration - 500L)
+                    val naturalEnded = nearEnd && shouldTreatAsNaturalPlaybackCompletion(
+                        hasRenderedFirstFrame = firstFrameReady,
+                        hasFatalError = !_uiState.value.error.isNullOrBlank(),
+                        durationMs = playerDuration
+                    )
                     val wasEnded = _uiState.value.playbackEnded
                     _uiState.update { state ->
                         state.copy(
@@ -202,7 +230,7 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                             // Snap the loading-logo fill to 100% once playback is
                             // ready so the logo finishes filling on dismissal.
                             loadingProgress = if (firstFrameReady && state.loadingProgress != null) 1f else state.loadingProgress,
-                            playbackEnded = ended
+                            playbackEnded = naturalEnded
                         )
                     }
                     updateMpvAvailableTracks()
@@ -211,10 +239,10 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                         positionMs = pos,
                         durationMs = playerDuration
                     )
-                    if (ended && !wasEnded) {
-                        emitCompletionScrobbleStop(progressPercent = 99.5f)
-                        saveWatchProgress()
-                        resetPostPlayStateAfterPlaybackEnded()
+                    if (naturalEnded && !wasEnded) {
+                        // Short placeholders never set naturalEnded, so they cannot mark
+                        // watched or auto-advance (see #2819).
+                        handleNaturalPlaybackEnded()
                     }
                 }
                 delay(500)
@@ -580,11 +608,54 @@ internal fun PlayerRuntimeController.getEffectiveDuration(position: Long): Long 
     return effectiveDuration
 }
 
-private fun isShortPlaceholderDuration(duration: Long) = duration in 1..120999
-
 private fun PlayerRuntimeController.isShortPlaceholderStream(): Boolean {
     val position = currentPlaybackPositionMs() ?: return false
     return isShortPlaceholderDuration(getEffectiveDuration(position))
+}
+
+/**
+ * Handles a natural end-of-playback event for ExoPlayer / MPV.
+ *
+ * Short debrid placeholders and fatal-error states must not mark the episode
+ * watched or trigger auto-play next.
+ */
+internal fun PlayerRuntimeController.handleNaturalPlaybackEnded() {
+    val position = currentPlaybackPositionMs() ?: 0L
+    val duration = getEffectiveDuration(position)
+    val hasFatalError = !_uiState.value.error.isNullOrBlank()
+    if (!shouldTreatAsNaturalPlaybackCompletion(
+            hasRenderedFirstFrame = hasRenderedFirstFrame,
+            hasFatalError = hasFatalError,
+            durationMs = duration
+        )
+    ) {
+        Log.i(
+            PlayerRuntimeController.TAG,
+            "Ignoring non-natural ENDED: firstFrame=$hasRenderedFirstFrame " +
+                "error=$hasFatalError durationMs=$duration positionMs=$position"
+        )
+        // Prevent PlayerScreen from dispatching onPlaybackEnded / next-episode navigation.
+        _uiState.update { it.copy(playbackEnded = false) }
+        nextEpisodeAutoPlayJob?.cancel()
+        nextEpisodeAutoPlayJob = null
+        return
+    }
+
+    emitCompletionScrobbleStop(progressPercent = 99.5f)
+    saveWatchProgress()
+    resetPostPlayStateAfterPlaybackEnded()
+}
+
+/**
+ * Cancels any in-flight next-episode auto-play / still-watching prompt when a
+ * fatal player error is shown. Callers should also clear [PlayerUiState.playbackEnded]
+ * and [PlayerUiState.postPlayMode] in the same state update as the error message.
+ */
+internal fun PlayerRuntimeController.cancelNextEpisodeAutoPlayOnFatalError() {
+    nextEpisodeAutoPlayJob?.cancel()
+    nextEpisodeAutoPlayJob = null
+    stillWatchingPromptJob?.cancel()
+    stillWatchingPromptJob = null
 }
 
 internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, duration: Long, syncRemote: Boolean = true) {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/NaturalPlaybackCompletionRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/NaturalPlaybackCompletionRulesTest.kt
@@ -1,0 +1,100 @@
+package com.nuvio.tv.ui.screens.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NaturalPlaybackCompletionRulesTest {
+
+    @Test
+    fun `real episode end is treated as natural completion`() {
+        assertTrue(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = false,
+                durationMs = 2_400_000L // 40 min
+            )
+        )
+    }
+
+    @Test
+    fun `short debrid placeholder is not natural completion`() {
+        // Comet-style cache-sync / error clips are a few seconds long.
+        assertFalse(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = false,
+                durationMs = 5_000L
+            )
+        )
+        assertFalse(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = false,
+                durationMs = 30_000L
+            )
+        )
+        assertFalse(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = false,
+                durationMs = 120_999L
+            )
+        )
+    }
+
+    @Test
+    fun `just over placeholder threshold is natural completion`() {
+        assertTrue(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = false,
+                durationMs = 121_000L
+            )
+        )
+    }
+
+    @Test
+    fun `no first frame is not natural completion`() {
+        assertFalse(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = false,
+                hasFatalError = false,
+                durationMs = 2_400_000L
+            )
+        )
+    }
+
+    @Test
+    fun `fatal error is not natural completion`() {
+        assertFalse(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = true,
+                durationMs = 2_400_000L
+            )
+        )
+    }
+
+    @Test
+    fun `zero or unknown duration is still allowed when first frame rendered`() {
+        // Match external-player behavior: missing duration is left to the normal path.
+        assertTrue(
+            shouldTreatAsNaturalPlaybackCompletion(
+                hasRenderedFirstFrame = true,
+                hasFatalError = false,
+                durationMs = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `isShortPlaceholderDuration covers error and cache-sync clips`() {
+        assertTrue(isShortPlaceholderDuration(1L))
+        assertTrue(isShortPlaceholderDuration(5_000L))
+        assertTrue(isShortPlaceholderDuration(120_999L))
+        assertFalse(isShortPlaceholderDuration(0L))
+        assertFalse(isShortPlaceholderDuration(121_000L))
+        assertFalse(isShortPlaceholderDuration(2_400_000L))
+    }
+}


### PR DESCRIPTION
## Summary

Stops the internal player from treating short debrid/error streams as a finished episode. When a source fails (RAR-only, service unavailable, short cache-sync placeholder clips), Nuvio no longer marks the current episode as watched or auto-plays the next one.

## PR type

- [x] Critical bug fix

## Why

Debrid cache-sync placeholders and unplayable source responses often report a short duration and reach `STATE_ENDED` (or near-end progress). The internal player treated that as a natural finish:

1. Forced Trakt scrobble stop at 99.5% (marks watched)
2. Armed next-episode post-play / auto-play when enabled
3. Chained through an entire season without any real playback

The internal player already refused to *save progress* for streams shorter than ~2:01 (`isShortPlaceholderDuration`), but completion scrobble and auto-play next still ran. The external player has a similar short-playback guard. This extends the existing internal placeholder check to natural completion, post-play overlay, and fatal-error cleanup.

## Issue or approval

Fixes #2819

## Reproduction steps

1. Enable **Auto-play Next Episode**
2. Open a series and start an episode
3. Select a stream that fails (e.g. debrid RAR-only, service unavailable, short error/placeholder clip)
4. Observe before: placeholder/error ends → current episode marked watched → next episode auto-plays

After this fix: episode is **not** marked watched, next episode is **not** auto-played.

## UI / behavior impact

- [x] No visible UI redesign — only restores expected error/completion behavior
- Short placeholder / fatal-error streams no longer complete-and-advance

## Policy check

- [x] Critical bug fix with linked GitHub issue
- [x] Minimal and focused on the reported bug
- [x] No new features, UI redesign, or drive-by refactors
- [x] Reuses the existing internal short-placeholder threshold (~2:01)
- [x] Backward compatible for real episode finishes
- [x] No new dependencies

## Scope boundaries

- Internal player natural-completion path only (ExoPlayer `STATE_ENDED`, MPV near-end, post-play overlay, fatal error cancel)
- Does not change stream selection, debrid resolution, or external-player logic

## Testing

- Unit tests: `NaturalPlaybackCompletionRulesTest` covering short placeholder, fatal error, missing first frame, and real episode duration
- Existing pure-rule coverage style matches `PostPlayResetRulesTest`
- Real full-length episode ends still mark watched and auto-play next when enabled (guard only rejects short/error paths)

## Screenshots / Video

Not a UI layout change.

## Breaking changes

None.

## Linked issues

Fixes #2819