### PR TITLE
fix(home): stop freezing shimmer URLs on landscape cards (#2421)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -448,17 +448,23 @@ internal fun buildCatalogItem(
     // Carry forward the frozen URLs from the previous cache entry so that
     // TMDB enrichment never changes the image shown on landscape cards,
     // even after the composable remember-state is lost (e.g. navigation).
-    val carriedBackdrop = previousCachedItem?.heroPreview?.frozenBackdropUrl
-    val carriedLogo = previousCachedItem?.heroPreview?.frozenLogoUrl
+    // Never carry shimmer placeholder URLs — they are not real art and would
+    // stick on first-visible cards when LazyRow reuses index-based keys.
+    val carriedBackdrop = realImageUrl(previousCachedItem?.heroPreview?.frozenBackdropUrl)
+    val carriedLogo = realImageUrl(previousCachedItem?.heroPreview?.frozenLogoUrl)
 
-    val currentBackdrop = item.backdropUrl
-    val currentLogo = item.logo
+    val currentBackdrop = realImageUrl(item.backdropUrl)
+    val currentLogo = realImageUrl(item.logo)
 
-    // First non-blank value wins and is never replaced.
-    val frozenBackdrop = carriedBackdrop?.takeIf { it.isNotBlank() }
-        ?: currentBackdrop
-    val frozenLogo = carriedLogo?.takeIf { it.isNotBlank() }
-        ?: currentLogo
+    // First real (non-placeholder) value wins and is never replaced.
+    val frozenBackdrop = carriedBackdrop ?: currentBackdrop
+    val frozenLogo = carriedLogo ?: currentLogo
+
+    val cardImageUrl = if (useLandscapePosters) {
+        firstRealImageUrl(item.backdropUrl, item.poster)
+    } else {
+        firstRealImageUrl(item.poster, item.backdropUrl)
+    }
 
     val heroPreview = HeroPreview(
         title = item.name,
@@ -480,11 +486,7 @@ internal fun buildCatalogItem(
         genres = item.genres.take(3).asStable(),
         poster = item.poster,
         backdrop = item.backdropUrl,
-        imageUrl = if (useLandscapePosters) {
-            item.backdropUrl ?: item.poster
-        } else {
-            item.poster ?: item.backdropUrl
-        },
+        imageUrl = cardImageUrl,
         frozenBackdropUrl = frozenBackdrop,
         frozenLogoUrl = frozenLogo
     )
@@ -493,11 +495,7 @@ internal fun buildCatalogItem(
         key = "catalog_${row.key()}_${item.id}_${occurrence}",
         title = item.name,
         subtitle = item.releaseInfo,
-        imageUrl = if (useLandscapePosters) {
-            item.backdropUrl ?: item.poster
-        } else {
-            item.poster ?: item.backdropUrl
-        },
+        imageUrl = cardImageUrl,
         heroPreview = heroPreview,
         payload = ModernPayload.Catalog(
             focusKey = "${row.key()}::${item.id}",
@@ -602,6 +600,34 @@ internal fun isSeriesType(type: String?): Boolean {
 
 internal fun firstNonBlank(vararg candidates: String?): String? {
     return candidates.firstOrNull { !it.isNullOrBlank() }?.trim()
+}
+
+/** Shimmer / skeleton cards use this scheme until real catalog data arrives. */
+internal const val PLACEHOLDER_IMAGE_SCHEME = "placeholder://"
+
+/**
+ * True for synthetic shimmer URLs such as `placeholder://empty`.
+ * These must never be frozen as landscape art — LazyRow reuses the same
+ * index-based keys when placeholders are replaced by real items, so a frozen
+ * placeholder URL would stick on the first visible cards until recycle.
+ */
+internal fun isPlaceholderImageUrl(url: String?): Boolean {
+    return !url.isNullOrBlank() && url.startsWith(PLACEHOLDER_IMAGE_SCHEME)
+}
+
+/** Non-blank, non-placeholder image URL suitable for Coil / landscape freeze. */
+internal fun realImageUrl(url: String?): String? {
+    val trimmed = url?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    return if (trimmed.startsWith(PLACEHOLDER_IMAGE_SCHEME)) null else trimmed
+}
+
+/** First usable real image URL among candidates (skips blank + placeholder). */
+internal fun firstRealImageUrl(vararg candidates: String?): String? {
+    for (candidate in candidates) {
+        val real = realImageUrl(candidate)
+        if (real != null) return real
+    }
+    return null
 }
 
 internal fun extractYear(releaseInfo: String?): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -1045,12 +1045,20 @@ private fun ModernCarouselCard(
     // The first non-blank value wins and is never replaced.
     // Primary source of truth is the data-layer frozen value (survives navigation);
     // the remember-state acts as a secondary guard within the same composition.
-    val dataFrozenLogo = item.heroPreview.frozenLogoUrl
-    val frozenLogoUrl = remember(item.key) { mutableStateOf(dataFrozenLogo ?: item.heroPreview.logo) }
-    if (frozenLogoUrl.value.isNullOrBlank() && !item.heroPreview.logo.isNullOrBlank()) {
-        frozenLogoUrl.value = item.heroPreview.logo
+    // Never freeze shimmer placeholder URLs. LazyRow reuses index-based item keys
+    // when placeholder cards become real catalog items, so a sticky placeholder
+    // would leave the first visible landscape cards blank until recycle (#2421).
+    val dataFrozenLogo = realImageUrl(item.heroPreview.frozenLogoUrl)
+    val frozenLogoUrl = remember(item.key) {
+        mutableStateOf(dataFrozenLogo ?: realImageUrl(item.heroPreview.logo))
     }
-    if (!enrichedLogoUrl.isNullOrBlank() && frozenLogoUrl.value != enrichedLogoUrl) {
+    if (realImageUrl(frozenLogoUrl.value) == null) {
+        realImageUrl(item.heroPreview.logo)?.let { frozenLogoUrl.value = it }
+    }
+    if (!enrichedLogoUrl.isNullOrBlank() &&
+        !isPlaceholderImageUrl(enrichedLogoUrl) &&
+        frozenLogoUrl.value != enrichedLogoUrl
+    ) {
         // Outside landscape we always pick up the enriched URL so manual artwork
         // updates land instantly. Inside landscape we still adopt the enriched
         // URL when there was no logo to begin with — otherwise the card would
@@ -1058,37 +1066,54 @@ private fun ModernCarouselCard(
         // ships items without a logo even
         // though TMDB has one. Once we have any non-blank value we keep it
         // frozen to avoid mid-scroll flicker on enrichment refresh.
-        if (!useLandscapeOverlayTreatment || frozenLogoUrl.value.isNullOrBlank()) {
+        if (!useLandscapeOverlayTreatment || realImageUrl(frozenLogoUrl.value) == null) {
             frozenLogoUrl.value = enrichedLogoUrl
         }
     }
-    val effectiveLogoUrl = frozenLogoUrl.value
+    val effectiveLogoUrl = realImageUrl(frozenLogoUrl.value)
     // Freeze the backdrop URL for landscape cards - prevents image reload when enrichment updates backdrop.
-    val dataFrozenBackdrop = item.heroPreview.frozenBackdropUrl
-    val frozenBackdropUrl = remember(item.key) { mutableStateOf(dataFrozenBackdrop ?: item.heroPreview.backdrop) }
-    if (frozenBackdropUrl.value.isNullOrBlank() && !item.heroPreview.backdrop.isNullOrBlank()) {
-        frozenBackdropUrl.value = item.heroPreview.backdrop
+    val dataFrozenBackdrop = realImageUrl(item.heroPreview.frozenBackdropUrl)
+    val frozenBackdropUrl = remember(item.key) {
+        mutableStateOf(dataFrozenBackdrop ?: realImageUrl(item.heroPreview.backdrop))
     }
-    if (!useLandscapeOverlayTreatment && !enrichedBackdropUrl.isNullOrBlank() && frozenBackdropUrl.value != enrichedBackdropUrl) {
+    if (realImageUrl(frozenBackdropUrl.value) == null) {
+        realImageUrl(item.heroPreview.backdrop)?.let { frozenBackdropUrl.value = it }
+            ?: realImageUrl(item.heroPreview.poster)?.let { frozenBackdropUrl.value = it }
+            ?: realImageUrl(item.imageUrl)?.let { frozenBackdropUrl.value = it }
+    }
+    if (!useLandscapeOverlayTreatment &&
+        !enrichedBackdropUrl.isNullOrBlank() &&
+        !isPlaceholderImageUrl(enrichedBackdropUrl) &&
+        frozenBackdropUrl.value != enrichedBackdropUrl
+    ) {
         frozenBackdropUrl.value = enrichedBackdropUrl
     }
-    val effectiveBackdropUrl = frozenBackdropUrl.value
+    val effectiveBackdropUrl = realImageUrl(frozenBackdropUrl.value)
     var isFocused by remember { mutableStateOf(false) }
     val payload = item.payload as? ModernPayload.CollectionFolder
     val isCollectionFolder = item.payload is ModernPayload.CollectionFolder
     val baseImageUrl = if (focusedPosterBackdropExpandEnabled && isBackdropExpanded) {
         if (useLandscapeOverlayTreatment) {
-            effectiveBackdropUrl ?: item.heroPreview.backdrop ?: item.imageUrl ?: item.heroPreview.poster
+            firstRealImageUrl(
+                effectiveBackdropUrl,
+                item.heroPreview.backdrop,
+                item.imageUrl,
+                item.heroPreview.poster
+            )
         } else {
-            item.heroPreview.backdrop ?: item.imageUrl ?: item.heroPreview.poster
+            firstRealImageUrl(
+                item.heroPreview.backdrop,
+                item.imageUrl,
+                item.heroPreview.poster
+            )
         }
     } else if (useLandscapeOverlayTreatment && !isCollectionFolder) {
-        effectiveBackdropUrl ?: item.heroPreview.poster
+        firstRealImageUrl(effectiveBackdropUrl, item.heroPreview.poster, item.imageUrl)
     } else if (isCollectionFolder && !payload?.coverEmoji.isNullOrBlank()) {
         // Emoji cover folders: never fall back to backdrop for the card poster
-        item.imageUrl
+        realImageUrl(item.imageUrl)
     } else {
-        item.imageUrl ?: item.heroPreview.poster ?: item.heroPreview.backdrop
+        firstRealImageUrl(item.imageUrl, item.heroPreview.poster, item.heroPreview.backdrop)
     }
     val imageUrl = when {
         payload == null -> baseImageUrl

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/LandscapePlaceholderImageUrlTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/LandscapePlaceholderImageUrlTest.kt
@@ -1,0 +1,189 @@
+package com.nuvio.tv.ui.screens.home
+
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression for #2421: with Landscape Posters enabled, the first visible cards
+ * stayed blank after shimmer placeholders were replaced by real catalog items.
+ *
+ * Root cause: LazyRow reuses index-based keys, so composition state froze
+ * `placeholder://empty` as the landscape backdrop and never adopted the real URL.
+ */
+class LandscapePlaceholderImageUrlTest {
+
+    @Test
+    fun `placeholder scheme is detected`() {
+        assertTrue(isPlaceholderImageUrl("placeholder://empty"))
+        assertTrue(isPlaceholderImageUrl("placeholder://shimmer"))
+        assertFalse(isPlaceholderImageUrl(null))
+        assertFalse(isPlaceholderImageUrl(""))
+        assertFalse(isPlaceholderImageUrl("https://cdn.example/poster.jpg"))
+    }
+
+    @Test
+    fun `realImageUrl strips placeholders and blanks`() {
+        assertNull(realImageUrl(null))
+        assertNull(realImageUrl("  "))
+        assertNull(realImageUrl("placeholder://empty"))
+        assertEquals(
+            "https://cdn.example/bg.jpg",
+            realImageUrl("  https://cdn.example/bg.jpg  "),
+        )
+    }
+
+    @Test
+    fun `firstRealImageUrl skips placeholder then picks poster`() {
+        assertEquals(
+            "https://cdn.example/poster.jpg",
+            firstRealImageUrl(
+                "placeholder://empty",
+                null,
+                "https://cdn.example/poster.jpg",
+            ),
+        )
+        assertNull(firstRealImageUrl("placeholder://empty", null, "  "))
+    }
+
+    @Test
+    fun `buildCatalogItem does not freeze placeholder backdrop`() {
+        val row = sampleRow()
+        val placeholderItem = sampleMeta(
+            id = "__placeholder_top_0",
+            poster = "placeholder://empty",
+            background = null,
+        )
+
+        val built = buildCatalogItem(
+            item = placeholderItem,
+            row = row,
+            useLandscapePosters = true,
+            occurrence = 0,
+        )
+
+        assertNull(built.heroPreview.frozenBackdropUrl)
+        assertNull(built.imageUrl)
+        assertNull(realImageUrl(built.heroPreview.backdrop))
+    }
+
+    @Test
+    fun `buildCatalogItem ignores carried placeholder when real art arrives`() {
+        val row = sampleRow()
+        val stickyPlaceholder = buildCatalogItem(
+            item = sampleMeta(
+                id = "old",
+                poster = "placeholder://empty",
+                background = "placeholder://empty",
+            ),
+            row = row,
+            useLandscapePosters = true,
+            occurrence = 0,
+        ).let { item ->
+            // Simulate a corrupt cache entry that somehow froze a placeholder.
+            item.copy(
+                heroPreview = item.heroPreview.copy(
+                    frozenBackdropUrl = "placeholder://empty",
+                    frozenLogoUrl = "placeholder://empty",
+                ),
+            )
+        }
+
+        val real = buildCatalogItem(
+            item = sampleMeta(
+                id = "tt123",
+                poster = "https://cdn.example/poster.jpg",
+                background = "https://cdn.example/backdrop.jpg",
+                logo = "https://cdn.example/logo.png",
+            ),
+            row = row,
+            useLandscapePosters = true,
+            occurrence = 0,
+            previousCachedItem = stickyPlaceholder,
+        )
+
+        assertEquals("https://cdn.example/backdrop.jpg", real.heroPreview.frozenBackdropUrl)
+        assertEquals("https://cdn.example/logo.png", real.heroPreview.frozenLogoUrl)
+        assertEquals("https://cdn.example/backdrop.jpg", real.imageUrl)
+    }
+
+    @Test
+    fun `buildCatalogItem landscape freezes first real backdrop and keeps it over later enrichment`() {
+        val row = sampleRow()
+        val first = buildCatalogItem(
+            item = sampleMeta(
+                id = "tt123",
+                poster = "https://cdn.example/poster.jpg",
+                background = "https://cdn.example/backdrop-addon.jpg",
+            ),
+            row = row,
+            useLandscapePosters = true,
+            occurrence = 0,
+        )
+        val enriched = buildCatalogItem(
+            item = sampleMeta(
+                id = "tt123",
+                poster = "https://cdn.example/poster.jpg",
+                background = "https://cdn.example/backdrop-tmdb.jpg",
+            ),
+            row = row,
+            useLandscapePosters = true,
+            occurrence = 0,
+            previousCachedItem = first,
+        )
+
+        assertEquals("https://cdn.example/backdrop-addon.jpg", first.heroPreview.frozenBackdropUrl)
+        assertEquals(
+            "https://cdn.example/backdrop-addon.jpg",
+            enriched.heroPreview.frozenBackdropUrl,
+        )
+    }
+
+    @Test
+    fun `landscape card image recovery prefers real art over sticky placeholder`() {
+        // Models the compose recovery path when remember(item.key) still holds
+        // a placeholder from the shimmer card that shared this LazyRow key.
+        val stickyFrozen = "placeholder://empty"
+        val recovered = firstRealImageUrl(
+            realImageUrl(stickyFrozen),
+            "https://cdn.example/backdrop.jpg",
+            "https://cdn.example/poster.jpg",
+        )
+        assertEquals("https://cdn.example/backdrop.jpg", recovered)
+    }
+
+    private fun sampleRow(): CatalogRow = CatalogRow(
+        addonId = "cinemeta",
+        addonName = "Cinemeta",
+        addonBaseUrl = "https://v3-cinemeta.strem.io",
+        catalogId = "top",
+        catalogName = "Top",
+        type = ContentType.MOVIE,
+        items = emptyList(),
+    )
+
+    private fun sampleMeta(
+        id: String,
+        poster: String?,
+        background: String?,
+        logo: String? = null,
+    ): MetaPreview = MetaPreview(
+        id = id,
+        type = ContentType.MOVIE,
+        name = "Sample",
+        poster = poster,
+        posterShape = PosterShape.POSTER,
+        background = background,
+        logo = logo,
+        description = null,
+        releaseInfo = "2024",
+        imdbRating = null,
+        genres = emptyList(),
+    )
+}


### PR DESCRIPTION
## Summary

Fix blank first-visible landscape catalog cards after shimmer placeholders resolve to real items (#2421).

When **Landscape Posters** is enabled, modern home / Follow Layout rows freeze the first backdrop URL so TMDB enrichment cannot flicker the art. LazyRow reuses **index-based** item keys (`stableItemKey(index)`), so the first visible cards keep composition state from the shimmer pass. That state was freezing `placeholder://empty` as the landscape image, which Coil cannot load — cards stayed blank until scrolled off-screen and recycled.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With Landscape Posters on (especially collection folders with Follow Home Layout), the first ~5 cards in a row often render with no image. Scrolling right loads later cards correctly; scrolling the blank cards off-screen and back makes them appear. Disabling Landscape Posters works around it. Multiple reporters confirmed the pattern on Fire TV / Android TV with addon-backed catalogs.

## Issue or approval

Fixes #2421

## Reproduction steps

1. Enable **Settings → Layout → Home → Landscape Posters**.
2. Prefer a collection folder with **Follow Home Layout** (or any modern catalog row that shows shimmer placeholders while loading).
3. Open a collection / catalog that loads via addon metadata (not pure TMDB-only).
4. Observe the first visible landscape cards: blank/empty art.
5. Scroll right: later cards show images.
6. Scroll the first cards off-screen and back: they populate.

Expected after fix: first visible cards show real poster/backdrop as soon as catalog data replaces shimmer.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does **not** change landscape layout metrics, trailer autoplay, or enrichment policy for real URLs.
- Does **not** change portrait poster path (already used live `item.imageUrl` and was not sticky-broken the same way).
- Still freezes the first **real** backdrop for landscape to avoid mid-scroll TMDB flicker.
- Does **not** redesign LazyRow keys (would be a larger, riskier change).

## Testing

**Unit**
```text
.\gradlew.bat :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.home.LandscapePlaceholderImageUrlTest"
```
PASSED — covers placeholder detection, `buildCatalogItem` freeze rules, and sticky-placeholder recovery.

**Compile**
```text
.\gradlew.bat :app:compileFullDebugKotlin
```
PASSED

**Logic repro (unit-encoded)**
- Placeholder meta → no frozen backdrop / no card image URL
- Carried `placeholder://empty` cache entry ignored when real art arrives
- Landscape still freezes first real backdrop across enrichment rebuilds

**Emulator / device**
- Not fully run here with real addon catalogs + collections (needs configured addons).
- Please verify on Android TV / Fire OS with Landscape Posters ON + a loading collection row.

## Screenshots / Video

Not a visual redesign — restores missing landscape card art after load. Happy to add before/after captures if maintainers want them from a debug build.

## Breaking changes

None

## Linked issues

Fixes #2421
