### PR TITLE
fix(details): restore long synopsis navigation and scrolling

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -337,7 +337,12 @@ fun HeroContentSection(
                                     if (descriptionTruncated) {
                                         Modifier
                                             .offset(x = -highlightInset)
-                                            .onFocusChanged { descriptionFocused = it.isFocused }
+                                            .onFocusChanged {
+                                                descriptionFocused = it.isFocused
+                                                if (it.isFocused) {
+                                                    onHeroActionFocused()
+                                                }
+                                            }
                                             .background(
                                                 color = if (descriptionFocused) {
                                                     Color.White.copy(alpha = 0.10f)
@@ -345,6 +350,15 @@ fun HeroContentSection(
                                                     Color.Transparent
                                                 },
                                                 shape = RoundedCornerShape(8.dp)
+                                            )
+                                            .then(
+                                                if (playButtonFocusRequester != null) {
+                                                    Modifier.focusProperties {
+                                                        up = playButtonFocusRequester
+                                                    }
+                                                } else {
+                                                    Modifier
+                                                }
                                             )
                                             .clickable(
                                                 interactionSource = descriptionInteraction,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -177,7 +178,10 @@ fun HeroContentSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .animateContentSize(animationSpec = tween(600))
+                .animateContentSize(
+                    animationSpec = tween(600),
+                    alignment = Alignment.BottomStart
+                )
                 .padding(start = NuvioTheme.spacing.xxxl, end = NuvioTheme.spacing.xxxl, bottom = NuvioTheme.spacing.lg),
             verticalArrangement = Arrangement.Bottom
         ) {
@@ -322,7 +326,7 @@ fun HeroContentSection(
                     // pressing OK opens the full, scrollable text overlay.
                     meta.description?.let { description ->
                         var descriptionFocused by remember { mutableStateOf(false) }
-                        var descriptionTruncated by remember(description) { mutableStateOf(false) }
+                        var descriptionTruncated by rememberSaveable(description) { mutableStateOf(false) }
                         val descriptionInteraction = remember { MutableInteractionSource() }
                         // Inset of the focus highlight; offset back by the same amount so the text
                         // stays left-aligned with the rest of the hero while the highlight gets

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1674,7 +1674,7 @@ private fun MetaDetailsContent(
                         onHeroActionFocused = {
                             if (listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0) {
                                 coroutineScope.launch {
-                                    listState.scrollToItem(0)
+                                    listState.animateScrollToItem(0)
                                 }
                             }
                             initialHeroFocusRequested = true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
@@ -55,9 +56,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -123,7 +127,10 @@ import com.nuvio.tv.ui.components.posteroptions.TrackingRemovalConfirmationDialo
 import com.nuvio.tv.core.tracking.LOCAL_LIBRARY_LIST_KEY
 import com.nuvio.tv.core.tracking.supportsMembershipFor
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.exp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.rememberCoroutineScope
@@ -1667,7 +1674,7 @@ private fun MetaDetailsContent(
                         onHeroActionFocused = {
                             if (listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0) {
                                 coroutineScope.launch {
-                                    listState.animateScrollToItem(0)
+                                    listState.scrollToItem(0)
                                 }
                             }
                             initialHeroFocusRequested = true
@@ -2140,9 +2147,42 @@ private fun SynopsisOverlay(
     val scrollState = rememberScrollState()
     val coroutineScope = rememberCoroutineScope()
     val contentFocusRequester = remember { FocusRequester() }
+    var requestedScrollPosition by remember { mutableIntStateOf(0) }
+    var scrollAnimationJob by remember { mutableStateOf<Job?>(null) }
 
-    LaunchedEffect(Unit) {
-        contentFocusRequester.requestFocus()
+    fun requestSmoothScroll(target: Int) {
+        requestedScrollPosition = target.coerceIn(0, scrollState.maxValue)
+        if (scrollAnimationJob?.isActive == true) return
+
+        scrollAnimationJob = coroutineScope.launch {
+            scrollState.scroll {
+                var previousFrame = withFrameNanos { it }
+                while (true) {
+                    val frame = withFrameNanos { it }
+                    val elapsedSeconds = ((frame - previousFrame) / 1_000_000_000f)
+                        .coerceIn(0f, 0.05f)
+                    previousFrame = frame
+
+                    val targetPosition = requestedScrollPosition.toFloat()
+                    val distance = targetPosition - scrollState.value.toFloat()
+                    if (abs(distance) < 0.5f) {
+                        scrollBy(distance)
+                        if (requestedScrollPosition == targetPosition.toInt()) break
+                        continue
+                    }
+
+                    val smoothing = 1f - exp(-12f * elapsedSeconds)
+                    scrollBy(distance * smoothing)
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(description) {
+        scrollAnimationJob?.cancel()
+        requestedScrollPosition = 0
+        scrollState.scrollTo(0)
+        contentFocusRequester.requestFocusAfterFrames()
         scrollState.scrollTo(0)
     }
 
@@ -2179,37 +2219,67 @@ private fun SynopsisOverlay(
                     modifier = Modifier
                         .fillMaxWidth(0.78f)
                         .weight(1f)
-                        .verticalScroll(scrollState)
-                        .focusRequester(contentFocusRequester)
-                        .focusable()
+                        .drawWithContent {
+                            drawContent()
+
+                            val maxScroll = scrollState.maxValue.toFloat()
+                            if (maxScroll > 0f) {
+                                val viewportHeight = size.height
+                                val trackInset = 8.dp.toPx()
+                                val trackHeight = (viewportHeight - trackInset * 2f).coerceAtLeast(0f)
+                                val contentHeight = viewportHeight + maxScroll
+                                val thumbHeight = (trackHeight * viewportHeight / contentHeight)
+                                    .coerceAtLeast(36.dp.toPx())
+                                    .coerceAtMost(trackHeight)
+                                val thumbTop = trackInset + (trackHeight - thumbHeight) *
+                                    (scrollState.value.toFloat() / maxScroll)
+                                val scrollbarX = size.width - 6.dp.toPx()
+
+                                drawLine(
+                                    color = Color.White.copy(alpha = 0.07f),
+                                    start = Offset(scrollbarX, trackInset),
+                                    end = Offset(scrollbarX, viewportHeight - trackInset),
+                                    strokeWidth = 1.dp.toPx(),
+                                    cap = StrokeCap.Round
+                                )
+                                drawLine(
+                                    color = Color.White.copy(alpha = 0.30f),
+                                    start = Offset(scrollbarX, thumbTop),
+                                    end = Offset(scrollbarX, thumbTop + thumbHeight),
+                                    strokeWidth = 2.5.dp.toPx(),
+                                    cap = StrokeCap.Round
+                                )
+                            }
+                        }
                         .onPreviewKeyEvent { event ->
                             when {
                                 event.type != KeyEventType.KeyDown -> false
                                 event.key == Key.DirectionDown && scrollState.value < scrollState.maxValue -> {
-                                    coroutineScope.launch {
-                                        scrollState.animateScrollTo(
-                                            (scrollState.value + 260).coerceAtMost(scrollState.maxValue)
-                                        )
-                                    }
+                                    requestSmoothScroll((
+                                        maxOf(requestedScrollPosition, scrollState.value) + 260
+                                    ).coerceAtMost(scrollState.maxValue))
                                     true
                                 }
                                 event.key == Key.DirectionUp && scrollState.value > 0 -> {
-                                    coroutineScope.launch {
-                                        scrollState.animateScrollTo(
-                                            (scrollState.value - 260).coerceAtLeast(0)
-                                        )
-                                    }
+                                    requestSmoothScroll((
+                                        minOf(requestedScrollPosition, scrollState.value) - 260
+                                    ).coerceAtLeast(0))
                                     true
                                 }
                                 else -> false
                             }
                         }
+                        .focusRequester(contentFocusRequester)
+                        .focusable()
+                        .verticalScroll(scrollState)
                 ) {
                     Text(
                         text = description,
                         style = MaterialTheme.typography.bodyLarge,
                         color = Color.White.copy(alpha = 0.92f),
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(end = NuvioTheme.spacing.lg)
                     )
                 }
 


### PR DESCRIPTION
## Summary

Long synopsis overlays now open at the beginning and keep remote scrolling responsive during repeated D-pad input. A subtle position indicator shows how much text remains. Pressing Up from the truncated synopsis returns to Play, and returning to the hero keeps its normal smooth motion without the metadata row appearing separately from below.

This keeps the full synopsis behavior introduced in #2401 while updating its focus and scrolling behavior for the current details screen.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Read more could open partway through a long description because focus relocation and the initial scroll reset happened during the same layout pass. The synopsis also relied on spatial focus search when moving Up, which could select Trailer instead of Play. When the hero reentered composition, its overflow state was recalculated while the parent size animation was anchored at the top, allowing the bottom metadata row to appear separately from below.

The overlay now resets before requesting focus, keeps the focus target around the viewport, and handles scrolling through one continuous frame driven operation. The truncated synopsis has an explicit Up target. Hero restoration keeps the existing smooth list animation, while bottom aligned size changes and saved overflow state keep the metadata stable when the hero is recomposed.

## Issue or approval

Fixes #2877

## Reproduction steps

1. Open a title with a description long enough to show Read more.
2. Focus the description and press OK.
3. Navigate repeatedly with D-pad Down and Up.
4. Close the overlay and press Up from the truncated description.
5. Move into a lower details section and return to the hero.

Before this fix, the overlay could open partway down, repeated scrolling could feel uneven, Up could focus Trailer, and hero metadata could slide into place. After this fix, the synopsis starts at the beginning, scrolls continuously with a position indicator, returns to Play, and restores the hero smoothly without the metadata appearing separately.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes focus restoration and scrolling inside the existing details hero and synopsis overlay. It does not change synopsis text, truncation limits, metadata, content layout, dependencies, or other navigation flows.

## Testing

- Built the full debug variant with `:app:assembleFullDebug`.
- Tested on an NVIDIA Shield TV running Android 11.
- Confirmed the Claymore synopsis opens at the top and scrolls smoothly through repeated Up and Down input.
- Confirmed the scrollbar tracks the current position.
- Confirmed closing and reopening resets to the top.
- Confirmed Up from Read more returns to Play.
- Confirmed returning from lower details sections keeps the existing smooth transition without the hero metadata appearing separately from below.

## Screenshots / Video

### Original DM report

<img width="927" height="706" alt="Original DM report" src="https://github.com/user-attachments/assets/f62a3536-79bb-412d-a4de-873086394f0b" />

### After

https://github.com/user-attachments/assets/3945f8f0-f1a4-478e-b97e-7a210198fd4b

## Breaking changes

None.

## Linked issues

Fixes #2877
