### PR TITLE
fix(library): respect player choice and auto next for Cloud files

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryModels.kt
+++ b/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryModels.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.core.cloud
 
 import com.nuvio.tv.core.debrid.DebridProvider
+import com.nuvio.tv.domain.model.Video
 
 enum class CloudLibraryItemType {
     Torrent,
@@ -82,8 +83,57 @@ data class CloudLibraryPlaybackInfo(
     val file: CloudLibraryFile,
     val url: String,
     val filename: String? = null,
-    val videoSizeBytes: Long? = null
+    val videoSizeBytes: Long? = null,
+    val sessionToken: String,
+    val sequenceIndex: Int
 )
+
+data class CloudLibraryPlaybackContext(
+    val item: CloudLibraryItem,
+    val currentFileKey: String
+) {
+    val currentIndex: Int
+        get() = item.playableFiles.indexOfFirst { it.stableKey == currentFileKey }
+
+    val currentFile: CloudLibraryFile?
+        get() = item.playableFiles.getOrNull(currentIndex)
+
+    val nextFile: CloudLibraryFile?
+        get() = item.playableFiles.getOrNull(currentIndex + 1)
+
+    fun advanceTo(file: CloudLibraryFile): CloudLibraryPlaybackContext =
+        copy(currentFileKey = file.stableKey)
+
+    fun videoId(file: CloudLibraryFile): String = "${item.stableKey}:${file.stableKey}"
+
+    fun episodeNumber(file: CloudLibraryFile): Int? =
+        item.playableFiles.indexOfFirst { it.stableKey == file.stableKey }
+            .takeIf { it >= 0 }
+            ?.plus(1)
+
+    fun asVideos(): List<Video> = item.playableFiles.mapIndexed { index, file ->
+        Video(
+            id = videoId(file),
+            title = file.name,
+            released = null,
+            thumbnail = null,
+            season = 1,
+            episode = index + 1,
+            overview = null,
+            available = true
+        )
+    }
+
+    companion object {
+        fun create(item: CloudLibraryItem, file: CloudLibraryFile): CloudLibraryPlaybackContext? {
+            val context = CloudLibraryPlaybackContext(
+                item = item,
+                currentFileKey = file.stableKey
+            )
+            return context.takeIf { it.currentIndex >= 0 }
+        }
+    }
+}
 
 const val TorboxCloudLibraryPosterUrl = "https://torbox.app/assets/logo-bb7a9579.svg"
 const val PremiumizeCloudLibraryPosterUrl = "https://www.premiumize.me/icon_normal.svg"

--- a/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryModels.kt
+++ b/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryModels.kt
@@ -106,6 +106,11 @@ data class CloudLibraryPlaybackContext(
 
     fun videoId(file: CloudLibraryFile): String = "${item.stableKey}:${file.stableKey}"
 
+    fun fileForVideoId(videoId: String?): CloudLibraryFile? =
+        videoId?.let { requestedId ->
+            item.playableFiles.firstOrNull { file -> videoId(file) == requestedId }
+        } ?: currentFile
+
     fun episodeNumber(file: CloudLibraryFile): Int? =
         item.playableFiles.indexOfFirst { it.stableKey == file.stableKey }
             .takeIf { it >= 0 }

--- a/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryPlaybackProgressStore.kt
+++ b/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryPlaybackProgressStore.kt
@@ -1,0 +1,77 @@
+package com.nuvio.tv.core.cloud
+
+import android.content.Context
+import android.util.Base64
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.json.JSONObject
+
+data class CloudLibraryFileProgress(
+    val positionMs: Long,
+    val durationMs: Long,
+    val completed: Boolean,
+    val updatedAtMs: Long
+) {
+    val resumePositionMs: Long
+        get() = if (completed) 0L else positionMs.coerceAtLeast(0L)
+
+    val isInProgress: Boolean
+        get() = !completed && positionMs >= MIN_RESUME_POSITION_MS &&
+            (durationMs <= 0L || positionMs.toFloat() / durationMs.toFloat() < COMPLETED_FRACTION)
+
+    private companion object {
+        const val MIN_RESUME_POSITION_MS = 1_000L
+        const val COMPLETED_FRACTION = 0.90f
+    }
+}
+
+/** Local-only Cloud file progress. It deliberately does not feed Continue Watching or sync. */
+@Singleton
+class CloudLibraryPlaybackProgressStore @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    fun load(item: CloudLibraryItem, file: CloudLibraryFile): CloudLibraryFileProgress? {
+        val raw = preferences.getString(progressKey(item, file), null) ?: return null
+        return runCatching {
+            JSONObject(raw).let { json ->
+                CloudLibraryFileProgress(
+                    positionMs = json.optLong("positionMs", 0L),
+                    durationMs = json.optLong("durationMs", 0L),
+                    completed = json.optBoolean("completed", false),
+                    updatedAtMs = json.optLong("updatedAtMs", 0L)
+                )
+            }
+        }.getOrNull()
+    }
+
+    fun save(
+        item: CloudLibraryItem,
+        file: CloudLibraryFile,
+        positionMs: Long,
+        durationMs: Long,
+        completed: Boolean
+    ) {
+        val value = JSONObject().apply {
+            put("positionMs", positionMs.coerceAtLeast(0L))
+            put("durationMs", durationMs.coerceAtLeast(0L))
+            put("completed", completed)
+            put("updatedAtMs", System.currentTimeMillis())
+        }
+        preferences.edit().putString(progressKey(item, file), value.toString()).apply()
+    }
+
+    private fun progressKey(item: CloudLibraryItem, file: CloudLibraryFile): String {
+        val identity = "${item.stableKey}\u0000${file.stableKey}"
+        return Base64.encodeToString(
+            identity.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING
+        )
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "cloud_library_playback_progress"
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryPlaybackSessionStore.kt
+++ b/app/src/main/java/com/nuvio/tv/core/cloud/CloudLibraryPlaybackSessionStore.kt
@@ -1,0 +1,133 @@
+package com.nuvio.tv.core.cloud
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.json.JSONArray
+import org.json.JSONObject
+
+@Singleton
+class CloudLibraryPlaybackSessionStore @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val sessions = java.util.concurrent.ConcurrentHashMap<String, CloudLibraryPlaybackContext>()
+
+    fun create(context: CloudLibraryPlaybackContext): String {
+        val token = UUID.randomUUID().toString()
+        sessions[token] = context
+        preferences.edit()
+            .putString(sessionKey(token), context.toJson().toString())
+            .putLong(timestampKey(token), System.currentTimeMillis())
+            .apply()
+        trimOldSessions()
+        return token
+    }
+
+    fun load(token: String?): CloudLibraryPlaybackContext? {
+        if (token.isNullOrBlank()) return null
+        sessions[token]?.let { return it }
+        val raw = preferences.getString(sessionKey(token), null) ?: return null
+        return runCatching { JSONObject(raw).toPlaybackContext() }
+            .getOrNull()
+            ?.also { sessions[token] = it }
+    }
+
+    fun update(token: String, context: CloudLibraryPlaybackContext) {
+        sessions[token] = context
+        preferences.edit()
+            .putString(sessionKey(token), context.toJson().toString())
+            .putLong(timestampKey(token), System.currentTimeMillis())
+            .apply()
+    }
+
+    private fun trimOldSessions() {
+        val tokens = preferences.all.keys
+            .filter { it.startsWith(SESSION_PREFIX) }
+            .map { it.removePrefix(SESSION_PREFIX) }
+        if (tokens.size <= MAX_SESSIONS) return
+        val expired = tokens
+            .sortedBy { preferences.getLong(timestampKey(it), 0L) }
+            .take(tokens.size - MAX_SESSIONS)
+        preferences.edit().apply {
+            expired.forEach { token ->
+                sessions.remove(token)
+                remove(sessionKey(token))
+                remove(timestampKey(token))
+            }
+        }.apply()
+    }
+
+    private fun CloudLibraryPlaybackContext.toJson(): JSONObject = JSONObject().apply {
+        put("currentFileKey", currentFileKey)
+        put("providerId", item.providerId)
+        put("providerName", item.providerName)
+        put("itemId", item.id)
+        put("itemType", item.type.name)
+        put("itemName", item.name)
+        item.status?.let { put("status", it) }
+        item.sizeBytes?.let { put("sizeBytes", it) }
+        item.progressFraction?.let { put("progressFraction", it.toDouble()) }
+        put("files", JSONArray().apply {
+            item.files.forEach { file ->
+                put(JSONObject().apply {
+                    file.id?.let { put("id", it) }
+                    put("name", file.name)
+                    file.sizeBytes?.let { put("sizeBytes", it) }
+                    file.mimeType?.let { put("mimeType", it) }
+                    put("playable", file.playable)
+                })
+            }
+        })
+    }
+
+    private fun JSONObject.toPlaybackContext(): CloudLibraryPlaybackContext {
+        val filesJson = getJSONArray("files")
+        val files = buildList {
+            for (index in 0 until filesJson.length()) {
+                val file = filesJson.getJSONObject(index)
+                add(
+                    CloudLibraryFile(
+                        id = file.optString("id").takeIf { it.isNotBlank() },
+                        name = file.getString("name"),
+                        sizeBytes = file.optLongOrNull("sizeBytes"),
+                        mimeType = file.optString("mimeType").takeIf { it.isNotBlank() },
+                        playable = file.optBoolean("playable", true)
+                    )
+                )
+            }
+        }
+        return CloudLibraryPlaybackContext(
+            item = CloudLibraryItem(
+                providerId = getString("providerId"),
+                providerName = getString("providerName"),
+                id = getString("itemId"),
+                type = CloudLibraryItemType.valueOf(getString("itemType")),
+                name = getString("itemName"),
+                status = optString("status").takeIf { it.isNotBlank() },
+                sizeBytes = optLongOrNull("sizeBytes"),
+                progressFraction = optDoubleOrNull("progressFraction")?.toFloat(),
+                files = files
+            ),
+            currentFileKey = getString("currentFileKey")
+        )
+    }
+
+    private fun JSONObject.optLongOrNull(key: String): Long? =
+        takeIf { has(key) && !isNull(key) }?.optLong(key)
+
+    private fun JSONObject.optDoubleOrNull(key: String): Double? =
+        takeIf { has(key) && !isNull(key) }?.optDouble(key)
+
+    private fun sessionKey(token: String) = "$SESSION_PREFIX$token"
+    private fun timestampKey(token: String) = "$TIMESTAMP_PREFIX$token"
+
+    private companion object {
+        const val PREFERENCES_NAME = "cloud_library_playback_sessions"
+        const val SESSION_PREFIX = "session:"
+        const val TIMESTAMP_PREFIX = "timestamp:"
+        const val MAX_SESSIONS = 8
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -2,6 +2,9 @@ package com.nuvio.tv.core.player
 
 import android.content.Context
 import android.util.Log
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackResult
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
+import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.tracking.TrackingMediaKind
 import com.nuvio.tv.core.tracking.TrackingMediaReference
@@ -59,6 +62,9 @@ data class ExternalPlaybackMetadata(
      */
     fun buildPlayerTitle(includeEpisodeTitle: Boolean = false): String {
         val base = contentName
+        if (contentType.equals("cloud", ignoreCase = true)) {
+            return episodeTitle?.takeIf { it.isNotBlank() } ?: base
+        }
         if (season == null || episode == null) return base
         val seasonEp = "S${season.toString().padStart(2, '0')}E${episode.toString().padStart(2, '0')}"
         return if (includeEpisodeTitle && !episodeTitle.isNullOrBlank()) {
@@ -165,7 +171,9 @@ class ExternalPlaybackTracker @Inject constructor(
     private val trackingScrobbleCoordinator: TrackingScrobbleCoordinator,
     private val metaRepository: MetaRepository,
     private val playerSettingsDataStore: PlayerSettingsDataStore,
-    private val skipIntroRepository: SkipIntroRepository
+    private val skipIntroRepository: SkipIntroRepository,
+    private val cloudLibraryRepository: CloudLibraryRepository,
+    private val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore
 ) {
     companion object {
         private const val TAG = "ExtPlaybackTracker"
@@ -226,6 +234,7 @@ class ExternalPlaybackTracker @Inject constructor(
     private var nextEpisodePrefetchJob: Job? = null
     private var nextEpisodeSnapshot: ExternalNextEpisodeSnapshot = ExternalNextEpisodeSnapshot.Unknown
     private var autoNextEnabledForPendingLaunch: Boolean? = null
+    private var pendingCloudSessionToken: String? = null
 
     private val autoPlayNextNavigationEvents = ExternalAutoNextNavigationEvents(
         maxAgeMs = AUTO_NEXT_OVERLAY_TIMEOUT_MS
@@ -270,7 +279,8 @@ class ExternalPlaybackTracker @Inject constructor(
         metadata: ExternalPlaybackMetadata,
         autoLaunch: Boolean = false,
         nextEpisodeSnapshot: ExternalNextEpisodeSnapshot? = null,
-        autoNextEnabled: Boolean? = null
+        autoNextEnabled: Boolean? = null,
+        cloudSessionToken: String? = null
     ) {
         // A manual stream choice supersedes any completion handoff still resolving for the
         // previous player session. Auto-launched continuations keep their handoff alive.
@@ -283,6 +293,7 @@ class ExternalPlaybackTracker @Inject constructor(
         staleReturnWatchdogJob?.cancel()
         staleReturnWatchdogJob = null
         pendingMetadata = metadata
+        pendingCloudSessionToken = cloudSessionToken
         isAutoLaunch = autoLaunch
         // A manual launch is always fresh; only an auto-launch within the window is a continuation
         // that keeps a user's abort in effect (so one Back press stops a runaway chain).
@@ -302,7 +313,7 @@ class ExternalPlaybackTracker @Inject constructor(
         this.nextEpisodeSnapshot = nextEpisodeSnapshot ?: ExternalNextEpisodeSnapshot.Unknown
         autoNextEnabledForPendingLaunch = autoNextEnabled
         // Persist so progress-save + auto-next survive the player killing our process.
-        persistMetadata(metadata)
+        persistMetadata(metadata, cloudSessionToken)
         persistAutoNextState(this.nextEpisodeSnapshot, autoNextEnabled)
         startNextEpisodePrefetch(metadata)
 
@@ -348,6 +359,7 @@ class ExternalPlaybackTracker @Inject constructor(
         subtitles: List<SubtitleInput>? = null,
         autoLaunch: Boolean = false,
         nextEpisodeSnapshot: ExternalNextEpisodeSnapshot? = null,
+        cloudSessionToken: String? = null,
         context: Context
     ): Boolean {
         if (shouldCancelPendingAutoLaunch(autoLaunch)) {
@@ -364,7 +376,8 @@ class ExternalPlaybackTracker @Inject constructor(
             metadata = metadata,
             autoLaunch = autoLaunch,
             nextEpisodeSnapshot = nextEpisodeSnapshot,
-            autoNextEnabled = autoNextEnabled
+            autoNextEnabled = autoNextEnabled,
+            cloudSessionToken = cloudSessionToken
         )
 
         // Resolve resume position (if not given) and intro/outro skip segments off the main
@@ -408,6 +421,7 @@ class ExternalPlaybackTracker @Inject constructor(
      * content can't be identified, or nothing is found.
      */
     private suspend fun resolveSkipSegmentsJson(metadata: ExternalPlaybackMetadata): String? {
+        if (metadata.contentType.equals("cloud", ignoreCase = true)) return null
         // Opt-in via the External Player setting (not the internal player's "Skip Intro", which is
         // greyed out while external player is selected).
         if (!playerSettingsDataStore.playerSettings.first().externalPlayerSendSkipSegments) return null
@@ -538,6 +552,7 @@ class ExternalPlaybackTracker @Inject constructor(
             Log.d(TAG, "onActivityResult recovered metadata from disk (process was recreated)")
             nextEpisodeSnapshot = loadPersistedNextEpisodeSnapshot()
             autoNextEnabledForPendingLaunch = loadPersistedAutoNextEnabled()
+            pendingCloudSessionToken = loadPersistedCloudSessionToken()
         }
 
         if (result == null) {
@@ -599,6 +614,13 @@ class ExternalPlaybackTracker @Inject constructor(
             // WatchProgress.isCompleted(), which makes the repository flag the item watched
             // (and sync it) regardless of the reported position/duration.
             saveProgress(metadata, result.positionMs, result.durationMs, explicitPercent = 100f)
+            val cloudSessionToken = pendingCloudSessionToken ?: loadPersistedCloudSessionToken()
+            if (metadata.contentType.equals("cloud", ignoreCase = true) && cloudSessionToken != null) {
+                clearPersistedMetadata()
+                stopTracking()
+                maybeTriggerCloudAutoNext(metadata, cloudSessionToken)
+                return
+            }
             // Try to auto-advance to the next episode.
             maybeTriggerAutoNextEpisode(metadata)
         } else {
@@ -623,6 +645,7 @@ class ExternalPlaybackTracker @Inject constructor(
      * (episode runtime for series, top-level runtime for movies). Returns 0 if unknown.
      */
     private suspend fun resolveFallbackDurationMs(metadata: ExternalPlaybackMetadata): Long {
+        if (metadata.contentType.equals("cloud", ignoreCase = true)) return 0L
         val existing = currentSavedProgress(metadata)
         if (existing != null && existing.duration > 0L) return existing.duration
         return fetchRuntimeMsFromMeta(metadata)
@@ -666,7 +689,7 @@ class ExternalPlaybackTracker @Inject constructor(
 
     // --- Disk persistence for pendingMetadata (survives process death) -------------
 
-    private fun persistMetadata(m: ExternalPlaybackMetadata) {
+    private fun persistMetadata(m: ExternalPlaybackMetadata, cloudSessionToken: String?) {
         persistedPrefs.edit()
             .putString("contentId", m.contentId)
             .putString("contentType", m.contentType)
@@ -679,8 +702,12 @@ class ExternalPlaybackTracker @Inject constructor(
             .putInt("episode", m.episode ?: Int.MIN_VALUE)
             .putString("episodeTitle", m.episodeTitle)
             .putString("year", m.year)
+            .putString("cloudSessionToken", cloudSessionToken)
             .apply()
     }
+
+    private fun loadPersistedCloudSessionToken(): String? =
+        persistedPrefs.getString("cloudSessionToken", null)
 
     private fun persistAutoNextState(
         snapshot: ExternalNextEpisodeSnapshot,
@@ -954,6 +981,74 @@ class ExternalPlaybackTracker @Inject constructor(
         }
     }
 
+    private fun maybeTriggerCloudAutoNext(
+        metadata: ExternalPlaybackMetadata,
+        sessionToken: String
+    ) {
+        val playbackContext = cloudPlaybackSessionStore.load(sessionToken)
+        val nextFile = playbackContext?.nextFile
+        if (playbackContext == null || nextFile == null || autoNextCancelled || autoNextChainAborted) {
+            _autoNextOverlay.value = null
+            return
+        }
+
+        _autoNextOverlay.value = _autoNextOverlay.value?.copy(
+            title = nextFile.name.takeIf { it.isNotBlank() } ?: metadata.contentName
+        )
+
+        autoNextJob?.cancel()
+        autoNextJob = scope.launch {
+            val enabled = autoNextEnabledForPendingLaunch
+                ?: playerSettingsDataStore.playerSettings.first()
+                    .streamAutoPlayNextEpisodeEnabled
+            if (!enabled) {
+                _autoNextOverlay.value = null
+                return@launch
+            }
+
+            val result = withTimeoutOrNull(AUTO_NEXT_OVERLAY_TIMEOUT_MS) {
+                cloudLibraryRepository.resolvePlayback(playbackContext.item, nextFile)
+            }
+            if (result !is CloudLibraryPlaybackResult.Success) {
+                Log.d(AUTO_NEXT_TAG, "Cloud auto-next could not resolve ${nextFile.stableKey}")
+                _autoNextOverlay.value = null
+                return@launch
+            }
+
+            val nextEpisode = playbackContext.episodeNumber(nextFile) ?: run {
+                _autoNextOverlay.value = null
+                return@launch
+            }
+            val nextContext = playbackContext.advanceTo(nextFile)
+            val filename = result.filename ?: nextFile.name
+            _autoNextOverlay.value = _autoNextOverlay.value?.copy(title = filename)
+            val nextMetadata = metadata.copy(
+                videoId = playbackContext.videoId(nextFile),
+                season = 1,
+                episode = nextEpisode,
+                episodeTitle = filename
+            )
+
+            lastAutoNextEmitMs = System.currentTimeMillis()
+            autoNextNavigationPending = true
+            cloudPlaybackSessionStore.update(sessionToken, nextContext)
+            val launched = launchPlayer(
+                metadata = nextMetadata,
+                url = result.url,
+                title = filename,
+                headers = null,
+                autoLaunch = true,
+                cloudSessionToken = sessionToken,
+                context = appContext
+            )
+            if (!launched) {
+                cloudPlaybackSessionStore.update(sessionToken, playbackContext)
+                autoNextNavigationPending = false
+                _autoNextOverlay.value = null
+            }
+        }
+    }
+
     // ===================== "Loading next episode" loader =====================
     // WARNING: autoNextOverlay is the ONLY cover for the player->Nuvio transition. To hide the
     // episode-list flash, raise THIS loader early (raiseAutoNextOverlayOnReturn). Do NOT add a
@@ -1064,6 +1159,7 @@ class ExternalPlaybackTracker @Inject constructor(
         if (recoveredFromDisk) {
             nextEpisodeSnapshot = loadPersistedNextEpisodeSnapshot()
             autoNextEnabledForPendingLaunch = loadPersistedAutoNextEnabled()
+            pendingCloudSessionToken = loadPersistedCloudSessionToken()
         }
         raiseAutoNextOverlay(metadata, allowUnknownNextEpisode = true)
         // In-process handoffs keep pendingMetadata, so onActivityResult is guaranteed to run and
@@ -1093,6 +1189,24 @@ class ExternalPlaybackTracker @Inject constructor(
         metadata: ExternalPlaybackMetadata,
         allowUnknownNextEpisode: Boolean = false
     ) {
+        if (metadata.contentType.equals("cloud", ignoreCase = true)) {
+            val sessionToken = pendingCloudSessionToken ?: loadPersistedCloudSessionToken()
+            val nextFile = cloudPlaybackSessionStore.load(sessionToken)?.nextFile
+            if (!autoNextCancelled &&
+                !autoNextChainAborted &&
+                !autoNextOverlaySuppressed &&
+                _autoNextOverlay.value == null &&
+                autoNextEnabledForPendingLaunch != false &&
+                nextFile != null
+            ) {
+                _autoNextOverlay.value = ExternalAutoNextOverlay(
+                    backdrop = metadata.backdrop ?: metadata.poster,
+                    logo = metadata.logo,
+                    title = nextFile.name.takeIf { it.isNotBlank() } ?: metadata.contentName
+                )
+            }
+            return
+        }
         val hasNextEpisode = nextEpisodeSnapshot.hasNextEpisode
         val shouldRaise = ExternalAutoNextPolicy.shouldRaiseLoader(
             episode = metadata.episode,
@@ -1126,6 +1240,7 @@ class ExternalPlaybackTracker @Inject constructor(
         zidooMonitorJob?.cancel()
         zidooMonitorJob = null
         pendingMetadata = null
+        pendingCloudSessionToken = null
         isAutoLaunch = false
         ExternalPlaybackKeepAliveService.stop(appContext)
         Log.d(TAG, "Stopped tracking")
@@ -1158,6 +1273,7 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private suspend fun getResumePosition(metadata: ExternalPlaybackMetadata): Long {
+        if (metadata.contentType.equals("cloud", ignoreCase = true)) return 0L
         val flow = if (metadata.season != null && metadata.episode != null) {
             watchProgressRepository.getEpisodeProgress(metadata.contentId, metadata.season, metadata.episode)
         } else {
@@ -1180,6 +1296,9 @@ class ExternalPlaybackTracker @Inject constructor(
         durationMs: Long?,
         explicitPercent: Float? = null
     ) {
+        // The synthetic sequence values are only for Cloud Library auto-next. Do not create
+        // Continue Watching or tracking entries for files that did not have them before.
+        if (metadata.contentType.equals("cloud", ignoreCase = true)) return
         val effectiveDuration = durationMs ?: 0L
 
         scope.launch {

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.core.player
 import android.content.Context
 import android.util.Log
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackResult
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackProgressStore
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
 import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.network.NetworkResult
@@ -173,6 +174,7 @@ class ExternalPlaybackTracker @Inject constructor(
     private val playerSettingsDataStore: PlayerSettingsDataStore,
     private val skipIntroRepository: SkipIntroRepository,
     private val cloudLibraryRepository: CloudLibraryRepository,
+    private val cloudPlaybackProgressStore: CloudLibraryPlaybackProgressStore,
     private val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore
 ) {
     companion object {
@@ -608,19 +610,32 @@ class ExternalPlaybackTracker @Inject constructor(
             return
         }
 
-        if (isPlaybackCompleted(result)) {
+        val completed = isPlaybackCompleted(result)
+        val cloudSessionToken = pendingCloudSessionToken ?: loadPersistedCloudSessionToken()
+        if (metadata.contentType.equals("cloud", ignoreCase = true) && cloudSessionToken != null) {
+            saveCloudProgress(
+                metadata = metadata,
+                sessionToken = cloudSessionToken,
+                positionMs = result.positionMs,
+                durationMs = result.durationMs,
+                completed = completed
+            )
+            clearPersistedMetadata()
+            stopTracking()
+            if (completed) {
+                maybeTriggerCloudAutoNext(metadata, cloudSessionToken)
+            } else {
+                _autoNextOverlay.value = null
+            }
+            return
+        }
+
+        if (completed) {
             // Mark watched even when the player returns no position/duration (e.g. Just
             // Player sends only end_by=playback_completion). An explicit 100% forces
             // WatchProgress.isCompleted(), which makes the repository flag the item watched
             // (and sync it) regardless of the reported position/duration.
             saveProgress(metadata, result.positionMs, result.durationMs, explicitPercent = 100f)
-            val cloudSessionToken = pendingCloudSessionToken ?: loadPersistedCloudSessionToken()
-            if (metadata.contentType.equals("cloud", ignoreCase = true) && cloudSessionToken != null) {
-                clearPersistedMetadata()
-                stopTracking()
-                maybeTriggerCloudAutoNext(metadata, cloudSessionToken)
-                return
-            }
             // Try to auto-advance to the next episode.
             maybeTriggerAutoNextEpisode(metadata)
         } else {
@@ -1273,7 +1288,12 @@ class ExternalPlaybackTracker @Inject constructor(
     }
 
     private suspend fun getResumePosition(metadata: ExternalPlaybackMetadata): Long {
-        if (metadata.contentType.equals("cloud", ignoreCase = true)) return 0L
+        if (metadata.contentType.equals("cloud", ignoreCase = true)) {
+            val sessionToken = pendingCloudSessionToken ?: loadPersistedCloudSessionToken()
+            val playbackContext = cloudPlaybackSessionStore.load(sessionToken) ?: return 0L
+            val file = playbackContext.fileForVideoId(metadata.videoId) ?: return 0L
+            return cloudPlaybackProgressStore.load(playbackContext.item, file)?.resumePositionMs ?: 0L
+        }
         val flow = if (metadata.season != null && metadata.episode != null) {
             watchProgressRepository.getEpisodeProgress(metadata.contentId, metadata.season, metadata.episode)
         } else {
@@ -1342,6 +1362,25 @@ class ExternalPlaybackTracker @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun saveCloudProgress(
+        metadata: ExternalPlaybackMetadata,
+        sessionToken: String,
+        positionMs: Long,
+        durationMs: Long?,
+        completed: Boolean
+    ) {
+        if (!completed && positionMs < 1_000L) return
+        val playbackContext = cloudPlaybackSessionStore.load(sessionToken) ?: return
+        val file = playbackContext.fileForVideoId(metadata.videoId) ?: return
+        cloudPlaybackProgressStore.save(
+            item = playbackContext.item,
+            file = file,
+            positionMs = positionMs,
+            durationMs = durationMs ?: 0L,
+            completed = completed
+        )
     }
 
     private fun buildScrobbleItem(metadata: ExternalPlaybackMetadata): TrackingMediaReference? =

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -728,6 +728,11 @@ fun NuvioNavHost(
                     nullable = true
                     defaultValue = null
                 },
+                navArgument("cloudSessionToken") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
                 navArgument("launchStartedAtMs") {
                     type = NavType.StringType
                     nullable = true
@@ -1048,10 +1053,14 @@ fun NuvioNavHost(
                             contentType = "cloud",
                             contentName = info.item.name,
                             videoId = "${info.item.stableKey}:${info.file.stableKey}",
+                            season = 1,
+                            episode = info.sequenceIndex + 1,
+                            episodeTitle = filename,
                             filename = filename,
                             videoSize = info.videoSizeBytes,
                             addonName = info.item.providerName,
-                            streamDescription = info.item.name
+                            streamDescription = info.item.name,
+                            cloudSessionToken = info.sessionToken
                         )
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -65,7 +65,7 @@ sealed class Screen(val route: String) {
             return "stream/$encodedVideoId/$encodedContentTypePath/$encodedTitle?poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&season=${season ?: ""}&episode=${episode ?: ""}&episodeName=$encodedEpisodeName&genres=$encodedGenres&year=$encodedYear&contentId=$encodedContentId&contentName=$encodedContentName&runtime=${runtime ?: ""}&manualSelection=$manualSelection&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&startFromBeginning=$startFromBeginning&contentLanguage=$encodedContentLanguage"
         }
     }
-    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}&startFromBeginning={startFromBeginning}&addonName={addonName}&addonLogo={addonLogo}&streamDescription={streamDescription}&infoHash={infoHash}&fileIdx={fileIdx}&sources={sources}&contentLanguage={contentLanguage}&launchStartedAtMs={launchStartedAtMs}") {
+    data object Player : Screen("player/{streamUrl}/{title}?streamName={streamName}&year={year}&headers={headers}&contentId={contentId}&contentType={contentType}&contentName={contentName}&poster={poster}&backdrop={backdrop}&logo={logo}&videoId={videoId}&season={season}&episode={episode}&episodeTitle={episodeTitle}&bingeGroup={bingeGroup}&autoPlayNav={autoPlayNav}&returnToDetailOnBack={returnToDetailOnBack}&returnToHomeOnBack={returnToHomeOnBack}&filename={filename}&videoHash={videoHash}&videoSize={videoSize}&startFromBeginning={startFromBeginning}&addonName={addonName}&addonLogo={addonLogo}&streamDescription={streamDescription}&infoHash={infoHash}&fileIdx={fileIdx}&sources={sources}&contentLanguage={contentLanguage}&cloudSessionToken={cloudSessionToken}&launchStartedAtMs={launchStartedAtMs}") {
         private fun encode(value: String): String =
             URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
@@ -100,6 +100,7 @@ sealed class Screen(val route: String) {
             fileIdx: Int? = null,
             sources: List<String>? = null,
             contentLanguage: String? = null,
+            cloudSessionToken: String? = null,
             launchStartedAtMs: Long = SystemClock.elapsedRealtime()
         ): String {
             val encodedUrl = encode(streamUrl)
@@ -126,7 +127,8 @@ sealed class Screen(val route: String) {
             val encodedInfoHash = infoHash ?: ""
             val encodedSources = sources?.let { encode(org.json.JSONArray(it).toString()) } ?: ""
             val encodedContentLanguage = contentLanguage?.let { encode(it) } ?: ""
-            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}&startFromBeginning=$startFromBeginning&addonName=$encodedAddonName&addonLogo=$encodedAddonLogo&streamDescription=$encodedStreamDescription&infoHash=$encodedInfoHash&fileIdx=${fileIdx ?: ""}&sources=$encodedSources&contentLanguage=$encodedContentLanguage&launchStartedAtMs=$launchStartedAtMs"
+            val encodedCloudSessionToken = cloudSessionToken?.let { encode(it) } ?: ""
+            return "player/$encodedUrl/$encodedTitle?streamName=$encodedStreamName&year=$encodedYear&headers=$encodedHeaders&contentId=$encodedContentId&contentType=$encodedContentType&contentName=$encodedContentName&poster=$encodedPoster&backdrop=$encodedBackdrop&logo=$encodedLogo&videoId=$encodedVideoId&season=${season ?: ""}&episode=${episode ?: ""}&episodeTitle=$encodedEpisodeTitle&bingeGroup=$encodedBingeGroup&autoPlayNav=$autoPlayNav&returnToDetailOnBack=$returnToDetailOnBack&returnToHomeOnBack=$returnToHomeOnBack&filename=$encodedFilename&videoHash=$encodedVideoHash&videoSize=${videoSize ?: ""}&startFromBeginning=$startFromBeginning&addonName=$encodedAddonName&addonLogo=$encodedAddonLogo&streamDescription=$encodedStreamDescription&infoHash=$encodedInfoHash&fileIdx=${fileIdx ?: ""}&sources=$encodedSources&contentLanguage=$encodedContentLanguage&cloudSessionToken=$encodedCloudSessionToken&launchStartedAtMs=$launchStartedAtMs"
         }
     }
     data object Search : Screen("search")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -53,6 +54,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -79,11 +81,14 @@ import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.model.TraktListPrivacy
+import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.ui.components.EmptyScreenState
 import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
 import com.nuvio.tv.ui.screens.home.HeroBackdropState
+import com.nuvio.tv.ui.screens.stream.PlayerChoiceDialog
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.NuvioDialog
@@ -128,10 +133,14 @@ fun LibraryScreen(
     val uiState by viewModel.uiState.collectAsState()
     val watchedMovieIds by viewModel.watchedMovieIds.collectAsState()
     val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsState()
+    val activityContext = LocalContext.current
+    val scope = rememberCoroutineScope()
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var expandedPicker by remember { mutableStateOf<String?>(null) }
     var viewMode by rememberSaveable { mutableStateOf(LibraryViewMode.Saved) }
     var activeCloudItem by remember { mutableStateOf<CloudLibraryItem?>(null) }
+    var pendingCloudPlayback by remember { mutableStateOf<CloudLibraryPlaybackInfo?>(null) }
+    var showCloudPlayerChoice by remember { mutableStateOf(false) }
     val primaryFocusRequester = remember { FocusRequester() }
     val selectorFocusRequester = remember { FocusRequester() }
     val gridState = rememberLazyGridState()
@@ -148,6 +157,21 @@ fun LibraryScreen(
     }
     val firstVisiblePosterKey = visibleItemKeys.firstOrNull()
     val posterCardStyle = PosterCardDefaults.Style
+
+    val routeCloudPlayback: (CloudLibraryPlaybackInfo) -> Unit = { info ->
+        scope.launch {
+            when (viewModel.getPlayerPreference()) {
+                PlayerPreference.INTERNAL -> onCloudPlaybackResolved(info)
+                PlayerPreference.EXTERNAL -> {
+                    viewModel.launchCloudPlaybackExternally(info, activityContext)
+                }
+                PlayerPreference.ASK_EVERY_TIME -> {
+                    pendingCloudPlayback = info
+                    showCloudPlayerChoice = true
+                }
+            }
+        }
+    }
 
     LaunchedEffect(viewMode, uiState.cloudLibrary.isEnabled, uiState.cloudLibrary.isLoaded, uiState.cloudLibrarySettingsVersion) {
         if (viewMode == LibraryViewMode.Cloud) {
@@ -502,7 +526,7 @@ fun LibraryScreen(
                         val playableFiles = item.playableFiles
                         when (playableFiles.size) {
                             0 -> viewModel.onCloudItemHasNoPlayableFiles()
-                            1 -> viewModel.resolveCloudPlayback(item, playableFiles.first(), onCloudPlaybackResolved)
+                            1 -> viewModel.resolveCloudPlayback(item, playableFiles.first(), routeCloudPlayback)
                             else -> activeCloudItem = item
                         }
                     }
@@ -560,10 +584,32 @@ fun LibraryScreen(
             onPlay = { file ->
                 viewModel.resolveCloudPlayback(item, file) { info ->
                     activeCloudItem = null
-                    onCloudPlaybackResolved(info)
+                    routeCloudPlayback(info)
                 }
             },
             onDismiss = { activeCloudItem = null }
+        )
+    }
+
+    if (showCloudPlayerChoice && pendingCloudPlayback != null) {
+        PlayerChoiceDialog(
+            onInternalSelected = {
+                showCloudPlayerChoice = false
+                pendingCloudPlayback?.let(onCloudPlaybackResolved)
+                pendingCloudPlayback = null
+            },
+            onExternalSelected = {
+                showCloudPlayerChoice = false
+                val info = pendingCloudPlayback
+                pendingCloudPlayback = null
+                if (info != null) {
+                    scope.launch { viewModel.launchCloudPlaybackExternally(info, activityContext) }
+                }
+            },
+            onDismiss = {
+                showCloudPlayerChoice = false
+                pendingCloudPlayback = null
+            }
         )
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -7,9 +7,13 @@ import com.nuvio.tv.core.cloud.CloudLibraryFile
 import com.nuvio.tv.core.cloud.CloudLibraryItem
 import com.nuvio.tv.core.cloud.CloudLibraryItemType
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackInfo
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackContext
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackResult
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
 import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.cloud.CloudLibraryUiState
+import com.nuvio.tv.core.player.ExternalPlaybackMetadata
+import com.nuvio.tv.core.player.ExternalPlaybackTracker
 import com.nuvio.tv.core.debrid.DebridProviderCapability
 import com.nuvio.tv.core.debrid.DebridProviders
 import com.nuvio.tv.core.debrid.supports
@@ -18,6 +22,8 @@ import com.nuvio.tv.core.tracking.providerId
 import com.nuvio.tv.data.local.DebridSettingsDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.LibraryPreferences
+import com.nuvio.tv.data.local.PlayerPreference
+import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.repository.TraktLibraryService
 import com.nuvio.tv.domain.model.AuthState
 import com.nuvio.tv.domain.model.LibraryEntry
@@ -137,6 +143,9 @@ data class LibraryUiState(
 class LibraryViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val cloudLibraryRepository: CloudLibraryRepository,
+    private val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore,
+    private val externalPlaybackTracker: ExternalPlaybackTracker,
+    private val playerSettingsDataStore: PlayerSettingsDataStore,
     private val metaRepository: com.nuvio.tv.domain.repository.MetaRepository,
     private val debridSettingsDataStore: DebridSettingsDataStore,
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
@@ -311,13 +320,21 @@ class LibraryViewModel @Inject constructor(
             _uiState.update { it.copy(resolvingCloudFileKey = null) }
             when (result) {
                 is CloudLibraryPlaybackResult.Success -> {
+                    val playbackContext = CloudLibraryPlaybackContext.create(item, file)
+                    if (playbackContext == null) {
+                        setError(context.getString(R.string.cloud_library_play_failed))
+                        return@launch
+                    }
+                    val sessionToken = cloudPlaybackSessionStore.create(playbackContext)
                     onResolved(
                         CloudLibraryPlaybackInfo(
                             item = item,
                             file = file,
                             url = result.url,
                             filename = result.filename ?: file.name.takeIf { it.isNotBlank() },
-                            videoSizeBytes = result.videoSizeBytes ?: file.sizeBytes
+                            videoSizeBytes = result.videoSizeBytes ?: file.sizeBytes,
+                            sessionToken = sessionToken,
+                            sequenceIndex = playbackContext.currentIndex
                         )
                     )
                 }
@@ -333,6 +350,41 @@ class LibraryViewModel @Inject constructor(
             }
         }
     }
+
+    suspend fun launchCloudPlaybackExternally(
+        info: CloudLibraryPlaybackInfo,
+        activityContext: Context
+    ): Boolean {
+        val filename = info.filename ?: info.file.name
+        val metadata = ExternalPlaybackMetadata(
+            contentId = info.item.stableKey,
+            contentType = "cloud",
+            contentName = info.item.name,
+            poster = null,
+            backdrop = null,
+            logo = null,
+            videoId = "${info.item.stableKey}:${info.file.stableKey}",
+            season = 1,
+            episode = info.sequenceIndex + 1,
+            episodeTitle = filename,
+            year = null
+        )
+        val launched = runCatching {
+            externalPlaybackTracker.launchPlayer(
+                metadata = metadata,
+                url = info.url,
+                title = filename,
+                headers = null,
+                cloudSessionToken = info.sessionToken,
+                context = activityContext
+            )
+        }.getOrDefault(false)
+        if (!launched) setError(context.getString(R.string.cloud_library_play_failed))
+        return launched
+    }
+
+    suspend fun getPlayerPreference(): PlayerPreference =
+        playerSettingsDataStore.playerSettings.first().playerPreference
 
     fun onRefresh() {
         if (_uiState.value.isSyncing) return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNavigationArgs.kt
@@ -32,6 +32,7 @@ internal data class PlayerNavigationArgs(
     val fileIdx: Int?,
     val sourcesJson: String?,
     val contentLanguage: String?,
+    val cloudSessionToken: String?,
     val rememberedAudioLanguage: String?,
     val rememberedAudioName: String?,
     val launchStartedAtMs: Long?
@@ -90,6 +91,7 @@ internal data class PlayerNavigationArgs(
                 fileIdx = savedStateHandle.get<String>("fileIdx")?.toIntOrNull(),
                 sourcesJson = decodedOrNull("sources"),
                 contentLanguage = decodedOrNull("contentLanguage"),
+                cloudSessionToken = decodedOrNull("cloudSessionToken"),
                 rememberedAudioLanguage = decodedOrNull("rememberedAudioLanguage"),
                 rememberedAudioName = decodedOrNull("rememberedAudioName"),
                 launchStartedAtMs = savedStateHandle.get<String>("launchStartedAtMs")?.toLongOrNull()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -16,6 +16,7 @@ import com.nuvio.tv.core.player.LastPlaybackDiagnostics
 import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.debrid.DirectDebridStreamPreparer
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackContext
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackProgressStore
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
 import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.plugin.PluginManager
@@ -91,6 +92,7 @@ class PlayerRuntimeController(
     internal val directDebridResolver: DirectDebridResolver,
     internal val directDebridStreamPreparer: DirectDebridStreamPreparer,
     internal val cloudLibraryRepository: CloudLibraryRepository,
+    internal val cloudPlaybackProgressStore: CloudLibraryPlaybackProgressStore,
     internal val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore,
     internal val streamBadgePresentation: com.nuvio.tv.core.streams.StreamBadgePresentation,
     internal val playbackIssueReportRepository: PlaybackIssueReportRepository,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -15,6 +15,9 @@ import com.nuvio.tv.core.player.BitrateAwareLoadControl
 import com.nuvio.tv.core.player.LastPlaybackDiagnostics
 import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.debrid.DirectDebridStreamPreparer
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackContext
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
+import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.tracking.TrackingMediaReference
 import com.nuvio.tv.core.tracking.TrackingScrobbleCoordinator
@@ -87,6 +90,8 @@ class PlayerRuntimeController(
     internal val tmdbSettingsDataStore: com.nuvio.tv.data.local.TmdbSettingsDataStore,
     internal val directDebridResolver: DirectDebridResolver,
     internal val directDebridStreamPreparer: DirectDebridStreamPreparer,
+    internal val cloudLibraryRepository: CloudLibraryRepository,
+    internal val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore,
     internal val streamBadgePresentation: com.nuvio.tv.core.streams.StreamBadgePresentation,
     internal val playbackIssueReportRepository: PlaybackIssueReportRepository,
     savedStateHandle: SavedStateHandle,
@@ -172,6 +177,7 @@ class PlayerRuntimeController(
     internal val launchStartedAtElapsedMs: Long? = navigationArgs.launchStartedAtMs
     internal val rememberedAudioLanguage: String? = navigationArgs.rememberedAudioLanguage
     internal val rememberedAudioName: String? = navigationArgs.rememberedAudioName
+    internal val cloudSessionToken: String? = navigationArgs.cloudSessionToken
     internal val mediaSourceFactory = PlayerMediaSourceFactory(context.applicationContext)
 
     internal var currentVideoHash: String? = navigationArgs.videoHash
@@ -357,6 +363,8 @@ class PlayerRuntimeController(
     /** Back buffer (ms) the user configured, captured at build to restore once DV7 status is known. */
     internal var configuredBackBufferMs: Int = 0
     internal var metaVideos: List<Video> = emptyList()
+    internal var cloudPlaybackContext: CloudLibraryPlaybackContext? =
+        cloudPlaybackSessionStore.load(cloudSessionToken)
     internal var metaGenres: List<String> = emptyList()
     internal var metaCountry: String? = null
     internal var metaFetchJob: Job? = null
@@ -557,7 +565,11 @@ class PlayerRuntimeController(
         // causing the resume seek to be silently lost when ExoPlayer's STATE_READY
         // fired before the DB read completed.
         observeSubtitleSettings()
-        fetchMetaDetails(contentId, contentType)
+        if (contentType.equals("cloud", ignoreCase = true)) {
+            initializeCloudPlaybackSequence()
+        } else {
+            fetchMetaDetails(contentId, contentType)
+        }
         observeBlurUnwatchedEpisodes()
         observeEpisodeWatchProgress()
         observeTorrentSettings()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -36,6 +36,25 @@ internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?
     }
 }
 
+internal fun PlayerRuntimeController.initializeCloudPlaybackSequence() {
+    val playbackContext = cloudPlaybackContext ?: return
+    metaVideos = playbackContext.asVideos()
+    val currentFile = playbackContext.currentFile ?: return
+    currentVideoId = playbackContext.videoId(currentFile)
+    currentSeason = 1
+    currentEpisode = playbackContext.currentIndex + 1
+    currentEpisodeTitle = currentFile.name
+    _uiState.update {
+        it.copy(
+            currentVideoId = currentVideoId,
+            currentSeason = currentSeason,
+            currentEpisode = currentEpisode,
+            currentEpisodeTitle = currentEpisodeTitle
+        )
+    }
+    recomputeNextEpisode(resetVisibility = false)
+}
+
 internal fun PlayerRuntimeController.applyMetaDetails(meta: Meta) {
     metaVideos = meta.videos
     metaGenres = meta.genres
@@ -79,9 +98,11 @@ internal fun PlayerRuntimeController.updateEpisodeDescription() {
     // Push episode metadata to the MediaSession so Google Home shows the new episode.
     updateMediaSessionMetadata()
 
-    // Re-enrich from TMDB for the new episode.
-    scope.launch {
-        enrichDescriptionFromTmdb(contentId, contentType)
+    // Cloud library IDs belong to the provider, not TMDB.
+    if (!contentType.equals("cloud", ignoreCase = true)) {
+        scope.launch {
+            enrichDescriptionFromTmdb(contentId, contentType)
+        }
     }
 }
 
@@ -161,13 +182,13 @@ private suspend fun PlayerRuntimeController.enrichDescriptionFromTmdb(id: String
 
 internal fun PlayerRuntimeController.recomputeNextEpisode(resetVisibility: Boolean) {
     val normalizedType = contentType?.lowercase()
-    if (normalizedType !in listOf("series", "tv", "other")) {
+    if (normalizedType !in listOf("series", "tv", "other", "cloud")) {
         nextEpisodeVideo = null
         clearNextEpisodeAndCancelPostPlay()
         return
     }
 
-    if (normalizedType == "other") {
+    if (normalizedType == "other" || normalizedType == "cloud") {
         val currentId = currentVideoId
         val idx = if (currentId != null) metaVideos.indexOfFirst { it.id == currentId } else -1
         val resolvedNext = if (idx >= 0 && idx < metaVideos.size - 1) metaVideos[idx + 1] else null
@@ -186,7 +207,7 @@ internal fun PlayerRuntimeController.recomputeNextEpisode(resetVisibility: Boole
             released = resolvedNext.released,
             hasAired = true,
             unairedMessage = null,
-            isOtherType = true
+            isOtherType = normalizedType == "other" || normalizedType == "cloud"
         )
         applyRecomputedNextEpisode(nextInfo, resetVisibility)
         return

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.domain.model.Subtitle
+import com.nuvio.tv.domain.model.WatchProgress
 import com.nuvio.tv.domain.model.enabledAddons
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -459,14 +460,18 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
 }
 
 internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode: Int?) {
-    if (contentId == null) return
+    val isCloudLibraryPlayback = contentType.equals("cloud", ignoreCase = true)
+    val progressContentId = contentId
+    if (!isCloudLibraryPlayback && progressContentId == null) return
 
     scope.launch {
         pendingResumeProgress = null
-        val progress = if (season != null && episode != null) {
-            watchProgressRepository.getEpisodeProgress(contentId, season, episode).firstOrNull()
+        val progress = if (isCloudLibraryPlayback) {
+            loadCloudLibraryResumeProgress()
+        } else if (season != null && episode != null) {
+            watchProgressRepository.getEpisodeProgress(progressContentId!!, season, episode).firstOrNull()
         } else {
-            watchProgressRepository.getProgress(contentId).firstOrNull()
+            watchProgressRepository.getProgress(progressContentId!!).firstOrNull()
         }
 
         progress?.let { saved ->
@@ -500,13 +505,17 @@ internal fun PlayerRuntimeController.loadSavedProgressFor(season: Int?, episode:
  * player lifecycle and can lose the resume position entirely.
  */
 internal suspend fun PlayerRuntimeController.loadSavedProgressSuspend(season: Int?, episode: Int?) {
-    if (contentId == null) return
+    val isCloudLibraryPlayback = contentType.equals("cloud", ignoreCase = true)
+    val progressContentId = contentId
+    if (!isCloudLibraryPlayback && progressContentId == null) return
 
     pendingResumeProgress = null
-    val progress = if (season != null && episode != null) {
-        watchProgressRepository.getEpisodeProgress(contentId, season, episode).firstOrNull()
+    val progress = if (isCloudLibraryPlayback) {
+        loadCloudLibraryResumeProgress()
+    } else if (season != null && episode != null) {
+        watchProgressRepository.getEpisodeProgress(progressContentId!!, season, episode).firstOrNull()
     } else {
-        watchProgressRepository.getProgress(contentId).firstOrNull()
+        watchProgressRepository.getProgress(progressContentId!!).firstOrNull()
     }
 
     progress?.let { saved ->
@@ -520,6 +529,30 @@ internal suspend fun PlayerRuntimeController.loadSavedProgressSuspend(season: In
             )
         }
     }
+}
+
+private fun PlayerRuntimeController.loadCloudLibraryResumeProgress(): WatchProgress? {
+    val playbackContext = cloudPlaybackContext ?: return null
+    val file = playbackContext.fileForVideoId(currentVideoId) ?: return null
+    val saved = cloudPlaybackProgressStore.load(playbackContext.item, file) ?: return null
+    if (!saved.isInProgress) return null
+
+    return WatchProgress(
+        contentId = playbackContext.item.stableKey,
+        contentType = "cloud",
+        name = playbackContext.item.name,
+        poster = null,
+        backdrop = null,
+        logo = null,
+        videoId = playbackContext.videoId(file),
+        season = 1,
+        episode = playbackContext.episodeNumber(file),
+        episodeTitle = file.name,
+        position = saved.positionMs,
+        duration = saved.durationMs,
+        lastWatched = saved.updatedAtMs,
+        progressPercent = if (saved.durationMs <= 0L) 5f else null
+    )
 }
 
 internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int?, episode: Int?) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -647,7 +647,11 @@ internal fun PlayerRuntimeController.handleNaturalPlaybackEnded() {
     }
 
     emitCompletionScrobbleStop(progressPercent = 99.5f)
-    saveWatchProgress()
+    if (contentType.equals("cloud", ignoreCase = true)) {
+        saveCloudLibraryProgress(position, duration, completed = true)
+    } else {
+        saveWatchProgress()
+    }
     resetPostPlayStateAfterPlaybackEnded()
 }
 
@@ -664,6 +668,10 @@ internal fun PlayerRuntimeController.cancelNextEpisodeAutoPlayOnFatalError() {
 }
 
 internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, duration: Long, syncRemote: Boolean = true) {
+    if (contentType.equals("cloud", ignoreCase = true)) {
+        saveCloudLibraryProgress(position, duration, completed = false)
+        return
+    }
     val parentContentId = contentId?.takeIf { it.isNotEmpty() } ?: return
     val parentContentType = contentType?.takeIf { it.isNotEmpty() } ?: return
 
@@ -706,6 +714,23 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, d
             watchProgressRepository.saveProgress(normalizedProgress, syncRemote = syncRemote)
         }
     }
+}
+
+private fun PlayerRuntimeController.saveCloudLibraryProgress(
+    position: Long,
+    duration: Long,
+    completed: Boolean
+) {
+    if (!completed && position < 1_000L) return
+    val playbackContext = cloudPlaybackContext ?: return
+    val file = playbackContext.fileForVideoId(currentVideoId) ?: return
+    cloudPlaybackProgressStore.save(
+        item = playbackContext.item,
+        file = file,
+        positionMs = position,
+        durationMs = duration,
+        completed = completed
+    )
 }
 
 internal fun PlayerRuntimeController.currentPlaybackProgressPercent(): Float {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 /** Hard ceiling for next-episode stream search to prevent hanging forever. */
 private const val NEXT_EPISODE_HARD_TIMEOUT_MS = 120_000L
+private const val CLOUD_LIBRARY_AUTO_NEXT_TIMEOUT_MS = 65_000L
 
 /**
  * Schedules incremental badge matching for source streams in the background.
@@ -1516,6 +1517,11 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
         return
     }
 
+    if (type.equals("cloud", ignoreCase = true)) {
+        playNextCloudLibraryFile(nextVideo = nextVideo, userInitiated = userInitiated)
+        return
+    }
+
     val episodeForMode = state.nextEpisode ?: nextInfo
     _uiState.update {
         it.copy(
@@ -1756,6 +1762,79 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                 )
             }
             showEpisodeStreamPicker(video = nextVideo, forceRefresh = false)
+        }
+    }
+}
+
+private fun PlayerRuntimeController.playNextCloudLibraryFile(
+    nextVideo: Video,
+    userInitiated: Boolean
+) {
+    val playbackContext = cloudPlaybackContext ?: return
+    val nextFile = playbackContext.nextFile ?: return
+    val nextInfo = _uiState.value.nextEpisode ?: return
+    _uiState.update {
+        it.copy(postPlayMode = PostPlayMode.AutoPlay(nextEpisode = nextInfo, searching = true))
+    }
+
+    nextEpisodeAutoPlayJob?.cancel()
+    nextEpisodeAutoPlayJob = scope.launch {
+        try {
+            when (val result = withTimeoutOrNull(CLOUD_LIBRARY_AUTO_NEXT_TIMEOUT_MS) {
+                cloudLibraryRepository.resolvePlayback(playbackContext.item, nextFile)
+            }) {
+                is com.nuvio.tv.core.cloud.CloudLibraryPlaybackResult.Success -> {
+                    val filename = result.filename ?: nextFile.name
+                    val stream = Stream(
+                        name = playbackContext.item.providerName,
+                        title = filename,
+                        description = playbackContext.item.name,
+                        url = result.url,
+                        ytId = null,
+                        infoHash = null,
+                        fileIdx = null,
+                        externalUrl = null,
+                        behaviorHints = com.nuvio.tv.domain.model.StreamBehaviorHints(
+                            notWebReady = null,
+                            bingeGroup = null,
+                            countryWhitelist = null,
+                            proxyHeaders = null,
+                            videoSize = result.videoSizeBytes ?: nextFile.sizeBytes,
+                            filename = filename
+                        ),
+                        addonName = playbackContext.item.providerName,
+                        addonLogo = null
+                    )
+                    val advancedContext = playbackContext.advanceTo(nextFile)
+                    cloudSessionToken?.let { cloudPlaybackSessionStore.update(it, advancedContext) }
+                    cloudPlaybackContext = advancedContext
+                    _uiState.update { it.copy(title = filename) }
+                    switchToEpisodeStream(
+                        stream = stream,
+                        forcedTargetVideo = nextVideo,
+                        isAutoPlay = !userInitiated
+                    )
+                }
+                else -> {
+                    _uiState.update {
+                        it.copy(
+                            postPlayMode = null,
+                            postPlayDismissedForCurrentEpisode = true,
+                            error = context.getString(com.nuvio.tv.R.string.cloud_library_play_failed)
+                        )
+                    }
+                }
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            _uiState.update {
+                it.copy(
+                    postPlayMode = null,
+                    postPlayDismissedForCurrentEpisode = true,
+                    error = context.getString(com.nuvio.tv.R.string.cloud_library_play_failed)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.exoplayer.ExoPlayer
 import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.debrid.DirectDebridStreamPreparer
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
+import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.tracking.TrackingScrobbleCoordinator
 import com.nuvio.tv.core.torrent.TorrentService
@@ -63,6 +65,8 @@ class PlayerViewModel @Inject constructor(
     private val trailerPlayerPool: com.nuvio.tv.core.player.TrailerPlayerPool,
     private val directDebridResolver: DirectDebridResolver,
     private val directDebridStreamPreparer: DirectDebridStreamPreparer,
+    private val cloudLibraryRepository: CloudLibraryRepository,
+    private val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore,
     private val streamBadgePresentation: com.nuvio.tv.core.streams.StreamBadgePresentation,
     private val playbackIssueReportRepository: com.nuvio.tv.data.repository.PlaybackIssueReportRepository,
     private val externalPlaybackTracker: com.nuvio.tv.core.player.ExternalPlaybackTracker,
@@ -104,6 +108,8 @@ class PlayerViewModel @Inject constructor(
         tmdbSettingsDataStore = tmdbSettingsDataStore,
         directDebridResolver = directDebridResolver,
         directDebridStreamPreparer = directDebridStreamPreparer,
+        cloudLibraryRepository = cloudLibraryRepository,
+        cloudPlaybackSessionStore = cloudPlaybackSessionStore,
         streamBadgePresentation = streamBadgePresentation,
         playbackIssueReportRepository = playbackIssueReportRepository,
         savedStateHandle = savedStateHandle,
@@ -208,7 +214,9 @@ class PlayerViewModel @Inject constructor(
             onResult(false)
             return
         }
-        val contentId = controller.contentId ?: run {
+        val contentId = controller.contentId
+            ?: controller.cloudPlaybackContext?.item?.stableKey
+            ?: run {
             onResult(false)
             return
         }
@@ -276,6 +284,7 @@ class PlayerViewModel @Inject constructor(
                     resumePositionMs = resumePositionMs,
                     subtitles = cachedSubtitles,
                     nextEpisodeSnapshot = nextEpisodeSnapshot,
+                    cloudSessionToken = controller.cloudSessionToken,
                     context = activityContext
                 )
             } catch (_: Exception) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.nuvio.tv.core.debrid.DirectDebridResolver
 import com.nuvio.tv.core.debrid.DirectDebridStreamPreparer
 import com.nuvio.tv.core.cloud.CloudLibraryPlaybackSessionStore
+import com.nuvio.tv.core.cloud.CloudLibraryPlaybackProgressStore
 import com.nuvio.tv.core.cloud.CloudLibraryRepository
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.tracking.TrackingScrobbleCoordinator
@@ -66,6 +67,7 @@ class PlayerViewModel @Inject constructor(
     private val directDebridResolver: DirectDebridResolver,
     private val directDebridStreamPreparer: DirectDebridStreamPreparer,
     private val cloudLibraryRepository: CloudLibraryRepository,
+    private val cloudPlaybackProgressStore: CloudLibraryPlaybackProgressStore,
     private val cloudPlaybackSessionStore: CloudLibraryPlaybackSessionStore,
     private val streamBadgePresentation: com.nuvio.tv.core.streams.StreamBadgePresentation,
     private val playbackIssueReportRepository: com.nuvio.tv.data.repository.PlaybackIssueReportRepository,
@@ -109,6 +111,7 @@ class PlayerViewModel @Inject constructor(
         directDebridResolver = directDebridResolver,
         directDebridStreamPreparer = directDebridStreamPreparer,
         cloudLibraryRepository = cloudLibraryRepository,
+        cloudPlaybackProgressStore = cloudPlaybackProgressStore,
         cloudPlaybackSessionStore = cloudPlaybackSessionStore,
         streamBadgePresentation = streamBadgePresentation,
         playbackIssueReportRepository = playbackIssueReportRepository,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -1280,7 +1280,7 @@ private fun StreamCard(
 }
 
 @Composable
-private fun PlayerChoiceDialog(
+internal fun PlayerChoiceDialog(
     onInternalSelected: () -> Unit,
     onExternalSelected: () -> Unit,
     onDismiss: () -> Unit


### PR DESCRIPTION
## Summary

Cloud Library playback now respects the configured player mode, retains its playable file sequence for auto next, and saves progress against the exact Cloud file being played.

- Routes Cloud files through Internal, External, or Ask every time.
- Resolves a fresh provider URL before advancing to the next playable Cloud file.
- Supports internal and external auto next without sending Cloud files through addon source selection.
- Shows the next filename while the handoff is loading.
- Stops normally after the final playable file.
- Persists the Cloud sequence so external playback can recover after process recreation.
- Saves and restores progress separately for each Cloud file using its synthetic video ID.
- Saves the current file before auto next advances to the next file.
- Keeps Cloud progress local without adding synthetic Continue Watching or Nuvio Sync entries.
- Clears the loader and keeps the current sequence position when the next URL or external launch fails.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Cloud Library playback bypassed the configured player preference and always opened the internal player. It also passed only one resolved URL into playback, so neither the internal nor external completion path knew which Cloud file came next.

The fix carries a Cloud only session token through playback. That session owns the ordered playable files and current position. Auto next resolves a fresh URL for only the next Cloud file and advances the stored position only when the handoff succeeds.

Cloud files do not have a normal media ID, so their playback progress also could not safely follow the sequence. Progress is now stored locally per Cloud item and file. The synthetic video ID resolves the exact file before its position is saved or restored, which prevents one file from overwriting another as auto next advances.

## Issue or approval

Fixes #3024

## Reproduction steps

1. Connect a supported Cloud Library provider containing a multi file item.
2. Select External player or Ask every time in playback settings.
3. Play a file from the Cloud Library.
4. Stop partway through and reopen the same file to confirm it resumes.
5. Enable auto next and complete a non final file.
6. Repeat using the internal player.
7. Complete the final playable file.

Before this fix, Cloud playback always opened internally and did not advance. After this fix, the configured player is respected, progress belongs to the correct Cloud file, the next file launches with a fresh provider URL, the loader names the next file, and the final file exits without another handoff.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This applies only when playback is identified as Cloud Library content or carries a Cloud playback session token.

It does not change normal addon source selection, stream selection timeout, binge group behavior, regular internal auto next, regular external auto next, metadata enrichment, skip intervals, normal watch progress, or tracking. Cloud progress remains local and does not create Continue Watching or Nuvio Sync entries.

## Testing

- `./gradlew :app:assembleFullDebug --no-daemon --console=plain` passed, including lint vital.
- Installed and tested on NVIDIA Shield TV running Android 11.
- Verified Cloud Library playback respects both internal and external player modes.
- Verified internal and external completion resolve and launch the next playable Cloud file.
- Verified the loading screen updates to the next filename.
- Verified Cloud progress is stored per file and restored through the synthetic video ID.
- Reviewed the failure paths to confirm a failed next URL or external launch releases the loading state without advancing the stored Cloud position.
- `:app:testFullDebugUnitTest` is currently blocked before test execution by existing upstream test source compilation errors in TMDB collection, trailer service, and search concurrency tests. None of those files are changed here.

## Screenshots / Video

**Internal player Cloud auto next**

https://github.com/user-attachments/assets/610087c9-d607-49ed-93e6-1fcc9757539a

**External player Cloud auto next**

https://github.com/user-attachments/assets/4ba215b8-e965-4d41-acee-12227575942e

## Breaking changes

None.

## Linked issues

Fixes #3024
