### PR TITLE
Add 'strip_hdr10plus_sei' to settings sync exclusions

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -95,6 +95,7 @@ private val localOnlyPlayerProfileSettingsKeys = setOf(
     "dv7_handling_mode",
     "map_dv7_to_hevc",
     "dv7_libdovi_mode_override",
+    "strip_hdr10plus_sei",
     "mpv_hardware_decode_mode",
     "frame_rate_matching",
     "frame_rate_matching_mode",


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->
Fixes `strip_hdr10plus_sei` incorrectly syncing across devices via profile settings sync. Added it to the device-local exclusion set in `ProfileSettingsSyncService.kt` alongside the other player-only keys.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

<!-- Why this change is needed. Explain the critical bug or localization update. -->
`strip_hdr10plus_sei` was missing from `localOnlyPlayerProfileSettingsKeys`, so it was being pushed/pulled as part of the synced profile settings blob instead of staying device-local like other hardware/decode-dependent player settings (e.g. `dv7_handling_mode`, buffer settings). This causes the setting to incorrectly propagate between devices with different HDR10+ decoding capabilities.

## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->
None.

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->
1. Enable "Strip HDR10+" on Device A.
2. Sign into the same profile on Device B.
3. Observe Device B's HDR10+ strip setting now matches Device A instead of remaining independent.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
No other keys in `localOnlyPlayerProfileSettingsKeys` were touched. No UI, no unrelated behavior changes.

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->
- Verified `shouldExcludePreferenceFromProfileSettingsSync("player_settings", "strip_hdr10plus_sei")` returns `true` after the change.
- Manually toggled the setting on one device, confirmed it's no longer included in the pushed profile settings blob.

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
Not a UI change.

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
None.