### PR TITLE
fix(modern-home): do not expand focused poster when card loses focus (#2815)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -261,10 +261,15 @@ fun ModernHomeContent(
         shouldActivateFocusedPosterFlow,
         trailerPlaybackTarget,
         uiState.focusedPosterBackdropExpandDelaySeconds,
-        verticalRowListState.isScrollInProgress
+        verticalRowListState.isScrollInProgress,
+        // Re-run when the sidebar takes/returns focus so a pending expand cannot
+        // complete while the user is on the Home button (#2815).
+        isSidebarExpanded.value
     ) {
+        // Always clear first so sidebar open / selection change collapses immediately.
         expandedCatalogFocusKey.value = null
         if (!shouldActivateFocusedPosterFlow) return@LaunchedEffect
+        if (isSidebarExpanded.value) return@LaunchedEffect
         if (verticalRowListState.isScrollInProgress) return@LaunchedEffect
         val selection = focusedCatalogSelection.value ?: return@LaunchedEffect
         if (selection.payload !is ModernPayload.Catalog) return@LaunchedEffect
@@ -272,6 +277,7 @@ fun ModernHomeContent(
         delay(expansionDelayMs)
         if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return@LaunchedEffect
         if (shouldActivateFocusedPosterFlow &&
+            !isSidebarExpanded.value &&
             !verticalRowListState.isScrollInProgress &&
             focusedCatalogSelection.value?.focusKey == selection.focusKey
         ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -317,8 +317,13 @@ private fun ModernCatalogRowItem(
     val suppressCardExpansionForHeroTrailer =
         effectiveAutoplayEnabled &&
                 trailerPlaybackTarget == FocusedPosterTrailerPlaybackTarget.HERO_MEDIA
+    // Expansion is armed from a parent-level focusKey timer that can outlive real
+    // card focus (e.g. user moves left into the sidebar). Never show the expanded
+    // backdrop on a card that is not actually focused (#2815).
     val effectiveBackdropExpanded by remember(isBackdropExpanded, suppressCardExpansionForHeroTrailer) {
-        derivedStateOf { isBackdropExpanded() && !suppressCardExpansionForHeroTrailer }
+        derivedStateOf {
+            isCardFocused && isBackdropExpanded() && !suppressCardExpansionForHeroTrailer
+        }
     }
 
     val isSidebarExpanded = LocalSidebarExpanded.current


### PR DESCRIPTION
## Summary

Prevents Modern Home catalog posters from expanding to backdrop after focus has already left the card (for example when navigating left to the sidebar Home button).

## PR type

- [x] Critical bug fix

## Why

Focused-poster expansion is armed from a parent-level `focusedCatalogSelection` timer. That selection can outlive the card's real Compose focus:

1. User focuses a catalog card
2. Selection is stored after the horizontal focus debounce
3. User moves left into the sidebar before the expand delay elapses
4. The delay still completes and sets `expandedCatalogFocusKey`
5. The unfocused card expands to backdrop width

Classic `ContentCard` already collapses on `!isFocused`. Modern home only checked the parent expand key and hero-trailer suppression, not live card focus.

## Issue or approval

Fixes #2815

## Reproduction steps

1. Settings → Layout → Focused Poster
2. Enable **Expand Focused Poster to Backdrop**
3. Enable **Autoplay Trailer** (also reproduces with autoplay off)
4. Open Home (Modern), focus the first catalog card
5. Move left to the Home sidebar button before/while the expand delay runs
6. Observe: poster expands while out of focus

After this fix: poster stays collapsed when the card is not focused.

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug
- Expanded backdrop still works while the card remains focused
- No change to expand delay settings or trailer playback targets

## Policy check

- [x] Critical bug fix with linked GitHub issue
- [x] Minimal and focused on the reported glitch
- [x] No feature work, redesign, or drive-by refactors
- [x] No new dependencies
- [x] Backward compatible for normal focused expansion

## Scope boundaries

- Modern Home expand arming + per-card expand visibility only
- Does not change Classic home (already focus-gated), settings, or trailer fetch

## Testing

- Gate expanded backdrop on `isCardFocused` (matches Classic `ContentCard` behavior)
- Expansion timer restarts/clears when `LocalSidebarExpanded` becomes true, so pending delays cannot arm expand while the sidebar owns focus
- Focused expand-after-delay behavior unchanged when focus stays on the card

## Screenshots / Video

Focus/layout glitch only — no visual redesign. Before: unfocused catalog card expands to backdrop width after delay. After: card remains at base poster width whenever it is not focused.

## Breaking changes

None.

## Linked issues

Fixes #2815