### PR TITLE
fix(player): bind exact addon subtitle track on manual switch (#2601)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.Tracks
 import com.nuvio.tv.domain.model.Subtitle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -105,62 +106,174 @@ internal fun PlayerRuntimeController.rememberAudioSelection(trackIndex: Int) {
     persistTrackPreference()
 }
 
-internal fun PlayerRuntimeController.applyAddonSubtitleOverride(addonTrackId: String): Boolean {
-    val player = _exoPlayer ?: return false
-    player.currentTracks.groups.forEach { trackGroup ->
-        if (trackGroup.type != C.TRACK_TYPE_TEXT) return@forEach
-        for (i in 0 until trackGroup.length) {
-            val format = trackGroup.getTrackFormat(i)
-            if (format.id?.contains(addonTrackId) == true || format.id == addonTrackId) {
-                val override = TrackSelectionOverride(trackGroup.mediaTrackGroup, i)
-                player.trackSelectionParameters = player.trackSelectionParameters
-                    .buildUpon()
-                    .setOverrideForType(override)
-                    .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
-                    .build()
-                Log.d(
-                    PlayerRuntimeController.TAG,
-                    "applyAddonSubtitleOverride: found id=${format.id} at group/track $i " +
-                        "mime=${format.sampleMimeType} codecs=${format.codecs} label=${format.label} lang=${format.language}"
-                )
-                return true
-            }
-        }
+/**
+ * True when [formatId] identifies the same sidecar track as [addonTrackId].
+ *
+ * Media3 usually preserves [MediaItem.SubtitleConfiguration] ids on text
+ * [Format]s, but some merge/sidecar paths truncate or rewrite them. Prefer
+ * exact / contains matches, then a unique soft match on the addon subtitle id
+ * portion (`nuvio-addon-sub:<subtitleId>:…`).
+ */
+private fun formatMatchesAddonTrackId(formatId: String?, addonTrackId: String): Boolean {
+    if (formatId.isNullOrBlank() || addonTrackId.isBlank()) return false
+    if (formatId == addonTrackId) return true
+    if (formatId.contains(addonTrackId)) return true
+    // Truncated Format.id that is still a prefix of our full track id.
+    if (
+        formatId.startsWith(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) &&
+        addonTrackId.startsWith(formatId)
+    ) {
+        return true
     }
-    Log.d(PlayerRuntimeController.TAG, "applyAddonSubtitleOverride: track not found yet for id=$addonTrackId")
     return false
 }
 
-internal fun PlayerRuntimeController.applyAddonSubtitleOverrideByLanguage(
-    language: String
+private fun addonSubtitleIdFromTrackId(addonTrackId: String): String? {
+    if (!addonTrackId.startsWith(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX)) {
+        return null
+    }
+    val remainder = addonTrackId.removePrefix(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX)
+    // track id is "<subtitleId>:<urlHash>"; subtitleId itself may contain ':' so
+    // strip only the trailing hash segment.
+    val hashSeparator = remainder.lastIndexOf(':')
+    if (hashSeparator <= 0) return remainder.takeIf { it.isNotBlank() }
+    return remainder.substring(0, hashSeparator).takeIf { it.isNotBlank() }
+}
+
+private fun PlayerRuntimeController.applyTextTrackOverride(
+    trackGroup: Tracks.Group,
+    trackIndexInGroup: Int
 ): Boolean {
     val player = _exoPlayer ?: return false
+    val override = TrackSelectionOverride(trackGroup.mediaTrackGroup, trackIndexInGroup)
+    player.trackSelectionParameters = player.trackSelectionParameters
+        .buildUpon()
+        .setOverrideForType(override)
+        .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+        .build()
+    return true
+}
+
+private data class AddonTextTrackCandidate(
+    val group: Tracks.Group,
+    val index: Int,
+    val formatId: String?
+)
+
+internal fun PlayerRuntimeController.applyAddonSubtitleOverride(addonTrackId: String): Boolean {
+    val player = _exoPlayer ?: return false
+
+    val strict = mutableListOf<AddonTextTrackCandidate>()
+    val soft = mutableListOf<AddonTextTrackCandidate>()
+    val softSubtitleId = addonSubtitleIdFromTrackId(addonTrackId)
+
     player.currentTracks.groups.forEach { trackGroup ->
         if (trackGroup.type != C.TRACK_TYPE_TEXT) return@forEach
         for (i in 0 until trackGroup.length) {
             val format = trackGroup.getTrackFormat(i)
-            if (format.id?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) != true) {
+            val formatId = format.id
+            if (formatMatchesAddonTrackId(formatId, addonTrackId)) {
+                strict += AddonTextTrackCandidate(trackGroup, i, formatId)
+                continue
+            }
+            // Soft match only when Format.id is exactly our prefix+subtitleId, or that
+            // prefix followed by ":…". Avoid bare contains() on short ids like "en".
+            if (softSubtitleId != null && formatId != null) {
+                val softPrefix =
+                    PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX + softSubtitleId
+                if (formatId == softPrefix || formatId.startsWith("$softPrefix:")) {
+                    soft += AddonTextTrackCandidate(trackGroup, i, formatId)
+                }
+            }
+        }
+    }
+
+    val chosen = when {
+        strict.size == 1 -> strict[0]
+        strict.size > 1 -> {
+            // Prefer exact id equality when multiple contain-matches fire.
+            strict.firstOrNull { it.formatId == addonTrackId } ?: strict[0]
+        }
+        soft.size == 1 -> soft[0]
+        else -> null
+    }
+    val chosenFromSoft = chosen != null && strict.isEmpty()
+
+    if (chosen != null) {
+        applyTextTrackOverride(chosen.group, chosen.index)
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "applyAddonSubtitleOverride: found id=${chosen.formatId} at group/track ${chosen.index} " +
+                "targetId=$addonTrackId soft=$chosenFromSoft"
+        )
+        return true
+    }
+
+    Log.d(
+        PlayerRuntimeController.TAG,
+        "applyAddonSubtitleOverride: track not found yet for id=$addonTrackId " +
+            "(strict=${strict.size}, soft=${soft.size})"
+    )
+    return false
+}
+
+/**
+ * Language-only addon override. Safe only when a single addon text track matches
+ * [language], or when [preferredTrackId] uniquely identifies the target.
+ *
+ * Never pick the first same-language track: preferred-language startup attaches
+ * every matching addon (OpenSubtitles + SubMaker + …), and first-match would
+ * keep the original auto-pick while the UI shows the user's choice (#2601).
+ */
+internal fun PlayerRuntimeController.applyAddonSubtitleOverrideByLanguage(
+    language: String,
+    preferredTrackId: String? = null
+): Boolean {
+    val player = _exoPlayer ?: return false
+
+    val preferred = mutableListOf<AddonTextTrackCandidate>()
+    val languageMatches = mutableListOf<AddonTextTrackCandidate>()
+
+    player.currentTracks.groups.forEach { trackGroup ->
+        if (trackGroup.type != C.TRACK_TYPE_TEXT) return@forEach
+        for (i in 0 until trackGroup.length) {
+            val format = trackGroup.getTrackFormat(i)
+            val formatId = format.id
+            if (formatId?.contains(PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX) != true) {
+                continue
+            }
+            if (!preferredTrackId.isNullOrBlank() && formatMatchesAddonTrackId(formatId, preferredTrackId)) {
+                preferred += AddonTextTrackCandidate(trackGroup, i, formatId)
                 continue
             }
             if (!PlayerSubtitleUtils.matchesLanguageCode(format.language, language)) {
                 continue
             }
-            val override = TrackSelectionOverride(trackGroup.mediaTrackGroup, i)
-            player.trackSelectionParameters = player.trackSelectionParameters
-                .buildUpon()
-                .setOverrideForType(override)
-                .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
-                .build()
-            Log.d(
-                PlayerRuntimeController.TAG,
-                "applyAddonSubtitleOverrideByLanguage: found id=${format.id} lang=${format.language} at group/track $i"
-            )
-            return true
+            languageMatches += AddonTextTrackCandidate(trackGroup, i, formatId)
         }
     }
+
+    val chosen = when {
+        preferred.isNotEmpty() -> preferred[0]
+        languageMatches.size == 1 -> languageMatches[0]
+        else -> null
+    }
+
+    if (chosen != null) {
+        applyTextTrackOverride(chosen.group, chosen.index)
+        Log.d(
+            PlayerRuntimeController.TAG,
+            "applyAddonSubtitleOverrideByLanguage: found id=${chosen.formatId} lang=$language " +
+                "at group/track ${chosen.index} preferredTrackId=$preferredTrackId " +
+                "languageMatches=${languageMatches.size}"
+        )
+        return true
+    }
+
     Log.d(
         PlayerRuntimeController.TAG,
-        "applyAddonSubtitleOverrideByLanguage: track not found yet for language=$language"
+        "applyAddonSubtitleOverrideByLanguage: no unique track for language=$language " +
+            "preferredTrackId=$preferredTrackId languageMatches=${languageMatches.size}"
     )
     return false
 }
@@ -321,7 +434,8 @@ internal fun PlayerRuntimeController.refreshActiveSubtitleTrackAfterTimingChange
             val trackId = buildAddonSubtitleTrackId(latestAddon)
             val restored = applyAddonSubtitleOverride(trackId) ||
                 applyAddonSubtitleOverrideByLanguage(
-                    PlayerSubtitleUtils.normalizeLanguageCode(latestAddon.lang)
+                    language = PlayerSubtitleUtils.normalizeLanguageCode(latestAddon.lang),
+                    preferredTrackId = trackId
                 )
             if (!restored) {
                 Log.w(
@@ -446,7 +560,16 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
 
     _exoPlayer?.let { player ->
         val currentlySelected = _uiState.value.selectedAddonSubtitle
+        val addonTrackId = buildAddonSubtitleTrackId(subtitle)
         if (currentlySelected?.id == subtitle.id && currentlySelected.url == subtitle.url) {
+            // Re-assert the player override if UI and Exo selection drifted (e.g. after a
+            // preferred-language auto-pick left the wrong same-lang sidecar active).
+            if (!applyAddonSubtitleOverride(addonTrackId)) {
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "Re-selecting already-chosen ADDON subtitle; track not active yet id=${subtitle.id}"
+                )
+            }
             return@let
         }
         resetSubtitleAutoSyncState()
@@ -459,16 +582,17 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
                 "url=${subtitle.url}"
         )
 
-        val addonTrackId = buildAddonSubtitleTrackId(subtitle)
         val preAttachedByStartup = attachedAddonSubtitleKeys.contains(addonSubtitleKey(subtitle))
-        val appliedWithoutReload = applyAddonSubtitleOverride(addonTrackId) ||
-            (preAttachedByStartup && applyAddonSubtitleOverrideByLanguage(normalizedLang))
+        // Never fall back to language-only selection here. Preferred-language startup
+        // attaches every matching addon; first-language-match would keep OpenSubtitles
+        // (or whichever loaded first) while the UI shows SubMaker (#2601).
+        val appliedWithoutReload = applyAddonSubtitleOverride(addonTrackId)
 
         if (appliedWithoutReload) {
             Log.d(
                 PlayerRuntimeController.TAG,
                 "Switching ADDON subtitle without media reload addon=${subtitle.addonName} id=${subtitle.id} " +
-                    "trackId=$addonTrackId"
+                    "trackId=$addonTrackId preAttached=$preAttachedByStartup"
             )
             pendingAddonSubtitleLanguage = null
             pendingAddonSubtitleTrackId = null
@@ -493,7 +617,7 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         Log.d(
             PlayerRuntimeController.TAG,
             "Selecting ADDON subtitle with media refresh addon=${subtitle.addonName} id=${subtitle.id} " +
-                "attachedConfigs=${subtitleConfigurations.size}"
+                "attachedConfigs=${subtitleConfigurations.size} preAttached=$preAttachedByStartup"
         )
         attachedAddonSubtitleKeys = (_uiState.value.addonSubtitles + subtitle)
             .distinctBy { addonSubtitleKey(it) }
@@ -519,7 +643,9 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         player.prepare()
         player.playWhenReady = playWhenReady
 
-        
+        // Clear any previous TEXT override so pendingAddonSubtitleTrackId can bind the
+        // exact sidecar once tracks land. Preferred language alone is not enough when
+        // multiple same-language addon tracks are attached.
         player.trackSelectionParameters = player.trackSelectionParameters
             .buildUpon()
             .clearOverridesOfType(C.TRACK_TYPE_TEXT)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTracks.kt
@@ -252,7 +252,16 @@ internal fun PlayerRuntimeController.updateAvailableTracks(tracks: Tracks) {
 
     val pendingAddonTrackId = pendingAddonSubtitleTrackId
     if (!pendingAddonTrackId.isNullOrBlank()) {
-        if (applyAddonSubtitleOverride(pendingAddonTrackId)) {
+        val pendingLang = pendingAddonSubtitleLanguage
+        val appliedPending = applyAddonSubtitleOverride(pendingAddonTrackId) ||
+            (
+                !pendingLang.isNullOrBlank() &&
+                    applyAddonSubtitleOverrideByLanguage(
+                        language = pendingLang,
+                        preferredTrackId = pendingAddonTrackId
+                    )
+            )
+        if (appliedPending) {
             Log.d(PlayerRuntimeController.TAG, "Selecting pending addon subtitle track id=$pendingAddonTrackId")
             pendingAddonSubtitleTrackId = null
             pendingAddonSubtitleLanguage = null


### PR DESCRIPTION
## Summary

When the user manually switches from one preferred-language addon subtitle (e.g. OpenSubtitles v3) to another in the same language (e.g. SubMaker | ElfHosted), ExoPlayer now binds the **exact** selected sidecar track instead of re-selecting the first same-language match. The subtitle overlay already updated `selectedAddonSubtitle`, so the UI looked correct while playback kept the previous track.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With addon subtitle startup on preferred languages, every matching-language sidecar is attached up front. Manual switch used a language-only `TrackSelectionOverride` fallback when applying a pre-attached track, which always hit the first same-language track (often the auto-selected OpenSubtitles entry). Users saw SubMaker selected in the UI while OpenSubtitles cues kept playing.

## Issue or approval

Fixes #2601

## Reproduction steps

1. Install both OpenSubtitles v3 and SubMaker | ElfHosted (or any two subtitle addons for the same preferred language).
2. Set addon subtitle loading to preferred languages (as in the report).
3. Play content where both addons return subtitles (e.g. anime S2E1 as reported).
4. Confirm auto-select picks OpenSubtitles (or any first match).
5. Open the subtitle overlay and select the SubMaker (or second-addon) entry for the same language.
6. Observe cues still come from the first addon while the UI shows the second selected.

After this fix, step 6 applies the selected track id override (or reloads media and binds that pending id); cues match the chosen addon.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- ExoPlayer addon-sidecar selection only (`selectAddonSubtitle`, track-id / language override helpers, pending track application after media refresh).
- Does not change MPV external-subtitle path, auto-select preference order, subtitle UI layout, or startup attachment policy.
- Language-only override still works when exactly one same-language addon track exists, or when a preferred track id is supplied (timing refresh / pending bind).

## Testing

- Static review of ExoPlayer switch path against #2601: preferred-language multi-addon attach → language-first fallback → UI/player desync.
- Confirmed no-reload path no longer calls language-only apply; reload path keeps `pendingAddonSubtitleTrackId` and binds by id (with preferred-id language helper as secondary).
- Confirmed timing-refresh restore passes `preferredTrackId` so delay bounce cannot re-pick the wrong same-lang sidecar.
- No device/emulator run in this environment; relies on CI `fullDebug` build and logic review.

## Screenshots / Video

Not a UI change (selection highlight already updated; this restores player track binding to match).

## Breaking changes

None.

## Linked issues

Fixes #2601