### PR TITLE
fix(search): prevent stale searches from hanging (#2917)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -29,6 +29,7 @@ import com.nuvio.tv.domain.model.PLACEHOLDER_IMAGE_URL
 import com.nuvio.tv.domain.repository.CatalogRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -71,6 +72,9 @@ class SearchViewModel @Inject constructor(
     private val catalogOrder = mutableListOf<String>()
 
     private var activeSearchJobs: List<Job> = emptyList()
+    private var searchRunJob: Job? = null
+    private var activeSearchQuery: String? = null
+    private var searchGeneration = 0L
     private var discoverJob: Job? = null
     private var catalogRowsUpdateJob: Job? = null
     private var suggestionJob: Job? = null
@@ -201,6 +205,7 @@ class SearchViewModel @Inject constructor(
                 // An explicit retry must refetch even though nothing about the request changed.
                 lastRequestKey = null
                 lastCompletedRequestKey = null
+                cancelSearchRun()
                 performSearch(uiState.value.submittedQuery.ifBlank { uiState.value.query })
             }
         }
@@ -221,8 +226,7 @@ class SearchViewModel @Inject constructor(
         }
 
         // Drop in-flight requests for the previous keystroke before scheduling the next run.
-        activeSearchJobs.forEach { it.cancel() }
-        activeSearchJobs = emptyList()
+        cancelSearchRun()
 
         // Live search: results follow what you type, like mobile. Debounced because each run hits
         // every enabled addon catalog.
@@ -337,6 +341,15 @@ class SearchViewModel @Inject constructor(
         pendingCatalogResponses = 0
     }
 
+    private fun cancelSearchRun() {
+        searchGeneration++
+        searchRunJob?.cancel()
+        searchRunJob = null
+        activeSearchJobs.forEach { it.cancel() }
+        activeSearchJobs = emptyList()
+        activeSearchQuery = null
+    }
+
     /**
      * Identifies a search by everything that changes what it would return: the query, the released
      * filter, and the exact set of catalogs it would hit. Enabling an addon or flipping the filter
@@ -370,8 +383,7 @@ class SearchViewModel @Inject constructor(
         }
 
         if (query.length < MIN_SEARCH_QUERY_LENGTH) {
-            activeSearchJobs.forEach { it.cancel() }
-            activeSearchJobs = emptyList()
+            cancelSearchRun()
             catalogRowsUpdateJob?.cancel()
             resetCatalogAccumulator()
             lastRequestKey = null
@@ -387,13 +399,26 @@ class SearchViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
+        // Submit can immediately follow the debounced live-search launch. Reuse an active run for
+        // the same query, but cancel a different query's entire scope before starting this one.
+        if (activeSearchQuery == query && searchRunJob?.isActive == true) return
+        cancelSearchRun()
+        val generation = searchGeneration
+        activeSearchQuery = query
+
+        val job = viewModelScope.launch {
             val addons = try {
                 addonRepository.getInstalledAddons().first().enabledAddons()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                _uiState.update { it.copy(isSearching = false, error = e.message ?: context.getString(com.nuvio.tv.R.string.search_error_load_addons_failed)) }
+                if (generation == searchGeneration && activeSearchQuery == query) {
+                    _uiState.update { it.copy(isSearching = false, error = e.message ?: context.getString(com.nuvio.tv.R.string.search_error_load_addons_failed)) }
+                }
                 return@launch
             }
+
+            if (generation != searchGeneration || activeSearchQuery != query) return@launch
 
             val searchTargets = buildSearchTargets(addons)
 
@@ -495,37 +520,43 @@ class SearchViewModel @Inject constructor(
             }
 
             val jobs = searchTargets.map { (addon, catalog) ->
-                viewModelScope.launch {
-                    loadCatalog(addon, catalog, query)
+                launch {
+                    loadCatalog(addon, catalog, query, generation)
                 }
             }
             pendingCatalogResponses = jobs.size
             activeSearchJobs = jobs
 
             // Wait for all jobs to complete so we can stop showing the global loading state.
-            viewModelScope.launch {
-                try {
-                    jobs.joinAll()
-                } catch (_: Exception) {
-                    // Cancellations are expected when query changes.
-                } finally {
-                    if (uiState.value.submittedQuery.trim() == query) {
-                        lastCompletedRequestKey = requestKey
-                        _uiState.update { it.copy(isSearching = false) }
-                        // Remembered once it has actually returned something, so backing out still
-                        // saves what you typed while typos that match nothing never get recorded.
-                        if (catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
-                            viewModelScope.launch {
-                                searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
-                            }
+            try {
+                jobs.joinAll()
+            } finally {
+                if (
+                    generation == searchGeneration &&
+                    activeSearchQuery == query &&
+                    uiState.value.submittedQuery.trim() == query
+                ) {
+                    lastCompletedRequestKey = requestKey
+                    _uiState.update { it.copy(isSearching = false) }
+                    // Remembered once it has actually returned something, so backing out still
+                    // saves what you typed while typos that match nothing never get recorded.
+                    if (catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
+                        viewModelScope.launch {
+                            searchHistoryDataStore.saveRecentSearch(query, MAX_RECENT_SEARCHES)
                         }
                     }
                 }
             }
         }
+        searchRunJob = job
     }
 
-    private suspend fun loadCatalog(addon: Addon, catalog: CatalogDescriptor, query: String) {
+    private suspend fun loadCatalog(
+        addon: Addon,
+        catalog: CatalogDescriptor,
+        query: String,
+        generation: Long
+    ) {
         val supportsSkip = catalog.supportsExtra("skip")
         val skipStep = catalog.skipStep()
         catalogRepository.getCatalog(
@@ -542,7 +573,7 @@ class SearchViewModel @Inject constructor(
         ).collect { result ->
             when (result) {
                 is NetworkResult.Success -> {
-                    if (uiState.value.submittedQuery.trim() != query) return@collect
+                    if (!isCurrentSearch(generation, query)) return@collect
                     val key = catalogKey(
                         addonId = addon.id,
                         addonBaseUrl = addon.baseUrl,
@@ -554,7 +585,7 @@ class SearchViewModel @Inject constructor(
                     scheduleCatalogRowsUpdate()
                 }
                 is NetworkResult.Error -> {
-                    if (uiState.value.submittedQuery.trim() != query) return@collect
+                    if (!isCurrentSearch(generation, query)) return@collect
                     pendingCatalogResponses = (pendingCatalogResponses - 1).coerceAtLeast(0)
                     // Ignore per-catalog errors unless we have nothing to show.
                     if (catalogsMap.isEmpty()) {
@@ -568,6 +599,9 @@ class SearchViewModel @Inject constructor(
             }
         }
     }
+
+    private fun isCurrentSearch(generation: Long, query: String): Boolean =
+        generation == searchGeneration && uiState.value.submittedQuery.trim() == query
 
     private fun loadMoreCatalogItems(catalogId: String, addonId: String, type: String) {
         val (key, currentRow) = catalogsMap.entries.firstOrNull { (_, row) ->

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -1,0 +1,214 @@
+package com.nuvio.tv.ui.screens.search
+
+import android.content.Context
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.data.local.SearchHistoryDataStore
+import com.nuvio.tv.data.local.WatchedSeriesStateHolder
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogExtra
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.repository.AddonRepository
+import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
+import com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runCurrent
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchViewModelConcurrencyTest {
+
+    private val mainDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `older search outer job cannot leave newer multi-word search loading`() = runTest {
+        val firstAddonLookup = CompletableDeferred<Unit>()
+        val addon = searchableAddon()
+        val addonRepository = GatedAddonRepository(addon, firstAddonLookup)
+        val catalogRepository = ImmediateCatalogRepository(addon)
+        val viewModel = newViewModel(addonRepository, catalogRepository)
+
+        // This is the Fire TV keyboard/voice sequence: the field receives the text and the
+        // submitted query immediately follows it.
+        viewModel.onEvent(SearchEvent.QueryChanged("Deep"))
+        viewModel.onEvent(SearchEvent.SubmitSearch)
+        runCurrent()
+
+        // Q1 is suspended in the addon lookup; before the fix, the outer coroutine owning this
+        // lookup was untracked and could resume after Q2.
+        viewModel.onEvent(SearchEvent.QueryChanged("Deep Cover"))
+        viewModel.onEvent(SearchEvent.SubmitSearch)
+        runCurrent()
+        advanceUntilIdle()
+
+        // Q2 has completed and is no longer loading before the stale Q1 outer coroutine resumes.
+        assertEquals("Deep Cover", viewModel.uiState.value.submittedQuery)
+        assertFalse(viewModel.uiState.value.isSearching)
+        assertTrue(catalogRepository.queries.contains("Deep Cover"))
+
+        // Completing the stale Q1 lookup must not revive work for the old generation.
+        firstAddonLookup.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("Deep Cover", viewModel.uiState.value.submittedQuery)
+        assertFalse(viewModel.uiState.value.isSearching)
+        assertEquals(listOf("Deep Cover"), catalogRepository.queries.distinct())
+    }
+
+    private fun newViewModel(
+        addonRepository: AddonRepository,
+        catalogRepository: CatalogRepository
+    ): SearchViewModel {
+        val layoutPreferences = mockk<LayoutPreferenceDataStore>()
+        every { layoutPreferences.discoverLocation } returns flowOf(com.nuvio.tv.domain.model.DiscoverLocation.OFF)
+        every { layoutPreferences.posterCardWidthDp } returns flowOf(126)
+        every { layoutPreferences.posterLabelsEnabled } returns flowOf(true)
+        every { layoutPreferences.catalogAddonNameEnabled } returns flowOf(true)
+        every { layoutPreferences.posterCardHeightDp } returns flowOf(189)
+        every { layoutPreferences.posterCardCornerRadiusDp } returns flowOf(12)
+        every { layoutPreferences.catalogTypeSuffixEnabled } returns flowOf(true)
+        every { layoutPreferences.hideUnreleasedContent } returns flowOf(false)
+
+        val history = mockk<SearchHistoryDataStore>(relaxed = true)
+        every { history.recentSearches } returns flowOf(emptyList())
+
+        val watchProgress = mockk<WatchProgressRepository>()
+        every { watchProgress.observeWatchedMovieIds() } returns flowOf(emptySet())
+
+        val watchedSeries = mockk<WatchedSeriesStateHolder>()
+        every { watchedSeries.fullyWatchedSeriesIds } returns MutableStateFlow(emptySet())
+
+        return SearchViewModel(
+            addonRepository = addonRepository,
+            catalogRepository = catalogRepository,
+            layoutPreferenceDataStore = layoutPreferences,
+            searchHistoryDataStore = history,
+            watchProgressRepository = watchProgress,
+            watchedSeriesStateHolder = watchedSeries,
+            posterOptions = mockk<PosterOptionsController>(relaxed = true),
+            context = mockk<Context>(relaxed = true)
+        )
+    }
+
+    private class GatedAddonRepository(
+        private val addon: Addon,
+        private val firstLookupGate: CompletableDeferred<Unit>
+    ) : AddonRepository {
+        private val lookups = AtomicInteger()
+
+        override fun getInstalledAddons(): Flow<List<Addon>> = flow {
+            if (lookups.getAndIncrement() == 0) {
+                firstLookupGate.await()
+            }
+            emit(listOf(addon))
+        }
+
+        override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> = error("unused")
+        override suspend fun addAddon(url: String) = error("unused")
+        override suspend fun removeAddon(url: String) = error("unused")
+        override suspend fun setAddonOrder(urls: List<String>) = error("unused")
+        override suspend fun setAddonEnabled(url: String, enabled: Boolean) = error("unused")
+    }
+
+    private class ImmediateCatalogRepository(
+        private val addon: Addon
+    ) : CatalogRepository {
+        val queries = mutableListOf<String>()
+
+        override fun getCatalog(
+            addonBaseUrl: String,
+            addonId: String,
+            addonName: String,
+            catalogId: String,
+            catalogName: String,
+            type: String,
+            skip: Int,
+            skipStep: Int,
+            extraArgs: Map<String, String>,
+            supportsSkip: Boolean
+        ): Flow<NetworkResult<CatalogRow>> = flow {
+            val query = extraArgs.getValue("search")
+            queries += query
+            emit(NetworkResult.Loading)
+            emit(NetworkResult.Success(row(addon, query)))
+        }
+
+        private fun row(addon: Addon, query: String): CatalogRow = CatalogRow(
+            addonId = addon.id,
+            addonName = addon.displayName,
+            addonBaseUrl = addon.baseUrl,
+            catalogId = addon.catalogs.single().id,
+            catalogName = addon.catalogs.single().name,
+            type = ContentType.MOVIE,
+            items = listOf(
+                MetaPreview(
+                    id = query,
+                    type = ContentType.MOVIE,
+                    name = query,
+                    poster = null,
+                    posterShape = PosterShape.POSTER,
+                    background = null,
+                    logo = null,
+                    description = null,
+                    releaseInfo = null,
+                    imdbRating = null,
+                    genres = emptyList()
+                )
+            )
+        )
+    }
+
+    private fun searchableAddon(): Addon {
+        val catalog = CatalogDescriptor(
+            type = ContentType.MOVIE,
+            id = "top",
+            name = "Top",
+            extra = listOf(CatalogExtra(name = "search"))
+        )
+        return Addon(
+            id = "addon",
+            name = "Addon",
+            version = "1",
+            description = null,
+            logo = null,
+            baseUrl = "https://example.test",
+            catalogs = listOf(catalog),
+            types = listOf(ContentType.MOVIE),
+            resources = emptyList()
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Prevent an older live-search run from resuming after a newer query and cancelling the newer query's catalog jobs. The complete search run is now tracked and cancelled as one structured coroutine scope, while a generation token prevents stale results or completion handlers from updating current UI state.

A deterministic JVM regression test reproduces the out-of-order `Deep` -> `Deep Cover` sequence reported on Fire TV.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`performSearch` previously launched the installed-addon lookup in an untracked `viewModelScope` coroutine and tracked only the later catalog jobs. If the lookup for an older query resumed after a newer multi-word query had already started, the older run could cancel the newer catalog jobs and replace them with stale work.

The stale run's completion was then ignored because `submittedQuery` already contained the newer query, leaving `isSearching` set to `true` indefinitely. This matches the reported behavior where a single-word search succeeds but submitting the full multi-word title remains on the loading state.

The Stremio path encoding was also checked independently: Cinemeta returned HTTP 200 with eight results for `Deep Cover` using both `%20` and `+`, so the failure is not caused by encoding.

## Issue or approval

Fixes #2917

## Reproduction steps

1. Open Search on Fire TV.
2. Submit a single-word query such as `Deep`.
3. Quickly replace it with and submit a multi-word query such as `Deep Cover` (the Fire TV keyboard or voice input can trigger this timing).
4. Under the affected timing, the older addon lookup resumes after the newer search starts.
5. Before this fix, the newer catalog jobs are cancelled and Search remains loading indefinitely.
6. After this fix, only `Deep Cover` completes and the loading state clears.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This changes only Search run lifecycle and stale-result protection. It does not change query encoding, catalog URL construction, result ordering, search presentation, suggestions, history behavior, addon configuration, or any UI styling.

## Testing

- Regression proof before the production change: `SearchViewModelConcurrencyTest` failed after the delayed old lookup resumed because `isSearching` became `true` and stale `Deep` work was observed.
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.search.SearchViewModelConcurrencyTest" --rerun-tasks` — passed after the fix.
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.search.*"` — passed.
- `./gradlew :app:compileFullDebugKotlin` — passed.
- `git diff --check` — passed.
- No Fire TV, Android emulator, or physical device was used; the reported ordering is reproduced deterministically with controlled coroutine scheduling and addon lookup completion.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

- Fixes #2917