### PR TITLE
fix(tmdb): resolve anime IDs through ARM for enrichment

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.core.tmdb
 import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.repository.AnimeIdResolver
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -22,7 +23,8 @@ private val TMDB_API_KEY = BuildConfig.TMDB_API_KEY
  */
 @Singleton
 class TmdbService @Inject constructor(
-    private val tmdbApi: TmdbApi
+    private val tmdbApi: TmdbApi,
+    private val animeIdResolver: AnimeIdResolver
 ) {
     // Cache: IMDB ID -> TMDB ID
     private val imdbToTmdbCache = ConcurrentHashMap<String, Int>()
@@ -222,13 +224,26 @@ class TmdbService @Inject constructor(
         }
         
         // If it looks like a numeric ID, assume it's already a TMDB ID
-        if (idPart.all { it.isDigit() }) {
+        if (idPart.isNotEmpty() && idPart.all { it.isDigit() }) {
             return idPart
         }
         
         // Unknown format
         Log.w(TAG, "Unknown video ID format: $videoId")
         return null
+    }
+
+    /** Resolve IDs for metadata enrichment without changing normal playback ID handling. */
+    suspend fun ensureTmdbIdForEnrichment(videoId: String, mediaType: String): String? {
+        return if (animeIdResolver.supports(videoId)) {
+            animeIdResolver.resolveTmdbId(videoId)?.toString()
+        } else {
+            ensureTmdbId(videoId, mediaType)
+        }
+    }
+
+    suspend fun prefetchTmdbIdsForEnrichment(videoIds: Collection<String>) {
+        animeIdResolver.prefetchTmdbIds(videoIds)
     }
     
     /**
@@ -250,6 +265,7 @@ class TmdbService @Inject constructor(
         tmdbToImdbCache.clear()
         imdbToTmdbInFlight.clear()
         tmdbToImdbInFlight.clear()
+        animeIdResolver.clearCache()
         Log.d(TAG, "Cache cleared")
     }
     

--- a/app/src/main/java/com/nuvio/tv/data/local/AnimeIdCacheStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/AnimeIdCacheStore.kt
@@ -1,0 +1,96 @@
+package com.nuvio.tv.data.local
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.json.JSONObject
+
+data class CachedAnimeTmdbMapping(
+    val tmdbId: Int?,
+    val expiresAtMs: Long,
+    val missCount: Int
+)
+
+@Singleton
+class AnimeIdCacheStore @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val lock = Any()
+
+    fun get(source: String, id: String, nowMs: Long = System.currentTimeMillis()): CachedAnimeTmdbMapping? {
+        val raw = synchronized(lock) { preferences.getString(cacheKey(source, id), null) } ?: return null
+        val parsed = runCatching {
+            val json = JSONObject(raw)
+            CachedAnimeTmdbMapping(
+                tmdbId = json.optInt("tmdbId").takeIf { json.has("tmdbId") && !json.isNull("tmdbId") },
+                expiresAtMs = json.getLong("expiresAtMs"),
+                missCount = json.optInt("missCount", 0)
+            )
+        }.getOrNull() ?: return null
+        return parsed.takeIf { it.expiresAtMs > nowMs }
+    }
+
+    fun putSuccess(source: String, id: String, tmdbId: Int, nowMs: Long = System.currentTimeMillis()) {
+        put(source, id, tmdbId, nowMs + POSITIVE_TTL_MS, missCount = 0)
+    }
+
+    fun putMiss(source: String, id: String, nowMs: Long = System.currentTimeMillis()) {
+        val missCount = (readMissCount(source, id) + 1).coerceAtMost(3)
+        val ttl = when (missCount) {
+            1 -> FIRST_MISS_TTL_MS
+            2 -> SECOND_MISS_TTL_MS
+            else -> LATER_MISS_TTL_MS
+        }
+        put(source, id, tmdbId = null, expiresAtMs = nowMs + ttl, missCount = missCount)
+    }
+
+    fun putFailure(source: String, id: String, nowMs: Long = System.currentTimeMillis()) {
+        put(
+            source = source,
+            id = id,
+            tmdbId = null,
+            expiresAtMs = nowMs + FAILURE_TTL_MS,
+            missCount = readMissCount(source, id)
+        )
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            preferences.edit().clear().apply()
+        }
+    }
+
+    private fun put(
+        source: String,
+        id: String,
+        tmdbId: Int?,
+        expiresAtMs: Long,
+        missCount: Int
+    ) {
+        val json = JSONObject()
+            .put("tmdbId", tmdbId ?: JSONObject.NULL)
+            .put("expiresAtMs", expiresAtMs)
+            .put("missCount", missCount)
+        synchronized(lock) {
+            preferences.edit().putString(cacheKey(source, id), json.toString()).apply()
+        }
+    }
+
+    private fun readMissCount(source: String, id: String): Int {
+        val raw = synchronized(lock) { preferences.getString(cacheKey(source, id), null) } ?: return 0
+        return runCatching { JSONObject(raw).optInt("missCount", 0) }.getOrDefault(0)
+    }
+
+    private fun cacheKey(source: String, id: String): String = "$source:$id"
+
+    private companion object {
+        const val PREFERENCES_NAME = "anime_tmdb_id_mappings_v2"
+        const val POSITIVE_TTL_MS = 30L * 24 * 60 * 60 * 1000
+        const val FIRST_MISS_TTL_MS = 6L * 60 * 60 * 1000
+        const val SECOND_MISS_TTL_MS = 12L * 60 * 60 * 1000
+        const val LATER_MISS_TTL_MS = 24L * 60 * 60 * 1000
+        const val FAILURE_TTL_MS = 15L * 60 * 1000
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/SkipIntroApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/SkipIntroApi.kt
@@ -76,6 +76,13 @@ data class AniSkipInterval(
 // --- ARM API (IMDB -> MAL ID resolution) ---
 
 interface ArmApi {
+    @GET("ids")
+    suspend fun resolveId(
+        @Query("source") source: String,
+        @Query("id") id: String,
+        @Query("include") include: String = "themoviedb"
+    ): Response<ArmEntry>
+
     // /imdb?id=...&include=myanimelist,anilist,kitsu  → List<ArmEntry> (one per season)
     @GET("imdb")
     suspend fun resolveImdbToAll(
@@ -129,7 +136,8 @@ data class ArmEntry(
     @Json(name = "myanimelist") val myanimelist: Int? = null,
     @Json(name = "anilist") val anilist: Int? = null,
     @Json(name = "kitsu") val kitsu: Int? = null,
-    @Json(name = "imdb") val imdb: String? = null
+    @Json(name = "imdb") val imdb: String? = null,
+    @Json(name = "themoviedb") val themoviedb: Int? = null
 )
 
 // --- Anime-Skip API (GraphQL) ---

--- a/app/src/main/java/com/nuvio/tv/data/repository/AnimeIdResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AnimeIdResolver.kt
@@ -1,0 +1,165 @@
+package com.nuvio.tv.data.repository
+
+import android.util.Log
+import com.nuvio.tv.data.local.AnimeIdCacheStore
+import com.nuvio.tv.data.remote.api.ArmApi
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+
+@Singleton
+class AnimeIdResolver @Inject constructor(
+    private val armApi: ArmApi,
+    private val cacheStore: AnimeIdCacheStore
+) {
+    private val resolverScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val inFlight = ConcurrentHashMap<String, Deferred<Int?>>()
+    private val requestSemaphore = Semaphore(MAX_CONCURRENT_REQUESTS)
+    private val cacheGeneration = AtomicLong(0L)
+
+    fun supports(rawId: String): Boolean = parseArmRequest(rawId) != null
+
+    suspend fun resolveTmdbId(rawId: String): Int? {
+        val request = parseArmRequest(rawId) ?: return null
+        return resolveRequest(request)
+    }
+
+    private suspend fun resolveRequest(request: AnimeIdRequest): Int? {
+        cacheStore.get(request.source, request.id)?.let { return it.tmdbId }
+
+        val requestDeferred = inFlight.computeIfAbsent(request.cacheKey) {
+            val requestGeneration = cacheGeneration.get()
+            resolverScope.async(start = CoroutineStart.LAZY) {
+                fetchAndCache(request, requestGeneration)
+            }.also { deferred ->
+                deferred.invokeOnCompletion {
+                    inFlight.remove(request.cacheKey, deferred)
+                }
+            }
+        }
+        requestDeferred.start()
+        return requestDeferred.await()
+    }
+
+    suspend fun prefetchTmdbIds(rawIds: Collection<String>) {
+        val requests = rawIds
+            .asSequence()
+            .mapNotNull(::parseArmRequest)
+            .distinctBy { it.cacheKey }
+            .toList()
+        if (requests.isEmpty()) return
+
+        withContext(Dispatchers.IO) {
+            withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
+                coroutineScope {
+                    requests.map { request ->
+                        async { resolveRequest(request) }
+                    }.awaitAll()
+                }
+            }
+        }
+    }
+
+    fun clearCache() {
+        cacheGeneration.incrementAndGet()
+        inFlight.values.forEach { it.cancel() }
+        inFlight.clear()
+        cacheStore.clear()
+    }
+
+    private suspend fun fetchAndCache(request: AnimeIdRequest, requestGeneration: Long): Int? =
+        try {
+            withTimeout(REQUEST_TIMEOUT_MS) {
+                fetchOne(request, requestGeneration)
+            }
+        } catch (timeout: TimeoutCancellationException) {
+            Log.w(TAG, "ARM mapping timed out for ${request.cacheKey}")
+            if (cacheGeneration.get() == requestGeneration) {
+                cacheStore.putFailure(request.source, request.id)
+            }
+            null
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Log.w(TAG, "ARM mapping failed for ${request.cacheKey}: ${error.message}")
+            if (cacheGeneration.get() == requestGeneration) {
+                cacheStore.putFailure(request.source, request.id)
+            }
+            null
+        }
+
+    internal fun parseArmRequest(rawId: String): AnimeIdRequest? {
+        val normalized = rawId.trim().substringBefore('/').lowercase()
+        val rawParts = normalized.split(':').filter { it.isNotBlank() }
+        val parts = if (rawParts.firstOrNull() in setOf("movie", "series", "tv")) {
+            rawParts.drop(1)
+        } else {
+            rawParts
+        }
+        if (parts.size < 2) return null
+
+        val source = when (parts.first()) {
+            "mal", "myanimelist", "my-anime-list" -> "myanimelist"
+            "anilist", "ani-list" -> "anilist"
+            "kitsu" -> "kitsu"
+            "anidb", "ani-db" -> "anidb"
+            "animeplanet", "anime-planet" -> "anime-planet"
+            "animecountdown", "anime-countdown" -> "animecountdown"
+            "animenewsnetwork", "anime-news-network", "ann" -> "animenewsnetwork"
+            "anisearch", "ani-search" -> "anisearch"
+            "livechart", "live-chart" -> "livechart"
+            else -> return null
+        }
+        val id = parts.drop(1).firstOrNull { part ->
+            if (source == "anime-planet") part.isNotBlank() else part.all(Char::isDigit)
+        } ?: return null
+        return AnimeIdRequest(source = source, id = id)
+    }
+
+    private suspend fun fetchOne(request: AnimeIdRequest, requestGeneration: Long): Int? =
+        requestSemaphore.withPermit {
+            val response = armApi.resolveId(
+                source = request.source,
+                id = request.id,
+                include = "themoviedb"
+            )
+            if (!response.isSuccessful) {
+                throw IllegalStateException("ARM returned HTTP ${response.code()}")
+            }
+            val tmdbId = response.body()?.themoviedb
+            if (cacheGeneration.get() == requestGeneration) {
+                if (tmdbId != null) {
+                    cacheStore.putSuccess(request.source, request.id, tmdbId)
+                } else {
+                    cacheStore.putMiss(request.source, request.id)
+                }
+            }
+            tmdbId
+        }
+
+    internal data class AnimeIdRequest(val source: String, val id: String) {
+        val cacheKey: String = "$source:$id"
+    }
+
+    private companion object {
+        const val TAG = "AnimeIdResolver"
+        const val MAX_CONCURRENT_REQUESTS = 4
+        const val REQUEST_TIMEOUT_MS = 30_000L
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/MDBListRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MDBListRepository.kt
@@ -275,10 +275,13 @@ class MDBListRepository @Inject constructor(
         }
 
         val lookupType = if (fallbackItemType.isNotBlank()) fallbackItemType else mediaType
-        val converted = tmdbService.ensureTmdbId(meta.id, lookupType)?.toIntOrNull()?.let { tmdbNumericId ->
-            tmdbService.tmdbToImdb(tmdbNumericId, lookupType)
+        for (candidateId in listOf(meta.id, fallbackItemId).distinct()) {
+            val converted = tmdbService.ensureTmdbIdForEnrichment(candidateId, lookupType)
+                ?.toIntOrNull()
+                ?.let { tmdbNumericId -> tmdbService.tmdbToImdb(tmdbNumericId, lookupType) }
+            converted?.takeIf { it.startsWith("tt") }?.let { return it }
         }
-        return converted?.takeIf { it.startsWith("tt") }
+        return null
     }
 
     private fun extractImdbId(rawId: String?): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailViewModel.kt
@@ -1132,7 +1132,7 @@ class FolderDetailViewModel @Inject constructor(
 
             var enrichment: com.nuvio.tv.core.tmdb.TmdbEnrichment? = null
             if (tmdbEnabled) {
-                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                val tmdbId = runCatching { tmdbService.ensureTmdbIdForEnrichment(item.id, item.apiType) }.getOrNull()
                 if (tmdbId != null) {
                     enrichment = runCatching {
                         tmdbMetadataService.fetchEnrichment(
@@ -1406,7 +1406,7 @@ class FolderDetailViewModel @Inject constructor(
             try {
                 var tmdbEnriched = false
                 if (tmdbEnabled) {
-                    val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                    val tmdbId = runCatching { tmdbService.ensureTmdbIdForEnrichment(item.id, item.apiType) }.getOrNull()
                     if (tmdbId != null) {
                         val enrichment = runCatching {
                             tmdbMetadataService.fetchEnrichment(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1097,8 +1097,8 @@ class MetaDetailsViewModel @Inject constructor(
                     val settings = tmdbSettingsDataStore.settings.first()
                     val tmdbContentType = resolveTmdbContentType(meta)
                     val tmdbLookupType = tmdbContentType.toApiString()
-                    val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
-                        ?: tmdbService.ensureTmdbId(itemId, itemType)
+                    val tmdbId = tmdbService.ensureTmdbIdForEnrichment(meta.id, tmdbLookupType)
+                        ?: tmdbService.ensureTmdbIdForEnrichment(itemId, itemType)
                     if (tmdbId.isNullOrBlank()) {
                         _uiState.update { it.copy(moreLikeThis = emptyList(), moreLikeThisSource = null) }
                         return@launch
@@ -1237,8 +1237,8 @@ class MetaDetailsViewModel @Inject constructor(
                 }
 
                 val tmdbLookupType = tmdbContentType.toApiString()
-                val tmdbIdString = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
-                    ?: tmdbService.ensureTmdbId(itemId, itemType)
+                val tmdbIdString = tmdbService.ensureTmdbIdForEnrichment(meta.id, tmdbLookupType)
+                    ?: tmdbService.ensureTmdbIdForEnrichment(itemId, itemType)
                 val tmdbId = tmdbIdString?.toIntOrNull()
                 val imdbId = extractImdbId(meta.id) ?: extractImdbId(itemId)
 
@@ -1298,8 +1298,8 @@ class MetaDetailsViewModel @Inject constructor(
 
         val tmdbContentType = resolveTmdbContentType(meta)
         val tmdbLookupType = tmdbContentType.toApiString()
-        val tmdbId = tmdbService.ensureTmdbId(meta.id, tmdbLookupType)
-            ?: tmdbService.ensureTmdbId(itemId, itemType)
+        val tmdbId = tmdbService.ensureTmdbIdForEnrichment(meta.id, tmdbLookupType)
+            ?: tmdbService.ensureTmdbIdForEnrichment(itemId, itemType)
             ?: return meta
 
         val isSeries = meta.apiType in listOf("series", "tv")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1847,7 +1847,7 @@ private suspend fun HomeViewModel.enrichInProgressItem(
         async(Dispatchers.IO) {
             val cacheKey = "${item.progress.contentType}:${item.progress.contentId}"
             synchronized(cwTmdbIdCache) { cwTmdbIdCache[cacheKey] }
-                ?: runCatching { tmdbService.ensureTmdbId(item.progress.contentId, item.progress.contentType) }.getOrNull()
+                ?: runCatching { tmdbService.ensureTmdbIdForEnrichment(item.progress.contentId, item.progress.contentType) }.getOrNull()
         }
     } else null
 
@@ -1923,7 +1923,7 @@ private suspend fun HomeViewModel.enrichNextUpItem(
         async(Dispatchers.IO) {
             val cacheKey = "${progressSeed.contentType}:${progressSeed.contentId}"
             synchronized(cwTmdbIdCache) { cwTmdbIdCache[cacheKey] }
-                ?: runCatching { tmdbService.ensureTmdbId(progressSeed.contentId, progressSeed.contentType) }.getOrNull()
+                ?: runCatching { tmdbService.ensureTmdbIdForEnrichment(progressSeed.contentId, progressSeed.contentType) }.getOrNull()
         }
     } else null
 
@@ -2938,7 +2938,7 @@ private suspend fun HomeViewModel.resolveTmdbIdForNextUp(
         .distinct()
 
     for (candidate in candidates) {
-        tmdbService.ensureTmdbId(candidate, progress.contentType)?.let {
+        tmdbService.ensureTmdbIdForEnrichment(candidate, progress.contentType)?.let {
             synchronized(cwTmdbIdCache) {
                 cwTmdbIdCache[cacheKey] = it
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -485,7 +485,7 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
             var tmdbEnriched = false
 
             if (tmdbEnabledForCurrentLayout) {
-                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                val tmdbId = runCatching { tmdbService.ensureTmdbIdForEnrichment(item.id, item.apiType) }.getOrNull()
 
                 val enrichmentDeferred = if (tmdbId != null) async {
                     runCatching {
@@ -578,7 +578,7 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
         try {
             var tmdbEnriched = false
             if (tmdbEnabledForCurrentLayout) {
-                val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
+                val tmdbId = runCatching { tmdbService.ensureTmdbIdForEnrichment(item.id, item.apiType) }.getOrNull()
                 val enrichment = if (tmdbId != null) runCatching {
                     tmdbMetadataService.fetchEnrichment(
                         tmdbId = tmdbId,
@@ -828,12 +828,14 @@ internal suspend fun HomeViewModel.enrichHeroItemsPipeline(
     val mdbSettings = currentMdbListSettings
     val mdbEnabled = mdbSettings.enabled && mdbSettings.apiKey.isNotBlank()
 
+    tmdbService.prefetchTmdbIdsForEnrichment(items.map { it.id })
+
     return coroutineScope {
         items.map { item ->
             async(Dispatchers.IO) {
                 try {
                     val tmdbDeferred = async {
-                        val tmdbId = tmdbService.ensureTmdbId(item.id, item.apiType) ?: return@async null
+                        val tmdbId = tmdbService.ensureTmdbIdForEnrichment(item.id, item.apiType) ?: return@async null
                         tmdbId.toIntOrNull()?.let { numericId ->
                             runCatching { tmdbService.tmdbToImdb(numericId, item.apiType) }
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -90,7 +90,7 @@ private suspend fun PlayerRuntimeController.enrichDescriptionFromTmdb(id: String
     val settings = tmdbSettingsDataStore.settings.first()
     if (!settings.enabled || !settings.useBasicInfo) return
 
-    val tmdbId = runCatching { tmdbService.ensureTmdbId(id, type) }.getOrNull() ?: return
+    val tmdbId = runCatching { tmdbService.ensureTmdbIdForEnrichment(id, type) }.getOrNull() ?: return
     val contentType = when (type.lowercase()) {
         "series", "tv" -> ContentType.SERIES
         else -> ContentType.MOVIE

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbServiceTest.kt
@@ -1,0 +1,32 @@
+package com.nuvio.tv.core.tmdb
+
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.repository.AnimeIdResolver
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TmdbServiceTest {
+
+    @Test
+    fun `arm mapping is limited to enrichment resolution`() = runTest {
+        val animeIdResolver = mockk<AnimeIdResolver>()
+        every { animeIdResolver.supports("mal:62322") } returns true
+        coEvery { animeIdResolver.resolveTmdbId("mal:62322") } returns 298994
+        val service = TmdbService(
+            tmdbApi = mockk<TmdbApi>(relaxed = true),
+            animeIdResolver = animeIdResolver
+        )
+
+        assertNull(service.ensureTmdbId("mal:62322", "series"))
+        coVerify(exactly = 0) { animeIdResolver.resolveTmdbId(any()) }
+
+        assertEquals("298994", service.ensureTmdbIdForEnrichment("mal:62322", "series"))
+        coVerify(exactly = 1) { animeIdResolver.resolveTmdbId("mal:62322") }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/AnimeIdResolverTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AnimeIdResolverTest.kt
@@ -1,0 +1,163 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.data.local.AnimeIdCacheStore
+import com.nuvio.tv.data.local.CachedAnimeTmdbMapping
+import com.nuvio.tv.data.remote.api.ArmApi
+import com.nuvio.tv.data.remote.api.ArmEntry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import retrofit2.Response
+
+class AnimeIdResolverTest {
+
+    @Test
+    fun `mal id resolves directly to arm themoviedb mapping`() = runTest {
+        val api = mockk<ArmApi>()
+        val cache = mockk<AnimeIdCacheStore>(relaxed = true)
+        every { cache.get(any(), any(), any()) } returns null
+        coEvery {
+            api.resolveId(source = "myanimelist", id = "62322", include = "themoviedb")
+        } returns Response.success(ArmEntry(themoviedb = 298994))
+        val resolver = AnimeIdResolver(api, cache)
+
+        val tmdbId = resolver.resolveTmdbId("mal:62322:1:4")
+
+        assertEquals(298994, tmdbId)
+        coVerify(exactly = 1) {
+            api.resolveId(source = "myanimelist", id = "62322", include = "themoviedb")
+        }
+    }
+
+    @Test
+    fun `cached arm mapping avoids a network request`() = runTest {
+        val api = mockk<ArmApi>()
+        val cache = mockk<AnimeIdCacheStore>(relaxed = true)
+        every { cache.get("kitsu", "3505", any()) } returns CachedAnimeTmdbMapping(
+            tmdbId = 24835,
+            expiresAtMs = Long.MAX_VALUE,
+            missCount = 0
+        )
+        val resolver = AnimeIdResolver(api, cache)
+
+        assertEquals(24835, resolver.resolveTmdbId("kitsu:3505"))
+        coVerify(exactly = 0) { api.resolveId(any(), any(), any()) }
+    }
+
+    @Test
+    fun `prefetch resolves supported anime ids`() = runTest {
+        val api = mockk<ArmApi>()
+        val cache = mockk<AnimeIdCacheStore>(relaxed = true)
+        every { cache.get(any(), any(), any()) } returns null
+        coEvery {
+            api.resolveId("myanimelist", "62322", "themoviedb")
+        } returns Response.success(ArmEntry(themoviedb = 298994))
+        coEvery {
+            api.resolveId("anilist", "4181", "themoviedb")
+        } returns Response.success(ArmEntry(themoviedb = 24835))
+        val resolver = AnimeIdResolver(api, cache)
+
+        resolver.prefetchTmdbIds(listOf("mal:62322", "anilist:4181"))
+
+        coVerify(exactly = 1) {
+            api.resolveId("myanimelist", "62322", "themoviedb")
+            api.resolveId("anilist", "4181", "themoviedb")
+        }
+    }
+
+    @Test
+    fun `prefetch shares an in flight request with direct resolution`() = runTest {
+        val api = mockk<ArmApi>()
+        val cache = mockk<AnimeIdCacheStore>(relaxed = true)
+        val cacheChecks = AtomicInteger()
+        val secondCacheCheck = CompletableDeferred<Unit>()
+        every { cache.get(any(), any(), any()) } answers {
+            if (cacheChecks.incrementAndGet() >= 2) secondCacheCheck.complete(Unit)
+            null
+        }
+        val requestStarted = CompletableDeferred<Unit>()
+        val releaseRequest = CompletableDeferred<Unit>()
+        coEvery {
+            api.resolveId("myanimelist", "62322", "themoviedb")
+        } coAnswers {
+            requestStarted.complete(Unit)
+            releaseRequest.await()
+            Response.success(ArmEntry(themoviedb = 298994))
+        }
+        val resolver = AnimeIdResolver(api, cache)
+
+        val directLookup = async { resolver.resolveTmdbId("mal:62322") }
+        requestStarted.await()
+        val prefetch = async { resolver.prefetchTmdbIds(listOf("mal:62322")) }
+        secondCacheCheck.await()
+        releaseRequest.complete(Unit)
+
+        assertEquals(298994, directLookup.await())
+        prefetch.await()
+        coVerify(exactly = 1) {
+            api.resolveId("myanimelist", "62322", "themoviedb")
+        }
+    }
+
+    @Test
+    fun `one cancelled caller does not cancel a shared mapping request`() = runTest {
+        val api = mockk<ArmApi>()
+        val cache = mockk<AnimeIdCacheStore>(relaxed = true)
+        val cacheChecks = AtomicInteger()
+        val secondCacheCheck = CompletableDeferred<Unit>()
+        every { cache.get(any(), any(), any()) } answers {
+            if (cacheChecks.incrementAndGet() >= 2) secondCacheCheck.complete(Unit)
+            null
+        }
+        val requestStarted = CompletableDeferred<Unit>()
+        val releaseRequest = CompletableDeferred<Unit>()
+        coEvery {
+            api.resolveId("kitsu", "3505", "themoviedb")
+        } coAnswers {
+            requestStarted.complete(Unit)
+            releaseRequest.await()
+            Response.success(ArmEntry(themoviedb = 24835))
+        }
+        val resolver = AnimeIdResolver(api, cache)
+
+        val firstCaller = async { resolver.resolveTmdbId("kitsu:3505") }
+        requestStarted.await()
+        firstCaller.cancel()
+        val secondCaller = async { resolver.resolveTmdbId("kitsu:3505") }
+        secondCacheCheck.await()
+        releaseRequest.complete(Unit)
+
+        assertEquals(24835, secondCaller.await())
+        coVerify(exactly = 1) {
+            api.resolveId("kitsu", "3505", "themoviedb")
+        }
+    }
+
+    @Test
+    fun `imdb ids are not treated as arm anime aliases`() {
+        val api = mockk<ArmApi>()
+        val resolver = AnimeIdResolver(armApi = api, cacheStore = mockk(relaxed = true))
+
+        assertNull(resolver.parseArmRequest("tt1118804"))
+        assertEquals("myanimelist", resolver.parseArmRequest("mal:4181")?.source)
+        assertEquals("4181", resolver.parseArmRequest("mal:4181")?.id)
+    }
+
+    @Test
+    fun `prefetch ignores non anime ids without contacting arm`() = runTest {
+        val api = mockk<ArmApi>()
+        val resolver = AnimeIdResolver(armApi = api, cacheStore = mockk(relaxed = true))
+
+        resolver.prefetchTmdbIds(listOf("tt1118804", "tmdb:24835", "24835"))
+
+        coVerify(exactly = 0) { api.resolveId(any(), any(), any()) }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/MDBListRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/MDBListRepositoryTest.kt
@@ -1,0 +1,124 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.MDBListSettingsDataStore
+import com.nuvio.tv.data.remote.api.MDBListApi
+import com.nuvio.tv.data.remote.dto.mdblist.MDBListRatingItemDto
+import com.nuvio.tv.data.remote.dto.mdblist.MDBListRatingResponseDto
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MDBListSettings
+import com.nuvio.tv.domain.model.Meta
+import com.nuvio.tv.domain.model.PosterShape
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+class MDBListRepositoryTest {
+
+    @Test
+    fun `anime id is mapped through arm before requesting mdblist rating`() = runTest {
+        val api = mockk<MDBListApi>()
+        val settings = mockk<MDBListSettingsDataStore>()
+        val tmdbService = mockk<TmdbService>()
+        every { settings.settings } returns flowOf(
+            MDBListSettings(enabled = true, apiKey = "test-key")
+        )
+        coEvery {
+            tmdbService.ensureTmdbIdForEnrichment("mal:62322", "series")
+        } returns "298994"
+        coEvery {
+            tmdbService.tmdbToImdb(298994, "series")
+        } returns "tt38262097"
+        coEvery {
+            api.getRating(
+                mediaType = "show",
+                ratingType = "imdb",
+                apiKey = "test-key",
+                body = any()
+            )
+        } returns Response.success(
+            MDBListRatingResponseDto(
+                ratings = listOf(MDBListRatingItemDto(rating = 8.4))
+            )
+        )
+        val repository = MDBListRepository(api, settings, tmdbService)
+
+        val rating = repository.getImdbRatingForItem("mal:62322", "series")
+
+        assertEquals(8.4, rating ?: 0.0, 0.0)
+        coVerify(exactly = 1) {
+            tmdbService.ensureTmdbIdForEnrichment("mal:62322", "series")
+            tmdbService.tmdbToImdb(298994, "series")
+        }
+    }
+
+    @Test
+    fun `fallback anime id is used when resolved meta id cannot be mapped`() = runTest {
+        val api = mockk<MDBListApi>()
+        val settings = mockk<MDBListSettingsDataStore>()
+        val tmdbService = mockk<TmdbService>()
+        every { settings.settings } returns flowOf(
+            MDBListSettings(
+                enabled = true,
+                apiKey = "test-key",
+                showTrakt = false,
+                showTmdb = false,
+                showLetterboxd = false,
+                showTomatoes = false,
+                showAudience = false,
+                showMetacritic = false,
+                showMal = false
+            )
+        )
+        coEvery {
+            tmdbService.ensureTmdbIdForEnrichment("addon:resolved-title", "series")
+        } returns null
+        coEvery {
+            tmdbService.ensureTmdbIdForEnrichment("mal:62322", "series")
+        } returns "298994"
+        coEvery { tmdbService.tmdbToImdb(298994, "series") } returns "tt38262097"
+        coEvery {
+            api.getRating("show", "imdb", "test-key", any())
+        } returns Response.success(
+            MDBListRatingResponseDto(
+                ratings = listOf(MDBListRatingItemDto(rating = 8.4))
+            )
+        )
+        val repository = MDBListRepository(api, settings, tmdbService)
+        val meta = Meta(
+            id = "addon:resolved-title",
+            type = ContentType.SERIES,
+            name = "Test",
+            poster = null,
+            posterShape = PosterShape.POSTER,
+            background = null,
+            logo = null,
+            description = null,
+            releaseInfo = null,
+            imdbRating = null,
+            genres = emptyList(),
+            runtime = null,
+            director = emptyList(),
+            cast = emptyList(),
+            videos = emptyList(),
+            country = null,
+            awards = null,
+            language = null,
+            links = emptyList()
+        )
+
+        val result = repository.getRatingsForMeta(meta, "mal:62322", "series")
+
+        assertEquals(8.4, result?.ratings?.imdb ?: 0.0, 0.0)
+        coVerify(exactly = 1) {
+            tmdbService.ensureTmdbIdForEnrichment("addon:resolved-title", "series")
+            tmdbService.ensureTmdbIdForEnrichment("mal:62322", "series")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds provider independent anime ID mapping for TMDB and MDBList enrichment.

When metadata uses a supported MAL, AniList, Kitsu, AniDB, Anime Planet, AnimeCountdown, Anime News Network, AniSearch, or LiveChart ID, Nuvio resolves it through Anime Relations Mapping and passes the resulting TMDB ID into the existing enrichment paths. The original addon content ID is never replaced.

ARM resolution is restricted to metadata enrichment. Normal playback, stream lookup, addon routing, and the existing `ensureTmdbId` behavior do not use ARM.

Successful mappings are cached for 30 days. Confirmed misses retry after 6, 12, then 24 hours, while network failures retry after 15 minutes. Requests are deduplicated, limited to four concurrent lookups, and capped at 30 seconds. Home presentation prefetches supported IDs so successful mappings are ready before individual enrichment work begins.

This supersedes #2743. That PR depended on AIO Metadata's nonstandard `imdb_id` field and only worked for addons exposing the same custom alias. This implementation does not require or preserve addon aliases, so it works with supported anime IDs regardless of which compliant metadata addon supplied them.

The release date behavior from #2641 is unchanged.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

TMDB enrichment only understood IMDb and numeric TMDB IDs. Anime catalogs commonly use IDs from MAL, AniList, Kitsu, and other anime databases, so enrichment stopped before TMDB even when the title had a valid TMDB mapping.

The previous alias fallback did not solve the general problem because `imdb_id` is not part of the official Stremio meta contract. Resolving only supported anime ID formats through ARM fixes the missing enrichment without changing addon IDs or broadening normal playback ID handling.

## Issue or approval

Fixes #2906

## Reproduction steps

1. Enable TMDB enrichment and MDBList ratings.
2. Open anime metadata whose primary content ID is `mal:`, `anilist:`, `kitsu:`, or another supported anime provider ID.
3. Use metadata that does not contain AIO Metadata's custom `imdb_id` alias.
4. Before this fix, TMDB and MDBList enrichment remain unavailable because the primary ID is rejected.
5. After this fix, the ID maps through ARM and the existing TMDB and MDBList paths receive a canonical ID.
6. Repeat with ordinary IMDb, numeric TMDB, and unsupported addon IDs. Their existing behavior remains unchanged.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- ARM is used only for metadata enrichment.
- Addon content IDs are never replaced or rewritten.
- No alias fields are added to the metadata model.
- Normal stream lookup, playback IDs, addon routing, and external player behavior are unchanged.
- Existing IMDb and numeric TMDB behavior is unchanged.
- Ordinary non anime IDs never call ARM.
- TMDB settings, metadata precedence, release date selection, episode availability, and UI are unchanged.
- No artwork, layout, or loading behavior changes are included.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.data.repository.AnimeIdResolverTest" --tests "com.nuvio.tv.core.tmdb.TmdbServiceTest" --tests "com.nuvio.tv.data.repository.MDBListRepositoryTest"`
- `./gradlew :app:assembleFullDebug`
- Installed the full debug build on an NVIDIA Shield TV 2019 running Android 11.
- Verified supported anime IDs resolve through ARM for TMDB enrichment.
- Verified MDBList continues through the canonical TMDB to IMDb path.
- Verified successful mappings are reused from cache.
- Verified concurrent requests share one ARM lookup and caller cancellation does not cancel shared work.
- Verified ordinary addon IDs, existing IMDb IDs, and numeric TMDB IDs retain their previous behavior.
- Verified the release date behavior from #2641 remains separate and unchanged.

### Tester APK

[NuvioTV ARM enrichment test build](https://gofile.io/d/ECDHR6)

## Screenshots / Video

No UI layout change. These screenshots from #2743 still demonstrate the missing and restored enrichment result. The implementation producing the result is now provider independent and does not rely on the old alias fallback.

### Before

<img width="3840" height="2160" alt="BeforeAndroidTV" src="https://github.com/user-attachments/assets/745b9e75-0b3b-4028-9b19-4fc97a3929a3" />

### After

<img width="2688" height="1512" alt="AfterAndroidTV" src="https://github.com/user-attachments/assets/0ed644c4-e90f-4e5c-a41a-455901e47bf3" />

## Breaking changes

None.

## Linked issues

Fixes #2906

Supersedes #2743 and its alias specific issue #2742.

Mobile counterpart: NuvioMedia/NuvioMobile#1679 and NuvioMedia/NuvioMobile#1680

