### PR TITLE
fix(player): fallback to HLS mime type on container parsing error for debrid caching streams

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -435,20 +435,18 @@ internal fun PlayerRuntimeController.tryDv7HevcFallback(
     return true
 }
 
-private fun PlayerRuntimeController.handleParsingErrorFallback(error: PlaybackException) {
+internal fun PlayerRuntimeController.handleParsingErrorFallback(error: PlaybackException) {
     if (error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
         error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
         error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_UNSUPPORTED ||
         error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED
     ) {
-        if (currentStreamMimeType != null) {
-            Log.w(
-                PlayerRuntimeController.TAG,
-                "Parsing error [${error.errorCode}] detected with mimeType=$currentStreamMimeType. " +
-                        "Clearing mimeType override for fallback."
-            )
-            currentStreamMimeType = null
-            currentStreamResponseHeaders = emptyMap()
-        }
+        Log.w(
+            PlayerRuntimeController.TAG,
+            "Parsing error [${error.errorCode}] detected with previous mimeType=$currentStreamMimeType. " +
+                    "Setting mimeType to HLS (APPLICATION_M3U8) for retry fallback."
+        )
+        currentStreamMimeType = androidx.media3.common.MimeTypes.APPLICATION_M3U8
+        currentStreamResponseHeaders = emptyMap()
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1439,6 +1439,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                             return
                         }
 
+                        handleParsingErrorFallback(error)
+
                         // ── Main Engine Failover ──
                         if (maybeAutoSwitchInternalPlayerOnStartupError(detailedError = detailedError, allowEngineFailover = allowEngineFailover)) {
                             return


### PR DESCRIPTION
## Summary

Fixes playback crash and `ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED` exception when playing Debrid streams that are still caching. When Debrid services (e.g. `aiostreams.elfhosted.com`) redirect requests (via HTTP 307) to an HLS `.m3u8` video slate while a torrent is caching, ExoPlayer previously attempted progressive extraction based on the metadata filename (`.mkv`/`.mp4`), causing a container parsing failure. This PR adds an automatic fallback to HLS (`MimeTypes.APPLICATION_M3U8`) during error recovery so the Debrid provider's informational status video is displayed directly to the user.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Showing an unhelpful `ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED` error screen confuses users and makes them assume the issue stems from the NuvioTV player. When a torrent is still being downloaded or cached on Debrid providers, Debrid services return an HLS `.m3u8` video slate displaying an explicit status message (e.g., "This stream is still being downloaded to your debrid service"). 

By gracefully falling back to HLS format upon container parsing errors, the player presents the Debrid service's informational video instead of a crash/error overlay. This clearly communicates to the user that the stream is currently caching on Debrid and that the issue is not caused by the application, significantly improving UX and preventing misleading bug reports.

## Issue or approval

`ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED` on Debrid caching streams

## Reproduction steps

1. Select a stream on a Debrid service (such as `aiostreams.elfhosted.com`) where the item is currently in "still caching" status.
2. Attempt playback in NuvioTV.
3. Observe that ExoPlayer attempts progressive extraction using metadata filename (`.mkv`), receives an HLS redirect (`.m3u8`), and throws `ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED`.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- This change does not alter initial player initialization or pre-flight network probing.
- This change does not modify MPV player behavior or audio track fallbacks.
- This change is strictly scoped to `handleParsingErrorFallback` when ExoPlayer encounters container/manifest parsing errors.

## Testing

- Verified via `adb logcat` on Android TV device that `ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED` is caught during fallback handling.
- Confirmed that `currentStreamMimeType` is set to `APPLICATION_M3U8`, causing ExoPlayer's retry attempt to construct an `HlsMediaSource`.
- Verified clean compilation with `gradlew assembleDebug`.

## Screenshots / Video

### Before (Parsing Error Overlay)

<img width="1920" height="1080" alt="tv_screenshot" src="https://github.com/user-attachments/assets/6c6892c6-d564-492c-abca-566f11e434e9" />


### After (Debrid Caching Video Slate)
<img width="2560" height="1564" alt="photo_6010540473304420127_w (1)" src="https://github.com/user-attachments/assets/f6940212-87ba-42b9-a148-b49ec944a040" />


## Breaking changes

None

## Linked issues

`ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED` on Debrid caching streams