### PR TITLE
fix(tracking): include Simkl in seek scrobble dispatch (#2876)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklTrackingProvider.kt
@@ -9,6 +9,7 @@ import com.nuvio.tv.core.tracking.TrackingProviderId
 import com.nuvio.tv.core.tracking.TrackingScrobbleAction
 import com.nuvio.tv.core.tracking.TrackingScrobbleEvent
 import com.nuvio.tv.core.tracking.TrackingScrobbler
+import com.nuvio.tv.core.tracking.TrackingSeekScrobblePolicy
 import com.nuvio.tv.core.tracking.scrobbleDiagnosticSummary
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -26,6 +27,7 @@ class SimklTrackingScrobbler @Inject constructor(
     private val mutationService: SimklMutationService
 ) : TrackingScrobbler {
     override val providerId = TrackingProviderId.SIMKL
+    override val seekScrobblePolicy = TrackingSeekScrobblePolicy.STOP_AND_RESTART
 
     override suspend fun scrobble(
         action: TrackingScrobbleAction,


### PR DESCRIPTION
## Summary

Override `seekScrobblePolicy` in `SimklTrackingScrobbler` so that `dispatchTrackingSeekScrobble` includes Simkl when forwarding seek events to tracking providers.

## PR type

- [x] Critical bug fix

## Why

`TrackingScrobbleCoordinator.dispatchTrackingSeekScrobble` filters scrobblers by `seekScrobblePolicy == STOP_AND_RESTART`. `TraktTrackingScrobbler` overrides this property, so Trakt receives seek updates. `SimklTrackingScrobbler` did not override it (inherited `NONE`), so it was excluded from the filter — Simkl never received position updates after a seek during active playback.

## Issue or approval

Fixes #2876

## Reproduction steps

1. Set Simkl as the tracking provider.
2. Play any video and let it run for a bit.
3. While the video is actively playing, seek forward (e.g. from minute 4 to minute 15).
4. Continue watching for a few seconds.
5. Check the current watch progress on Simkl — it still shows the pre-seek position.

## UI / behavior impact

- [x] No visible UI changes — Simkl progress now correctly updates after seeking during playback

## Policy check

- [x] This PR addresses a single, focused bug
- [x] I have tested this change compiles without errors
- [x] The change is minimal and does not include unrelated modifications
- [x] I have read and followed the project's contributing guidelines
- [x] This PR does not introduce new dependencies
- [x] The commit message references the issue number
- [x] I confirm this is not a feature addition disguised as a bug fix

## Scope boundaries

Only `SimklTrackingProvider.kt` is modified. The change adds one property override and one import. No other tracking provider, player logic, or UI code is touched.

## Testing

- `./gradlew :app:compileFullDebugKotlin` passed (BUILD SUCCESSFUL).
- Code path verified by inspection: the coordinator filter `scrobblers.filter { it.seekScrobblePolicy == STOP_AND_RESTART }` now includes `SimklTrackingScrobbler`.
- No unit test added — the fix is a single property override and does not warrant a dedicated test file (per maintainer preference).
- Device verification of the full seek → Simkl sync flow is delegated to the reporter or a maintainer with Simkl configured. The PR APK artifact from CI can be used to verify.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2876
