### PR TITLE
Fix legacy SRT subtitle encoding

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/SubtitleCharsetNormalizer.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/SubtitleCharsetNormalizer.kt
@@ -1,0 +1,34 @@
+package com.nuvio.tv.core.player
+
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+
+internal object SubtitleCharsetNormalizer {
+
+    private val windows1252 = Charset.forName("windows-1252")
+
+    fun normalizeToUtf8(bytes: ByteArray): ByteArray {
+        if (bytes.isEmpty() || isValidUtf8(bytes)) {
+            return bytes
+        }
+
+        return bytes
+            .toString(windows1252)
+            .toByteArray(Charsets.UTF_8)
+    }
+
+    private fun isValidUtf8(bytes: ByteArray): Boolean {
+        return try {
+            Charsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+
+            true
+        } catch (_: CharacterCodingException) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
@@ -1,14 +1,16 @@
 package com.nuvio.tv.ui.screens.player
 
+import androidx.media3.common.MimeTypes
 import com.nuvio.tv.R
+import com.nuvio.tv.core.network.IPv4FirstDns
+import com.nuvio.tv.core.player.SubtitleCharsetNormalizer
 import com.nuvio.tv.domain.model.Subtitle
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import com.nuvio.tv.core.network.IPv4FirstDns
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.util.concurrent.TimeUnit
@@ -249,7 +251,17 @@ private fun PlayerRuntimeController.executeSubtitleDownload(url: String): String
         if (!response.isSuccessful) {
             error(context.getString(com.nuvio.tv.R.string.subtitle_download_failed_http, response.code))
         }
-        val body = response.body?.string().orEmpty()
+
+        val responseBody = response.body
+        val body = if (PlayerSubtitleUtils.mimeTypeFromUrl(url) == MimeTypes.APPLICATION_SUBRIP) {
+            // SRT files may use legacy Windows-1252 encoding. Normalize them to UTF-8
+            // before decoding so accented characters are not replaced with U+FFFD.
+            val bytes = responseBody.bytes()
+            SubtitleCharsetNormalizer.normalizeToUtf8(bytes).toString(Charsets.UTF_8)
+        } else {
+            responseBody.string()
+        }
+
         if (body.isBlank()) {
             error(context.getString(com.nuvio.tv.R.string.subtitle_download_empty_content))
         }

--- a/app/src/test/java/com/nuvio/tv/core/player/SubtitleCharsetNormalizerTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/SubtitleCharsetNormalizerTest.kt
@@ -1,0 +1,96 @@
+package com.nuvio.tv.core.player
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.charset.Charset
+
+class SubtitleCharsetNormalizerTest {
+
+    private val windows1252 = Charset.forName("windows-1252")
+
+    @Test
+    fun `empty input is left unchanged`() {
+        val input = byteArrayOf()
+
+        val result = SubtitleCharsetNormalizer.normalizeToUtf8(input)
+
+        assertArrayEquals(input, result)
+    }
+
+    @Test
+    fun `windows-1252 Spanish characters are converted to UTF-8`() {
+        val original =
+            "á é í ó ú Á É Í Ó Ú ñ Ñ ü Ü ¿ ¡"
+
+        val input = original.toByteArray(windows1252)
+
+        val result = SubtitleCharsetNormalizer.normalizeToUtf8(input)
+
+        assertEquals(
+            original,
+            result.toString(Charsets.UTF_8)
+        )
+    }
+
+    @Test
+    fun `windows-1252 Western European characters are converted to UTF-8`() {
+        val original =
+            "à â æ ç è ê ë ï ô œ ù û ÿ " +
+                "À Â Æ Ç È Ê Ë Ï Ô Œ Ù Û Ÿ " +
+                "ä ö ß Ä Ö " +
+                "ã õ Ã Õ " +
+                "å Å ø Ø " +
+                "€ “ ” ‘ ’ … – — ™"
+
+        val input = original.toByteArray(windows1252)
+
+        val result = SubtitleCharsetNormalizer.normalizeToUtf8(input)
+
+        assertEquals(
+            original,
+            result.toString(Charsets.UTF_8)
+        )
+    }
+
+    @Test
+    fun `valid UTF-8 is left unchanged`() {
+        val input = (
+            "á é í ó ú ñ Ñ ü ¿ ¡ " +
+                "Français: œ ç è " +
+                "Deutsch: ä ö ü ß " +
+                "Português: ã õ " +
+                "Русский язык " +
+                "Ελληνικά " +
+                "日本語 " +
+                "한국어 " +
+                "العربية"
+            ).toByteArray(Charsets.UTF_8)
+
+        val result = SubtitleCharsetNormalizer.normalizeToUtf8(input)
+
+        assertArrayEquals(input, result)
+    }
+
+    @Test
+    fun `windows-1252 SRT content is normalized without altering its structure`() {
+        val original = """
+            1
+            00:00:01,000 --> 00:00:03,000
+            ¿Por qué está aquí el niño?
+
+            2
+            00:00:04,000 --> 00:00:06,000
+            ¡Mañana será más fácil! <i>Señor</i>
+        """.trimIndent()
+
+        val input = original.toByteArray(windows1252)
+
+        val result = SubtitleCharsetNormalizer.normalizeToUtf8(input)
+
+        assertEquals(
+            original,
+            result.toString(Charsets.UTF_8)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fix [incorrectly rendered characters in legacy-encoded SRT subtitles when using ExoPlayer](https://www.reddit.com/r/Nuvio/comments/1vd3gyy/spanish_subtitles_problem/).

Some SRT subtitles provided by addons use Windows-1252 encoding rather than UTF-8. The subtitle download path previously decoded the response directly as text, which could replace accented characters and other affected characters with `�`.

This PR adds charset normalization for SRT subtitles before their raw bytes are decoded and parsed.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Some Spanish subtitles provided by addons use a legacy encoding that is not interpreted correctly, causing accented characters and other Windows-1252 characters to render incorrectly.

Since the subtitle source does not always provide encoding metadata, the SRT download path now validates the raw bytes as UTF-8 first and falls back to Windows-1252 when they are not valid UTF-8.

Valid UTF-8 subtitles are left unchanged.

## Issue or approval

Fixes #2062

## Reproduction steps

1. Use ExoPlayer as the internal player.
2. Play content with an addon providing an SRT subtitle encoded as Windows-1252.
3. Select a Spanish subtitle containing characters such as `á`, `é`, `í`, `ó`, `ú`, `ñ`, `¿`, or `¡`.
4. Before this fix, affected characters may be rendered as `�`.
5. With this fix, the original characters are rendered correctly.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

- Normalization is limited to SRT subtitles.
- Other subtitle formats are left unchanged.
- Valid UTF-8 input is preserved unchanged.
- No player UI or subtitle styling changes are included.
- No subtitle selection behavior is changed.
- No unrelated refactors or cleanup are included.

## Testing

- Added unit coverage for Windows-1252 Spanish characters.
- Added unit coverage for additional Western European Windows-1252 characters.
- Verified valid UTF-8 input remains unchanged.
- Verified SRT structure and content remain intact after normalization.
- `./gradlew :app:compileFullDebugKotlin`
- `CI_USE_DEBUG_SIGNING=true ./gradlew :app:assembleFullRelease`
- Installed the ARM64 release APK on an Android emulator.
- Tested playback with ExoPlayer and a real subtitle addon.
- Verified that affected Spanish characters render correctly after the fix.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2062