### PR TITLE
fix(ui): black plate under expanded-card trailer letterbox (#2852)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContentCard.kt
@@ -418,6 +418,15 @@ fun ContentCard(
                 }
 
                 if (shouldPlayTrailerPreview) {
+                    // Black plate under FIT-mode video so non-16:9 trailers letterbox
+                    // to black instead of revealing the expanded backdrop (#2852).
+                    // The backdrop cover above still hides load-in; it fades out after
+                    // the first frame, leaving black + trailer only.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Black)
+                    )
                     TrailerPlayer(
                         trailerUrl = trailerPreviewUrl,
                         trailerAudioUrl = trailerPreviewAudioUrl,


### PR DESCRIPTION
## Summary

When Classic View autoplays a trailer in an expanded focused card, non-16:9 trailers letterboxed against the expanded backdrop instead of a black card surface. This PR draws a solid black plate under `TrailerPlayer` while the trailer preview is active so letterbox/pillarbox areas stay black after the existing backdrop cover fades out.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Expanded-card trailer preview uses FIT resize mode on top of the expanded backdrop image. After the first video frame, the temporary backdrop cover alpha goes to 0, so any letterbox bars from non-16:9 trailers revealed the still-visible backdrop underneath. Users expect a black focused card behind the trailer, matching the reported expected behavior.

## Issue or approval

Fixes #2852

## Reproduction steps

1. Set Classic View.
2. Enable Autoplay Trailer in Expanded Card.
3. Focus a poster long enough for the card to expand and start trailer autoplay.
4. Use a title whose trailer is not 16:9 (no black bars baked into the video).
5. Observe letterbox/pillarbox areas: before fix they show the backdrop; after fix they are solid black.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Classic expanded `ContentCard` trailer stack only.
- Does not change Modern Home (already uses `cropToFill` zoom for expanded trailers).
- Does not change trailer resize mode, mute settings, or expand timing.
- No load-in transition redesign: existing backdrop cover fade remains.

## Testing

- Code-path review of Classic `ContentCard` layer order: base backdrop → black plate (new) → `TrailerPlayer` (FIT) → fading backdrop cover.
- Confirmed cover still fully hides load-in (`trailerCoverAlpha` 1 until first frame), then fades to reveal black + trailer only.
- No device/emulator run in this environment; CI fullDebug build is the compile gate.

## Screenshots / Video

UI layering fix only (black under non-16:9 trailer letterbox). No new chrome or layout change; screenshots not available from this environment.

## Breaking changes

None.

## Linked issues

Fixes #2852