### PR TITLE
fix(continue-watching): keep poster art when episode thumbnails are off

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -357,10 +357,11 @@ internal fun continueWatchingImageModel(
         fun firstUsable(vararg candidates: String?): String? =
             candidates.firstOrNull { !it.isNullOrBlank() && it !in brokenImageUrls }?.trim()
         // Movies carry no episode thumbnail, so they keep their poster without needing a content type check.
+        // A thumbnail that is switched off leaves the chain entirely, because Trakt rows hydrate their artwork late and a demoted thumbnail would show until it lands.
         return if (useEpisodeThumbnails) {
             firstUsable(thumbnail, poster, backdrop)
         } else {
-            firstUsable(poster, backdrop, thumbnail)
+            firstUsable(poster, backdrop)
         }
     }
     val progress = (item as? ContinueWatchingItem.InProgress)?.progress
@@ -369,11 +370,15 @@ internal fun continueWatchingImageModel(
         candidates.firstOrNull { !it.isNullOrBlank() && it !in brokenImageUrls }?.trim()
     return when {
         nextUp != null && !nextUp.hasAired ->
-            firstNonBroken(nextUp.backdrop, nextUp.poster, nextUp.thumbnail)
+            firstNonBroken(
+                nextUp.backdrop,
+                nextUp.poster,
+                nextUp.thumbnail.takeIf { useEpisodeThumbnails }
+            )
         nextUp != null && useEpisodeThumbnails ->
             firstNonBroken(nextUp.thumbnail, nextUp.backdrop, nextUp.poster)
         nextUp != null ->
-            firstNonBroken(nextUp.backdrop, nextUp.poster, nextUp.thumbnail)
+            firstNonBroken(nextUp.backdrop, nextUp.poster)
         useEpisodeThumbnails -> firstNonBroken(
             (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail,
             progress?.backdrop,
@@ -381,8 +386,7 @@ internal fun continueWatchingImageModel(
         )
         else -> firstNonBroken(
             progress?.backdrop,
-            progress?.poster,
-            (item as? ContinueWatchingItem.InProgress)?.episodeThumbnail
+            progress?.poster
         )
     }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/components/ContinueWatchingImageModelTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/components/ContinueWatchingImageModelTest.kt
@@ -1,0 +1,189 @@
+package com.nuvio.tv.ui.components
+
+import com.nuvio.tv.domain.model.ContinueWatchingCardStyle
+import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.ui.screens.home.ContinueWatchingItem
+import com.nuvio.tv.ui.screens.home.NextUpInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ContinueWatchingImageModelTest {
+
+    @Before
+    fun clearBrokenUrls() {
+        brokenImageUrls.clear()
+    }
+
+    private fun inProgress(
+        poster: String? = null,
+        backdrop: String? = null,
+        thumbnail: String? = null
+    ) = ContinueWatchingItem.InProgress(
+        progress = WatchProgress(
+            contentId = "tt123",
+            contentType = "series",
+            name = "Show",
+            poster = poster,
+            backdrop = backdrop,
+            logo = null,
+            videoId = "tt123:1:1",
+            season = 1,
+            episode = 1,
+            episodeTitle = "Pilot",
+            position = 60_000L,
+            duration = 600_000L,
+            lastWatched = 100L
+        ),
+        episodeThumbnail = thumbnail
+    )
+
+    private fun nextUp(
+        poster: String? = null,
+        backdrop: String? = null,
+        thumbnail: String? = null,
+        hasAired: Boolean = true
+    ) = ContinueWatchingItem.NextUp(
+        info = NextUpInfo(
+            contentId = "tt123",
+            contentType = "series",
+            name = "Show",
+            poster = poster,
+            backdrop = backdrop,
+            logo = null,
+            videoId = "tt123:1:2",
+            season = 1,
+            episode = 2,
+            episodeTitle = "Next",
+            thumbnail = thumbnail,
+            hasAired = hasAired,
+            lastWatched = 100L,
+            sortTimestamp = 100L
+        )
+    )
+
+    @Test
+    fun `poster style does not fall back to the episode thumbnail before artwork hydrates`() {
+        val item = inProgress(poster = null, backdrop = null, thumbnail = "thumb.jpg")
+
+        assertNull(
+            continueWatchingImageModel(item, useEpisodeThumbnails = false, preferPosterArtwork = true)
+        )
+    }
+
+    @Test
+    fun `poster style does not fall back to the thumbnail when the poster url is broken`() {
+        brokenImageUrls.add("poster.jpg")
+        val item = inProgress(poster = "poster.jpg", backdrop = null, thumbnail = "thumb.jpg")
+
+        assertNull(
+            continueWatchingImageModel(item, useEpisodeThumbnails = false, preferPosterArtwork = true)
+        )
+    }
+
+    @Test
+    fun `landscape style with thumbnails off does not fall back to the thumbnail`() {
+        val item = inProgress(poster = null, backdrop = null, thumbnail = "thumb.jpg")
+
+        assertNull(
+            continueWatchingImageModel(item, useEpisodeThumbnails = false, preferPosterArtwork = false)
+        )
+    }
+
+    @Test
+    fun `next up with thumbnails off does not fall back to the thumbnail`() {
+        val item = nextUp(poster = null, backdrop = null, thumbnail = "thumb.jpg")
+
+        assertNull(
+            continueWatchingImageModel(item, useEpisodeThumbnails = false, preferPosterArtwork = false)
+        )
+    }
+
+    @Test
+    fun `unaired next up with thumbnails off does not fall back to the thumbnail`() {
+        val item = nextUp(poster = null, backdrop = null, thumbnail = "thumb.jpg", hasAired = false)
+
+        assertNull(
+            continueWatchingImageModel(item, useEpisodeThumbnails = false, preferPosterArtwork = false)
+        )
+    }
+
+    @Test
+    fun `poster style still prefers poster then backdrop`() {
+        val withPoster = inProgress(poster = "poster.jpg", backdrop = "backdrop.jpg", thumbnail = "thumb.jpg")
+        assertEquals(
+            "poster.jpg",
+            continueWatchingImageModel(withPoster, useEpisodeThumbnails = false, preferPosterArtwork = true)
+        )
+
+        val backdropOnly = inProgress(poster = null, backdrop = "backdrop.jpg", thumbnail = "thumb.jpg")
+        assertEquals(
+            "backdrop.jpg",
+            continueWatchingImageModel(backdropOnly, useEpisodeThumbnails = false, preferPosterArtwork = true)
+        )
+    }
+
+    @Test
+    fun `thumbnails on still outrank poster art`() {
+        val item = inProgress(poster = "poster.jpg", backdrop = "backdrop.jpg", thumbnail = "thumb.jpg")
+
+        assertEquals(
+            "thumb.jpg",
+            continueWatchingImageModel(item, useEpisodeThumbnails = true, preferPosterArtwork = true)
+        )
+    }
+
+    @Test
+    fun `landscape style with thumbnails on still prefers the thumbnail`() {
+        val item = inProgress(poster = "poster.jpg", backdrop = "backdrop.jpg", thumbnail = "thumb.jpg")
+
+        assertEquals(
+            "thumb.jpg",
+            continueWatchingImageModel(item, useEpisodeThumbnails = true, preferPosterArtwork = false)
+        )
+    }
+
+    @Test
+    fun `unaired next up with thumbnails on keeps the thumbnail as a last resort`() {
+        val item = nextUp(poster = null, backdrop = null, thumbnail = "thumb.jpg", hasAired = false)
+
+        assertEquals(
+            "thumb.jpg",
+            continueWatchingImageModel(item, useEpisodeThumbnails = true, preferPosterArtwork = false)
+        )
+    }
+
+    @Test
+    fun `poster style disables episode thumbnails regardless of the setting`() {
+        assertFalse(
+            continueWatchingUsesEpisodeThumbnails(ContinueWatchingCardStyle.POSTER, useEpisodeThumbnails = true)
+        )
+        assertTrue(
+            continueWatchingUsesEpisodeThumbnails(ContinueWatchingCardStyle.CARD, useEpisodeThumbnails = true)
+        )
+        assertTrue(
+            continueWatchingUsesEpisodeThumbnails(ContinueWatchingCardStyle.WIDE, useEpisodeThumbnails = true)
+        )
+    }
+
+    @Test
+    fun `poster cards never blur because the thumbnail is never resolved`() {
+        val item = nextUp(poster = null, backdrop = null, thumbnail = "thumb.jpg")
+        val gated = continueWatchingUsesEpisodeThumbnails(
+            ContinueWatchingCardStyle.POSTER,
+            useEpisodeThumbnails = true
+        )
+
+        assertFalse(
+            continueWatchingShouldBlur(
+                item = item,
+                blurUnwatchedEpisodes = true,
+                useEpisodeThumbnails = gated,
+                preferPosterArtwork = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`continueWatchingImageModel` demoted the episode thumbnail to last when thumbnails were off instead of dropping it, so it still resolved whenever poster and backdrop were both unavailable. Now removed from the chain entirely in that case.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Trakt progress rows are built with `poster = null` and `backdrop = null` and hydrate artwork asynchronously, so until hydration landed the thumbnail was the only non-null candidate. Same result permanently for any item whose poster URL ends up in `brokenImageUrls`. The style gate from da9c3bc2 was correct; the leak was downstream in the fallback ordering.

## Issue or approval

Fixes #3026

## Reproduction steps

1. Trakt signed in, CW populated from provider progress.
2. CW card style set to Poster.
3. Relaunch the app, or clear the CW cache.
4. Before: episode thumbnail shows instead of poster art, inconsistently per item. After: poster art, with the standard placeholder during hydration.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Fallback ordering in `continueWatchingImageModel` only. Three branches leaked past the same gate and are corrected together: poster/wide, landscape with thumbnails off, and unaired next-up.

Unchanged: the gate itself, thumbnails-on ordering, `fallbackImageModel`, `continueWatchingShouldBlur`, movies, and `AndroidTvChannelSyncService`.

## Testing

`ContinueWatchingImageModelTest`, 11 cases covering the gated-off branches, the broken-URL path, and the unchanged thumbnails-on ordering.

`./gradlew testDebugUnitTest --tests '*ContinueWatchingImageModelTest*'`

Manual: Box S 3rd gen, Android 14, poster style, across relaunch and cache clear, compared against the Release APK.

## Screenshots / Video
Artwork swap only, covered by the reproduction steps and unit tests.

## Breaking changes

None.

## Linked issues

Fixes #3026