### PR TITLE
fix(player): keep subtitle menu focus off Skip Intro (#2874)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -844,11 +844,16 @@ fun PlayerScreen(
         )
 
         // Skip Intro button (bottom-left, lifted when controls are visible)
+        val skipIntroCanFocus = isSkipIntroCanFocus(
+            subtitleOverlayVisible = uiState.showSubtitleOverlay,
+        )
         SkipIntroButton(
             interval = if (uiState.showPauseOverlay || uiState.showLoadingOverlay) null else uiState.activeSkipInterval,
             dismissed = uiState.skipIntervalDismissed,
             controlsVisible = uiState.showControls,
-            suppressFocus = uiState.postPlayMode is PostPlayMode.AutoPlay,
+            // Autoplay next-episode card owns focus; subtitle menu must keep D-pad focus (#2874).
+            suppressFocus = uiState.postPlayMode is PostPlayMode.AutoPlay || !skipIntroCanFocus,
+            canFocus = skipIntroCanFocus,
             onSkip = { viewModel.onEvent(PlayerEvent.OnSkipIntro) },
             onDismiss = { viewModel.onEvent(PlayerEvent.OnDismissSkipIntro) },
             onVisibilityChanged = { skipButtonActuallyVisible = it },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroButton.kt
@@ -61,6 +61,7 @@ fun SkipIntroButton(
     dismissed: Boolean,
     controlsVisible: Boolean,
     suppressFocus: Boolean = false,
+    canFocus: Boolean = true,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
     onHideControls: (() -> Unit)? = null,
@@ -131,9 +132,10 @@ fun SkipIntroButton(
     LaunchedEffect(isVisible) { onVisibilityChanged(isVisible) }
 
     // Request focus when becoming visible or when controls hide
-    // but not when the next episode card has priority
-    LaunchedEffect(isVisible, controlsVisible, suppressFocus) {
-        if (isVisible && !controlsVisible && !suppressFocus) {
+    // but not when the next episode card has priority, and not when focus is
+    // reserved for an overlay (e.g. subtitle selection — #2874).
+    LaunchedEffect(isVisible, controlsVisible, suppressFocus, canFocus) {
+        if (isVisible && !controlsVisible && !suppressFocus && canFocus) {
             try { activeFocusRequester.requestFocus() } catch (_: Exception) {}
         }
     }
@@ -148,17 +150,13 @@ fun SkipIntroButton(
             onClick = onSkip,
             modifier = Modifier
                 .focusRequester(activeFocusRequester)
-                .then(
-                    if (downFocusRequester != null || upFocusRequester != null) {
-                        Modifier.focusProperties {
-                            downFocusRequester?.let { down = it }
-                            upFocusRequester?.let { up = it }
-                        }
-                    } else {
-                        Modifier
-                    }
-                )
+                .focusProperties {
+                    this.canFocus = canFocus
+                    downFocusRequester?.let { down = it }
+                    upFocusRequester?.let { up = it }
+                }
                 .onPreviewKeyEvent { keyEvent ->
+                    if (!canFocus) return@onPreviewKeyEvent false
                     if (keyEvent.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN) {
                         when (keyEvent.nativeKeyEvent.keyCode) {
                             android.view.KeyEvent.KEYCODE_DPAD_DOWN -> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRules.kt
@@ -30,6 +30,17 @@ internal fun isSkipIntroButtonVisible(
     return shouldShow && (!autoHidden || controlsVisible)
 }
 
+/**
+ * Whether the Skip Intro button may accept D-pad focus.
+ *
+ * While the subtitle selection overlay is open, Skip Intro stays on screen but
+ * must not be focusable — otherwise DPAD_DOWN past the last language/track card
+ * escapes the overlay onto Skip Intro (#2874).
+ */
+internal fun isSkipIntroCanFocus(
+    subtitleOverlayVisible: Boolean,
+): Boolean = !subtitleOverlayVisible
+
 internal fun skipIntroAutoHideRemainingMs(
     progress: Float,
     totalTimeoutMs: Int = SKIP_INTRO_AUTO_HIDE_TIMEOUT_MS,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/SkipIntroVisibilityRulesTest.kt
@@ -163,6 +163,19 @@ class SkipIntroVisibilityRulesTest {
         )
     }
 
+    // ── Focus while overlays open (#2874) ─────────────────────────────────
+
+    @Test
+    fun `skip intro can accept focus when subtitle overlay is closed`() {
+        assertTrue(isSkipIntroCanFocus(subtitleOverlayVisible = false))
+    }
+
+    @Test
+    fun `skip intro cannot accept focus while subtitle selection overlay is open`() {
+        // DPAD_DOWN past the last subtitle card must not escape onto Skip Intro.
+        assertFalse(isSkipIntroCanFocus(subtitleOverlayVisible = true))
+    }
+
     // ── Auto-hide countdown ────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

While Skip Intro is visible, opening the subtitle selection overlay and pressing DPAD_DOWN past the last language/track card let focus escape onto Skip Intro. Skip Intro now stays visible but refuses focus (and auto-focus) for the duration of the subtitle overlay.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Focus escaping the subtitle menu mid-selection is a clear remote-navigation bug: users leave the overlay unintentionally and can activate Skip Intro instead of choosing a subtitle track.

## Issue or approval

Fixes #2874

## Reproduction steps

1. Play content that shows Skip Intro / Skip Recap.
2. While the skip button is visible, open the subtitle selection menu.
3. Move focus to the last language or subtitle track card.
4. Press DPAD_DOWN once more.
5. **Before:** focus jumps to Skip Intro (escapes the overlay).
6. **After:** focus stays inside the subtitle menu; Skip Intro is not focusable.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Visual chrome is unchanged (Skip Intro still draws when active). Only focusability while the subtitle overlay is open is restricted.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Did **not** change Skip Intro visibility rules or auto-hide timing.
- Did **not** trap focus on every player panel (audio, sources, episodes); only the reported subtitle overlay case.
- Did **not** change subtitle selection rails, track selection logic, or #2768 Sync Line / delay overlay wiring.
- Did **not** reformat unrelated player code.

## Testing

**Automated**
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.SkipIntroVisibilityRulesTest"` — PASSED
- `./gradlew :app:compileFullDebugKotlin` — PASSED

**Logic covered by unit tests**
- `isSkipIntroCanFocus(false)` → true
- `isSkipIntroCanFocus(true)` → false (subtitle overlay open)

**Not run here**
- Full Android TV / FireOS playback with a real skip interval + subtitle menu D-pad path (no live stream / skip metadata in this environment).

**Manual verification plan (device/emulator)**
1. Play an episode with Skip Intro visible.
2. Open subtitle menu.
3. DPAD_DOWN past last language and past last track → focus must remain in the menu.
4. BACK dismisses the menu; Skip Intro is focusable again when the overlay is closed.

## Screenshots / Video

Not a visual layout change — focus-only behavior. No screenshots attached.

## Breaking changes

None.

## Linked issues

Fixes #2874
