### PR TITLE
Fix MKV playback when embedded subtitles use zlib compression.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -343,6 +343,13 @@ public class MatroskaExtractor implements Extractor {
   private static final int ID_CONTENT_COMPRESSION = 0x5034;
   private static final int ID_CONTENT_COMPRESSION_ALGORITHM = 0x4254;
   private static final int ID_CONTENT_COMPRESSION_SETTINGS = 0x4255;
+
+  /** Matroska {@code ContentCompAlgo} value for zlib-compressed sample payloads. */
+  private static final int CONTENT_COMPRESSION_ZLIB = 0;
+  /** Matroska {@code ContentCompAlgo} value for header stripping. */
+  private static final int CONTENT_COMPRESSION_HEADER_STRIP = 3;
+  /** Track has no Matroska content compression configured. */
+  private static final int CONTENT_COMPRESSION_NONE = -1;
   private static final int ID_CONTENT_ENCRYPTION = 0x5035;
   private static final int ID_CONTENT_ENCRYPTION_ALGORITHM = 0x47E1;
   private static final int ID_CONTENT_ENCRYPTION_KEY_ID = 0x47E2;
@@ -562,6 +569,15 @@ public class MatroskaExtractor implements Extractor {
   // Reused per-sample read buffer for Dolby Vision conversion; grows to the largest sample.
   private byte[] dolbyVisionSampleBuffer = new byte[0];
 
+  /** Reused zlib inflater for {@code ContentCompAlgo=0} tracks. */
+  private final MatroskaZlibSampleDecompressor zlibSampleDecompressor =
+      new MatroskaZlibSampleDecompressor();
+  /**
+   * When non-null, {@link #writeSampleData} is reading decompressed sample bytes from this buffer
+   * instead of the upstream {@link ExtractorInput}.
+   */
+  @Nullable private ParsableByteArray zlibSampleSource;
+
   private long segmentContentSize;
   private long segmentContentPosition = C.INDEX_UNSET;
   private long timecodeScale = C.TIME_UNSET;
@@ -778,7 +794,7 @@ public class MatroskaExtractor implements Extractor {
 
   @Override
   public final void release() {
-    // Do nothing
+    zlibSampleDecompressor.release();
   }
 
   @Override
@@ -997,6 +1013,10 @@ public class MatroskaExtractor implements Extractor {
         break;
       case ID_CONTENT_ENCODING:
         // TODO: check and fail if more than one content encoding is present.
+        break;
+      case ID_CONTENT_COMPRESSION:
+        // Matroska defaults ContentCompAlgo to zlib when the element is present.
+        getCurrentTrack(id).contentCompressionAlgorithm = CONTENT_COMPRESSION_ZLIB;
         break;
       case ID_CONTENT_ENCRYPTION:
         getCurrentTrack(id).hasContentEncryption = true;
@@ -1361,8 +1381,11 @@ public class MatroskaExtractor implements Extractor {
         }
         break;
       case ID_CONTENT_COMPRESSION_ALGORITHM:
-        // This extractor only supports header stripping.
-        if (value != 3) {
+        if (value == CONTENT_COMPRESSION_ZLIB) {
+          getCurrentTrack(id).contentCompressionAlgorithm = CONTENT_COMPRESSION_ZLIB;
+        } else if (value == CONTENT_COMPRESSION_HEADER_STRIP) {
+          getCurrentTrack(id).contentCompressionAlgorithm = CONTENT_COMPRESSION_HEADER_STRIP;
+        } else {
           throw ParserException.createForMalformedContainer(
               "ContentCompAlgo " + value + " not supported", /* cause= */ null);
         }
@@ -1976,6 +1999,15 @@ public class MatroskaExtractor implements Extractor {
   @RequiresNonNull("#2.output")
   private int writeSampleData(ExtractorInput input, Track track, int size, boolean isBlockGroup)
       throws IOException {
+    if (track.contentCompressionAlgorithm == CONTENT_COMPRESSION_ZLIB && zlibSampleSource == null) {
+      zlibSampleSource = zlibSampleDecompressor.decompress(input, size);
+      try {
+        return writeSampleData(input, track, zlibSampleSource.limit(), isBlockGroup);
+      } finally {
+        zlibSampleSource = null;
+      }
+    }
+
     boolean deferSupplementalMainSampleSizePrefix = false;
     if (CODEC_ID_SUBRIP.equals(track.codecId)) {
       writeSubtitleSampleData(input, SUBRIP_PREFIX, size);
@@ -1991,8 +2023,14 @@ public class MatroskaExtractor implements Extractor {
     if (track.waitingForDtsAnalysis) {
       checkNotNull(track.format);
       byte[] peekedData = new byte[size];
-      if (input.peekFully(peekedData, 0, size, true)) {
-        input.resetPeekPosition();
+      boolean hasPeekData =
+          zlibSampleSource != null
+              ? peekSampleBytesFromBuffer(zlibSampleSource, peekedData, size)
+              : input.peekFully(peekedData, 0, size, true);
+      if (hasPeekData) {
+        if (zlibSampleSource == null) {
+          input.resetPeekPosition();
+        }
         String mimeType = com.nuvio.tv.core.player.dvmkv.DtsUtil.getDtsAudioMimeType(peekedData);
         track.format = track.format.buildUpon().setSampleMimeType(mimeType).build();
       }
@@ -2366,7 +2404,11 @@ public class MatroskaExtractor implements Extractor {
     } else {
       System.arraycopy(samplePrefix, 0, subtitleSample.getData(), 0, samplePrefix.length);
     }
-    input.readFully(subtitleSample.getData(), samplePrefix.length, size);
+    if (zlibSampleSource != null) {
+      zlibSampleSource.readBytes(subtitleSample.getData(), samplePrefix.length, size);
+    } else {
+      input.readFully(subtitleSample.getData(), samplePrefix.length, size);
+    }
     subtitleSample.setPosition(0);
     subtitleSample.setLimit(sizeWithPrefix);
     // Defer writing the data to the track output. We need to modify the sample data by setting
@@ -2443,7 +2485,12 @@ public class MatroskaExtractor implements Extractor {
   private void writeToTarget(ExtractorInput input, byte[] target, int offset, int length)
       throws IOException {
     int pendingStrippedBytes = min(length, sampleStrippedBytes.bytesLeft());
-    input.readFully(target, offset + pendingStrippedBytes, length - pendingStrippedBytes);
+    if (zlibSampleSource != null) {
+      zlibSampleSource.readBytes(
+          target, offset + pendingStrippedBytes, length - pendingStrippedBytes);
+    } else {
+      input.readFully(target, offset + pendingStrippedBytes, length - pendingStrippedBytes);
+    }
     if (pendingStrippedBytes > 0) {
       sampleStrippedBytes.readBytes(target, offset, pendingStrippedBytes);
     }
@@ -2460,10 +2507,24 @@ public class MatroskaExtractor implements Extractor {
     if (strippedBytesLeft > 0) {
       bytesWritten = min(length, strippedBytesLeft);
       output.sampleData(sampleStrippedBytes, bytesWritten);
+    } else if (zlibSampleSource != null) {
+      bytesWritten = min(length, zlibSampleSource.bytesLeft());
+      output.sampleData(zlibSampleSource, bytesWritten);
     } else {
       bytesWritten = output.sampleData(input, length, false);
     }
     return bytesWritten;
+  }
+
+  private static boolean peekSampleBytesFromBuffer(
+      ParsableByteArray source, byte[] target, int length) {
+    if (source.bytesLeft() < length) {
+      return false;
+    }
+    int position = source.getPosition();
+    source.readBytes(target, 0, length);
+    source.setPosition(position);
+    return true;
   }
 
   /**
@@ -2837,6 +2898,7 @@ public class MatroskaExtractor implements Extractor {
     public int maxBlockAdditionId;
     private int blockAddIdType;
     public boolean hasContentEncryption;
+    public int contentCompressionAlgorithm = CONTENT_COMPRESSION_NONE;
     public byte @MonotonicNonNull [] sampleStrippedBytes;
     public TrackOutput.@MonotonicNonNull CryptoData cryptoData;
     public byte @MonotonicNonNull [] codecPrivate;

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaZlibSampleDecompressor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaZlibSampleDecompressor.java
@@ -1,0 +1,115 @@
+package com.nuvio.tv.core.player.dvmkv;
+
+import static java.lang.Math.max;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.ParserException;
+import androidx.media3.common.util.ParsableByteArray;
+import androidx.media3.common.util.Util;
+import androidx.media3.extractor.ExtractorInput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+/**
+ * Reusable zlib inflater for Matroska {@code ContentCompAlgo=0} samples.
+ *
+ * <p>Buffers and the {@link Inflater} are reused across samples to avoid per-sample allocations
+ * and inflater construction during playback.
+ */
+final class MatroskaZlibSampleDecompressor {
+
+  private static final int INITIAL_DECOMPRESSED_CAPACITY = 512;
+  private static final int INFLATE_SCRATCH_SIZE = 8192;
+
+  private byte[] compressedBuffer = Util.EMPTY_BYTE_ARRAY;
+  private byte[] decompressedBuffer = new byte[INITIAL_DECOMPRESSED_CAPACITY];
+  private final ParsableByteArray decompressedSample = new ParsableByteArray();
+
+  @Nullable private Inflater inflater;
+
+  void release() {
+    if (inflater != null) {
+      inflater.end();
+      inflater = null;
+    }
+  }
+
+  ParsableByteArray decompress(ExtractorInput input, int compressedSize) throws IOException {
+    ensureCompressedCapacity(compressedSize);
+    input.readFully(compressedBuffer, 0, compressedSize);
+    return inflate(compressedBuffer, 0, compressedSize);
+  }
+
+  /** Visible for unit tests that exercise the inflater without an {@link ExtractorInput}. */
+  ParsableByteArray decompress(byte[] compressed, int offset, int length) throws ParserException {
+    return inflate(compressed, offset, length);
+  }
+
+  private ParsableByteArray inflate(byte[] compressed, int offset, int length)
+      throws ParserException {
+    Inflater activeInflater = inflater;
+    if (activeInflater == null) {
+      activeInflater = new Inflater();
+      inflater = activeInflater;
+    } else {
+      activeInflater.reset();
+    }
+    activeInflater.setInput(compressed, offset, length);
+
+    ensureDecompressedCapacity(max(length * 4, INITIAL_DECOMPRESSED_CAPACITY));
+
+    int totalOut = 0;
+    try {
+      while (!activeInflater.finished()) {
+        if (activeInflater.needsInput()) {
+          break;
+        }
+        if (totalOut == decompressedBuffer.length) {
+          ensureDecompressedCapacity(decompressedBuffer.length * 2);
+        }
+        int count =
+            activeInflater.inflate(
+                decompressedBuffer, totalOut, decompressedBuffer.length - totalOut);
+        if (count > 0) {
+          totalOut += count;
+        } else if (activeInflater.needsDictionary()) {
+          throw ParserException.createForMalformedContainer(
+              "Zlib sample uses an unsupported preset dictionary", /* cause= */ null);
+        } else if (!activeInflater.finished()) {
+          ensureDecompressedCapacity(decompressedBuffer.length * 2);
+        }
+      }
+    } catch (DataFormatException e) {
+      throw ParserException.createForMalformedContainer(
+          "Failed to inflate zlib-compressed Matroska sample", e);
+    }
+
+    if (!activeInflater.finished() || totalOut == 0) {
+      throw ParserException.createForMalformedContainer(
+          "Zlib-compressed Matroska sample did not decompress completely", /* cause= */ null);
+    }
+
+    decompressedSample.reset(decompressedBuffer, totalOut);
+    return decompressedSample;
+  }
+
+  private void ensureCompressedCapacity(int requiredLength) {
+    if (compressedBuffer.length < requiredLength) {
+      compressedBuffer =
+          Arrays.copyOf(
+              compressedBuffer,
+              max(requiredLength, compressedBuffer.length == 0 ? requiredLength : compressedBuffer.length * 2));
+    }
+  }
+
+  private void ensureDecompressedCapacity(int requiredLength) {
+    if (decompressedBuffer.length < requiredLength) {
+      decompressedBuffer =
+          Arrays.copyOf(
+              decompressedBuffer,
+              max(requiredLength, decompressedBuffer.length * 2));
+    }
+  }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
@@ -11,8 +11,9 @@ import androidx.media3.extractor.ExtractorInput
 import androidx.media3.extractor.ExtractorOutput
 import androidx.media3.extractor.TrackOutput
 import androidx.media3.extractor.mkv.EbmlProcessor
-import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.text.SubtitleParser
+import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor
+import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor.DolbyVisionSampleTransformer
 import io.github.peerless2012.ass.media.AssHandler
 import io.github.peerless2012.ass.media.type.AssRenderType
 import java.io.ByteArrayOutputStream
@@ -24,8 +25,13 @@ import java.util.zip.Inflater
 internal class NuvioAssMatroskaExtractor(
     subtitleParserFactory: SubtitleParser.Factory,
     private val assHandler: AssHandler,
-    flags: Int = 0
-) : MatroskaExtractor(subtitleParserFactory, flags) {
+    flags: Int = 0,
+    dolbyVisionSampleTransformer: DolbyVisionSampleTransformer? = null
+) : MatroskaExtractor(
+    subtitleParserFactory,
+    flags,
+    dolbyVisionSampleTransformer
+) {
 
     private var currentAttachmentName: String? = null
     private var currentAttachmentMime: String? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerLibassCompat.kt
@@ -12,7 +12,7 @@ import androidx.media3.exoplayer.RenderersFactory
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
-import androidx.media3.extractor.mkv.MatroskaExtractor
+import androidx.media3.extractor.mkv.MatroskaExtractor as StockMatroskaExtractor
 import androidx.media3.extractor.text.SubtitleParser
 import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor as DvMatroskaExtractor
 import io.github.peerless2012.ass.media.AssHandler
@@ -102,17 +102,18 @@ private fun ExtractorsFactory.withAssMkvSupportCompat(
         val extractors = delegate.createExtractors()
         extractors.forEachIndexed { index, extractor ->
             // Stock MatroskaExtractor: replace with ASS-aware variant for libass support.
-            if (extractor is MatroskaExtractor) {
+            if (extractor is StockMatroskaExtractor) {
                 extractors[index] = NuvioAssMatroskaExtractor(subtitleParserFactory, assHandler)
             }
             // The DV7 factory swaps in a vendored DvMatroskaExtractor for DV conversion.
-            // AssMatroskaExtractor extends stock MatroskaExtractor and cannot handle DV7
-            // BlockAdditional RPU, but it IS required for libass ASS/SSA rendering.
-            // Replace DvMatroskaExtractor with AssMatroskaExtractor so that libass works.
-            // For actual DV content, maybeAdjustLibassPipelineForTracks will detect the DV
-            // video track and rebuild the player without libass, restoring DvMatroskaExtractor.
+            // Preserve its Dolby Vision transformer while enabling libass and zlib subtitle
+            // decompression from the same vendored Matroska extractor base class.
             if (extractor is DvMatroskaExtractor) {
-                extractors[index] = NuvioAssMatroskaExtractor(subtitleParserFactory, assHandler)
+                extractors[index] = NuvioAssMatroskaExtractor(
+                    subtitleParserFactory = subtitleParserFactory,
+                    assHandler = assHandler,
+                    dolbyVisionSampleTransformer = extractor.dolbyVisionSampleTransformer
+                )
             }
         }
         extractors

--- a/app/src/test/java/com/nuvio/tv/core/player/dvmkv/MatroskaZlibSampleDecompressorTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/dvmkv/MatroskaZlibSampleDecompressorTest.kt
@@ -1,0 +1,57 @@
+package com.nuvio.tv.core.player.dvmkv
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
+
+class MatroskaZlibSampleDecompressorTest {
+
+    @Test
+    fun `decompress restores zlib-compressed subtitle payload`() {
+        val original = "Dialogue: 0,0:00:01.00,0:00:04.00,Default,,0,0,0,,Hello".toByteArray()
+        val compressed = deflate(original)
+
+        val decompressor = MatroskaZlibSampleDecompressor()
+        val decompressed = decompressor.decompress(compressed, 0, compressed.size)
+
+        assertEquals(original.size, decompressed.limit())
+        assertArrayEquals(original, decompressed.data.copyOfRange(0, decompressed.limit()))
+    }
+
+    @Test
+    fun `decompress reuses inflater and grows output buffer across calls`() {
+        val first = "First".toByteArray()
+        val second = "Second subtitle line with more bytes".toByteArray()
+
+        val decompressor = MatroskaZlibSampleDecompressor()
+        val firstOut =
+            decompressor.decompress(deflate(first), 0, deflate(first).size).let { sample ->
+                sample.data.copyOfRange(0, sample.limit())
+            }
+        val secondOut =
+            decompressor.decompress(deflate(second), 0, deflate(second).size).let { sample ->
+                sample.data.copyOfRange(0, sample.limit())
+            }
+
+        assertArrayEquals(first, firstOut)
+        assertArrayEquals(second, secondOut)
+    }
+
+    private fun deflate(input: ByteArray): ByteArray {
+        val deflater = Deflater()
+        deflater.setInput(input)
+        deflater.finish()
+        val output = ByteArrayOutputStream(input.size)
+        val scratch = ByteArray(256)
+        while (!deflater.finished()) {
+            val count = deflater.deflate(scratch)
+            if (count > 0) {
+                output.write(scratch, 0, count)
+            }
+        }
+        deflater.end()
+        return output.toByteArray()
+    }
+}


### PR DESCRIPTION
## Summary

Fix MKV direct playback failing when a track uses Matroska content compression (`ContentCompAlgo 0`, zlib). ExoPlayer's vendored `MatroskaExtractor` previously threw `ContentCompAlgo 0 not supported` and aborted parsing before video could start.

This change adds a reusable zlib sample decompressor, accepts `ContentCompAlgo 0` during track parsing, and routes decompressed subtitle/binary samples through the existing sample pipeline. Libass now builds on the same vendored extractor base so zlib support also applies on the libass + Dolby Vision path.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

Some MKV releases (common in remux/anime/usenet flows) store embedded subtitles with Matroska `ContentCompression` using zlib (`ContentCompAlgo 0`). That is valid per the Matroska spec, but NuvioTV previously failed container parsing immediately with:

`ContentCompAlgo 0 not supported {contentIsMalformed=true, dataType=1}`

Playback never started even though the video/audio stream itself was valid. This is a playback-blocking parser failure on otherwise playable files.

## Issue or approval

Reported via Discord.

## Reproduction steps


1. Obtain an MKV with an embedded subtitle track using Matroska zlib content compression (`ContentCompAlgo 0`), e.g. the release above or similar PGS/ASS remux release.
2. Open the stream in NuvioTV on the `dev` branch (before this fix).
3. Observe immediate playback failure with `ContentCompAlgo 0 not supported` / `ERROR_CODE_PARSING_CONTAINER_MALFORMED`.
4. Build this branch and replay the same stream.
5. Expected: container parses successfully and playback starts; embedded subtitles on zlib-compressed tracks are decompressed during extraction instead of aborting the file.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

- No UI changes.
- No transcoding/remux/server-side fallback logic.
- No changes to unrelated player settings or stream selection.
- Zlib handling is limited to Matroska sample decompression in the vendored extractor; HTTP-level compression is unchanged.
- Only `ContentCompAlgo 0` (zlib) and existing `3` (header strip) are supported; other compression algorithms still fail explicitly.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.core.player.dvmkv.MatroskaZlibSampleDecompressorTest"` — passed (2/2).
- `./gradlew :app:compileFullDebugJavaWithJavac :app:compileFullDebugKotlin` — passed.
- Manual investigation: probed failing AIOStreams MKV URL; confirmed valid EBML header and `ContentCompAlgo 0` parser failure path on previous extractor behavior..

## Screenshots / Video

| Before (`dev`) | After (this branch) |
| --- | --- |
| <img width="961" height="1280" alt="image" src="https://github.com/user-attachments/assets/196c9284-09c8-4b90-83af-cb44f968e069" /> | <img width="2560" height="1392" alt="c2011e77-0f8c-454f-b6d5-c4626fc1cb63" src="https://github.com/user-attachments/assets/244946ab-9011-4b57-9a07-634ccceb17f8" /> |

## Breaking changes

None.

## Linked issues

Reported via Discord. No GitHub issue filed yet for this playback failure.
