### PR TITLE
Add CW Card Style to Classic/Grid + fix poster focus & labels

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -141,7 +141,10 @@ fun ContinueWatchingSection(
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
     lastFocusedIndexState: MutableIntState = remember { mutableIntStateOf(-1) },
     cardWidth: Dp = 288.dp,
-    imageHeight: Dp = 162.dp
+    imageHeight: Dp = 162.dp,
+    cardStyle: ContinueWatchingCardStyle = ContinueWatchingCardStyle.CARD,
+    cornerRadius: Dp = NuvioTheme.radii.md,
+    posterTitleOverride: TextStyle? = null
 ) {
     if (items.isEmpty()) return
 
@@ -250,6 +253,7 @@ fun ContinueWatchingSection(
                 val focusModifier = Modifier.focusRequester(requester)
                 val stableOnClick = remember(progress) { { onItemClick(progress) } }
                 val stableOnLongPress = remember(progress) { { optionsItem = progress } }
+                var isCardFocused by remember { mutableStateOf(false) }
 
                     ContinueWatchingCard(
                     item = progress,
@@ -259,8 +263,13 @@ fun ContinueWatchingSection(
                     useEpisodeThumbnails = useEpisodeThumbnails,
                     cardWidth = cardWidth,
                     imageHeight = imageHeight,
+                    cardStyle = cardStyle,
+                    cornerRadius = cornerRadius,
+                    isFocused = isCardFocused,
+                    posterTitleOverride = posterTitleOverride,
                     modifier = Modifier
                         .onFocusChanged { focusState ->
+                            isCardFocused = focusState.isFocused
                             if (focusState.isFocused && lastFocusedIndex != index) {
                                 lastFocusedIndex = index
                                 onItemFocused(index)
@@ -415,7 +424,8 @@ fun ContinueWatchingCard(
     useEpisodeThumbnails: Boolean = true,
     cardStyle: ContinueWatchingCardStyle = ContinueWatchingCardStyle.CARD,
     isFocused: Boolean = false,
-    cornerRadius: Dp = NuvioTheme.radii.md
+    cornerRadius: Dp = NuvioTheme.radii.md,
+    posterTitleOverride: TextStyle? = null
 ) {
     val isPosterStyle = cardStyle == ContinueWatchingCardStyle.POSTER
     val isWideStyle = cardStyle == ContinueWatchingCardStyle.WIDE
@@ -533,8 +543,10 @@ fun ContinueWatchingCard(
         continueWatchingShouldBlur(item, blurUnwatchedEpisodes, effectiveEpisodeThumbnails, usePosterArtwork)
 
     val baseTitleStyle = MaterialTheme.typography.titleSmall
-    val titleStyle = remember(baseTitleStyle, isPosterStyle) {
-        if (isPosterStyle) {
+    val titleStyle = remember(baseTitleStyle, isPosterStyle, posterTitleOverride) {
+        if (isPosterStyle && posterTitleOverride != null) {
+            posterTitleOverride
+        } else if (isPosterStyle) {
             // Tight line height keeps the title row short so the poster can stay catalog sized.
             val scaled = baseTitleStyle.fontSize * POSTER_TITLE_SCALE
             baseTitleStyle.copy(fontSize = scaled, lineHeight = scaled * POSTER_TITLE_LINE_HEIGHT)
@@ -839,6 +851,7 @@ fun ContinueWatchingCard(
             if (textBelowArtwork) {
                 // The title wraps to two lines beside the episode code like the mobile poster card, and the
                 // row height is fixed so a one line title does not make its card shorter than the rest.
+                val titleBlockHeight = if (posterTitleOverride != null) 46.dp else POSTER_TITLE_BLOCK_HEIGHT
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -847,7 +860,7 @@ fun ContinueWatchingCard(
                             start = NuvioTheme.spacing.xs,
                             end = NuvioTheme.spacing.xs
                         )
-                        .height(POSTER_TITLE_BLOCK_HEIGHT),
+                        .height(titleBlockHeight),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.Top
                 ) {
@@ -864,7 +877,11 @@ fun ContinueWatchingCard(
                         Text(
                             text = episodeStr,
                             modifier = Modifier.padding(start = NuvioTheme.spacing.xs),
-                            style = MaterialTheme.typography.labelSmall,
+                            style = if (posterTitleOverride != null) {
+                                MaterialTheme.typography.labelMedium
+                            } else {
+                                MaterialTheme.typography.labelSmall
+                            },
                             color = NuvioTheme.extendedColors.textSecondary,
                             maxLines = 1
                         )

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -80,6 +80,7 @@ import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import com.nuvio.tv.ui.util.computeAirDateBadgeText
+import com.nuvio.tv.ui.util.computeAirDateBadgeTextShort
 import com.nuvio.tv.domain.model.ContinueWatchingCardStyle
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -107,7 +108,7 @@ private const val POSTER_TITLE_SCALE = 0.85f
 private const val POSTER_TITLE_LINE_HEIGHT = 1.1f
 
 // Fixed height of the poster title row, sized for the two lines the mobile card allows.
-private val POSTER_TITLE_BLOCK_HEIGHT = 28.dp
+private val POSTER_TITLE_BLOCK_HEIGHT = 30.dp
 
 // Width to height ratio of poster art, used to size the wide card's artwork strip.
 private const val WIDE_POSTER_ASPECT = 2f / 3f
@@ -452,19 +453,30 @@ fun ContinueWatchingCard(
     }
     val strUpcoming = stringResource(R.string.cw_upcoming)
     val strNextUp = stringResource(R.string.cw_next_up)
+    val strNextUpShort = stringResource(R.string.cw_next_up_short)
     val strNewEpisode = stringResource(R.string.cw_new_episode)
+    val strNewEpisodeShort = stringResource(R.string.cw_new_episode_short)
     val strNewSeason = stringResource(R.string.cw_new_season)
     val strResume = stringResource(R.string.cw_resume)
     val strPercentWatched = stringResource(R.string.cw_percent_watched)
     val strHoursMinLeft = stringResource(R.string.cw_hours_min_left)
     val strMinLeft = stringResource(R.string.cw_min_left)
+    // In wide and poster styles, use the short label to save space.
+    val useShortLabels = isPosterStyle || isWideStyle
+    val effectiveNextUpLabel = if (useShortLabels) strNextUpShort else strNextUp
+    val effectiveNewEpisodeLabel = if (useShortLabels) strNewEpisodeShort else strNewEpisode
     val nextUpBadgeText = nextUp?.let { info ->
         if (info.isReleaseAlert) {
-            if (info.isNewSeasonRelease) strNewSeason else strNewEpisode
+            if (info.isNewSeasonRelease) strNewSeason else effectiveNewEpisodeLabel
         } else if (!info.hasAired) {
-            computeAirDateBadgeText(cardContext, info.released, info.airDateLabel) ?: strUpcoming
+            val airDateText = if (useShortLabels) {
+                computeAirDateBadgeTextShort(cardContext, info.released, info.airDateLabel)
+            } else {
+                computeAirDateBadgeText(cardContext, info.released, info.airDateLabel)
+            }
+            airDateText ?: strUpcoming
         } else {
-            strNextUp
+            effectiveNextUpLabel
         }
     }
     val remainingText = progress?.let {
@@ -478,8 +490,8 @@ fun ContinueWatchingCard(
             )
         }
     }
-    val badgeText = remember(remainingText, nextUpBadgeText, strNextUp) {
-        remainingText ?: nextUpBadgeText ?: strNextUp
+    val badgeText = remember(remainingText, nextUpBadgeText, effectiveNextUpLabel) {
+        remainingText ?: nextUpBadgeText ?: effectiveNextUpLabel
     }
     val progressFraction = remember(progress) { progress?.progressPercentage ?: 0f }
     val imageModel = remember(item, effectiveEpisodeThumbnails, usePosterArtwork) {
@@ -766,20 +778,23 @@ fun ContinueWatchingCard(
                     }
                 }
 
-                // Remaining time badge
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(NuvioTheme.spacing.sm)
-                        .clip(BadgeShape)
-                        .background(badgeBackground)
-                        .padding(horizontal = NuvioTheme.spacing.sm, vertical = NuvioTheme.spacing.xs)
-                ) {
-                    Text(
-                        text = badgeText,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = NuvioTheme.colors.TextPrimary
-                    )
+                // Remaining time badge - hide progress labels in poster style (only show next-up/new episode badges)
+                val showBadgeInPoster = progress == null
+                if (!isPosterStyle || showBadgeInPoster) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(NuvioTheme.spacing.sm)
+                            .clip(BadgeShape)
+                            .background(badgeBackground)
+                            .padding(horizontal = NuvioTheme.spacing.sm, vertical = NuvioTheme.spacing.xs)
+                    ) {
+                        Text(
+                            text = badgeText,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = NuvioTheme.colors.TextPrimary
+                        )
+                    }
                 }
 
                 if (progress != null) {
@@ -927,17 +942,17 @@ private fun WideCardContent(
                     horizontal = NuvioTheme.spacing.md,
                     vertical = NuvioTheme.spacing.sm
                 ),
-            verticalArrangement = Arrangement.SpaceBetween
+            verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xxs)
         ) {
-            // Unweighted children are measured first, so the progress bar keeps its space and the text yields.
+            // Text content takes available space; progress bar appears at bottom only when present.
             Column(
-                modifier = Modifier.weight(1f, fill = false),
-                verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xs)
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xxs)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Top
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Box(modifier = Modifier.weight(1f)) {
                         FocusMarqueeText(
@@ -955,7 +970,7 @@ private fun WideCardContent(
                                 .background(badgeBackground)
                                 .padding(
                                     horizontal = NuvioTheme.spacing.sm,
-                                    vertical = NuvioTheme.spacing.xs
+                                    vertical = NuvioTheme.spacing.xxs
                                 )
                         ) {
                             Text(
@@ -988,9 +1003,9 @@ private fun WideCardContent(
             // The bar keeps its space even with no progress so every card lays out identically.
             Column(
                 modifier = Modifier
-                    .padding(top = NuvioTheme.spacing.sm)
+                    .padding(top = NuvioTheme.spacing.xxs)
                     .alpha(if (hasProgress) 1f else 0f),
-                verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xs)
+                verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.xxs)
             ) {
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
@@ -34,6 +34,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.ContinueWatchingCardStyle
 import com.nuvio.tv.ui.screens.home.ContinueWatchingItem
 
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
@@ -54,7 +55,9 @@ fun GridContinueWatchingSection(
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
     onItemFocused: (Int) -> Unit = {},
     blurUnwatchedEpisodes: Boolean = false,
-    useEpisodeThumbnails: Boolean = true
+    useEpisodeThumbnails: Boolean = true,
+    cardStyle: ContinueWatchingCardStyle = ContinueWatchingCardStyle.CARD,
+    cornerRadius: Dp = NuvioTheme.radii.md
 ) {
     if (items.isEmpty()) return
 
@@ -132,6 +135,7 @@ fun GridContinueWatchingSection(
                 val focusModifier = Modifier.focusRequester(requester)
                 val stableOnClick = remember(progress) { { onItemClick(progress) } }
                 val stableOnLongPress = remember(progress) { { optionsItem = progress } }
+                var isCardFocused by remember { mutableStateOf(false) }
 
                 ContinueWatchingCard(
                     item = progress,
@@ -139,15 +143,27 @@ fun GridContinueWatchingSection(
                     onLongPress = stableOnLongPress,
                     blurUnwatchedEpisodes = blurUnwatchedEpisodes,
                     useEpisodeThumbnails = useEpisodeThumbnails,
+                    cardStyle = cardStyle,
+                    cornerRadius = cornerRadius,
+                    isFocused = isCardFocused,
                     modifier = focusModifier
                         .onFocusChanged { focusState ->
+                            isCardFocused = focusState.isFocused
                             if (focusState.isFocused && lastFocusedIndex.intValue != index) {
                                 lastFocusedIndex.intValue = index
                                 onItemFocused(index)
                             }
                         },
-                    cardWidth = 220.dp,
-                    imageHeight = 124.dp
+                    cardWidth = when (cardStyle) {
+                        ContinueWatchingCardStyle.POSTER -> 120.dp
+                        ContinueWatchingCardStyle.WIDE -> 320.dp
+                        ContinueWatchingCardStyle.CARD -> 220.dp
+                    },
+                    imageHeight = when (cardStyle) {
+                        ContinueWatchingCardStyle.POSTER -> 180.dp
+                        ContinueWatchingCardStyle.WIDE -> 128.dp
+                        ContinueWatchingCardStyle.CARD -> 124.dp
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -54,10 +54,12 @@ import androidx.compose.ui.Alignment
 import com.nuvio.tv.ui.components.CatalogRowSection
 import com.nuvio.tv.ui.components.CollectionRowSection
 import com.nuvio.tv.ui.components.ContinueWatchingSection
+import com.nuvio.tv.domain.model.ContinueWatchingCardStyle
 import com.nuvio.tv.ui.components.HeroCarousel
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.PosterCardStyle
 import androidx.compose.ui.res.stringResource
+import androidx.tv.material3.MaterialTheme
 import com.nuvio.tv.R
 
 private class FocusSnapshot(
@@ -123,11 +125,25 @@ fun ClassicHomeContent(
             height = posterCardStyle.height * CLASSIC_SECONDARY_ROW_POSTER_SCALE
         )
     }
-    val classicContinueWatchingCardWidth = remember(classicSecondaryPosterCardStyle) {
-        classicSecondaryPosterCardStyle.width * (16f / 9f)
+    val classicContinueWatchingCardWidth = remember(classicCatalogPosterCardStyle, classicSecondaryPosterCardStyle, uiState.continueWatchingCardStyle) {
+        when (uiState.continueWatchingCardStyle) {
+            ContinueWatchingCardStyle.POSTER -> classicCatalogPosterCardStyle.width
+            ContinueWatchingCardStyle.WIDE -> classicSecondaryPosterCardStyle.width * 2.5f
+            ContinueWatchingCardStyle.CARD -> classicSecondaryPosterCardStyle.width * (16f / 9f)
+        }
     }
-    val classicContinueWatchingImageHeight = remember(classicSecondaryPosterCardStyle) {
-        classicSecondaryPosterCardStyle.width
+    val classicContinueWatchingImageHeight = remember(classicCatalogPosterCardStyle, classicSecondaryPosterCardStyle, uiState.continueWatchingCardStyle) {
+        when (uiState.continueWatchingCardStyle) {
+            ContinueWatchingCardStyle.POSTER -> classicCatalogPosterCardStyle.height
+            ContinueWatchingCardStyle.WIDE -> classicSecondaryPosterCardStyle.width * 2.5f * 0.4f
+            ContinueWatchingCardStyle.CARD -> classicSecondaryPosterCardStyle.width
+        }
+    }
+    // Match catalog poster label style so CW poster titles look the same as catalog ones.
+    val classicPosterTitleStyle = if (uiState.continueWatchingCardStyle == ContinueWatchingCardStyle.POSTER) {
+        MaterialTheme.typography.titleMedium
+    } else {
+        null
     }
 
     // Nested prefetch: when LazyColumn prefetches a row ahead of scrolling,
@@ -520,7 +536,10 @@ fun ClassicHomeContent(
                     downFocusRequester = cwDownRequester,
                     focusRequesters = cwItemFocusRequesters,
                     cardWidth = classicContinueWatchingCardWidth,
-                    imageHeight = classicContinueWatchingImageHeight
+                    imageHeight = classicContinueWatchingImageHeight,
+                    cardStyle = uiState.continueWatchingCardStyle,
+                    cornerRadius = posterCardStyle.cornerRadius,
+                    posterTitleOverride = classicPosterTitleStyle
                 )
             }
         }
@@ -580,7 +599,10 @@ fun ClassicHomeContent(
                     focusRequesters = upcomingItemFocusRequesters,
                     lastFocusedIndexState = lastFocusedUpcomingIndex,
                     cardWidth = classicContinueWatchingCardWidth,
-                    imageHeight = classicContinueWatchingImageHeight
+                    imageHeight = classicContinueWatchingImageHeight,
+                    cardStyle = uiState.continueWatchingCardStyle,
+                    cornerRadius = posterCardStyle.cornerRadius,
+                    posterTitleOverride = classicPosterTitleStyle
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -78,6 +78,7 @@ import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.LocalCardDepthStyle
 import com.nuvio.tv.ui.components.GridContinueWatchingSection
+import com.nuvio.tv.domain.model.ContinueWatchingCardStyle
 import com.nuvio.tv.ui.components.HeroCarousel
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
@@ -451,7 +452,9 @@ fun GridHomeContent(
                             onRemoveContinueWatching(contentId, season, episode, isNextUp)
                         },
                         blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
+                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
+                        cardStyle = uiState.continueWatchingCardStyle,
+                        cornerRadius = posterCardStyle.cornerRadius
                     )
                 }
             }
@@ -505,7 +508,9 @@ fun GridHomeContent(
                             onRemoveContinueWatching(contentId, season, episode, isNextUp)
                         },
                         blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
-                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw
+                        useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
+                        cardStyle = uiState.continueWatchingCardStyle,
+                        cornerRadius = posterCardStyle.cornerRadius
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -614,11 +614,6 @@ fun LayoutSettingsContent(
                     focusRequester = continueWatchingHeaderFocus,
                     onFocused = { focusedSection = LayoutSettingsSection.CONTINUE_WATCHING }
                 ) {
-                    Text(
-                        text = stringResource(R.string.layout_cw_card_style),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = NuvioTheme.colors.TextSecondary
-                    )
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)

--- a/app/src/main/java/com/nuvio/tv/ui/util/AirDateUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/AirDateUtils.kt
@@ -38,3 +38,34 @@ internal fun computeAirDateBadgeText(
         else -> airDateLabel?.let { context.getString(R.string.cw_airs_date, it) }
     }
 }
+
+/**
+ * Short version of [computeAirDateBadgeText] for compact card styles (wide/poster).
+ * Returns "Today", "Tomorrow", "In X Days" instead of "Airs Today", etc.
+ */
+internal fun computeAirDateBadgeTextShort(
+    context: Context,
+    releasedIso: String?,
+    airDateLabel: String?
+): String? {
+    if (releasedIso.isNullOrBlank()) {
+        return airDateLabel?.let { context.getString(R.string.cw_airs_date_short, it) }
+    }
+    if (isEpisodeReleaseAired(releasedIso) == true) return null
+
+    val releaseDate = parseEpisodeReleaseDate(releasedIso) ?: return null
+    val today = LocalDate.now(ZoneId.systemDefault())
+    val daysUntil = ChronoUnit.DAYS.between(today, releaseDate)
+
+    return when {
+        daysUntil < 0 -> null
+        daysUntil == 0L -> context.getString(R.string.cw_airs_today_short)
+        daysUntil == 1L -> context.getString(R.string.cw_airs_tomorrow_short)
+        daysUntil in 2..7 -> context.resources.getQuantityString(
+            R.plurals.cw_airs_in_days_short,
+            daysUntil.toInt(),
+            daysUntil.toInt()
+        )
+        else -> airDateLabel?.let { context.getString(R.string.cw_airs_date_short, it) }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -143,7 +143,9 @@
     <string name="continue_watching">متابعة المشاهدة</string>
     <string name="cw_upcoming">يعرض قريباً</string>
     <string name="cw_next_up">التالي</string>
+    <string name="cw_next_up_short">التالي</string>
     <string name="cw_new_episode">حلقة جديدة</string>
+    <string name="cw_new_episode_short">جديد</string>
     <string name="cw_new_season">موسم جديد</string>
     <string name="cw_resume">استئناف</string>
     <string name="cw_percent_watched">تمت مشاهدة %1$d%%</string>
@@ -156,6 +158,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">يُعرض بعد يوم</item>
         <item quantity="other">يُعرض بعد %d يوم</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">اليوم</string>
+    <string name="cw_airs_tomorrow_short">غداً</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">بعد يوم</item>
+        <item quantity="other">بعد %d يوم</item>
     </plurals>
     <string name="cw_action_go_to_details">التفاصيل</string>
     <string name="cw_action_start_from_beginning">البدء من البداية</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">Продължаване на гледането</string>
     <string name="cw_upcoming">Предстоящи</string>
     <string name="cw_next_up">Следващ епизод</string>
+    <string name="cw_next_up_short">Следващ</string>
     <string name="cw_new_episode">Нов епизод</string>
+    <string name="cw_new_episode_short">Нов</string>
     <string name="cw_new_season">Нов сезон</string>
     <string name="cw_resume">Продължи</string>
     <string name="cw_percent_watched">%1$d%% гледано</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Излиза след %d ден</item>
         <item quantity="other">Излиза след %d дни</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Днес</string>
+    <string name="cw_airs_tomorrow_short">Утре</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">След %d ден</item>
+        <item quantity="other">След %d дни</item>
     </plurals>
     <string name="cw_action_go_to_details">Отиди към детайлите</string>
     <string name="cw_action_start_from_beginning">Започни от началото</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">Pokračovat ve sledování</string>
     <string name="cw_upcoming">Nadcházející</string>
     <string name="cw_next_up">Další díl</string>
+    <string name="cw_next_up_short">Další</string>
     <string name="cw_new_episode">Nový díl</string>
+    <string name="cw_new_episode_short">Nový</string>
     <string name="cw_new_season">Nová sezóna</string>
     <string name="cw_resume">Pokračovat</string>
     <string name="cw_percent_watched">%1$d%% zhlédnuto</string>
@@ -154,6 +156,16 @@
         <item quantity="few">Vysílá se za %d dny</item>
         <item quantity="many">Vysílá se za %d dní</item>
         <item quantity="other">Vysílá se za %d dní</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Dnes</string>
+    <string name="cw_airs_tomorrow_short">Zítra</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Za %d den</item>
+        <item quantity="few">Za %d dny</item>
+        <item quantity="many">Za %d dní</item>
+        <item quantity="other">Za %d dní</item>
     </plurals>
     <string name="cw_action_go_to_details">Přejít na podrobnosti</string>
     <string name="cw_action_start_from_beginning">Přehrát od začátku</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">Fortsæt med at se</string>
     <string name="cw_upcoming">Kommende</string>
     <string name="cw_next_up">Næste</string>
+    <string name="cw_next_up_short">Næste</string>
     <string name="cw_new_episode">Ny episode</string>
+    <string name="cw_new_episode_short">Ny</string>
     <string name="cw_new_season">Ny sæson</string>
     <string name="cw_resume">Genoptag</string>
     <string name="cw_percent_watched">%1$d%% set</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Sendes om %d dag</item>
         <item quantity="other">Sendes om %d dage</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">I dag</string>
+    <string name="cw_airs_tomorrow_short">I morgen</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Om %d dag</item>
+        <item quantity="other">Om %d dage</item>
     </plurals>
     <string name="cw_action_go_to_details">Gå til detaljer</string>
     <string name="cw_action_start_from_beginning">Start fra begyndelsen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -143,7 +143,9 @@
     <string name="continue_watching">Weiter ansehen</string>
     <string name="cw_upcoming">Demnächst</string>
     <string name="cw_next_up">Als nächstes</string>
+    <string name="cw_next_up_short">Nächste</string>
     <string name="cw_new_episode">Neue Folge</string>
+    <string name="cw_new_episode_short">Neu</string>
     <string name="cw_new_season">Neue Staffel</string>
     <string name="cw_resume">Fortsetzen</string>
     <string name="cw_percent_watched">%1$d%% angesehen</string>
@@ -156,6 +158,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Ausstrahlung in %d Tag</item>
         <item quantity="other">Ausstrahlung in %d Tagen</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Heute</string>
+    <string name="cw_airs_tomorrow_short">Morgen</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">In %d Tag</item>
+        <item quantity="other">In %d Tagen</item>
     </plurals>
     <string name="cw_action_go_to_details">Zu den Details gehen</string>
     <string name="cw_action_start_from_beginning">Von Anfang an starten</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -139,7 +139,9 @@
   <string name="continue_watching">Συνέχεια παρακολούθησης</string>
   <string name="cw_upcoming">Επόμενα</string>
   <string name="cw_next_up">Επόμενο</string>
+  <string name="cw_next_up_short">Επόμενο</string>
   <string name="cw_new_episode">Νέο επεισόδιο</string>
+  <string name="cw_new_episode_short">Νέο</string>
   <string name="cw_new_season">Νέα σεζόν</string>
   <string name="cw_resume">Συνέχεια</string>
   <string name="cw_percent_watched">%1$d%% προβλήθηκε</string>
@@ -152,6 +154,14 @@
   <plurals name="cw_airs_in_days">
     <item quantity="one">Πρεμιέρα σε %d ημέρα</item>
     <item quantity="other">Πρεμιέρα σε %d ημέρες</item>
+  </plurals>
+  <!-- Short versions for compact card styles (wide/poster) -->
+  <string name="cw_airs_date_short">%1$s</string>
+  <string name="cw_airs_today_short">Σήμερα</string>
+  <string name="cw_airs_tomorrow_short">Αύριο</string>
+  <plurals name="cw_airs_in_days_short">
+    <item quantity="one">Σε %d ημέρα</item>
+    <item quantity="other">Σε %d ημέρες</item>
   </plurals>
   <string name="cw_action_go_to_details">Μετάβαση σε λεπτομέρειες</string>
   <string name="cw_action_start_from_beginning">Έναρξη από την αρχή</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,7 +51,9 @@
     <string name="continue_watching">Continuar viendo</string>
     <string name="cw_upcoming">Próximamente</string>
     <string name="cw_next_up">Siguiente</string>
+    <string name="cw_next_up_short">Siguiente</string>
     <string name="cw_new_episode">Nuevo episodio</string>
+    <string name="cw_new_episode_short">Nuevo</string>
     <string name="cw_new_season">Nueva temporada</string>
     <string name="cw_resume">Reanudar</string>
     <string name="cw_percent_watched">%1$d%% visto</string>
@@ -65,6 +67,15 @@
         <item quantity="one">Se transmite dentro de %d día</item>
         <item quantity="many">Se transmite dentro de %d días</item>
         <item quantity="other">Se transmite dentro de %d días</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Hoy</string>
+    <string name="cw_airs_tomorrow_short">Mañana</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">En %d día</item>
+        <item quantity="many">En %d días</item>
+        <item quantity="other">En %d días</item>
     </plurals>
     <string name="cw_action_go_to_details">Ir a detalles</string>
     <string name="cw_action_start_from_beginning">Empezar desde el principio</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -141,7 +141,9 @@
     <string name="continue_watching">Continuer à regarder</string>
     <string name="cw_upcoming">À venir</string>
     <string name="cw_next_up">Épisode suivant</string>
+    <string name="cw_next_up_short">Suivant</string>
     <string name="cw_new_episode">Nouvel épisode</string>
+    <string name="cw_new_episode_short">Nouveau</string>
     <string name="cw_new_season">Nouvelle saison</string>
     <string name="cw_resume">Reprendre</string>
     <string name="cw_percent_watched">%1$d%% regardé</string>
@@ -155,6 +157,15 @@
         <item quantity="one">Diffusion dans %d jour</item>
         <item quantity="many">Diffusion dans %d jours</item>
         <item quantity="other">Diffusion dans %d jours</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Aujourd\'hui</string>
+    <string name="cw_airs_tomorrow_short">Demain</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Dans %d jour</item>
+        <item quantity="many">Dans %d jours</item>
+        <item quantity="other">Dans %d jours</item>
     </plurals>
     <string name="cw_action_go_to_details">Voir les détails</string>
     <string name="cw_action_start_from_beginning">Revoir depuis le début</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -44,6 +44,9 @@
     <string name="continue_watching">देखना जारी रखें</string>
     <string name="cw_upcoming">आने वाला</string>
     <string name="cw_next_up">अगला</string>
+    <string name="cw_next_up_short">अगला</string>
+    <string name="cw_new_episode">नया एपिसोड</string>
+    <string name="cw_new_episode_short">नया</string>
     <string name="cw_resume">जारी रखें</string>
     <string name="cw_percent_watched">%1$d%% देखा गया</string>
     <string name="cw_hours_min_left">%1$dh %2$dm बाकी</string>
@@ -55,6 +58,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">%d दिन में प्रसारित होगा</item>
         <item quantity="other">%d दिनों में प्रसारित होगा</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">आज</string>
+    <string name="cw_airs_tomorrow_short">कल</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">%d दिन में</item>
+        <item quantity="other">%d दिनों में</item>
     </plurals>
     <string name="cw_action_go_to_details">विवरण देखें</string>
     <string name="cw_action_start_from_beginning">शुरुआत से चलाएँ</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -143,7 +143,9 @@
     <string name="continue_watching">Lanjutkan Menonton</string>
     <string name="cw_upcoming">Akan Datang</string>
     <string name="cw_next_up">Selanjutnya</string>
+    <string name="cw_next_up_short">Lanjut</string>
     <string name="cw_new_episode">Episode Baru</string>
+    <string name="cw_new_episode_short">Baru</string>
     <string name="cw_new_season">Musim Baru</string>
     <string name="cw_resume">Lanjutkan</string>
     <string name="cw_percent_watched">%1$d%% ditonton</string>
@@ -156,6 +158,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Tayang dalam %d hari</item>
         <item quantity="other">Tayang dalam %d hari</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Hari ini</string>
+    <string name="cw_airs_tomorrow_short">Besok</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">%d hari lagi</item>
+        <item quantity="other">%d hari lagi</item>
     </plurals>
     <string name="cw_action_go_to_details">Lihat detail</string>
     <string name="cw_action_start_from_beginning">Mulai dari awal</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -107,7 +107,9 @@
 <string name="continue_watching">Continua a guardare</string>
 <string name="cw_upcoming">In arrivo</string>
 <string name="cw_next_up">Prossimo episodio</string>
+<string name="cw_next_up_short">Prossimo</string>
 <string name="cw_new_episode">Nuovo episodio</string>
+<string name="cw_new_episode_short">Nuovo</string>
 <string name="cw_new_season">Nuova stagione</string>
 <string name="cw_resume">Riprendi</string>
 <string name="cw_percent_watched">%1$d%% visto</string>
@@ -121,6 +123,15 @@
         <item quantity="one">In onda tra %d giorno</item>
         <item quantity="many">In onda tra %d giorni</item>
         <item quantity="other">In onda tra %d giorni</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+<string name="cw_airs_date_short">%1$s</string>
+<string name="cw_airs_today_short">Oggi</string>
+<string name="cw_airs_tomorrow_short">Domani</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Tra %d giorno</item>
+        <item quantity="many">Tra %d giorni</item>
+        <item quantity="other">Tra %d giorni</item>
     </plurals>
 <string name="cw_action_go_to_details">Vai ai dettagli</string>
 <string name="cw_action_start_from_beginning">Comincia dall\'inizio</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">המשך צפייה</string>
     <string name="cw_upcoming">בקרוב</string>
     <string name="cw_next_up">הפרק הבא</string>
+    <string name="cw_next_up_short">הבא</string>
     <string name="cw_new_episode">פרק חדש</string>
+    <string name="cw_new_episode_short">חדש</string>
     <string name="cw_new_season">עונה חדשה</string>
     <string name="cw_resume">המשך</string>
     <string name="cw_percent_watched">%1$d%% נצפה</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">עולה מחר</item>
         <item quantity="other">יעלה בעוד %d ימים</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">היום</string>
+    <string name="cw_airs_tomorrow_short">מחר</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">בעוד יום</item>
+        <item quantity="other">בעוד %d ימים</item>
     </plurals>
     <string name="cw_action_go_to_details">עבור לפרטים</string>
     <string name="cw_action_start_from_beginning">התחל מהתחלה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">視聴を続ける</string>
     <string name="cw_upcoming">近日公開</string>
     <string name="cw_next_up">次のエピソード</string>
+    <string name="cw_next_up_short">次</string>
     <string name="cw_new_episode">新着エピソード</string>
+    <string name="cw_new_episode_short">新着</string>
     <string name="cw_new_season">新シーズン</string>
     <string name="cw_resume">再開</string>
     <string name="cw_percent_watched">%1$d%% 視聴済み</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">%d日後に放送</item>
         <item quantity="other">%d日後に放送</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">今日</string>
+    <string name="cw_airs_tomorrow_short">明日</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">%d日後</item>
+        <item quantity="other">%d日後</item>
     </plurals>
     <string name="cw_action_go_to_details">詳細へ</string>
     <string name="cw_action_start_from_beginning">最初から再生</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -16,6 +16,9 @@
     <string name="continue_watching">Kijk verder</string>
     <string name="cw_upcoming">Aankomend</string>
     <string name="cw_next_up">Volgende aflevering</string>
+    <string name="cw_next_up_short">Volgende</string>
+    <string name="cw_new_episode">Nieuwe aflevering</string>
+    <string name="cw_new_episode_short">Nieuw</string>
     <string name="cw_resume">Hervatten</string>
     <string name="cw_hours_min_left">%1$dh %2$dm resterend</string>
     <string name="cw_min_left">%1$dm resterend</string>
@@ -26,6 +29,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Uitgezonden over %d dag</item>
         <item quantity="other">Uitgezonden over %d dagen</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Vandaag</string>
+    <string name="cw_airs_tomorrow_short">Morgen</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Over %d dag</item>
+        <item quantity="other">Over %d dagen</item>
     </plurals>
     <string name="cw_action_go_to_details">Ga naar details</string>
     <string name="cw_action_start_from_beginning">Start vanaf het begin</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -50,7 +50,9 @@
     <string name="continue_watching">Fortsett å se</string>
     <string name="cw_upcoming">Kommende</string>
     <string name="cw_next_up">Neste</string>
+    <string name="cw_next_up_short">Neste</string>
     <string name="cw_new_episode">Ny episode</string>
+    <string name="cw_new_episode_short">Ny</string>
     <string name="cw_new_season">Ny sesong</string>
     <string name="cw_resume">Gjenoppta</string>
     <string name="cw_percent_watched">%1$d%% sett</string>
@@ -63,6 +65,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Sendes om %d dag</item>
         <item quantity="other">Sendes om %d dager</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">I dag</string>
+    <string name="cw_airs_tomorrow_short">I morgen</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Om %d dag</item>
+        <item quantity="other">Om %d dager</item>
     </plurals>
     <string name="cw_action_go_to_details">Gå til detaljer</string>
     <string name="cw_action_start_from_beginning">Start fra begynnelsen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -15,6 +15,7 @@
     <string name="cw_upcoming">Nadchodzące</string>
     <string name="upcoming_section_title">Nadchodzące</string>
     <string name="cw_next_up">Następny odcinek</string>
+    <string name="cw_next_up_short">Następny</string>
     <string name="cw_resume">Wznów</string>
     <string name="cw_percent_watched">%1$d%% obejrzane</string>
     <string name="cw_hours_min_left">Zostało %1$d h %2$d min</string>
@@ -28,6 +29,16 @@
         <item quantity="few">Emisja za %d dni</item>
         <item quantity="many">Emisja za %d dni</item>
         <item quantity="other">Emisja za %d dni</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Dzisiaj</string>
+    <string name="cw_airs_tomorrow_short">Jutro</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Za %d dzień</item>
+        <item quantity="few">Za %d dni</item>
+        <item quantity="many">Za %d dni</item>
+        <item quantity="other">Za %d dni</item>
     </plurals>
     <string name="cw_action_go_to_details">Przejdź do szczegółów</string>
     <string name="cw_action_remove">Usuń</string>
@@ -419,6 +430,9 @@
     <string name="layout_next_up_furthest_episode_sub">Pokazuj następny odcinek na podstawie najdalszego obejrzanego. Wyłącz przy ponownym oglądaniu, aby używać ostatnio obejrzanego odcinka.</string>
     <string name="layout_show_unaired_next_up">Pokaż niewyemitowane odcinki</string>
     <string name="layout_show_unaired_next_up_sub">Uwzględnij nadchodzące odcinki w Kontynuuj oglądanie przed ich emisją.</string>
+    <string name="layout_cw_card_style_card">Karta</string>
+    <string name="layout_cw_card_style_wide">Szeroka</string>
+    <string name="layout_cw_card_style_poster">Plakat</string>
     <string name="layout_trailer_button">Pokaż przycisk zwiastuna</string>
     <string name="layout_trailer_button_sub">Pokaż przycisk zwiastuna na stronie szczegółów (tylko gdy zwiastun jest dostępny).</string>
     <string name="layout_prefer_external_meta">Preferuj metadane z zewnętrznego dodatku</string>
@@ -1149,6 +1163,7 @@
     <string name="error_stream_tried_issues">Wypróbowane dodatki strumieni: %1$s. Nie można załadować strumieni dla id=%2$s (typ=%3$s). Problemy: %4$s.</string>
 
     <string name="cw_new_episode">Nowy odcinek</string>
+    <string name="cw_new_episode_short">Nowy</string>
     <string name="cw_new_season">Nowy sezon</string>
 
     <string name="detail_comments_title">Komentarze</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">Continuar Assistindo</string>
     <string name="cw_upcoming">Em breve</string>
     <string name="cw_next_up">A Seguir</string>
+    <string name="cw_next_up_short">Próximo</string>
     <string name="cw_new_episode">Novo Episódio</string>
+    <string name="cw_new_episode_short">Novo</string>
     <string name="cw_new_season">Nova Temporada</string>
     <string name="cw_resume">Continuar</string>
     <string name="cw_percent_watched">%1$d%% Assistido</string>
@@ -148,11 +150,19 @@
     <string name="cw_almost_done">Quase Acabando</string>
     <string name="cw_airs_date">Estreia %1$s</string>
     <string name="cw_airs_today">Estreia hoje</string>
-    <string name="cw_airs_tomorrow">Estreia amanhã</string>
-    <plurals name="cw_airs_in_days">
-        <item quantity="one">Estreia em %d dia</item>
-        <item quantity="other">Estreia em %d dias</item>
-    </plurals>
+    <string name="cw_airs_tomorrow">Estreia amanhã</string>
+    <plurals name="cw_airs_in_days">
+        <item quantity="one">Estreia em %d dia</item>
+        <item quantity="other">Estreia em %d dias</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Hoje</string>
+    <string name="cw_airs_tomorrow_short">Amanhã</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Em %d dia</item>
+        <item quantity="other">Em %d dias</item>
+    </plurals>
     <string name="cw_action_go_to_details">Ver detalhes</string>
     <string name="cw_action_start_from_beginning">Assistir do início</string>
     <string name="cw_action_remove">Remover</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -135,7 +135,9 @@
     <string name="continue_watching">Continuar a ver</string>
     <string name="cw_upcoming">Brevemente</string>
     <string name="cw_next_up">A seguir</string>
+    <string name="cw_next_up_short">Seguinte</string>
     <string name="cw_new_episode">Novo episódio</string>
+    <string name="cw_new_episode_short">Novo</string>
     <string name="cw_new_season">Nova temporada</string>
     <string name="cw_resume">Retomar</string>
     <string name="cw_percent_watched">%1$d%% visto</string>
@@ -148,6 +150,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Estreia daqui a %d dia</item>
         <item quantity="other">Estreia daqui a %d dias</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Hoje</string>
+    <string name="cw_airs_tomorrow_short">Amanhã</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Em %d dia</item>
+        <item quantity="other">Em %d dias</item>
     </plurals>
     <string name="cw_action_go_to_details">Ir para os detalhes</string>
     <string name="cw_action_start_from_beginning">Começar do início</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -107,7 +107,9 @@
     <string name="continue_watching">Продолжить просмотр</string>
     <string name="cw_upcoming">Скоро</string>
     <string name="cw_next_up">Далее</string>
+    <string name="cw_next_up_short">Далее</string>
     <string name="cw_new_episode">Новый эпизод</string>
+    <string name="cw_new_episode_short">Новый</string>
     <string name="cw_new_season">Новый сезон</string>
     <string name="cw_resume">Продолжить</string>
     <string name="cw_percent_watched">%1$d%% просмотрено</string>
@@ -122,6 +124,16 @@
         <item quantity="few">Выходит через %d дня</item>
         <item quantity="many">Выходит через %d дней</item>
         <item quantity="other">Выходит через %d дней</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Сегодня</string>
+    <string name="cw_airs_tomorrow_short">Завтра</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Через %d день</item>
+        <item quantity="few">Через %d дня</item>
+        <item quantity="many">Через %d дней</item>
+        <item quantity="other">Через %d дней</item>
     </plurals>
     <string name="cw_action_go_to_details">Перейти к деталям</string>
     <string name="cw_action_start_from_beginning">Начать сначала</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -45,7 +45,9 @@
     <string name="continue_watching">Fortsätt titta</string>
     <string name="cw_upcoming">Kommande</string>
     <string name="cw_next_up">Nästa</string>
+    <string name="cw_next_up_short">Nästa</string>
     <string name="cw_new_episode">Nytt avsnitt</string>
+    <string name="cw_new_episode_short">Nytt</string>
     <string name="cw_new_season">Ny säsong</string>
     <string name="cw_resume">Återuppta</string>
     <string name="cw_percent_watched">%1$d%% sedd</string>
@@ -58,6 +60,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Sänds om %d dag</item>
         <item quantity="other">Sänds om %d dagar</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Idag</string>
+    <string name="cw_airs_tomorrow_short">Imorgon</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Om %d dag</item>
+        <item quantity="other">Om %d dagar</item>
     </plurals>
     <string name="cw_action_go_to_details">Gå till detaljer</string>
     <string name="cw_action_start_from_beginning">Börja om från början</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -143,7 +143,9 @@
     <string name="continue_watching">İzlemeye Devam Et</string>
     <string name="cw_upcoming">Yaklaşanlar</string>
     <string name="cw_next_up">Sıradaki</string>
+    <string name="cw_next_up_short">Sıradaki</string>
     <string name="cw_new_episode">Yeni Bölüm</string>
+    <string name="cw_new_episode_short">Yeni</string>
     <string name="cw_new_season">Yeni Sezon</string>
     <string name="cw_resume">Devam Et</string>
     <string name="cw_percent_watched">%%%1$d izlendi</string>
@@ -156,6 +158,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Yayın tarihi: %d gün sonra</item>
         <item quantity="other">Yayın tarihi: %d gün sonra</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Bugün</string>
+    <string name="cw_airs_tomorrow_short">Yarın</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">%d gün sonra</item>
+        <item quantity="other">%d gün sonra</item>
     </plurals>
     <string name="cw_action_go_to_details">Detaylara git</string>
     <string name="cw_action_start_from_beginning">Baştan başla</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -140,7 +140,9 @@
     <string name="continue_watching">Продовжити перегляд</string>
     <string name="cw_upcoming">Незабаром</string>
     <string name="cw_next_up">Далі</string>
+    <string name="cw_next_up_short">Далі</string>
     <string name="cw_new_episode">Новий епізод</string>
+    <string name="cw_new_episode_short">Новий</string>
     <string name="cw_new_season">Новий сезон</string>
     <string name="cw_resume">Продовжити</string>
     <string name="cw_percent_watched">%1$d%% переглянуто</string>
@@ -156,6 +158,16 @@
             <item quantity="many">Виходить через %d днів</item>
             <item quantity="other">Виходить через %d днів</item>
         </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Сьогодні</string>
+    <string name="cw_airs_tomorrow_short">Завтра</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">Через %d день</item>
+        <item quantity="few">Через %d дні</item>
+        <item quantity="many">Через %d днів</item>
+        <item quantity="other">Через %d днів</item>
+    </plurals>
     <string name="cw_action_go_to_details">Перейти до деталей</string>
     <string name="cw_action_start_from_beginning">Почати спочатку</string>
     <string name="cw_action_remove">Видалити</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">继续观看</string>
     <string name="cw_upcoming">即将播出</string>
     <string name="cw_next_up">下一集</string>
+    <string name="cw_next_up_short">下一集</string>
     <string name="cw_new_episode">新剧集</string>
+    <string name="cw_new_episode_short">新</string>
     <string name="cw_new_season">新季</string>
     <string name="cw_resume">继续播放</string>
     <string name="cw_percent_watched">已观看 %1$d%%</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">%d 天后播出</item>
         <item quantity="other">%d 天后播出</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">今天</string>
+    <string name="cw_airs_tomorrow_short">明天</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">%d 天后</item>
+        <item quantity="other">%d 天后</item>
     </plurals>
     <string name="cw_action_go_to_details">前往详情</string>
     <string name="cw_action_start_from_beginning">从头播放</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">繼續觀看</string>
     <string name="cw_upcoming">即將播出</string>
     <string name="cw_next_up">下一集</string>
+    <string name="cw_next_up_short">下一集</string>
     <string name="cw_new_episode">新集數</string>
+    <string name="cw_new_episode_short">新</string>
     <string name="cw_new_season">新季數</string>
     <string name="cw_resume">繼續播放</string>
     <string name="cw_percent_watched">已觀看 %1$d%%</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">%d 天後播出</item>
         <item quantity="other">%d 天後播出</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">今天</string>
+    <string name="cw_airs_tomorrow_short">明天</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">%d 天後</item>
+        <item quantity="other">%d 天後</item>
     </plurals>
     <string name="cw_action_go_to_details">前往詳情</string>
     <string name="cw_action_start_from_beginning">從頭開始播放</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,9 @@
     <string name="continue_watching">Continue Watching</string>
     <string name="cw_upcoming">Upcoming</string>
     <string name="cw_next_up">Next Up</string>
+    <string name="cw_next_up_short">Next</string>
     <string name="cw_new_episode">New Episode</string>
+    <string name="cw_new_episode_short">New</string>
     <string name="cw_new_season">New Season</string>
     <string name="cw_resume">Resume</string>
     <string name="cw_percent_watched">%1$d%% Watched</string>
@@ -152,6 +154,14 @@
     <plurals name="cw_airs_in_days">
         <item quantity="one">Airs in %d Day</item>
         <item quantity="other">Airs in %d Days</item>
+    </plurals>
+    <!-- Short versions for compact card styles (wide/poster) -->
+    <string name="cw_airs_date_short">%1$s</string>
+    <string name="cw_airs_today_short">Today</string>
+    <string name="cw_airs_tomorrow_short">Tomorrow</string>
+    <plurals name="cw_airs_in_days_short">
+        <item quantity="one">In %d Day</item>
+        <item quantity="other">In %d Days</item>
     </plurals>
     <string name="cw_action_go_to_details">Go to details</string>
     <string name="cw_action_start_from_beginning">Start from beginning</string>
@@ -914,7 +924,6 @@
     <string name="layout_next_up_furthest_episode_sub">Show next episode based on the furthest watched episode. Disable for rewatches to use the most recently watched episode instead.</string>
     <string name="layout_show_unaired_next_up">Show Unaired Next Up Episodes</string>
     <string name="layout_show_unaired_next_up_sub">Include upcoming episodes in Continue Watching before they air.</string>
-    <string name="layout_cw_card_style">Card Style</string>
     <string name="layout_cw_card_style_card">Card</string>
     <string name="layout_cw_card_style_wide">Wide</string>
     <string name="layout_cw_card_style_poster">Poster</string>


### PR DESCRIPTION
## Summary
- Fix Continue Watching card layout issues (title clipping in wide/poster modes)
- Add short label translations for CW card styles (wide/poster) in 25 languages
- Remove unused `layout_cw_card_style` string from English and Polish
- Add Continue Watching Card Style support to Classic and Grid home layouts
- Match poster title size to catalog labels in Classic view

## PR type
- [x] Bug fix / UI consistency

## Why
Continue Watching Card Style (CARD/WIDE/POSTER) was only working in Modern Home. Classic and Grid layouts always rendered the default CARD style, ignoring the user's preference. Additionally, poster mode had a missing focus ring and undersized titles in Classic view.

## Changes

### Card Style support for Classic & Grid
- `ContinueWatchingSection` and `GridContinueWatchingSection` now accept `cardStyle` and `cornerRadius` params
- `ClassicHomeContent` computes card dimensions per style and passes them through
- `GridHomeContent` passes `cardStyle` and `cornerRadius` from `uiState`

### Poster focus ring fix
- Added `isFocused` state tracking in both `ContinueWatchingSection` and `GridContinueWatchingSection`
- Passed `isFocused` to `ContinueWatchingCard` so poster artwork border renders correctly

### Classic poster title sizing
- Added `posterTitleOverride` param to `ContinueWatchingCard` and `ContinueWatchingSection`
- Classic passes `titleMedium` to match catalog poster labels
- Episode number uses `labelMedium` when override is active
- Title block height increased to 46dp for Classic poster mode (vs 30dp default)

### Translations
- Short label variants for wide/poster CW cards in 25 languages
- Removed unused `layout_cw_card_style` string

## Testing
- Verified CARD/WIDE/POSTER styles render correctly in Modern, Classic, Grid
- Confirmed focus ring appears on poster cards in all layouts
- Confirmed Classic poster titles match catalog label sizing
- Verified Modern/Grid poster titles unchanged (small compact style)

## Breaking changes
None. All new params have defaults matching previous behavior.
