### PR TITLE
Disable tunneled playback when prefer app decoder is active.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -296,6 +296,24 @@ data class PlayerSettings(
     // Nuvio ExoPlayer Performance Mode
     val nuvioPerformanceModeEnabled: Boolean = DEFAULT_NUVIO_PERFORMANCE_MODE_ENABLED
 ) {
+    /** Prefer FFmpeg/extension audio decoder (EXTENSION_RENDERER_MODE_PREFER). */
+    val isPreferAppDecoder: Boolean
+        get() = decoderPriority == 2
+
+    /** FFmpeg downmix only runs when the app decoder is preferred. */
+    val effectiveDownmixEnabled: Boolean
+        get() = downmixEnabled && isPreferAppDecoder
+
+    /**
+     * Tunneled playback cannot share the FFmpeg audio path. Prefer-app decoder
+     * (required for downmix) plus tunneling races at startup and playback never begins.
+     */
+    val isTunnelingCompatible: Boolean
+        get() = !isPreferAppDecoder
+
+    val effectiveTunnelingEnabled: Boolean
+        get() = tunnelingEnabled && isTunnelingCompatible
+
     companion object {
         const val DEFAULT_STILL_WATCHING_EPISODE_THRESHOLD = 3
         const val MIN_STILL_WATCHING_EPISODE_THRESHOLD = 2

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -245,7 +245,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     resizeMode = playerSettings.resizeMode,
                     aspectMode = deviceAspectMode,
                     playbackIssueReportsEnabled = playerSettings.playbackIssueReportsEnabled,
-                    tunnelingEnabled = playerSettings.tunnelingEnabled &&
+                    tunnelingEnabled = playerSettings.effectiveTunnelingEnabled &&
                             effectiveInternalPlayerEngine != InternalPlayerEngine.MVP_PLAYER
                 )
             }
@@ -676,7 +676,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                 }
             }.apply {
                 setParameters(buildUponParameters().setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true))
-                if (playerSettings.tunnelingEnabled && !safeAudioModeEnabled) {
+                if (playerSettings.effectiveTunnelingEnabled && !safeAudioModeEnabled) {
                     setParameters(buildUponParameters().setTunnelingEnabled(true))
                 } else if (safeAudioModeEnabled) {
                     setParameters(buildUponParameters().setTunnelingEnabled(false).setConstrainAudioChannelCountToDeviceCapabilities(true))
@@ -788,7 +788,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             }
             // A2DP is stereo; force a clean 2.0 downmix so surround content is audible and balanced.
             val bluetoothStereoDownmix = isBluetoothAudioOutput
-            val effectiveDownmixEnabled = playerSettings.downmixEnabled || bluetoothStereoDownmix
+            val effectiveDownmixEnabled = playerSettings.effectiveDownmixEnabled || bluetoothStereoDownmix
             val effectiveAudioOutputChannels = if (bluetoothStereoDownmix) {
                 com.nuvio.tv.data.local.AudioOutputChannels.CHANNELS_2_0
             } else {
@@ -978,7 +978,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                         "playbackSpeed=${_uiState.value.playbackSpeed} " +
                         "resumePositionMs=$initialResumePosition mime=${currentStreamMimeType ?: "unknown"} " +
                         "bufferEngine=${playerSettings.bufferEngineEnabled} parallel=${mediaSourceFactory.useParallelConnections} " +
-                        "vodCache=${mediaSourceFactory.vodCacheEnabled} tunneling=${playerSettings.tunnelingEnabled}"
+                        "vodCache=${mediaSourceFactory.vodCacheEnabled} tunneling=${playerSettings.effectiveTunnelingEnabled}"
                 )
                 val initialMediaSource = mediaSourceFactory.createMediaSource(
                     context = context,
@@ -1004,7 +1004,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     phase = "starting_stream",
                     message = context.getString(R.string.player_loading_starting)
                 )
-                val isTunneledPlayback = playerSettings.tunnelingEnabled
+                val isTunneledPlayback = playerSettings.effectiveTunnelingEnabled
                 // Hold playWhenReady=false through prepare() so audio does not race ahead
                 // while the video decoder is still opening. The first STATE_READY primes the
                 // pipeline (ColdStartPrime); synchronized play() begins in onRenderedFirstFrame().

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.domain.model.Subtitle
 import com.nuvio.tv.domain.model.enabledAddons
 import kotlinx.coroutines.Job
@@ -306,7 +307,8 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
                     osdClockEnabled = settings.osdClockEnabled,
                     internalPlayerEngine = resolvedInternalPlayerEngine,
                     frameRateMatchingMode = settings.frameRateMatchingMode,
-                    tunnelingEnabled = settings.tunnelingEnabled,
+                    tunnelingEnabled = settings.effectiveTunnelingEnabled &&
+                            resolvedInternalPlayerEngine != InternalPlayerEngine.MVP_PLAYER,
                     persistAudioAmplification = settings.persistAudioAmplification,
                     audioAmplificationDb = resolvedAudioAmplificationDb,
                     centerMixLevelDb = resolvedCenterMixLevelDb

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -214,14 +214,16 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
                 icon = Icons.Default.Tune,
                 title = stringResource(R.string.audio_enable_downmix_title),
                 subtitle = stringResource(R.string.audio_enable_downmix_subtitle),
-                isChecked = playerSettings.downmixEnabled,
+                // Show off outside Prefer app decoders so a persisted value doesn't
+                // read as active (same pattern as optical passthrough / DV8.1-only toggles).
+                isChecked = playerSettings.effectiveDownmixEnabled,
                 onCheckedChange = onSetDownmixEnabled,
                 onFocused = onItemFocused,
-                enabled = enabled
+                enabled = enabled && playerSettings.isPreferAppDecoder
             )
         }
 
-        if (playerSettings.downmixEnabled) {
+        if (playerSettings.effectiveDownmixEnabled) {
             item(key = "audio_number_of_channels") {
                 NavigationSettingsItem(
                     icon = Icons.Default.VolumeUp,
@@ -251,10 +253,14 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
                 icon = Icons.Default.VolumeUp,
                 title = stringResource(R.string.audio_tunneled),
                 subtitle = stringResource(R.string.audio_tunneled_sub),
-                isChecked = playerSettings.tunnelingEnabled,
+                // Show off when prefer-app decoder is active so a persisted value
+                // doesn't read as active (same pattern as optical passthrough /
+                // DV8.1-only toggles). Downmix also requires prefer-app, so this
+                // covers that path too.
+                isChecked = playerSettings.effectiveTunnelingEnabled,
                 onCheckedChange = onSetTunnelingEnabled,
                 onFocused = onItemFocused,
-                enabled = enabled
+                enabled = enabled && playerSettings.isTunnelingCompatible
             )
         }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -639,7 +639,6 @@
     <string name="audio_decoder_prefer_app">الأولوية لفك التشفير عبر التطبيق (FFmpeg)</string>
     <string name="audio_decoder_priority">أولوية فك التشفير</string>
     <string name="audio_enable_downmix_title">تفعيل دمج القنوات (Downmix).</string>
-    <string name="audio_enable_downmix_subtitle">يستخدم مسار دمج القنوات الخاص بـ FFmpeg. عند تعطيله، يتبع الصوت مسار الجهاز الافتراضي.</string>
     <string name="audio_tunneled">التشغيل النفقي</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
     <!-- DV7 Handling Mode -->

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -699,7 +699,6 @@
     <string name="audio_decoder_prefer_app">Preferir decodificadores de la app (FFmpeg)</string>
     <string name="audio_decoder_priority">Prioridad de Decodificación</string>
     <string name="audio_enable_downmix_title">Activar downmix</string>
-    <string name="audio_enable_downmix_subtitle">Utiliza la ruta de downmix de FFmpeg. Cuando está desactivado, el audio utiliza la ruta anterior de Android/dispositivo.</string>
     <string name="audio_tunneled">Reproducción en túnel</string>
     <string name="audio_tunneled_sub">Sincronización de audio y video a nivel de hardware. Puede mejorar la reproducción en algunos dispositivos Android TV.</string>
     <string name="audio_force_optical_passthrough">Forzar transcodificación AC-3 (Óptico/SPDIF)</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -632,7 +632,6 @@
     <string name="audio_decoder_prefer_app">Предпочитай декодери на приложението (FFmpeg)</string>
     <string name="audio_decoder_priority">Приоритет на декодера</string>
     <string name="audio_enable_downmix_title">Включи downmix</string>
-    <string name="audio_enable_downmix_subtitle">Използва FFmpeg downmix пътя. Когато е изключено, аудиото следва предишния Android/устройство път.</string>
     <string name="audio_tunneled">Tunneled възпроизвеждане</string>
     <string name="audio_tunneled_sub">Синхронизация на аудио/видео на хардуерно ниво. Може да подобри възпроизвеждането на някои Android TV устройства</string>
     <!-- DV7 Handling Mode -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -681,7 +681,6 @@
     <string name="audio_decoder_prefer_app">Preferovat dekodéry aplikace (FFmpeg)</string>
     <string name="audio_decoder_priority">Priorita dekodéru</string>
     <string name="audio_enable_downmix_title">Povolit downmix</string>
-    <string name="audio_enable_downmix_subtitle">Používá cestu downmixu FFmpeg. Pokud je vypnuto, zvuk se řídí předchozí cestou Android/zařízení.</string>
     <string name="audio_tunneled">Tunelované přehrávání</string>
     <string name="audio_tunneled_sub">Hardwarová synchronizace audio/video. Může zlepšit přehrávání na některých Android TV zařízeních</string>
     <string name="audio_force_optical_passthrough">Vynutit transkódování AC-3 (Optical/SPDIF)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -636,7 +636,6 @@
     <string name="audio_decoder_prefer_app">Foretræk app-decodere (FFmpeg)</string>
     <string name="audio_decoder_priority">Decoder-prioritet</string>
     <string name="audio_enable_downmix_title">Aktivér downmix</string>
-    <string name="audio_enable_downmix_subtitle">Bruger FFmpeg-downmix-stien. Når deaktiveret følger lyden den tidligere Android/enheds-sti.</string>
     <string name="audio_tunneled">Tunneleret afspilning</string>
     <string name="audio_tunneled_sub">Lyd/video-synkronisering på hardwareniveau. Kan forbedre afspilning på nogle Android TV-enheder</string>
     <string name="audio_force_optical_passthrough">Gennemtving AC-3 Transkodning (Optical/SPDIF)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -627,7 +627,6 @@
   <string name="audio_decoder_prefer_app">Προτίμηση αποκωδικοποιητών εφαρμογής (FFmpeg)</string>
   <string name="audio_decoder_priority">Προτεραιότητα αποκωδικοποιητή</string>
   <string name="audio_enable_downmix_title">Ενεργοποίηση downmix</string>
-  <string name="audio_enable_downmix_subtitle">Χρησιμοποιεί τη διαδρομή downmix FFmpeg. Όταν είναι απενεργοποιημένο, ο ήχος ακολουθεί την προηγούμενη διαδρομή Android/συσκευής.</string>
   <string name="audio_tunneled">Αναπαραγωγή tunneled</string>
   <string name="audio_tunneled_sub">Συγχρονισμός ήχου/βίντεο σε επίπεδο υλικού. Μπορεί να βελτιώσει την αναπαραγωγή σε ορισμένες συσκευές Android TV</string>
   <string name="audio_mpv_hwdec_title">Αποκωδικοποίηση υλικού (μόνο MPV)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2469,7 +2469,6 @@
 
     <!-- Audio&#160;: downmix FFmpeg -->
     <string name="audio_enable_downmix_title">Activer le downmix</string>
-    <string name="audio_enable_downmix_subtitle">Utilise le chemin de downmix FFmpeg. Quand il est désactivé, l’audio suit le chemin Android/appareil précédent.</string>
     <string name="audio_number_of_channels">Nombre de canaux</string>
     <string name="audio_number_of_channels_desc">Définit la disposition des haut-parleurs utilisée pour le downmix FFmpeg.</string>
     <string name="audio_center_mix_label">Downmix&#160;: niveau du canal central</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -699,7 +699,6 @@
     <string name="audio_decoder_prefer_app">Alkalmazás dekódereinek előnyben részesítése (FFmpeg)</string>
     <string name="audio_decoder_priority">Dekóder prioritása</string>
     <string name="audio_enable_downmix_title">Lekeverés engedélyezése</string>
-    <string name="audio_enable_downmix_subtitle">Az FFmpeg lekeverési utat használja. Ha le van tiltva, a hang a korábbi Android/eszköz utat követi.</string>
     <string name="audio_tunneled">Alagutazott (tunneled) lejátszás</string>
     <string name="audio_tunneled_sub">Hang/videó szinkronizálása hardveres szinten. Javíthatja a lejátszást egyes Android TV eszközökön.</string>
     <string name="audio_force_optical_passthrough">AC-3 átkódolás kényszerítése (optikai/SPDIF)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -640,7 +640,6 @@
     <string name="audio_decoder_prefer_app">Utamakan dekoder aplikasi (FFmpeg)</string>
     <string name="audio_decoder_priority">Prioritas Dekoder</string>
     <string name="audio_enable_downmix_title">Aktifkan downmix</string>
-    <string name="audio_enable_downmix_subtitle">Menggunakan jalur downmix FFmpeg. Jika dinonaktifkan, audio akan mengikuti jalur Android/perangkat sebelumnya.</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Sinkronisasi audio/video tingkat hardware. Mungkin meningkatkan pemutaran di beberapa perangkat Android TV</string>
     <string name="audio_mpv_hwdec_title">Dekoding Hardware (Hanya MPV)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2235,7 +2235,6 @@
   <string name="audio_number_of_channels">Numero di canali</string>
   <string name="audio_number_of_channels_desc">Imposta il layout degli altoparlanti utilizzato per il downmix di FFmpeg.</string>
   <string name="audio_enable_downmix_title">Abilita downmix</string>
-  <string name="audio_enable_downmix_subtitle">Utilizza il percorso di downmix FFmpeg. Se disabilitato, l\'audio segue il percorso predefinito di Android o del dispositivo.</string>
   <string name="autoplay_reuse_binge_group">Riutilizza gruppo Binge Watch</string>
   <string name="autoplay_reuse_binge_group_sub">Ricorda e riutilizza l\'ultimo gruppo di visione continua tra le varie sessioni (Continua a guardare, Dettagli, ecc.).</string>
   <string name="debrid_title">Servizi collegati</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -700,7 +700,6 @@
     <string name="audio_decoder_prefer_app">העדף מפענחי אפליקציה (FFmpeg)</string>
     <string name="audio_decoder_priority">איך לנגן את הקול</string>
     <string name="audio_enable_downmix_title">הפעל downmix</string>
-    <string name="audio_enable_downmix_subtitle">משתמש בנתיב ה-downmix של FFmpeg. כשמושבת, השמע פועל לפי נתיב האנדרואיד/המכשיר הקודם.</string>
     <string name="audio_tunneled">הפעלה ממונרת</string>
     <string name="audio_tunneled_sub">מסייע לסנכרן בין הקול לתמונה. נסה אם יש חוסר סנכרון בחלק מהמכשירים.</string>
     <string name="audio_force_optical_passthrough_sub">ממיר פורמטים רב-ערוציים (TrueHD, DTS, AAC וכו׳) ל-Dolby Digital 5.1 בזמן אמת עבור חיבורי Optical/SPDIF.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -640,7 +640,6 @@
     <string name="audio_decoder_prefer_app">アプリデコーダーを優先（FFmpeg）</string>
     <string name="audio_decoder_priority">デコーダー優先度</string>
     <string name="audio_enable_downmix_title">ダウンミックスを有効にする</string>
-    <string name="audio_enable_downmix_subtitle">FFmpegダウンミックスパスを使用します。無効にすると、以前のAndroid/デバイスパスに従います。</string>
     <string name="audio_tunneled">トンネル再生</string>
     <string name="audio_tunneled_sub">ハードウェアレベルの音声/映像同期。一部のAndroid TVデバイスで再生を改善する可能性があります</string>
     <string name="audio_force_optical_passthrough">AC-3トランスコードを強制（光学/SPDIF）</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -268,7 +268,6 @@
     <string name="audio_decoder_prefer_app_desc">Używaj dekoderów FFmpeg gdy dostępne. Lepsza obsługa formatów, ale wyższe użycie CPU.</string>
     <string name="audio_decoder_controls">Kontroluje czy używane są dekodery sprzętowe czy programowe (FFmpeg) dla audio i wideo</string>
     <string name="audio_enable_downmix_title">Włącz downmix</string>
-    <string name="audio_enable_downmix_subtitle">Używa ścieżki downmix FFmpeg. Po wyłączeniu audio podąża za poprzednią ścieżką Android/urządzenia.</string>
     <string name="audio_maintain_original_audio_on_downmix_title">Zachowaj oryginalne audio przy downmix</string>
     <string name="audio_maintain_original_audio_on_downmix_subtitle">Po wyłączeniu normalizacja downmix może zmniejszyć ogólną głośność.</string>
     <string name="audio_number_of_channels">Liczba kanałów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -677,7 +677,6 @@
     <string name="audio_decoder_prefer_app">Preferir decodificadores do app</string>
     <string name="audio_decoder_priority">Prioridade do decodificador</string>
     <string name="audio_enable_downmix_title">Ativar mixagem de áudio (downmix)</string>
-    <string name="audio_enable_downmix_subtitle">Utiliza a mixagem do FFmpeg. Se desativado, o áudio segue o caminho padrão do dispositivo/Android.</string>
     <string name="audio_tunneled">Reprodução tunneled</string>
     <string name="audio_tunneled_sub">Melhora a sincronização de áudio e vídeo usando o hardware.</string>
     <string name="audio_force_optical_passthrough">Forçar transcodificação AC-3 (Óptico/SPDIF)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -618,7 +618,6 @@
     <string name="audio_decoder_prefer_app">Preferir descodificadores da app (FFmpeg)</string>
     <string name="audio_decoder_priority">Prioridade do descodificador</string>
     <string name="audio_enable_downmix_title">Ativar downmix</string>
-    <string name="audio_enable_downmix_subtitle">Utiliza o caminho de downmix do FFmpeg. Quando desativado, o áudio segue o caminho anterior do Android/dispositivo.</string>
     <string name="audio_tunneled">Reprodução em túnel (Tunneled)</string>
     <string name="audio_tunneled_sub">Sincronização de áudio/vídeo ao nível do hardware. Pode melhorar a reprodução em alguns dispositivos Android TV</string>
     <!-- DV7 Handling Mode -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1743,7 +1743,6 @@
     <string name="audio_number_of_channels">Количество каналов</string>
     <string name="audio_number_of_channels_desc">Задаёт раскладку динамиков для подмешивания FFmpeg.</string>
     <string name="audio_enable_downmix_title">Включить подмешивание</string>
-    <string name="audio_enable_downmix_subtitle">Использует путь подмешивания FFmpeg. При отключении аудио следует предыдущему пути Android/устройства.</string>
     <string name="dv7_handling_title">Обработка Dolby Vision Profile 7</string>
     <string name="dv7_handling_dialog_subtitle">Выберите, как обрабатываются потоки DV Profile 7 при воспроизведении.</string>
     <string name="dv7_mode_auto">Авто (рекомендуется)</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -630,7 +630,6 @@
     <string name="audio_decoder_prefer_app">Preferovať dekodéry aplikácie (FFmpeg)</string>
     <string name="audio_decoder_priority">Priorita dekodéra</string>
     <string name="audio_enable_downmix_title">Povoliť downmix</string>
-    <string name="audio_enable_downmix_subtitle">Používa FFmpeg downmix cestu. Keď je vypnuté, audio používa predchádzajúcu Android/zariadenie cestu.</string>
     <string name="audio_tunneled">Tunelované prehrávanie</string>
     <string name="audio_tunneled_sub">Hardvérová synchronizácia audia a videa. Môže zlepšiť prehrávanie na niektorých Android TV zariadeniach.</string>
     <string name="audio_dv_sub">Mapovať Dolby Vision Profile 7 na štandardné HEVC pre zariadenia bez hardvérovej podpory DV</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -721,7 +721,7 @@
     <string name="audio_decoder_prefer_app">Uygulama kod çözücülerini (FFmpeg) tercih et</string>
     <string name="audio_decoder_priority">Decoder Önceliği</string>
     <string name="audio_enable_downmix_title">Downmix\'i etkinleştir</string>
-    <string name="audio_enable_downmix_subtitle">FFmpeg downmix yolunu kullanır. Devre dışı bırakıldığında ses önceki Android/cihaz yolunu takip eder.</string>
+    <string name="audio_enable_downmix_subtitle">FFmpeg downmix yolunu kullanır. Uygulama kod çözücülerini (FFmpeg) tercih et seçeneğini gerektirir. Devre dışı bırakıldığında ses önceki Android/cihaz yolunu takip eder.</string>
     <string name="audio_tunneled">Tünelli Oynatma</string>
     <string name="audio_tunneled_sub">Donanım seviyesinde ses/video senkronizasyonu. Bazı Android TV cihazlarında performansı artırabilir</string>
     <string name="audio_force_optical_passthrough">AC-3 Dönüştürmeyi Zorla (Optik/SPDIF)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -637,7 +637,6 @@
     <string name="audio_decoder_prefer_app">Надавати перевагу програмним декодерам (FFmpeg)</string>
     <string name="audio_decoder_priority">Пріоритет декодерів</string>
     <string name="audio_enable_downmix_title">Увімкнути мікшування</string>
-    <string name="audio_enable_downmix_subtitle">Використовує шлях мікшування FFmpeg. При вимкненні аудіо слідує попередньому шляху Android/пристрою.</string>
     <string name="audio_tunneled">Тунельне відтворення</string>
     <string name="audio_tunneled_sub">Апаратна синхронізація аудіо/відео. Може покращити відтворення на деяких пристроях Android TV</string>
     <!-- DV7 Handling Mode -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -677,7 +677,6 @@
     <string name="audio_decoder_prefer_app">偏好应用解码器 (FFmpeg)</string>
     <string name="audio_decoder_priority">解码器优先级</string>
     <string name="audio_enable_downmix_title">启用混音下转</string>
-    <string name="audio_enable_downmix_subtitle">使用 FFmpeg 混音下转路径。禁用时，音频将遵循先前的 Android/设备路径。</string>
     <string name="audio_tunneled">通道化播放</string>
     <string name="audio_tunneled_sub">硬件级别的音频/视频同步。可能在部分 Android TV 设备上改善播放。</string>
     <string name="audio_force_optical_passthrough">强制 AC-3 转码 (光纤/SPDIF)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -677,7 +677,6 @@
     <string name="audio_decoder_prefer_app">偏好應用程式解碼器 (FFmpeg)</string>
     <string name="audio_decoder_priority">解碼器優先順序</string>
     <string name="audio_enable_downmix_title">啟用混音下轉</string>
-    <string name="audio_enable_downmix_subtitle">使用 FFmpeg 混音下轉路徑。停用時，音訊將遵循先前的 Android/裝置路徑。</string>
     <string name="audio_tunneled">通道化播放</string>
     <string name="audio_tunneled_sub">硬體層級的音訊/影片同步。可能在部分 Android TV 裝置上改善播放。</string>
     <string name="audio_force_optical_passthrough">強制 AC-3 轉碼 (光纖/SPDIF)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -712,7 +712,7 @@
     <string name="audio_decoder_prefer_app">Prefer app decoders (FFmpeg)</string>
     <string name="audio_decoder_priority">Decoder Priority</string>
     <string name="audio_enable_downmix_title">Enable downmix</string>
-    <string name="audio_enable_downmix_subtitle">Uses the FFmpeg downmix path. When disabled, audio follows the previous Android/device path.</string>
+    <string name="audio_enable_downmix_subtitle">Uses the FFmpeg downmix path. Requires Prefer app decoders (FFmpeg). When disabled, audio follows the previous Android/device path.</string>
     <string name="audio_tunneled">Tunneled Playback</string>
     <string name="audio_tunneled_sub">Hardware-level audio/video sync. May improve playback on some Android TV devices</string>
     <string name="audio_force_optical_passthrough">Force AC-3 Transcoding (Optical/SPDIF)</string>


### PR DESCRIPTION
## Summary

Fixes playback never starting when Tunneled Playback is on together with Prefer app decoders (FFmpeg). That combination races at startup because tunneled playback cannot share the FFmpeg audio path.

Downmix already requires Prefer app decoders. Downmix is off and unselectable unless Prefer app is selected, and tunneled playback is off and unselectable while Prefer app is selected. Stored values are kept; they are just not applied in the incompatible combination.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Prefer app decoders (required for FFmpeg downmix) plus tunneled playback races at player startup, so playback never begins. Users can still have tunneling stored as on while they enable Prefer app / downmix. The player must ignore tunneling in that case, and the settings row must show it as off and unselectable so the conflict cannot be turned back on.

## Issue or approval

Discord notified.

## Reproduction steps

1. Open Playback settings and set Decoder Priority to Prefer app decoders (FFmpeg).
2. Enable downmix (now allowed) and enable Tunneled Playback if it was already stored on.
3. Start playback of a stream on ExoPlayer.
4. **Before this fix:** playback stays stuck and never starts (FFmpeg audio path races with tunneling).
5. **After this fix:** Tunneled Playback shows off and cannot be selected while Prefer app is active; playback starts on the non-tunneled path. Downmix stays off and unselectable unless Prefer app is selected.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not persist-clear tunneling or downmix; stored values return when Prefer app is turned off.
- Does not change MPV tunneling (already excluded) or Bluetooth-forced downmix/prefer-app runtime overrides beyond using the same effective downmix/tunneling helpers.
- Downmix subtitle copy updated in English and Turkish only; other locales fall back to English.

## Testing

- Settings: Prefer device / device-only — downmix row disabled and shown off even if previously stored on; tunneling remains selectable.
- Settings: Prefer app decoders — downmix becomes selectable; tunneling row disabled and shown off even if previously stored on.
- Playback: Prefer app + stored tunneling on — player initializes with tunneling off (`effectiveTunnelingEnabled`), startup uses the non-tunneled first-frame path, playback starts.
- Playback: Prefer app + downmix on — FFmpeg downmix still applies; tunneling stays off.
- Playback: Prefer device + tunneling on — tunneling still applied as before.

## Screenshots / Video

Settings-only state change to prevent the incompatible combination: Tunneled Playback appears off and unselectable when Prefer app decoders is selected; Enable downmix appears off and unselectable unless Prefer app is selected. No new screens or layout.

## Breaking changes

None.

## Linked issues

Discord notified.
