### PR TITLE
fix(catalog): restore See All focus by stable item key (#2505)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -60,10 +60,14 @@ import com.nuvio.tv.ui.screens.home.HomeEvent
 import com.nuvio.tv.ui.screens.home.HomeViewModel
 import com.nuvio.tv.ui.screens.search.SearchEvent
 import com.nuvio.tv.ui.screens.search.SearchViewModel
+import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.legacyKey
 import com.nuvio.tv.domain.model.stableItemKey
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
+
+/** Stable focus key for a catalog poster (survives list reloads; not a grid index). */
+private fun catalogItemFocusKey(item: MetaPreview): String = "${item.apiType}:${item.id}"
 
 @Composable
 fun CatalogSeeAllScreen(
@@ -114,9 +118,19 @@ fun CatalogSeeAllScreen(
 
     val gridState = rememberLazyGridState()
     val restoreFocusRequester = remember { FocusRequester() }
-    var focusedItemIndex by rememberSaveable(catalogKey) { mutableStateOf(0) }
+    // Persist the focused catalog item by stable id (not grid index) so return-from-Details
+    // can re-focus the same poster even if the row reloads or the first cell steals focus.
+    var focusedItemKey by rememberSaveable(catalogKey) { mutableStateOf<String?>(null) }
     var shouldRestoreFocus by rememberSaveable(catalogKey) { mutableStateOf(true) }
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    val focusedItemIndex = remember(catalogRow?.items, focusedItemKey) {
+        val items = catalogRow?.items.orEmpty()
+        if (items.isEmpty()) return@remember 0
+        val key = focusedItemKey
+        if (key.isNullOrBlank()) return@remember 0
+        items.indexOfFirst { catalogItemFocusKey(it) == key }.takeIf { it >= 0 } ?: 0
+    }
 
     // Load more when scrolling near the bottom
     LaunchedEffect(gridState, catalogRow?.items?.size) {
@@ -156,12 +170,12 @@ fun CatalogSeeAllScreen(
         }
     }
 
-    LaunchedEffect(shouldRestoreFocus, catalogRow?.items?.size, focusedItemIndex) {
+    LaunchedEffect(shouldRestoreFocus, catalogRow?.items?.size, focusedItemKey) {
         if (!shouldRestoreFocus) return@LaunchedEffect
-        val itemsCount = catalogRow?.items?.size ?: 0
-        if (itemsCount == 0) return@LaunchedEffect
+        val items = catalogRow?.items.orEmpty()
+        if (items.isEmpty()) return@LaunchedEffect
 
-        val targetIndex = focusedItemIndex.coerceIn(0, itemsCount - 1)
+        val targetIndex = focusedItemIndex.coerceIn(0, items.lastIndex)
         val isTargetVisible = gridState.layoutInfo.visibleItemsInfo.any { it.index == targetIndex }
         if (!isTargetVisible) {
             gridState.animateScrollToItem(targetIndex)
@@ -234,14 +248,26 @@ fun CatalogSeeAllScreen(
                                 com.nuvio.tv.ui.screens.home.homeItemStatusKey(item.id, item.apiType)
                             ] == true
                         }
+                        val itemFocusKey = catalogItemFocusKey(item)
                         GridContentCard(
                             item = item,
                             posterCardStyle = posterCardStyle,
                             showLabel = uiState.posterLabelsEnabled,
                             isWatched = isWatched,
                             focusRequester = if (index == focusedItemIndex) restoreFocusRequester else null,
-                            onFocused = { focusedItemIndex = index },
+                            onFocused = {
+                                // While restoring after Details/resume, ignore transient focus on the
+                                // first/leftmost cell so it cannot overwrite the saved poster key.
+                                if (shouldRestoreFocus &&
+                                    focusedItemKey != null &&
+                                    itemFocusKey != focusedItemKey
+                                ) {
+                                    return@GridContentCard
+                                }
+                                focusedItemKey = itemFocusKey
+                            },
                             onClick = {
+                                focusedItemKey = itemFocusKey
                                 onNavigateToDetail(
                                     item.id,
                                     item.apiType,
@@ -249,7 +275,7 @@ fun CatalogSeeAllScreen(
                                 )
                             },
                             onLongPress = {
-                                focusedItemIndex = index
+                                focusedItemKey = itemFocusKey
                                 posterOptionsController.show(item, catalogRow.addonBaseUrl)
                             }
                         )


### PR DESCRIPTION
## Summary

Fixes Catalog **See All** focus restore after returning from Details: the previously selected poster is restored instead of the leftmost item in Grid/Classic (and Search) See All grids.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On Home **Grid** and **Classic** layouts, opening **See All** for a catalog, selecting a non-first poster, opening Details, then pressing Back always restored focus to the leftmost item. Transient focus on the first composed cell overwrote the saved grid index during resume, so users had to re-navigate every time they checked Details.

## Issue or approval

Fixes #2505

## Reproduction steps

1. Use Home layout **Grid** or **Classic**.
2. Open a catalog via **See All**.
3. Move focus to a poster that is not the first/leftmost item.
4. Open Details and wait until the page has fully loaded.
5. Press Back.

**Before:** focus lands on the leftmost poster.  
**After:** focus returns to the same poster that was selected before Details.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- **In scope:** `CatalogSeeAllScreen` only (Home Grid/Classic See All and Search See All).
- **Out of scope:** Collections **ROWS** / **TABBED_GRID** focus restore paths also described in #2505 (separate layouts; not changed here).
- No visual redesign, no navigation graph changes, no player/library changes.

## Testing

- Logic review of focus save/restore race on `CatalogSeeAllScreen`.
- Confirmed restore target is keyed by `apiType:id` (stable across reloads) rather than raw grid index.
- Confirmed `onFocused` ignores non-matching cells while `shouldRestoreFocus` is true so the leftmost cell cannot clobber the saved key on resume.
- Confirmed click/long-press pins the focus key before navigating to Details or poster options.
- Did not run a local full Gradle/device build (no full device environment in this session). CI fullDebug build is the verification path.

## Screenshots / Video

Not a visual UI change (focus restoration only; no layout/styling changes).

## Breaking changes

None.

## Linked issues

Fixes #2505