### PR TITLE
fix(plugin): use absolute anime episode for kitsu/mal/anilist video IDs (#2549)

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/cloudstream/ExternalExtensionRunner.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/cloudstream/ExternalExtensionRunner.kt
@@ -22,6 +22,7 @@ import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.app
 import com.nuvio.tv.core.plugin.TestDiagnostics
+import com.nuvio.tv.core.plugin.matchPluginEpisodeIndex
 import com.nuvio.tv.core.tmdb.TmdbMetadataService
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.domain.model.ContentType
@@ -754,25 +755,12 @@ class ExternalExtensionRunner @Inject constructor(
     }
 
     private fun findEpisode(episodes: List<Episode>, season: Int?, episode: Int?): Episode? {
-        if (episodes.isEmpty()) return null
-
-        if (season != null && episode != null) {
-            episodes.firstOrNull { it.season == season && it.episode == episode }?.let { return it }
-        }
-
-        if (episode != null) {
-            episodes.firstOrNull { it.episode == episode && (it.season == null || it.season == season) }
-                ?.let { return it }
-        }
-
-        if (season != null && episode != null) {
-            val absoluteEpisode = episodes.indexOfFirst {
-                (it.season == season || it.season == null) && it.episode == episode
-            }
-            if (absoluteEpisode >= 0) return episodes[absoluteEpisode]
-        }
-
-        return null
+        val index = matchPluginEpisodeIndex(
+            entries = episodes.map { it.season to it.episode },
+            season = season,
+            episode = episode
+        ) ?: return null
+        return episodes.getOrNull(index)
     }
 
     private fun calculateSimilarity(s1: String, s2: String): Double {

--- a/app/src/main/java/com/nuvio/tv/core/plugin/PluginEpisodeRequestRules.kt
+++ b/app/src/main/java/com/nuvio/tv/core/plugin/PluginEpisodeRequestRules.kt
@@ -1,0 +1,88 @@
+package com.nuvio.tv.core.plugin
+
+import java.util.Locale
+
+/**
+ * Pure helpers for mapping anime video IDs into plugin season/episode args.
+ *
+ * CloudStream / local plugins often catalog anime with **absolute** episode
+ * numbers (season omitted). Meta video IDs for anime trackers are always:
+ * - `kitsu:6448:68` → absolute episode 68
+ * - `mal:63375:68` → absolute episode 68
+ * - `anilist:12345:12` → absolute episode 12
+ * - `anidb:…:N` → absolute episode N
+ *
+ * These trackers have no season component in the video ID (never
+ * `mal:…:season:episode`). Season coordinates live only in TMDB/TVDB-style
+ * IDs such as `tt2098220:2:10`.
+ *
+ * Passing UI S2E10 into absolute-episode providers matches absolute episode 10
+ * (S1E10) instead of absolute 68. When the videoId already encodes the
+ * absolute episode, plugins must use that with `season = null`.
+ */
+
+private val ANIME_ID_PREFIXES = setOf("kitsu", "mal", "anilist", "anidb")
+
+/**
+ * Absolute episode number encoded in [videoId], or null when the id is not an
+ * anime absolute-episode form (`prefix:showId:episode`).
+ */
+fun absoluteAnimeEpisodeNumber(videoId: String): Int? {
+    val parts = videoId.trim().split(':')
+    // MAL/Kitsu/AniList/AniDB episode IDs are exactly three segments.
+    // There is no season field on these trackers.
+    if (parts.size != 3) return null
+    val prefix = parts[0].lowercase(Locale.US)
+    if (prefix !in ANIME_ID_PREFIXES) return null
+    // Require a non-empty numeric show id so garbage like "mal::12" is rejected.
+    if (parts[1].isBlank() || parts[1].toLongOrNull() == null) return null
+    return parts[2].toIntOrNull()
+}
+
+/**
+ * Season/episode pair to send to local plugins for [videoId].
+ *
+ * Absolute anime IDs force `season = null` and the absolute episode number so
+ * providers that store flat episode lists resolve the correct entry.
+ */
+fun resolvePluginSeasonEpisode(
+    videoId: String,
+    season: Int?,
+    episode: Int?
+): Pair<Int?, Int?> {
+    val absolute = absoluteAnimeEpisodeNumber(videoId)
+    return if (absolute != null) {
+        null to absolute
+    } else {
+        season to episode
+    }
+}
+
+/**
+ * Index of the plugin catalog entry that safely matches [season]/[episode].
+ *
+ * [entries] are `(season, episode)` pairs from a CloudStream/local provider catalog.
+ *
+ * Rules:
+ * - Season-bearing requests only match the exact S/E pair (no episode-number-only
+ *   fallback — that is what mapped S2E10 → absolute episode 10 on flat lists).
+ * - Absolute requests (`season == null`) prefer season-less entries, then any
+ *   entry with that episode number (some absolute catalogs tag every row as S1).
+ */
+fun matchPluginEpisodeIndex(
+    entries: List<Pair<Int?, Int?>>,
+    season: Int?,
+    episode: Int?
+): Int? {
+    if (entries.isEmpty() || episode == null) return null
+
+    if (season != null) {
+        val exact = entries.indexOfFirst { (s, e) -> s == season && e == episode }
+        return exact.takeIf { it >= 0 }
+    }
+
+    val absolute = entries.indexOfFirst { (s, e) -> e == episode && s == null }
+    if (absolute >= 0) return absolute
+    val anyEpisode = entries.indexOfFirst { (_, e) -> e == episode }
+    return anyEpisode.takeIf { it >= 0 }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.core.network.safeApiCall
 import com.nuvio.tv.core.debrid.DebridStreamPresentation
 import com.nuvio.tv.core.debrid.LocalDebridAvailabilityService
 import com.nuvio.tv.core.plugin.PluginManager
+import com.nuvio.tv.core.plugin.resolvePluginSeasonEpisode
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.mapper.toDomain
 import com.nuvio.tv.data.remote.api.AddonApi
@@ -155,13 +156,20 @@ class StreamRepositoryImpl @Inject constructor(
                 if (pluginRequest != null) {
                     launch {
                         try {
-                            // Stream plugins individually
+                            // Anime absolute IDs (kitsu:/mal:/anilist:…:N) must pass the
+                            // absolute episode to plugins; SxE would match the wrong entry
+                            // on flat absolute episode lists (e.g. S2E10 → absolute ep 10).
+                            val (pluginSeason, pluginEpisode) = resolvePluginSeasonEpisode(
+                                videoId = videoId,
+                                season = season,
+                                episode = episode
+                            )
                             streamLocalPlugins(
                                 pluginId = pluginRequest.id,
                                 mediaType = pluginRequest.mediaType,
                                 pluginSource = pluginRequest.source,
-                                season = season,
-                                episode = episode,
+                                season = pluginSeason,
+                                episode = pluginEpisode,
                                 resultChannel = resultChannel
                             ) {
                                 if (completedJobs.incrementAndGet() >= totalJobs) {

--- a/app/src/test/java/com/nuvio/tv/core/plugin/PluginEpisodeRequestRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/plugin/PluginEpisodeRequestRulesTest.kt
@@ -1,0 +1,163 @@
+package com.nuvio.tv.core.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PluginEpisodeRequestRulesTest {
+
+    @Test
+    fun `absoluteAnimeEpisodeNumber reads kitsu absolute form`() {
+        assertEquals(68, absoluteAnimeEpisodeNumber("kitsu:6448:68"))
+        assertEquals(1, absoluteAnimeEpisodeNumber("kitsu:6448:1"))
+    }
+
+    @Test
+    fun `absoluteAnimeEpisodeNumber reads mal anilist and anidb absolute form`() {
+        assertEquals(68, absoluteAnimeEpisodeNumber("mal:63375:68"))
+        assertEquals(12, absoluteAnimeEpisodeNumber("anilist:12345:12"))
+        assertEquals(7, absoluteAnimeEpisodeNumber("anidb:9541:7"))
+    }
+
+    @Test
+    fun `absoluteAnimeEpisodeNumber rejects content-only anime ids without episode`() {
+        assertNull(absoluteAnimeEpisodeNumber("mal:63375"))
+        assertNull(absoluteAnimeEpisodeNumber("kitsu:6448"))
+    }
+
+    @Test
+    fun `absoluteAnimeEpisodeNumber rejects malformed anime ids`() {
+        // Trackers never encode season; extra segments are not a valid S/E form.
+        assertNull(absoluteAnimeEpisodeNumber("mal:63375:1:5"))
+        assertNull(absoluteAnimeEpisodeNumber("kitsu:6448:2:10"))
+        assertNull(absoluteAnimeEpisodeNumber("mal::12"))
+        assertNull(absoluteAnimeEpisodeNumber("mal:abc:12"))
+        assertNull(absoluteAnimeEpisodeNumber("mal:63375:ep12"))
+    }
+
+    @Test
+    fun `absoluteAnimeEpisodeNumber ignores non-anime ids`() {
+        assertNull(absoluteAnimeEpisodeNumber("tt2098220:2:10"))
+        assertNull(absoluteAnimeEpisodeNumber("tt2098220"))
+        assertNull(absoluteAnimeEpisodeNumber("tmdb:12345:2:10"))
+        assertNull(absoluteAnimeEpisodeNumber("tmdb:12345"))
+    }
+
+    @Test
+    fun `resolvePluginSeasonEpisode forces absolute for anime tracker video ids`() {
+        assertEquals(
+            null to 68,
+            resolvePluginSeasonEpisode(
+                videoId = "kitsu:6448:68",
+                season = 2,
+                episode = 10
+            )
+        )
+        assertEquals(
+            null to 68,
+            resolvePluginSeasonEpisode(
+                videoId = "mal:63375:68",
+                season = 2,
+                episode = 10
+            )
+        )
+        assertEquals(
+            null to 7,
+            resolvePluginSeasonEpisode(
+                videoId = "anidb:9541:7",
+                season = 1,
+                episode = 7
+            )
+        )
+    }
+
+    @Test
+    fun `resolvePluginSeasonEpisode keeps SxE for non-anime or incomplete ids`() {
+        assertEquals(
+            2 to 10,
+            resolvePluginSeasonEpisode(
+                videoId = "tt2098220:2:10",
+                season = 2,
+                episode = 10
+            )
+        )
+        // Content-only anime id (no episode segment) → fall back to UI S/E.
+        assertEquals(
+            2 to 10,
+            resolvePluginSeasonEpisode(
+                videoId = "kitsu:6448",
+                season = 2,
+                episode = 10
+            )
+        )
+        // Malformed extra segments → not absolute; keep UI coordinates.
+        assertEquals(
+            1 to 5,
+            resolvePluginSeasonEpisode(
+                videoId = "mal:63375:1:5",
+                season = 1,
+                episode = 5
+            )
+        )
+    }
+
+    @Test
+    fun `matchPluginEpisodeIndex exact SxE without episode-only fallback`() {
+        // Flat absolute catalog (season null on every entry).
+        val absoluteCatalog = listOf(
+            null to 1,
+            null to 10,
+            null to 68
+        )
+        // S2E10 must NOT silently hit absolute episode 10.
+        assertNull(matchPluginEpisodeIndex(absoluteCatalog, season = 2, episode = 10))
+        // Absolute request for 68 hits the right row.
+        assertEquals(2, matchPluginEpisodeIndex(absoluteCatalog, season = null, episode = 68))
+        assertEquals(1, matchPluginEpisodeIndex(absoluteCatalog, season = null, episode = 10))
+    }
+
+    @Test
+    fun `matchPluginEpisodeIndex exact multi-season catalog`() {
+        val multiSeason = listOf(
+            1 to 10,
+            2 to 10,
+            2 to 11
+        )
+        assertEquals(0, matchPluginEpisodeIndex(multiSeason, season = 1, episode = 10))
+        assertEquals(1, matchPluginEpisodeIndex(multiSeason, season = 2, episode = 10))
+        assertNull(matchPluginEpisodeIndex(multiSeason, season = 3, episode = 10))
+    }
+
+    @Test
+    fun `matchPluginEpisodeIndex absolute request accepts season-1 tagged catalogs`() {
+        val seasonOneTagged = listOf(
+            1 to 1,
+            1 to 10,
+            1 to 68
+        )
+        assertEquals(2, matchPluginEpisodeIndex(seasonOneTagged, season = null, episode = 68))
+        // Season-bearing request still requires exact S/E.
+        assertEquals(1, matchPluginEpisodeIndex(seasonOneTagged, season = 1, episode = 10))
+        assertNull(matchPluginEpisodeIndex(seasonOneTagged, season = 2, episode = 10))
+    }
+
+    @Test
+    fun `end-to-end plugin request for kitsu absolute id`() {
+        // Issue #2549: UI shows S2E10, videoId encodes absolute 68.
+        val (pluginSeason, pluginEpisode) = resolvePluginSeasonEpisode(
+            videoId = "kitsu:6448:68",
+            season = 2,
+            episode = 10
+        )
+        assertEquals(null to 68, pluginSeason to pluginEpisode)
+
+        val absoluteCatalog = (1..70).map { null to it }
+        assertEquals(
+            67,
+            matchPluginEpisodeIndex(absoluteCatalog, pluginSeason, pluginEpisode)
+        )
+        // Pre-fix behavior would have used S2/E10 and either wrong-matched or failed.
+        assertNull(matchPluginEpisodeIndex(absoluteCatalog, season = 2, episode = 10))
+    }
+}
+


### PR DESCRIPTION
## Summary

Plugin stream resolution for multi-season anime could launch the wrong episode (e.g. selecting S2E10 started S1E10) when the provider catalog uses **absolute** episode numbering.

Root cause:
1. Stream requests always passed UI season/episode (`2`/`10`) into local plugins.
2. CloudStream episode matching fell back to “match episode number only” when the exact S/E pair was missing, so absolute episode `10` was chosen instead of absolute episode `68` (encoded in IDs like `kitsu:6448:68`).

This PR:
1. Derives absolute episode numbers from anime-tracker video IDs in the only form those trackers use: `kitsu|mal|anilist|anidb:showId:episode` (no season segment) and passes `season=null` + that absolute episode to plugins
2. Leaves TMDB/IMDb-style S/E IDs alone (`tt…:2:10`)
3. Tightens CloudStream episode matching so a season-bearing request never falls back to episode-number-only matching (avoids silent wrong-episode hits)

## PR type

- [x] Critical bug fix

## Why

NuvioTV plugin playback must use the absolute anime episode index when the meta video ID already encodes it. Matching only the within-season episode number against absolute catalogs selects the wrong season.

MAL / Kitsu / AniList / AniDB video IDs do **not** carry season details (there is no `mal:…:season:episode` form). Absolute episode is always the third segment.

## Issue or approval

Fixes #2549

## Reproduction steps

1. Use AIOMetadata (or similar) with anime stream compatibility IDs that produce video IDs like `kitsu:6448:68` for a season-2 episode.
2. Open a multi-season anime and select a plugin stream for episode **2x10** (or any S2+ episode).
3. Before: playback/plugin resolution could resolve absolute episode 10 (S1E10).
4. After: plugins receive the absolute episode from the video ID (e.g. 68), so the correct episode is loaded. Multi-season non-absolute catalogs still use exact S/E matching.

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not implement full anime absolute↔SxE mapping tables for non-anime video IDs (IMDb/TMDB-only SxE without kitsu/mal/anilist/anidb absolute in the videoId still uses S/E matching).
- Does not change addon stream resolution (addons already used the video ID path correctly per the issue).
- Does not change CloudStream search title matching beyond episode selection.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.plugin.PluginEpisodeRequestRulesTest` — **passed**
  - Absolute parsing for `kitsu:` / `mal:` / `anilist:` / `anidb:` (`prefix:showId:episode` only)
  - Rejects content-only and malformed multi-segment IDs (no invented season form)
  - `resolvePluginSeasonEpisode` forces `season=null` + absolute episode for tracker IDs; keeps UI SxE for IMDb
  - `matchPluginEpisodeIndex` regression: S2E10 must not hit absolute episode 10 on flat catalogs
  - End-to-end pure path for issue #2549 (`kitsu:6448:68` + UI S2E10 → absolute 68)
- Kotlin compile of fullDebug during the unit-test task succeeded
- Manual device check still recommended with AIOMetadata + a multi-season anime plugin stream (e.g. EasyStreams) selecting S2+ episode

## Screenshots / Video

Not a UI change.

## Breaking changes

None. Safer plugin episode matching may return no plugin result instead of a wrong episode when a season-bearing request cannot be matched exactly on an absolute-only catalog and the videoId is not an absolute anime ID.

## Linked issues

Fixes #2549