### PR TITLE
fix(trailer): restore high-resolution trailer playback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
@@ -29,7 +29,7 @@ private const val EXTRACTOR_TIMEOUT_MS = 30_000L
 private const val DEFAULT_USER_AGENT =
     "Mozilla/5.0 (Linux; Android 12; Android TV) AppleWebKit/537.36 " +
         "(KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
-private const val PREFERRED_SEPARATE_CLIENT = "android_vr"
+private const val PREFERRED_SEPARATE_CLIENT = "visionos"
 
 private val VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
 private val API_KEY_REGEX = Regex("\"INNERTUBE_API_KEY\":\"([^\"]+)\"")
@@ -85,20 +85,18 @@ private val DEFAULT_HEADERS = mapOf(
 
 private val CLIENTS = listOf(
     YouTubeClient(
-        key = "android_vr",
-        id = "28",
-        version = "1.56.21",
-        userAgent = "com.google.android.apps.youtube.vr.oculus/1.56.21 " +
-            "(Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1) gzip",
+        key = "visionos",
+        id = "101",
+        version = "1.02",
+        userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 " +
+            "(KHTML, like Gecko) Version/26.0 Safari/605.1.15",
         context = mapOf(
-            "clientName" to "ANDROID_VR",
-            "clientVersion" to "1.56.21",
-            "deviceMake" to "Oculus",
-            "deviceModel" to "Quest 3",
-            "osName" to "Android",
-            "osVersion" to "12",
-            "platform" to "MOBILE",
-            "androidSdkVersion" to 32,
+            "clientName" to "VISIONOS",
+            "clientVersion" to "1.02",
+            "deviceMake" to "Apple",
+            "deviceModel" to "RealityDevice17,1",
+            "osName" to "visionOS",
+            "osVersion" to "26.5.23O471",
             "hl" to "en",
             "gl" to "US"
         ),


### PR DESCRIPTION
## Summary

Trailers were playing at ~360p because the preferred in-app YouTube client `android_vr` now
returns `LOGIN_REQUIRED`, so the adaptive path fails its reachability probe and the extractor
falls back to the progressive stream (itag 18). This replaces `android_vr` with the `visionos`
client — currently token-free and returning direct (non-ciphered) URLs — and points
`PREFERRED_SEPARATE_CLIENT` at it. No logic changes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`InAppYouTubeExtractor` tries several innertube clients and prefers the token-free `android_vr`
for the adaptive (separate video+audio) path. YouTube has tightened attestation, and `android_vr`
now returns `LOGIN_REQUIRED`; `android`/`ios` still return high-res URLs but those URLs fail the
extractor's reachability probe (they are PO-token gated). With no reachable adaptive pair, the
extractor falls through to the progressive itag-18 stream at ~360p.

The `visionos` client is currently both token-free (its stream URLs are reachable without a PO
token) and direct-URL (non-ciphered, so the existing extractor can use them). Switching the
preferred client to `visionos` lets the existing selection resolve a reachable high-resolution
pair. Measured across ~15 trailers on a Ugoos AM9 Pro: `android_vr` returned `LOGIN_REQUIRED`,
`android`/`ios` high-res URLs failed the reachability probe, and `visionos` was reachable in every
case, restoring 1080p (and higher where the source offers it).

## Issue or approval

Fixes #3079 

## Reproduction steps

1. Open the app.
2. Navigate to any movie or series that has a trailer.
3. Let the trailer autoplay on the Focused Poster / detail screen.
4. Observe it plays at ~360p instead of high resolution.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Swaps the one gated client (`android_vr`) for a working token-free client (`visionos`) and repoints
`PREFERRED_SEPARATE_CLIENT`. No selection-logic changes, no new dependencies, no other clients or
behaviour touched. `android`/`ios` remain as fallbacks exactly as before.

## Testing

Built `assembleFullDebug` and installed on a Ugoos AM9 Pro (Android TV, arm64-v8a).
- Before: trailers played at ~360p.
- After: trailers play at the source's resolution — 1080p (and 2160p where offered); titles that
  only exist at ≤720p at the source play at their own maximum, as expected.
- Verified across ~15 trailers via on-screen resolution and logcat. 
[trailer-diag.txt](https://github.com/user-attachments/files/31182890/trailer-diag.txt)

## Screenshots / Video

Not a UI change. 

## Breaking changes

None

## Linked issues

Fixes #3079 