### PR TITLE
fix: baseline profile generator covers browse journey, report home fully drawn

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.home
 
 import com.nuvio.tv.ui.theme.NuvioTheme
 
+import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import android.util.Log
@@ -215,6 +216,9 @@ fun HomeScreen(
         !uiState.isLoading && !hasAnyContent -> !homeStableGateReleased
         else -> !homeStableGateReleased || !modernPresentationReady || !showHomeContentWithAnimation
     }
+
+    // Reports the home screen as fully drawn once it leaves the loading state so startup timing is measurable and post-launch work can be deferred.
+    ReportDrawnWhen { !showStartupLoader }
 
     Box(
         modifier = Modifier.fillMaxSize()

--- a/baselineprofile/src/main/java/com/nuvio/tv/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/nuvio/tv/baselineprofile/BaselineProfileGenerator.kt
@@ -1,16 +1,17 @@
 package com.nuvio.tv.baselineprofile
 
-import androidx.benchmark.macro.BaselineProfileMode
-import androidx.benchmark.macro.CompilationMode
-import androidx.benchmark.macro.StartupMode
-import androidx.benchmark.macro.StartupTimingMetric
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.StaleObjectException
+import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import java.util.regex.Pattern
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private const val ONBOARDING_FIRST_LABEL = "Continue without account"
 
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
@@ -28,7 +29,83 @@ class BaselineProfileGenerator {
             pressHome()
             startActivityAndWait()
             device.wait(Until.hasObject(By.pkg(targetPackage)), 5_000)
+            device.waitForIdle()
+
+            // Step through the first-run onboarding with D-pad focus, skipping it entirely on later iterations where the app already opens on home.
+            if (device.wait(Until.hasObject(By.text(ONBOARDING_FIRST_LABEL)), 8_000) != null) {
+                device.focusAndSelect(ONBOARDING_FIRST_LABEL)
+                device.focusAndSelect("Advanced")
+                device.focusAndSelect("Continue")
+            }
+            device.waitForIdle()
             Thread.sleep(3_000)
+
+            // Move focus off the sidebar into the content grid.
+            device.pressDPadRight()
+            device.waitForIdle()
+
+            // Scroll across the focused row to compile the row and card rendering paths.
+            repeat(6) {
+                device.pressDPadRight()
+                device.waitForIdle()
+                Thread.sleep(120)
+            }
+
+            // Scroll down through the rows to compile the vertical list and prefetch paths.
+            repeat(6) {
+                device.pressDPadDown()
+                device.waitForIdle()
+                Thread.sleep(150)
+            }
+
+            // Move back up toward a focused title.
+            repeat(2) {
+                device.pressDPadUp()
+                device.waitForIdle()
+                Thread.sleep(120)
+            }
+
+            // Open a title to compile the detail screen render path.
+            device.pressDPadCenter()
+            device.waitForIdle()
+            Thread.sleep(2_500)
+
+            // Return to the home screen.
+            device.pressBack()
+            device.waitForIdle()
+            Thread.sleep(800)
         }
+    }
+}
+
+// Moves D-pad focus until the control carrying the given label is focused and then selects it, since TV devices have no touch input.
+private fun UiDevice.focusAndSelect(label: String, maxSteps: Int = 24): Boolean {
+    val pattern = Pattern.compile(Pattern.quote(label), Pattern.CASE_INSENSITIVE)
+    if (wait(Until.hasObject(By.text(pattern)), 10_000) == null) return false
+    repeat(maxSteps) { step ->
+        if (isFocusedLabel(label, pattern)) {
+            pressDPadCenter()
+            waitForIdle()
+            Thread.sleep(1_500)
+            // Treat the step as done only once the label is gone, so a mis-selection keeps searching instead of moving on.
+            if (wait(Until.gone(By.text(pattern)), 5_000) == true) return true
+        }
+        // Alternate directions so both vertical lists and side-by-side cards are reachable.
+        if (step % 2 == 0) pressDPadDown() else pressDPadRight()
+        waitForIdle()
+        Thread.sleep(250)
+    }
+    return false
+}
+
+// Reports whether the currently focused control carries the label, treating nodes that disappear mid-query as a non-match.
+private fun UiDevice.isFocusedLabel(label: String, pattern: Pattern): Boolean {
+    return try {
+        val focused = findObject(By.focused(true)) ?: return false
+        if (focused.text?.equals(label, ignoreCase = true) == true) return true
+        // Require the focused node to be the clickable control itself so a large parent container is not mistaken for the button.
+        focused.isClickable && focused.findObject(By.text(pattern)) != null
+    } catch (e: StaleObjectException) {
+        false
     }
 }


### PR DESCRIPTION
## Summary
The baseline profile generator only cold-started the app and idled for three seconds, so the shipped profile never covered the browse paths users actually hit. This drives the journey through the home rows and a detail screen, and reports the home screen as fully drawn so startup timing is measurable.

## PR type
<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why
`BaselineProfileGenerator.generate()` ran `startActivityAndWait()` followed by `Thread.sleep(3_000)`. Anything past the first frame, including row scrolling, card composition, image loading and the detail screen, was never exercised, so those paths were absent from the profile and ran interpreted on a fresh install or after an update. The generator also could not get past first-run onboarding, so it could not reach the home screen at all on a clean device.

`MainActivity` calls `installSplashScreen()` but nothing ever reported the app as fully drawn, so Time To Full Display was not measurable.

## Issue or approval
Fixes #1711 #1331


## Reproduction steps
1. Install a fresh build on an Android TV device.
2. Run `./gradlew :app:generateBaselineProfile`.
3. Observe the run stops at the first-run onboarding screen and never reaches home, and that the recorded journey contains only cold start plus an idle wait.

## UI / behavior impact
<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The only runtime change is `ReportDrawnWhen` on the home screen, which reports an existing state to the platform. The generator is test-only code.

## Policy check
<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
Intentionally not changed:

- The committed `baseline-prof.txt` and `startup-prof.txt` are untouched. 
- Dependencies, or the app's startup sequence.
- The onboarding steps use the existing button labels and are skipped automatically when the app opens straight to home.

Two files touched: `BaselineProfileGenerator.kt` and `HomeScreen.kt`.

## Testing
Device: Xiaomi Mi TV (MiTV-AFMU0), Android 14

- Ran `./gradlew :app:generateBaselineProfile` against a freshly installed app and confirmed the generator clears onboarding, reaches the home screen, scrolls the rows and opens a detail screen, journey was validated on device across iterations.
- Confirmed the run is a no-op on the onboarding steps when the app already opens on home.
- Built and installed `assembleFullDebug` and confirmed the home screen renders and behaves unchanged with `ReportDrawnWhen` in place.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #1711 #1331