### PR TITLE
fix: exit player on back press when skip intro button is hidden

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -275,7 +275,7 @@ fun PlayerScreen(
             if (skipButtonActuallyVisible) {
                 runCatching { skipIntroFocusRequester.requestFocus() }
             }
-        } else if (uiState.activeSkipInterval != null && !uiState.skipIntervalDismissed && !uiState.showControls) {
+        } else if (skipButtonActuallyVisible && !uiState.showControls) {
             viewModel.onEvent(PlayerEvent.OnDismissSkipIntro)
         } else if (uiState.postPlayMode is PostPlayMode.StillWatching) {
             viewModel.onEvent(PlayerEvent.OnDismissStillWatchingPrompt)


### PR DESCRIPTION
## Summary

Fix an issue where pressing the Back button does not close the player when the Skip Intro button is auto-hidden during an active skip interval. Changed `handleBackPress` in `PlayerScreen.kt` to check `skipButtonActuallyVisible` instead of checking `activeSkipInterval != null && !skipIntervalDismissed`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When an intro/outro segment starts, `activeSkipInterval` is set and the Skip Intro button appears. After 10 seconds, the button automatically fades out (`autoHidden = true`, `skipButtonActuallyVisible = false`). However, while playback is still inside the intro interval, `activeSkipInterval` remains non-null and `skipIntervalDismissed` remains false.

Previously, `handleBackPress` checked:
```kotlin
} else if (uiState.activeSkipInterval != null && !uiState.skipIntervalDismissed && !uiState.showControls) {
    viewModel.onEvent(PlayerEvent.OnDismissSkipIntro)
}
```
This caused the Back key to be swallowed to dismiss an already hidden button rather than exiting the player. With this fix, `handleBackPress` checks `skipButtonActuallyVisible && !uiState.showControls`, allowing the player to exit immediately on Back press once the button is hidden.

## Issue or approval

reported on discord

## Reproduction steps

1. Play any video or episode with an active intro segment (e.g., anime with AniSkip or content with IntroDB).
2. Wait 10 seconds for the Skip Intro button to automatically hide while still inside the intro interval.
3. Ensure player controls/OSD are hidden.
4. Press the Back button on the remote/keyboard.
5. **Expected behavior:** The player should close and return to the previous screen.
6. **Previous behavior:** The player did not close on the first Back press because the event was consumed to dismiss the already hidden button.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI changed only to fix a documented glitch/bug
- [ ] No behavior change
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- This PR only updates the condition in `handleBackPress` in `PlayerScreen.kt`.
- It does not modify button UI, auto-hide timings, skip interval detection, or any other overlay behavior.

## Testing

- Verified Kotlin compilation via `./gradlew :app:compileFullDebugKotlin` (Build successful).
- Validated that `skipButtonActuallyVisible` properly tracks visible state when button appears, auto-hides after 10s, or is manually dismissed.
- Verified that back press behavior when controls are visible, when side panels are open, and when the button is visible remain completely intact.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

reported on discord
