### PR TITLE
fix(search): time out unresponsive addon catalogs (#2917 follow-up)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 @HiltViewModel
@@ -98,6 +99,9 @@ class SearchViewModel @Inject constructor(
          * it waits longer than the suggestion debounce to avoid a request storm per keystroke.
          */
         const val LIVE_SEARCH_DEBOUNCE_MS = 350L
+        // A synced configurable addon can leave a catalog request open indefinitely. Keep one
+        // unresponsive catalog from holding the entire search screen in its loading state.
+        const val SEARCH_CATALOG_TIMEOUT_MS = 30_000L
 
         const val MAX_SUGGESTIONS = 8
         const val MAX_RECENT_SEARCHES = 8
@@ -551,7 +555,13 @@ class SearchViewModel @Inject constructor(
 
             val jobs = searchTargets.map { (addon, catalog) ->
                 launch {
-                    loadCatalog(addon, catalog, query, generation)
+                    val completed = withTimeoutOrNull(SEARCH_CATALOG_TIMEOUT_MS) {
+                        loadCatalog(addon, catalog, query, generation)
+                        true
+                    } ?: false
+                    if (!completed) {
+                        onCatalogTimeout(addon, catalog, generation, query)
+                    }
                 }
             }
             pendingCatalogResponses = jobs.size
@@ -628,6 +638,40 @@ class SearchViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun onCatalogTimeout(
+        addon: Addon,
+        catalog: CatalogDescriptor,
+        generation: Long,
+        query: String
+    ) {
+        if (!isCurrentSearch(generation, query)) return
+        pendingCatalogResponses = (pendingCatalogResponses - 1).coerceAtLeast(0)
+        val timedOutKey = catalogKey(
+            addonId = addon.id,
+            addonBaseUrl = addon.baseUrl,
+            type = catalog.apiType,
+            catalogId = catalog.id
+        )
+        // The placeholder was installed before this request started. Remove it explicitly so a
+        // timed-out catalog cannot keep rendering shimmer after the run itself has settled.
+        _uiState.update { state ->
+            val remainingRows = state.catalogRows.filterNot { row ->
+                row.stableKey() == timedOutKey &&
+                    row.isLoading &&
+                    row.items.firstOrNull()?.id?.startsWith("__placeholder_") == true
+            }
+            state.copy(
+                catalogRows = remainingRows,
+                error = if (catalogsMap.isEmpty()) {
+                    context.getString(R.string.search_error_failed)
+                } else {
+                    state.error
+                }
+            )
+        }
+        scheduleCatalogRowsUpdate()
     }
 
     private fun isCurrentSearch(generation: Long, query: String): Boolean =

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -14,6 +14,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
 import io.mockk.every
@@ -25,7 +26,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -89,6 +92,28 @@ class SearchViewModelConcurrencyTest {
         assertEquals(listOf("Deep Cover"), catalogRepository.queries.distinct())
     }
 
+    @Test
+    fun `unresponsive synced catalog cannot keep a search loading`() = runTest {
+        val addon = searchableAddon().copy(
+            catalogs = listOf(
+                searchableCatalog(id = "responsive"),
+                searchableCatalog(id = "synced-hanging")
+            )
+        )
+        val viewModel = newViewModel(
+            addonRepository = StaticAddonRepository(addon),
+            catalogRepository = OneHangingCatalogRepository(addon)
+        )
+
+        viewModel.onEvent(SearchEvent.QueryChanged("Deep Cover"))
+        viewModel.onEvent(SearchEvent.SubmitSearch)
+        advanceTimeBy(30_000L)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSearching)
+        assertEquals(listOf("responsive"), viewModel.uiState.value.catalogRows.map { it.catalogId })
+    }
+
     private fun newViewModel(
         addonRepository: AddonRepository,
         catalogRepository: CatalogRepository
@@ -115,6 +140,7 @@ class SearchViewModelConcurrencyTest {
         return SearchViewModel(
             addonRepository = addonRepository,
             catalogRepository = catalogRepository,
+            metaRepository = mockk<MetaRepository>(relaxed = true),
             layoutPreferenceDataStore = layoutPreferences,
             searchHistoryDataStore = history,
             watchProgressRepository = watchProgress,
@@ -192,13 +218,69 @@ class SearchViewModelConcurrencyTest {
         )
     }
 
+    private class StaticAddonRepository(
+        private val addon: Addon
+    ) : AddonRepository {
+        override fun getInstalledAddons(): Flow<List<Addon>> = flowOf(listOf(addon))
+
+        override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> = error("unused")
+        override suspend fun addAddon(url: String) = error("unused")
+        override suspend fun removeAddon(url: String) = error("unused")
+        override suspend fun setAddonOrder(urls: List<String>) = error("unused")
+        override suspend fun setAddonEnabled(url: String, enabled: Boolean) = error("unused")
+    }
+
+    private class OneHangingCatalogRepository(
+        private val addon: Addon
+    ) : CatalogRepository {
+        override fun getCatalog(
+            addonBaseUrl: String,
+            addonId: String,
+            addonName: String,
+            catalogId: String,
+            catalogName: String,
+            type: String,
+            skip: Int,
+            skipStep: Int,
+            extraArgs: Map<String, String>,
+            supportsSkip: Boolean
+        ): Flow<NetworkResult<CatalogRow>> = flow {
+            emit(NetworkResult.Loading)
+            if (catalogId == "synced-hanging") {
+                awaitCancellation()
+            }
+            emit(
+                NetworkResult.Success(
+                    CatalogRow(
+                        addonId = addon.id,
+                        addonName = addon.displayName,
+                        addonBaseUrl = addon.baseUrl,
+                        catalogId = catalogId,
+                        catalogName = catalogName,
+                        type = ContentType.MOVIE,
+                        items = listOf(
+                            MetaPreview(
+                                id = extraArgs.getValue("search"),
+                                type = ContentType.MOVIE,
+                                name = extraArgs.getValue("search"),
+                                poster = null,
+                                posterShape = PosterShape.POSTER,
+                                background = null,
+                                logo = null,
+                                description = null,
+                                releaseInfo = null,
+                                imdbRating = null,
+                                genres = emptyList()
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
     private fun searchableAddon(): Addon {
-        val catalog = CatalogDescriptor(
-            type = ContentType.MOVIE,
-            id = "top",
-            name = "Top",
-            extra = listOf(CatalogExtra(name = "search"))
-        )
+        val catalog = searchableCatalog(id = "top")
         return Addon(
             id = "addon",
             name = "Addon",
@@ -211,4 +293,12 @@ class SearchViewModelConcurrencyTest {
             resources = emptyList()
         )
     }
+
+    private fun searchableCatalog(id: String): CatalogDescriptor =
+        CatalogDescriptor(
+            type = ContentType.MOVIE,
+            id = id,
+            name = "Top",
+            extra = listOf(CatalogExtra(name = "search"))
+        )
 }


### PR DESCRIPTION
## Summary

Prevent one unresponsive search catalog from keeping the entire Search screen in a loading state indefinitely.

Each searchable addon catalog now gets a 30-second collection budget. If one catalog does not terminate, its placeholder is removed, responsive addon results stay visible, and the overall search settles normally.

## PR type

- [x] Critical bug fix

## Why

Follow-up to #2917 / merged PR #2938.

#2938 fixed a stale-search coroutine race. The reporter confirmed that PR APK worked while signed out, but later reported that 0.8.3-beta still failed after login. Login restores the synced addon list, so the authenticated session can query additional configurable search catalogs.

The remaining failure is reproducible deterministically: one catalog returns results while another emits Loading and never completes. Search currently waits for every catalog job with `joinAll()`, so the second catalog leaves `isSearching = true` forever even though usable results already exist.

## Issue or approval

Follow-up to #2917 and merged fix #2938.

## Reproduction steps

1. Use two enabled searchable catalogs.
2. Let one return normal results.
3. Let the other start but never complete.
4. Before: responsive rows appear, but global search loading/shimmer never settles.
5. After 30 seconds: the stalled catalog is dropped for that search, responsive rows remain, and loading clears.

## UI / behavior impact

- [x] No UI redesign
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] Critical bug follow-up, limited to Search request completion.
- [x] Two files only; no unrelated cleanup.
- [x] Deterministic regression coverage included.

## Scope boundaries

No change to query encoding, addon synchronization, catalog ordering, result ranking, or the stale-generation protection from #2938. Cancellation of an obsolete query still propagates normally; only the per-catalog timeout is converted into a settled catalog result.

A very slow but otherwise valid catalog may be omitted after 30 seconds for that search.

## Testing

- Added `SearchViewModelConcurrencyTest.unresponsive synced catalog cannot keep a search loading`.
- The deterministic fixture has one responsive catalog and one flow that suspends indefinitely. It verifies that loading clears and only the responsive row remains after the timeout.
- Targeted Search test: **2 tests, 0 failures/errors**.
- `./gradlew :app:compileFullDebugKotlin` — **BUILD SUCCESSFUL**.
- `git diff --check` — clean.
- Current `dev` contains four unrelated test-fixture type errors (TMDB/trailer `Flow` vs `StateFlow`). For local execution only, I applied the mechanical fixture corrections, ran the targeted Search test successfully, then removed those unrelated changes before committing.

## Device confirmation

The exact reporter addon/configuration is not available yet. The reporter has been asked to retry with only Cinemeta, then re-enable synced search addons one at a time. This PR remains draft pending that confirmation or maintainer review.

## Screenshots / Video

Not a visual change.

## Breaking changes

None.

## Linked issues

- Follow-up to #2917
- Follow-up to #2938