### PR TITLE
fix(collections): use stable item keys in TABBED_GRID to prevent scroll jump (#2511)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -448,9 +448,11 @@ private fun TabbedGridContent(
             ) {
                 itemsIndexed(
                     items = items,
-                    key = { index, item -> "${item.id}_$index" }
-                ) { index, item ->
-                    val itemKey = "${item.id}_$index"
+                    // Stable keys (no list index): index-based keys remapped when load-more
+                    // appends pages and made LazyVerticalGrid jump toward the start (#2511).
+                    key = { _, item -> "${item.apiType}:${item.id}" }
+                ) { _, item ->
+                    val itemKey = "${item.apiType}:${item.id}"
                     val focusReq = itemFocusRequesters.getOrPut(itemKey) { FocusRequester() }
                     ContentCard(
                         item = item,


### PR DESCRIPTION
## Summary

Prevents TABBED_GRID collections from jumping toward the start of the list when browsing near the end of long catalogs.

## PR type

- [x] Critical bug fix

## Why

TABBED_GRID used LazyVerticalGrid item keys of the form `id_index`. When load-more appended another page, every new composition still keyed older rows by their index, but focus/item identity was tied to unstable index suffixes. Near the end of long lists (where load-more fires often), that remapping made the grid jump back toward the beginning so the last items were hard or impossible to reach.

Stable keys (`apiType:id`) keep item identity across page appends.

## Issue or approval

Fixes #2511

## Reproduction steps

1. Open a long collection using **TABBED_GRID**
2. Scroll toward the end of the list with the D-pad
3. Continue when load-more loads additional pages

Before: viewport jumps toward the start; final items may be unreachable.  
After: scroll position remains stable while new pages append.

## UI / behavior impact

- [x] UI changed only to fix a documented navigation/scroll glitch
- No layout redesign

## Policy check

- [x] Critical bug fix with linked GitHub issue
- [x] Minimal one-file change
- [x] No new dependencies
- [x] Load-more / tab logic unchanged

## Scope boundaries

- TABBED_GRID item keys in `FolderDetailScreen` only

## Testing

- Key factory no longer includes list index
- Focus requester map keys match stable item keys
- Append-only load-more keeps existing keys valid

## Screenshots / Video

Scroll/focus glitch only. Before: jump toward start near end of long TABBED_GRID. After: continuous scroll through appended pages.

## Breaking changes

None.

## Linked issues

Fixes #2511