### PR TITLE
fix(player): fix skip intro button lingering regression

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -364,7 +364,7 @@ internal fun PlayerRuntimeController.showStreamSourceIndicator(stream: Stream) {
 internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) {
     if (skipIntervals.isEmpty()) {
         if (_uiState.value.activeSkipInterval != null) {
-            _uiState.update { it.copy(activeSkipInterval = null) }
+            _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = false) }
         }
         return
     }
@@ -374,11 +374,7 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
     // skip button to appear instead of auto-skipping.
     if (!playerSettingsInitialized) return
 
-    val positionSec = positionMs / 1000.0
-    val active = skipIntervals.find { interval ->
-        positionSec >= interval.startTime && positionSec < interval.endTime
-    }
-
+    val active = nextActiveSkipInterval(skipIntervals, positionMs)
     val currentActive = _uiState.value.activeSkipInterval
 
     if (active != null) {
@@ -396,6 +392,8 @@ internal fun PlayerRuntimeController.updateActiveSkipInterval(positionMs: Long) 
             autoSkippedIntervalKeys.add(activeKey)
             skipInterval(active)
         }
+    } else if (currentActive != null) {
+        _uiState.update { it.copy(activeSkipInterval = null, skipIntervalDismissed = false) }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
@@ -49,12 +49,11 @@ import androidx.tv.material3.Text
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
 import com.nuvio.tv.data.repository.SkipInterval
-import kotlinx.coroutines.delay
 
 /**
  * Skip Intro/Outro/Recap button for the player.
  * Appears at bottom-left when playback is within a skip interval.
- * Auto-hides after 15 seconds. Focusable for D-pad navigation.
+ * Auto-hides after 10 seconds. Focusable for D-pad navigation.
  */
 @Composable
 fun SkipIntroButton(
@@ -75,7 +74,8 @@ fun SkipIntroButton(
 
     var lastType by remember { mutableStateOf(interval?.type) }
     if (interval != null) lastType = interval.type
-    val shouldShow = interval != null && (!dismissed || controlsVisible)
+    val hasActiveInterval = interval != null
+    val shouldShow = hasActiveInterval && (!dismissed || controlsVisible)
 
     var autoHidden by remember { mutableStateOf(false) }
     var manuallyDismissed by remember { mutableStateOf(false) }
@@ -106,7 +106,7 @@ fun SkipIntroButton(
     LaunchedEffect(shouldShow, autoHidden, controlsVisible) {
         if (shouldShow && !autoHidden && !controlsVisible) {
             progress.animateTo(1f, animationSpec = tween(
-                durationMillis = ((1f - progress.value) * 10000).toInt().coerceAtLeast(1),
+                durationMillis = skipIntroAutoHideRemainingMs(progress.value),
                 easing = LinearEasing
             ))
             autoHidden = true
@@ -121,7 +121,12 @@ fun SkipIntroButton(
         }
     }
 
-    val isVisible = shouldShow && (!autoHidden || controlsVisible)
+    val isVisible = isSkipIntroButtonVisible(
+        hasActiveInterval = hasActiveInterval,
+        dismissed = dismissed,
+        controlsVisible = controlsVisible,
+        autoHidden = autoHidden,
+    )
 
     LaunchedEffect(isVisible) { onVisibilityChanged(isVisible) }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRules.kt
@@ -1,0 +1,36 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.data.repository.SkipInterval
+
+internal const val SKIP_INTRO_AUTO_HIDE_TIMEOUT_MS = 10_000
+
+internal fun findActiveSkipInterval(
+    intervals: List<SkipInterval>,
+    positionMs: Long,
+): SkipInterval? {
+    if (intervals.isEmpty()) return null
+    val positionSec = positionMs / 1000.0
+    return intervals.find { interval ->
+        positionSec >= interval.startTime && positionSec < interval.endTime
+    }
+}
+
+internal fun nextActiveSkipInterval(
+    intervals: List<SkipInterval>,
+    positionMs: Long,
+): SkipInterval? = findActiveSkipInterval(intervals, positionMs)
+
+internal fun isSkipIntroButtonVisible(
+    hasActiveInterval: Boolean,
+    dismissed: Boolean,
+    controlsVisible: Boolean,
+    autoHidden: Boolean,
+): Boolean {
+    val shouldShow = hasActiveInterval && (!dismissed || controlsVisible)
+    return shouldShow && (!autoHidden || controlsVisible)
+}
+
+internal fun skipIntroAutoHideRemainingMs(
+    progress: Float,
+    totalTimeoutMs: Int = SKIP_INTRO_AUTO_HIDE_TIMEOUT_MS,
+): Int = ((1f - progress.coerceIn(0f, 1f)) * totalTimeoutMs).toInt().coerceAtLeast(1)

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRulesTest.kt
@@ -1,0 +1,185 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.data.repository.SkipInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SkipIntroVisibilityRulesTest {
+
+    private val intro = SkipInterval(
+        startTime = 10.0,
+        endTime = 70.0,
+        type = "intro",
+        provider = "introdb",
+    )
+
+    private val intervals = listOf(intro)
+
+    // ── Interval matching (ViewModel) ──────────────────────────────────────
+
+    @Test
+    fun `interval is inactive before start`() {
+        assertNull(nextActiveSkipInterval(intervals, positionMs = 9_999L))
+    }
+
+    @Test
+    fun `interval is active at start boundary`() {
+        assertEquals(intro, nextActiveSkipInterval(intervals, positionMs = 10_000L))
+    }
+
+    @Test
+    fun `interval stays active through mid segment`() {
+        assertEquals(intro, nextActiveSkipInterval(intervals, positionMs = 40_000L))
+    }
+
+    @Test
+    fun `interval stays active in the final half-second of the segment`() {
+        assertNotNull(nextActiveSkipInterval(intervals, positionMs = 69_600L))
+        assertEquals(intro, nextActiveSkipInterval(intervals, positionMs = 69_999L))
+    }
+
+    @Test
+    fun `interval clears exactly at endTime`() {
+        assertNull(nextActiveSkipInterval(intervals, positionMs = 70_000L))
+        assertNull(nextActiveSkipInterval(intervals, positionMs = 120_000L))
+    }
+
+    @Test
+    fun `empty intervals always resolve to null`() {
+        assertNull(nextActiveSkipInterval(emptyList(), positionMs = 30_000L))
+    }
+
+    @Test
+    fun `state transition clears previous active when playhead exits`() {
+        val whileInside = nextActiveSkipInterval(intervals, positionMs = 30_000L)
+        assertEquals(intro, whileInside)
+
+        val afterExit = nextActiveSkipInterval(intervals, positionMs = 70_000L)
+        assertNull(
+            "activeSkipInterval must become null once playhead leaves the segment",
+            afterExit,
+        )
+    }
+
+    // ── Button visibility (SkipIntroButton) ────────────────────────────────
+
+    @Test
+    fun `button visible when interval active and not dismissed or auto-hidden`() {
+        assertTrue(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = true,
+                dismissed = false,
+                controlsVisible = false,
+                autoHidden = false,
+            )
+        )
+    }
+
+    @Test
+    fun `button auto-hides after timeout while controls are hidden`() {
+        assertFalse(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = true,
+                dismissed = false,
+                controlsVisible = false,
+                autoHidden = true,
+            )
+        )
+    }
+
+    @Test
+    fun `auto-hidden button reappears only while controls are visible`() {
+        assertTrue(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = true,
+                dismissed = false,
+                controlsVisible = true,
+                autoHidden = true,
+            )
+        )
+        assertFalse(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = true,
+                dismissed = false,
+                controlsVisible = false,
+                autoHidden = true,
+            )
+        )
+    }
+
+    @Test
+    fun `manually dismissed button stays hidden until controls are shown`() {
+        assertFalse(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = true,
+                dismissed = true,
+                controlsVisible = false,
+                autoHidden = false,
+            )
+        )
+        assertTrue(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = true,
+                dismissed = true,
+                controlsVisible = true,
+                autoHidden = false,
+            )
+        )
+    }
+
+    @Test
+    fun `no active interval means button is never visible`() {
+        assertFalse(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = false,
+                dismissed = false,
+                controlsVisible = true,
+                autoHidden = false,
+            )
+        )
+        assertFalse(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = false,
+                dismissed = false,
+                controlsVisible = false,
+                autoHidden = false,
+            )
+        )
+    }
+
+    @Test
+    fun `after interval clears auto-hidden state cannot keep button on screen`() {
+        assertFalse(
+            isSkipIntroButtonVisible(
+                hasActiveInterval = false,
+                dismissed = false,
+                controlsVisible = false,
+                autoHidden = false,
+            )
+        )
+    }
+
+    // ── Auto-hide countdown ────────────────────────────────────────────────
+
+    @Test
+    fun `auto-hide remaining duration is full timeout at progress zero`() {
+        assertEquals(
+            SKIP_INTRO_AUTO_HIDE_TIMEOUT_MS,
+            skipIntroAutoHideRemainingMs(progress = 0f),
+        )
+    }
+
+    @Test
+    fun `auto-hide remaining duration halves at mid progress`() {
+        assertEquals(5_000, skipIntroAutoHideRemainingMs(progress = 0.5f))
+    }
+
+    @Test
+    fun `auto-hide remaining duration collapses to 1ms when progress already complete`() {
+        assertEquals(1, skipIntroAutoHideRemainingMs(progress = 1f))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes active skip interval lingering bug where the "Skip Intro" button remained eligible for display for the remainder of an episode after the playhead passed the segment end boundary (regression from PR #2788 / #2582). Also extracts skip interval visibility rules into a pure helper file with 100% unit test coverage.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When the playhead exited a skip segment, `PlayerRuntimeController.updateActiveSkipInterval` failed to clear `activeSkipInterval` state, leaving the skip button visible/eligible indefinitely and breaking episode playback UX.

## Issue or approval

regression from PR #2788 / #2582

## Reproduction steps

1. Play an episode with intro skip timestamps.
2. Allow the video playhead to cross past `interval.endTime` without clicking Skip Intro.
3. Observe that the skip button state persisted for the remainder of the episode.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to player skip interval active state reset and pure visibility helper extraction. No UI layout changes made.

## Testing

Ran `.\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.SkipIntroVisibilityRulesTest" --rerun-tasks` (16/16 unit tests passed, 100% success rate). Verified manually on physical target hardware: Android 14 TCL Google TV.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

regression from PR #2788 / #2582
