### PR TITLE
fix(subtitles) hide "�" from subtitles

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -2176,6 +2176,10 @@ private fun FfmpegAudioRenderer.applyDownmixSettings(
     }
 }
 
+// The Unicode replacement character ("�") that shows up when a subtitle byte sequence fails to
+// decode with the detected/assumed charset.
+private const val REPLACEMENT_CHARACTER = '\uFFFD'
+
 private class CueNormalizingTextOutput(
     private val delegate: TextOutput,
     private val shouldNormalizeCuePositionProvider: () -> Boolean,
@@ -2194,7 +2198,8 @@ private class CueNormalizingTextOutput(
     }
 
     private fun processCue(cue: Cue): Cue {
-        var processed = fixRtlCueText(cue)
+        var processed = stripReplacementCharacter(cue)
+        processed = fixRtlCueText(processed)
         if (shouldNormalizeCuePositionProvider()) {
             processed = normalizeCuePosition(processed)
         }
@@ -2236,6 +2241,22 @@ private class CueNormalizingTextOutput(
             .setLine(Cue.DIMEN_UNSET, Cue.TYPE_UNSET)
             .setLineAnchor(Cue.TYPE_UNSET)
             .build()
+    }
+
+    // Malformed/mis-encoded subtitle files sometimes decode a character as U+FFFD (the "�"
+    // replacement character). Strip it from cues shown to the viewer during playback. This does
+    // NOT affect PlayerSubtitleCueParser / the Sync Line preview list in SubtitleTimingDialog,
+    // which read the raw subtitle text independently for the manual-sync picker.
+    private fun stripReplacementCharacter(cue: Cue): Cue {
+        val text = cue.text ?: return cue
+        if (!text.contains(REPLACEMENT_CHARACTER)) return cue
+        val builder = android.text.SpannableStringBuilder(text)
+        for (i in builder.length - 1 downTo 0) {
+            if (builder[i] == REPLACEMENT_CHARACTER) {
+                builder.delete(i, i + 1)
+            }
+        }
+        return cue.buildUpon().setText(builder).build()
     }
 
     private fun fixRtlCueText(cue: Cue): Cue {


### PR DESCRIPTION
There are subtitles that display the character � (uFFFD). I have simply removed it from the subtitle display.

## Summary

Added a stripReplacementCharacter() step to CueNormalizingTextOutput.processCue() in PlayerRuntimeControllerInitialization.kt, the single pipeline that every subtitle cue passes through before being shown on screen during playback.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

Some subtitle files contain bytes that don’t decode cleanly with the character encoding being used (e.g. a subtitle saved in a legacy encoding like Windows-1255/1256 being read as UTF-8, or a genuinely corrupted byte). When that happens, the decoder can’t map that byte sequence to a real character, so it substitutes the “�” placeholder instead of silently dropping it. That placeholder was passing straight through to the on-screen subtitle renderer, showing up as a distracting stray character in otherwise normal dialogue lines.

## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
