### PR TITLE
fix(trakt): prevent incorrect bulk watch-progress scrobbles (#2740)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -865,7 +865,19 @@ internal fun PlayerRuntimeController.emitScrobblePause(progressPercent: Float? =
 }
 
 internal fun PlayerRuntimeController.emitCompletionScrobbleStop(progressPercent: Float) {
-    if (progressPercent < 80f || hasSentCompletionScrobbleForCurrentItem) return
+    val duration = currentPlaybackDurationMs().takeIf { it > 0L } ?: lastKnownDuration
+    if (!shouldEmitCompletionScrobbleStop(
+            progressPercent = progressPercent,
+            hasSentCompletionScrobble = hasSentCompletionScrobbleForCurrentItem,
+            durationMs = duration
+        )
+    ) {
+        logScrobbleDiagnostic(
+            "completion_stop_skipped",
+            "progress=$progressPercent durationMs=$duration sent=$hasSentCompletionScrobbleForCurrentItem"
+        )
+        return
+    }
     hasSentCompletionScrobbleForCurrentItem = true
     emitScrobbleStop(progressPercent = progressPercent)
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScrobblePolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScrobblePolicy.kt
@@ -18,3 +18,21 @@ internal fun shouldSendStopScrobble(
     hasActiveScrobble: Boolean,
     progressPercent: Float
 ): Boolean = hasActiveScrobble || progressPercent >= 80f
+
+/**
+ * Whether a natural-completion scrobble/stop at [progressPercent] should be sent.
+ *
+ * Never invent a 99.5% completion when duration is unknown/zero or a short
+ * debrid/error placeholder. That path bulk-marked unwatched episodes on Trakt
+ * whenever broken streams reached ENDED and chained auto-play (#2740).
+ */
+internal fun shouldEmitCompletionScrobbleStop(
+    progressPercent: Float,
+    hasSentCompletionScrobble: Boolean,
+    durationMs: Long
+): Boolean {
+    if (progressPercent < 80f || hasSentCompletionScrobble) return false
+    if (durationMs <= 0L) return false
+    if (isShortPlaceholderDuration(durationMs)) return false
+    return true
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/NaturalPlaybackCompletionRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/NaturalPlaybackCompletionRulesTest.kt
@@ -97,4 +97,55 @@ class NaturalPlaybackCompletionRulesTest {
         assertFalse(isShortPlaceholderDuration(121_000L))
         assertFalse(isShortPlaceholderDuration(2_400_000L))
     }
+
+    @Test
+    fun `completion scrobble requires real non-placeholder duration`() {
+        // Real episode end: allow Trakt completion stop.
+        assertTrue(
+            shouldEmitCompletionScrobbleStop(
+                progressPercent = 99.5f,
+                hasSentCompletionScrobble = false,
+                durationMs = 2_400_000L
+            )
+        )
+        // Unknown/zero duration must not invent a watched history row (#2740).
+        assertFalse(
+            shouldEmitCompletionScrobbleStop(
+                progressPercent = 99.5f,
+                hasSentCompletionScrobble = false,
+                durationMs = 0L
+            )
+        )
+        // Short debrid/error placeholders must not scrobble as completed.
+        assertFalse(
+            shouldEmitCompletionScrobbleStop(
+                progressPercent = 99.5f,
+                hasSentCompletionScrobble = false,
+                durationMs = 5_000L
+            )
+        )
+        assertFalse(
+            shouldEmitCompletionScrobbleStop(
+                progressPercent = 99.5f,
+                hasSentCompletionScrobble = false,
+                durationMs = 120_999L
+            )
+        )
+        // Already sent once this item — no duplicate bulk history.
+        assertFalse(
+            shouldEmitCompletionScrobbleStop(
+                progressPercent = 99.5f,
+                hasSentCompletionScrobble = true,
+                durationMs = 2_400_000L
+            )
+        )
+        // Below Trakt watched threshold — never a completion stop.
+        assertFalse(
+            shouldEmitCompletionScrobbleStop(
+                progressPercent = 50f,
+                hasSentCompletionScrobble = false,
+                durationMs = 2_400_000L
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Gate natural-completion Trakt scrobble/stop so ENDED events with unknown/zero duration or short debrid/error placeholders do not invent watched history rows that bulk-mark unwatched episodes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On natural ENDED, completion scrobble could fire at high progress even when duration was 0/unknown or a short error placeholder. Broken streams that reach ENDED (and autoplay-chain) bulk-logged unwatched episodes on Trakt and contributed to Continue Watching emptying once remote treated them as watched.

## Issue or approval

Fixes #2740

## Reproduction steps

1. Play a broken/short debrid placeholder or a stream that ends with unknown duration.
2. Allow natural ENDED (or autoplay chain through failed items).
3. Before: Trakt history gains bulk near-identical watched entries for unwatched episodes.
4. After: completion stop is skipped when duration is missing or placeholder-short; real full-length finishes still scrobble.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Natural completion scrobble gate only. Intentional mark-watched / season history batch APIs unchanged. Does not rewrite full Trakt sync.

## Testing

- Added/extended pure unit tests for `shouldEmitCompletionScrobbleStop` and short-placeholder duration rules.
- Unit tests green.
- No device run; CI fullDebug build.

## Screenshots / Video

Not a UI change

## Breaking changes

None for successful full-length completion. Placeholder/zero-duration ENDED no longer scrobbles as watched.

## Linked issues

Fixes #2740