### PR TITLE
fix(home): honor poster corner radius on Continue Watching cards (#2911)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -81,8 +81,6 @@ import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import com.nuvio.tv.ui.util.computeAirDateBadgeText
 
-private val CwCardShape = RoundedCornerShape(NuvioTheme.radii.md)
-private val CwClipShape = RoundedCornerShape(topStart = NuvioTheme.spacing.md, topEnd = NuvioTheme.spacing.md)
 private val BadgeShape = RoundedCornerShape(NuvioTheme.radii.xs)
 private val CwNewEpisodeBadgeColor = Color(0xFF1D4ED8)
 private val CwNewSeasonBadgeColor = Color(0xFFB45309)
@@ -111,7 +109,8 @@ fun ContinueWatchingSection(
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
     lastFocusedIndexState: MutableIntState = remember { mutableIntStateOf(-1) },
     cardWidth: Dp = 288.dp,
-    imageHeight: Dp = 162.dp
+    imageHeight: Dp = 162.dp,
+    cornerRadius: Dp = NuvioTheme.radii.md,
 ) {
     if (items.isEmpty()) return
 
@@ -229,6 +228,7 @@ fun ContinueWatchingSection(
                     useEpisodeThumbnails = useEpisodeThumbnails,
                     cardWidth = cardWidth,
                     imageHeight = imageHeight,
+                    cornerRadius = cornerRadius,
                     modifier = Modifier
                         .onFocusChanged { focusState ->
                             if (focusState.isFocused && lastFocusedIndex != index) {
@@ -352,11 +352,17 @@ fun ContinueWatchingCard(
     cardWidth: Dp = 288.dp,
     imageHeight: Dp = 162.dp,
     blurUnwatchedEpisodes: Boolean = false,
-    useEpisodeThumbnails: Boolean = true
+    useEpisodeThumbnails: Boolean = true,
+    cornerRadius: Dp = NuvioTheme.radii.md,
 ) {
     var longPressTriggered by remember { mutableStateOf(false) }
     val cardDepthStyle = LocalCardDepthStyle.current
     val longPressKeyTracker = rememberLongPressKeyTracker()
+    // Match Settings > Layout poster corner radius (catalog rows already honor this).
+    val cwCardShape = remember(cornerRadius) { RoundedCornerShape(cornerRadius) }
+    val cwClipShape = remember(cornerRadius) {
+        RoundedCornerShape(topStart = cornerRadius, topEnd = cornerRadius)
+    }
 
     val progress = remember(item) { (item as? ContinueWatchingItem.InProgress)?.progress }
     val nextUp = remember(item) { (item as? ContinueWatchingItem.NextUp)?.info }
@@ -507,7 +513,7 @@ fun ContinueWatchingCard(
                 }
                 false
             },
-        shape = CardDefaults.shape(shape = CwCardShape),
+        shape = CardDefaults.shape(shape = cwCardShape),
         colors = CardDefaults.colors(
             containerColor = Color.Transparent,
             focusedContainerColor = Color.Transparent
@@ -515,7 +521,7 @@ fun ContinueWatchingCard(
         border = CardDefaults.border(
             focusedBorder = Border(
                 border = BorderStroke(NuvioTheme.spacing.xxs, NuvioTheme.colors.FocusRing),
-                shape = CwCardShape
+                shape = cwCardShape
             )
         ),
         scale = CardDefaults.scale(focusedScale = 1f)
@@ -523,7 +529,7 @@ fun ContinueWatchingCard(
         Column(
             modifier = Modifier
                 .nuvioCardDepth(
-                    shape = CwCardShape,
+                    shape = cwCardShape,
                     surface = CardDepthSurface.CONTINUE_WATCHING,
                     style = cardDepthStyle
                 )
@@ -533,7 +539,7 @@ fun ContinueWatchingCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(imageHeight)
-                    .clip(CwClipShape)
+                    .clip(cwClipShape)
             ) {
                 // Background image with size hints for efficient decoding
                 if (effectiveImageModel.isNullOrBlank()) {
@@ -548,7 +554,7 @@ fun ContinueWatchingCard(
                                 compositingStrategy =
                                     CompositingStrategy.Offscreen
                             }
-                            .clip(CwClipShape)
+                            .clip(cwClipShape)
 
                             // Gradient overlay for text legibility
                             .drawWithContent {

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
@@ -54,7 +54,8 @@ fun GridContinueWatchingSection(
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
     onItemFocused: (Int) -> Unit = {},
     blurUnwatchedEpisodes: Boolean = false,
-    useEpisodeThumbnails: Boolean = true
+    useEpisodeThumbnails: Boolean = true,
+    cornerRadius: Dp = NuvioTheme.radii.md,
 ) {
     if (items.isEmpty()) return
 
@@ -139,6 +140,7 @@ fun GridContinueWatchingSection(
                     onLongPress = stableOnLongPress,
                     blurUnwatchedEpisodes = blurUnwatchedEpisodes,
                     useEpisodeThumbnails = useEpisodeThumbnails,
+                    cornerRadius = cornerRadius,
                     modifier = focusModifier
                         .onFocusChanged { focusState ->
                             if (focusState.isFocused && lastFocusedIndex.intValue != index) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -520,7 +520,8 @@ fun ClassicHomeContent(
                     downFocusRequester = cwDownRequester,
                     focusRequesters = cwItemFocusRequesters,
                     cardWidth = classicContinueWatchingCardWidth,
-                    imageHeight = classicContinueWatchingImageHeight
+                    imageHeight = classicContinueWatchingImageHeight,
+                    cornerRadius = posterCardStyle.cornerRadius,
                 )
             }
         }
@@ -577,6 +578,7 @@ fun ClassicHomeContent(
                     useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
                     entryFocusRequester = upcomingSectionFocusRequester,
                     downFocusRequester = upcomingDownRequester,
+                    cornerRadius = posterCardStyle.cornerRadius,
                     focusRequesters = upcomingItemFocusRequesters,
                     lastFocusedIndexState = lastFocusedUpcomingIndex,
                     cardWidth = classicContinueWatchingCardWidth,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -451,7 +451,8 @@ fun GridHomeContent(
                             onRemoveContinueWatching(contentId, season, episode, isNextUp)
                         },
                         blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
+                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
+                        cornerRadius = posterCardStyle.cornerRadius,
                     )
                 }
             }
@@ -505,7 +506,8 @@ fun GridHomeContent(
                             onRemoveContinueWatching(contentId, season, episode, isNextUp)
                         },
                         blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
+                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
+                        cornerRadius = posterCardStyle.cornerRadius,
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -160,6 +160,7 @@ private fun ModernContinueWatchingRowItem(
     imageHeight: Dp,
     blurUnwatchedEpisodes: Boolean,
     useEpisodeThumbnails: Boolean,
+    cornerRadius: Dp,
     onFocused: () -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onShowOptions: (ContinueWatchingItem) -> Unit,
@@ -198,6 +199,7 @@ private fun ModernContinueWatchingRowItem(
         imageHeight = imageHeight,
         blurUnwatchedEpisodes = blurUnwatchedEpisodes,
         useEpisodeThumbnails = useEpisodeThumbnails,
+        cornerRadius = cornerRadius,
         modifier = modifier
             .focusRequester(requester)
             .onFocusChanged {
@@ -903,6 +905,7 @@ internal fun ModernRowSection(
                                 imageHeight = continueWatchingCardHeight,
                                 blurUnwatchedEpisodes = blurUnwatchedEpisodes,
                                 useEpisodeThumbnails = useEpisodeThumbnails,
+                                cornerRadius = posterCardCornerRadius,
                                 onFocused = onFocused,
                                 onContinueWatchingClick = onContinueWatchingClick,
                                 onShowOptions = onContinueWatchingOptions


### PR DESCRIPTION
## Summary

Continue Watching (and Upcoming) cards now use the same Settings → Layout poster corner radius as catalog rows. Previously they used a hardcoded medium radius for the card shape, focus ring, depth surface, and artwork clip.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With poster corners set to **sharp**, catalog posters render square while Continue Watching cards stay rounded (including the focus ring and artwork clip). Home looks inconsistent for any non-default corner radius.

## Issue or approval

Fixes #2911

## Reproduction steps

1. Open **Settings → Layout**.
2. Set **poster corner radius** to **sharp** (0).
3. Return to the home screen.
4. Compare a catalog row against the **Continue Watching** row (and **Upcoming** if visible).

**Before:** catalog posters are square; Continue Watching cards stay rounded.  
**After:** Continue Watching / Upcoming cards, focus rings, and artwork clips use the same corner radius as catalogs.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- **In scope:** wire existing `posterCardCornerRadius` / `PosterCardStyle.cornerRadius` into `ContinueWatchingCard` (card shape, focus border, depth surface, top artwork clip) for Classic / Grid / Modern home, including Upcoming rows that reuse the same card.
- **Out of scope:** Continue Watching card style variants (poster/wide), layout settings UI, catalog sizing, progress bar chrome.
- **Related open work:** #2900 also touches corner radius as part of a broader CW card-style feature. This PR is intentionally **bug-only** so #2911 can land without the feature surface. Happy to close this if maintainers prefer #2900 as the vehicle for the same fix.

## Testing

- `./gradlew :app:compileFullDebugKotlin` — **PASSED**
- Unit tests: n/a (pure Compose shape parameter plumbing; no pure-logic module)
- Emulator / device UI: not run in this environment; root cause is hardcoded `RoundedCornerShape(NuvioTheme.radii.md)` / top-clip using theme spacing instead of the layout preference, which catalog rows already receive

### Manual verification checklist (device/emulator)

1. Layout poster radius → **sharp** → CW + catalog both square.
2. Layout poster radius → a mid value → CW + catalog match.
3. Focus a CW card → focus ring follows the same radius.
4. Classic, Grid, and Modern home layouts if available.

@ram130 for awareness: this overlaps the corner-radius portion of #2900 only; no card-style feature work here.

## Screenshots / Video

Not a visual redesign — wiring only. Device before/after welcome if helpful; none attached from this machine.

## Breaking changes

None.

## Linked issues

Fixes #2911
