### PR TITLE
fix(home): keep expanded card open during long-press action menu (#2574)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -566,6 +566,13 @@ fun ContentCard(
     }
 }
 
+/**
+ * Keys that should collapse an expanded poster so navigation can re-arm expand.
+ *
+ * Select keys (Center / Enter) are intentionally excluded: holding them opens the
+ * action menu. Resetting the expand timer on those keys collapsed and re-expanded
+ * the card while the menu was opening (#2574).
+ */
 private fun shouldResetBackdropTimer(nativeEvent: AndroidKeyEvent): Boolean {
     val key = nativeEvent.keyCode
     return when (key) {
@@ -573,9 +580,6 @@ private fun shouldResetBackdropTimer(nativeEvent: AndroidKeyEvent): Boolean {
         AndroidKeyEvent.KEYCODE_DPAD_DOWN,
         AndroidKeyEvent.KEYCODE_DPAD_LEFT,
         AndroidKeyEvent.KEYCODE_DPAD_RIGHT,
-        AndroidKeyEvent.KEYCODE_DPAD_CENTER,
-        AndroidKeyEvent.KEYCODE_ENTER,
-        AndroidKeyEvent.KEYCODE_NUMPAD_ENTER,
         AndroidKeyEvent.KEYCODE_BACK -> true
         else -> false
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -1420,15 +1420,20 @@ private fun ModernCarouselCard(
 }
 
 
+/**
+ * Keys that should collapse an expanded poster so navigation can re-arm expand.
+ *
+ * Select keys (Center / Enter) are intentionally excluded: holding them opens the
+ * action menu / long-press options. Resetting the expand timer on those keys made
+ * the Expanded Card collapse and re-expand (and restart trailers) while the menu
+ * was opening (#2574).
+ */
 private fun shouldResetBackdropTimer(key: Key): Boolean {
     return when (key) {
         Key.DirectionUp,
         Key.DirectionDown,
         Key.DirectionLeft,
         Key.DirectionRight,
-        Key.DirectionCenter,
-        Key.Enter,
-        Key.NumPadEnter,
         Key.Back -> true
         else -> false
     }


### PR DESCRIPTION
## Summary

Keeps the Expanded Card open when the user holds D-pad Center / Enter to open the poster action menu, so the card no longer collapses (and trailers no longer restart) while the menu is opening.

## PR type

- [x] Critical bug fix

## Why

Expanded-poster code resets its expand timer on several key presses so horizontal/vertical navigation can collapse and re-arm expansion cleanly. Select keys (`DirectionCenter`, `Enter`, `NumPadEnter`) were included in that list.

Holding Center/Enter to open the action menu therefore:

1. Fired an expand-timer reset on key down → card collapsed immediately
2. Left focus on the same item → expand delay re-armed → card expanded again
3. With delay 0, key-repeat produced continuous collapse/expand flicker and trailer restarts

Select keys do not change focus to another item, so they should not reset the expand timer. Navigation keys (and Back) still do.

## Issue or approval

Fixes #2574

## Reproduction steps

1. Enable Expanded Cards and trailer playback inside Expanded Cards
2. Focus a catalog item and wait for the Expanded Card
3. Press and hold D-pad Center (or Enter) to open the action menu

Before: card collapses (or flickers collapse/expand); trailer restarts.  
After: card stays expanded while the action menu opens.

## UI / behavior impact

- [x] UI changed only to fix a documented focus/navigation glitch
- Horizontal/vertical D-pad still collapses and re-arms expand as before
- Short-press Center to open Details is unchanged

## Policy check

- [x] Critical bug fix with linked GitHub issue
- [x] Minimal and focused on the reported glitch
- [x] No feature work, redesign, or drive-by refactors
- [x] No new dependencies
- [x] Applied to both Modern Home and Classic ContentCard paths

## Scope boundaries

- Only which keys reset the expand timer
- Does not change long-press detection, action menu content, or expand delay settings

## Testing

- Logic: select keys removed from `shouldResetBackdropTimer` in `ModernHomeRows` and `ContentCard`
- Navigation keys (Up/Down/Left/Right) and Back still reset the timer
- Long-press / Menu handling paths unchanged

## Screenshots / Video

Focus/navigation glitch only. Before: hold Center collapses Expanded Card. After: hold Center keeps Expanded Card open while the action menu appears.

## Breaking changes

None.

## Linked issues

Fixes #2574