### PR TITLE
fix(home): restore focused-poster trailer autoplay when enabled (#2646)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -184,6 +184,16 @@ class HomeViewModel @Inject constructor(
     internal var activeTrailerPreviewItemId: String? = null
     internal var trailerPreviewRequestVersion: Long = 0L
     internal var trailerPreviewJob: Job? = null
+    /** Trailer preview requested during [startupGracePeriodActive]; flushed when grace ends. */
+    internal var deferredTrailerPreview: DeferredTrailerPreview? = null
+
+    internal data class DeferredTrailerPreview(
+        val itemId: String,
+        val title: String,
+        val releaseInfo: String?,
+        val apiType: String,
+        val fallbackYtId: String?
+    )
     internal var currentTmdbSettings: TmdbSettings = TmdbSettings()
     internal var currentMdbListSettings: MDBListSettings = MDBListSettings()
     internal var heroEnrichmentJob: Job? = null
@@ -362,6 +372,19 @@ class HomeViewModel @Inject constructor(
             deferredEnrichItem?.let { item ->
                 deferredEnrichItem = null
                 onItemFocusPipeline(item)
+            }
+            // Flush trailer preview requested during grace. UI may have already set
+            // lastRequestedTrailerFocusKey, so without this the focused poster never
+            // loads a trailer until focus moves to another item (#2646).
+            deferredTrailerPreview?.let { pending ->
+                deferredTrailerPreview = null
+                requestTrailerPreviewPipeline(
+                    itemId = pending.itemId,
+                    title = pending.title,
+                    releaseInfo = pending.releaseInfo,
+                    apiType = pending.apiType,
+                    fallbackYtId = pending.fallbackYtId
+                )
             }
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -179,6 +179,7 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
     trailerPreviewAudioUrlsState.clear()
     activeTrailerPreviewItemId = null
     trailerPreviewRequestVersion = 0L
+    deferredTrailerPreview = null
     prefetchedExternalMetaIds.clear()
     externalMetaPrefetchInFlightIds.clear()
     externalMetaPrefetchJob?.cancel()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -347,27 +347,51 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
     fallbackYtId: String? = null
 ) {
     if (!AppFeaturePolicy.inAppTrailerPlaybackEnabled) return
-    if (startupGracePeriodActive) return
 
     // Resolve fallbackYtId from catalog item if not provided
     val resolvedFallbackYtId = fallbackYtId ?: findCatalogItemById(itemId)?.trailerYtIds?.firstOrNull()
 
-    // Always bump version — only the latest request (highest version) will proceed after debounce
-    activeTrailerPreviewItemId = itemId
-    trailerPreviewRequestVersion++
-    val requestVersion = trailerPreviewRequestVersion
+    // During startup grace, remember the latest focused poster and load after grace
+    // ends. Dropping the request entirely left lastRequestedTrailerFocusKey set in
+    // the UI with no in-flight load, so the poster never autoplayed until focus
+    // moved (#2646).
+    if (startupGracePeriodActive) {
+        deferredTrailerPreview = HomeViewModel.DeferredTrailerPreview(
+            itemId = itemId,
+            title = title,
+            releaseInfo = releaseInfo,
+            apiType = apiType,
+            fallbackYtId = resolvedFallbackYtId
+        )
+        return
+    }
+
+    // Only bump the request version when focus moves to a different item.
+    // Always bumping (previous behavior) cancelled any in-flight load for the
+    // same item when a second request arrived while loadingIds still held it
+    // (e.g. enrichment retry race, or re-entrant focus). The stale job then
+    // exited without writing a URL and the UI would not re-request (#2646).
+    // FolderDetailViewModel uses the same "bump only on item change" pattern.
+    if (activeTrailerPreviewItemId != itemId) {
+        activeTrailerPreviewItemId = itemId
+        trailerPreviewRequestVersion++
+    }
 
     if (trailerPreviewNegativeCache.contains(itemId)) return
     if (trailerPreviewUrlsState.containsKey(itemId)) return
     if (!trailerPreviewLoadingIds.add(itemId)) return
+
+    val requestVersion = trailerPreviewRequestVersion
 
     viewModelScope.launch(Dispatchers.IO) {
         try {
             // Debounce: wait for focus to settle before hitting network
             delay(180)
 
-            // Only the LATEST request proceeds — all earlier ones are stale
-            if (trailerPreviewRequestVersion != requestVersion) {
+            // Only the LATEST request for the currently focused item proceeds
+            if (trailerPreviewRequestVersion != requestVersion ||
+                activeTrailerPreviewItemId != itemId
+            ) {
                 return@launch
             }
 
@@ -385,6 +409,12 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
             )
 
             withContext(Dispatchers.Main) {
+                // Focus may have moved during the network call — do not write stale results.
+                if (trailerPreviewRequestVersion != requestVersion ||
+                    activeTrailerPreviewItemId != itemId
+                ) {
+                    return@withContext
+                }
                 if (trailerSource?.videoUrl.isNullOrBlank()) {
                     val fallbackSource = resolvedFallbackYtId?.let { ytId ->
                         trailerService.getTrailerPlaybackSourceFromYouTubeUrl(


### PR DESCRIPTION
## Summary

Fix focused-poster trailer autoplay: do not cancel in-flight loads for the same item by always bumping request version, and defer trailer requests during startup grace instead of dropping them.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With Autoplay Trailer enabled, trailers stopped for all view types. Root causes: (1) every request bumped `trailerPreviewRequestVersion`, cancelling the same-item load; (2) requests during startup grace returned early while the UI still marked the focus key as requested, so no later load ran until focus moved.

## Issue or approval

Fixes #2646

## Reproduction steps

1. Enable Autoplay Trailer in settings.
2. Cold-start app and focus posters on Home (classic or modern).
3. Before: no trailer autoplays after grace / re-entrant focus.
4. After: trailer loads for the focused poster once grace ends and same-item re-requests do not wipe the load.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Trailer preview request pipeline only. No trailer UI redesign, no settings changes.

## Testing

- Logic review of version bump / grace defer / post-network focus re-check (aligned with folder-detail pattern).
- No device run; CI fullDebug build.

## Screenshots / Video

Behavior fix for existing trailer overlay; no layout change. Device verification of autoplay recommended if maintainers want visual proof.

## Breaking changes

None.

## Linked issues

Fixes #2646