### PR TITLE
fix(streams): refresh and retain source results in selection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -32,9 +32,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
 import java.net.URLEncoder
 import java.security.MessageDigest
@@ -54,6 +56,11 @@ class StreamRepositoryImpl @Inject constructor(
     private val localDebridAvailabilityService: LocalDebridAvailabilityService
 ) : StreamRepository {
     private val streamSearchSessions = StreamSearchSessionCache()
+    private val localPluginSearchPaused = MutableStateFlow(false)
+
+    override fun setLocalPluginSearchPaused(paused: Boolean) {
+        localPluginSearchPaused.value = paused
+    }
 
     private enum class StreamFailureKind {
         MISSING,
@@ -145,6 +152,7 @@ class StreamRepositoryImpl @Inject constructor(
         }
     }
 
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     private fun fetchStreamsFromAllSources(
         type: String,
         videoId: String,
@@ -249,14 +257,21 @@ class StreamRepositoryImpl @Inject constructor(
                             season = season,
                             episode = episode
                         )
-                        streamLocalPlugins(
-                            pluginId = pluginRequest.id,
-                            mediaType = pluginRequest.mediaType,
-                            pluginSource = pluginRequest.source,
-                            season = pluginSeason,
-                            episode = pluginEpisode,
-                            resultChannel = resultChannel
-                        )
+                        localPluginSearchPaused
+                            .transformLatest { paused ->
+                                if (!paused) {
+                                    streamLocalPlugins(
+                                        pluginId = pluginRequest.id,
+                                        mediaType = pluginRequest.mediaType,
+                                        pluginSource = pluginRequest.source,
+                                        season = pluginSeason,
+                                        episode = pluginEpisode,
+                                        resultChannel = resultChannel
+                                    )
+                                    emit(Unit)
+                                }
+                            }
+                            .first()
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         Log.e(TAG, "Plugin execution failed: ${e.message}")

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -9,11 +9,14 @@ import com.nuvio.tv.core.debrid.DebridStreamPresentation
 import com.nuvio.tv.core.debrid.LocalDebridAvailabilityService
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.plugin.resolvePluginSeasonEpisode
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.DebridSettingsDataStore
 import com.nuvio.tv.data.mapper.toDomain
 import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonStreams
+import com.nuvio.tv.domain.model.DebridSettings
 import com.nuvio.tv.domain.model.LocalScraperResult
 import com.nuvio.tv.domain.model.PluginRepository
 import com.nuvio.tv.domain.model.ProxyHeaders
@@ -29,10 +32,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import java.net.URLEncoder
+import java.security.MessageDigest
 import javax.inject.Inject
 
 private const val TAG = "StreamRepositoryImpl"
@@ -42,10 +47,14 @@ class StreamRepositoryImpl @Inject constructor(
     private val api: AddonApi,
     private val addonRepository: AddonRepository,
     private val pluginManager: PluginManager,
+    private val profileManager: ProfileManager,
+    private val debridSettingsDataStore: DebridSettingsDataStore,
     private val tmdbService: TmdbService,
     private val debridStreamPresentation: DebridStreamPresentation,
     private val localDebridAvailabilityService: LocalDebridAvailabilityService
 ) : StreamRepository {
+    private val streamSearchSessions = StreamSearchSessionCache()
+
     private enum class StreamFailureKind {
         MISSING,
         REQUEST_FAILED
@@ -57,17 +66,97 @@ class StreamRepositoryImpl @Inject constructor(
         val detail: String
     )
 
+    private data class StreamSourceConfigurationSnapshot(
+        val profileId: Int,
+        val addons: List<Addon>,
+        val pluginsEnabled: Boolean,
+        val enabledScrapers: List<ScraperInfo>,
+        val groupPluginsByRepository: Boolean,
+        val pluginRepositories: List<PluginRepository>,
+        val debridSettings: DebridSettings
+    )
+
     override fun getStreamsFromAllAddons(
         type: String,
         videoId: String,
         season: Int?,
-        episode: Int?
+        episode: Int?,
+        forceRefresh: Boolean
+    ): Flow<NetworkResult<List<AddonStreams>>> = flow {
+        val sourceConfiguration = captureSourceConfiguration()
+        val requestKey = StreamSearchRequestKey(
+            profileId = sourceConfiguration.profileId,
+            type = type.lowercase(),
+            videoId = videoId,
+            season = season,
+            episode = episode,
+            sourceConfiguration = buildSourceConfigurationKey(
+                addons = sourceConfiguration.addons,
+                pluginsEnabled = sourceConfiguration.pluginsEnabled,
+                enabledScrapers = sourceConfiguration.enabledScrapers,
+                groupPluginsByRepository = sourceConfiguration.groupPluginsByRepository,
+                pluginRepositories = sourceConfiguration.pluginRepositories,
+                debridPresentationConfiguration = sourceConfiguration.debridSettings
+                    .withoutRawCredentials()
+                    .toString()
+            )
+        )
+
+        emitAll(
+            streamSearchSessions.observe(
+                key = requestKey,
+                forceRefresh = forceRefresh
+            ) {
+                fetchStreamsFromAllSources(
+                    type = type,
+                    videoId = videoId,
+                    season = season,
+                    episode = episode,
+                    addons = sourceConfiguration.addons,
+                    debridSettings = sourceConfiguration.debridSettings,
+                    hasCompatiblePlugins = sourceConfiguration.pluginsEnabled &&
+                        sourceConfiguration.enabledScrapers.any { scraper -> scraper.supportsType(type) }
+                )
+            }
+        )
+    }
+
+    private suspend fun captureSourceConfiguration(): StreamSourceConfigurationSnapshot {
+        while (true) {
+            val profileId = profileManager.activeProfileId.value
+            val addons = addonRepository.getInstalledAddons().first().enabledAddons()
+            val pluginsEnabled = pluginManager.pluginsEnabled.first()
+            val enabledScrapers = if (pluginsEnabled) pluginManager.enabledScrapers.first() else emptyList()
+            val groupPluginsByRepository = pluginsEnabled && pluginManager.groupStreamsByRepository.first()
+            val pluginRepositories = if (groupPluginsByRepository) pluginManager.repositories.first() else emptyList()
+            val debridSettings = debridSettingsDataStore.settings.first()
+
+            if (profileManager.activeProfileId.value != profileId) continue
+
+            return StreamSourceConfigurationSnapshot(
+                profileId = profileId,
+                addons = addons,
+                pluginsEnabled = pluginsEnabled,
+                enabledScrapers = enabledScrapers,
+                groupPluginsByRepository = groupPluginsByRepository,
+                pluginRepositories = pluginRepositories,
+                debridSettings = debridSettings
+            )
+        }
+    }
+
+    private fun fetchStreamsFromAllSources(
+        type: String,
+        videoId: String,
+        season: Int?,
+        episode: Int?,
+        addons: List<Addon>,
+        debridSettings: DebridSettings,
+        hasCompatiblePlugins: Boolean
     ): Flow<NetworkResult<List<AddonStreams>>> = flow {
         emit(NetworkResult.Loading)
 
         try {
-            val addons = addonRepository.getInstalledAddons().first().enabledAddons()
-            
             // Filter addons that support streams for this type and id
             val streamAddons = addons.filter { addon ->
                 addon.supportsStreamResource(type, videoId)
@@ -149,8 +238,6 @@ class StreamRepositoryImpl @Inject constructor(
 
                 launch {
                     try {
-                        val hasCompatiblePlugins = pluginManager.enabledScrapers.first()
-                            .any { scraper -> scraper.supportsType(type) }
                         if (!hasCompatiblePlugins) return@launch
 
                         val tmdbId = tmdbService.ensureTmdbId(videoId, type)
@@ -184,7 +271,7 @@ class StreamRepositoryImpl @Inject constructor(
                 for (result in resultChannel) {
                     val checkingResult = localDebridAvailabilityService.markChecking(listOf(result)).firstOrNull() ?: result
                     val checkedResult = localDebridAvailabilityService.annotateCachedAvailability(listOf(checkingResult)).firstOrNull() ?: checkingResult
-                    mergePresentedResult(accumulatedResults, checkedResult)
+                    mergePresentedResult(accumulatedResults, checkedResult, debridSettings)
                     emit(NetworkResult.Success(accumulatedResults.toList()))
                     Log.d(TAG, "Emitted ${accumulatedResults.size} addon(s), latest: ${checkedResult.addonName} with ${checkedResult.streams.size} streams")
                 }
@@ -210,6 +297,42 @@ class StreamRepositoryImpl @Inject constructor(
             emit(NetworkResult.Error(e.message ?: context.getString(com.nuvio.tv.R.string.stream_error_fetch_failed)))
         }
     }
+
+    private fun buildSourceConfigurationKey(
+        addons: List<Addon>,
+        pluginsEnabled: Boolean,
+        enabledScrapers: List<ScraperInfo>,
+        groupPluginsByRepository: Boolean,
+        pluginRepositories: List<PluginRepository>,
+        debridPresentationConfiguration: String
+    ): String = buildString {
+        append("addons:")
+        addons.forEach { addon ->
+            append("|addon:").append(addon)
+        }
+        append("plugins:").append(pluginsEnabled)
+        append("|grouped:").append(groupPluginsByRepository)
+        enabledScrapers.forEach { scraper ->
+            append("|scraper:").append(scraper)
+        }
+        if (groupPluginsByRepository) {
+            pluginRepositories.forEach { repository ->
+                append("|repo:").append(repository)
+            }
+        }
+        append("|debrid:").append(debridPresentationConfiguration)
+    }.sha256()
+
+    private fun DebridSettings.withoutRawCredentials(): DebridSettings = copy(
+        torboxApiKey = torboxApiKey.sha256(),
+        premiumizeApiKey = premiumizeApiKey.sha256(),
+        realDebridApiKey = realDebridApiKey.sha256()
+    )
+
+    private fun String.sha256(): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(toByteArray(Charsets.UTF_8))
+            .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
 
     private data class PluginRequest(
         val id: String,
@@ -257,7 +380,8 @@ class StreamRepositoryImpl @Inject constructor(
 
     private suspend fun mergePresentedResult(
         accumulatedResults: MutableList<AddonStreams>,
-        result: AddonStreams
+        result: AddonStreams,
+        debridSettings: DebridSettings
     ) {
         val existingIndex = accumulatedResults.indexOfFirst { it.addonName == result.addonName }
         if (existingIndex >= 0) {
@@ -265,15 +389,16 @@ class StreamRepositoryImpl @Inject constructor(
             val merged = existing.copy(
                 streams = mergeStreams(existing.streams, result.streams)
             )
-            accumulatedResults[existingIndex] = presentStreams(merged)
+            accumulatedResults[existingIndex] = presentStreams(merged, debridSettings)
         } else {
-            accumulatedResults.add(presentStreams(result))
+            accumulatedResults.add(presentStreams(result, debridSettings))
         }
     }
 
-    private suspend fun presentStreams(result: AddonStreams): AddonStreams {
+    private fun presentStreams(result: AddonStreams, debridSettings: DebridSettings): AddonStreams {
         return debridStreamPresentation.apply(
             groups = listOf(result),
+            settings = debridSettings,
             includeBadgeMatches = false
         ).firstOrNull() ?: result
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamSearchSessionCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamSearchSessionCache.kt
@@ -1,0 +1,228 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.domain.model.AddonStreams
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+internal data class StreamSearchRequestKey(
+    val profileId: Int,
+    val type: String,
+    val videoId: String,
+    val season: Int?,
+    val episode: Int?,
+    val sourceConfiguration: String
+)
+
+/**
+ * Keeps a small set of source searches alive independently of UI collectors.
+ * Completed results are memory-only and short-lived because addon URLs may expire.
+ */
+internal class StreamSearchSessionCache(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val nowMs: () -> Long = System::currentTimeMillis,
+    private val completedTtlMs: Long = DEFAULT_COMPLETED_TTL_MS,
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES
+) {
+    private data class Snapshot(
+        val result: NetworkResult<List<AddonStreams>>,
+        val version: Long,
+        val isComplete: Boolean
+    )
+
+    private class Session(
+        val state: MutableStateFlow<Snapshot>
+    ) {
+        lateinit var job: Job
+        @Volatile var invalidated: Boolean = false
+        var completedAtMs: Long? = null
+        var lastSuccessfulResult: NetworkResult.Success<List<AddonStreams>>? = null
+    }
+
+    private val mutex = Mutex()
+    private val sessions = LinkedHashMap<StreamSearchRequestKey, Session>(16, 0.75f, true)
+
+    fun observe(
+        key: StreamSearchRequestKey,
+        forceRefresh: Boolean,
+        producer: () -> Flow<NetworkResult<List<AddonStreams>>>
+    ): Flow<NetworkResult<List<AddonStreams>>> = flow {
+        val session = acquireSession(key, forceRefresh, producer)
+        var emittedVersion = -1L
+        emitAll(
+            session.state.transformWhile { snapshot ->
+                if (snapshot.version != emittedVersion) {
+                    emittedVersion = snapshot.version
+                    emit(snapshot.result)
+                }
+                !snapshot.isComplete
+            }
+        )
+    }
+
+    private suspend fun acquireSession(
+        key: StreamSearchRequestKey,
+        forceRefresh: Boolean,
+        producer: () -> Flow<NetworkResult<List<AddonStreams>>>
+    ): Session {
+        var created: Session? = null
+        val selected = mutex.withLock {
+            removeExpiredLocked()
+            removeObsoleteSessionsLocked(key)
+
+            if (forceRefresh) {
+                sessions.remove(key)?.cancelAndComplete()
+            } else {
+                sessions[key]?.let { return@withLock it }
+            }
+
+            createSession(key, producer).also { session ->
+                sessions[key] = session
+                trimToSizeLocked()
+                created = session
+            }
+        }
+        withContext(NonCancellable) {
+            created?.job?.start()
+        }
+        return selected
+    }
+
+    private fun createSession(
+        key: StreamSearchRequestKey,
+        producer: () -> Flow<NetworkResult<List<AddonStreams>>>
+    ): Session {
+        val session = Session(
+            MutableStateFlow(
+                Snapshot(
+                    result = NetworkResult.Loading,
+                    version = 0L,
+                    isComplete = false
+                )
+            )
+        )
+        session.job = scope.launch(start = CoroutineStart.LAZY) {
+            try {
+                producer().collect { result ->
+                    if (result is NetworkResult.Success) {
+                        session.lastSuccessfulResult = result
+                    }
+                    session.state.update { current ->
+                        Snapshot(
+                            result = result,
+                            version = current.version + 1,
+                            isComplete = false
+                        )
+                    }
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                session.state.update { current ->
+                    Snapshot(
+                        result = NetworkResult.Error(error.message ?: "Failed to fetch streams"),
+                        version = current.version + 1,
+                        isComplete = false
+                    )
+                }
+            } finally {
+                completeSession(key, session)
+            }
+        }
+        return session
+    }
+
+    private suspend fun completeSession(key: StreamSearchRequestKey, session: Session) {
+        if (session.invalidated) return
+        session.state.update { current ->
+            val lastSuccess = session.lastSuccessfulResult
+            if (lastSuccess != null && current.result !is NetworkResult.Success) {
+                Snapshot(
+                    result = lastSuccess,
+                    version = current.version + 1,
+                    isComplete = true
+                )
+            } else {
+                current.copy(isComplete = true)
+            }
+        }
+        mutex.withLock {
+            if (sessions[key] !== session) return@withLock
+            if (session.lastSuccessfulResult != null) {
+                session.completedAtMs = nowMs()
+            } else {
+                sessions.remove(key)
+            }
+        }
+    }
+
+    private fun removeObsoleteSessionsLocked(requestedKey: StreamSearchRequestKey) {
+        val iterator = sessions.entries.iterator()
+        while (iterator.hasNext()) {
+            val (existingKey, session) = iterator.next()
+            val belongsToAnotherProfile = existingKey.profileId != requestedKey.profileId
+            val sourceConfigurationChanged = existingKey.matchesMediaRequest(requestedKey) &&
+                existingKey.sourceConfiguration != requestedKey.sourceConfiguration
+            if (belongsToAnotherProfile || sourceConfigurationChanged) {
+                iterator.remove()
+                session.cancelAndComplete()
+            }
+        }
+    }
+
+    private fun removeExpiredLocked() {
+        val now = nowMs()
+        val iterator = sessions.entries.iterator()
+        while (iterator.hasNext()) {
+            val session = iterator.next().value
+            val completedAt = session.completedAtMs ?: continue
+            if (now - completedAt >= completedTtlMs) {
+                iterator.remove()
+                session.cancelAndComplete()
+            }
+        }
+    }
+
+    private fun trimToSizeLocked() {
+        while (sessions.size > maxEntries) {
+            val iterator = sessions.entries.iterator()
+            if (!iterator.hasNext()) return
+            val session = iterator.next().value
+            iterator.remove()
+            session.cancelAndComplete()
+        }
+    }
+
+    private fun Session.cancelAndComplete() {
+        invalidated = true
+        state.update { current -> current.copy(isComplete = true) }
+        job.cancel()
+    }
+
+    private fun StreamSearchRequestKey.matchesMediaRequest(other: StreamSearchRequestKey): Boolean =
+        profileId == other.profileId &&
+            type == other.type &&
+            videoId == other.videoId &&
+            season == other.season &&
+            episode == other.episode
+
+    private companion object {
+        const val DEFAULT_COMPLETED_TTL_MS = 15 * 60 * 1_000L
+        const val DEFAULT_MAX_ENTRIES = 12
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamSearchSessionCache.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamSearchSessionCache.kt
@@ -119,7 +119,7 @@ internal class StreamSearchSessionCache(
         session.job = scope.launch(start = CoroutineStart.LAZY) {
             try {
                 producer().collect { result ->
-                    if (result is NetworkResult.Success) {
+                    if (result is NetworkResult.Success && result.data.isNotEmpty()) {
                         session.lastSuccessfulResult = result
                     }
                     session.state.update { current ->

--- a/app/src/main/java/com/nuvio/tv/domain/repository/StreamRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/StreamRepository.kt
@@ -18,7 +18,8 @@ interface StreamRepository {
         type: String,
         videoId: String,
         season: Int? = null,
-        episode: Int? = null
+        episode: Int? = null,
+        forceRefresh: Boolean = false
     ): Flow<NetworkResult<List<AddonStreams>>>
 
     /**

--- a/app/src/main/java/com/nuvio/tv/domain/repository/StreamRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/StreamRepository.kt
@@ -6,6 +6,9 @@ import com.nuvio.tv.domain.model.Stream
 import kotlinx.coroutines.flow.Flow
 
 interface StreamRepository {
+    /** Suspends local plugin work while playback owns the device, then resumes the same search. */
+    fun setLocalPluginSearchPaused(paused: Boolean)
+
     /**
      * Fetches streams from all installed addons for a given video ID
      * @param type The content type (movie, series, etc.)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -217,7 +217,8 @@ internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
             type = type,
             videoId = vid,
             season = seasonArg,
-            episode = episodeArg
+            episode = episodeArg,
+            forceRefresh = forceRefresh
         ).collect { result ->
             when (result) {
                 is NetworkResult.Success -> {
@@ -1026,7 +1027,8 @@ internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRe
             type = type,
             videoId = video.id,
             season = video.season,
-            episode = video.episode
+            episode = video.episode,
+            forceRefresh = forceRefresh
         ).collect { result ->
             when (result) {
                 is NetworkResult.Success -> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -420,6 +421,7 @@ fun StreamScreen(
                     badgePlacement = streamBadgeSettings.badgePlacement,
                     hasBadgeRules = streamBadgeSettings.rules.hasImport,
                     onAddonFilterSelected = { viewModel.onEvent(StreamScreenEvent.OnAddonFilterSelected(it)) },
+                    onRefresh = { viewModel.onEvent(StreamScreenEvent.OnRefresh) },
                     onStreamSelected = { stream ->
                         val currentIndex = uiState.filteredStreams.indexOfFirst {
                             it.url == stream.url &&
@@ -693,6 +695,7 @@ private fun RightStreamSection(
     badgePlacement: StreamBadgePlacement,
     hasBadgeRules: Boolean = false,
     onAddonFilterSelected: (String?) -> Unit,
+    onRefresh: () -> Unit,
     onStreamSelected: (Stream) -> Unit,
     focusedStreamIndex: Int,
     shouldRestoreFocusedStream: Boolean,
@@ -714,11 +717,11 @@ private fun RightStreamSection(
         }
     }
     val chipFocusRequesters = remember(orderedAddonNames.size) {
-        List(orderedAddonNames.size + 1) { FocusRequester() }
+        List(orderedAddonNames.size + 2) { FocusRequester() }
     }
     fun onAddonFilterSelectedGuarded(addon: String?) {
         onAddonFilterSelected(addon)
-        val idx = if (addon == null) 0 else orderedAddonNames.indexOf(addon) + 1
+        val idx = if (addon == null) 1 else orderedAddonNames.indexOf(addon) + 2
         focusJob?.cancel()
         focusJob = scope.coroutineLaunch {
             withFrameNanos {}
@@ -755,6 +758,7 @@ private fun RightStreamSection(
                     addons = availableAddons,
                     sourceChips = sourceChips,
                     selectedAddon = selectedAddonFilter,
+                    onRefresh = onRefresh,
                     onAddonSelected = { onAddonFilterSelectedGuarded(it) },
                     focusRequesters = chipFocusRequesters,
                     orderedNames = orderedAddonNames
@@ -827,6 +831,7 @@ private fun AddonFilterChips(
     addons: List<String>,
     sourceChips: List<SourceChipItem>,
     selectedAddon: String?,
+    onRefresh: () -> Unit,
     onAddonSelected: (String?) -> Unit,
     focusRequesters: List<FocusRequester>,
     orderedNames: List<String>
@@ -837,14 +842,27 @@ private fun AddonFilterChips(
     // Track the focused chip index to handle duplicate addon names correctly.
     // indexOf(selectedAddon) would always return the first duplicate.
     var focusedChipIndex by remember { mutableStateOf(
-        if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+        if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
     ) }
     LaunchedEffect(selectedAddon, orderedNames) {
-        val idx = if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+        val idx = if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
         focusedChipIndex = idx
     }
     val scope = rememberCoroutineScope()
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
+    fun moveFocusTo(targetIndex: Int) {
+        focusedChipIndex = targetIndex
+        if (targetIndex == 0) {
+            scope.coroutineLaunch {
+                withFrameNanos {}
+                try { focusRequesters[0].requestFocus() } catch (_: Exception) {}
+            }
+            return
+        }
+
+        val selectedFilter = if (targetIndex == 1) null else orderedNames[targetIndex - 2]
+        onAddonSelected(selectedFilter)
+    }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
         contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.sm, vertical = NuvioTheme.spacing.xs),
@@ -869,27 +887,34 @@ private fun AddonFilterChips(
                     lastKeyRepeatDispatchRef.set(now)
                 }
 
-                val allOptions = listOf<String?>(null) + orderedNames
-                val currentIdx = focusedChipIndex.coerceIn(0, allOptions.lastIndex)
+                val lastIndex = orderedNames.size + 1
+                val currentIdx = focusedChipIndex.coerceIn(0, lastIndex)
                 when (event.key) {
                     androidx.compose.ui.input.key.Key.DirectionLeft -> {
                         if (isRtl) {
-                            if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
                         } else {
-                            if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
                         }
                     }
                     androidx.compose.ui.input.key.Key.DirectionRight -> {
                         if (isRtl) {
-                            if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
                         } else {
-                            if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
                         }
                     }
                     else -> false
                 }
             }
     ) {
+        item {
+            RefreshFilterChip(
+                onClick = onRefresh,
+                modifier = Modifier.focusRequester(focusRequesters[0])
+            )
+        }
+
         item {
             SourceStatusFilterChip(
                 name = stringResource(R.string.stream_filter_all),
@@ -898,7 +923,7 @@ private fun AddonFilterChips(
                 isSelectable = true,
                 onClick = { onAddonSelected(null) },
                 modifier = Modifier
-                    .focusRequester(focusRequesters[0])
+                    .focusRequester(focusRequesters[1])
                     .focusProperties { canFocus = selectedAddon == null || chipRowHasFocus }
             )
         }
@@ -913,9 +938,52 @@ private fun AddonFilterChips(
                 status = chipStatus,
                 isSelectable = isSelectable,
                 onClick = { if (isSelectable) onAddonSelected(addon) },
-                modifier = Modifier.focusRequester(focusRequesters[i + 1])
+                modifier = Modifier.focusRequester(focusRequesters[i + 2])
             )
         }
+    }
+}
+
+@Composable
+private fun RefreshFilterChip(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val contentColor = if (isFocused) {
+        NuvioTheme.colors.OnSecondary
+    } else {
+        NuvioTheme.colors.TextSecondary
+    }
+
+    FilterChip(
+        selected = false,
+        onClick = onClick,
+        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
+        colors = FilterChipDefaults.colors(
+            containerColor = NuvioTheme.colors.BackgroundCard,
+            focusedContainerColor = NuvioTheme.colors.Secondary,
+            contentColor = contentColor,
+            focusedContentColor = contentColor
+        ),
+        border = FilterChipDefaults.border(
+            border = Border(
+                border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
+                shape = RoundedCornerShape(20.dp)
+            ),
+            focusedBorder = Border(
+                border = BorderStroke(NuvioTheme.spacing.xxs, NuvioTheme.colors.FocusRing),
+                shape = RoundedCornerShape(20.dp)
+            )
+        ),
+        shape = FilterChipDefaults.shape(shape = RoundedCornerShape(20.dp))
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Refresh,
+            contentDescription = stringResource(R.string.cd_refresh),
+            modifier = Modifier.size(20.dp),
+            tint = contentColor
+        )
     }
 }
 
@@ -1120,8 +1188,8 @@ private fun StreamsList(
                         else -> null
                     },
                     onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{
-                        val idx = if (selectedAddonFilter == null) 0
-                                  else orderedAddonNames.indexOf(selectedAddonFilter) + 1
+                        val idx = if (selectedAddonFilter == null) 1
+                                  else orderedAddonNames.indexOf(selectedAddonFilter) + 2
                         if (idx >= 0 && idx < chipFocusRequesters.size) {
                             try { chipFocusRequesters[idx].requestFocus() } catch (_: Exception) {}
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -705,9 +705,10 @@ private fun RightStreamSection(
 ) {
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     var enter by remember { mutableStateOf(false) }
-    var shouldFocusFirstStream by remember { mutableStateOf(false) }
-    var wasLoading by remember { mutableStateOf(true) }
+    var firstStreamFocusRequestId by remember { mutableStateOf(0) }
     var listHasFocus by remember { mutableStateOf(false) }
+    var userMovedFromFirstResult by remember { mutableStateOf(shouldRestoreFocusedStream) }
+    var lastObservedFirstStreamKey by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
     val orderedAddonNames = remember(availableAddons, sourceChips) {
@@ -716,10 +717,21 @@ private fun RightStreamSection(
             sourceChips.forEach { if (it.name !in this) add(it.name) }
         }
     }
-    val chipFocusRequesters = remember(orderedAddonNames.size) {
-        List(orderedAddonNames.size + 2) { FocusRequester() }
+    val firstStreamKey = streams.firstOrNull()?.stableKey(0)
+    val refreshFocusRequester = remember { FocusRequester() }
+    val allFocusRequester = remember { FocusRequester() }
+    val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val chipFocusRequesters = remember(orderedAddonNames) {
+        buildList {
+            add(refreshFocusRequester)
+            add(allFocusRequester)
+            orderedAddonNames.forEach { addon ->
+                add(addonFocusRequesters.getOrPut(addon) { FocusRequester() })
+            }
+        }
     }
     fun onAddonFilterSelectedGuarded(addon: String?) {
+        userMovedFromFirstResult = true
         onAddonFilterSelected(addon)
         val idx = if (addon == null) 1 else orderedAddonNames.indexOf(addon) + 2
         focusJob?.cancel()
@@ -734,11 +746,28 @@ private fun RightStreamSection(
     LaunchedEffect(Unit) {
         enter = true
     }
-    LaunchedEffect(isLoading, streams.size) {
-        if (wasLoading && !isLoading && streams.isNotEmpty()) {
-            shouldFocusFirstStream = true
+    LaunchedEffect(shouldRestoreFocusedStream) {
+        if (shouldRestoreFocusedStream) {
+            userMovedFromFirstResult = true
         }
-        wasLoading = isLoading
+    }
+    LaunchedEffect(isLoading, firstStreamKey, userMovedFromFirstResult) {
+        if (!isLoading && firstStreamKey != null) {
+            val firstResultChanged = lastObservedFirstStreamKey != firstStreamKey
+            lastObservedFirstStreamKey = firstStreamKey
+            if (!userMovedFromFirstResult && firstResultChanged) {
+                firstStreamFocusRequestId += 1
+            }
+        }
+    }
+    fun requestChipFocus(index: Int) {
+        if (index !in chipFocusRequesters.indices) return
+        userMovedFromFirstResult = true
+        focusJob?.cancel()
+        focusJob = scope.coroutineLaunch {
+            withFrameNanos { }
+            runCatching { chipFocusRequesters[index].requestFocus() }
+        }
     }
 
     Column(
@@ -758,7 +787,11 @@ private fun RightStreamSection(
                     addons = availableAddons,
                     sourceChips = sourceChips,
                     selectedAddon = selectedAddonFilter,
-                    onRefresh = onRefresh,
+                    onRefresh = {
+                        userMovedFromFirstResult = false
+                        lastObservedFirstStreamKey = null
+                        onRefresh()
+                    },
                     onAddonSelected = { onAddonFilterSelectedGuarded(it) },
                     focusRequesters = chipFocusRequesters,
                     orderedNames = orderedAddonNames
@@ -805,8 +838,7 @@ private fun RightStreamSection(
                             focusedStreamIndex = focusedStreamIndex,
                             shouldRestoreFocusedStream = shouldRestoreFocusedStream,
                             onRestoreFocusedStreamHandled = onRestoreFocusedStreamHandled,
-                            requestInitialFocus = shouldFocusFirstStream,
-                            onInitialFocusConsumed = { shouldFocusFirstStream = false },
+                            firstStreamFocusRequestId = firstStreamFocusRequestId,
                             availableAddons = availableAddons,
                             selectedAddonFilter = selectedAddonFilter,
                             showFileSizeBadges = showFileSizeBadges,
@@ -814,8 +846,11 @@ private fun RightStreamSection(
                             badgePlacement = badgePlacement,
                             hasBadgeRules = hasBadgeRules,
                             onAddonFilterSelected = { onAddonFilterSelectedGuarded(it) },
-                            chipFocusRequesters = chipFocusRequesters,
                             orderedAddonNames = orderedAddonNames,
+                            onRequestChipFocus = { requestChipFocus(it) },
+                            onUserNavigatedFromFirstResult = {
+                                userMovedFromFirstResult = true
+                            },
                             onFocusChanged = { listHasFocus = it }
                         )
                     }
@@ -911,7 +946,9 @@ private fun AddonFilterChips(
         item {
             RefreshFilterChip(
                 onClick = onRefresh,
-                modifier = Modifier.focusRequester(focusRequesters[0])
+                modifier = Modifier
+                    .focusRequester(focusRequesters[0])
+                    .focusProperties { canFocus = focusedChipIndex == 0 }
             )
         }
 
@@ -1081,8 +1118,7 @@ private fun StreamsList(
     focusedStreamIndex: Int = 0,
     shouldRestoreFocusedStream: Boolean = false,
     onRestoreFocusedStreamHandled: () -> Unit = {},
-    requestInitialFocus: Boolean = false,
-    onInitialFocusConsumed: () -> Unit = {},
+    firstStreamFocusRequestId: Int = 0,
     availableAddons: List<String> = emptyList(),
     selectedAddonFilter: String? = null,
     showFileSizeBadges: Boolean = true,
@@ -1090,32 +1126,44 @@ private fun StreamsList(
     badgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM,
     hasBadgeRules: Boolean = false,
     onAddonFilterSelected: (String?) -> Unit = {},
-    chipFocusRequesters: List<FocusRequester> = emptyList(),
     orderedAddonNames: List<String> = emptyList(),
+    onRequestChipFocus: (Int) -> Unit = {},
+    onUserNavigatedFromFirstResult: () -> Unit = {},
     onFocusChanged: (Boolean) -> Unit = {}
 ) {
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
-    val firstCardFocusRequester = remember { FocusRequester() }
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
     val restoreFocusRequester = remember { FocusRequester() }
     val streamListState = rememberLazyListState()
-    val firstStreamKey = streams.firstOrNull()?.let { first ->
-        "${first.addonName}_${first.url ?: first.infoHash ?: first.ytId ?: "unknown"}"
+    val streamKeys = remember(streams) {
+        val seen = mutableMapOf<String, Int>()
+        streams.map { stream ->
+            val base = stream.stableKey(0)
+            val occurrence = seen.getOrDefault(base, 0)
+            seen[base] = occurrence + 1
+            stream.stableKey(occurrence)
+        }
     }
-
+    val firstStreamKey = streamKeys.firstOrNull()
+    val streamFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    streamKeys.forEach { key ->
+        streamFocusRequesters.getOrPut(key) { FocusRequester() }
+    }
+    var firstCardHasFocus by remember(firstStreamKey) { mutableStateOf(false) }
     // Reset scroll position to the top when the addon filter changes (#2538).
     LaunchedEffect(selectedAddonFilter) {
         streamListState.scrollToItem(0)
     }
 
-    LaunchedEffect(requestInitialFocus, firstStreamKey) {
-        if (!requestInitialFocus || streams.isEmpty()) return@LaunchedEffect
-        repeat(2) { withFrameNanos { } }
-        try {
-            firstCardFocusRequester.requestFocus()
-        } catch (_: Exception) {
+    LaunchedEffect(firstStreamFocusRequestId) {
+        val requestedKey = firstStreamKey
+        if (firstStreamFocusRequestId <= 0 || requestedKey == null) return@LaunchedEffect
+        streamListState.scrollToItem(0)
+        repeat(30) {
+            withFrameNanos { }
+            if (firstCardHasFocus) return@LaunchedEffect
+            runCatching { streamFocusRequesters.getValue(requestedKey).requestFocus() }
         }
-        onInitialFocusConsumed()
     }
 
     LaunchedEffect(shouldRestoreFocusedStream, focusedStreamIndex, streams.size) {
@@ -1147,6 +1195,9 @@ private fun StreamsList(
                     if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
                     lastKeyRepeatDispatchRef.set(now)
                 }
+                if (event.key == Key.DirectionDown) {
+                    onUserNavigatedFromFirstResult()
+                }
                 if (availableAddons.isEmpty()) return@onKeyEvent false
                 val allOptions = listOf<String?>(null) + availableAddons
                 val currentIdx = allOptions.indexOf(selectedAddonFilter)
@@ -1171,8 +1222,8 @@ private fun StreamsList(
         verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
         contentPadding = PaddingValues(start = NuvioTheme.spacing.sm, end = NuvioTheme.spacing.sm, top = NuvioTheme.spacing.sm, bottom = NuvioTheme.spacing.xxl)
     ) {
-        itemsIndexed(streams, key = { index, stream ->
-            stream.stableKey(index)
+        itemsIndexed(streams, key = { index, _ ->
+            streamKeys[index]
         }) { index, stream ->
             Box(modifier = Modifier.padding(vertical = NuvioTheme.spacing.xs)) {
                 StreamCard(
@@ -1184,15 +1235,17 @@ private fun StreamsList(
                     onClick = { onStreamSelected(stream) },
                     focusRequester = when {
                         shouldRestoreFocusedStream && index == focusedStreamIndex.coerceIn(0, (streams.lastIndex).coerceAtLeast(0)) -> restoreFocusRequester
-                        index == 0 -> firstCardFocusRequester
-                        else -> null
+                        else -> streamFocusRequesters.getValue(streamKeys[index])
                     },
-                    onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{
+                    onFocusChanged = { focused ->
+                        if (index == 0) {
+                            firstCardHasFocus = focused
+                        }
+                    },
+                    onUpKey = if (index == 0) {{
                         val idx = if (selectedAddonFilter == null) 1
                                   else orderedAddonNames.indexOf(selectedAddonFilter) + 2
-                        if (idx >= 0 && idx < chipFocusRequesters.size) {
-                            try { chipFocusRequesters[idx].requestFocus() } catch (_: Exception) {}
-                        }
+                        onRequestChipFocus(idx)
                     }} else null
                 )
             }
@@ -1210,6 +1263,7 @@ private fun StreamCard(
     reserveBadgeSpace: Boolean = false,
     onClick: () -> Unit,
     focusRequester: FocusRequester? = null,
+    onFocusChanged: ((Boolean) -> Unit)? = null,
     onUpKey: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
@@ -1247,7 +1301,10 @@ private fun StreamCard(
         modifier = Modifier
             .fillMaxWidth()
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-            .onFocusChanged { isFocused = it.isFocused }
+            .onFocusChanged {
+                isFocused = it.isFocused
+                onFocusChanged?.invoke(it.isFocused)
+            }
             .then(if (onUpKey != null) Modifier.onKeyEvent { event ->
                 if (event.nativeKeyEvent.action == KeyEvent.ACTION_DOWN && event.key == Key.DirectionUp) {
                     onUpKey(); true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -708,7 +708,7 @@ private fun RightStreamSection(
     var firstStreamFocusRequestId by remember { mutableStateOf(0) }
     var listHasFocus by remember { mutableStateOf(false) }
     var userMovedFromFirstResult by remember { mutableStateOf(shouldRestoreFocusedStream) }
-    var lastObservedFirstStreamKey by remember { mutableStateOf<String?>(null) }
+    var firstResultFocusAssigned by remember { mutableStateOf(shouldRestoreFocusedStream) }
     val scope = rememberCoroutineScope()
     var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
     val orderedAddonNames = remember(availableAddons, sourceChips) {
@@ -751,13 +751,10 @@ private fun RightStreamSection(
             userMovedFromFirstResult = true
         }
     }
-    LaunchedEffect(isLoading, firstStreamKey, userMovedFromFirstResult) {
-        if (!isLoading && firstStreamKey != null) {
-            val firstResultChanged = lastObservedFirstStreamKey != firstStreamKey
-            lastObservedFirstStreamKey = firstStreamKey
-            if (!userMovedFromFirstResult && firstResultChanged) {
-                firstStreamFocusRequestId += 1
-            }
+    LaunchedEffect(isLoading, firstStreamKey, userMovedFromFirstResult, firstResultFocusAssigned) {
+        if (!isLoading && firstStreamKey != null && !userMovedFromFirstResult && !firstResultFocusAssigned) {
+            firstResultFocusAssigned = true
+            firstStreamFocusRequestId += 1
         }
     }
     fun requestChipFocus(index: Int) {
@@ -789,7 +786,7 @@ private fun RightStreamSection(
                     selectedAddon = selectedAddonFilter,
                     onRefresh = {
                         userMovedFromFirstResult = false
-                        lastObservedFirstStreamKey = null
+                        firstResultFocusAssigned = false
                         onRefresh()
                     },
                     onAddonSelected = { onAddonFilterSelectedGuarded(it) },
@@ -874,6 +871,7 @@ private fun AddonFilterChips(
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val chipMap = sourceChips.associateBy { it.name }
     var chipRowHasFocus by remember { mutableStateOf(false) }
+    var refreshHasFocus by remember { mutableStateOf(false) }
     // Track the focused chip index to handle duplicate addon names correctly.
     // indexOf(selectedAddon) would always return the first duplicate.
     var focusedChipIndex by remember { mutableStateOf(
@@ -946,6 +944,7 @@ private fun AddonFilterChips(
         item {
             RefreshFilterChip(
                 onClick = onRefresh,
+                onFocusChanged = { refreshHasFocus = it },
                 modifier = Modifier
                     .focusRequester(focusRequesters[0])
                     .focusProperties { canFocus = focusedChipIndex == 0 }
@@ -955,7 +954,7 @@ private fun AddonFilterChips(
         item {
             SourceStatusFilterChip(
                 name = stringResource(R.string.stream_filter_all),
-                isSelected = selectedAddon == null,
+                isSelected = selectedAddon == null && !refreshHasFocus,
                 status = SourceChipStatus.SUCCESS,
                 isSelectable = true,
                 onClick = { onAddonSelected(null) },
@@ -984,6 +983,7 @@ private fun AddonFilterChips(
 @Composable
 private fun RefreshFilterChip(
     onClick: () -> Unit,
+    onFocusChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var isFocused by remember { mutableStateOf(false) }
@@ -996,7 +996,10 @@ private fun RefreshFilterChip(
     FilterChip(
         selected = false,
         onClick = onClick,
-        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
+        modifier = modifier.onFocusChanged {
+            isFocused = it.isFocused
+            onFocusChanged(it.isFocused)
+        },
         colors = FilterChipDefaults.colors(
             containerColor = NuvioTheme.colors.BackgroundCard,
             focusedContainerColor = NuvioTheme.colors.Secondary,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenUiState.kt
@@ -45,6 +45,7 @@ sealed class StreamScreenEvent {
     data class OnAddonFilterSelected(val addonName: String?) : StreamScreenEvent()
     data class OnStreamSelected(val stream: Stream) : StreamScreenEvent()
     data object OnAutoPlayConsumed : StreamScreenEvent()
+    data object OnRefresh : StreamScreenEvent()
     data object OnRetry : StreamScreenEvent()
     data object OnBackPress : StreamScreenEvent()
     data object OnResume : StreamScreenEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -442,7 +442,7 @@ class StreamScreenViewModel @Inject constructor(
 
             updateUiStateIfChanged {
                 it.copy(
-                    isLoading = true,
+                    isLoading = forceRefresh || it.allStreams.isEmpty(),
                     error = null,
                     showDirectAutoPlayOverlay = if (directFlowActive) true else it.showDirectAutoPlayOverlay
                 )
@@ -723,7 +723,7 @@ class StreamScreenViewModel @Inject constructor(
                         NetworkResult.Loading -> {
                             updateUiStateIfChanged {
                                 it.copy(
-                                    isLoading = true,
+                                    isLoading = forceRefresh || it.allStreams.isEmpty(),
                                     showDirectAutoPlayOverlay = if (directAutoPlayFlowEnabledForSession) {
                                         true
                                     } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -285,6 +285,18 @@ class StreamScreenViewModel @Inject constructor(
                     )
                 }
             }
+            StreamScreenEvent.OnRefresh -> {
+                // A user refresh is a clean request, not a resume of a partially
+                // completed load captured before playback.
+                resumeBaselineStreams = null
+                updateUiStateIfChanged {
+                    it.copy(
+                        selectedAddonFilter = null,
+                        filteredStreams = it.allStreams
+                    )
+                }
+                loadStreams()
+            }
             StreamScreenEvent.OnRetry -> loadStreams()
             StreamScreenEvent.OnBackPress -> { /* Handle in screen */ }
             StreamScreenEvent.OnResume -> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -96,10 +96,6 @@ class StreamScreenViewModel @Inject constructor(
     private var streamLoadJob: Job? = null
     private var streamLoadScope: kotlinx.coroutines.CoroutineScope? = null
     private var streamLoadCompleted = false
-    // Snapshot of addon streams captured when loading is cancelled mid-flight.
-    // On resume, new repository emissions are merged with this baseline so
-    // already-fetched results stay visible while missing addons get re-fetched.
-    private var resumeBaselineStreams: List<AddonStreams>? = null
     private var sourceChipErrorDismissJob: Job? = null
     private var pendingCacheSaveJob: Job? = null
     private var streamBadgePresentationJob: Job? = null
@@ -286,25 +282,22 @@ class StreamScreenViewModel @Inject constructor(
                 }
             }
             StreamScreenEvent.OnRefresh -> {
-                // A user refresh is a clean request, not a resume of a partially
-                // completed load captured before playback.
-                resumeBaselineStreams = null
                 updateUiStateIfChanged {
                     it.copy(
+                        isLoading = true,
+                        error = null,
                         selectedAddonFilter = null,
-                        filteredStreams = it.allStreams
+                        filteredStreams = emptyList()
                     )
                 }
-                loadStreams()
+                loadStreams(forceRefresh = true)
             }
             StreamScreenEvent.OnRetry -> loadStreams()
             StreamScreenEvent.OnBackPress -> { /* Handle in screen */ }
             StreamScreenEvent.OnResume -> {
                 hostInForeground.value = true
-                // If loading was cancelled (e.g. user went to player) and
-                // hasn't completed yet, resume it. The baseline snapshot
-                // captured at cancel time keeps existing results visible
-                // while the repository re-fetches remaining addons.
+                // Reattach to the repository-owned session if playback stopped
+                // this screen's collector before every source finished.
                 if (!streamLoadCompleted && streamLoadJob == null) {
                     loadStreams()
                 }
@@ -313,12 +306,6 @@ class StreamScreenViewModel @Inject constructor(
     }
 
     fun cancelStreamsLoad() {
-        // Capture current results as baseline before cancelling, so that
-        // resuming loading can merge new data on top of what we already have.
-        val currentStreams = _uiState.value.addonStreams
-        if (currentStreams.isNotEmpty()) {
-            resumeBaselineStreams = currentStreams
-        }
         streamLoadScope?.cancel()
         streamLoadScope = null
         streamLoadJob = null
@@ -334,13 +321,15 @@ class StreamScreenViewModel @Inject constructor(
         return streamAutoPlayMode != StreamAutoPlayMode.MANUAL
     }
 
-    private fun loadStreams() {
+    private fun loadStreams(forceRefresh: Boolean = false) {
         streamLoadScope?.cancel()
         streamLoadScope = null
         streamLoadJob = null
         streamBadgePresentationJob?.cancel()
         streamBadgePresentationRequestId += 1
-        if (resumeBaselineStreams == null) badgedAddonNames = emptySet()
+        if (forceRefresh || _uiState.value.addonStreams.isEmpty()) {
+            badgedAddonNames = emptySet()
+        }
         sourceChipErrorDismissJob?.cancel()
         val newScope = kotlinx.coroutines.CoroutineScope(viewModelScope.coroutineContext + kotlinx.coroutines.SupervisorJob())
         streamLoadScope = newScope
@@ -576,29 +565,16 @@ class StreamScreenViewModel @Inject constructor(
                 }
             }
 
-            // Grab and clear the baseline snapshot.  When non-null we are
-            // resuming after a cancel and should merge incoming repository
-            // emissions with these previously-fetched results.
-            val baseline = resumeBaselineStreams
-            resumeBaselineStreams = null
-
-            // If resuming, seed the UI with the baseline immediately so
-            // the user sees their previous results right away.
-            if (baseline != null) {
-                applySuccess(baseline, isAllLoaded = false)
+            val alreadySucceededNames = if (forceRefresh) {
+                emptySet()
+            } else {
+                _uiState.value.addonStreams.mapTo(linkedSetOf()) { it.addonName }
             }
-
-            updateSourceChipsForFetchStart(installedAddons, directDebridSourceNames, baseline)
-
-            // Merges repository data with the resume baseline.  Addons
-            // present in the new data override the baseline; addons only
-            // in the baseline are preserved until the repository catches up.
-            fun mergeWithBaseline(repoData: List<AddonStreams>): List<AddonStreams> {
-                if (baseline == null) return repoData
-                val repoAddonNames = repoData.map { it.addonName }.toSet()
-                val preserved = baseline.filter { it.addonName !in repoAddonNames }
-                return repoData + preserved
-            }
+            updateSourceChipsForFetchStart(
+                installedAddons = installedAddons,
+                directDebridSourceNames = directDebridSourceNames,
+                alreadySucceededNames = alreadySucceededNames
+            )
 
             var lastSuccessData: List<AddonStreams>? = null
             var autoSelectTriggered = false
@@ -653,21 +629,21 @@ class StreamScreenViewModel @Inject constructor(
                     type = contentType,
                     videoId = videoId,
                     season = season,
-                    episode = episode
+                    episode = episode,
+                    forceRefresh = forceRefresh
                 ).collect { result ->
                     when (result) {
                         is NetworkResult.Success -> {
-                            val merged = mergeWithBaseline(result.data)
-                            lastSuccessData = merged
-                            applySuccess(merged, isAllLoaded = false)
-                            launchDirectDebridPreparationIfNeeded(merged)
+                            lastSuccessData = result.data
+                            applySuccess(result.data, isAllLoaded = false)
+                            launchDirectDebridPreparationIfNeeded(result.data)
 
                             if (autoSelectTriggered || resolvedAutoPlayTarget || autoPlayHandledForSession) {
                                 // Already resolved — nothing more to do.
                             } else if (timeoutElapsed) {
                                 // Timeout elapsed: run full auto-select (binge
                                 // group preferred, then fallback to mode).
-                                applySuccess(merged, isAllLoaded = true)
+                                applySuccess(result.data, isAllLoaded = true)
                                 if (resolvedAutoPlayTarget) {
                                     autoSelectTriggered = true
                                 } else if (directAutoPlayFlowEnabledForSession && !isUnlimitedTimeout) {
@@ -676,7 +652,7 @@ class StreamScreenViewModel @Inject constructor(
                                     // debrid cache check, wait for the next emission
                                     // (which will carry the CACHED/NOT_CACHED result)
                                     // instead of showing the picker immediately.
-                                    val hasCheckingTorrents = merged.any { group ->
+                                    val hasCheckingTorrents = result.data.any { group ->
                                         group.streams.any { s ->
                                             s.isTorrent() && s.debridCacheStatus?.state == com.nuvio.tv.domain.model.StreamDebridCacheState.CHECKING
                                         }
@@ -699,7 +675,7 @@ class StreamScreenViewModel @Inject constructor(
                                 // match is found we can start playback immediately
                                 // without waiting for the full timeout.
                                 val orderedStreams = StreamAutoPlaySelector.orderAddonStreams(
-                                    merged, installedAddonOrder
+                                    result.data, installedAddonOrder
                                 )
                                 val allStreams = orderedStreams.flatMap { it.streams }
                                 val earlyMatch = StreamAutoPlaySelector.selectAutoPlayStream(
@@ -903,7 +879,7 @@ class StreamScreenViewModel @Inject constructor(
     private suspend fun updateSourceChipsForFetchStart(
         installedAddons: List<com.nuvio.tv.domain.model.Addon>,
         directDebridSourceNames: List<String>,
-        baseline: List<AddonStreams>? = null
+        alreadySucceededNames: Set<String> = emptySet()
     ) {
         val addonNames = installedAddons
             .filter { it.supportsStreamResourceForChip(contentType) }
@@ -939,16 +915,10 @@ class StreamScreenViewModel @Inject constructor(
             return
         }
 
-        // When resuming, addons that already returned results in the
-        // previous run keep their SUCCESS status instead of flashing
-        // back to LOADING.  Only genuinely-pending sources show the
-        // loading indicator.
-        val alreadySucceeded = baseline?.map { it.addonName }?.toSet() ?: emptySet()
-
         updateUiStateIfChanged { state ->
             state.copy(
                 sourceChips = orderedNames.map { name ->
-                    if (name in alreadySucceeded) {
+                    if (name in alreadySucceededNames) {
                         SourceChipItem(name = name, status = SourceChipStatus.SUCCESS)
                     } else {
                         SourceChipItem(name = name, status = SourceChipStatus.LOADING)
@@ -1318,7 +1288,7 @@ class StreamScreenViewModel @Inject constructor(
             )
         }
         if (refreshStreams) {
-            loadStreams()
+            loadStreams(forceRefresh = true)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -296,6 +296,9 @@ class StreamScreenViewModel @Inject constructor(
             StreamScreenEvent.OnBackPress -> { /* Handle in screen */ }
             StreamScreenEvent.OnResume -> {
                 hostInForeground.value = true
+                if (!externalPlaybackTracker.isTracking) {
+                    streamRepository.setLocalPluginSearchPaused(false)
+                }
                 // Reattach to the repository-owned session if playback stopped
                 // this screen's collector before every source finished.
                 if (!streamLoadCompleted && streamLoadJob == null) {
@@ -322,6 +325,7 @@ class StreamScreenViewModel @Inject constructor(
     }
 
     private fun loadStreams(forceRefresh: Boolean = false) {
+        streamRepository.setLocalPluginSearchPaused(false)
         streamLoadScope?.cancel()
         streamLoadScope = null
         streamLoadJob = null
@@ -1202,6 +1206,7 @@ class StreamScreenViewModel @Inject constructor(
     }
 
     fun onInternalPlayerLaunching() {
+        streamRepository.setLocalPluginSearchPaused(true)
         updateUiStateIfChanged {
             it.copy(showDirectAutoPlayOverlay = false, directAutoPlayMessage = null)
         }
@@ -1258,6 +1263,7 @@ class StreamScreenViewModel @Inject constructor(
         } else {
             externalPlaybackTracker.stopTracking()
         }
+        streamRepository.setLocalPluginSearchPaused(false)
         updateUiStateIfChanged {
             it.copy(
                 showDirectAutoPlayOverlay = false,
@@ -1403,6 +1409,7 @@ class StreamScreenViewModel @Inject constructor(
         autoLaunch: Boolean = false,
         context: android.content.Context
     ) {
+        streamRepository.setLocalPluginSearchPaused(true)
         externalOverlayHideJob?.cancel()
         // Preserve the current message; blanking it made the card's Crossfade flash
         // empty before the subtitle/skip fetch set the next one.
@@ -1542,6 +1549,7 @@ class StreamScreenViewModel @Inject constructor(
                     )
                 }
                 externalPlaybackTracker.releaseAutoNextOverlay(forceRelease = true)
+                streamRepository.setLocalPluginSearchPaused(false)
                 return
             } finally {
                 call?.cancel()
@@ -1615,6 +1623,7 @@ class StreamScreenViewModel @Inject constructor(
             context = context
         )
         if (!launched) {
+            streamRepository.setLocalPluginSearchPaused(false)
             externalPlayerLaunched = false
             externalPlayerLaunchTimeMs = 0L
             updateUiStateIfChanged {

--- a/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryPluginIsolationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryPluginIsolationTest.kt
@@ -5,13 +5,16 @@ import com.nuvio.tv.core.debrid.DebridStreamPresentation
 import com.nuvio.tv.core.debrid.LocalDebridAvailabilityService
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.plugin.PluginManager
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.DebridSettingsDataStore
 import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.data.remote.dto.StreamDto
 import com.nuvio.tv.data.remote.dto.StreamResponseDto
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonResource
 import com.nuvio.tv.domain.model.AddonStreams
+import com.nuvio.tv.domain.model.DebridSettings
 import com.nuvio.tv.domain.model.RepositoryType
 import com.nuvio.tv.domain.model.ScraperInfo
 import com.nuvio.tv.domain.repository.AddonRepository
@@ -22,7 +25,9 @@ import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
@@ -32,7 +37,7 @@ import retrofit2.Response
 
 class StreamRepositoryPluginIsolationTest {
     @Test
-    fun `addon results arrive while plugin TMDB lookup is pending`() = runTest {
+    fun `addon results arrive while plugin TMDB lookup is pending`() = runBlocking {
         val harness = newHarness(listOf(compatibleScraper()))
         val tmdbResult = CompletableDeferred<String?>()
         coEvery { harness.tmdbService.ensureTmdbId("tt1341338", "movie") } coAnswers {
@@ -53,6 +58,8 @@ class StreamRepositoryPluginIsolationTest {
         assertEquals(1, groups.single().streams.size)
         assertTrue(tmdbResult.isActive)
         coVerify(exactly = 1) { harness.api.getStreams(any()) }
+        tmdbResult.complete(null)
+        Unit
     }
 
     @Test
@@ -92,10 +99,17 @@ class StreamRepositoryPluginIsolationTest {
         val pluginManager = mockk<PluginManager>(relaxed = true)
         every { pluginManager.enabledScrapers } returns flowOf(enabledScrapers)
         every { pluginManager.pluginsEnabled } returns flowOf(enabledScrapers.isNotEmpty())
+        every { pluginManager.groupStreamsByRepository } returns flowOf(false)
+        every { pluginManager.repositories } returns flowOf(emptyList())
+
+        val profileManager = mockk<ProfileManager>(relaxed = true)
+        every { profileManager.activeProfileId } returns MutableStateFlow(1)
 
         val tmdbService = mockk<TmdbService>(relaxed = true)
+        val debridSettingsDataStore = mockk<DebridSettingsDataStore>()
+        every { debridSettingsDataStore.settings } returns flowOf(DebridSettings())
         val presentation = mockk<DebridStreamPresentation>()
-        coEvery { presentation.apply(any(), any<Boolean>()) } coAnswers {
+        every { presentation.apply(any(), any<DebridSettings>(), any(), any()) } answers {
             firstArg<List<AddonStreams>>()
         }
         val availability = mockk<LocalDebridAvailabilityService>()
@@ -112,6 +126,8 @@ class StreamRepositoryPluginIsolationTest {
                 api = api,
                 addonRepository = addonRepository,
                 pluginManager = pluginManager,
+                profileManager = profileManager,
+                debridSettingsDataStore = debridSettingsDataStore,
                 tmdbService = tmdbService,
                 debridStreamPresentation = presentation,
                 localDebridAvailabilityService = availability


### PR DESCRIPTION
## Summary

Adds the source refresh action already available in NuvioMobile and NuvioDesktop, then makes source searches session owned so results do not disappear or restart unnecessarily when the source screen is left and reopened.

- Adds Refresh before the All filter.
- Retains partial and completed source results in a short lived, memory only session keyed by profile, media, enabled sources, plugins, and debrid presentation settings.
- Keeps an in progress source search running when the screen collector stops, then reattaches when source selection opens again.
- Makes Refresh cancel the old session generation and start a clean request across enabled addon and plugin sources.
- Preserves addon order while results arrive progressively.
- Caches only non empty successful searches so an empty result is searched again next time.
- Waits for the final ordered result set before assigning initial focus to the first source.
- Returns focus to the first source after Refresh.
- Preserves the user's selected source when later results arrive.
- Keeps Refresh and All visually distinct so both cannot appear focused at once.
- Pauses local plugin execution while the player is opening and resumes unfinished plugin work afterward.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

NuvioTV previously required leaving source selection and reopening it to request fresh sources. It also lost already returned results when the screen stopped collecting, which meant playback and source screen navigation could discard useful in progress work.

This matches the refresh action in Mobile and Desktop while making the underlying request lifecycle safe for progressive addon and plugin results. The follow up changes also prevent empty searches from being reused, stop focus from jumping while results arrive, and keep local plugin work away from the heavier player launch path.

## Issue or approval

Fixes #3030
Fixes #1796

## Reproduction steps

1. Open source selection for a movie or episode.
2. Wait for all enabled addon and plugin sources to finish.
3. Confirm focus lands on the first source result.
4. Move focus to another source while a late source is still loading.
5. Confirm the late result does not steal focus.
6. Select Refresh and wait for the new search to finish.
7. Confirm focus returns to the first result and All does not appear focused with Refresh.
8. Open the player while a local plugin is still working, then return to source selection.

Before this change, refreshing required leaving the source screen, cached or in progress results could be lost, focus could jump as results arrived, and plugin work could compete with player startup.

After this change, Refresh starts a clean request in place, useful results survive screen navigation, empty searches are not cached, focus settles predictably, and local plugin work yields while the player opens.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes the source search lifecycle, explicit source refresh, addon and plugin result reuse, plugin execution around player launch, and focus behavior within source selection.

It does not change source ranking, stream resolution, autoplay selection, binge group behavior, or internal and external player handoffs.

## Testing

- Built `:app:compileFullDebugKotlin` successfully.
- Built `:app:assembleFullDebug --max-workers=1` successfully, including lint vital.
- Installed the ARM64 full debug APK with `adb install -r` on an NVIDIA Shield TV running Android 11.
- Verified source refresh reruns enabled sources without leaving source selection.
- Verified movie and episode searches focus the first result after the search settles.
- Verified Refresh returns focus to the first result.
- Verified manual navigation is preserved when later addon results arrive.
- Verified Refresh and All do not appear focused together.
- The focused unit test task is currently blocked before these tests run by existing unrelated unit test compilation errors in TMDB, trailer, and search test fixtures.

## Screenshots / Video

https://github.com/user-attachments/assets/c35ce04e-ada2-4f92-be86-5245d504f618

## Breaking changes

None.

## Linked issues

Fixes #3030
Fixes #1796
