### PR TITLE
fix(search): keep caret after typed characters on live search (#2845)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -79,7 +79,9 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import com.nuvio.tv.ui.util.RtlKeyUtils
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -855,6 +857,20 @@ private fun SearchInputField(
     var isDiscoverButtonFocused by remember { mutableStateOf(false) }
     var isVoiceButtonFocused by remember { mutableStateOf(false) }
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    // Keep caret/selection in the field itself. A bare String value loses selection on the
+    // live-search recompositions that follow each keystroke (clear button appears, recent
+    // searches hide, short-query performSearch), which on TV put the caret back at index 0.
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = query, selection = TextRange(query.length)))
+    }
+    // Only apply external query changes (clear, voice, recent chip). Never write during the
+    // composition that follows a local keystroke — that would see a still-stale query prop and
+    // wipe the character the user just typed.
+    LaunchedEffect(query) {
+        if (query != textFieldValue.text) {
+            textFieldValue = TextFieldValue(text = query, selection = TextRange(query.length))
+        }
+    }
 
     Row(
         modifier = Modifier
@@ -983,8 +999,11 @@ private fun SearchInputField(
         }
 
         OutlinedTextField(
-            value = query,
-            onValueChange = onQueryChanged,
+            value = textFieldValue,
+            onValueChange = { nextValue ->
+                textFieldValue = nextValue
+                onQueryChanged(nextValue.text)
+            },
             modifier = Modifier
                 .weight(1f)
                 .focusRequester(searchFocusRequester)
@@ -1059,30 +1078,43 @@ private fun SearchInputField(
 
         // Clear button, requested in review. Placed beside the field rather than as a trailing
         // icon so it is reachable with the D-pad, matching the voice button's treatment.
-        if (query.isNotEmpty()) {
-            var isClearButtonFocused by remember { mutableStateOf(false) }
-            Spacer(modifier = Modifier.width(NuvioTheme.spacing.md))
-            IconButton(
-                onClick = { onQueryChanged("") },
-                modifier = Modifier
-                    .onFocusChanged { isClearButtonFocused = it.isFocused }
-                    .size(NuvioTheme.spacing.huge)
-                    .border(
-                        width = if (isClearButtonFocused) NuvioTheme.spacing.xxs else NuvioTheme.spacing.hairline,
-                        color = if (isClearButtonFocused) NuvioTheme.colors.FocusRing else NuvioTheme.colors.Border,
-                        shape = RoundedCornerShape(NuvioTheme.radii.md)
-                    )
-                    .background(
-                        color = NuvioTheme.colors.BackgroundCard,
-                        shape = RoundedCornerShape(NuvioTheme.radii.md)
-                    )
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(R.string.cd_clear_search),
-                    tint = NuvioTheme.colors.TextPrimary
+        // Always reserve the trailing slot so the first keystroke does not insert a new focusable
+        // neighbor mid-edit (that reshuffle was contributing to the caret jump on TV).
+        var isClearButtonFocused by remember { mutableStateOf(false) }
+        Spacer(modifier = Modifier.width(NuvioTheme.spacing.md))
+        IconButton(
+            onClick = {
+                textFieldValue = TextFieldValue()
+                onQueryChanged("")
+            },
+            enabled = query.isNotEmpty(),
+            modifier = Modifier
+                .focusProperties { canFocus = query.isNotEmpty() }
+                .onFocusChanged { isClearButtonFocused = it.isFocused && query.isNotEmpty() }
+                .size(NuvioTheme.spacing.huge)
+                .border(
+                    width = if (isClearButtonFocused) NuvioTheme.spacing.xxs else NuvioTheme.spacing.hairline,
+                    color = when {
+                        query.isEmpty() -> NuvioTheme.colors.Border.copy(alpha = 0f)
+                        isClearButtonFocused -> NuvioTheme.colors.FocusRing
+                        else -> NuvioTheme.colors.Border
+                    },
+                    shape = RoundedCornerShape(NuvioTheme.radii.md)
                 )
-            }
+                .background(
+                    color = if (query.isEmpty()) {
+                        NuvioTheme.colors.BackgroundCard.copy(alpha = 0f)
+                    } else {
+                        NuvioTheme.colors.BackgroundCard
+                    },
+                    shape = RoundedCornerShape(NuvioTheme.radii.md)
+                )
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.cd_clear_search),
+                tint = NuvioTheme.colors.TextPrimary.copy(alpha = if (query.isEmpty()) 0f else 1f)
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Search no longer jumps the text caret to the start of the field after the first typed character. The search field now keeps selection in a local `TextFieldValue`, and the clear control always reserves its trailing slot so the first keystroke does not reshuffle focus neighbors mid-edit.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On Android TV, typing the first letter in Search moved the caret in front of that letter. Further D-pad movement then left the field (often to Discover) instead of continuing to type, so search became unusable until the user repositioned the caret with the pointer.

## Issue or approval

Fixes #2845

## Reproduction steps

1. Open Search on Android TV.
2. Focus the search field and type a single letter (for example `A`).
3. Observe the caret jumps before the letter.
4. Try to move past the letter / keep typing; focus often leaves the field (e.g. to Discover).
5. Expected after fix: caret stays after the typed character and typing continues normally.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change live-search debounce, suggestion, or discover routing logic.
- Clear button remains D-pad reachable when the query is non-empty; when empty it stays non-focusable and visually transparent while still reserving layout space.
- No library search or other TextField sites changed.

## Testing

- `./gradlew :app:compileFullDebugKotlin` — PASSED
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.search.SearchPresentationRulesTest"` — PASSED
- Manual Android TV device verification of caret position while typing not run in this environment; the fix controls selection explicitly on each keystroke.

## Screenshots / Video

Not a visual redesign; behavior-only caret/focus correctness on Search. Clear control still appears in the same place when the query is non-empty.

## Breaking changes

None.

## Linked issues

Fixes #2845