### PR TITLE
perf: continue watching episode thumbnail scroll optimization

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -295,6 +295,53 @@ fun ContinueWatchingSection(
     }
 }
 
+// Selects the primary Continue Watching image URL, shared by the card and the home-row prefetch so both request the same model.
+internal fun continueWatchingImageModel(
+    item: ContinueWatchingItem,
+    useEpisodeThumbnails: Boolean
+): String? {
+    val progress = (item as? ContinueWatchingItem.InProgress)?.progress
+    val nextUp = (item as? ContinueWatchingItem.NextUp)?.info
+    fun firstNonBroken(vararg candidates: String?): String? =
+        candidates.firstOrNull { !it.isNullOrBlank() && it !in brokenImageUrls }?.trim()
+    return when {
+        nextUp != null && !nextUp.hasAired ->
+            firstNonBroken(nextUp.backdrop, nextUp.poster, nextUp.thumbnail)
+        nextUp != null && useEpisodeThumbnails ->
+            firstNonBroken(nextUp.thumbnail, nextUp.backdrop, nextUp.poster)
+        nextUp != null ->
+            firstNonBroken(nextUp.backdrop, nextUp.poster, nextUp.thumbnail)
+        useEpisodeThumbnails -> firstNonBroken(
+            (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail,
+            progress?.backdrop,
+            progress?.poster
+        )
+        else -> firstNonBroken(
+            progress?.backdrop,
+            progress?.poster,
+            (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail
+        )
+    }
+}
+
+// Whether the unwatched-episode spoiler blur applies to this item.
+internal fun continueWatchingShouldBlur(
+    item: ContinueWatchingItem,
+    blurUnwatchedEpisodes: Boolean,
+    useEpisodeThumbnails: Boolean
+): Boolean {
+    val nextUp = (item as? ContinueWatchingItem.NextUp)?.info
+    return blurUnwatchedEpisodes && useEpisodeThumbnails && nextUp != null
+}
+
+// Builds the Coil memory-cache key that the card and prefetch must share, including the blur suffix, so the prefetch is not wasted.
+internal fun continueWatchingImageCacheKey(
+    model: String?,
+    widthPx: Int,
+    heightPx: Int,
+    shouldBlur: Boolean
+): String = "${model}_${widthPx}x${heightPx}_blur${shouldBlur}"
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun ContinueWatchingCard(
@@ -355,37 +402,8 @@ fun ContinueWatchingCard(
         remainingText ?: nextUpBadgeText ?: strNextUp
     }
     val progressFraction = remember(progress) { progress?.progressPercentage ?: 0f }
-    val imageModel = remember(nextUp, progress, item, useEpisodeThumbnails) {
-        fun firstNonBroken(vararg candidates: String?): String? {
-            return candidates.firstOrNull { !it.isNullOrBlank() && it !in brokenImageUrls }?.trim()
-        }
-        when {
-            nextUp != null && !nextUp.hasAired -> firstNonBroken(
-                nextUp.backdrop,
-                nextUp.poster,
-                nextUp.thumbnail
-            )
-            nextUp != null && useEpisodeThumbnails -> firstNonBroken(
-                nextUp.thumbnail,
-                nextUp.backdrop,
-                nextUp.poster
-            )
-            nextUp != null -> firstNonBroken(
-                nextUp.backdrop,
-                nextUp.poster,
-                nextUp.thumbnail
-            )
-            useEpisodeThumbnails -> firstNonBroken(
-                (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail,
-                progress?.backdrop,
-                progress?.poster
-            )
-            else -> firstNonBroken(
-                progress?.backdrop,
-                progress?.poster,
-                (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail
-            )
-        }
+    val imageModel = remember(item, useEpisodeThumbnails) {
+        continueWatchingImageModel(item, useEpisodeThumbnails)
     }
     val fallbackImageModel = remember(nextUp, progress, item) {
         when {
@@ -421,12 +439,16 @@ fun ContinueWatchingCard(
     val requestHeightPx = remember(imageHeight, density) {
         with(density) { imageHeight.roundToPx() }.coerceAtLeast(1)
     }
-    val shouldBlur = blurUnwatchedEpisodes && useEpisodeThumbnails && nextUp != null
+    val shouldBlur = continueWatchingShouldBlur(item, blurUnwatchedEpisodes, useEpisodeThumbnails)
     val imageRequest = remember(effectiveImageModel, requestWidthPx, requestHeightPx, shouldBlur) {
         ImageRequest.Builder(context)
             .data(effectiveImageModel)
             .crossfade(true)
-            .memoryCacheKey("${effectiveImageModel}_${requestWidthPx}x${requestHeightPx}_blur${shouldBlur}")
+            .memoryCacheKey(
+                continueWatchingImageCacheKey(
+                    effectiveImageModel, requestWidthPx, requestHeightPx, shouldBlur
+                )
+            )
             .size(width = requestWidthPx, height = requestHeightPx)
             .apply {
                 if (shouldBlur) transformations(com.nuvio.tv.ui.util.BlurTransformation())

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -101,11 +101,15 @@ import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
 import coil3.request.CachePolicy
 import coil3.request.crossfade
+import coil3.request.transformations
 import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.FocusedPosterTrailerPlaybackTarget
 import com.nuvio.tv.domain.model.CardDepthSurface
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.ContinueWatchingCard
+import com.nuvio.tv.ui.components.continueWatchingImageCacheKey
+import com.nuvio.tv.ui.components.continueWatchingImageModel
+import com.nuvio.tv.ui.components.continueWatchingShouldBlur
 import com.nuvio.tv.ui.components.LocalCardDepthStyle
 import com.nuvio.tv.ui.components.MonochromePosterPlaceholder
 import com.nuvio.tv.ui.components.TrailerPlayer
@@ -608,16 +612,18 @@ internal fun ModernRowSection(
             landscapeCatalogCardWidth,
             landscapeCatalogCardHeight,
             continueWatchingCardWidth,
-            continueWatchingCardHeight
+            continueWatchingCardHeight,
+            useEpisodeThumbnails,
+            blurUnwatchedEpisodes
         ) {
             if (!isActiveRow() || isVerticalRowsScrollingState.value) return@LaunchedEffect
             delay(150) // Wait before spamming image requests to survive rapid vertical D-pad scrolls!
             val cwWidthPx = with(density) { continueWatchingCardWidth.roundToPx() }
             val cwHeightPx = with(density) { continueWatchingCardHeight.roundToPx() }
             fun imageUrlAndKey(item: ModernCarouselItem): Pair<String, String>? {
-                val url = item.imageUrl ?: return null
-                return when (item.payload) {
+                return when (val payload = item.payload) {
                     is ModernPayload.Catalog -> {
+                        val url = item.imageUrl ?: return null
                         val metrics = item.catalogCardMetrics(
                             useLandscapePosters = useLandscapePosters,
                             portraitCardWidth = portraitCatalogCardWidth,
@@ -630,6 +636,7 @@ internal fun ModernRowSection(
                         url to "${url}_${widthPx}x${heightPx}"
                     }
                     is ModernPayload.CollectionFolder -> {
+                        val url = item.imageUrl ?: return null
                         val metrics = item.catalogCardMetrics(
                             useLandscapePosters = useLandscapePosters,
                             portraitCardWidth = portraitCatalogCardWidth,
@@ -641,18 +648,32 @@ internal fun ModernRowSection(
                         val heightPx = with(density) { metrics.height.roundToPx() }
                         url to "${url}_${widthPx}x${heightPx}"
                     }
-                    is ModernPayload.ContinueWatching -> url to "${url}_${cwWidthPx}x${cwHeightPx}"
+                    is ModernPayload.ContinueWatching -> {
+                        // Use the same model and cache key the card computes so the prefetch warms the entry the card actually reads.
+                        val model = continueWatchingImageModel(payload.item, useEpisodeThumbnails)
+                            ?: return null
+                        val blur = continueWatchingShouldBlur(
+                            payload.item, blurUnwatchedEpisodes, useEpisodeThumbnails
+                        )
+                        model to continueWatchingImageCacheKey(model, cwWidthPx, cwHeightPx, blur)
+                    }
                 }
             }
             fun enqueueIfNeeded(item: ModernCarouselItem, widthPx: Int, heightPx: Int) {
                 if (widthPx <= 0 || heightPx <= 0) return
                 val (url, cacheKey) = imageUrlAndKey(item) ?: return
                 if (imageLoader.memoryCache?.get(MemoryCache.Key(cacheKey)) != null) return
+                val payload = item.payload
+                val blur = payload is ModernPayload.ContinueWatching &&
+                    continueWatchingShouldBlur(payload.item, blurUnwatchedEpisodes, useEpisodeThumbnails)
                 imageLoader.enqueue(
                     ImageRequest.Builder(context)
                         .data(url)
                         .memoryCacheKey(cacheKey)
                         .size(width = widthPx, height = heightPx)
+                        .apply {
+                            if (blur) transformations(com.nuvio.tv.ui.util.BlurTransformation())
+                        }
                         .build()
                 )
             }


### PR DESCRIPTION
## Summary
With "Use Episode Thumbnails in Continue Watching" enabled, the Continue Watching row stutters while scrolling. The card and the home-row prefetch build different Coil memory-cache keys, so the prefetch never satisfies the card's lookup and every thumbnail is decoded during the scroll instead of ahead of it.

This unifies the image model, blur decision, and cache key behind three shared helpers so the prefetch warms exactly the entry the card reads.

## PR type
<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why
The home row already implements prefetching so images are decoded ahead of the scroll position. For Continue Watching that prefetch was silently ineffective: the keys never matched, so the work was thrown away and the decode landed on the scrolling frame. This restores the intended prefetch behavior rather than adding anything new.

Backdrop artwork masked the problem because the same URL is usually already warm in memory from catalog rows, the hero, or the detail screen. A per-episode still has no other warm copy, so the wasted prefetch was fully exposed, and `bitmapFactoryMaxParallelism(2)` serialized those decodes.

## Issue or approval
Fixes 

- #605 
- #523 
- #398 
- #405 
---
We didn't add in scope for users who used this Episode Thumbnails option as well and caused the issue to still remain for them. Consider this a  part 2. 

## Reproduction steps
1. Open Settings - Layout - Continue Watching and enable "Use Episode Thumbnails in Continue Watching".
2. Return to home with several series in the Continue Watching row.
3. Hold the D-pad to scroll horizontally through the row and observe the stutter.
4. Disable the toggle so the row falls back to backdrops and repeat: scrolling is smooth.

## UI / behavior impact
<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The only behavior change is caching: the prefetch now writes the key the card reads. Image selection, blur rules, and layout are unchanged.

## Policy check
<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
Intentionally not changed:

- Which image a card displays. The source precedence rules were moved into a shared helper without altering their order or outcome.
- The unwatched-episode spoiler blur rules.
- Card layout, sizing, styling, and focus behavior.
- Catalog and collection prefetch paths, which keep their existing keys.
- No dependencies, architecture, or public contracts changed.

Two files touched: `ContinueWatchingSection.kt` and `ModernHomeRows.kt`.

## Testing
Device: Xiaomi Mi TV (MiTV-AFMU0), Android 14

- With "Use Episode Thumbnails in Continue Watching" enabled, scrolled the Continue Watching row with the D-pad held down, before and after the change, and compared smoothness against the toggle disabled.
- Toggled the setting off and on and confirmed the row re-primes and still renders the correct images, since the setting is now part of the prefetch effect keys.
- Verified "Blur Unwatched in Continue Watching" still renders correctly for NextUp items, and that blurred and unblurred variants do not collide in the cache.
- Confirmed catalog and collection rows are unaffected.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
- #605 
- #523 
- #398 
- #405 
