### PR TITLE
fix(player): sync local plugin search pause with player stream lifecycle

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -151,6 +151,7 @@ internal fun PlayerRuntimeController.buildSourceRequestKey(type: String, videoId
 }
 
 internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
+    streamRepository.setLocalPluginSearchPaused(false)
     val type: String
     val vid: String
     val seasonArg: Int?
@@ -368,6 +369,7 @@ internal fun PlayerRuntimeController.dismissSourcesPanel() {
     sourceStreamsScope = null
     sourceStreamsJob = null
     sourceChipErrorDismissJob?.cancel()
+    streamRepository.setLocalPluginSearchPaused(true)
     _uiState.update {
         it.copy(
             showSourcesPanel = false,
@@ -660,6 +662,7 @@ internal fun PlayerRuntimeController.switchToSourceStream(
     sourceStreamsScope?.cancel()
     sourceStreamsScope = null
     sourceStreamsJob = null
+    streamRepository.setLocalPluginSearchPaused(true)
     if (openExternalStreamInBrowser(stream = stream, fromEpisodePanel = false)) {
         return
     }
@@ -809,6 +812,7 @@ internal fun PlayerRuntimeController.dismissEpisodesPanel() {
     episodeStreamsScope?.cancel()
     episodeStreamsScope = null
     episodeStreamsJob = null
+    streamRepository.setLocalPluginSearchPaused(true)
     _uiState.update {
         it.copy(
             showEpisodesPanel = false,
@@ -972,6 +976,7 @@ internal fun PlayerRuntimeController.buildEpisodeRequestKey(type: String, video:
 }
 
 internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRefresh: Boolean) {
+    streamRepository.setLocalPluginSearchPaused(false)
     val type = contentType
     if (type.isNullOrBlank()) {
         _uiState.update { it.copy(episodeStreamsError = context.getString(com.nuvio.tv.R.string.player_stream_error_missing_content_type)) }
@@ -1373,6 +1378,7 @@ private fun PlayerRuntimeController.switchToEpisodeStreamCommon(
     nextEpisodeAutoPlayJob = null
     stillWatchingPromptJob?.cancel()
     stillWatchingPromptJob = null
+    streamRepository.setLocalPluginSearchPaused(true)
     flushPlaybackSnapshotForSwitchOrExit()
 
     val targetVideo = forcedTargetVideo
@@ -1538,6 +1544,7 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = scope.launch {
         try {
+            streamRepository.setLocalPluginSearchPaused(false)
             val playerSettings = playerSettingsDataStore.playerSettings.first()
             val shouldAutoSelectInManualMode =
                 playerSettings.streamAutoPlayMode == StreamAutoPlayMode.MANUAL &&


### PR DESCRIPTION
## Summary

Fixes an issue where local plugin stream querying is blocked in the player (source streams sidebar, episode stream picker, and auto-play / next episode transitions). Synchronizes `streamRepository.setLocalPluginSearchPaused` with player search and playback lifecycle events.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

In commit `5ee893401366b31435739308056c2014af0395f9`), `setLocalPluginSearchPaused(true)` was introduced to suspend local JS scraper tasks during video playback. However, because it was only unpaused upon exiting to `StreamScreen`, `localPluginSearchPaused` remained `true` while inside the player. 

As a result, when users opened the player's Stream Sources sidebar, opened the episode streams picker, or when auto-play attempted to fetch the next episode, the plugin query coroutine hung indefinitely on `localPluginSearchPaused.transformLatest { ... }.first()`. This blocked plugin stream discovery and prevented the stream search channel/flow from completing.

## Issue or approval

None. 

## Reproduction steps

1. Install and enable a local plugin scraper (e.g. JS scraper).
2. Start playing a movie or series episode.
3. Open the player stream sources sidebar (or wait for episode end auto-play / open episode stream picker).
4. Observe that plugin streams never arrive and the search loader hangs / plugin streams fail to load.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only unpauses local plugin search during active player search queries (`loadSourceStreams`, `loadStreamsForEpisode`, `playNextEpisode`) and pauses during active playback and panel dismissals. Does not alter `StreamSearchSessionCache`, StreamScreen refresh logic, or add extra behavior changes.

## Testing

- Verified plugin search unpauses when opening player stream sidebar (`loadSourceStreams`) and pauses on stream switch (`switchToSourceStream`) or panel dismissal (`dismissSourcesPanel`).
- Verified next episode stream query unpauses in `playNextEpisode` and pauses in `switchToEpisodeStreamCommon`.
- Verified episode stream picker (`loadStreamsForEpisode`) queries plugin streams properly.
- Code logic reviewed against `StreamSearchSessionCache` and `StreamScreenViewModel` lifecycle.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues
None. 
