### PR TITLE
fix(continue-watching): stop wiping in-progress items after update (#2716)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProjection.kt
@@ -3,20 +3,43 @@ package com.nuvio.tv.core.tracking
 import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.model.WatchedItem
 
+/**
+ * Merges provider progress with local shadow copies.
+ *
+ * Provider entries win by default. Local rows are kept when:
+ * - [retainsLocalProgress] says the id cannot be represented remotely (kitsu/mal/…), or
+ * - the local row is still in-progress and the provider has no in-progress entry for the
+ *   same content/season/episode (fills the gap after a Trakt/Simkl refresh that dropped
+ *   playback while local saveProgress still has resume data — #2716).
+ *
+ * Local in-progress also replaces a completed-only remote row for the same key so a
+ * rewatch that only saved locally still appears in Continue Watching.
+ */
 internal fun mergeProgressProjectionWithRetainedLocal(
     providerEntries: List<WatchProgress>,
     localEntries: List<WatchProgress>,
     retainsLocalProgress: (String) -> Boolean
 ): List<WatchProgress> {
-    val providerKeys = providerEntries.mapTo(mutableSetOf(), WatchProgress::projectionKey)
-    return buildList {
-        addAll(providerEntries)
-        localEntries.forEach { progress ->
-            if (retainsLocalProgress(progress.contentId) && progress.projectionKey() !in providerKeys) {
-                add(progress)
+    val mergedByKey = LinkedHashMap<Triple<String, Int?, Int?>, WatchProgress>(providerEntries.size)
+    providerEntries.forEach { progress ->
+        mergedByKey[progress.projectionKey()] = progress
+    }
+    localEntries.forEach { progress ->
+        val key = progress.projectionKey()
+        val existing = mergedByKey[key]
+        when {
+            existing == null -> {
+                if (retainsLocalProgress(progress.contentId) || progress.isInProgress()) {
+                    mergedByKey[key] = progress
+                }
+            }
+            progress.isInProgress() && !existing.isInProgress() -> {
+                // Prefer local resume over completed-only remote for the same episode.
+                mergedByKey[key] = progress
             }
         }
-    }.sortedByDescending(WatchProgress::lastWatched)
+    }
+    return mergedByKey.values.sortedByDescending(WatchProgress::lastWatched)
 }
 
 private fun WatchProgress.projectionKey() = Triple(contentId, season, episode)

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingProgressProjectionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingProgressProjectionTest.kt
@@ -7,29 +7,73 @@ import org.junit.Test
 
 class TrackingProgressProjectionTest {
     @Test
-    fun `projection keeps eligible local entries without replacing provider entries`() {
+    fun `projection keeps eligible local entries without replacing provider in-progress`() {
         val providerEntry = progress("tt100", 1, 1, 10L, 25L)
         val duplicateLocal = progress("tt100", 1, 1, 30L, 75L)
         val retainedLocal = progress("kitsu:44", 1, 2, 20L, 50L)
-        val excludedLocal = progress("tt200", null, null, 40L, 60L)
+        val excludedCompletedLocal = progress("tt200", null, null, 40L, 95L, duration = 100L)
 
         val result = mergeProgressProjectionWithRetainedLocal(
             providerEntries = listOf(providerEntry),
-            localEntries = listOf(duplicateLocal, retainedLocal, excludedLocal),
+            localEntries = listOf(duplicateLocal, retainedLocal, excludedCompletedLocal),
             retainsLocalProgress = { contentId -> contentId.startsWith("kitsu:") }
         )
 
+        // Provider in-progress wins over duplicate local; unsupported local kept; completed local dropped.
         assertEquals(listOf(retainedLocal, providerEntry), result)
     }
 
     @Test
-    fun `projection stays provider exclusive when no local entries are retained`() {
+    fun `projection retains in-progress local even when retain policy is false`() {
         val providerEntry = progress("simkl:100", null, null, 10L, 25L)
         val localEntry = progress("kitsu:44", null, null, 20L, 50L)
 
         val result = mergeProgressProjectionWithRetainedLocal(
             providerEntries = listOf(providerEntry),
             localEntries = listOf(localEntry),
+            retainsLocalProgress = { false }
+        )
+
+        // Local is still in-progress so it fills the provider gap (#2716).
+        assertEquals(listOf(localEntry, providerEntry), result)
+    }
+
+    @Test
+    fun `local in-progress fills gap when provider has no row for that episode`() {
+        val providerOther = progress("tt100", 1, 1, 10L, 25L)
+        val localInProgress = progress("tt200", 2, 3, 50L, 40L)
+
+        val result = mergeProgressProjectionWithRetainedLocal(
+            providerEntries = listOf(providerOther),
+            localEntries = listOf(localInProgress),
+            retainsLocalProgress = { false }
+        )
+
+        assertEquals(listOf(localInProgress, providerOther), result)
+    }
+
+    @Test
+    fun `local in-progress replaces completed-only remote for same episode`() {
+        val remoteCompleted = progress("tt100", 1, 5, 10L, 100L, duration = 100L)
+        val localRewatch = progress("tt100", 1, 5, 20L, 40L)
+
+        val result = mergeProgressProjectionWithRetainedLocal(
+            providerEntries = listOf(remoteCompleted),
+            localEntries = listOf(localRewatch),
+            retainsLocalProgress = { false }
+        )
+
+        assertEquals(listOf(localRewatch), result)
+    }
+
+    @Test
+    fun `local completed is not retained without retain policy`() {
+        val providerEntry = progress("tt100", 1, 1, 10L, 25L)
+        val localCompleted = progress("tt200", 1, 1, 50L, 100L, duration = 100L)
+
+        val result = mergeProgressProjectionWithRetainedLocal(
+            providerEntries = listOf(providerEntry),
+            localEntries = listOf(localCompleted),
             retainsLocalProgress = { false }
         )
 
@@ -59,7 +103,8 @@ class TrackingProgressProjectionTest {
         season: Int?,
         episode: Int?,
         lastWatched: Long,
-        position: Long
+        position: Long,
+        duration: Long = 100L
     ) = WatchProgress(
         contentId = contentId,
         contentType = if (season == null) "movie" else "series",
@@ -72,7 +117,7 @@ class TrackingProgressProjectionTest {
         episode = episode,
         episodeTitle = null,
         position = position,
-        duration = 100L,
+        duration = duration,
         lastWatched = lastWatched
     )
 


### PR DESCRIPTION
## Summary

When merging Trakt/Simkl provider progress with local shadow progress, retain local in-progress rows that fill provider gaps (and prefer local resume over completed-only remote rows) so Continue Watching is not emptied after remote refresh.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

After update, CW lost most in-progress shows while history-based next-up (including TBC) could remain. `mergeProgressProjectionWithRetainedLocal` only kept local rows for unsupported IDs; normal IMDb/TMDB local resume was dropped after provider refresh when remote playback was empty/missing.

## Issue or approval

Fixes #2716

## Reproduction steps

1. Watch several series with local/provider progress and Trakt (or Simkl) as progress source.
2. Trigger a progress refresh / update path that reloads provider progress.
3. Before: CW empties most in-progress rows.
4. After: local in-progress gaps and rewatch resume remain visible in the projection.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Projection merge only. Does not change Trakt scrobble bulk history (see related #2740 separately). No CW UI redesign.

## Testing

- Updated `TrackingProgressProjectionTest` for gap-fill and local-in-progress-over-completed-remote cases.
- Unit tests green for projection helpers.
- No device run; CI fullDebug build.

## Screenshots / Video

Not a UI change

## Breaking changes

None. Provider entries still win when they carry in-progress data for the same key.

## Linked issues

Fixes #2716