### PR TITLE
fix(player): merge simultaneously active unpositioned subtitle cues to prevent overlapping

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -2226,11 +2226,9 @@ private class CueNormalizingTextOutput(
                 modifiedList?.add(original)
             }
         }
-        if (modifiedList != null) {
-            delegate.onCues(CueGroup(modifiedList, cueGroup.presentationTimeUs))
-        } else {
-            delegate.onCues(cueGroup)
-        }
+        val processedCues = modifiedList ?: cues
+        val mergedCues = PlayerSubtitleUtils.mergeOverlappingCues(processedCues)
+        delegate.onCues(CueGroup(mergedCues, cueGroup.presentationTimeUs))
     }
 
     @Deprecated("Uses the deprecated Media3 callback for text outputs.")
@@ -2259,7 +2257,9 @@ private class CueNormalizingTextOutput(
                 modifiedList?.add(original)
             }
         }
-        delegate.onCues(modifiedList ?: cues)
+        val processedCues = modifiedList ?: cues
+        val mergedCues = PlayerSubtitleUtils.mergeOverlappingCues(processedCues)
+        delegate.onCues(mergedCues)
     }
 
     private fun processCue(cue: Cue): Cue {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSidecarSubtitles.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSidecarSubtitles.kt
@@ -187,13 +187,14 @@ internal fun PlayerRuntimeController.renderSidecarCuesAtCurrentPosition() {
     val active = collectActiveSidecarCues(cues, positionUs).let { current ->
         if (currentPlayerSettingsForReport.subtitleStyle.stripSdh) SubtitleSdhFilter.filterCues(current) else current
     }
-    val signature = activeCueSignature(active)
+    val merged = PlayerSubtitleUtils.mergeOverlappingCues(active)
+    val signature = activeCueSignature(merged)
     if (signature == lastSidecarCueSignature) return
     lastSidecarCueSignature = signature
     val currentKey = activeSidecarSubtitleKey ?: return
     postToSubtitleView { view ->
         if (view.getTag(R.id.player_view_sidecar_generation_tag) == currentKey) {
-            view.setCues(active)
+            view.setCues(merged)
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
 import androidx.media3.common.MimeTypes
+import androidx.media3.common.text.Cue
 import com.nuvio.tv.ui.util.LANGUAGE_OVERRIDES
 
 internal object PlayerSubtitleUtils {
@@ -206,5 +207,17 @@ internal object PlayerSubtitleUtils {
             MimeTypes.TEXT_SSA,
             MimeTypes.APPLICATION_TTML
         ).toList()
+    }
+
+    /**
+     * Merges simultaneously active unpositioned text cues into a single multi-line cue
+     * to prevent Media3 SubtitlePainter from drawing colliding lines on top of each other.
+     */
+    fun mergeOverlappingCues(cues: List<Cue>): List<Cue> {
+        if (cues.size <= 1 || !cues.all { it.bitmap == null && it.line == Cue.DIMEN_UNSET }) {
+            return cues
+        }
+        val text = cues.mapNotNull { it.text }.filter { it.isNotBlank() }.distinct().joinToString("\n")
+        return if (text.isBlank()) emptyList() else listOf(cues[0].buildUpon().setText(text).build())
     }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtilsMimeTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtilsMimeTest.kt
@@ -66,4 +66,29 @@ class PlayerSubtitleUtilsMimeTest {
         assertTrue(candidates.contains(MimeTypes.APPLICATION_SUBRIP))
         assertEquals(candidates.size, candidates.distinct().size)
     }
+
+    @Test
+    fun mergeOverlappingCues_mergesMultipleUnpositionedCues() {
+        val cue1 = androidx.media3.common.text.Cue.Builder().setText(">> (sputtering)").build()
+        val cue2 = androidx.media3.common.text.Cue.Builder().setText(">> HEY!").build()
+        val merged = PlayerSubtitleUtils.mergeOverlappingCues(listOf(cue1, cue2))
+        assertEquals(1, merged.size)
+        assertEquals(">> (sputtering)\n>> HEY!", merged[0].text.toString())
+    }
+
+    @Test
+    fun mergeOverlappingCues_preservesPositionedCues() {
+        val cue1 = androidx.media3.common.text.Cue.Builder().setText("TOP").setLine(0.1f, androidx.media3.common.text.Cue.LINE_TYPE_FRACTION).build()
+        val cue2 = androidx.media3.common.text.Cue.Builder().setText("BOTTOM").setLine(0.9f, androidx.media3.common.text.Cue.LINE_TYPE_FRACTION).build()
+        val result = PlayerSubtitleUtils.mergeOverlappingCues(listOf(cue1, cue2))
+        assertEquals(2, result.size)
+        assertEquals("TOP", result[0].text.toString())
+        assertEquals("BOTTOM", result[1].text.toString())
+    }
+
+    @Test
+    fun mergeOverlappingCues_singleCue_returnsSame() {
+        val list = listOf(androidx.media3.common.text.Cue.Builder().setText("Single").build())
+        org.junit.Assert.assertSame(list, PlayerSubtitleUtils.mergeOverlappingCues(list))
+    }
 }


### PR DESCRIPTION
## Summary

Fixes overlapping and garbled subtitle rendering when multiple unpositioned subtitle cues are active simultaneously during playback. In subtitles with overlapping timestamps (common in Closed Captions [EIA-608], SDH tracks, or simultaneous dialogue rips like in *Little Bear* or *Pulp Fiction*), Media3's `SubtitleView` (`CanvasSubtitleOutput`) places all unpositioned cues (`line == Cue.DIMEN_UNSET`) at the exact same bottom-center canvas coordinates without vertical collision avoidance, drawing characters directly on top of each other. This change merges simultaneously active unpositioned text cues into a single multi-line `Cue` joined with newlines (`\n`), allowing Android's `StaticLayout` to cleanly stack lines vertically.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When an SRT, VTT, or embedded subtitle stream contains overlapping time intervals (e.g., a background sound effect `>> (sputtering)` and spoken dialogue `>> HEY!`, or two characters speaking at the exact same timestamp), ExoPlayer/Media3 emits multiple separate `Cue` objects for that time window. Because these cues lack explicit vertical positioning (`line == Cue.DIMEN_UNSET`), Media3's default subtitle painter renders them on the identical pixel coordinates at the bottom center. This causes characters to overlap into unreadable text (e.g., `- Coffeerpleaseb?aDecaf.`).

## Issue or approval

Reported on Discord (overlapping Closed Caption / subtitle cues on TV)

## Reproduction steps

1. Play a video with Closed Captions / SDH or simultaneous dialogue cues (e.g., *Pulp Fiction* with English OpenSubtitles at `35:39` or *Little Bear* S01E07 at `16:00`).
2. Observe the subtitle rendering during simultaneous cues (e.g. `35:39` where line 1 is `- Come on, baby` and line 2 is `- Coffee, please ? Decaf.`).
3. **Before this fix:** Both cues render on the exact same bottom pixel coordinates, drawing text on top of each other into an unreadable garbled mess.
4. **After this fix:** Simultaneously active unpositioned cues are merged into a single multi-line cue separated by `\n`, rendering cleanly stacked on two distinct vertical lines.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only merges cues that are unpositioned (`line == Cue.DIMEN_UNSET`) and non-bitmap.
- Explicitly positioned cues (e.g., top forced translation signs vs. bottom dialogue) and bitmap/image cues are preserved untouched without regression.
- Applied consistently across both embedded subtitle streams (`CueNormalizingTextOutput`) and external sidecar subtitles (`PlayerSidecarSubtitles`).
- Zero performance overhead: fast-paths immediately if `cues.size <= 1`.

## Testing

- Unit tests added in `PlayerSubtitleUtilsMimeTest.kt` verifying:
  - Overlapping unpositioned cues merge with `\n` separator.
  - Distinctly positioned cues (top/bottom) remain separate.
  - Single cues return the exact same instance with zero overhead.
- Verified on Android TV hardware:
  - Tested *Pulp Fiction* (`35:39`): confirmed two simultaneous lines render cleanly stacked instead of overlapping.
  - Tested *Little Bear* (sound effect + dialogue): confirmed clean vertical layout.

## Screenshots / Video

Fixed overlapping subtitle rendering on TV (merged into 2 stacked lines).

## Breaking changes

None.

## Linked issues

Reported on Discord