### PR TITLE
fix(catalog): honor short-form manifest extras when parsing catalog descriptors (#2427)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/domain/model/CatalogDescriptorExtensions.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/CatalogDescriptorExtensions.kt
@@ -2,11 +2,39 @@ package com.nuvio.tv.domain.model
 
 private const val DEFAULT_SKIP_STEP = 100
 
+/**
+ * Whether this catalog supports a given extra argument (e.g. "skip", "search", "genre").
+ *
+ * Stremio manifests declare extras in either:
+ * - full form: `extra: [{ "name": "skip" }, ...]`
+ * - short form: `extraSupported: ["skip", ...]` / `extraRequired: [...]`
+ *
+ * Both must be checked; otherwise short-form catalogs never paginate (hasMore stays false
+ * after the first batch).
+ */
 fun CatalogDescriptor.supportsExtra(name: String): Boolean {
-    return extra.any { it.name.equals(name, ignoreCase = true) }
+    if (extra.any { it.name.equals(name, ignoreCase = true) }) return true
+    if (extraSupported.any { it.equals(name, ignoreCase = true) }) return true
+    if (extraRequired.any { it.equals(name, ignoreCase = true) }) return true
+    return false
 }
 
 fun CatalogDescriptor.skipStep(defaultStep: Int = DEFAULT_SKIP_STEP): Int {
     if (pageSize != null && pageSize > 0) return pageSize
+    // Prefer step inferred from skip extra options when present (e.g. ["0","50","100"]).
+    val skipExtra = extra.firstOrNull { it.name.equals("skip", ignoreCase = true) }
+    val numericOptions = skipExtra?.options
+        .orEmpty()
+        .mapNotNull { it.trim().toIntOrNull() }
+        .filter { it >= 0 }
+        .distinct()
+        .sorted()
+    if (numericOptions.size >= 2) {
+        val step = numericOptions
+            .zipWithNext()
+            .mapNotNull { (a, b) -> (b - a).takeIf { it > 0 } }
+            .minOrNull()
+        if (step != null && step > 0) return step
+    }
     return defaultStep
 }

--- a/app/src/test/java/com/nuvio/tv/domain/model/CatalogDescriptorExtensionsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/domain/model/CatalogDescriptorExtensionsTest.kt
@@ -1,0 +1,73 @@
+package com.nuvio.tv.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CatalogDescriptorExtensionsTest {
+
+    @Test
+    fun `supportsExtra reads full extra list`() {
+        val catalog = descriptor(
+            extra = listOf(CatalogExtra(name = "skip"), CatalogExtra(name = "genre"))
+        )
+        assertTrue(catalog.supportsExtra("skip"))
+        assertTrue(catalog.supportsExtra("genre"))
+        assertFalse(catalog.supportsExtra("search"))
+    }
+
+    @Test
+    fun `supportsExtra reads short-form extraSupported`() {
+        val catalog = descriptor(extraSupported = listOf("search", "skip"))
+        assertTrue(catalog.supportsExtra("skip"))
+        assertTrue(catalog.supportsExtra("SKIP"))
+        assertFalse(catalog.supportsExtra("genre"))
+    }
+
+    @Test
+    fun `supportsExtra reads short-form extraRequired`() {
+        val catalog = descriptor(extraRequired = listOf("search"))
+        assertTrue(catalog.supportsExtra("search"))
+        assertFalse(catalog.supportsExtra("skip"))
+    }
+
+    @Test
+    fun `skipStep prefers pageSize`() {
+        val catalog = descriptor(pageSize = 20)
+        assertEquals(20, catalog.skipStep())
+    }
+
+    @Test
+    fun `skipStep infers step from skip options`() {
+        val catalog = descriptor(
+            extra = listOf(
+                CatalogExtra(name = "skip", options = listOf("0", "50", "100", "150"))
+            )
+        )
+        assertEquals(50, catalog.skipStep())
+    }
+
+    @Test
+    fun `skipStep falls back to default when no pageSize or options`() {
+        val catalog = descriptor()
+        assertEquals(100, catalog.skipStep())
+    }
+
+    private fun descriptor(
+        extra: List<CatalogExtra> = emptyList(),
+        pageSize: Int? = null,
+        extraSupported: List<String> = emptyList(),
+        extraRequired: List<String> = emptyList()
+    ): CatalogDescriptor {
+        return CatalogDescriptor(
+            type = ContentType.MOVIE,
+            id = "top",
+            name = "Top",
+            extra = extra,
+            pageSize = pageSize,
+            extraSupported = extraSupported,
+            extraRequired = extraRequired
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Honor short-form manifest extras when parsing catalog descriptors. Catalogs that declare their extras via `extraSupported` / `extraRequired` (Stremio short form) never reported `supportsExtra("skip")`, so `hasMore` stayed false after the first batch and the catalog never paginated.

## PR type

- [x] Critical bug fix

## Why

Catalogs (TMDB, Trakt, etc.) can declare supported extras in either the full form (`extra: [{ "name": "skip" }]`) or the short form (`extraSupported: ["skip"]` / `extraRequired`). The descriptor parser only read the full form, so short-form catalogs stopped after 10-20 items even though the addon exposes hundreds. `skipStep` is also inferred from the `skip` extra options when present, so pagination uses the real page step instead of a hardcoded 100 default.

## Issue or approval

Fixes #2427

## Reproduction steps

1. Add any catalog whose addon manifest declares extras in short form (`extraSupported: ["skip", ...]`).
2. Open the catalog: only the first batch (10–20 items) loads.
3. Expected: the catalog keeps paginating through all available items.

## UI / behavior impact

- [x] No visible UI change — catalogs that previously loaded only a partial page now continue to load further pages.

## Policy check

- [x] The PR **in some way** addresses a high priority problem independently verified by a developer
- [x] The PR is well researched, tested, and the PR meets the correct coding standards
- [x] The PR remains focused on a single bug and does not introduce unrelated features or changes
- [x] The PR uses correct and consistent naming and code formatting consistent with the project's conventions
- [x] The PR has an accompanying issue

## Scope boundaries

Only catalog descriptor parsing (`supportsExtra`, `skipStep`) is touched. No UI, repository, or home-pipeline changes are included.

## Testing

- Unit tests: `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.domain.model.CatalogDescriptorExtensionsTest"` passes (full- and short-form extra detection, `skipStep` page-size/options inference).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2422