### PR TITLE
fix(tmdb): restore production company browse card focus after Back (#2836)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.LazyListPrefetchStrategy
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -38,10 +39,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
@@ -83,6 +85,7 @@ import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
+import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
@@ -163,6 +166,7 @@ private fun TmdbEntityBrowseContent(
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     var pendingRestoreItemId by rememberSaveable(data.header.id) { mutableStateOf<String?>(null) }
+    var pendingRestoreRailKey by rememberSaveable(data.header.id) { mutableStateOf<String?>(null) }
     var restoreFocusToken by rememberSaveable(data.header.id) { mutableIntStateOf(0) }
 
     DisposableEffect(lifecycleOwner, pendingRestoreItemId) {
@@ -182,8 +186,20 @@ private fun TmdbEntityBrowseContent(
     val localDensity = LocalDensity.current
     val focusedItemIndexByRail = remember { mutableMapOf<String, Int>() }
     val railListStates = remember { mutableMapOf<String, LazyListState>() }
+    val railsListState = rememberLazyListState()
     val firstCardFocusRequester = remember(data.header.id) { FocusRequester() }
     var initialFocusRequested by rememberSaveable(data.header.id) { mutableStateOf(false) }
+
+    // Bring the rail that owns the restored card into the column viewport before the row restore runs.
+    LaunchedEffect(restoreFocusToken, pendingRestoreRailKey, data.rails) {
+        if (restoreFocusToken <= 0 || pendingRestoreItemId == null) return@LaunchedEffect
+        val railKey = pendingRestoreRailKey ?: return@LaunchedEffect
+        val railIndex = data.rails.indexOfFirst {
+            "${it.mediaType.value}_${it.railType.value}" == railKey
+        }
+        if (railIndex < 0) return@LaunchedEffect
+        runCatching { railsListState.scrollToItem(railIndex) }
+    }
 
     val backgroundRequest = rememberBackgroundRequest(
         data = data,
@@ -241,6 +257,7 @@ private fun TmdbEntityBrowseContent(
 
                 CompositionLocalProvider(LocalBringIntoViewSpec provides railsBringIntoViewSpec) {
                     LazyColumn(
+                        state = railsListState,
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
@@ -253,11 +270,11 @@ private fun TmdbEntityBrowseContent(
                         ) { railIndex, rail ->
                             val railKey = "${rail.mediaType.value}_${rail.railType.value}"
                             val rememberedFocusedIndex = focusedItemIndexByRail[railKey] ?: 0
+                            val isRestoreRail = pendingRestoreRailKey == null || pendingRestoreRailKey == railKey
                             EntityRailRow(
                                 rail = rail,
                                 initialFocusRequester = if (railIndex == 0) firstCardFocusRequester else null,
                                 shouldRequestInitialFocus = railIndex == 0 && !initialFocusRequested && pendingRestoreItemId == null,
-                                rememberedFocusedIndex = rememberedFocusedIndex,
                                 rowListState = railListStates.getOrPut(railKey) {
                                     LazyListState(
                                         firstVisibleItemIndex = rememberedFocusedIndex,
@@ -265,15 +282,19 @@ private fun TmdbEntityBrowseContent(
                                     )
                                 },
                                 posterCardStyle = posterCardStyle,
-                                restoreItemId = pendingRestoreItemId,
-                                restoreFocusToken = restoreFocusToken,
+                                restoreItemId = if (isRestoreRail) pendingRestoreItemId else null,
+                                restoreFocusToken = if (isRestoreRail) restoreFocusToken else 0,
                                 onInitialFocusHandled = { initialFocusRequested = true },
-                                onRestoreFocusHandled = { pendingRestoreItemId = null },
+                                onRestoreFocusHandled = {
+                                    pendingRestoreItemId = null
+                                    pendingRestoreRailKey = null
+                                },
                                 onFocusedItemIndexChanged = { focusedIndex ->
                                     focusedItemIndexByRail[railKey] = focusedIndex
                                 },
                                 onItemClick = { item ->
                                     pendingRestoreItemId = item.id
+                                    pendingRestoreRailKey = railKey
                                     onNavigateToDetail(item.id, item.apiType, null)
                                 },
                                 onItemLongPress = onItemLongPress,
@@ -417,13 +438,12 @@ private fun TmdbEntityHero(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
 private fun EntityRailRow(
     rail: TmdbEntityRail,
     initialFocusRequester: FocusRequester?,
     shouldRequestInitialFocus: Boolean,
-    rememberedFocusedIndex: Int,
     rowListState: LazyListState,
     posterCardStyle: PosterCardStyle,
     restoreItemId: String?,
@@ -438,34 +458,42 @@ private fun EntityRailRow(
     val focusRequesters = remember(rail.mediaType, rail.railType) {
         mutableMapOf<String, FocusRequester>()
     }
+    val restoreFocusRequester = remember(rail.mediaType, rail.railType) { FocusRequester() }
+    var restorePending by remember(rail.mediaType, rail.railType) { mutableStateOf(false) }
     val itemIds = remember(rail.items) { rail.items.map { it.id }.toSet() }
     focusRequesters.keys.retainAll(itemIds)
-    val initialFocusIndex = rememberedFocusedIndex
-        .coerceIn(0, (rail.items.size - 1).coerceAtLeast(0))
+    val firstItemFocusRequester = initialFocusRequester
+        ?: remember(rail.mediaType, rail.railType) { FocusRequester() }
     var lastLoadMoreRequestTotal by remember(rail.mediaType, rail.railType) { mutableIntStateOf(-1) }
 
-    LaunchedEffect(shouldRequestInitialFocus, initialFocusRequester, rail.items.firstOrNull()?.id) {
-        if (!shouldRequestInitialFocus || initialFocusRequester == null || rail.items.isEmpty()) return@LaunchedEffect
-        repeat(2) { withFrameNanos { } }
-        repeat(4) { attempt ->
-            val focused = runCatching {
-                initialFocusRequester.requestFocus()
-                true
-            }.getOrDefault(false)
-            if (focused) {
-                onInitialFocusHandled()
-                return@LaunchedEffect
-            }
-            if (attempt < 3) withFrameNanos { }
+    LaunchedEffect(shouldRequestInitialFocus, firstItemFocusRequester, rail.items.firstOrNull()?.id) {
+        if (!shouldRequestInitialFocus || rail.items.isEmpty()) return@LaunchedEffect
+        val focused = firstItemFocusRequester.requestFocusAfterFrames(frames = 2)
+        if (focused) {
+            onInitialFocusHandled()
         }
     }
 
-    LaunchedEffect(restoreItemId, restoreFocusToken) {
-        if (restoreFocusToken <= 0 || restoreItemId == null) return@LaunchedEffect
-        val requester = focusRequesters[restoreItemId] ?: return@LaunchedEffect
-        repeat(2) { withFrameNanos { } }
-        runCatching { requester.requestFocus() }
-        onRestoreFocusHandled()
+    // Scroll the target card into composition, then request focus with retries.
+    // Looking up a FocusRequester that was never composed (off-screen LazyRow items)
+    // used to exit early and leave focus on a random card after Back.
+    LaunchedEffect(restoreItemId, restoreFocusToken, rail.items) {
+        if (restoreFocusToken <= 0 || restoreItemId.isNullOrBlank()) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        val targetIndex = rail.items.indexOfFirst { it.id == restoreItemId }
+        if (targetIndex < 0) {
+            restorePending = false
+            return@LaunchedEffect
+        }
+        restorePending = true
+        runCatching { rowListState.scrollToItem(targetIndex) }
+        val focused = restoreFocusRequester.requestFocusAfterFrames(frames = 2)
+        if (!focused) {
+            // One more attempt after layout settles (common after column rail scroll).
+            restoreFocusRequester.requestFocusAfterFrames(frames = 3)
+        }
     }
 
     LaunchedEffect(rail.mediaType, rail.railType, rowListState, rail.hasMore, rail.isLoading) {
@@ -525,33 +553,43 @@ private fun EntityRailRow(
         }
         CompositionLocalProvider(LocalBringIntoViewSpec provides rowBringIntoViewSpec) {
             LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRestorer {
+                        if (restorePending) restoreFocusRequester else firstItemFocusRequester
+                    },
                 state = rowListState,
                 contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.xxxl),
                 horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
             ) {
-            itemsIndexed(
-                items = rail.items,
-                key = { _, item -> item.id }
-            ) { itemIndex, item ->
-                val requester = if (itemIndex == 0 && initialFocusRequester != null) {
-                    focusRequesters[item.id] = initialFocusRequester
-                    initialFocusRequester
-                } else {
-                    focusRequesters.getOrPut(item.id) { FocusRequester() }
-                }
-                GridContentCard(
-                    item = item,
-                    onClick = { onItemClick(item) },
-                    onLongPress = { onItemLongPress(item) },
-                    posterCardStyle = posterCardStyle,
-                    showLabel = true,
-                    focusRequester = requester,
-                    onFocused = {
-                        onFocusedItemIndexChanged(itemIndex)
+                itemsIndexed(
+                    items = rail.items,
+                    key = { _, item -> item.id }
+                ) { itemIndex, item ->
+                    val isRestoreTarget = item.id == restoreItemId
+                    val isFirstItem = itemIndex == 0
+                    val requester = when {
+                        isRestoreTarget -> restoreFocusRequester
+                        isFirstItem -> firstItemFocusRequester
+                        else -> focusRequesters.getOrPut(item.id) { FocusRequester() }
                     }
-                )
+                    GridContentCard(
+                        item = item,
+                        onClick = { onItemClick(item) },
+                        onLongPress = { onItemLongPress(item) },
+                        posterCardStyle = posterCardStyle,
+                        showLabel = true,
+                        focusRequester = requester,
+                        onFocused = {
+                            onFocusedItemIndexChanged(itemIndex)
+                            if (isRestoreTarget && restoreFocusToken > 0) {
+                                restorePending = false
+                                onRestoreFocusHandled()
+                            }
+                        }
+                    )
+                }
             }
-        }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes focus restoration on the TMDB production company / network browse screen. After opening a title from a company rail and pressing Back, focus now returns to the same poster card instead of jumping to a different card.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Opening a production company from Meta Details shows catalog rails of titles. Selecting a title and pressing Back left focus on a random card because restore looked up a `FocusRequester` that only exists for currently composed LazyRow items. Off-screen (or recreated) cards caused an early exit with no scroll-into-view, so focus landed elsewhere. Discover already restores correctly; this path did not.

## Issue or approval

Fixes #2836

## Reproduction steps

1. Open any movie details that lists production companies.
2. Scroll to Production and open a company.
3. Move focus to any poster that is not the first card (or a card further along the rail).
4. Open that title, then press Back.
5. **Before:** focus lands on a different card.
6. **After:** focus returns to the same card that was opened.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `TmdbEntityBrowseScreen` focus restore path (company/network browse).
- No Discover, Meta Details company-logo restore, or catalog redesign changes.
- No player, debrid, or addon changes.

## Testing

- Code review of restore path against Cast Detail / More Like This patterns.
- Logic verification:
  - Pending item id + rail key saved on click (`rememberSaveable`).
  - On `ON_RESUME`, column scrolls to the owning rail, row scrolls to the item index, then `requestFocusAfterFrames` + `focusRestorer` target the same card.
  - Restore no longer depends on a FocusRequester that only exists after composition.
- Not run on physical Android TV hardware in this environment; CI fullDebug build will compile the change.

## Screenshots / Video

Not a visual redesign — focus-only restore behavior on existing company browse rails.

## Breaking changes

None.

## Linked issues

Fixes #2836