### PR TITLE
fix(continue-watching): resume from saved position instead of 0:00

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.core.tracking.buildTrackingMediaReference
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.model.WatchProgressLookup
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.data.repository.SkipIntroRepository
@@ -629,12 +630,11 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private suspend fun currentSavedProgress(metadata: ExternalPlaybackMetadata): WatchProgress? {
-        val flow = if (metadata.season != null && metadata.episode != null) {
-            watchProgressRepository.getEpisodeProgress(metadata.contentId, metadata.season, metadata.episode)
-        } else {
-            watchProgressRepository.getProgress(metadata.contentId)
-        }
-        return flow.firstOrNull()
+        return watchProgressRepository.getResumeProgress(
+            contentId = metadata.contentId,
+            season = metadata.season,
+            episode = metadata.episode
+        )
     }
 
     private suspend fun fetchRuntimeMsFromMeta(metadata: ExternalPlaybackMetadata): Long {
@@ -1158,13 +1158,12 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private suspend fun getResumePosition(metadata: ExternalPlaybackMetadata): Long {
-        val flow = if (metadata.season != null && metadata.episode != null) {
-            watchProgressRepository.getEpisodeProgress(metadata.contentId, metadata.season, metadata.episode)
-        } else {
-            watchProgressRepository.getProgress(metadata.contentId)
-        }
-        val wp = flow.firstOrNull() ?: return 0L
-        if (wp.isCompleted()) return 0L
+        val wp = watchProgressRepository.getResumeProgress(
+            contentId = metadata.contentId,
+            season = metadata.season,
+            episode = metadata.episode
+        ) ?: return 0L
+        if (!WatchProgressLookup.isResumable(wp)) return 0L
         return if (wp.duration > 0L) {
             wp.resolveResumePosition(wp.duration)
         } else {

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncReducer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncReducer.kt
@@ -1,0 +1,156 @@
+package com.nuvio.tv.core.sync
+
+import com.nuvio.tv.domain.model.WatchProgress
+
+/**
+ * Pure watch-progress sync merge rules used by [WatchProgressSyncService] and
+ * [com.nuvio.tv.data.local.WatchProgressPreferences]. Kept free of Android /
+ * Supabase so the Continue Watching resume-from-0 regressions can be reproduced
+ * in unit tests.
+ */
+internal object WatchProgressSyncReducer {
+    const val MIN_USABLE_POSITION_MS = 1_000L
+    const val MIN_USABLE_PERCENT = 2f
+
+    fun hasUsableResumeData(progress: WatchProgress): Boolean {
+        if (progress.position >= MIN_USABLE_POSITION_MS) return true
+        val percent = progress.progressPercent ?: return false
+        return percent >= MIN_USABLE_PERCENT && percent < 100f
+    }
+
+    fun shouldPushToRemote(progress: WatchProgress): Boolean {
+        val dummyCompletedSentinel = progress.position <= 1L &&
+            progress.duration <= 1L &&
+            progress.duration > 0L
+        if (dummyCompletedSentinel) return false
+        return hasUsableResumeData(progress) || progress.isCompleted()
+    }
+
+    fun episodeKey(contentId: String, season: Int, episode: Int): String {
+        return "${contentId}_s${season}e${episode}"
+    }
+
+    fun isSeriesType(contentType: String): Boolean {
+        return contentType.lowercase() in setOf("series", "tv")
+    }
+
+    fun canonicalizeForRemote(rawEntries: Map<String, WatchProgress>): Map<String, WatchProgress> {
+        if (rawEntries.isEmpty()) return rawEntries
+
+        val canonical = rawEntries.toMutableMap()
+        rawEntries.forEach { (key, progress) ->
+            val isSeriesMirrorKey = key == progress.contentId &&
+                isSeriesType(progress.contentType) &&
+                progress.season != null &&
+                progress.episode != null
+            if (!isSeriesMirrorKey) return@forEach
+
+            val season = progress.season ?: return@forEach
+            val episode = progress.episode ?: return@forEach
+            val episodeProgress = rawEntries[episodeKey(progress.contentId, season, episode)]
+                ?: return@forEach
+
+            val exactMirror = progress.position == episodeProgress.position &&
+                progress.duration == episodeProgress.duration &&
+                progress.lastWatched == episodeProgress.lastWatched
+            val episodeIsAtLeastAsFresh = episodeProgress.lastWatched >= progress.lastWatched - 1_000L
+
+            if (exactMirror || episodeIsAtLeastAsFresh) {
+                canonical.remove(key)
+            }
+        }
+
+        return canonical.filterValues(::shouldPushToRemote)
+    }
+
+    fun normalizePulledEntries(
+        entries: List<Pair<String, WatchProgress>>
+    ): List<Pair<String, WatchProgress>> {
+        if (entries.isEmpty()) return entries
+
+        val byKey = linkedMapOf<String, WatchProgress>()
+        entries.sortedByDescending { it.second.lastWatched }
+            .forEach { (key, progress) ->
+                val existing = byKey[key]
+                if (existing == null || progress.lastWatched > existing.lastWatched) {
+                    byKey[key] = progress
+                }
+            }
+
+        val latestEpisodeByContent = byKey.entries
+            .asSequence()
+            .mapNotNull { (key, progress) ->
+                if (isSeriesType(progress.contentType) &&
+                    progress.season != null &&
+                    progress.episode != null &&
+                    key != progress.contentId
+                ) {
+                    progress
+                } else {
+                    null
+                }
+            }
+            .groupBy { it.contentId }
+            .mapValues { (_, episodes) ->
+                episodes.maxWithOrNull(
+                    compareBy<WatchProgress> { it.lastWatched }
+                        .thenBy { it.season ?: 0 }
+                        .thenBy { it.episode ?: 0 }
+                )
+            }
+
+        latestEpisodeByContent.forEach { (contentId, latestEpisode) ->
+            val latest = latestEpisode ?: return@forEach
+            val existingSeriesEntry = byKey[contentId]
+            if (existingSeriesEntry == null || existingSeriesEntry.lastWatched < latest.lastWatched) {
+                byKey[contentId] = latest
+            }
+        }
+
+        return byKey.entries
+            .sortedByDescending { it.value.lastWatched }
+            .map { it.key to it.value }
+    }
+
+    /**
+     * Newer [WatchProgress.lastWatched] wins, but an empty remote row must not
+     * erase a local in-progress position. That overwrite is the Nuvio-sync
+     * path that makes Continue Watching resume from 0:00.
+     */
+    fun shouldReplaceLocalWithRemote(
+        local: WatchProgress?,
+        remote: WatchProgress,
+        lastSuccessfulPushMs: Long
+    ): MergeDecision {
+        if (local == null) return MergeDecision.AcceptRemote
+        if (remote.lastWatched > local.lastWatched) {
+            if (!hasUsableResumeData(remote) &&
+                !remote.isCompleted() &&
+                hasUsableResumeData(local)
+            ) {
+                return MergeDecision.KeepLocalEmptyRemote
+            }
+            return MergeDecision.AcceptRemote
+        }
+        if (local.lastWatched > remote.lastWatched && local.lastWatched > lastSuccessfulPushMs) {
+            return MergeDecision.KeepLocalNewerUnsynced
+        }
+        return MergeDecision.KeepLocalAlreadySynced
+    }
+
+    fun shouldPreserveLocalMissingFromRemote(
+        local: WatchProgress,
+        lastSuccessfulPushMs: Long,
+        isNonTraktId: ((String) -> Boolean)?
+    ): Boolean {
+        if (isNonTraktId != null && isNonTraktId(local.contentId)) return true
+        return local.lastWatched > lastSuccessfulPushMs
+    }
+
+    enum class MergeDecision {
+        AcceptRemote,
+        KeepLocalEmptyRemote,
+        KeepLocalNewerUnsynced,
+        KeepLocalAlreadySynced
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/WatchProgressSyncService.kt
@@ -165,9 +165,7 @@ class WatchProgressSyncService @Inject constructor(
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val rawEntries = watchProgressPreferences.getAllRawEntries(profileId)
-            val entries = canonicalizeForRemote(rawEntries).filterValues { progress ->
-                !(progress.position <= 1L && progress.duration <= 1L && progress.duration > 0L)
-            }
+            val entries = WatchProgressSyncReducer.canonicalizeForRemote(rawEntries)
             Log.d(TAG, "pushToRemote: ${rawEntries.size} local entries, ${entries.size} canonical entries to push for profile $profileId")
             entries.forEach { (key, progress) ->
                 Log.d(TAG, "  push entry: key=$key contentId=${progress.contentId} type=${progress.contentType} pos=${progress.position} dur=${progress.duration} lastWatched=${progress.lastWatched}")
@@ -306,7 +304,7 @@ class WatchProgressSyncService @Inject constructor(
                 )
             }
 
-            val normalized = normalizePulledEntries(pulled)
+            val normalized = WatchProgressSyncReducer.normalizePulledEntries(pulled)
             Log.d(TAG, "pullFromRemote: normalized ${pulled.size} -> ${normalized.size} entries")
             Result.success(normalized)
         } catch (e: Exception) {
@@ -486,96 +484,6 @@ class WatchProgressSyncService @Inject constructor(
             usedSnapshot = true,
             preservedLocalItems = hadUnsyncedProgress
         )
-    }
-
-    private fun canonicalizeForRemote(
-        rawEntries: Map<String, WatchProgress>
-    ): Map<String, WatchProgress> {
-        if (rawEntries.isEmpty()) return rawEntries
-
-        val canonical = rawEntries.toMutableMap()
-        rawEntries.forEach { (key, progress) ->
-            val isSeriesMirrorKey = key == progress.contentId &&
-                isSeriesType(progress.contentType) &&
-                progress.season != null &&
-                progress.episode != null
-            if (!isSeriesMirrorKey) return@forEach
-
-            val season = progress.season
-            val episode = progress.episode
-            val episodeKey = episodeKey(
-                contentId = progress.contentId,
-                season = season,
-                episode = episode
-            )
-            val episodeProgress = rawEntries[episodeKey] ?: return@forEach
-
-            val exactMirror = progress.position == episodeProgress.position &&
-                progress.duration == episodeProgress.duration &&
-                progress.lastWatched == episodeProgress.lastWatched
-            val episodeIsAtLeastAsFresh = episodeProgress.lastWatched >= progress.lastWatched - 1_000L
-
-            if (exactMirror || episodeIsAtLeastAsFresh) {
-                canonical.remove(key)
-            }
-        }
-
-        return canonical
-    }
-
-    private fun normalizePulledEntries(
-        entries: List<Pair<String, WatchProgress>>
-    ): List<Pair<String, WatchProgress>> {
-        if (entries.isEmpty()) return entries
-
-        val byKey = linkedMapOf<String, WatchProgress>()
-        entries.sortedByDescending { it.second.lastWatched }
-            .forEach { (key, progress) ->
-                val existing = byKey[key]
-                if (existing == null || progress.lastWatched > existing.lastWatched) {
-                    byKey[key] = progress
-                }
-            }
-
-        val latestEpisodeByContent = byKey.entries
-            .asSequence()
-            .mapNotNull { (key, progress) ->
-                if (isSeriesType(progress.contentType) &&
-                    progress.season != null &&
-                    progress.episode != null &&
-                    key != progress.contentId
-                ) {
-                    progress
-                } else {
-                    null
-                }
-            }
-            .groupBy { it.contentId }
-            .mapValues { (_, episodes) -> episodes.maxWithOrNull(
-                compareBy<WatchProgress> { it.lastWatched }
-                    .thenBy { it.season ?: 0 }
-                    .thenBy { it.episode ?: 0 }
-            ) }
-
-        latestEpisodeByContent.forEach { (contentId, latestEpisode) ->
-            val latest = latestEpisode ?: return@forEach
-            val existingSeriesEntry = byKey[contentId]
-            if (existingSeriesEntry == null || existingSeriesEntry.lastWatched < latest.lastWatched) {
-                byKey[contentId] = latest
-            }
-        }
-
-        return byKey.entries
-            .sortedByDescending { it.value.lastWatched }
-            .map { it.key to it.value }
-    }
-
-    private fun episodeKey(contentId: String, season: Int, episode: Int): String {
-        return "${contentId}_s${season}e${episode}"
-    }
-
-    private fun isSeriesType(contentType: String): Boolean {
-        return contentType.lowercase() in setOf("series", "tv")
     }
 
     private fun SupabaseWatchProgressEvent.toWatchProgress(): WatchProgress {

--- a/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/WatchProgressPreferences.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.Preferences
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.sync.WatchProgressSyncReducer
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
@@ -467,11 +468,17 @@ class WatchProgressPreferences @Inject constructor(
                 val removedKeys = local.keys - remoteEntries.keys
                 removedKeys.forEach { key ->
                     val localEntry = local[key]
-                    if (localEntry != null && isNonTraktId != null && isNonTraktId(localEntry.contentId)) {
-                        Log.d("WatchProgressPrefs", "  preserved key=$key (non-Trakt ID: ${localEntry.contentId})")
-                        preservedLocalItems = true
-                    } else if (localEntry != null && localEntry.lastWatched > lastSuccessfulPushMs) {
-                        Log.d("WatchProgressPrefs", "  preserved key=$key (lastWatched=${localEntry.lastWatched} > lastPush=$lastSuccessfulPushMs)")
+                    if (localEntry != null &&
+                        WatchProgressSyncReducer.shouldPreserveLocalMissingFromRemote(
+                            local = localEntry,
+                            lastSuccessfulPushMs = lastSuccessfulPushMs,
+                            isNonTraktId = isNonTraktId
+                        )
+                    ) {
+                        Log.d(
+                            "WatchProgressPrefs",
+                            "  preserved key=$key (lastWatched=${localEntry.lastWatched} lastPush=$lastSuccessfulPushMs)"
+                        )
                         preservedLocalItems = true
                     } else {
                         local.remove(key)
@@ -482,14 +489,28 @@ class WatchProgressPreferences @Inject constructor(
 
             for ((key, remote) in remoteEntries) {
                 val existing = local[key]
-                if (existing == null || remote.lastWatched > existing.lastWatched) {
-                    local[key] = mergeDisplayMetadata(remote, existing)
-                    Log.d("WatchProgressPrefs", "  merged key=$key (existing=${existing != null})")
-                } else if (existing.lastWatched > remote.lastWatched && existing.lastWatched > lastSuccessfulPushMs) {
-                    Log.d("WatchProgressPrefs", "  skipped key=$key (local is newer)")
-                    preservedLocalItems = true
-                } else {
-                    Log.d("WatchProgressPrefs", "  skipped key=$key (already synced)")
+                when (
+                    WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+                        local = existing,
+                        remote = remote,
+                        lastSuccessfulPushMs = lastSuccessfulPushMs
+                    )
+                ) {
+                    WatchProgressSyncReducer.MergeDecision.AcceptRemote -> {
+                        local[key] = mergeDisplayMetadata(remote, existing)
+                        Log.d("WatchProgressPrefs", "  merged key=$key (existing=${existing != null})")
+                    }
+                    WatchProgressSyncReducer.MergeDecision.KeepLocalEmptyRemote -> {
+                        Log.d("WatchProgressPrefs", "  skipped key=$key (empty remote would wipe local resume)")
+                        preservedLocalItems = true
+                    }
+                    WatchProgressSyncReducer.MergeDecision.KeepLocalNewerUnsynced -> {
+                        Log.d("WatchProgressPrefs", "  skipped key=$key (local is newer)")
+                        preservedLocalItems = true
+                    }
+                    WatchProgressSyncReducer.MergeDecision.KeepLocalAlreadySynced -> {
+                        Log.d("WatchProgressPrefs", "  skipped key=$key (already synced)")
+                    }
                 }
             }
 
@@ -525,10 +546,21 @@ class WatchProgressPreferences @Inject constructor(
 
             upserts.forEach { (key, remote) ->
                 val existing = local[key]
-                if (existing == null || remote.lastWatched > existing.lastWatched) {
-                    local[key] = mergeDisplayMetadata(remote, existing)
-                } else if (existing.lastWatched > remote.lastWatched && existing.lastWatched > lastSuccessfulPushMs) {
-                    preservedLocalItems = true
+                when (
+                    WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+                        local = existing,
+                        remote = remote,
+                        lastSuccessfulPushMs = lastSuccessfulPushMs
+                    )
+                ) {
+                    WatchProgressSyncReducer.MergeDecision.AcceptRemote -> {
+                        local[key] = mergeDisplayMetadata(remote, existing)
+                    }
+                    WatchProgressSyncReducer.MergeDecision.KeepLocalEmptyRemote,
+                    WatchProgressSyncReducer.MergeDecision.KeepLocalNewerUnsynced -> {
+                        preservedLocalItems = true
+                    }
+                    WatchProgressSyncReducer.MergeDecision.KeepLocalAlreadySynced -> Unit
                 }
             }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.nuvio.tv.data.local.WatchProgressSource
 import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.model.WatchProgressLookup
 import com.nuvio.tv.domain.model.WatchedItem
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.core.tracking.TrackingHistoryItem
@@ -404,6 +405,36 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     watchProgressPreferences.getEpisodeProgress(contentId, season, episode)
                 }
             }
+    }
+
+    override suspend fun getResumeProgress(
+        contentId: String,
+        season: Int?,
+        episode: Int?
+    ): WatchProgress? {
+        val local = if (season != null && episode != null) {
+            watchProgressPreferences.getEpisodeProgress(contentId, season, episode).first()
+        } else {
+            watchProgressPreferences.getProgress(contentId).first()
+        }
+        val provider = activeProgressProvider() ?: return local?.takeIf(WatchProgressLookup::isResumable)
+        val remote = withTimeoutOrNull(2_000L) {
+            if (season != null && episode != null) {
+                val fromAll = provider.allProgress.first()
+                    .filter { progress ->
+                        progress.contentId.equals(contentId, ignoreCase = true) &&
+                            progress.season == season &&
+                            progress.episode == episode
+                    }
+                WatchProgressLookup.pickResumeProgressFromCandidates(fromAll)
+                    ?: provider.episodeProgress(contentId).first()[season to episode]
+            } else {
+                val fromAll = provider.allProgress.first()
+                    .filter { progress -> progress.contentId.equals(contentId, ignoreCase = true) }
+                WatchProgressLookup.pickResumeProgressFromCandidates(fromAll)
+            }
+        }
+        return WatchProgressLookup.pickResumeProgress(remote, local)
     }
 
     override fun getAllEpisodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> {

--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
@@ -63,10 +63,17 @@ data class WatchProgress(
     fun isCompleted(threshold: Float = completionThreshold()): Boolean = progressPercentage >= threshold
 
     /**
-     * Returns true if the content has been started but not completed
+     * Returns true if the content has been started but not completed.
+     *
+     * A saved [position] with unknown [duration] (paused player, Nuvio sync
+     * without progressPercent) must still count as in-progress. Otherwise
+     * Continue Watching resume silently starts at 0:00.
      */
-    fun isInProgress(startThreshold: Float = STARTED_THRESHOLD, endThreshold: Float = completionThreshold()): Boolean =
-        progressPercentage >= startThreshold && progressPercentage < endThreshold
+    fun isInProgress(startThreshold: Float = STARTED_THRESHOLD, endThreshold: Float = completionThreshold()): Boolean {
+        if (isCompleted(endThreshold)) return false
+        if (progressPercentage >= startThreshold) return true
+        return position > 0L && duration <= 0L
+    }
 
     private fun completionThreshold(): Float =
         if (source == SOURCE_SIMKL_PLAYBACK) SIMKL_COMPLETED_THRESHOLD else COMPLETED_THRESHOLD

--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchProgressLookup.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchProgressLookup.kt
@@ -1,0 +1,47 @@
+package com.nuvio.tv.domain.model
+
+/**
+ * Picks the watch-progress row that should drive Continue Watching resume.
+ * Local playback stores a millisecond position; Trakt/Simkl often only have
+ * a percent with position=0. Prefer the precise local row when both exist.
+ */
+internal object WatchProgressLookup {
+
+    fun isResumable(progress: WatchProgress): Boolean {
+        if (progress.isCompleted()) return false
+        if (progress.position > 0L) return true
+        return progress.isInProgress()
+    }
+
+    fun pickResumeProgress(provider: WatchProgress?, local: WatchProgress?): WatchProgress? {
+        val resumableProvider = provider?.takeIf(::isResumable)
+        val resumableLocal = local?.takeIf(::isResumable)
+        if (resumableProvider == null) return resumableLocal
+        if (resumableLocal == null) return resumableProvider
+
+        val providerHasPosition = resumableProvider.position > 0L
+        val localHasPosition = resumableLocal.position > 0L
+        return when {
+            localHasPosition && !providerHasPosition -> resumableLocal
+            providerHasPosition && !localHasPosition -> resumableProvider
+            else -> {
+                if (resumableLocal.lastWatched >= resumableProvider.lastWatched) {
+                    resumableLocal
+                } else {
+                    resumableProvider
+                }
+            }
+        }
+    }
+
+    fun pickResumeProgressFromCandidates(candidates: List<WatchProgress>): WatchProgress? {
+        val resumable = candidates.filter(::isResumable)
+        if (resumable.isEmpty()) return null
+        val withPosition = resumable.filter { it.position > 0L }
+        val pool = withPosition.ifEmpty { resumable }
+        return pool.maxWithOrNull(
+            compareBy<WatchProgress> { it.lastWatched }
+                .thenBy { it.position }
+        )
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -32,6 +32,13 @@ interface WatchProgressRepository {
      * Get watch progress for a specific episode
      */
     fun getEpisodeProgress(contentId: String, season: Int, episode: Int): Flow<WatchProgress?>
+
+    /**
+     * Resolve the progress row that should drive player resume. Merges local
+     * millisecond position with tracking-provider percent-only rows and ignores
+     * empty first emissions from episode snapshots.
+     */
+    suspend fun getResumeProgress(contentId: String, season: Int?, episode: Int?): WatchProgress?
     
     /**
      * Get all episode progress for a series as a map of (season, episode) to progress

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -463,15 +463,10 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
 
     scope.launch {
         pendingResumeProgress = null
-        val progress = if (season != null && episode != null) {
-            watchProgressRepository.getEpisodeProgress(contentId, season, episode).firstOrNull()
-        } else {
-            watchProgressRepository.getProgress(contentId).firstOrNull()
-        }
+        val progress = watchProgressRepository.getResumeProgress(contentId, season, episode)
 
         progress?.let { saved ->
-
-            if (saved.isInProgress()) {
+            if (WatchProgressResumePolicy.isResumable(saved)) {
                 pendingResumeProgress = saved
                 if (isUsingMpvEngine()) {
                     _uiState.update { it.copy(pendingSeekPosition = null) }
@@ -503,14 +498,10 @@ internal suspend fun PlayerRuntimeController.loadSavedProgressSuspend(season: In
     if (contentId == null) return
 
     pendingResumeProgress = null
-    val progress = if (season != null && episode != null) {
-        watchProgressRepository.getEpisodeProgress(contentId, season, episode).firstOrNull()
-    } else {
-        watchProgressRepository.getProgress(contentId).firstOrNull()
-    }
+    val progress = watchProgressRepository.getResumeProgress(contentId, season, episode)
 
     progress?.let { saved ->
-        if (saved.isInProgress()) {
+        if (WatchProgressResumePolicy.isResumable(saved)) {
             pendingResumeProgress = saved
             Log.d(
                 PlayerRuntimeController.TAG,
@@ -577,36 +568,36 @@ internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int
 
 internal fun PlayerRuntimeController.tryApplyPendingResumeProgress(player: Player) {
     val saved = pendingResumeProgress ?: return
-    if (!player.isCurrentMediaItemSeekable) {
-        pendingResumeProgress = null
-        _uiState.update { it.copy(pendingSeekPosition = null) }
-        return
+    when (
+        val decision = WatchProgressResumePolicy.decideReadySeek(
+            saved = saved,
+            playerDurationMs = player.duration,
+            isSeekable = player.isCurrentMediaItemSeekable
+        )
+    ) {
+        WatchProgressResumePolicy.ReadySeekDecision.KeepPending -> return
+        WatchProgressResumePolicy.ReadySeekDecision.Clear -> {
+            pendingResumeProgress = null
+            _uiState.update { it.copy(pendingSeekPosition = null) }
+        }
+        is WatchProgressResumePolicy.ReadySeekDecision.Seek -> {
+            player.seekTo(decision.positionMs)
+            _uiState.update { it.copy(pendingSeekPosition = null) }
+            pendingResumeProgress = null
+        }
     }
-    val duration = player.duration
-    val target = when {
-        duration > 0L -> saved.resolveResumePosition(duration)
-        saved.position > 0L -> saved.position
-        else -> 0L
-    }
-
-    if (target > 0L) {
-        player.seekTo(target)
-    }
-    _uiState.update { it.copy(pendingSeekPosition = null) }
-    pendingResumeProgress = null
 }
 
 internal fun PlayerRuntimeController.resolvePendingInitialResumePosition(): Long {
     val saved = pendingResumeProgress ?: return 0L
-    val target = when {
-        saved.duration > 0L -> saved.resolveResumePosition(saved.duration)
-        saved.position > 0L -> saved.position
-        else -> 0L
+    val target = WatchProgressResumePolicy.resolveInitialResumePosition(saved)
+    if (target > 0L) {
+        return target
     }
-    if (target <= 0L && saved.progressPercent == null) {
+    if (!WatchProgressResumePolicy.shouldKeepPendingAfterInitialPrepare(saved, target)) {
         clearPendingInitialResumePosition()
     }
-    return target.coerceAtLeast(0L)
+    return 0L
 }
 
 internal fun PlayerRuntimeController.clearPendingInitialResumePosition() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/WatchProgressResumePolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/WatchProgressResumePolicy.kt
@@ -1,0 +1,70 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.model.WatchProgressLookup
+
+/**
+ * Pure Continue Watching resume decisions. Extracted so unit tests can reproduce
+ * the "resume starts at 0:00" cases without spinning up ExoPlayer.
+ */
+internal object WatchProgressResumePolicy {
+
+    sealed class ReadySeekDecision {
+        data class Seek(val positionMs: Long) : ReadySeekDecision()
+        data object KeepPending : ReadySeekDecision()
+        data object Clear : ReadySeekDecision()
+    }
+
+    fun isResumable(progress: WatchProgress): Boolean = WatchProgressLookup.isResumable(progress)
+
+    fun pickResumeProgress(provider: WatchProgress?, local: WatchProgress?): WatchProgress? =
+        WatchProgressLookup.pickResumeProgress(provider, local)
+
+    fun pickResumeProgressFromCandidates(candidates: List<WatchProgress>): WatchProgress? =
+        WatchProgressLookup.pickResumeProgressFromCandidates(candidates)
+
+    /**
+     * Position to pass into ExoPlayer.setMediaSource / MPV setMedia.
+     * Percent-only Trakt/Simkl rows have position=0 and duration=0, so this
+     * returns 0 and the real seek must happen once the player knows duration.
+     */
+    fun resolveInitialResumePosition(saved: WatchProgress): Long {
+        if (!isResumable(saved)) return 0L
+        return when {
+            saved.duration > 0L -> saved.resolveResumePosition(saved.duration)
+            saved.position > 0L -> saved.position
+            else -> 0L
+        }.coerceAtLeast(0L)
+    }
+
+    fun shouldKeepPendingAfterInitialPrepare(saved: WatchProgress, initialPositionMs: Long): Boolean {
+        if (!isResumable(saved)) return false
+        if (initialPositionMs > 0L) return false
+        return saved.progressPercent != null || saved.position > 0L
+    }
+
+    fun decideReadySeek(
+        saved: WatchProgress,
+        playerDurationMs: Long,
+        isSeekable: Boolean
+    ): ReadySeekDecision {
+        if (!isResumable(saved)) return ReadySeekDecision.Clear
+        if (!isSeekable) return ReadySeekDecision.KeepPending
+
+        val needsDurationForPercent = saved.position <= 0L &&
+            saved.progressPercent != null &&
+            playerDurationMs <= 0L
+        if (needsDurationForPercent) return ReadySeekDecision.KeepPending
+
+        val target = when {
+            playerDurationMs > 0L -> saved.resolveResumePosition(playerDurationMs)
+            saved.position > 0L -> saved.position
+            else -> 0L
+        }
+        return if (target > 0L) {
+            ReadySeekDecision.Seek(target)
+        } else {
+            ReadySeekDecision.KeepPending
+        }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/sync/WatchProgressSyncReducerTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/WatchProgressSyncReducerTest.kt
@@ -1,0 +1,293 @@
+package com.nuvio.tv.core.sync
+
+import com.nuvio.tv.core.sync.WatchProgressSyncReducer.MergeDecision
+import com.nuvio.tv.domain.model.WatchProgress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WatchProgressSyncReducerTest {
+
+    @Test
+    fun `zero position and duration is not usable resume data`() {
+        val empty = progress(position = 0L, duration = 0L, lastWatched = 50L)
+
+        assertFalse(WatchProgressSyncReducer.hasUsableResumeData(empty))
+        assertFalse(WatchProgressSyncReducer.shouldPushToRemote(empty))
+    }
+
+    @Test
+    fun `paused save with position and unknown duration is still pushed`() {
+        val paused = progress(position = 600_000L, duration = 0L, lastWatched = 50L)
+
+        assertTrue(WatchProgressSyncReducer.hasUsableResumeData(paused))
+        assertTrue(WatchProgressSyncReducer.shouldPushToRemote(paused))
+    }
+
+    @Test
+    fun `dummy completed sentinel is not pushed`() {
+        val sentinel = progress(position = 1L, duration = 1L, lastWatched = 50L)
+
+        assertFalse(WatchProgressSyncReducer.shouldPushToRemote(sentinel))
+    }
+
+    @Test
+    fun `canonicalize drops series mirror when episode row is at least as fresh`() {
+        val episode = episodeProgress(
+            contentId = "tt111",
+            season = 1,
+            episode = 3,
+            position = 400_000L,
+            lastWatched = 20L
+        )
+        val mirror = episode.copy(lastWatched = 19L)
+        val raw = mapOf(
+            "tt111" to mirror,
+            "tt111_s1e3" to episode
+        )
+
+        val canonical = WatchProgressSyncReducer.canonicalizeForRemote(raw)
+
+        assertFalse("tt111" in canonical)
+        assertEquals(episode, canonical["tt111_s1e3"])
+    }
+
+    @Test
+    fun `canonicalize keeps a series row that is actually a movie`() {
+        val movie = progress(contentId = "tt222", position = 90_000L, lastWatched = 5L)
+
+        val canonical = WatchProgressSyncReducer.canonicalizeForRemote(mapOf("tt222" to movie))
+
+        assertEquals(movie, canonical["tt222"])
+    }
+
+    @Test
+    fun `canonicalize drops empty remote-bound rows so they cannot wipe other devices`() {
+        val empty = progress(contentId = "tt333", position = 0L, duration = 0L, lastWatched = 99L)
+        val good = progress(contentId = "tt444", position = 120_000L, lastWatched = 10L)
+
+        val canonical = WatchProgressSyncReducer.canonicalizeForRemote(
+            mapOf("tt333" to empty, "tt444" to good)
+        )
+
+        assertFalse("tt333" in canonical)
+        assertTrue("tt444" in canonical)
+    }
+
+    @Test
+    fun `snapshot normalize synthesizes a series key from the latest episode`() {
+        val s1e1 = episodeProgress("tt555", 1, 1, position = 10_000L, lastWatched = 1L)
+        val s1e2 = episodeProgress("tt555", 1, 2, position = 250_000L, lastWatched = 5L)
+
+        val normalized = WatchProgressSyncReducer.normalizePulledEntries(
+            listOf(
+                "tt555_s1e1" to s1e1,
+                "tt555_s1e2" to s1e2
+            )
+        ).toMap()
+
+        assertEquals(s1e2, normalized["tt555_s1e2"])
+        assertEquals(s1e2, normalized["tt555"])
+        assertEquals(s1e1, normalized["tt555_s1e1"])
+    }
+
+    @Test
+    fun `snapshot normalize does not replace a newer series-level movie-like row`() {
+        val episode = episodeProgress("tt666", 1, 1, position = 50_000L, lastWatched = 2L)
+        val newerSeries = episode.copy(lastWatched = 9L)
+
+        val normalized = WatchProgressSyncReducer.normalizePulledEntries(
+            listOf(
+                "tt666_s1e1" to episode,
+                "tt666" to newerSeries
+            )
+        ).toMap()
+
+        assertEquals(newerSeries, normalized["tt666"])
+    }
+
+    @Test
+    fun `duplicate pulled keys keep the newest lastWatched`() {
+        val older = progress(contentId = "tt777", position = 10_000L, lastWatched = 1L)
+        val newer = progress(contentId = "tt777", position = 80_000L, lastWatched = 8L)
+
+        val normalized = WatchProgressSyncReducer.normalizePulledEntries(
+            listOf("tt777" to older, "tt777" to newer)
+        )
+
+        assertEquals(1, normalized.size)
+        assertEquals(80_000L, normalized.single().second.position)
+    }
+
+    @Test
+    fun `newer empty remote must not replace local in-progress position`() {
+        val local = progress(position = 700_000L, duration = 2_400_000L, lastWatched = 10L)
+        val remote = progress(position = 0L, duration = 0L, lastWatched = 99L)
+
+        val decision = WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+            local = local,
+            remote = remote,
+            lastSuccessfulPushMs = 0L
+        )
+
+        assertEquals(MergeDecision.KeepLocalEmptyRemote, decision)
+    }
+
+    @Test
+    fun `newer remote with real position replaces local`() {
+        val local = progress(position = 100_000L, duration = 2_400_000L, lastWatched = 10L)
+        val remote = progress(position = 800_000L, duration = 2_400_000L, lastWatched = 20L)
+
+        val decision = WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+            local = local,
+            remote = remote,
+            lastSuccessfulPushMs = 0L
+        )
+
+        assertEquals(MergeDecision.AcceptRemote, decision)
+    }
+
+    @Test
+    fun `unsynced local newer than last push is preserved against older remote`() {
+        val local = progress(position = 500_000L, lastWatched = 50L)
+        val remote = progress(position = 100_000L, lastWatched = 20L)
+
+        val decision = WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+            local = local,
+            remote = remote,
+            lastSuccessfulPushMs = 30L
+        )
+
+        assertEquals(MergeDecision.KeepLocalNewerUnsynced, decision)
+    }
+
+    @Test
+    fun `already-synced equal timestamps keep local`() {
+        val local = progress(position = 500_000L, lastWatched = 20L)
+        val remote = progress(position = 500_000L, lastWatched = 20L)
+
+        val decision = WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+            local = local,
+            remote = remote,
+            lastSuccessfulPushMs = 20L
+        )
+
+        assertEquals(MergeDecision.KeepLocalAlreadySynced, decision)
+    }
+
+    @Test
+    fun `missing remote row is preserved when it was created after last push`() {
+        val local = progress(position = 300_000L, lastWatched = 80L)
+
+        assertTrue(
+            WatchProgressSyncReducer.shouldPreserveLocalMissingFromRemote(
+                local = local,
+                lastSuccessfulPushMs = 40L,
+                isNonTraktId = null
+            )
+        )
+        assertFalse(
+            WatchProgressSyncReducer.shouldPreserveLocalMissingFromRemote(
+                local = local,
+                lastSuccessfulPushMs = 90L,
+                isNonTraktId = null
+            )
+        )
+    }
+
+    @Test
+    fun `non-trakt ids are preserved even when missing from a trakt remote snapshot`() {
+        val local = progress(contentId = "kitsu:44", position = 300_000L, lastWatched = 1L)
+
+        assertTrue(
+            WatchProgressSyncReducer.shouldPreserveLocalMissingFromRemote(
+                local = local,
+                lastSuccessfulPushMs = 99L,
+                isNonTraktId = { it.startsWith("kitsu:") }
+            )
+        )
+    }
+
+    @Test
+    fun `full save-push-pull-resume loop keeps movie position`() {
+        val saved = progress(contentId = "tt888", position = 1_111_000L, duration = 3_000_000L, lastWatched = 40L)
+        val pushed = WatchProgressSyncReducer.canonicalizeForRemote(mapOf("tt888" to saved))
+        val pulled = WatchProgressSyncReducer.normalizePulledEntries(pushed.toList())
+        val mergedDecision = WatchProgressSyncReducer.shouldReplaceLocalWithRemote(
+            local = saved,
+            remote = pulled.single().second,
+            lastSuccessfulPushMs = 40L
+        )
+
+        assertEquals(1_111_000L, pushed.getValue("tt888").position)
+        assertEquals(1_111_000L, pulled.single().second.position)
+        assertEquals(MergeDecision.KeepLocalAlreadySynced, mergedDecision)
+    }
+
+    @Test
+    fun `full save-push-pull-resume loop keeps episode position and series mirror`() {
+        val saved = episodeProgress("tt999", 3, 2, position = 222_000L, lastWatched = 12L)
+        val pushed = WatchProgressSyncReducer.canonicalizeForRemote(mapOf("tt999_s3e2" to saved))
+        val pulled = WatchProgressSyncReducer.normalizePulledEntries(pushed.toList()).toMap()
+
+        assertEquals(222_000L, pulled.getValue("tt999_s3e2").position)
+        assertEquals(222_000L, pulled.getValue("tt999").position)
+        assertEquals(3, pulled.getValue("tt999").season)
+        assertEquals(2, pulled.getValue("tt999").episode)
+    }
+
+    @Test
+    fun `delta upsert of empty progress does not win over local in-progress`() {
+        val local = episodeProgress("tt1000", 1, 1, position = 333_000L, lastWatched = 5L)
+        val remoteEmpty = local.copy(position = 0L, duration = 0L, lastWatched = 6L)
+
+        assertEquals(
+            MergeDecision.KeepLocalEmptyRemote,
+            WatchProgressSyncReducer.shouldReplaceLocalWithRemote(local, remoteEmpty, lastSuccessfulPushMs = 0L)
+        )
+    }
+
+    private fun progress(
+        contentId: String = "tt1234567",
+        position: Long,
+        duration: Long = 2_400_000L,
+        lastWatched: Long
+    ) = WatchProgress(
+        contentId = contentId,
+        contentType = "movie",
+        name = contentId,
+        poster = null,
+        backdrop = null,
+        logo = null,
+        videoId = contentId,
+        season = null,
+        episode = null,
+        episodeTitle = null,
+        position = position,
+        duration = duration,
+        lastWatched = lastWatched
+    )
+
+    private fun episodeProgress(
+        contentId: String,
+        season: Int,
+        episode: Int,
+        position: Long,
+        lastWatched: Long
+    ) = WatchProgress(
+        contentId = contentId,
+        contentType = "series",
+        name = contentId,
+        poster = null,
+        backdrop = null,
+        logo = null,
+        videoId = "$contentId:$season:$episode",
+        season = season,
+        episode = episode,
+        episodeTitle = null,
+        position = position,
+        duration = 1_800_000L,
+        lastWatched = lastWatched
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolverTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolverTest.kt
@@ -19,8 +19,8 @@ import com.nuvio.tv.domain.model.TmdbSettings
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
@@ -32,7 +32,7 @@ import retrofit2.http.Query
 class TmdbCollectionSourceResolverTest {
     private val context = mockk<Context>(relaxed = true)
     private val settings = mockk<TmdbSettingsDataStore> {
-        every { this@mockk.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { this@mockk.settings } returns MutableStateFlow(TmdbSettings(language = "en"))
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/data/local/WatchProgressPreferencesStorageTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/WatchProgressPreferencesStorageTest.kt
@@ -239,6 +239,53 @@ class WatchProgressPreferencesStorageTest {
     }
 
     @Test
+    fun `newer empty remote does not wipe local in-progress position`() = runTest {
+        val local = progress("tt-resume", lastWatched = 10L).copy(position = 700_000L, duration = 2_400_000L)
+        val harness = harness(mapOf("tt-resume" to local))
+        harness.preferences.getAllRawEntries()
+        val emptyRemote = local.copy(position = 0L, duration = 0L, lastWatched = 99L)
+
+        harness.preferences.mergeRemoteEntries(
+            remoteEntries = mapOf("tt-resume" to emptyRemote),
+            removeMissingRemoteEntries = false
+        )
+
+        val result = harness.preferences.getAllRawEntries().getValue("tt-resume")
+        assertEquals(700_000L, result.position)
+        assertEquals(2_400_000L, result.duration)
+    }
+
+    @Test
+    fun `newer remote with real position replaces local in-progress`() = runTest {
+        val local = progress("tt-resume", lastWatched = 10L).copy(position = 100_000L, duration = 2_400_000L)
+        val harness = harness(mapOf("tt-resume" to local))
+        harness.preferences.getAllRawEntries()
+        val remote = local.copy(position = 800_000L, lastWatched = 20L)
+
+        harness.preferences.mergeRemoteEntries(
+            remoteEntries = mapOf("tt-resume" to remote),
+            removeMissingRemoteEntries = false
+        )
+
+        assertEquals(800_000L, harness.preferences.getAllRawEntries().getValue("tt-resume").position)
+    }
+
+    @Test
+    fun `delta empty upsert does not wipe local in-progress position`() = runTest {
+        val local = progress("tt-resume", lastWatched = 10L).copy(position = 450_000L, duration = 1_800_000L)
+        val harness = harness(mapOf("tt-resume" to local))
+        harness.preferences.getAllRawEntries()
+        val emptyRemote = local.copy(position = 0L, duration = 0L, lastWatched = 11L)
+
+        harness.preferences.applyRemoteChanges(
+            upserts = mapOf("tt-resume" to emptyRemote),
+            deletes = emptyList()
+        )
+
+        assertEquals(450_000L, harness.preferences.getAllRawEntries().getValue("tt-resume").position)
+    }
+
+    @Test
     fun `clear preserving non trakt ids filters both buckets`() = runTest {
         val entries = legacyEntries().toMutableMap().apply {
             this["custom:recent"] = progress("custom:recent", lastWatched = 2_000L)

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceUseTrailersGateTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceUseTrailersGateTest.kt
@@ -11,7 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertNull
@@ -92,7 +92,7 @@ class TrailerServiceUseTrailersGateTest {
         val tmdbApi = mockk<TmdbApi>(relaxed = true)
         val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
         val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
-            every { settings } returns flowOf(TmdbSettings(language = "en", useTrailers = enabled))
+            every { settings } returns MutableStateFlow(TmdbSettings(language = "en", useTrailers = enabled))
         }
         val tmdbService = mockk<TmdbService> {
             every { apiKey() } returns "tmdb-key"

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceYouTubeSessionCacheTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceYouTubeSessionCacheTest.kt
@@ -8,7 +8,7 @@ import com.nuvio.tv.data.remote.api.TrailerApi
 import com.nuvio.tv.data.remote.api.TrailerResponse
 import com.nuvio.tv.domain.model.TmdbSettings
 import io.mockk.*
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -40,7 +40,7 @@ class TrailerServiceYouTubeSessionCacheTest {
         val extractor = mockk<InAppYouTubeExtractor>()
         val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore>()
         val tmdbService = mockk<TmdbService>()
-        every { tmdbSettingsDataStore.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { tmdbSettingsDataStore.settings } returns MutableStateFlow(TmdbSettings(language = "en"))
         every { tmdbService.apiKey() } returns "tmdb-key"
         val service = TrailerService(trailerApi, tmdbApi, extractor, tmdbSettingsDataStore, tmdbService)
 
@@ -70,7 +70,7 @@ class TrailerServiceYouTubeSessionCacheTest {
         val extractor = mockk<InAppYouTubeExtractor>()
         val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore>()
         val tmdbService = mockk<TmdbService>()
-        every { tmdbSettingsDataStore.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { tmdbSettingsDataStore.settings } returns MutableStateFlow(TmdbSettings(language = "en"))
         every { tmdbService.apiKey() } returns "tmdb-key"
         val service = TrailerService(trailerApi, tmdbApi, extractor, tmdbSettingsDataStore, tmdbService)
 

--- a/app/src/test/java/com/nuvio/tv/domain/model/WatchProgressTest.kt
+++ b/app/src/test/java/com/nuvio/tv/domain/model/WatchProgressTest.kt
@@ -1,6 +1,8 @@
 package com.nuvio.tv.domain.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class WatchProgressTest {
@@ -82,6 +84,35 @@ class WatchProgressTest {
         )
         val result = wp.resolveResumePosition(actualDuration = 0)
         assertEquals(0, result)
+    }
+
+    @Test
+    fun `isInProgress is true when position is saved but duration is unknown`() {
+        val wp = watchProgress(
+            position = 60000,
+            duration = 0
+        )
+        assertTrue(wp.isInProgress())
+        assertFalse(wp.isCompleted())
+    }
+
+    @Test
+    fun `isInProgress is true for trakt percent-only playback`() {
+        val wp = watchProgress(
+            position = 0,
+            duration = 0,
+            progressPercent = 42f
+        )
+        assertTrue(wp.isInProgress())
+    }
+
+    @Test
+    fun `isInProgress is false for unstarted content`() {
+        val wp = watchProgress(
+            position = 0,
+            duration = 0
+        )
+        assertFalse(wp.isInProgress())
     }
 
     private fun watchProgress(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/WatchProgressResumePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/WatchProgressResumePolicyTest.kt
@@ -1,0 +1,229 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.domain.model.WatchProgress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WatchProgressResumePolicyTest {
+
+    @Test
+    fun `trakt percent-only movie is resumable even with position and duration zero`() {
+        val saved = traktPlayback(percent = 42f)
+
+        assertTrue(WatchProgressResumePolicy.isResumable(saved))
+        assertEquals(0L, WatchProgressResumePolicy.resolveInitialResumePosition(saved))
+        assertTrue(
+            WatchProgressResumePolicy.shouldKeepPendingAfterInitialPrepare(saved, initialPositionMs = 0L)
+        )
+    }
+
+    @Test
+    fun `trakt percent-only episode seeks once player duration is known`() {
+        val saved = traktPlayback(percent = 35f, season = 1, episode = 4)
+        val duration = 2_400_000L
+
+        val decision = WatchProgressResumePolicy.decideReadySeek(
+            saved = saved,
+            playerDurationMs = duration,
+            isSeekable = true
+        )
+
+        assertEquals(
+            WatchProgressResumePolicy.ReadySeekDecision.Seek(840_000L),
+            decision
+        )
+    }
+
+    @Test
+    fun `unseekable first STATE_READY must keep pending instead of starting at zero`() {
+        val saved = localMovie(position = 600_000L, duration = 2_400_000L)
+
+        val decision = WatchProgressResumePolicy.decideReadySeek(
+            saved = saved,
+            playerDurationMs = 0L,
+            isSeekable = false
+        )
+
+        assertEquals(WatchProgressResumePolicy.ReadySeekDecision.KeepPending, decision)
+    }
+
+    @Test
+    fun `percent-only progress waits for duration instead of seeking to zero`() {
+        val saved = traktPlayback(percent = 50f)
+
+        val decision = WatchProgressResumePolicy.decideReadySeek(
+            saved = saved,
+            playerDurationMs = 0L,
+            isSeekable = true
+        )
+
+        assertEquals(WatchProgressResumePolicy.ReadySeekDecision.KeepPending, decision)
+    }
+
+    @Test
+    fun `local millisecond position is preferred over trakt percent-only row`() {
+        val local = localMovie(position = 900_000L, duration = 2_400_000L, lastWatched = 10L)
+        val trakt = traktPlayback(percent = 10f, lastWatched = 20L)
+
+        val picked = WatchProgressResumePolicy.pickResumeProgress(provider = trakt, local = local)
+
+        assertEquals(900_000L, picked?.position)
+        assertEquals(WatchProgress.SOURCE_LOCAL, picked?.source)
+    }
+
+    @Test
+    fun `provider row wins when it also has a real position and is newer`() {
+        val local = localMovie(position = 100_000L, duration = 2_400_000L, lastWatched = 10L)
+        val simkl = simklPlayback(position = 800_000L, duration = 2_400_000L, lastWatched = 20L)
+
+        val picked = WatchProgressResumePolicy.pickResumeProgress(provider = simkl, local = local)
+
+        assertEquals(800_000L, picked?.position)
+        assertEquals(WatchProgress.SOURCE_SIMKL_PLAYBACK, picked?.source)
+    }
+
+    @Test
+    fun `empty first episode-progress emission must not beat local in-progress`() {
+        val local = localEpisode(position = 450_000L, duration = 1_800_000L)
+
+        val picked = WatchProgressResumePolicy.pickResumeProgressFromCandidates(
+            listOfNotNull(null, local)
+        )
+
+        assertEquals(450_000L, picked?.position)
+    }
+
+    @Test
+    fun `completed history rows are not used as resume targets`() {
+        val completed = watchProgress(
+            position = 1L,
+            duration = 1L,
+            progressPercent = 100f,
+            source = WatchProgress.SOURCE_TRAKT_HISTORY
+        )
+
+        assertFalse(WatchProgressResumePolicy.isResumable(completed))
+        assertNull(
+            WatchProgressResumePolicy.pickResumeProgress(provider = completed, local = null)
+        )
+    }
+
+    @Test
+    fun `paused local save with unknown duration still resumes from position`() {
+        val saved = watchProgress(
+            position = 600_000L,
+            duration = 0L,
+            progressPercent = 5f
+        )
+
+        assertTrue(WatchProgressResumePolicy.isResumable(saved))
+        assertEquals(600_000L, WatchProgressResumePolicy.resolveInitialResumePosition(saved))
+        assertEquals(
+            WatchProgressResumePolicy.ReadySeekDecision.Seek(600_000L),
+            WatchProgressResumePolicy.decideReadySeek(
+                saved = saved,
+                playerDurationMs = 2_400_000L,
+                isSeekable = true
+            )
+        )
+    }
+
+    @Test
+    fun `continue watching click with local position must not collapse to zero`() {
+        val cwItem = localEpisode(position = 1_250_000L, duration = 3_000_000L)
+        val emptyEpisodeSnapshot: WatchProgress? = null
+
+        val resume = WatchProgressResumePolicy.pickResumeProgress(
+            provider = emptyEpisodeSnapshot,
+            local = cwItem
+        )
+        val initial = WatchProgressResumePolicy.resolveInitialResumePosition(resume!!)
+        val ready = WatchProgressResumePolicy.decideReadySeek(
+            saved = resume,
+            playerDurationMs = 3_000_000L,
+            isSeekable = true
+        )
+
+        assertEquals(1_250_000L, initial)
+        assertEquals(WatchProgressResumePolicy.ReadySeekDecision.Seek(1_250_000L), ready)
+    }
+
+    private fun traktPlayback(
+        percent: Float,
+        season: Int? = null,
+        episode: Int? = null,
+        lastWatched: Long = 1L
+    ) = watchProgress(
+        contentType = if (season == null) "movie" else "series",
+        season = season,
+        episode = episode,
+        position = 0L,
+        duration = 0L,
+        progressPercent = percent,
+        lastWatched = lastWatched,
+        source = WatchProgress.SOURCE_TRAKT_PLAYBACK
+    )
+
+    private fun simklPlayback(
+        position: Long,
+        duration: Long,
+        lastWatched: Long
+    ) = watchProgress(
+        position = position,
+        duration = duration,
+        lastWatched = lastWatched,
+        progressPercent = ((position.toFloat() / duration.toFloat()) * 100f),
+        source = WatchProgress.SOURCE_SIMKL_PLAYBACK
+    )
+
+    private fun localMovie(
+        position: Long,
+        duration: Long,
+        lastWatched: Long = 1L
+    ) = watchProgress(
+        position = position,
+        duration = duration,
+        lastWatched = lastWatched
+    )
+
+    private fun localEpisode(
+        position: Long,
+        duration: Long
+    ) = watchProgress(
+        contentType = "series",
+        season = 2,
+        episode = 5,
+        position = position,
+        duration = duration
+    )
+
+    private fun watchProgress(
+        contentType: String = "movie",
+        season: Int? = null,
+        episode: Int? = null,
+        position: Long,
+        duration: Long,
+        progressPercent: Float? = null,
+        lastWatched: Long = 1L,
+        source: String = WatchProgress.SOURCE_LOCAL
+    ) = WatchProgress(
+        contentId = "tt1234567",
+        contentType = contentType,
+        name = "Test",
+        poster = null,
+        backdrop = null,
+        logo = null,
+        videoId = "tt1234567",
+        season = season,
+        episode = episode,
+        episodeTitle = null,
+        position = position,
+        duration = duration,
+        lastWatched = lastWatched,
+        progressPercent = progressPercent,
+        source = source
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -14,6 +14,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
 import io.mockk.every
@@ -115,6 +116,7 @@ class SearchViewModelConcurrencyTest {
         return SearchViewModel(
             addonRepository = addonRepository,
             catalogRepository = catalogRepository,
+            metaRepository = mockk<MetaRepository>(relaxed = true),
             layoutPreferenceDataStore = layoutPreferences,
             searchHistoryDataStore = history,
             watchProgressRepository = watchProgress,


### PR DESCRIPTION
## Summary

Continue Watching resume no longer starts at `0:00` when a saved position exists.

1. **Merge local progress with tracking providers.** Resume no longer uses the first empty Trakt/Simkl episode snapshot. `getResumeProgress` waits for provider `allProgress` (up to 2s) and picks with `WatchProgressLookup`: a local millisecond `position` wins over a percent-only Trakt/Simkl row (`pos=0`). That is the `pick=local_position_over_provider_percent` path in NUV-0EECB3 / NUV-CDB7E3. The player loads that row in `loadSavedProgressSuspend` *before* `initializePlayer`, then `resolveInitialResumePosition` passes it into `setMediaSource`.
2. **Keep pending resume until the stream is seekable.** HLS/debrid often is not seekable on the first `STATE_READY`. The old code cleared `pendingResumeProgress` there, so the seek was lost. `WatchProgressResumePolicy.decideReadySeek` now returns `KeepPending` until the item is seekable (or duration is known for percent-only rows), then seeks.
3. **Ignore empty remote sync rows.** A newer remote row with `position=0, duration=0` no longer overwrites a usable local save (`WatchProgressSyncReducer`). `isInProgress()` also treats `position > 0` with unknown duration as in-progress, so paused saves remain resume targets.

NUV-0EECB3 and NUV-CDB7E3 both land on (1): local ms start position, no extra READY seek needed. (2) and (3) cover the other 0:00 

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Opening a title from Continue Watching showed the in-progress card, but playback started at the beginning. 

The failure was confirmed on device with a **temporary playback issue report** (existing `schemaVersion: 1` payload, no new backend fields). Those captures are **NUV-0EECB3** and **NUV-CDB7E3**: series episodes on Amazon Fire TV, ExoPlayer, Trakt connected, with both a local millisecond save and a Trakt percent-only row (`pos=0`). Before this fix that mix dropped resume: the episode snapshot emitted empty before Trakt loaded, or the percent-only Trakt row replaced the local position, so `setMediaSource` started at `0`.

- **NUV-0EECB3** — local `pos=721260` (~12:01). After this fix the first frame is at `721260 ms` (`pick=local_position_over_provider_percent`, `cause=APPLIED`).
- **NUV-CDB7E3** — local `pos=944151` (~15:44, ~77% of the real file). Trakt is percent-only `32.53%` on a `1500000 ms` estimate (~6:40 on the real duration). After this fix playback starts at `944151 ms`, not the Trakt percent. This is the case where preferring local milliseconds actually changes the resume point.

The temporary report path is not part of this PR; it was only used to collect those IDs.

## Issue or approval

Field reports (temporary playback issue report): NUV-0EECB3, NUV-CDB7E3

## Reproduction steps

1. Sign in to Trakt (or Simkl) so Continue Watching uses a tracking provider.
2. Play a series episode for several minutes, then exit before the end.
3. Confirm the title appears on Continue Watching with progress.
4. Open it again from Continue Watching (`startFromBeginning=false`).
5. **Before this fix:** player starts at `0:00` even though a local save exists .
6. **After this fix / NUV-0EECB3:** playback starts at the saved local position (`721260 ms` / ~12:01), not `0:00`.
7. **After this fix / NUV-CDB7E3:** playback starts at the local save (`944151 ms` / ~15:44), not Trakt’s `32.53%` (~6:40). Local millisecond progress is kept over the Trakt percent-only row.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Player UI, overlays, and settings are unchanged.
- No new playback-report schema fields; backend payload stays `schemaVersion: 1`.
- Does not change Continue Watching row layout or catalog ranking beyond using the same saved progress the player now honors.
- The temporary playback issue report used to collect NUV-0EECB3 / NUV-CDB7E3 is not included in this PR.

## Testing

- Unit: `WatchProgressResumePolicyTest`, `WatchProgressSyncReducerTest`, extra `WatchProgressTest` / `WatchProgressPreferencesStorageTest` cases for in-progress-with-unknown-duration and empty-remote merge.
- Field reports were taken with a temporary playback issue report (same device: Amazon Fire TV, ExoPlayer, Trakt):
  - **NUV-0EECB3** — resume applied at `721260 ms`; report position `728969 ms`; first frame already at the saved position. `loadSavedProgress=true`, `resumePositionMs=721260`.
  - **NUV-CDB7E3** — local `944151 ms` preferred over Trakt `pct=32.5302` / `dur=1500000`; first frame and `resumePositionMs=944151`; report position `949614 ms`. Using the Trakt percent on the real file duration would have resumed near `6:40` instead of `15:44`.
- Manual path covered by both reports: series episode, local position preferred over Trakt percent-only, no tunneling, `setMediaSource` start position sufficient (no extra READY seek).

Relevant excerpts from the temporary playback issue reports (titles omitted):

**NUV-0EECB3**

```json
{
  "device": { "manufacturer": "Amazon", "model": "AFTKRT", "androidRelease": "11" },
  "content": { "contentType": "series", "season": 5, "episode": 9 },
  "player": { "engine": "EXOPLAYER", "positionMs": 728969, "durationMs": 2581704 },
  "playbackAnalytics": {
    "startPositionMs": 721260,
    "rawEventLines": [
      "PREPARE_PLAYBACK: loadSavedProgress=true currentSeason=5 currentEpisode=9",
      "PLAYER_INIT: engine=EXOPLAYER resumePositionMs=721260 tunneling=false",
      "EXO_EVENT: name=rendered_first_frame elapsedMs=9416 positionMs=721260",
      "RESUME_DIAG: cause=APPLIED engine=EXOPLAYER S5E9 providerId=trakt providerTimedOut=false pick=local_position_over_provider_percent local=src=local;pos=721260;dur=2581704;pct=-1.0;S5E9 provider=src=trakt_playback;pos=0;dur=2580000;pct=27.9367;S5E9 startFromBeginning=false loadRequested=true resumable=true initialMs=721260 keptPending=false seekIssued=true seekTargetMs=721260 firstFrameMs=721260 settledMs=721260 expectedMs=721260 reportMs=728969 reportDurMs=2581704"
    ]
  }
}
```

**NUV-CDB7E3**

```json
{
  "device": { "manufacturer": "Amazon", "model": "AFTKRT", "androidRelease": "11" },
  "content": { "contentType": "series", "season": 9, "episode": 12 },
  "player": { "engine": "EXOPLAYER", "positionMs": 949614, "durationMs": 1230176 },
  "playbackAnalytics": {
    "startPositionMs": 944151,
    "rawEventLines": [
      "PREPARE_PLAYBACK: loadSavedProgress=true currentSeason=9 currentEpisode=12",
      "PLAYER_INIT: engine=EXOPLAYER resumePositionMs=944151 tunneling=false",
      "EXO_EVENT: name=rendered_first_frame elapsedMs=9013 positionMs=944151",
      "RESUME_DIAG: cause=APPLIED engine=EXOPLAYER S9E12 providerId=trakt providerTimedOut=false pick=local_position_over_provider_percent local=src=local;pos=944151;dur=1230176;pct=-1.0;S9E12 provider=src=trakt_playback;pos=0;dur=1500000;pct=32.5302;S9E12 startFromBeginning=false loadRequested=true resumable=true initialMs=944151 keptPending=false seekIssued=true seekTargetMs=944151 firstFrameMs=944151 settledMs=944151 expectedMs=944151 reportMs=949614 reportDurMs=1230176"
    ]
  }
}
```

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Playback issue reports (temporary capture): NUV-0EECB3, NUV-CDB7E3
