### PR TITLE
chore(i18n): translate Continue Watching card styles and fix Plugins section label (Greek)

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -805,6 +805,9 @@
   <string name="layout_next_up_furthest_episode_sub">Εμφάνιση επόμενου επεισοδίου με βάση το πιο προχωρημένο προβληθέν επεισόδιο. Απενεργοποιήστε το για επαναπροβολές ώστε να χρησιμοποιείται το πιο πρόσφατα προβληθέν επεισόδιο.</string>
   <string name="layout_show_unaired_next_up">Εμφάνιση μη προβληθέντων επόμενων επεισοδίων</string>
   <string name="layout_show_unaired_next_up_sub">Συμπερίληψη επερχόμενων επεισοδίων στη Συνέχεια παρακολούθησης πριν την προβολή τους.</string>
+  <string name="layout_cw_card_style_card">Κάρτα</string>
+  <string name="layout_cw_card_style_wide">Ευρεία</string>
+  <string name="layout_cw_card_style_poster">Αφίσα</string>
   <string name="layout_cw_sort_mode">Σειρά ταξινόμησης</string>
   <string name="layout_cw_sort_mode_sub">Πώς ταξινομούνται τα στοιχεία Συνέχεια παρακολούθησης</string>
   <string name="layout_cw_sort_default">Προεπιλογή</string>
@@ -1747,7 +1750,7 @@
   <string name="plugin_readonly_notice">Χρησιμοποιείτε τα πρόσθετα του κύριου προφίλ και δεν μπορούν να αλλάξουν</string>
   <string name="plugin_repositories_section">Αποθετήρια (%1$d)</string>
   <string name="plugin_providers_section">Πάροχοι (%1$d)</string>
-  <string name="plugin_title">Πρόσθετα</string>
+  <string name="plugin_title">Αποθετήρια πρόσθετων</string>
   <string name="plugin_subtitle">Διαχείριση τοπικών ανιχνευτών και παρόχων</string>
   <string name="plugin_enable_plugins_title">Καθολική ενεργοποίηση παρόχων πρόσθετων</string>
   <string name="plugin_enable_plugins_subtitle">Χρήση παρόχων πρόσθετων κατά την αναζήτηση ροών</string>


### PR DESCRIPTION
## Summary

Greek (`values-el`) localization update:

- Added the 3 missing translations for the new Continue Watching card style options (`layout_cw_card_style_card` → Κάρτα, `layout_cw_card_style_wide` → Ευρεία, `layout_cw_card_style_poster` → Αφίσα), matching existing terminology (e.g. `collections_editor_shape_poster` is already Αφίσα).
- Fixed the duplicate label in the Content & Discovery settings section: the second entry (`plugin_title`) now reads Αποθετήρια πρόσθετων instead of repeating Πρόσθετα, matching the section's existing vocabulary (`settings_content_discovery_plugins_subtitle` = Διαχείριση αποθετηρίων και παρόχων ροών, `plugin_repositories_section` = Αποθετήρια).

Scope: only `app/src/main/res/values-el/strings.xml` (1 file, +4/-1).

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Translation/localization only
- [ ] Critical bug fix

## Why

Keep the Greek locale in full parity with the default strings after the recent CW card styles feature landed upstream. Two fixes: the three new card style option strings were missing from the Greek file, and the Plugins row in Content & Discovery was mistranslated as a duplicate of the Add-ons row.

## Issue or approval

No linked issue: localization-only update.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `app/src/main/res/values-el/strings.xml`. No code, other locales, or default strings were touched.

## Testing

- Compared `values-el/strings.xml` against `values/strings.xml` programmatically (fast-xml-parser): full 1:1 key parity (2739 = 2739 keys), zero missing, zero extra, no duplicates.
- Verified placeholder token parity (e.g. `%1$d`, `%1$s`) between the two files for every key — no mismatches.
- Confirmed all remaining strings identical to English are intentional keeps (brand names, technical terms, format strings, URLs) consistent with the established Greek conventions.
- XML well-formedness validated.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.