### PR TITLE
Simkl CW duplicates on batch mark and stale next-up after marking

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationReceipt.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationReceipt.kt
@@ -116,8 +116,7 @@ internal fun SimklApiResponse.toHistoryMutationReceipt(
         mutation = SimklCommittedMutation.AddToHistory(accepted),
         requiresReconciliation = accepted.any { resolved ->
             resolved.status == null ||
-                resolved.request.media.kind != TrackingMediaKind.MOVIE &&
-                resolved.request.media.episode == null
+                resolved.request.media.kind != TrackingMediaKind.MOVIE
         }
     )
 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklScrobbleReconciliation.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklScrobbleReconciliation.kt
@@ -243,16 +243,16 @@ internal fun SimklMedia.matchesTarget(target: SimklMedia): Boolean {
 
 private fun TrackingExternalIds.comparableMatch(target: TrackingExternalIds): Boolean? {
     if (simkl != null && target.simkl != null) return simkl == target.simkl
-    if (mal != null && target.mal != null) return mal == target.mal
-    if (anidb != null && target.anidb != null) return anidb == target.anidb
-    if (anilist != null && target.anilist != null) return anilist == target.anilist
-    if (kitsu != null && target.kitsu != null) return kitsu == target.kitsu
-    if (!tvdb.isNullOrBlank() && !target.tvdb.isNullOrBlank()) {
-        return tvdb.equals(target.tvdb, ignoreCase = true)
-    }
     if (!imdb.isNullOrBlank() && !target.imdb.isNullOrBlank()) {
         return imdb.equals(target.imdb, ignoreCase = true)
     }
     if (tmdb != null && target.tmdb != null) return tmdb == target.tmdb
+    if (!tvdb.isNullOrBlank() && !target.tvdb.isNullOrBlank()) {
+        return tvdb.equals(target.tvdb, ignoreCase = true)
+    }
+    if (mal != null && target.mal != null) return mal == target.mal
+    if (anidb != null && target.anidb != null) return anidb == target.anidb
+    if (anilist != null && target.anilist != null) return anilist == target.anilist
+    if (kitsu != null && target.kitsu != null) return kitsu == target.kitsu
     return null
 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklSyncEngine.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklSyncEngine.kt
@@ -76,9 +76,19 @@ fun mergeSimklDelta(
     val merged = current.mapNotNull { entry -> entry.stableKey()?.let { key -> key to entry } }
         .toMap()
         .toMutableMap()
+    val deltaEntries = mutableListOf<SimklLibraryEntry>()
     delta.presentTypes().forEach { type ->
         delta.entriesFor(type).forEach { entry ->
             entry.stableKey()?.let { key -> merged[key] = entry }
+            deltaEntries += entry
+        }
+    }
+    deltaEntries.forEach { deltaEntry ->
+        val deltaMedia = deltaEntry.media ?: return@forEach
+        merged.entries.removeIf { (key, existing) ->
+            key != deltaEntry.stableKey() &&
+                existing.mediaType == deltaEntry.mediaType &&
+                existing.media?.matchesTarget(deltaMedia) == true
         }
     }
     return merged.values.sortedWith(simklEntryComparator)


### PR DESCRIPTION
## Summary

- Fix stale optimistic entries persisting in Simkl snapshot after sync refresh, causing duplicate CW items for anime with multiple seasons 
- Fix comparableMatch priority order so shared IDs (IMDb/TMDB/TVDB) are checked before per-season anime IDs (kitsu/mal/anilist), preventing false mismatches during optimistic reconciliation
- Fix addToHistory not triggering sync refresh for series episodes, causing CW to show stale next-to-watch after batch marking a season as watched

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When marking anime seasons as watched in quick succession:
1. Each season's optimistic commit created a new entry in the Simkl snapshot with only kitsu ID (from videoId)
2. When sync refresh fetched the real data from Simkl API (keyed by imdb id), the stale optimistic entries were not removed because mergeSimklDelta matched by stableKey which differed between optimistic ("kitsu:X") and API ("ttXXXXX") entries
3. The orphaned optimistic entries produced separate next-up seeds with kitsu/mal-based contentIds, resulting in duplicate CW items
4. Additionally, after marking all episodes watched, CW didn't update because addToHistory with episodes didn't trigger a sync refresh

## Issue or approval

No linked issue - discovered during testing.

## Reproduction steps

1. Open anime series details (e.g. Spy x Family) with multiple seasons on Simkl
2. Mark season 1 as watched, then immediately season 2, then season 3
3. Go to home -> Continue Watching shows 3-4 duplicate entries for the same anime
4. Additionally: mark all episodes of a season -> CW still shows next-up for that season until manual refresh

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only Simkl tracking provider affected
- No changes to Trakt, local progress, or CW pipeline logic
- comparableMatch reorder is safe because simkl ID (highest priority) is still checked first

## Testing

- TCL Android TV, debug build
- Verified: mark 4 seasons of anime in quick succession -> single CW entry after sync refresh
- Verified: mark all episodes of last season -> CW removes the item after sync refresh (within seconds)
- Verified: Demon Slayer (shared IMDb across seasons) resolves to single next-up entry
- Verified: no regression for non-anime shows (Arcane, etc.)

## Screenshots / Video

Not a UI change (fixes duplicate CW items back to single entry)

## Breaking changes

None.

## Linked issues

None - discovered during testing.
