### PR TITLE
fix(library): backfill year/genre metadata for library filters (#2875)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/LibraryPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LibraryPreferences.kt
@@ -134,6 +134,63 @@ class LibraryPreferences @Inject constructor(
         }
     }
 
+    /**
+     * Quietly fills missing filter-facing metadata (year/genre) without enqueueing a
+     * remote push. Used to backfill older library rows that predate full meta capture.
+     */
+    suspend fun updateFilterMetadata(
+        id: String,
+        type: String,
+        genres: List<String>? = null,
+        releaseInfo: String? = null,
+        imdbRating: Float? = null,
+        profileId: Int = profileManager.activeProfileId.value
+    ): Boolean {
+        var changed = false
+        store(profileId).edit { preferences ->
+            val state = preferences.toLibrarySyncState()
+            val updatedItems = state.items.map { item ->
+                if (item.id != id || !item.type.equals(type, ignoreCase = true)) {
+                    item
+                } else {
+                    val nextGenres = if (item.genres.isEmpty() && !genres.isNullOrEmpty()) {
+                        genres
+                    } else {
+                        item.genres
+                    }
+                    val nextReleaseInfo = if (item.releaseInfo.isNullOrBlank() && !releaseInfo.isNullOrBlank()) {
+                        releaseInfo
+                    } else {
+                        item.releaseInfo
+                    }
+                    val nextImdbRating = if (item.imdbRating == null && imdbRating != null) {
+                        imdbRating
+                    } else {
+                        item.imdbRating
+                    }
+                    if (
+                        nextGenres != item.genres ||
+                        nextReleaseInfo != item.releaseInfo ||
+                        nextImdbRating != item.imdbRating
+                    ) {
+                        changed = true
+                        item.copy(
+                            genres = nextGenres,
+                            releaseInfo = nextReleaseInfo,
+                            imdbRating = nextImdbRating
+                        )
+                    } else {
+                        item
+                    }
+                }
+            }
+            if (changed) {
+                preferences.writeLibrarySyncState(state.copy(items = updatedItems))
+            }
+        }
+        return changed
+    }
+
     override suspend fun getSyncState(profileId: Int): LibrarySyncState {
         return store(profileId).data.first().toLibrarySyncState()
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
@@ -64,7 +64,8 @@ class LibraryRepositoryImpl @Inject constructor(
 ) : LibraryRepository {
 
     private val syncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val hydratedLogoIds = mutableSetOf<String>()
+    private val hydratedFilterMetadataIds = mutableSetOf<String>()
+    private var filterMetadataHydrationJob: Job? = null
     private var syncJob: Job? = null
     private val _isSyncingFromRemote = MutableStateFlow(false)
     var isSyncingFromRemote: Boolean
@@ -128,6 +129,8 @@ class LibraryRepositoryImpl @Inject constructor(
                             addonBaseUrl = saved.addonBaseUrl,
                             listedAt = saved.addedAt
                         )
+                    }.also { entries ->
+                        scheduleFilterMetadataHydration(entries)
                     }
                 }
             }
@@ -362,17 +365,52 @@ class LibraryRepositoryImpl @Inject constructor(
         )
     }
 
-    private suspend fun hydrateLibraryLogos(items: List<LibraryEntry>) {
-        items.take(20).forEach { entry ->
-            hydratedLogoIds.add(entry.id)
+    /**
+     * Backfills year/genre fields for older local library rows so Library filters
+     * can list them. Network-bound and throttled; each id is attempted once per process.
+     */
+    private fun scheduleFilterMetadataHydration(entries: List<LibraryEntry>) {
+        val needsHydration = entries.filter { entry ->
+            entry.id !in hydratedFilterMetadataIds &&
+                (entry.genres.isEmpty() || entry.releaseInfo.isNullOrBlank())
+        }
+        if (needsHydration.isEmpty()) return
+        if (filterMetadataHydrationJob?.isActive == true) return
+
+        filterMetadataHydrationJob = syncScope.launch {
+            hydrateMissingFilterMetadata(needsHydration)
+        }
+    }
+
+    private suspend fun hydrateMissingFilterMetadata(items: List<LibraryEntry>) {
+        for (entry in items) {
+            if (entry.id in hydratedFilterMetadataIds) continue
+            hydratedFilterMetadataIds.add(entry.id)
             runCatching {
                 val result = metaRepository.getMetaFromPrimaryAddon(entry.type, entry.id)
                     .firstOrNull { it is NetworkResult.Success }
-                val logo = (result as? NetworkResult.Success)?.data?.logo
-                if (logo != null) {
-                    libraryPreferences.updateLogo(entry.id, entry.type, logo)
+                val meta = (result as? NetworkResult.Success)?.data ?: return@runCatching
+                val genres = meta.genres.filter { it.isNotBlank() }
+                val releaseInfo = meta.releaseInfo?.takeIf { it.isNotBlank() }
+                    ?: meta.released?.takeIf { it.isNotBlank() }
+                if (genres.isEmpty() && releaseInfo.isNullOrBlank() && meta.imdbRating == null) {
+                    return@runCatching
                 }
-            }.onFailure { Log.w("LibraryRepo", "Logo hydration failed for ${entry.id}", it) }
+                libraryPreferences.updateFilterMetadata(
+                    id = entry.id,
+                    type = entry.type,
+                    genres = genres.takeIf { it.isNotEmpty() },
+                    releaseInfo = releaseInfo,
+                    imdbRating = meta.imdbRating
+                )
+            }.onFailure {
+                Log.w("LibraryRepo", "Filter metadata hydration failed for ${entry.id}", it)
+            }
+            delay(HYDRATE_FILTER_METADATA_THROTTLE_MS)
         }
+    }
+
+    private companion object {
+        const val HYDRATE_FILTER_METADATA_THROTTLE_MS = 75L
     }
 }

--- a/app/src/main/java/com/nuvio/tv/domain/model/LibrarySyncReducer.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/LibrarySyncReducer.kt
@@ -107,7 +107,7 @@ object LibrarySyncReducer {
         remoteItems.forEach { remoteItem ->
             if (remoteItem.id.isBlank() || remoteItem.type.isBlank()) return@forEach
             val identity = librarySyncIdentity(remoteItem.id, remoteItem.type)
-            remoteItemsByKey[identity] = remoteItem.withPreservedLogo(localItems[identity])
+            remoteItemsByKey[identity] = remoteItem.withPreservedLocalMetadata(localItems[identity])
         }
         val pendingUpserts = current.pendingUpsertKeys.toKeyMap()
         val pendingDeletes = current.pendingDeleteKeys.toKeyMap()
@@ -169,7 +169,7 @@ object LibrarySyncReducer {
 
             when (event.operation.trim().lowercase()) {
                 "upsert" -> {
-                    items[identity] = event.item.withPreservedLogo(items[identity])
+                    items[identity] = event.item.withPreservedLocalMetadata(items[identity])
                     appliedUpserts += 1
                 }
                 "delete" -> {
@@ -237,10 +237,25 @@ private fun kotlin.collections.Collection<LibrarySyncKey>.toKeyMap(): LinkedHash
     return result
 }
 
-private fun SavedLibraryItem.withPreservedLogo(localItem: SavedLibraryItem?): SavedLibraryItem {
-    return if (logo == null && localItem?.logo != null) {
-        copy(logo = localItem.logo)
-    } else {
-        this
+/**
+ * When cloud/remote rows are sparse (common for older library records), keep richer
+ * local fields so year/genre filters and logos do not regress after a pull.
+ */
+internal fun SavedLibraryItem.withPreservedLocalMetadata(localItem: SavedLibraryItem?): SavedLibraryItem {
+    if (localItem == null) return this
+    val preserveLogo = logo == null && localItem.logo != null
+    val preserveReleaseInfo = releaseInfo.isNullOrBlank() && !localItem.releaseInfo.isNullOrBlank()
+    val preserveGenres = genres.isEmpty() && localItem.genres.isNotEmpty()
+    val preserveImdbRating = imdbRating == null && localItem.imdbRating != null
+    val preserveDescription = description.isNullOrBlank() && !localItem.description.isNullOrBlank()
+    if (!preserveLogo && !preserveReleaseInfo && !preserveGenres && !preserveImdbRating && !preserveDescription) {
+        return this
     }
+    return copy(
+        logo = if (preserveLogo) localItem.logo else logo,
+        releaseInfo = if (preserveReleaseInfo) localItem.releaseInfo else releaseInfo,
+        genres = if (preserveGenres) localItem.genres else genres,
+        imdbRating = if (preserveImdbRating) localItem.imdbRating else imdbRating,
+        description = if (preserveDescription) localItem.description else description
+    )
 }

--- a/app/src/test/java/com/nuvio/tv/domain/model/LibrarySyncReducerTest.kt
+++ b/app/src/test/java/com/nuvio/tv/domain/model/LibrarySyncReducerTest.kt
@@ -112,6 +112,75 @@ class LibrarySyncReducerTest {
     }
 
     @Test
+    fun deltaPreservesLocalGenresAndReleaseInfoWhenRemoteSparse() {
+        val existing = libraryItem(
+            id = "existing",
+            logo = "local-logo",
+            releaseInfo = "2014",
+            genres = listOf("Action", "Drama")
+        )
+        val remoteSparse = libraryItem("existing", addedAt = 2L)
+        val state = LibrarySyncState(
+            items = listOf(existing),
+            deltaCursorEventId = 5L,
+            deltaInitialized = true
+        )
+
+        val result = LibrarySyncReducer.applyDelta(
+            state = state,
+            events = listOf(LibraryDeltaEvent(6L, "upsert", remoteSparse))
+        )
+
+        val merged = result.state.items.single { it.id == "existing" }
+        assertEquals("local-logo", merged.logo)
+        assertEquals("2014", merged.releaseInfo)
+        assertEquals(listOf("Action", "Drama"), merged.genres)
+    }
+
+    @Test
+    fun snapshotPreservesLocalFilterMetadataWhenRemoteSparse() {
+        val local = libraryItem(
+            id = "old",
+            releaseInfo = "1999",
+            genres = listOf("Comedy"),
+            imdbRating = 8.2f
+        )
+        val state = LibrarySyncState(
+            items = listOf(local),
+            deltaInitialized = true
+        )
+
+        val result = LibrarySyncReducer.applySnapshot(
+            state = state,
+            remoteItems = listOf(libraryItem("old", addedAt = 10L)),
+            cursorEventId = 3L
+        )
+
+        val merged = result.state.items.single { it.id == "old" }
+        assertEquals("1999", merged.releaseInfo)
+        assertEquals(listOf("Comedy"), merged.genres)
+        assertEquals(8.2f, merged.imdbRating)
+    }
+
+    @Test
+    fun withPreservedLocalMetadataPrefersRemoteWhenRemoteHasValues() {
+        val local = libraryItem(
+            id = "item",
+            releaseInfo = "2001",
+            genres = listOf("Local")
+        )
+        val remote = libraryItem(
+            id = "item",
+            releaseInfo = "2020",
+            genres = listOf("Remote")
+        )
+
+        val merged = remote.withPreservedLocalMetadata(local)
+        assertEquals("2020", merged.releaseInfo)
+        assertEquals(listOf("Remote"), merged.genres)
+    }
+
+    @Test
     fun deltaPreservesPendingLocalMutationAndAdvancesCursor() {
         val local = libraryItem("local", addedAt = 20L)
         val state = LibrarySyncState(
@@ -174,7 +243,10 @@ class LibrarySyncReducerTest {
     private fun libraryItem(
         id: String,
         addedAt: Long = 1L,
-        logo: String? = null
+        logo: String? = null,
+        releaseInfo: String? = null,
+        genres: List<String> = emptyList(),
+        imdbRating: Float? = null
     ): SavedLibraryItem {
         return SavedLibraryItem(
             id = id,
@@ -184,9 +256,9 @@ class LibrarySyncReducerTest {
             posterShape = PosterShape.POSTER,
             background = null,
             description = null,
-            releaseInfo = null,
-            imdbRating = null,
-            genres = emptyList(),
+            releaseInfo = releaseInfo,
+            imdbRating = imdbRating,
+            genres = genres,
             addonBaseUrl = null,
             logo = logo,
             addedAt = addedAt


### PR DESCRIPTION
## Summary

Library Year/Genre filters only listed options for items that already stored `releaseInfo`/`genres`. Older local library rows often lacked those fields, so a library of ~129 titles could show only two years and a handful of genres. This PR backfills missing filter metadata from the primary meta addon and preserves richer local fields when sparse Nuvio Sync rows would wipe them.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Year and Genre filters in Library are built only from stored per-item metadata. Items added before full meta was persisted (or pulled as sparse cloud rows) contribute nothing to the facet lists, so the filters look empty/incomplete even though the posters are present. New adds work because they store genres/year at insert time.

## Issue or approval

Fixes #2875

## Reproduction steps

1. Open Library → Saved with a large library that includes older items.
2. Open the Year filter.
3. Observe only a few years (often with count 1) despite many titles in the grid.
4. Open the Genre filter and observe the same sparse option list.
5. Add a new title from details → it appears in the Year/Genre lists after add.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Filter dropdowns populate more completely as missing metadata is backfilled; no layout/chrome changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does **not** change Trakt/Simkl library projections (Simkl still projects empty genres; separate path).
- Does **not** reintroduce logo hydration on the library flow.
- Does **not** force a cloud push for every backfilled row (quiet local update, same pattern as logo).
- Does **not** alter filter UI chrome or sort behavior.
- Remote values still win when the cloud already has non-empty genres/year.

## Testing

**Automated**
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.domain.model.LibrarySyncReducerTest"` — PASSED (10 tests, 0 failures)
- `./gradlew :app:compileFullDebugKotlin` — PASSED

**Unit coverage added**
- Sparse remote delta/snapshot preserves local genres + releaseInfo + rating
- Remote non-empty values still override local

**Not run here**
- Full Android TV emulator with a large real library + live meta addon (network backfill path)
- End-to-end Nuvio Sync pull after hydration

**Manual verification plan (device/emulator with library)**
1. Install build from this branch.
2. Open Library → Saved on a library that previously showed sparse Year/Genre options.
3. Wait briefly for background meta hydration (throttled ~75ms/item).
4. Re-open Year and Genre filters → expect many more years/genres with counts matching library titles that have meta.
5. Pull Nuvio Sync (if logged in) → enriched local genres/year should not disappear when remote rows are sparse.

@haveAnIssue if you can try a debug build from this PR branch on your library: open Year/Genre filters after staying on Library for a minute and confirm older titles now appear in the option lists.

## Screenshots / Video

Not a layout/UI chrome change. Filter option lists become complete once metadata is present (same dropdown component).

## Breaking changes

None.

## Linked issues

Fixes #2875
