### PR TITLE
fix(search): only remember explicitly submitted searches in recent history (#2928)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
@@ -3,6 +3,8 @@ package com.nuvio.tv.ui.screens.search
 sealed interface SearchEvent {
     data class QueryChanged(val query: String) : SearchEvent
     data object SubmitSearch : SearchEvent
+    /** Opening a result counts as confirming the current search (see #2928 review). */
+    data object RememberSearchFromResults : SearchEvent
     data object ClearRecentSearches : SearchEvent
 
     data class LoadMoreCatalog(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
@@ -3,8 +3,8 @@ package com.nuvio.tv.ui.screens.search
 sealed interface SearchEvent {
     data class QueryChanged(val query: String) : SearchEvent
     data object SubmitSearch : SearchEvent
-    /** Opening a result counts as confirming the current search (see #2928 review). */
-    data object RememberSearchFromResults : SearchEvent
+    /** Moving from the text input to the results confirms the current search (see #2928 review). */
+    data object RememberSearchFromTextInput : SearchEvent
     data object ClearRecentSearches : SearchEvent
 
     data class LoadMoreCatalog(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -528,7 +528,12 @@ fun SearchScreen(
                     isVoiceListening = isVoiceListening,
                     voiceRmsLevel = voiceRmsLevel,
                     onVoiceSearch = launchVoiceSearch,
-                    onMoveToResults = { focusResults = true },
+                    onMoveToResults = {
+                        // D-pad down from the text field is the user's confirmation that the
+                        // live-search results are useful, even before a particular card opens.
+                        viewModel.onEvent(SearchEvent.RememberSearchFromTextInput)
+                        focusResults = true
+                    },
                     onOpenDiscover = onOpenDiscover,
                     showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
                     keyboardController = keyboardController,
@@ -722,9 +727,6 @@ fun SearchScreen(
                                 },
                                 onItemClick = { id, type, addonBaseUrl ->
                                     lastFocusedRowKey = catalogKey
-                                    // Entering a result confirms the query for recent history
-                                    // (keyboard Done is not required after live search).
-                                    viewModel.onEvent(SearchEvent.RememberSearchFromResults)
                                     // Save focus state to ViewModel before navigating
                                     viewModel.savedFocusRowKey = catalogKey
                                     viewModel.savedFocusItemIndex = searchRowFocusedItemIndex[catalogKey] ?: 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -722,6 +722,9 @@ fun SearchScreen(
                                 },
                                 onItemClick = { id, type, addonBaseUrl ->
                                     lastFocusedRowKey = catalogKey
+                                    // Entering a result confirms the query for recent history
+                                    // (keyboard Done is not required after live search).
+                                    viewModel.onEvent(SearchEvent.RememberSearchFromResults)
                                     // Save focus state to ViewModel before navigating
                                     viewModel.savedFocusRowKey = catalogKey
                                     viewModel.savedFocusItemIndex = searchRowFocusedItemIndex[catalogKey] ?: 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -191,6 +191,7 @@ class SearchViewModel @Inject constructor(
         when (event) {
             is SearchEvent.QueryChanged -> onQueryChanged(event.query)
             SearchEvent.SubmitSearch -> submitSearch()
+            SearchEvent.RememberSearchFromResults -> rememberSearchFromResults()
             SearchEvent.ClearRecentSearches -> clearRecentSearches()
             is SearchEvent.LoadMoreCatalog -> loadMoreCatalogItems(
                 catalogId = event.catalogId,
@@ -325,7 +326,27 @@ class SearchViewModel @Inject constructor(
     private fun submitSearch() {
         // An explicit submit just skips the remaining debounce; the live run would land anyway.
         liveSearchJob?.cancel()
-        performSearch(_uiState.value.query)
+        performSearch(_uiState.value.query, rememberToHistory = true)
+    }
+
+    /**
+     * Entering a search result confirms the current query the same way Done/submit does.
+     * Live search may already have results on screen without an explicit submit; saving here
+     * avoids losing useful history while still not recording every keystroke prefix.
+     */
+    private fun rememberSearchFromResults() {
+        val state = _uiState.value
+        val query = state.submittedQuery.trim().ifBlank { state.query.trim() }
+        if (query.length < MIN_SEARCH_QUERY_LENGTH) return
+        val hasRealResults = state.catalogRows.any { row ->
+            row.items.any { item -> !item.id.startsWith("__placeholder_") }
+        } || catalogsMap.values.any { row ->
+            row.items.any { item -> !item.id.startsWith("__placeholder_") }
+        }
+        if (!hasRealResults) return
+        viewModelScope.launch {
+            searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
+        }
     }
 
     private fun clearRecentSearches() {
@@ -371,7 +392,7 @@ class SearchViewModel @Inject constructor(
     }
 
 
-    private fun performSearch(rawQuery: String) {
+    private fun performSearch(rawQuery: String, rememberToHistory: Boolean = false) {
         val query = rawQuery.trim()
         suggestionJob?.cancel()
         _uiState.update {
@@ -430,7 +451,17 @@ class SearchViewModel @Inject constructor(
             val requestKey = buildRequestKey(query, searchTargets)
             val alreadySatisfied = requestKey == lastRequestKey &&
                 (requestKey == lastCompletedRequestKey || activeSearchJobs.any { it.isActive })
-            if (alreadySatisfied) return@launch
+            if (alreadySatisfied) {
+                // An explicit submit that lands on a query the live search already finished still
+                // counts as a search the user confirmed, so remember it instead of skipping out
+                // of the history save below.
+                if (rememberToHistory && catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
+                    viewModelScope.launch {
+                        searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
+                    }
+                }
+                return@launch
+            }
             lastRequestKey = requestKey
 
             // Committed to a new run: drop the previous query's work and accumulated rows.
@@ -538,9 +569,10 @@ class SearchViewModel @Inject constructor(
                 ) {
                     lastCompletedRequestKey = requestKey
                     _uiState.update { it.copy(isSearching = false) }
-                    // Remembered once it has actually returned something, so backing out still
-                    // saves what you typed while typos that match nothing never get recorded.
-                    if (catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
+                    // Only explicit submit (or opening a result — see rememberSearchFromResults)
+                    // writes history. Live search fires per keystroke and would otherwise record
+                    // every prefix ("do", "dog") even when the user never confirmed the search.
+                    if (rememberToHistory && catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
                         viewModelScope.launch {
                             searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -191,7 +191,7 @@ class SearchViewModel @Inject constructor(
         when (event) {
             is SearchEvent.QueryChanged -> onQueryChanged(event.query)
             SearchEvent.SubmitSearch -> submitSearch()
-            SearchEvent.RememberSearchFromResults -> rememberSearchFromResults()
+            SearchEvent.RememberSearchFromTextInput -> rememberSearchFromTextInput()
             SearchEvent.ClearRecentSearches -> clearRecentSearches()
             is SearchEvent.LoadMoreCatalog -> loadMoreCatalogItems(
                 catalogId = event.catalogId,
@@ -330,11 +330,12 @@ class SearchViewModel @Inject constructor(
     }
 
     /**
-     * Entering a search result confirms the current query the same way Done/submit does.
-     * Live search may already have results on screen without an explicit submit; saving here
+     * Moving from the text input into the results confirms the current query the same way
+     * Done/submit does. Live search may already have results on screen without an explicit
+     * submit; saving here
      * avoids losing useful history while still not recording every keystroke prefix.
      */
-    private fun rememberSearchFromResults() {
+    private fun rememberSearchFromTextInput() {
         val state = _uiState.value
         val query = state.submittedQuery.trim().ifBlank { state.query.trim() }
         if (query.length < MIN_SEARCH_QUERY_LENGTH) return
@@ -569,7 +570,8 @@ class SearchViewModel @Inject constructor(
                 ) {
                     lastCompletedRequestKey = requestKey
                     _uiState.update { it.copy(isSearching = false) }
-                    // Only explicit submit (or opening a result — see rememberSearchFromResults)
+                    // Only explicit submit (or moving into results from the text input — see
+                    // rememberSearchFromTextInput)
                     // writes history. Live search fires per keystroke and would otherwise record
                     // every prefix ("do", "dog") even when the user never confirmed the search.
                     if (rememberToHistory && catalogsMap.values.any { row -> row.items.isNotEmpty() }) {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -17,6 +17,7 @@ import com.nuvio.tv.domain.repository.CatalogRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
 import io.mockk.every
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -89,9 +90,29 @@ class SearchViewModelConcurrencyTest {
         assertEquals(listOf("Deep Cover"), catalogRepository.queries.distinct())
     }
 
+    @Test
+    fun `moving from text input to live-search results remembers the query`() = runTest {
+        val addon = searchableAddon()
+        val history = mockk<SearchHistoryDataStore>(relaxed = true)
+        every { history.recentSearches } returns flowOf(emptyList())
+        val viewModel = newViewModel(
+            addonRepository = GatedAddonRepository(addon, CompletableDeferred(Unit)),
+            catalogRepository = ImmediateCatalogRepository(addon),
+            history = history
+        )
+
+        viewModel.onEvent(SearchEvent.QueryChanged("Deep Cover"))
+        advanceUntilIdle()
+        viewModel.onEvent(SearchEvent.RememberSearchFromTextInput)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { history.saveRecentSearch("Deep Cover", 8) }
+    }
+
     private fun newViewModel(
         addonRepository: AddonRepository,
-        catalogRepository: CatalogRepository
+        catalogRepository: CatalogRepository,
+        history: SearchHistoryDataStore = mockk(relaxed = true)
     ): SearchViewModel {
         val layoutPreferences = mockk<LayoutPreferenceDataStore>()
         every { layoutPreferences.discoverLocation } returns flowOf(com.nuvio.tv.domain.model.DiscoverLocation.OFF)
@@ -103,7 +124,6 @@ class SearchViewModelConcurrencyTest {
         every { layoutPreferences.catalogTypeSuffixEnabled } returns flowOf(true)
         every { layoutPreferences.hideUnreleasedContent } returns flowOf(false)
 
-        val history = mockk<SearchHistoryDataStore>(relaxed = true)
         every { history.recentSearches } returns flowOf(emptyList())
 
         val watchProgress = mockk<WatchProgressRepository>()


### PR DESCRIPTION
## Summary

Search only records an entry in Recent Searches when the user explicitly confirms the query (Done / voice / selecting a suggestion or recent item / moving focus from the text input into live results). The live search that runs per keystroke no longer saves every intermediate prefix into history.

## PR type

- [x] Critical bug fix

## Why

Typing e.g. "dog" and then deleting character by character saved "do" and "dog" into Recent Searches even though the user never confirmed a search. Because the live search fires per keystroke (debounced), and every run that returned results persisted its query, any prefix with results became a separate history entry. The expected behaviour, per the report, is that simply typing and deleting adds nothing to history.

## Issue or approval

Fixes #2928

## Reproduction steps

1. Open Search.
2. Type "dog", then delete one character at a time until empty.
3. Open Recent Searches.

Result before fix: "do" and "dog" both appear, even though neither was confirmed.
Result after fix: nothing is added unless the user explicitly submits the search.

## UI / behavior impact

- [x] Behavior change: Recent Searches is now only updated on explicit search submission, not on every live-search keystroke, so partial/prefix queries the user did not confirm no longer pollute history.

## Policy check

- [x] Fix is limited to the described bug (single issue).
- [x] Change is minimal and does not overlap other open PRs.
- [x] Equivalent duplicate issues check-up before working.

## Scope boundaries

No change to suggestion generation, discover flow, or how results render. The change only gates where the query gets written into Recent Searches: live-search runs no longer persist; explicit submit and D-pad focus transfer from the text input into live results do. Opening a specific result is not a separate history trigger.

## Testing

Verified with `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.search.*" :app:compileFullDebugKotlin` (**BUILD SUCCESSFUL**, 5 tests, 0 failures). `SearchViewModelConcurrencyTest` now covers the review case: after live-search results arrive, moving from the text input into results saves the confirmed query exactly once.

## Screenshots / Video

Not a UI change.

## Breaking changes

No breaking changes.

## Linked issues

- Fixes #2928