### PR TITLE
fix(details): resolve episode watched ticks across sibling content ids (#2883)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -85,8 +85,25 @@ class WatchedItemsPreferences @Inject constructor(
     }
 
     fun getWatchedEpisodesForContent(contentId: String): Flow<Set<Pair<Int, Int>>> {
+        return getWatchedEpisodesForContents(listOf(contentId))
+    }
+
+    /**
+     * Union of watched S/E pairs for any of [contentIds].
+     * Used by the details page so ticks still resolve when history was stored under a
+     * sibling id (navigation/catalog id vs canonical meta/IMDB id).
+     */
+    fun getWatchedEpisodesForContents(contentIds: Collection<String>): Flow<Set<Pair<Int, Int>>> {
+        val idSet = contentIds
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+        if (idSet.isEmpty()) {
+            return allItems.map { emptySet() }
+        }
         return allItems.map { items ->
-            items.filter { it.contentId == contentId && it.season != null && it.episode != null }
+            items.asSequence()
+                .filter { it.contentId in idSet && it.season != null && it.episode != null }
                 .map { it.season!! to it.episode!! }
                 .toSet()
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeWatchedProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeWatchedProjection.kt
@@ -18,3 +18,41 @@ internal fun resolveEpisodeWatchedState(
     }
     return currentlyWatched
 }
+
+/**
+ * Content IDs that may hold Nuvio Sync watched/progress rows for the open details page.
+ *
+ * Playback often writes under the navigation/catalog id (e.g. `tmdb:123` or an addon id),
+ * while the details screen later prefers the canonical meta id (usually IMDB `tt…`).
+ * Looking up only one of those keys leaves episode ticks empty even though Continue
+ * Watching and mobile still see the same history.
+ */
+internal fun detailWatchedContentIds(
+    navigationItemId: String,
+    effectiveContentId: String,
+    metaId: String?,
+    metaImdbId: String?
+): List<String> {
+    val result = ArrayList<String>(4)
+    fun addId(raw: String?) {
+        val id = raw?.trim().orEmpty()
+        if (id.isNotEmpty() && id !in result) {
+            result.add(id)
+        }
+    }
+    addId(effectiveContentId)
+    addId(navigationItemId)
+    addId(metaId)
+    addId(metaImdbId)
+    return result
+}
+
+internal fun mergeEpisodeKeySets(
+    sets: Iterable<Set<Pair<Int, Int>>>
+): Set<Pair<Int, Int>> {
+    val merged = linkedSetOf<Pair<Int, Int>>()
+    for (set in sets) {
+        merged.addAll(set)
+    }
+    return merged
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -55,6 +56,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -415,31 +417,33 @@ class MetaDetailsViewModel @Inject constructor(
     private fun observeWatchProgress() {
         if (itemType.lowercase() == "movie") return
         viewModelScope.launch {
-            _effectiveContentId.flatMapLatest { cid ->
-                if (itemType.equals("other", ignoreCase = true)) {
-                    // For "other" type, videos lack season/episode.
-                    // Build progress map by matching video IDs to their
-                    // position in the meta video list.
-                    watchProgressRepository.allProgress.map { allProgress ->
-                        val meta = _uiState.value.meta
-                        val videos = meta?.videos ?: emptyList()
-                        val progressByVideoId = allProgress
-                            .filter { it.contentId == cid }
-                            .associateBy { it.videoId }
-                        val result = mutableMapOf<Pair<Int, Int>, WatchProgress>()
-                        videos.forEachIndexed { index, video ->
-                            val progress = progressByVideoId[video.id]
-                            if (progress != null) {
-                                // Use synthetic season=1, episode=index+1 as key
-                                result[1 to (index + 1)] = progress
+            detailWatchedContentIdFlow()
+                .flatMapLatest { contentIds ->
+                    if (itemType.equals("other", ignoreCase = true)) {
+                        // For "other" type, videos lack season/episode.
+                        // Build progress map by matching video IDs to their
+                        // position in the meta video list.
+                        watchProgressRepository.allProgress.map { allProgress ->
+                            val idSet = contentIds.toSet()
+                            val meta = _uiState.value.meta
+                            val videos = meta?.videos ?: emptyList()
+                            val progressByVideoId = allProgress
+                                .filter { it.contentId in idSet }
+                                .associateBy { it.videoId }
+                            val result = mutableMapOf<Pair<Int, Int>, WatchProgress>()
+                            videos.forEachIndexed { index, video ->
+                                val progress = progressByVideoId[video.id]
+                                if (progress != null) {
+                                    // Use synthetic season=1, episode=index+1 as key
+                                    result[1 to (index + 1)] = progress
+                                }
                             }
+                            result as Map<Pair<Int, Int>, WatchProgress>
                         }
-                        result as Map<Pair<Int, Int>, WatchProgress>
+                    } else {
+                        mergeEpisodeProgressFlows(contentIds)
                     }
-                } else {
-                    watchProgressRepository.getAllEpisodeProgress(cid)
                 }
-            }
                 .distinctUntilChanged()
                 .collectLatest { progressMap ->
                 _uiState.update { state ->
@@ -454,6 +458,42 @@ class MetaDetailsViewModel @Inject constructor(
                 reevaluateSeriesWatchedBadge()
                 calculateNextToWatch()
             }
+        }
+    }
+
+    private fun detailWatchedContentIdFlow() = combine(
+        _effectiveContentId,
+        _uiState.map { it.meta?.id to it.meta?.imdbId }.distinctUntilChanged()
+    ) { effectiveId, metaIds ->
+        detailWatchedContentIds(
+            navigationItemId = itemId,
+            effectiveContentId = effectiveId,
+            metaId = metaIds.first,
+            metaImdbId = metaIds.second
+        )
+    }.distinctUntilChanged()
+
+    private fun mergeEpisodeProgressFlows(
+        contentIds: List<String>
+    ): Flow<Map<Pair<Int, Int>, WatchProgress>> {
+        if (contentIds.isEmpty()) {
+            return flowOf(emptyMap())
+        }
+        if (contentIds.size == 1) {
+            return watchProgressRepository.getAllEpisodeProgress(contentIds.first())
+        }
+        val flows = contentIds.map { watchProgressRepository.getAllEpisodeProgress(it) }
+        return combine(flows) { maps ->
+            val merged = linkedMapOf<Pair<Int, Int>, WatchProgress>()
+            for (map in maps) {
+                for ((key, progress) in map) {
+                    val existing = merged[key]
+                    if (existing == null || progress.lastWatched >= existing.lastWatched) {
+                        merged[key] = progress
+                    }
+                }
+            }
+            merged
         }
     }
 
@@ -493,10 +533,11 @@ class MetaDetailsViewModel @Inject constructor(
     private fun observeWatchedEpisodes() {
         if (itemType.lowercase() == "movie") return
         viewModelScope.launch {
-            _effectiveContentId.flatMapLatest { cid ->
+            detailWatchedContentIdFlow()
+                .flatMapLatest { contentIds ->
                 combine(
-                    watchedItemsPreferences.getWatchedEpisodesForContent(cid),
-                    watchProgressRepository.getAllEpisodeProgress(cid),
+                    watchedItemsPreferences.getWatchedEpisodesForContents(contentIds),
+                    mergeEpisodeProgressFlows(contentIds),
                     _uiState.map { it.meta?.videos }.distinctUntilChanged(),
                 ) { localWatched, progressMap, videos ->
                     val fromProgress = progressMap.filterValues { it.isCompleted() }.keys
@@ -848,11 +889,17 @@ class MetaDetailsViewModel @Inject constructor(
 
         // Pre-compute nextToWatch before applyMeta so the PlayButton text is stable
         // from the first composition — prevents focus invalidation from late recomposition.
-        val progressMap = watchProgressRepository
-            .getAllEpisodeProgress(_effectiveContentId.value)
-            .first()
+        // Union sibling content ids so ticks/next-up match Nuvio Sync history stored under
+        // the navigation id while the screen prefers the canonical meta/IMDB id (#2883).
+        val contentIds = detailWatchedContentIds(
+            navigationItemId = itemId,
+            effectiveContentId = _effectiveContentId.value,
+            metaId = enriched.id,
+            metaImdbId = enriched.imdbId
+        )
+        val progressMap = mergeEpisodeProgressFlows(contentIds).first()
         val watchedEpisodes = watchedItemsPreferences
-            .getWatchedEpisodesForContent(_effectiveContentId.value)
+            .getWatchedEpisodesForContents(contentIds)
             .first()
         val precomputedNextToWatch = computeNextToWatch(enriched, progressMap, watchedEpisodes)
         updateNextToWatch(precomputedNextToWatch)

--- a/app/src/test/java/com/nuvio/tv/ui/screens/detail/EpisodeWatchedProjectionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/detail/EpisodeWatchedProjectionTest.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.ui.screens.detail
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -89,6 +90,44 @@ class EpisodeWatchedProjectionTest {
                 optimisticallyUnmarked = true,
                 watchedByVideoId = true
             )
+        )
+    }
+
+    @Test
+    fun `detail watched lookup keeps navigation id when effective id is canonical imdb`() {
+        // Repro for #2883: CW/mobile store history under tmdb:/catalog id while
+        // details switches effective id to tt… and previously lost episode ticks.
+        assertEquals(
+            listOf("tt1234567", "tmdb:999", "tt9999999"),
+            detailWatchedContentIds(
+                navigationItemId = "tmdb:999",
+                effectiveContentId = "tt1234567",
+                metaId = "tt1234567",
+                metaImdbId = "tt9999999"
+            )
+        )
+    }
+
+    @Test
+    fun `detail watched lookup dedupes blank and identical ids`() {
+        assertEquals(
+            listOf("tt1", "tmdb:2"),
+            detailWatchedContentIds(
+                navigationItemId = " tmdb:2 ",
+                effectiveContentId = "tt1",
+                metaId = "tt1",
+                metaImdbId = "  "
+            )
+        )
+    }
+
+    @Test
+    fun `merge episode key sets unions sibling content id history`() {
+        val underTmdb = setOf(1 to 1, 1 to 2)
+        val underImdb = setOf(1 to 2, 1 to 3)
+        assertEquals(
+            setOf(1 to 1, 1 to 2, 1 to 3),
+            mergeEpisodeKeySets(listOf(underTmdb, underImdb))
         )
     }
 }


### PR DESCRIPTION
## Summary

On series details, episode watched ticks stayed empty for Nuvio Sync–only users even though Continue Watching advanced correctly and mobile showed the same history. The details screen looked up watched/progress under a single content id (usually the canonical meta/IMDB id after meta load), while playback often stored history under the navigation/catalog id. This PR unions sibling ids when projecting episode watched state and completed progress for the details page.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Reporter on #2883 (Nuvio sync only, no Trakt): after finishing episodes from Continue Watching, the home row advances but the series details page shows every episode unwatched and offers S01E01. Mobile already has the ticks. Looking up only `_effectiveContentId` misses sibling history keys, so `watchedEpisodes` stays empty.

Note: `046b5d43` (already on `dev`) correctly treats `isWatchedByVideoId == null` so provider misses no longer strip Nuvio-local ticks; this PR covers the remaining sibling-id gap for Nuvio-only history.

## Issue or approval

Fixes #2883

## Reproduction steps

1. Use Nuvio Sync only (no Trakt/Simkl) on Android TV.
2. Play an episode from Continue Watching until it completes.
3. Confirm Continue Watching advances to the next episode.
4. Long-press that card → View details.
5. Observe episode list: all episodes appear unwatched (no ticks); play action may still point at S01E01.
6. Confirm the same account on mobile shows watched ticks.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Episode tick badges and next-to-watch on the details page can now reflect history stored under sibling content ids. No layout chrome changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does **not** change Trakt/Simkl multi-device merge rules or source-of-truth policy.
- Does **not** rewrite stored content ids or migrate existing progress rows.
- Does **not** alter Continue Watching construction beyond what details already reads for next-up.
- Does **not** change mark/unmark write paths (still write under the active effective id).
- Does **not** touch external player / scrobble bulk history.

## Testing

**Automated**
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.detail.EpisodeWatchedProjectionTest"` — PASSED
- `./gradlew :app:compileFullDebugKotlin` — PASSED

**Unit coverage added**
- `detailWatchedContentIds` keeps navigation + effective + meta/imdb siblings and dedupes blanks
- `mergeEpisodeKeySets` unions S/E history from sibling keys
- Existing `resolveEpisodeWatchedState` Nuvio-null / provider cases still covered

**Not run here**
- Full Android TV emulator with a real Nuvio Sync account and multi-episode series
- End-to-end play-from-CW → details ticks on device

**Manual verification plan (device/emulator with Nuvio Sync)**
1. Install a build from this PR branch.
2. Nuvio Sync only (Trakt/Simkl off).
3. Finish an episode from Continue Watching.
4. Open series details from that CW card.
5. Expected: completed episodes show ticks; next-to-watch points at the next unwatched episode (not always S01E01).

## Screenshots / Video

Not a UI chrome change. Tick badges appear on episode rows once sibling history is resolved (same badge component).

## Breaking changes

None.

## Linked issues

Fixes #2883
