### PR TITLE
fix(progress): resume torrent streams from saved Continue Watching position (#2663)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -377,10 +377,17 @@ class WatchProgressRepositoryImpl @Inject constructor(
         return activeProgressProviderFlow()
             .flatMapLatest { provider ->
                 if (provider != null) {
-                    provider.allProgress.map { items ->
-                        items
-                            .filter { it.contentId.equals(contentId, ignoreCase = true) }
-                            .maxByOrNull(WatchProgress::lastWatched)
+                    // Merge provider playback with local so CW resume can use the precise
+                    // ms position saved on stop after process death (#2663).
+                    combine(
+                        provider.allProgress.map { items ->
+                            items
+                                .filter { it.contentId.equals(contentId, ignoreCase = true) }
+                                .maxByOrNull(WatchProgress::lastWatched)
+                        },
+                        watchProgressPreferences.getProgress(contentId)
+                    ) { providerEntry, local ->
+                        pickResumeWatchProgress(providerEntry, local)
                     }
                 } else {
                     watchProgressPreferences.getProgress(contentId)
@@ -392,7 +399,17 @@ class WatchProgressRepositoryImpl @Inject constructor(
         return activeProgressProviderFlow()
             .flatMapLatest { provider ->
                 if (provider != null) {
-                    provider.episodeProgress(contentId).map { items -> items[season to episode] }
+                    // Match getAllEpisodeProgress: provider season snapshots alone miss live
+                    // Trakt/Simkl playback rows that Continue Watching shows. Also fall back to
+                    // local DataStore so anime/non-Trakt ids (and precise ms positions) resume
+                    // after process death when optimistic provider state is gone (#2663).
+                    combine(
+                        getAllEpisodeProgress(contentId),
+                        watchProgressPreferences.getEpisodeProgress(contentId, season, episode)
+                    ) { allEpisodes, local ->
+                        val providerEntry = allEpisodes[season to episode]
+                        pickResumeWatchProgress(providerEntry, local)
+                    }
                 } else {
                     watchProgressPreferences.getEpisodeProgress(contentId, season, episode)
                 }
@@ -983,6 +1000,25 @@ class WatchProgressRepositoryImpl @Inject constructor(
         } else {
             progress.contentId
         }
+    }
+
+    /**
+     * Chooses the best watch-progress row for resume seeks.
+     * Prefer the most recently updated in-progress entry so local ms positions
+     * beat stale remote percent-only rows after a CW relaunch.
+     */
+    private fun pickResumeWatchProgress(
+        providerEntry: WatchProgress?,
+        local: WatchProgress?
+    ): WatchProgress? {
+        val inProgress = listOfNotNull(providerEntry, local).filter { it.isInProgress() }
+        if (inProgress.isNotEmpty()) {
+            return inProgress.maxByOrNull { entry ->
+                // Prefer absolute position when timestamps tie (local ms vs Trakt %).
+                entry.lastWatched * 2L + if (entry.position > 0L) 1L else 0L
+            }
+        }
+        return providerEntry ?: local
     }
 
     private suspend fun resolveRemoteDeleteKeys(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -958,7 +958,8 @@ internal fun PlayerRuntimeController.initializePlayer(
 
                 if (initialResumePosition > 0L) {
                     setMediaSource(initialMediaSource, initialResumePosition)
-                    clearPendingInitialResumePosition()
+                    // Keep pendingResumeProgress so STATE_READY can re-apply the seek if
+                    // a progressive torrent/debrid source ignored startPosition (#2663).
                     updatePlaybackTimeline(currentPosition = initialResumePosition)
                 } else {
                     setMediaSource(initialMediaSource)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -122,7 +122,8 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
                 "playbackSpeed=${_uiState.value.playbackSpeed} resumePositionMs=$initialResumePosition"
         )
         if (initialResumePosition > 0L) {
-            clearPendingInitialResumePosition()
+            // Keep pendingResumeProgress so applyPendingMpvSeekIfNeeded can re-apply
+            // if loadfile start position was ignored (torrent/debrid cold start) (#2663).
             updatePlaybackTimeline(currentPosition = initialResumePosition)
         }
         view.setPlaybackSpeed(_uiState.value.playbackSpeed)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -570,20 +570,29 @@ internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int
 
 internal fun PlayerRuntimeController.tryApplyPendingResumeProgress(player: Player) {
     val saved = pendingResumeProgress ?: return
+    // Progressive torrent/debrid sources often report unseekable until duration is
+    // known. Keep pending so a later STATE_READY can still apply the CW position (#2663).
     if (!player.isCurrentMediaItemSeekable) {
-        pendingResumeProgress = null
-        _uiState.update { it.copy(pendingSeekPosition = null) }
         return
     }
-    val duration = player.duration
+    val duration = player.duration.takeIf { it > 0L } ?: 0L
     val target = when {
         duration > 0L -> saved.resolveResumePosition(duration)
         saved.position > 0L -> saved.position
         else -> 0L
     }
 
+    // Percent-only remote progress needs duration; wait rather than dropping resume.
+    if (target <= 0L && saved.progressPercent != null && duration <= 0L) {
+        return
+    }
+
     if (target > 0L) {
-        player.seekTo(target)
+        val current = player.currentPosition.coerceAtLeast(0L)
+        // setMediaSource(..., startPosition) may already be at the resume point.
+        if (kotlin.math.abs(current - target) > 1_500L) {
+            player.seekTo(target)
+        }
     }
     _uiState.update { it.copy(pendingSeekPosition = null) }
     pendingResumeProgress = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStartup.kt
@@ -52,12 +52,12 @@ internal fun PlayerRuntimeController.startInitialPlaybackIfNeeded() {
                 Log.d("PlayerStartup", "Torrent stream ready: $localUrl")
                 currentStreamUrl = localUrl
                 currentHeaders = emptyMap()
-                // Use loadSavedProgress = true — TorrServer handles seeking via
-                // HTTP Range requests, so ExoPlayer's standard resume logic works.
+                // TorrServer handles seeking via HTTP Range requests, so ExoPlayer's
+                // standard resume logic works. Still honor startFromBeginning from CW.
                 preparePlaybackBeforeStart(
                     url = localUrl,
                     headers = emptyMap(),
-                    loadSavedProgress = true
+                    loadSavedProgress = !navigationArgs.startFromBeginning
                 )
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e


### PR DESCRIPTION
## Summary

Resume from Continue Watching for torrent/debrid streams now uses merged local+provider progress and keeps pending seek until media is seekable, so playback no longer restarts at 0:00 after leaving the app.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

CW could show correct progress while resume looked up provider-only rows (or percent-only remote data) and dropped pending seeks on progressive sources that were not yet seekable. Torrent/debrid paths often hit that case after process death.

## Issue or approval

Fixes #2663

## Reproduction steps

1. Play a torrent/debrid-backed episode (e.g. Torrentio) past a few minutes.
2. Leave the player and fully leave the app.
3. Return and resume from Continue Watching.
4. Before: starts at 0:00. After: seeks to saved position when media becomes seekable.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Resume lookup + pending seek application only. No CW card redesign, no Trakt scrobble policy changes.

## Testing

- Code review of `pickResumeWatchProgress` and `tryApplyPendingResumeProgress` seekable/duration guards.
- Verified torrent init path honors `startFromBeginning` like HTTP for load-saved-progress.
- No Android device run; CI fullDebug build.

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2663