### PR TITLE
fix upcoming stuck, image loading, movie watched badge, tmdb browse focus

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -131,6 +131,8 @@ class WatchProgressRepositoryImpl @Inject constructor(
         replay = 1,
         extraBufferCapacity = 16
     )
+    private val optimisticWatchedMovieAdditions = MutableStateFlow<Set<String>>(emptySet())
+    private val optimisticWatchedMovieRemovals = MutableStateFlow<Set<String>>(emptySet())
     private val metadataMutex = Mutex()
     private val inFlightMetadataKeys = mutableSetOf<String>()
     private val metadataHydrationLimit = 30
@@ -550,7 +552,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
 
     @OptIn(FlowPreview::class)
     override fun observeWatchedMovieIds(): Flow<Set<String>> {
-        return activeProgressProviderFlow()
+        val baseFlow = activeProgressProviderFlow()
             .flatMapLatest { provider ->
                 if (provider != null) {
                     provider.watchedMovieIds
@@ -578,7 +580,31 @@ class WatchProgressRepositoryImpl @Inject constructor(
                     }.debounce(500)
                 }
             }
-            .distinctUntilChanged()
+        return combine(
+            baseFlow,
+            optimisticWatchedMovieAdditions,
+            optimisticWatchedMovieRemovals
+        ) { base, additions, removals ->
+            (base + additions) - removals
+        }.distinctUntilChanged()
+    }
+
+    override fun applyOptimisticWatchedMovie(ids: Set<String>, add: Boolean) {
+        if (add) {
+            optimisticWatchedMovieAdditions.update { it + ids }
+            optimisticWatchedMovieRemovals.update { it - ids }
+        } else {
+            optimisticWatchedMovieRemovals.update { it + ids }
+            optimisticWatchedMovieAdditions.update { it - ids }
+        }
+    }
+
+    override fun revertOptimisticWatchedMovie(ids: Set<String>, add: Boolean) {
+        if (add) {
+            optimisticWatchedMovieAdditions.update { it - ids }
+        } else {
+            optimisticWatchedMovieRemovals.update { it - ids }
+        }
     }
 
     override suspend fun getWatchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>> {

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -71,6 +71,19 @@ interface WatchProgressRepository {
     fun observeWatchedMovieIds(): Flow<Set<String>>
 
     /**
+     * Apply an optimistic addition or removal to the watched movie IDs set.
+     * Used for immediate badge feedback before the backend confirms the change.
+     * Pass [add] = true to mark as watched, false to unmark.
+     * The [ids] should include all ID variants for the content (e.g. "tmdb:123", "tt1234567").
+     */
+    fun applyOptimisticWatchedMovie(ids: Set<String>, add: Boolean) {}
+
+    /**
+     * Revert a previous optimistic update (e.g. on failure).
+     */
+    fun revertOptimisticWatchedMovie(ids: Set<String>, add: Boolean) {}
+
+    /**
      * Returns per-show watched episodes from the active source.
      * Empty map when no data is available.
      */

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsController.kt
@@ -155,6 +155,7 @@ class PosterOptionsController @Inject constructor(
             _state.update { current ->
                 current.copy(
                     target = canonical,
+                    originalItemId = item.id,
                     addonBaseUrl = addonBaseUrl.orEmpty(),
                     isInLibrary = initialIsInLibrary,
                     isWatched = initialIsWatched,
@@ -405,10 +406,20 @@ class PosterOptionsController @Inject constructor(
         if (state.isWatchedPending) return
         val scope = this.scope ?: return
 
+        val currentlyWatched = state.isWatched
+        // Collect all known ID variants: original UI id (e.g. "tmdb:123"),
+        // canonical id (e.g. "tt1979376"), and imdbId field if available.
+        val optimisticIds = buildSet {
+            add(item.id)
+            state.originalItemId?.takeIf { it != item.id }?.let(::add)
+            item.imdbId?.takeIf(String::isNotBlank)?.let(::add)
+        }
+
+        watchProgressRepository.applyOptimisticWatchedMovie(optimisticIds, add = !currentlyWatched)
+
         _state.update { it.copy(isWatchedPending = true) }
         scope.launch {
             val canonical = ensureCanonical() ?: return@launch
-            val currentlyWatched = _state.value.isWatched
             runCatching {
                 if (currentlyWatched) {
                     watchProgressRepository.removeFromHistory(canonical.id, videoId = canonical.imdbId)
@@ -417,6 +428,8 @@ class PosterOptionsController @Inject constructor(
                 }
             }.onFailure { error ->
                 Log.w(TAG, "Failed to toggle watched for ${canonical.id}: ${error.message}")
+                // Revert optimistic update on failure
+                watchProgressRepository.revertOptimisticWatchedMovie(optimisticIds, add = !currentlyWatched)
             }
             _state.update { it.copy(isWatchedPending = false) }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsState.kt
@@ -9,6 +9,8 @@ import com.nuvio.tv.core.tracking.TrackingMembershipRemovalConfirmation
 @Immutable
 data class PosterOptionsState(
     val target: MetaPreview? = null,
+    /** The original item ID before canonicalization (e.g. "tmdb:123"). Used for optimistic badge updates. */
+    val originalItemId: String? = null,
     val addonBaseUrl: String = "",
     val isInLibrary: Boolean = false,
     val isWatched: Boolean = false,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -1575,7 +1575,34 @@ private suspend fun HomeViewModel.enrichVisibleContinueWatchingItems(
                                 overlay.season == item.info.season &&
                                 overlay.episode == item.info.episode
                             ) {
-                                item.copy(info = overlay)
+                                // Recalculate hasAired/isReleaseAlert from current time
+                                // so overlays cached while an episode was unaired don't
+                                // keep it stuck in "upcoming" after the air date passes.
+                                val freshHasAired = hasEpisodeAired(overlay.released, fallback = overlay.hasAired)
+                                if (freshHasAired != overlay.hasAired) {
+                                    val releaseTimestamp = parseEpisodeReleaseInstant(overlay.released)?.toEpochMilli()
+                                    val nowMs = System.currentTimeMillis()
+                                    val sixtyDaysMs = 60L * 24 * 60 * 60 * 1000
+                                    val isReleaseAlert = freshHasAired &&
+                                        releaseTimestamp != null &&
+                                        releaseTimestamp > overlay.lastWatched &&
+                                        (nowMs - releaseTimestamp) < sixtyDaysMs
+                                    val isNewSeasonRelease = isReleaseAlert &&
+                                        overlay.seedSeason != null &&
+                                        overlay.season != overlay.seedSeason
+                                    val updatedOverlay = overlay.copy(
+                                        hasAired = freshHasAired,
+                                        airDateLabel = if (freshHasAired) null else overlay.airDateLabel,
+                                        sortTimestamp = if (isReleaseAlert && releaseTimestamp != null) releaseTimestamp else overlay.lastWatched,
+                                        releaseTimestamp = releaseTimestamp,
+                                        isReleaseAlert = isReleaseAlert,
+                                        isNewSeasonRelease = isNewSeasonRelease
+                                    )
+                                    cwEnrichedNextUpOverlay[item.info.contentId] = updatedOverlay
+                                    item.copy(info = updatedOverlay)
+                                } else {
+                                    item.copy(info = overlay)
+                                }
                             } else {
                                 enrichNextUpItem(item, metaCache, debug)
                             }
@@ -2661,25 +2688,52 @@ private suspend fun HomeViewModel.applyContinueWatchingEnrichmentOverlay(
                         cwEnrichedNextUpOverlay.remove(item.info.contentId)
                         return@map item
                     }
-                    if (overlay.sortTimestamp != item.info.sortTimestamp) sortChanged = true
+                    // Recalculate hasAired from current time so stale overlays
+                    // don't keep episodes stuck in "upcoming".
+                    val freshHasAired = hasEpisodeAired(overlay.released, fallback = overlay.hasAired)
+                    val effectiveOverlay = if (freshHasAired != overlay.hasAired) {
+                        val releaseTimestamp = parseEpisodeReleaseInstant(overlay.released)?.toEpochMilli()
+                        val nowMs = System.currentTimeMillis()
+                        val sixtyDaysMs = 60L * 24 * 60 * 60 * 1000
+                        val isReleaseAlert = freshHasAired &&
+                            releaseTimestamp != null &&
+                            releaseTimestamp > overlay.lastWatched &&
+                            (nowMs - releaseTimestamp) < sixtyDaysMs
+                        val isNewSeasonRelease = isReleaseAlert &&
+                            overlay.seedSeason != null &&
+                            overlay.season != overlay.seedSeason
+                        val updated = overlay.copy(
+                            hasAired = freshHasAired,
+                            airDateLabel = if (freshHasAired) null else overlay.airDateLabel,
+                            sortTimestamp = if (isReleaseAlert && releaseTimestamp != null) releaseTimestamp else overlay.lastWatched,
+                            releaseTimestamp = releaseTimestamp,
+                            isReleaseAlert = isReleaseAlert,
+                            isNewSeasonRelease = isNewSeasonRelease
+                        )
+                        cwEnrichedNextUpOverlay[item.info.contentId] = updated
+                        updated
+                    } else {
+                        overlay
+                    }
+                    if (effectiveOverlay.sortTimestamp != item.info.sortTimestamp) sortChanged = true
                     item.copy(info = item.info.copy(
-                        name = overlay.name.takeIf { it.isNotBlank() } ?: item.info.name,
-                        episodeTitle = overlay.episodeTitle ?: item.info.episodeTitle,
-                        episodeDescription = overlay.episodeDescription ?: item.info.episodeDescription,
-                        thumbnail = overlay.thumbnail ?: item.info.thumbnail,
-                        poster = overlay.poster ?: item.info.poster,
-                        backdrop = overlay.backdrop ?: item.info.backdrop,
-                        logo = overlay.logo ?: item.info.logo,
-                        imdbRating = overlay.imdbRating ?: item.info.imdbRating,
-                        genres = overlay.genres.ifEmpty { item.info.genres },
-                        releaseInfo = overlay.releaseInfo ?: item.info.releaseInfo,
-                        sortTimestamp = overlay.sortTimestamp,
-                        isReleaseAlert = overlay.isReleaseAlert,
-                        isNewSeasonRelease = overlay.isNewSeasonRelease,
-                        hasAired = overlay.hasAired,
-                        airDateLabel = overlay.airDateLabel ?: item.info.airDateLabel,
-                        releaseTimestamp = overlay.releaseTimestamp ?: item.info.releaseTimestamp,
-                        contentLanguage = overlay.contentLanguage ?: item.info.contentLanguage
+                        name = effectiveOverlay.name.takeIf { it.isNotBlank() } ?: item.info.name,
+                        episodeTitle = effectiveOverlay.episodeTitle ?: item.info.episodeTitle,
+                        episodeDescription = effectiveOverlay.episodeDescription ?: item.info.episodeDescription,
+                        thumbnail = effectiveOverlay.thumbnail ?: item.info.thumbnail,
+                        poster = effectiveOverlay.poster ?: item.info.poster,
+                        backdrop = effectiveOverlay.backdrop ?: item.info.backdrop,
+                        logo = effectiveOverlay.logo ?: item.info.logo,
+                        imdbRating = effectiveOverlay.imdbRating ?: item.info.imdbRating,
+                        genres = effectiveOverlay.genres.ifEmpty { item.info.genres },
+                        releaseInfo = effectiveOverlay.releaseInfo ?: item.info.releaseInfo,
+                        sortTimestamp = effectiveOverlay.sortTimestamp,
+                        isReleaseAlert = effectiveOverlay.isReleaseAlert,
+                        isNewSeasonRelease = effectiveOverlay.isNewSeasonRelease,
+                        hasAired = effectiveOverlay.hasAired,
+                        airDateLabel = effectiveOverlay.airDateLabel ?: item.info.airDateLabel,
+                        releaseTimestamp = effectiveOverlay.releaseTimestamp ?: item.info.releaseTimestamp,
+                        contentLanguage = effectiveOverlay.contentLanguage ?: item.info.contentLanguage
                     ))
                 }
                 is ContinueWatchingItem.InProgress -> {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.BringIntoViewSpec
 import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.foundation.layout.Arrangement
@@ -191,6 +192,7 @@ private fun TmdbEntityBrowseContent(
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val localDensity = LocalDensity.current
     val focusedItemIndexByRail = remember { mutableMapOf<String, Int>() }
+    val railFocusRequesters = remember { mutableMapOf<String, MutableMap<Int, FocusRequester>>() }
     val railListStates = remember { mutableMapOf<String, LazyListState>() }
     val railsListState = rememberLazyListState()
     val firstCardFocusRequester = remember(data.header.id) { FocusRequester() }
@@ -287,6 +289,8 @@ private fun TmdbEntityBrowseContent(
                                         prefetchStrategy = LazyListPrefetchStrategy(nestedPrefetchItemCount = 2)
                                     )
                                 },
+                                itemFocusRequesters = railFocusRequesters.getOrPut(railKey) { mutableMapOf() },
+                                rememberedFocusedIndex = rememberedFocusedIndex,
                                 posterCardStyle = posterCardStyle,
                                 watchedMovieIds = watchedMovieIds,
                                 watchedSeriesIds = watchedSeriesIds,
@@ -453,6 +457,8 @@ private fun EntityRailRow(
     initialFocusRequester: FocusRequester?,
     shouldRequestInitialFocus: Boolean,
     rowListState: LazyListState,
+    itemFocusRequesters: MutableMap<Int, FocusRequester>,
+    rememberedFocusedIndex: Int,
     posterCardStyle: PosterCardStyle,
     watchedMovieIds: Set<String>,
     watchedSeriesIds: Set<String>,
@@ -465,15 +471,10 @@ private fun EntityRailRow(
     onItemLongPress: (MetaPreview) -> Unit = {},
     onLoadMore: (TmdbEntityMediaType, TmdbEntityRailType) -> Unit
 ) {
-    val focusRequesters = remember(rail.mediaType, rail.railType) {
-        mutableMapOf<String, FocusRequester>()
-    }
     val restoreFocusRequester = remember(rail.mediaType, rail.railType) { FocusRequester() }
     var restorePending by remember(rail.mediaType, rail.railType) { mutableStateOf(false) }
-    val itemIds = remember(rail.items) { rail.items.map { it.id }.toSet() }
-    focusRequesters.keys.retainAll(itemIds)
     val firstItemFocusRequester = initialFocusRequester
-        ?: remember(rail.mediaType, rail.railType) { FocusRequester() }
+        ?: itemFocusRequesters.getOrPut(0) { FocusRequester() }
     var lastLoadMoreRequestTotal by remember(rail.mediaType, rail.railType) { mutableIntStateOf(-1) }
 
     LaunchedEffect(shouldRequestInitialFocus, firstItemFocusRequester, rail.items.firstOrNull()?.id) {
@@ -566,8 +567,15 @@ private fun EntityRailRow(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRestorer {
-                        if (restorePending) restoreFocusRequester else firstItemFocusRequester
-                    },
+                        if (restorePending) {
+                            restoreFocusRequester
+                        } else {
+                            itemFocusRequesters[rememberedFocusedIndex]
+                                ?: itemFocusRequesters[0]
+                                ?: firstItemFocusRequester
+                        }
+                    }
+                    .focusGroup(),
                 state = rowListState,
                 contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.xxxl),
                 horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
@@ -577,11 +585,10 @@ private fun EntityRailRow(
                     key = { _, item -> item.id }
                 ) { itemIndex, item ->
                     val isRestoreTarget = item.id == restoreItemId
-                    val isFirstItem = itemIndex == 0
                     val requester = when {
                         isRestoreTarget -> restoreFocusRequester
-                        isFirstItem -> firstItemFocusRequester
-                        else -> focusRequesters.getOrPut(item.id) { FocusRequester() }
+                        itemIndex == 0 -> firstItemFocusRequester
+                        else -> itemFocusRequesters.getOrPut(itemIndex) { FocusRequester() }
                     }
                     GridContentCard(
                         item = item,


### PR DESCRIPTION
## Summary

Fix two regressions:

1. Episodes stuck in "upcoming" indefinitely after their air date passes - caused by stale in-memory enrichment overlay cache not recalculating hasAired.
2. Extremely slow image loading on home screen (grey placeholders for longer time) - caused by overly aggressive memory cache reduction and decoder parallelism limit.

**Additional fixes in this PR:**

3. Watched badge not updating on movie posters in TMDB entity browse, actors view, and details screen (more like this, collections) until app restart - caused by missing optimistic update and ID mismatch after canonicalization.
4. Missing focusGroup on TMDB entity browse rails causing broken D-pad vertical navigation between rows, and missing parent-level focus requester storage causing focus reset to row start when returning to a previously scrolled rail.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. **Upcoming stuck bug**: PR #3038 introduced an in-memory overlay cache (`cwEnrichedNextUpOverlay`) that stores enriched NextUpInfo per series. When an episode is first enriched while still unaired (`hasAired=false`), the overlay is cached. On subsequent pipeline runs, the overlay is reused without recalculating `hasAired` from the current time. The episode stays "upcoming" forever until the user manually toggles TMDB dates (which clears all caches).

2. **Slow image loading**: Memory cache was reduced from 20-25% to 12-15% of app memory, and `bitmapFactoryMaxParallelism` was cut from 4 to 2. Combined with `allowHardware(false)` (bitmaps on heap instead of GPU), this causes rapid eviction and slow re-decode of posters.

3. **Movie watched badge**: `PosterOptionsController.show()` canonicalizes item ID from `tmdb:123` to IMDb (`tt1234567`) before storing as target. `toggleMovieWatched()` had no optimistic update, and after backend sync the local snapshot only contained IMDb ID - not the `tmdb:` variant the UI checks against. Badge only appeared after restart when full Simkl sync fetched all ID variants.

4. **TMDB entity browse focus**: Rails lacked `.focusGroup()` so D-pad up/down entered individual items instead of jumping between rows. Additionally, per-item FocusRequesters were stored inside the row composable via `remember` - lost when the row scrolled out of LazyColumn viewport. Returning to the row always reset focus to index 0.

## Issue or approval

Regression introduced by PR #3038 (overlay cache) and commit #a22156381 (image cache reduction).
Items 3-4 are longstanding UX bugs in TMDB browse screens.

## Reproduction steps

**Upcoming stuck:**
1. Have a tracked series with a next episode that has a future air date
2. Wait until the air date passes
3. Observe the episode remains in "upcoming" row and never transitions to nextUp with release alert
4. Toggle TMDB integrated dates off/on -> episode correctly appears as released

**Slow images:**
1. Open home screen with multiple catalog rows
2. Scroll down through several rows
3. Scroll back up -> posters show grey placeholders for extended time

**Movie watched badge:**
1. Open TMDB entity browse (e.g. actor screen or collection)
2. Long-press a movie poster, select "mark as watched"
3. Observe badge does NOT appear on the poster
4. Restart app -> badge appears

**TMDB browse focus:**
1. Open TMDB entity browse with multiple rails
2. Scroll right in a rail to e.g. item 5
3. Press D-pad down to next rail, then back up
4. Observe focus jumps back to item 0 instead of item 5

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Prefetch distances and debounce timings are intentionally left unchanged from 0.8.5.
- `allowHardware(false)` is kept as-is (separate concern).
- The overlay cache optimization itself is preserved - only the missing hasAired recalculation is added.
- Optimistic movie watched IDs are additive overlay on top of provider flow - no changes to Simkl sync logic.
- Focus fix is minimal: added `.focusGroup()` and moved FocusRequester maps to parent scope.

## Testing

- TCL TV physical device
- Verified series with past air date transitions from upcoming to nextUp with release alert badge
- Verified toggling TMDB dates no longer needed as workaround
- Verified home screen catalogs load posters without extended grey placeholder delays
- Verified scrolling back up shows cached posters immediately
- Verified marking movie as watched in TMDB browse shows badge immediately
- Verified unmarking removes badge immediately
- Verified badge persists after navigating away and back
- Verified D-pad up/down navigates between rails as groups
- Verified returning to a previously scrolled rail restores focus position

## Screenshots / Video

Not a UI change - behavioral fix for existing UI elements.

## Breaking changes

None.

## Linked issues

Regression from PR #3038
