### PR TITLE
fix: ignore stale Matroska Dolby Vision config when color metadata is SDR

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DolbyVisionCompatibility.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DolbyVisionCompatibility.java
@@ -16,6 +16,7 @@
 package com.nuvio.tv.core.player.dvmkv;
 
 import androidx.annotation.Nullable;
+import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.UnstableApi;
@@ -83,6 +84,11 @@ public final class DolbyVisionCompatibility {
     }
     int profile = parseIntOrUnset(parts[1]);
     return profile == 7;
+  }
+
+  public static boolean isStaleContainerDolbyVisionConfig(
+      boolean hasColorInfo, @C.ColorTransfer int colorTransfer) {
+    return hasColorInfo && colorTransfer == C.COLOR_TRANSFER_SDR;
   }
 
   @Nullable

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -3175,6 +3175,13 @@ public class MatroskaExtractor implements Extractor {
         DolbyVisionConfig dolbyVisionConfig =
             DolbyVisionConfig.parse(new ParsableByteArray(this.dolbyVisionConfigBytes));
         if (dolbyVisionConfig != null) {
+          if (DolbyVisionCompatibility.isStaleContainerDolbyVisionConfig(
+              hasColorInfo, colorTransfer)) {
+            Log.i(
+                TAG,
+                "Ignoring stale Matroska Dolby Vision config: track color metadata indicates SDR");
+            dolbyVisionConfigBytes = null;
+          } else {
           codecs = dolbyVisionConfig.codecs;
           mimeType = MimeTypes.VIDEO_DOLBY_VISION;
           if (dolbyVisionSampleTransformer != null) {
@@ -3197,6 +3204,7 @@ public class MatroskaExtractor implements Extractor {
                 codecs = hevcCodecsString;
               }
             }
+          }
           }
         }
       } else if (dolbyVisionSampleTransformer != null && codecs != null) {


### PR DESCRIPTION
## Summary

Fix playback getting stuck on the loading overlay for some MKV direct-play streams. When a re-encoded file (e.g. YTS x265 SDR) retains stale Matroska Dolby Vision container metadata, ExoPlayer was routing the track to `video/dolby-vision` even though the bitstream is plain HEVC with BT.709 SDR color. Decoder init fails or the first frame never renders, so the loading overlay never dismisses.

This change ignores container DV config when track color metadata explicitly signals SDR, keeping the stream on the HEVC path in AUTO and all other DV handling modes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some MKV releases carry a leftover `DolbyVisionConfig` block from the source WEB-DL after x265 re-encode. ffprobe may report DOVI side data, but the actual video is SDR HEVC (`color_transfer=bt709`, x265 encoder tag, no HDR10/DV bitstream).

NuvioTV's vendored `MatroskaExtractor` treated any container DV config as real Dolby Vision and switched mime to `video/dolby-vision`. On devices without a matching DV decoder (or when AUTO leaves the stream on the native DV path), playback never reaches the first frame. The player stays in buffering/loading state with the overlay visible indefinitely.

## Issue or approval

Loading overlay stuck: on some MKV direct-play streams playback never starts and the loading overlay does not dismiss. Reproduced locally with a debrid direct-play MKV URL. No GitHub issue filed.

## Reproduction steps

**Sample stream tested:**


- Container: MKV (`video/x-matroska`)
- Video: HEVC Main 10, 3840×1606, SDR BT.709
- Stale MKV block: `Dolby Vision configuration` / `dvvC` from source, not a real DV encode

1. Open the stream in NuvioTV on `dev` with DV7 handling set to **AUTO** (default).
2. Player resolves mime as matroska and starts initialization.
3. Matroska extractor sees container DV config and advertises `video/dolby-vision`.
4. Decoder path fails or never renders a frame; loading overlay remains stuck.
5. Build this branch and replay the same stream.
6. Expected: log `Ignoring stale Matroska Dolby Vision config: track color metadata indicates SDR`, track stays `video/hevc`, first frame renders, overlay dismisses.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No UI or loading-overlay logic changes; fix is at Matroska format detection only.
- No changes to real HDR10/DV streams (PQ/HLG color transfer still trusts container DV config).
- No DV7 libdovi conversion, AUTO policy, or decoder fallback ladder changes.
- Two files only: `DolbyVisionCompatibility.java`, `MatroskaExtractor.java`.

## Testing

- `./gradlew :app:assembleFullDebug` — compile verified.
- ffprobe on sample URL: confirms SDR BT.709 HEVC with stale DOVI container side data.
- Manual flow: stale DV config ignored when `colorTransfer == SDR`; genuine HDR DV streams unchanged.

## Screenshots / Video

Not a UI change. Loading overlay dismisses once playback starts; no layout/visual changes.

## Breaking changes

None.

## Linked issues

Loading overlay stuck — stale Matroska DV container metadata routes playback to the wrong decoder, the first frame never renders, and the overlay never dismisses. Reproduced locally. No GitHub issue filed.
