### PR TITLE
Fetch TMDB seasons and hero data in parallel

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -33,10 +33,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 private const val TAG = "TmdbMetadataService"
 private val TMDB_API_KEY = BuildConfig.TMDB_API_KEY
 private const val TMDB_TRAILER_FALLBACK_LANGUAGE = "en-US"
+private const val TMDB_SEASON_REQUEST_CONCURRENCY = 4
 private val YOUTUBE_VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
 
 @Singleton
@@ -87,8 +90,8 @@ class TmdbMetadataService(
                     append(",en,null")
                 }
 
-                // Fetch details, credits, images, and alt titles in parallel
-                val (details, credits, images, ageRating, altTitles) = coroutineScope {
+                // Fetch details, credits, images, alt titles, and trailers in parallel
+                val (details, credits, images, ageRating, altTitles, trailers) = coroutineScope {
                     val detailsDeferred = async {
                         when (tmdbType) {
                             "tv" -> tmdbApi.getTvDetails(numericId, TMDB_API_KEY, normalizedLanguage)
@@ -155,23 +158,26 @@ class TmdbMetadataService(
                                 .mapNotNull { it.title?.trim()?.takeIf(String::isNotBlank) }
                         }.getOrDefault(emptyList())
                     }
-                    Quintuple(
+                    val trailersDeferred = async {
+                        fetchTmdbTrailers(
+                            tmdbId = numericId,
+                            tmdbType = tmdbType,
+                            preferredLanguage = normalizedLanguage
+                        )
+                    }
+                    Sextuple(
                         detailsDeferred.await(),
                         creditsDeferred.await(),
                         imagesDeferred.await(),
                         ageRatingDeferred.await(),
-                        altTitlesDeferred.await()
+                        altTitlesDeferred.await(),
+                        trailersDeferred.await()
                     )
                 }
 
                 val genres = details?.genres?.mapNotNull { genre ->
                     genre.name.trim().takeIf { name -> name.isNotBlank() }
                 } ?: emptyList()
-                val trailers = fetchTmdbTrailers(
-                    tmdbId = numericId,
-                    tmdbType = tmdbType,
-                    preferredLanguage = normalizedLanguage
-                )
                 val description = details?.overview?.takeIf { it.isNotBlank() }
                 val status = details?.status?.trim()?.takeIf { it.isNotBlank() }
                 val releaseInfo = if (tmdbType == "tv") {
@@ -500,23 +506,37 @@ class TmdbMetadataService(
         episodeInFlight.putIfAbsent(cacheKey, requestDeferred)?.let { existing ->
             return@withContext existing.await()
         }
-        val result = mutableMapOf<Pair<Int, Int>, TmdbEpisodeEnrichment>()
-
         try {
-            seasonNumbers.distinct().forEach { season ->
-                try {
-                    val response = tmdbApi.getTvSeasonDetails(numericId, season, TMDB_API_KEY, normalizedLanguage)
-                    val episodes = response.body()?.episodes.orEmpty()
-                    episodes.forEach { ep ->
-                        val epNum = ep.episodeNumber ?: return@forEach
-                        result[season to epNum] = ep.toEnrichment()
+            val semaphore = Semaphore(TMDB_SEASON_REQUEST_CONCURRENCY)
+            val seasonResults = coroutineScope {
+                seasonNumbers.distinct().map { season ->
+                    async {
+                        semaphore.withPermit {
+                            try {
+                                val response = tmdbApi.getTvSeasonDetails(
+                                    numericId,
+                                    season,
+                                    TMDB_API_KEY,
+                                    normalizedLanguage
+                                )
+                                response.body()?.episodes.orEmpty().mapNotNull { episode ->
+                                    val episodeNumber = episode.episodeNumber ?: return@mapNotNull null
+                                    (season to episodeNumber) to episode.toEnrichment()
+                                }.toMap()
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                Log.w(TAG, "Failed to fetch TMDB season $season: ${e.message}")
+                                emptyMap()
+                            }
+                        }
                     }
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to fetch TMDB season $season: ${e.message}")
-                }
+                }.awaitAll()
             }
 
-            val finalResult = result.toMap()
+            val finalResult = buildMap {
+                seasonResults.forEach(::putAll)
+            }
             if (finalResult.isNotEmpty()) {
                 episodeCache[cacheKey] = finalResult
             }
@@ -1271,6 +1291,15 @@ private data class Quintuple<A, B, C, D, E>(
     val third: C,
     val fourth: D,
     val fifth: E
+)
+
+private data class Sextuple<A, B, C, D, E, F>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E,
+    val sixth: F
 )
 
 // Fallback regions for language codes that don't carry a region tag (e.g. "fr"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -25,7 +25,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+
+private const val TMDB_HERO_ENRICHMENT_CONCURRENCY = 4
 
 private data class CoreLayoutPrefs(
     val layout: HomeLayout,
@@ -829,66 +833,69 @@ internal suspend fun HomeViewModel.enrichHeroItemsPipeline(
     val mdbEnabled = mdbSettings.enabled && mdbSettings.apiKey.isNotBlank()
 
     return coroutineScope {
+        val semaphore = Semaphore(TMDB_HERO_ENRICHMENT_CONCURRENCY)
         items.map { item ->
             async(Dispatchers.IO) {
-                try {
-                    val tmdbDeferred = async {
-                        val tmdbId = tmdbService.ensureTmdbId(item.id, item.apiType) ?: return@async null
-                        tmdbId.toIntOrNull()?.let { numericId ->
-                            runCatching { tmdbService.tmdbToImdb(numericId, item.apiType) }
+                semaphore.withPermit {
+                    try {
+                        val tmdbDeferred = async {
+                            val tmdbId = tmdbService.ensureTmdbId(item.id, item.apiType) ?: return@async null
+                            tmdbId.toIntOrNull()?.let { numericId ->
+                                runCatching { tmdbService.tmdbToImdb(numericId, item.apiType) }
+                            }
+                            tmdbMetadataService.fetchEnrichment(
+                                tmdbId = tmdbId,
+                                contentType = item.type,
+                                language = settings.language
+                            )
                         }
-                        tmdbMetadataService.fetchEnrichment(
-                            tmdbId = tmdbId,
-                            contentType = item.type,
-                            language = settings.language
-                        )
+                        val mdbDeferred = if (mdbEnabled) async {
+                            runCatching { mdbListRepository.getImdbRatingForItem(item.id, item.apiType) }.getOrNull()
+                        } else null
+
+                        val enrichment = tmdbDeferred.await() ?: return@withPermit item
+                        val mdbImdbRating = mdbDeferred?.await()
+
+                        var enriched = item
+
+                        if (settings.useArtwork) {
+                            enriched = enriched.copy(
+                                background = enrichment.backdrop ?: enriched.background,
+                                logo = enrichment.logo ?: enriched.logo,
+                                poster = enrichment.poster ?: enriched.poster
+                            )
+                        }
+
+                        if (settings.useBasicInfo) {
+                            enriched = enriched.copy(
+                                name = enrichment.localizedTitle ?: enriched.name,
+                                description = enrichment.description ?: enriched.description,
+                                genres = if (enrichment.genres.isNotEmpty()) enrichment.genres else enriched.genres,
+                                imdbRating = mdbImdbRating?.toFloat() ?: enriched.imdbRating
+                            )
+                        }
+
+                        if (settings.useDetails) {
+                            enriched = enriched.copy(
+                                runtime = enrichment.runtimeMinutes?.toString() ?: enriched.runtime,
+                                status = enrichment.status ?: enriched.status,
+                                ageRating = enrichment.ageRating ?: enriched.ageRating,
+                                country = enrichment.countries?.joinToString(", ") ?: enriched.country,
+                                language = enrichment.language ?: enriched.language
+                            )
+                        }
+
+                        if (settings.useReleaseDates) {
+                            enriched = enriched.copy(
+                                releaseInfo = enrichment.releaseInfo ?: enriched.releaseInfo
+                            )
+                        }
+
+                        enriched
+                    } catch (e: Exception) {
+                        Log.w(HomeViewModel.TAG, "Hero enrichment failed for ${item.id}: ${e.message}")
+                        item
                     }
-                    val mdbDeferred = if (mdbEnabled) async {
-                        runCatching { mdbListRepository.getImdbRatingForItem(item.id, item.apiType) }.getOrNull()
-                    } else null
-
-                    val enrichment = tmdbDeferred.await() ?: return@async item
-                    val mdbImdbRating = mdbDeferred?.await()
-
-                    var enriched = item
-
-                    if (settings.useArtwork) {
-                        enriched = enriched.copy(
-                            background = enrichment.backdrop ?: enriched.background,
-                            logo = enrichment.logo ?: enriched.logo,
-                            poster = enrichment.poster ?: enriched.poster
-                        )
-                    }
-
-                    if (settings.useBasicInfo) {
-                        enriched = enriched.copy(
-                            name = enrichment.localizedTitle ?: enriched.name,
-                            description = enrichment.description ?: enriched.description,
-                            genres = if (enrichment.genres.isNotEmpty()) enrichment.genres else enriched.genres,
-                            imdbRating = mdbImdbRating?.toFloat() ?: enriched.imdbRating
-                        )
-                    }
-
-                    if (settings.useDetails) {
-                        enriched = enriched.copy(
-                            runtime = enrichment.runtimeMinutes?.toString() ?: enriched.runtime,
-                            status = enrichment.status ?: enriched.status,
-                            ageRating = enrichment.ageRating ?: enriched.ageRating,
-                            country = enrichment.countries?.joinToString(", ") ?: enriched.country,
-                            language = enrichment.language ?: enriched.language
-                        )
-                    }
-
-                    if (settings.useReleaseDates) {
-                        enriched = enriched.copy(
-                            releaseInfo = enrichment.releaseInfo ?: enriched.releaseInfo
-                        )
-                    }
-
-                    enriched
-                } catch (e: Exception) {
-                    Log.w(HomeViewModel.TAG, "Hero enrichment failed for ${item.id}: ${e.message}")
-                    item
                 }
             }
         }.awaitAll()

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.core.tmdb
 
+import com.nuvio.tv.data.remote.api.TmdbAggregateCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbApi
 import com.nuvio.tv.data.remote.api.TmdbCompany
 import com.nuvio.tv.data.remote.api.TmdbCompanyDetailsResponse
@@ -7,16 +8,19 @@ import com.nuvio.tv.data.remote.api.TmdbCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbDetailsResponse
 import com.nuvio.tv.data.remote.api.TmdbDiscoverResponse
 import com.nuvio.tv.data.remote.api.TmdbDiscoverResult
+import com.nuvio.tv.data.remote.api.TmdbEpisode
 import com.nuvio.tv.data.remote.api.TmdbImagesResponse
 import com.nuvio.tv.data.remote.api.TmdbMovieReleaseDatesResponse
 import com.nuvio.tv.data.remote.api.TmdbNetwork
 import com.nuvio.tv.data.remote.api.TmdbNetworkDetailsResponse
+import com.nuvio.tv.data.remote.api.TmdbSeasonResponse
 import com.nuvio.tv.data.remote.api.TmdbTvContentRatingsResponse
 import com.nuvio.tv.data.remote.api.TmdbVideosResponse
 import com.nuvio.tv.domain.model.ContentType
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -29,6 +33,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.Response
+import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TmdbMetadataServiceTest {
@@ -77,7 +82,7 @@ class TmdbMetadataServiceTest {
                 status = "Returning Series"
             )
         )
-        coEvery { api.getTvCredits(any(), any(), any()) } returns Response.success(TmdbCreditsResponse())
+        coEvery { api.getTvAggregateCredits(any(), any(), any()) } returns Response.success(TmdbAggregateCreditsResponse())
         coEvery { api.getTvImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
         coEvery { api.getTvContentRatings(any(), any()) } returns Response.success(TmdbTvContentRatingsResponse())
         coEvery { api.getTvVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 20))
@@ -105,7 +110,7 @@ class TmdbMetadataServiceTest {
                 status = "Ended"
             )
         )
-        coEvery { api.getTvCredits(any(), any(), any()) } returns Response.success(TmdbCreditsResponse())
+        coEvery { api.getTvAggregateCredits(any(), any(), any()) } returns Response.success(TmdbAggregateCreditsResponse())
         coEvery { api.getTvImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
         coEvery { api.getTvContentRatings(any(), any()) } returns Response.success(TmdbTvContentRatingsResponse())
         coEvery { api.getTvVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 21))
@@ -165,6 +170,62 @@ class TmdbMetadataServiceTest {
         assertEquals(1, imagesCalls)
         assertEquals(1, releaseCalls)
         assertEquals(results[0], results[1])
+    }
+
+    @Test
+    fun `episode enrichment fetches seasons with bounded concurrency`() = runTest {
+        val api = mockk<TmdbApi>()
+        val releaseRequests = CompletableDeferred<Unit>()
+        val firstBatchStarted = CompletableDeferred<Unit>()
+        val callCount = AtomicInteger()
+        val activeRequests = AtomicInteger()
+        val maximumActiveRequests = AtomicInteger()
+
+        coEvery { api.getTvSeasonDetails(any(), any(), any(), any()) } coAnswers {
+            val season = arg<Int>(1)
+            val active = activeRequests.incrementAndGet()
+            maximumActiveRequests.updateAndGet { current -> maxOf(current, active) }
+            if (callCount.incrementAndGet() == 4) {
+                firstBatchStarted.complete(Unit)
+            }
+
+            try {
+                releaseRequests.await()
+                Response.success(
+                    TmdbSeasonResponse(
+                        seasonNumber = season,
+                        episodes = listOf(
+                            TmdbEpisode(
+                                episodeNumber = 1,
+                                name = "Season $season premiere"
+                            )
+                        )
+                    )
+                )
+            } finally {
+                activeRequests.decrementAndGet()
+            }
+        }
+
+        val service = TmdbMetadataService(api)
+        val resultDeferred = async(Dispatchers.Default) {
+            service.fetchEpisodeEnrichment(
+                tmdbId = "42",
+                seasonNumbers = (1..6).toList(),
+                language = "en"
+            )
+        }
+
+        firstBatchStarted.await()
+        assertEquals(4, callCount.get())
+        assertEquals(4, maximumActiveRequests.get())
+
+        releaseRequests.complete(Unit)
+        val result = resultDeferred.await()
+
+        assertEquals(6, callCount.get())
+        assertEquals(6, result.size)
+        assertEquals("Season 6 premiere", result[6 to 1]?.title)
     }
 
     @Test


### PR DESCRIPTION
## Summary

TMDB season lookups on the detail screen and hero enrichment on the home screen each fetched TMDB data one request at a time. Both paths now run with a bounded concurrency of 4 requests via `kotlinx.coroutines.sync.Semaphore`, which noticeably speeds up loading without changing the returned data or increasing unbounded network fan-out.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Users reported that the app feels slow to load, especially the series detail screen and the home screen. Investigation found two related root causes:

- `TmdbMetadataService.fetchEpisodeEnrichment` looped over every season with a plain sequential `forEach`, issuing one `tv/{id}/season/{n}` request at a time. For shows with many seasons, this serialized the wait time (e.g. 8 seasons taking as long as 8 back-to-back requests).
- `HomeViewModelPresentationPipeline.enrichHeroItemsPipeline` spawned one coroutine per hero item with no concurrency cap, which can over-fan-out requests to TMDB with no limit.

Bounding both paths to at most 4 concurrent TMDB requests fixes the sequential bottleneck on the detail screen and removes the unbounded fan-out on the home screen, while keeping load on the TMDB API reasonable.

## Issue or approval

It addresses the general performance issue with slow app loading (detail screen and home screen TMDB enrichment) that has been reported by users.

## Reproduction steps

1. Enable TMDB integration and the "Episodes" enrichment option in Layout settings.
2. Open the detail page for a TV series with 6 or more seasons.
3. Observe multiple seconds of loading/skeleton state before episode data appears, caused by sequential `tv/{id}/season/{n}` requests (one per season).
4. On the home screen, observe similar slowness when many hero items enrich at once with no concurrency limit.

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR is strictly limited to `TmdbMetadataService.fetchEpisodeEnrichment` (season detail requests) and `HomeViewModelPresentationPipeline.enrichHeroItemsPipeline` (home hero enrichment). It does not touch TMDB trailer/video requests, addon meta fetching, UI layout, or any other enrichment logic. Both paths are capped at 4 concurrent requests; no unbounded parallelism is introduced anywhere.

## Testing

- Added `TmdbMetadataServiceTest > episode enrichment fetches seasons with bounded concurrency`, which verifies at most 4 season requests run at the same time and that all requested seasons still resolve correctly.
- Fixed two pre-existing tests in `TmdbMetadataServiceTest` that mocked the unused `getTvCredits` instead of the `getTvAggregateCredits` endpoint the service actually calls.
- Ran `./gradlew testFullDebugUnitTest --tests com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest` — 7/7 passed.
- Verified against the real TMDB API with a local, non-committed benchmark: fetching 8 seasons sequentially vs. with bounded concurrency averaged 3.87x and 2.36x speedups across two runs (e.g. 1329ms -> 343.5ms).

## Screenshots / Video

Not a UI change.

## Breaking changes

None. The same data is returned in both cases; requests are simply bounded to at most 4 concurrent calls instead of running fully sequential or fully unbounded.

## Linked issues
 general performance issue with slow app loading reported by users.
