### PR TITLE
fix(subtitles): Detect and display text encoding correctly

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -429,6 +429,9 @@ dependencies {
     implementation(libs.moshi)
     ksp(libs.moshi.codegen)
 
+    // Detects legacy subtitle encodings and converts them to UTF-8.
+    implementation("com.github.albfernandez:juniversalchardet:2.5.0")
+
     // Coroutines
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.android)

--- a/app/src/main/java/com/nuvio/tv/core/player/SubtitleCharsetDetector.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/SubtitleCharsetDetector.kt
@@ -1,0 +1,82 @@
+package com.nuvio.tv.core.player
+
+import android.util.Log
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+import org.mozilla.universalchardet.UniversalDetector
+
+/**
+ * Detects subtitle encoding and normalizes it to UTF-8.
+ *
+ * UTF-8 is preferred. Other encodings are detected with UniversalDetector,
+ *    with Windows-1252 used as a fallback.
+ */
+object SubtitleCharsetDetector {
+
+    /** Decodes subtitle bytes using the detected encoding. */
+    fun decode(bytes: ByteArray, offset: Int = 0, length: Int = bytes.size - offset): String {
+        if (length <= 0) return ""
+        if (isValidUtf8(bytes, offset, length)) {
+            return String(bytes, offset, length, Charsets.UTF_8)
+        }
+        val charset = detectLegacyCharset(bytes, offset, length)
+        return String(bytes, offset, length, charset)
+    }
+
+    /**
+     * Converts subtitle bytes to UTF-8.
+     * Returns the original bytes when they are already valid UTF-8.
+     */
+    fun normalizeToUtf8(bytes: ByteArray, offset: Int = 0, length: Int = bytes.size - offset): ByteArray {
+        if (length <= 0) return ByteArray(0)
+        if (isValidUtf8(bytes, offset, length)) {
+            return if (offset == 0 && length == bytes.size) bytes else bytes.copyOfRange(offset, offset + length)
+        }
+        val charset = detectLegacyCharset(bytes, offset, length)
+        return String(bytes, offset, length, charset).toByteArray(Charsets.UTF_8)
+    }
+
+    /**
+     * Checks UTF-8 validity without replacing malformed sequences.
+     */
+    private fun isValidUtf8(bytes: ByteArray, offset: Int, length: Int): Boolean {
+        val decoder = Charsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+        return try {
+            decoder.decode(ByteBuffer.wrap(bytes, offset, length))
+            true
+        } catch (_: CharacterCodingException) {
+            false
+        }
+    }
+
+    private fun detectLegacyCharset(bytes: ByteArray, offset: Int, length: Int): Charset {
+        val detectedName = try {
+            val detector = UniversalDetector(null)
+            detector.handleData(bytes, offset, length)
+            detector.dataEnd()
+            val name = detector.detectedCharset
+            detector.reset()
+            name
+        } catch (e: Exception) {
+            Log.w(TAG, "Charset detection failed, falling back to $FALLBACK_CHARSET_NAME", e)
+            null
+        }
+
+        if (detectedName == null) return FALLBACK_CHARSET
+
+        return runCatching { Charset.forName(detectedName) }
+            .getOrElse {
+                Log.w(TAG, "Detected charset '$detectedName' unavailable on-device, falling back to $FALLBACK_CHARSET_NAME")
+                FALLBACK_CHARSET
+            }
+    }
+
+    private const val TAG = "SubtitleCharsetDetector"
+    private const val FALLBACK_CHARSET_NAME = "windows-1252"
+    private val FALLBACK_CHARSET: Charset =
+        runCatching { Charset.forName(FALLBACK_CHARSET_NAME) }.getOrDefault(Charsets.ISO_8859_1)
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioAssMatroskaExtractor.kt
@@ -12,6 +12,7 @@ import androidx.media3.extractor.ExtractorOutput
 import androidx.media3.extractor.TrackOutput
 import androidx.media3.extractor.mkv.EbmlProcessor
 import androidx.media3.extractor.text.SubtitleParser
+import com.nuvio.tv.core.player.SubtitleCharsetDetector
 import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor
 import com.nuvio.tv.core.player.dvmkv.MatroskaExtractor.DolbyVisionSampleTransformer
 import io.github.peerless2012.ass.media.AssHandler
@@ -166,6 +167,10 @@ private class NuvioAssSubtitleExtractorOutput(
     }
 }
 
+/**
+ * Wraps [TrackOutput] to detect and normalize the encoding of SSA/ASS dialogue
+ * samples before passing them to [AssHandler].
+ */
 @OptIn(UnstableApi::class)
 private class NuvioAssTrackOutput(
     private val delegate: TrackOutput,
@@ -242,14 +247,22 @@ private class NuvioAssTrackOutput(
         return 0
     }
 
+    /**
+     * Extracts and, if needed, decompresses the dialogue payload, then normalizes it
+     * to UTF-8 before passing it to [AssHandler].
+     */
     private fun ByteArray.dialoguePayload(offset: Int, limit: Int): ByteArray {
         if (offset >= limit) return EMPTY_BYTE_ARRAY
-        if (looksLikeZlib(offset, limit)) {
-            val inflated = maybeInflate(offset, size - offset)
-            if (inflated != null) return inflated
+        val raw = if (looksLikeZlib(offset, limit)) {
+            maybeInflate(offset, size - offset) ?: run {
+                val boundedLimit = limit.coerceIn(offset, size)
+                copyOfRange(offset, boundedLimit)
+            }
+        } else {
+            val boundedLimit = limit.coerceIn(offset, size)
+            copyOfRange(offset, boundedLimit)
         }
-        val boundedLimit = limit.coerceIn(offset, size)
-        return copyOfRange(offset, boundedLimit)
+        return SubtitleCharsetDetector.normalizeToUtf8(raw)
     }
 
     private fun ByteArray.looksLikeZlib(offset: Int, limit: Int): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
 import com.nuvio.tv.R
+import com.nuvio.tv.core.player.SubtitleCharsetDetector
 import com.nuvio.tv.domain.model.Subtitle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
@@ -249,7 +250,13 @@ private fun PlayerRuntimeController.executeSubtitleDownload(url: String): String
         if (!response.isSuccessful) {
             error(context.getString(com.nuvio.tv.R.string.subtitle_download_failed_http, response.code))
         }
-        val body = response.body?.string().orEmpty()
+        // Read raw bytes and decode them with SubtitleCharsetDetector to correctly handle
+        // legacy subtitle encodings that may be misdecoded by response.body?.string().
+        val bodyBytes = response.body?.bytes()
+        if (bodyBytes == null || bodyBytes.isEmpty()) {
+            error(context.getString(com.nuvio.tv.R.string.subtitle_download_empty_content))
+        }
+        val body = SubtitleCharsetDetector.decode(bodyBytes)
         if (body.isBlank()) {
             error(context.getString(com.nuvio.tv.R.string.subtitle_download_empty_content))
         }


### PR DESCRIPTION
## Summary

Fix subtitle character encoding detection for SRT/VTT/SSA/ASS files by automatically detecting non-UTF-8 encodings and normalizing subtitle content to UTF-8.

This is a follow-up to #3032 and #2880.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some subtitle files are encoded using legacy character encodings instead of UTF-8. Previously, these files could be decoded incorrectly, causing characters to be replaced with U+FFFD or displayed as corrupted text.

This PR uses juniversalchardet to detect the source encoding when the subtitle data is not valid UTF-8, then converts it to UTF-8 before it is processed.

This improves compatibility with legacy subtitle files, including files using codepages such as Windows-1255 for Hebrew.

This provides the following improvements:

* Correctly displays text from files using different character encodings, including UTF-8 and Latin-1.
* Prevents incorrectly decoded characters from being replaced with U+FFFD.
* Reduces text corruption and data loss during file parsing.
* Improves readability and compatibility for international text.

## Issue or approval

No linked issue. This is a critical bug fix for incorrect character encoding detection and decoding.

## Reproduction steps

1. Open a file containing text encoded with a character encoding other than the expected encoding.
2. Load the file in NuvioTV.
3. Observe that characters that cannot be decoded correctly are displayed as U+FFFD.
4. Apply the changes from this PR.
5. Reload the same file.
6. Verify that the original characters are now displayed correctly without replacement characters.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This PR is strictly limited to correcting character encoding detection and decoding for files where the encoding cannot be reliably determined in advance.

No UI changes, visual polish, unrelated behavior changes, refactoring, cleanup, or additional features are included.

## Testing

Full PR Debug

* Tested files using multiple character encodings, including UTF-8 and Latin-1.
* Verified that previously corrupted characters displaying as U+FFFD are now rendered correctly.
* Verified that existing UTF-8 files continue to display correctly.
* Verified that international characters are preserved during file parsing.
* Verified that the change does not introduce unrelated UI or behavioral changes.

## Screenshots / Video

BEFORE:
<img width="5712" height="2584" alt="IMG_3550" src="https://github.com/user-attachments/assets/198fc94c-a667-4f89-b41e-9549d8869599" />

AFTER:
<img width="5498" height="2344" alt="IMG_3551" src="https://github.com/user-attachments/assets/bf467dec-4f73-46a9-bc61-14508fea82e2" />

## Breaking changes

None.

## Linked issues

Follow-up to #3032 and #2880.
No new issue linked - this PR addresses the confirmed subtitle character encoding bug.
