### PR TITLE
enable embedded subtitle styles and preserve spans on merged cues

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1655,7 +1655,7 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
             )
         )
 
-        setApplyEmbeddedStyles(false)
+        setApplyEmbeddedStyles(true)
 
         val bottomPaddingFraction =
             (0.06f + (subtitleStyle.verticalOffset / 250f)).coerceIn(0f, 0.4f)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSubtitleUtils.kt
@@ -1,5 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
+import android.text.SpannableStringBuilder
+import android.text.Spanned
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.text.Cue
 import com.nuvio.tv.ui.util.LANGUAGE_OVERRIDES
@@ -217,7 +219,20 @@ internal object PlayerSubtitleUtils {
         if (cues.size <= 1 || !cues.all { it.bitmap == null && it.line == Cue.DIMEN_UNSET }) {
             return cues
         }
-        val text = cues.mapNotNull { it.text }.filter { it.isNotBlank() }.distinct().joinToString("\n")
-        return if (text.isBlank()) emptyList() else listOf(cues[0].buildUpon().setText(text).build())
+        val validTexts = cues.mapNotNull { it.text }.filter { it.isNotBlank() }
+        if (validTexts.isEmpty()) return emptyList()
+
+        val hasSpanned = validTexts.any { it is Spanned }
+        val mergedText: CharSequence = if (hasSpanned) {
+            val builder = SpannableStringBuilder()
+            for (i in validTexts.indices) {
+                if (i > 0) builder.append('\n')
+                builder.append(validTexts[i])
+            }
+            builder
+        } else {
+            validTexts.distinct().joinToString("\n")
+        }
+        return listOf(cues[0].buildUpon().setText(mergedText).build())
     }
 }


### PR DESCRIPTION
## Summary

- Enables embedded subtitle styles (`setApplyEmbeddedStyles(true)`) on `SubtitleView` in `PlayerScreen.kt` so that standard subtitle tags (such as `<i>` italics, `<b>` bold, and `<u>` underline) are properly rendered on screen.
- Updates `PlayerSubtitleUtils.mergeOverlappingCues` to preserve `Spanned` formatting styles using `SpannableStringBuilder` when simultaneously active cues overlap.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

- `SubtitleView.setApplyEmbeddedStyles(false)` was previously stripping all embedded style formatting tags from SRT/VTT subtitles, causing dialogues marked with `<i>...</i>` or `<b>...</b>` to be rendered as plain text without italics or bold formatting.
- In addition, when two cues were active at the same time, `mergeOverlappingCues` converted `Spanned` text into a plain `String`, stripping spans.

## Issue or approval

Fixes subtitle formatting tags (`<i>`, `<b>`, `<u>`) being stripped and ignored during ExoPlayer subtitle rendering.

## Reproduction steps

1. Play a video with an SRT subtitle containing `<i>...</i>` or `<b>...</b>` tags (e.g. *Toy Story* with Polish or English subtitles at 04:07).
2. Observe that without this change, italicized words (`<i>Przyjaciółki na zawsze, partnerko.</i>` / `<i>Friends forever, partner.</i>`) were displayed as plain regular text.
3. With this change, the subtitle text renders in proper italics/bold on screen.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Custom subtitle font size preferences (`setApplyEmbeddedFontSizes(false)` remains `false`) are preserved so external subtitle files cannot override the user's TV font size setting.
- User-configured text color, outline, background box, and vertical offset settings in `CaptionStyleCompat` remain fully active.
- Hebrew/Arabic RTL handling (`PlayerSubtitleRtlFix`) and libass / MPV playback engines are intentionally unaffected.

## Testing

- Verified with unit tests (`./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.player.PlayerSubtitle*"`).
- Verified on video playback with sample SRT subtitle files containing italics and bold formatting tags.
- Verified that overlapping multi-line subtitle cues preserve `Spanned` style formatting.

## Screenshots / Video

- Verified on screen with italic subtitle: `Przyjaciółki na zawsze, partnerko.`
<img width="320" height="53" alt="image" src="https://github.com/user-attachments/assets/343a2505-04db-4556-8626-19b98bc07537" />


## Breaking changes

None.

## Linked issues

Fixes subtitle formatting tags ignored in ExoPlayer SubtitleView.
