### PR TITLE
dynamically probe stream mime type on parsing error fallback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -25,6 +25,9 @@ import com.nuvio.tv.data.local.VodCacheSizeMode
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.net.SocketTimeoutException
 import java.net.URLDecoder
 import java.security.SecureRandom
@@ -455,6 +458,60 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                 filename = filename,
                 responseHeaders = responseHeaders
             )
+        }
+
+        suspend fun probeNetworkMimeType(
+            url: String,
+            headers: Map<String, String> = emptyMap()
+        ): String? = withContext(Dispatchers.IO) {
+            if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
+                return@withContext null
+            }
+            val sanitizedHeaders = sanitizeHeaders(headers)
+            val methods = listOf("HEAD", "GET")
+            for (method in methods) {
+                runCatching {
+                    val requestBuilder = Request.Builder().url(url)
+                    if (method == "GET") {
+                        requestBuilder.header("Range", "bytes=0-2048")
+                    }
+                    sanitizedHeaders.forEach { (key, value) ->
+                        if (!key.equals("Range", ignoreCase = true)) {
+                            requestBuilder.header(key, value)
+                        }
+                    }
+                    if (sanitizedHeaders.none { it.key.equals("User-Agent", ignoreCase = true) }) {
+                        requestBuilder.header("User-Agent", DEFAULT_USER_AGENT)
+                    }
+
+                    PlayerPlaybackNetworking.playbackHttpClient.newCall(requestBuilder.build()).execute().use { response ->
+                        if (!response.isSuccessful && response.code !in 200..308) {
+                            return@use null
+                        }
+
+                        val finalUrl = response.request.url.toString()
+                        inferAdaptiveMimeTypeFromPath(finalUrl)?.let { return@withContext it }
+
+                        val contentType = response.header("Content-Type")
+                        normalizeMimeType(contentType)?.let { return@withContext it }
+
+                        val responseHeadersMap = response.headers.names().associateWith { response.header(it).orEmpty() }
+                        inferMimeTypeFromResponseHeaders(responseHeadersMap)?.let { return@withContext it }
+
+                        if (method == "GET") {
+                            val snippet = response.body?.byteStream()?.use { stream ->
+                                val bytes = ByteArray(512)
+                                val read = stream.read(bytes)
+                                if (read > 0) String(bytes, 0, read, Charsets.UTF_8) else null
+                            }
+                            sniffManifestMimeType(snippet)?.let { return@withContext it }
+                        }
+
+                        inferMimeTypeFromPath(finalUrl)?.let { return@withContext it }
+                    }
+                }.getOrNull()?.let { return@withContext it }
+            }
+            null
         }
 
         private fun inferMimeTypeFromResponseHeaders(headers: Map<String, String>?): String? {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -462,6 +462,7 @@ class PlayerRuntimeController(
     internal var hasTriedDv7HevcFallback: Boolean = false
     internal var forceDv7ToHevc: Boolean = false
     internal var startupRetryCount: Int = 0
+    internal var parsingErrorProbeAttempted: Boolean = false
     internal var hasRetriedCurrentStreamAfterUnexpectedNpe: Boolean = false
     internal var hasRetriedCurrentStreamAfterMediaPeriodHolderCrash: Boolean = false
     internal var timeoutRecoveryAttempts: Int = 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerErrorRecovery.kt
@@ -35,8 +35,6 @@ internal fun PlayerRuntimeController.attemptStartupRecovery(
     if (!isRetryablePlaybackError(error)) return false
     if (startupRetryCount >= MAX_STARTUP_AUTO_RETRIES) return false
 
-    handleParsingErrorFallback(error)
-
     val paused = userPausedManually
     val attempt = startupRetryCount
     startupRetryCount++
@@ -246,8 +244,6 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
     if (!isRetryablePlaybackError(error)) return false
     if (errorRetryCount >= MAX_AUTO_RETRIES) return false
 
-    handleParsingErrorFallback(error)
-
     val paused = userPausedManually
     val attempt = errorRetryCount
     errorRetryCount++
@@ -309,6 +305,7 @@ internal fun PlayerRuntimeController.attemptAutoRetry(
 internal fun PlayerRuntimeController.resetErrorRetryState() {
     startupRetryCount = 0
     errorRetryCount = 0
+    parsingErrorProbeAttempted = false
     pendingAudioPcmFallbackRebuild = false
     errorRetryJob?.cancel()
     errorRetryJob = null
@@ -435,18 +432,78 @@ internal fun PlayerRuntimeController.tryDv7HevcFallback(
     return true
 }
 
-internal fun PlayerRuntimeController.handleParsingErrorFallback(error: PlaybackException) {
-    if (error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
+internal fun PlayerRuntimeController.tryParsingErrorProbeFallback(
+    error: PlaybackException,
+    detailedError: String,
+    allowEngineFailover: Boolean,
+    savedPosition: Long = 0L,
+    paused: Boolean = userPausedManually
+): Boolean {
+    val isSourceOrParsingError = error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
         error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
         error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_UNSUPPORTED ||
-        error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED
-    ) {
-        Log.w(
-            PlayerRuntimeController.TAG,
-            "Parsing error [${error.errorCode}] detected with previous mimeType=$currentStreamMimeType. " +
-                    "Setting mimeType to HLS (APPLICATION_M3U8) for retry fallback."
+        error.errorCode == PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED ||
+        error.errorCode == PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW ||
+        error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
+        error.findCauseOfType<androidx.media3.exoplayer.source.UnrecognizedInputFormatException>() != null ||
+        error.cause?.toString()?.contains("UnrecognizedInputFormatException") == true
+
+    if (!isSourceOrParsingError) return false
+    if (parsingErrorProbeAttempted) return false
+    parsingErrorProbeAttempted = true
+
+    val previousMimeType = currentStreamMimeType
+    Log.w(
+        PlayerRuntimeController.TAG,
+        "Source/parsing error [${error.errorCode}] detected (previous mimeType=$previousMimeType). " +
+            "Probing stream format..."
+    )
+
+    errorRetryJob?.cancel()
+    errorRetryJob = scope.launch {
+        showRecoveryOverlay()
+        val probedMime = PlayerMediaSourceFactory.probeNetworkMimeType(
+            url = currentStreamUrl,
+            headers = currentHeaders
         )
-        currentStreamMimeType = androidx.media3.common.MimeTypes.APPLICATION_M3U8
-        currentStreamResponseHeaders = emptyMap()
+
+        if (probedMime != null && probedMime != previousMimeType) {
+            Log.i(
+                PlayerRuntimeController.TAG,
+                "Stream probe resolved mimeType=$probedMime (was $previousMimeType). Retrying playback..."
+            )
+            currentStreamMimeType = probedMime
+            currentStreamResponseHeaders = emptyMap()
+            releasePlayer(flushPlaybackState = false)
+            if (savedPosition > 0L) {
+                _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
+            }
+            initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
+        } else if (previousMimeType == androidx.media3.common.MimeTypes.APPLICATION_M3U8) {
+            currentStreamMimeType = null
+            currentStreamResponseHeaders = emptyMap()
+            releasePlayer(flushPlaybackState = false)
+            if (savedPosition > 0L) {
+                _uiState.update { it.copy(pendingSeekPosition = savedPosition) }
+            }
+            initializePlayer(currentStreamUrl, currentHeaders, startPaused = paused)
+        } else {
+            if (maybeAutoSwitchInternalPlayerOnStartupError(detailedError = detailedError, allowEngineFailover = allowEngineFailover)) {
+                return@launch
+            }
+            if (attemptAutoRetry(error, detailedError)) {
+                return@launch
+            }
+            val userFacingError = error.toDisplayMessage(context)
+            _uiState.update {
+                it.copy(
+                    error = userFacingError,
+                    isBuffering = false,
+                    showLoadingOverlay = false,
+                    showPauseOverlay = false
+                )
+            }
+        }
     }
+    return true
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1499,7 +1499,15 @@ internal fun PlayerRuntimeController.initializePlayer(
                             return
                         }
 
-                        handleParsingErrorFallback(error)
+                        if (tryParsingErrorProbeFallback(
+                            error = error,
+                            detailedError = detailedError,
+                            allowEngineFailover = allowEngineFailover,
+                            savedPosition = currentPosition,
+                            paused = userPausedManually
+                        )) {
+                            return
+                        }
 
                         // ── Main Engine Failover ──
                         if (maybeAutoSwitchInternalPlayerOnStartupError(detailedError = detailedError, allowEngineFailover = allowEngineFailover)) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -511,6 +511,7 @@ private fun PlayerRuntimeController.applySelectedStreamState(
         filename = currentFilename,
         responseHeaders = currentStreamResponseHeaders
     )
+    parsingErrorProbeAttempted = false
     applyStreamMetadata(stream)
 }
 


### PR DESCRIPTION
## Summary

Replaces the unconditional HLS MIME type override on parsing errors with dynamic stream MIME probing fallback, bringing the TV player to full parity with NuvioMobile's proven implementation.

- Adds `probeNetworkMimeType` to `PlayerMediaSourceFactory` (matching NuvioMobile's `probeMimeType` mechanism) using fast `HEAD` and ranged `GET` probing to follow redirects and inspect `Content-Type` headers / manifest content (`#EXTM3U` / `<MPD`).
- Updates `tryParsingErrorProbeFallback` in `PlayerRuntimeControllerErrorRecovery` to probe origin URLs dynamically on container/source errors instead of unconditionally forcing `APPLICATION_M3U8`.
- If the probed stream is adaptive (HLS/DASH), playback retries with the resolved MIME type (e.g. Debrid caching slate streams).
- If the stream is progressive/non-adaptive, avoids corrupting MIME state and allows internal player auto-switch (MPV failover) or standard error reporting to proceed cleanly.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

PR #2851 introduced an unconditional `currentStreamMimeType = APPLICATION_M3U8` override whenever ExoPlayer encountered a container parsing error. For non-HLS streams (such as normal MKV/MP4/TS streams from addons that encounter initial container glitches), forcing `APPLICATION_M3U8` caused `HlsMediaSource` to attempt parsing binary container data as a text playlist, resulting in `PARSING_MANIFEST_MALFORMED` errors and blocking proper engine failover.

In NuvioMobile, this scenario is handled safely via dynamic stream MIME probing upon encountering source/parsing errors (`ERROR_CODE_IO_UNSPECIFIED`, `UnrecognizedInputFormatException`, behind live window). Adopting this same pattern in NuvioTV resolves false-positive HLS parsing crashes while maintaining full support for Debrid caching status videos.

## Issue or approval

Fixes #2975 (Follow-up and fix for PR #2851)

## Reproduction steps

1. Play a stream with an `.mkv` filename or progressive container from an addon where ExoPlayer encounters a container/source parsing issue.
2. In PR #2851, the player unconditionally forced the MIME type to `APPLICATION_M3U8` for all container parse errors.
3. ExoPlayer failed with `PARSING_MANIFEST_MALFORMED` because non-HLS binary data was parsed by `HlsPlaylistParser`, corrupting player state and preventing MPV engine failover.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No UI changes, aesthetic tweaks, or unrelated refactors. Only the error recovery fallback and dynamic network MIME probing logic in the player controller were modified.

## Testing

- `./gradlew compileFullDebugKotlin` — passed without warnings or errors.
- `./gradlew :app:testFullDebugUnitTest` — all player unit tests passed (`BUILD SUCCESSFUL`).
- `./gradlew assembleFullDebug` — full APK build succeeded (`BUILD SUCCESSFUL`).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2975
Follow-up to #2851