### PR TITLE
reduce playback stutter when marking episodes as watched

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchedItemsPreferences.kt
@@ -105,14 +105,9 @@ class WatchedItemsPreferences @Inject constructor(
     ) {
         store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
+            val itemKey = watchedItemKey(item)
             val filtered = current.filterNot { json ->
-                runCatching {
-                    gson.fromJson(json, WatchedItem::class.java)
-                }.getOrNull()?.let { existing ->
-                    existing.contentId == item.contentId &&
-                        existing.season == item.season &&
-                        existing.episode == item.episode
-                } ?: false
+                extractWatchedItemKey(json) == itemKey
             }
             preferences[watchedItemsKey] = filtered.toSet() + gson.toJson(item)
         }
@@ -125,13 +120,9 @@ class WatchedItemsPreferences @Inject constructor(
         if (items.isEmpty()) return
         store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
-            val newKeys = items.map { Triple(it.contentId, it.season, it.episode) }.toSet()
+            val newKeys = items.map { watchedItemKey(it) }.toSet()
             val filtered = current.filterNot { json ->
-                runCatching {
-                    gson.fromJson(json, WatchedItem::class.java)
-                }.getOrNull()?.let { existing ->
-                    Triple(existing.contentId, existing.season, existing.episode) in newKeys
-                } ?: false
+                extractWatchedItemKey(json) in newKeys
             }
             preferences[watchedItemsKey] = filtered.toSet() + items.map { gson.toJson(it) }
         }
@@ -143,16 +134,11 @@ class WatchedItemsPreferences @Inject constructor(
         episode: Int? = null,
         profileId: Int = profileManager.activeProfileId.value
     ) {
+        val removeKey = buildWatchedKey(contentId, season, episode)
         store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val filtered = current.filterNot { json ->
-                runCatching {
-                    gson.fromJson(json, WatchedItem::class.java)
-                }.getOrNull()?.let { existing ->
-                    existing.contentId == contentId &&
-                        existing.season == season &&
-                        existing.episode == episode
-                } ?: false
+                extractWatchedItemKey(json) == removeKey
             }
             preferences[watchedItemsKey] = filtered.toSet()
         }
@@ -164,15 +150,11 @@ class WatchedItemsPreferences @Inject constructor(
         profileId: Int = profileManager.activeProfileId.value
     ) {
         if (episodes.isEmpty()) return
-        val removeKeys = episodes.map { (s, e) -> Triple(contentId, s, e) }.toSet()
+        val removeKeys = episodes.map { (s, e) -> buildWatchedKey(contentId, s, e) }.toSet()
         store(profileId).edit { preferences ->
             val current = preferences[watchedItemsKey] ?: emptySet()
             val filtered = current.filterNot { json ->
-                runCatching {
-                    gson.fromJson(json, WatchedItem::class.java)
-                }.getOrNull()?.let { existing ->
-                    Triple(existing.contentId, existing.season, existing.episode) in removeKeys
-                } ?: false
+                extractWatchedItemKey(json) in removeKeys
             }
             preferences[watchedItemsKey] = filtered.toSet()
         }
@@ -284,5 +266,62 @@ class WatchedItemsPreferences @Inject constructor(
             preferences.remove(deltaCursorKey)
             preferences.remove(deltaInitializedKey)
         }
+    }
+
+    private fun watchedItemKey(item: WatchedItem): String =
+        buildWatchedKey(item.contentId, item.season, item.episode)
+
+    private fun buildWatchedKey(contentId: String, season: Int?, episode: Int?): String =
+        "$contentId|${season ?: "_"}|${episode ?: "_"}"
+
+    /**
+     * Extracts a composite key from a raw JSON string without full Gson deserialization.
+     * Looks for "contentId", "season", "episode" fields via simple string search.
+     * Falls back to full Gson parse only if the fast path fails.
+     */
+    private fun extractWatchedItemKey(json: String): String {
+        val contentId = extractJsonStringField(json, "contentId")
+        val season = extractJsonIntField(json, "season")
+        val episode = extractJsonIntField(json, "episode")
+        if (contentId != null) {
+            return buildWatchedKey(contentId, season, episode)
+        }
+        // Fallback: full deserialization (should rarely happen with well-formed JSON)
+        val item = runCatching { gson.fromJson(json, WatchedItem::class.java) }.getOrNull()
+            ?: return json // use raw json as unique key for malformed entries
+        return watchedItemKey(item)
+    }
+
+    private fun extractJsonStringField(json: String, field: String): String? {
+        val marker = "\"$field\""
+        val fieldIdx = json.indexOf(marker)
+        if (fieldIdx < 0) return null
+        val colonIdx = json.indexOf(':', fieldIdx + marker.length)
+        if (colonIdx < 0) return null
+        val openQuote = json.indexOf('"', colonIdx + 1)
+        if (openQuote < 0) return null
+        val closeQuote = json.indexOf('"', openQuote + 1)
+        if (closeQuote < 0) return null
+        return json.substring(openQuote + 1, closeQuote)
+    }
+
+    private fun extractJsonIntField(json: String, field: String): Int? {
+        val marker = "\"$field\""
+        val fieldIdx = json.indexOf(marker)
+        if (fieldIdx < 0) return null
+        val colonIdx = json.indexOf(':', fieldIdx + marker.length)
+        if (colonIdx < 0) return null
+        // Skip whitespace after colon
+        var i = colonIdx + 1
+        while (i < json.length && json[i].isWhitespace()) i++
+        if (i >= json.length) return null
+        // Handle null
+        if (json.startsWith("null", i)) return null
+        // Parse integer
+        val start = i
+        if (json[i] == '-') i++
+        while (i < json.length && json[i].isDigit()) i++
+        if (i == start) return null
+        return json.substring(start, i).toIntOrNull()
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -46,6 +46,7 @@ import com.nuvio.tv.domain.repository.StreamRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import androidx.media3.session.MediaSession
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -91,6 +92,8 @@ class PlayerRuntimeController(
     savedStateHandle: SavedStateHandle,
     internal val scope: CoroutineScope
 ) {
+
+    internal val watchedWriteDispatcher = Dispatchers.IO.limitedParallelism(1)
 
     companion object {
         internal const val TAG = "PlayerViewModel"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -686,7 +686,7 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, d
         progressPercent = fallbackPercent
     )
 
-    scope.launch(kotlinx.coroutines.NonCancellable) {
+    scope.launch(kotlinx.coroutines.NonCancellable + watchedWriteDispatcher) {
         val effectiveContentId = watchProgressRepository.normalizeParentContentId(
             parentContentId = progress.contentId,
             videoId = progress.videoId


### PR DESCRIPTION
## Summary

Fix playback stutter that occurs when an episode crosses the watched threshold (~90%) for users with large watch history. Two changes:
1. Replace O(N) Gson deserialization in WatchedItemsPreferences with lightweight JSON string key extraction
2. Isolate watched/progress DataStore writes on a dedicated single-thread dispatcher to prevent IO thread pool starvation during playback

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Users with thousands of watched items experience video stuttering/frame drops at ~90% playback. At that point `markAsCompleted` triggers a DataStore write that deserializes every JSON entry in the watched set via Gson to find duplicates. For large lists this causes GC pressure and thread pool contention on the shared IO dispatcher, starving the player's decode/network threads.

## Issue or approval

Reported by multiple users with large watch histories experiencing stuttering near episode completion.

## Reproduction steps

1. Have a large watched history (2000+ items)
2. Play any episode with the internal player
3. Let playback reach ~90% of the episode
4. Observe stutter/frame drops at the moment the episode is marked as watched

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No changes to watched items data format or DataStore schema
- No changes to the watched threshold values (90%/80%)
- No changes to sync logic or remote push behavior
- The `allItems` Flow, `mergeRemoteItems`, `applyRemoteChanges`, and `replaceWithRemoteItems` methods are untouched

## Testing

- Verified `extractWatchedItemKey` produces identical keys to full Gson deserialization for all WatchedItem field combinations (contentId only, with season/episode, with nulls)
- Verified `markAsWatched` correctly deduplicates existing entries
- Verified `unmarkAsWatched` and `unmarkAsWatchedBatch` correctly remove entries
- Verified playback reaches completion without stutter on device with 3000+ watched items
- Verified Continue Watching shows correct next episode after exiting player

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Reported by users with large watch history experiencing stuttering near episode completion.
