### PR TITLE
fix(player): keep playback running across Bluetooth route changes

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -250,6 +250,47 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         }
     }
 
+    fun setAudioDelayMs(delayMs: Int) {
+        if (!initialized) return
+        runCatching {
+            mpv.setPropertyDouble("audio-delay", audioDelayMsToSeconds(delayMs))
+        }.onFailure {
+            Log.w(TAG, "Failed to set audio delay on mpv (delayMs=$delayMs): ${it.message}")
+        }
+    }
+
+    /**
+     * Bluetooth A2DP/LE cannot carry encoded passthrough. Force a stereo PCM mix.
+     * Mid-session route changes pass [reloadOutput] so AudioTrack follows the new device
+     * without restarting video.
+     */
+    fun applyBluetoothAudioRoute(isBluetooth: Boolean, reloadOutput: Boolean = false) {
+        if (!initialized) return
+        runCatching {
+            mpv.setPropertyString("audio-channels", MpvBluetoothAudioPolicy.audioChannels(isBluetooth))
+            if (MpvBluetoothAudioPolicy.shouldClearAudioSpdif(isBluetooth)) {
+                mpv.setPropertyString("audio-spdif", "")
+            }
+            if (reloadOutput) {
+                reloadAudioOutput()
+            }
+        }.onFailure {
+            Log.w(TAG, "Failed to apply bluetooth audio route on mpv (bt=$isBluetooth): ${it.message}")
+        }
+    }
+
+    private fun reloadAudioOutput() {
+        val reloaded = runCatching {
+            mpv.command("ao-reload")
+            true
+        }.getOrDefault(false)
+        if (reloaded) return
+        val aid = mpv.getPropertyString("aid")
+        if (!aid.isNullOrBlank() && !aid.equals("no", ignoreCase = true)) {
+            runCatching { mpv.setPropertyString("aid", aid) }
+        }
+    }
+
     fun applyAspectMode(mode: AspectMode) {
         currentAspectMode = mode
         pendingAspectRetryCount = 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackSpeedAwareAudioSink.kt
@@ -45,15 +45,23 @@ internal class PlaybackSpeedAwareAudioSink(
     }
 
     /**
-     * Update Bluetooth policy without rebuilding the player when possible.
-     * Call [notifyAudioProcessingRequirementChanged] after flipping from false → true mid-session
-     * if the sink is already configured for passthrough.
+     * Update Bluetooth policy without rebuilding the player.
+     * Call [notifyAudioProcessingRequirementChanged] after a change so Media3 reselects
+     * decode-to-PCM vs passthrough on the live renderer.
+     *
+     * @return true when the effective PCM/passthrough policy changed.
      */
-    fun setBluetoothForcePcm(enabled: Boolean) {
+    fun setBluetoothForcePcm(enabled: Boolean): Boolean {
+        val wasBluetoothForce = bluetoothForcePcm
+        val wasSessionForce = forcePcmForCurrentSession
         bluetoothForcePcm = enabled
         if (enabled) {
             forcePcmForCurrentSession = true
+        } else if (!startedWithForcedPcm && playbackSpeed == 1f) {
+            // Session was not built as PCM-only; leaving Bluetooth can restore passthrough.
+            forcePcmForCurrentSession = false
         }
+        return wasBluetoothForce != bluetoothForcePcm || wasSessionForce != forcePcmForCurrentSession
     }
 
     fun isBluetoothForcePcm(): Boolean = bluetoothForcePcm

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -427,6 +427,7 @@ class PlayerRuntimeController(
     internal var rememberAudioDelayPerDeviceEnabled: Boolean = false
     internal var currentAudioOutputRoute: AudioOutputRoute? = null
     internal var audioOutputRouteCallback: AudioDeviceCallback? = null
+    internal var audioRouteChangeJob: Job? = null
 
     internal var lastBufferLogTimeMs: Long = 0L
     internal var pendingSeekFlush: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAudioDelayRoutes.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAudioDelayRoutes.kt
@@ -15,21 +15,49 @@ private const val AUDIO_ROUTE_CHANGE_DEBOUNCE_MS = 700L
 internal enum class BluetoothRoutePlaybackAction {
     NONE,
     UPDATE_SINK_IN_PLACE,
+    UPDATE_MPV_IN_PLACE,
 }
 
 /**
- * Bluetooth connect/disconnect must never rebuild ExoPlayer: that restarts video from a
- * seek point and shows the loading overlay. Update the PCM/passthrough sink policy in place.
+ * Bluetooth connect/disconnect must never rebuild the player: that restarts video from a
+ * seek point and shows the loading overlay. Update PCM/passthrough (Exo) or stereo/delay
+ * (MPV) on the live engine instead.
  */
 internal fun decideBluetoothRoutePlaybackAction(
     wasBluetooth: Boolean,
     isBluetooth: Boolean,
-    usingMpv: Boolean
+    usingMpv: Boolean,
+    oldRouteKey: String? = null,
+    newRouteKey: String? = null
 ): BluetoothRoutePlaybackAction {
-    if (usingMpv || wasBluetooth == isBluetooth) {
+    val bluetoothStateChanged = wasBluetooth != isBluetooth
+    val bluetoothDeviceChanged = isBluetooth &&
+        !oldRouteKey.isNullOrBlank() &&
+        !newRouteKey.isNullOrBlank() &&
+        oldRouteKey != newRouteKey
+    if (!bluetoothStateChanged && !bluetoothDeviceChanged) {
         return BluetoothRoutePlaybackAction.NONE
     }
-    return BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE
+    return if (usingMpv) {
+        BluetoothRoutePlaybackAction.UPDATE_MPV_IN_PLACE
+    } else {
+        BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE
+    }
+}
+
+internal object MpvBluetoothAudioPolicy {
+    const val STEREO_CHANNELS = "stereo"
+    const val AUTO_CHANNELS = "auto"
+
+    fun audioChannels(isBluetooth: Boolean): String {
+        return if (isBluetooth) STEREO_CHANNELS else AUTO_CHANNELS
+    }
+
+    fun shouldClearAudioSpdif(isBluetooth: Boolean): Boolean = isBluetooth
+}
+
+internal fun audioDelayMsToSeconds(delayMs: Int): Double {
+    return delayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS) / 1000.0
 }
 
 internal suspend fun PlayerRuntimeController.applyStoredAudioDelayForCurrentRouteIfEnabled() {
@@ -124,7 +152,9 @@ private fun PlayerRuntimeController.onAudioOutputRouteMaybeChanged(
             decideBluetoothRoutePlaybackAction(
                 wasBluetooth = wasBluetooth,
                 isBluetooth = isBluetooth,
-                usingMpv = isUsingMpvEngine()
+                usingMpv = isUsingMpvEngine(),
+                oldRouteKey = oldRoute?.key,
+                newRouteKey = (newRoute ?: currentAudioOutputRoute)?.key
             )
         ) {
             BluetoothRoutePlaybackAction.NONE -> {
@@ -141,6 +171,14 @@ private fun PlayerRuntimeController.onAudioOutputRouteMaybeChanged(
                         "updating PCM policy in place (player stays running)"
                 )
                 applyBluetoothAudioRouteInPlace(isBluetooth)
+            }
+            BluetoothRoutePlaybackAction.UPDATE_MPV_IN_PLACE -> {
+                Log.i(
+                    PlayerRuntimeController.TAG,
+                    "Bluetooth media route changed $wasBluetooth → $isBluetooth after device $reason; " +
+                        "updating MPV stereo/delay in place (player stays running)"
+                )
+                applyMpvBluetoothAudioRouteInPlace(isBluetooth)
             }
         }
     }
@@ -184,4 +222,12 @@ internal fun PlayerRuntimeController.applyBluetoothAudioRouteInPlace(isBluetooth
     _exoPlayer?.let { player ->
         player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().build()
     }
+}
+
+internal fun PlayerRuntimeController.applyMpvBluetoothAudioRouteInPlace(isBluetooth: Boolean) {
+    val view = mpvView ?: return
+    view.applyBluetoothAudioRoute(isBluetooth, reloadOutput = true)
+    // ao-reload can drop live properties; re-pin the current per-route delay.
+    view.setAudioDelayMs(_uiState.value.audioDelayMs)
+    view.applyAudioAmplificationDb(_uiState.value.audioAmplificationDb)
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAudioDelayRoutes.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAudioDelayRoutes.kt
@@ -5,11 +5,32 @@ import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
 import android.util.Log
+import com.nuvio.tv.data.local.AudioOutputChannels
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /** Debounce window so flapping add/remove events coalesce into one route decision. */
-private const val AUDIO_ROUTE_CHANGE_DEBOUNCE_MS = 350L
+private const val AUDIO_ROUTE_CHANGE_DEBOUNCE_MS = 700L
+
+internal enum class BluetoothRoutePlaybackAction {
+    NONE,
+    UPDATE_SINK_IN_PLACE,
+}
+
+/**
+ * Bluetooth connect/disconnect must never rebuild ExoPlayer: that restarts video from a
+ * seek point and shows the loading overlay. Update the PCM/passthrough sink policy in place.
+ */
+internal fun decideBluetoothRoutePlaybackAction(
+    wasBluetooth: Boolean,
+    isBluetooth: Boolean,
+    usingMpv: Boolean
+): BluetoothRoutePlaybackAction {
+    if (usingMpv || wasBluetooth == isBluetooth) {
+        return BluetoothRoutePlaybackAction.NONE
+    }
+    return BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE
+}
 
 internal suspend fun PlayerRuntimeController.applyStoredAudioDelayForCurrentRouteIfEnabled() {
     if (!rememberAudioDelayPerDeviceEnabled) return
@@ -82,7 +103,8 @@ private fun PlayerRuntimeController.onAudioOutputRouteMaybeChanged(
         "Audio device $reason (count=${devices.size}); scheduling route re-probe"
     )
 
-    scope.launch {
+    audioRouteChangeJob?.cancel()
+    audioRouteChangeJob = scope.launch {
         delay(AUDIO_ROUTE_CHANGE_DEBOUNCE_MS)
         if (isReleasingPlayer) return@launch
 
@@ -96,30 +118,70 @@ private fun PlayerRuntimeController.onAudioOutputRouteMaybeChanged(
             applyStoredAudioDelayForCurrentRouteIfEnabled()
         }
 
-        // Bluetooth ↔ non-Bluetooth requires a different sink capability policy
-        // (PCM-only vs passthrough). Rebuild Exo so AudioCapabilities pin + decoder path match.
-        if (isUsingMpvEngine()) {
-            // MPV uses its own audio device path; only refresh delay/route metadata above.
-            return@launch
-        }
-        if (_exoPlayer == null) return@launch
-
         val wasBluetooth = oldRoute?.isBluetooth == true
         val isBluetooth = (newRoute ?: currentAudioOutputRoute)?.isBluetooth == true
-        if (wasBluetooth == isBluetooth) {
-            Log.d(
-                PlayerRuntimeController.TAG,
-                "Audio route Bluetooth state unchanged ($isBluetooth) after device $reason"
+        when (
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = wasBluetooth,
+                isBluetooth = isBluetooth,
+                usingMpv = isUsingMpvEngine()
             )
-            return@launch
+        ) {
+            BluetoothRoutePlaybackAction.NONE -> {
+                Log.d(
+                    PlayerRuntimeController.TAG,
+                    "Audio route after device $reason: bluetooth=$isBluetooth (was=$wasBluetooth); player stays running"
+                )
+            }
+            BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE -> {
+                if (_exoPlayer == null) return@launch
+                Log.i(
+                    PlayerRuntimeController.TAG,
+                    "Bluetooth media route changed $wasBluetooth → $isBluetooth after device $reason; " +
+                        "updating PCM policy in place (player stays running)"
+                )
+                applyBluetoothAudioRouteInPlace(isBluetooth)
+            }
         }
+    }
+}
 
-        val positionMs = _exoPlayer?.currentPosition?.coerceAtLeast(0L) ?: 0L
-        Log.i(
+internal fun PlayerRuntimeController.applyBluetoothAudioRouteInPlace(isBluetooth: Boolean) {
+    val sink = playbackSpeedAwareAudioSink
+    if (sink != null && sink.isBluetoothForcePcm() == isBluetooth) {
+        Log.d(
             PlayerRuntimeController.TAG,
-            "Bluetooth media route changed $wasBluetooth → $isBluetooth after device $reason; " +
-                "reinitializing player for PCM/passthrough policy (pos=${positionMs}ms)"
+            "Bluetooth PCM policy already $isBluetooth; leaving player running"
         )
-        scheduleDeferredPlayerReinitialize(fromPositionMs = positionMs)
+        return
+    }
+
+    sink?.setBluetoothForcePcm(isBluetooth)
+
+    val settings = currentPlayerSettingsForReport
+    val forceOptical = !isBluetooth &&
+        settings.forceOpticalPassthrough &&
+        settings.decoderPriority != 0
+    val downmixEnabled = settings.effectiveDownmixEnabled || isBluetooth
+    val outputChannels = if (isBluetooth) {
+        AudioOutputChannels.CHANNELS_2_0
+    } else {
+        settings.audioOutputChannels
+    }
+    ffmpegAudioRenderer?.setForceOpticalPassthrough(forceOptical)
+    if (downmixEnabled) {
+        ffmpegAudioRenderer?.setAudioOutputChannels(
+            outputChannels.ffmpegLayoutName,
+            outputChannels.channelCount
+        )
+        ffmpegAudioRenderer?.setDownmixNormalizationEnabled(!settings.maintainOriginalAudioOnDownmix)
+    } else {
+        ffmpegAudioRenderer?.setAudioOutputChannels(null, 0)
+        ffmpegAudioRenderer?.setDownmixNormalizationEnabled(false)
+    }
+
+    sink?.notifyAudioProcessingRequirementChanged()
+    _exoPlayer?.let { player ->
+        player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().build()
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -201,7 +201,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             currentPlayerSettingsForReport = playerSettings
             rememberAudioDelayPerDeviceEnabled = playerSettings.rememberAudioDelayPerDevice
             // Always watch output-device changes so Bluetooth connect/disconnect can switch
-            // between PCM-only and passthrough sink policies (Media3 1.8.0 BT semantics).
+            // PCM/passthrough policy in place (Media3 1.8.0 BT semantics; do not rebuild).
             registerAudioDelayRouteCallback()
             currentAudioOutputRoute = AudioOutputRouteDetector.detect(context)
             if (rememberAudioDelayPerDeviceEnabled) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -19,6 +19,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
 
     notifyAudioSessionUpdate(false)
     unregisterAudioDelayRouteCallback()
+    audioRouteChangeJob?.cancel()
+    audioRouteChangeJob = null
 
     try {
         currentMediaSession?.release()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -33,6 +33,8 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         )
         view.applySubtitleStyle(_uiState.value.subtitleStyle)
         view.setSubtitleDelayMs(_uiState.value.subtitleDelayMs)
+        view.applyBluetoothAudioRoute(currentAudioOutputRoute?.isBluetooth == true)
+        view.setAudioDelayMs(_uiState.value.audioDelayMs)
         view.applyAspectMode(_uiState.value.aspectMode)
         view.setPaused(false)
         applyPendingMpvSeekIfNeeded(view)
@@ -137,6 +139,8 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         )
         view.applySubtitleStyle(_uiState.value.subtitleStyle)
         view.setSubtitleDelayMs(_uiState.value.subtitleDelayMs)
+        view.applyBluetoothAudioRoute(currentAudioOutputRoute?.isBluetooth == true)
+        view.setAudioDelayMs(_uiState.value.audioDelayMs)
         view.applyAspectMode(_uiState.value.aspectMode)
         view.setPaused(false)
         applyPendingMpvSeekIfNeeded(view)
@@ -467,6 +471,8 @@ internal fun PlayerRuntimeController.applyPendingMpvSeekIfNeeded(
     if (!canSeekNow) return
 
     view.seekToMs(target)
+    view.setSubtitleDelayMs(state.subtitleDelayMs)
+    view.setAudioDelayMs(state.audioDelayMs)
     if (state.pendingSeekPosition != target) {
         _uiState.update { it.copy(pendingSeekPosition = target) }
     }
@@ -507,8 +513,9 @@ internal fun PlayerRuntimeController.seekPlaybackTo(
     if (isUsingMpvEngine()) {
         mpvView?.let { view ->
             view.seekToMs(positionMs)
-            // Keep subtitle delay sticky during FF/RW seeks.
+            // Keep subtitle/audio delay sticky during FF/RW seeks.
             view.setSubtitleDelayMs(_uiState.value.subtitleDelayMs)
+            view.setAudioDelayMs(_uiState.value.audioDelayMs)
         }
     } else {
         _exoPlayer?.let { player ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -324,10 +324,7 @@ internal fun PlayerRuntimeController.observeSubtitleSettings() {
             }
 
             if (settings.rememberAudioDelayPerDevice && !wasRememberingAudioDelayPerDevice) {
-                registerAudioDelayRouteCallback()
                 applyStoredAudioDelayForCurrentRouteIfEnabled()
-            } else if (!settings.rememberAudioDelayPerDevice && wasRememberingAudioDelayPerDevice) {
-                unregisterAudioDelayRouteCallback()
             }
 
             bufferLogsEnabled = settings.enableBufferLogs

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -40,6 +40,9 @@ internal fun PlayerRuntimeController.applyAudioDelay(
     val clampedDelayMs = delayMs.coerceIn(AUDIO_DELAY_MIN_MS, AUDIO_DELAY_MAX_MS)
     audioDelayUs.set(clampedDelayMs.toLong() * 1000L)
     _uiState.update { it.copy(audioDelayMs = clampedDelayMs) }
+    if (isUsingMpvEngine()) {
+        mpvView?.setAudioDelayMs(clampedDelayMs)
+    }
     if (persistForCurrentRoute) {
         persistAudioDelayForCurrentRoute(clampedDelayMs)
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -157,18 +157,18 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
                 enabled = enabled
             )
         }
+    }
 
-        item(key = "audio_remember_delay_per_device") {
-            ToggleSettingsItem(
-                icon = Icons.Default.Timer,
-                title = stringResource(R.string.audio_remember_delay_per_device),
-                subtitle = stringResource(R.string.audio_remember_delay_per_device_sub),
-                isChecked = playerSettings.rememberAudioDelayPerDevice,
-                onCheckedChange = onSetRememberAudioDelayPerDevice,
-                onFocused = onItemFocused,
-                enabled = enabled
-            )
-        }
+    item(key = "audio_remember_delay_per_device") {
+        ToggleSettingsItem(
+            icon = Icons.Default.Timer,
+            title = stringResource(R.string.audio_remember_delay_per_device),
+            subtitle = stringResource(R.string.audio_remember_delay_per_device_sub),
+            isChecked = playerSettings.rememberAudioDelayPerDevice,
+            onCheckedChange = onSetRememberAudioDelayPerDevice,
+            onFocused = onItemFocused,
+            enabled = enabled
+        )
     }
 
     if (isExoEngine) {

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolverTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbCollectionSourceResolverTest.kt
@@ -19,6 +19,7 @@ import com.nuvio.tv.domain.model.TmdbSettings
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -32,7 +33,7 @@ import retrofit2.http.Query
 class TmdbCollectionSourceResolverTest {
     private val context = mockk<Context>(relaxed = true)
     private val settings = mockk<TmdbSettingsDataStore> {
-        every { this@mockk.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { this@mockk.settings } returns MutableStateFlow(TmdbSettings(language = "en"))
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceUseTrailersGateTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceUseTrailersGateTest.kt
@@ -11,7 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertNull
@@ -92,7 +92,7 @@ class TrailerServiceUseTrailersGateTest {
         val tmdbApi = mockk<TmdbApi>(relaxed = true)
         val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
         val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
-            every { settings } returns flowOf(TmdbSettings(language = "en", useTrailers = enabled))
+            every { settings } returns MutableStateFlow(TmdbSettings(language = "en", useTrailers = enabled))
         }
         val tmdbService = mockk<TmdbService> {
             every { apiKey() } returns "tmdb-key"

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceYouTubeSessionCacheTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceYouTubeSessionCacheTest.kt
@@ -8,7 +8,7 @@ import com.nuvio.tv.data.remote.api.TrailerApi
 import com.nuvio.tv.data.remote.api.TrailerResponse
 import com.nuvio.tv.domain.model.TmdbSettings
 import io.mockk.*
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -40,7 +40,7 @@ class TrailerServiceYouTubeSessionCacheTest {
         val extractor = mockk<InAppYouTubeExtractor>()
         val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore>()
         val tmdbService = mockk<TmdbService>()
-        every { tmdbSettingsDataStore.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { tmdbSettingsDataStore.settings } returns MutableStateFlow(TmdbSettings(language = "en"))
         every { tmdbService.apiKey() } returns "tmdb-key"
         val service = TrailerService(trailerApi, tmdbApi, extractor, tmdbSettingsDataStore, tmdbService)
 
@@ -70,7 +70,7 @@ class TrailerServiceYouTubeSessionCacheTest {
         val extractor = mockk<InAppYouTubeExtractor>()
         val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore>()
         val tmdbService = mockk<TmdbService>()
-        every { tmdbSettingsDataStore.settings } returns flowOf(TmdbSettings(language = "en"))
+        every { tmdbSettingsDataStore.settings } returns MutableStateFlow(TmdbSettings(language = "en"))
         every { tmdbService.apiKey() } returns "tmdb-key"
         val service = TrailerService(trailerApi, tmdbApi, extractor, tmdbSettingsDataStore, tmdbService)
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/BluetoothAudioRoutePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/BluetoothAudioRoutePolicyTest.kt
@@ -106,13 +106,65 @@ class BluetoothAudioRoutePolicyTest {
             )
         )
         assertEquals(
-            BluetoothRoutePlaybackAction.NONE,
+            BluetoothRoutePlaybackAction.UPDATE_MPV_IN_PLACE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = false,
+                isBluetooth = true,
+                usingMpv = true
+            )
+        )
+        assertEquals(
+            BluetoothRoutePlaybackAction.UPDATE_MPV_IN_PLACE,
             decideBluetoothRoutePlaybackAction(
                 wasBluetooth = true,
                 isBluetooth = false,
                 usingMpv = true
             )
         )
+        assertEquals(
+            BluetoothRoutePlaybackAction.NONE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = true,
+                isBluetooth = true,
+                usingMpv = true
+            )
+        )
+        assertEquals(
+            BluetoothRoutePlaybackAction.UPDATE_MPV_IN_PLACE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = true,
+                isBluetooth = true,
+                usingMpv = true,
+                oldRouteKey = "type:bluetooth_a2dp|name:speaker_a",
+                newRouteKey = "type:bluetooth_a2dp|name:speaker_b"
+            )
+        )
+        assertEquals(
+            BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = true,
+                isBluetooth = true,
+                usingMpv = false,
+                oldRouteKey = "type:bluetooth_a2dp|name:speaker_a",
+                newRouteKey = "type:bluetooth_a2dp|name:speaker_b"
+            )
+        )
+    }
+
+    @Test
+    fun `mpv bluetooth forces stereo and clears encoded passthrough`() {
+        assertEquals(MpvBluetoothAudioPolicy.STEREO_CHANNELS, MpvBluetoothAudioPolicy.audioChannels(true))
+        assertEquals(MpvBluetoothAudioPolicy.AUTO_CHANNELS, MpvBluetoothAudioPolicy.audioChannels(false))
+        assertTrue(MpvBluetoothAudioPolicy.shouldClearAudioSpdif(true))
+        assertFalse(MpvBluetoothAudioPolicy.shouldClearAudioSpdif(false))
+    }
+
+    @Test
+    fun `audio delay milliseconds map to mpv seconds and clamp`() {
+        assertEquals(0.200, audioDelayMsToSeconds(200), 0.0001)
+        assertEquals(-0.250, audioDelayMsToSeconds(-250), 0.0001)
+        assertEquals(AUDIO_DELAY_MAX_MS / 1000.0, audioDelayMsToSeconds(99_999), 0.0001)
+        assertEquals(AUDIO_DELAY_MIN_MS / 1000.0, audioDelayMsToSeconds(-99_999), 0.0001)
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/BluetoothAudioRoutePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/BluetoothAudioRoutePolicyTest.kt
@@ -79,6 +79,90 @@ class BluetoothAudioRoutePolicyTest {
         assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(eac3))
     }
 
+    @Test
+    fun `bluetooth connect or disconnect never asks to reinitialize the player`() {
+        assertEquals(
+            BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = false,
+                isBluetooth = true,
+                usingMpv = false
+            )
+        )
+        assertEquals(
+            BluetoothRoutePlaybackAction.UPDATE_SINK_IN_PLACE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = true,
+                isBluetooth = false,
+                usingMpv = false
+            )
+        )
+        assertEquals(
+            BluetoothRoutePlaybackAction.NONE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = true,
+                isBluetooth = true,
+                usingMpv = false
+            )
+        )
+        assertEquals(
+            BluetoothRoutePlaybackAction.NONE,
+            decideBluetoothRoutePlaybackAction(
+                wasBluetooth = true,
+                isBluetooth = false,
+                usingMpv = true
+            )
+        )
+    }
+
+    @Test
+    fun `mid-session bluetooth connect forces pcm without a rebuild flag`() {
+        val sink = PlaybackSpeedAwareAudioSink(
+            sink = AlwaysSupportedDelegateSink(),
+            initialForcePcm = false,
+            forcePcmForBluetooth = false
+        )
+        val eac3 = mime(MimeTypes.AUDIO_E_AC3)
+        assertFalse(sink.shouldForcePcmForFormat(eac3))
+
+        assertTrue(sink.setBluetoothForcePcm(true))
+        assertTrue(sink.isBluetoothForcePcm())
+        assertTrue(sink.shouldForcePcmForFormat(eac3))
+        assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(eac3))
+        assertFalse(sink.setBluetoothForcePcm(true))
+    }
+
+    @Test
+    fun `hdmi-started session restores passthrough after bluetooth disconnect`() {
+        val sink = PlaybackSpeedAwareAudioSink(
+            sink = AlwaysSupportedDelegateSink(),
+            initialForcePcm = false,
+            forcePcmForBluetooth = false
+        )
+        val eac3 = mime(MimeTypes.AUDIO_E_AC3)
+        sink.setBluetoothForcePcm(true)
+        assertTrue(sink.shouldForcePcmForFormat(eac3))
+
+        assertTrue(sink.setBluetoothForcePcm(false))
+        assertFalse(sink.isBluetoothForcePcm())
+        assertFalse(sink.shouldForcePcmForFormat(eac3))
+        assertEquals(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY, sink.getFormatSupport(eac3))
+    }
+
+    @Test
+    fun `session built for bluetooth stays on pcm after disconnect`() {
+        val sink = PlaybackSpeedAwareAudioSink(
+            sink = AlwaysSupportedDelegateSink(),
+            initialForcePcm = true,
+            forcePcmForBluetooth = true
+        )
+        val truehd = mime(MimeTypes.AUDIO_TRUEHD)
+        sink.setBluetoothForcePcm(false)
+        assertFalse(sink.isBluetoothForcePcm())
+        assertTrue(sink.shouldForcePcmForFormat(truehd))
+        assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(truehd))
+    }
+
     private fun mime(sampleMimeType: String): Format {
         return Format.Builder()
             .setSampleMimeType(sampleMimeType)

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -135,6 +135,7 @@ class SearchViewModelConcurrencyTest {
         return SearchViewModel(
             addonRepository = addonRepository,
             catalogRepository = catalogRepository,
+            metaRepository = mockk(relaxed = true),
             layoutPreferenceDataStore = layoutPreferences,
             searchHistoryDataStore = history,
             watchProgressRepository = watchProgress,


### PR DESCRIPTION
## Summary

Bluetooth connect/disconnect used to rebuild ExoPlayer, which restarted video from a seek point and showed the loading overlay. The audio-route callback now updates PCM/passthrough policy on the live sink, debounces flapping device add/remove events (700ms), and stays registered for the whole playback session.

When leaving Bluetooth, a session that was not built as PCM-only can restore passthrough in place. A session that started on Bluetooth stays on PCM after disconnect so the decoder path does not flip mid-stream.

MPV had the same mid-session Bluetooth gap, plus a broken delay path: the in-player Audio Delay slider never wrote libmpv `audio-delay`, and Remember audio delay per device was hidden for MPV. The slider now applies live, the per-device toggle is visible for both engines, and a Bluetooth connect / disconnect / speaker switch updates stereo PCM and the stored delay in place (`UPDATE_MPV_IN_PLACE`) without restarting playback.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Connecting or disconnecting a Bluetooth speaker/headset during playback tore down and recreated ExoPlayer. Playback jumped, the loading overlay appeared, and audio cut out. This is a critical mid-session playback interruption on TVs and phones that change audio routes while watching.

Media3 1.8.0 Bluetooth policy is PCM-only (A2DP / SCO / BLE). Encoded passthrough (E-AC3, TrueHD, DTS-HD, AC3) cannot ride the Bluetooth stack. The fix applies that policy on the live sink instead of rebuilding the player.

On MPV the delay slider was cosmetic (no `audio-delay` property), so Bluetooth lipsync could not be corrected, and a route change did not apply stereo PCM or the stored per-device delay. That is the same mid-session audio-route bug on the other internal engine.

## Issue or approval

Discord and Reddit notified. No GitHub issue created.

## Reproduction steps

1. Start playback with the internal ExoPlayer on HDMI or the built-in speaker.
2. Connect a Bluetooth speaker or headset while the video is playing.
3. Before this fix: ExoPlayer is rebuilt, video restarts from a seek point, and the loading overlay appears.
4. After this fix: video keeps playing; only the PCM/passthrough sink policy updates in place.
5. Disconnect Bluetooth and confirm the same: playback stays running instead of rebuilding.
6. Repeat connect/disconnect quickly (device flapping) and confirm a single coalesced route decision after ~700ms, not a burst of player restarts.
7. Switch the internal engine to Libmpv and repeat connect/disconnect: playback stays running; stereo PCM and the stored delay update in place.
8. On MPV, open the audio overlay, change Audio Delay, then reconnect the same Bluetooth speaker and confirm that delay is restored. Switch to a second Bluetooth speaker and confirm that speaker's stored delay is applied without a player restart.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The only settings change is showing the existing Remember audio delay per device toggle for MPV. It was Exo-only because the delay path did not work on libmpv.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Internal Bluetooth route handling for both engines. ExoPlayer updates PCM/passthrough on the live sink. MPV updates stereo PCM and `audio-delay` in place (`UPDATE_MPV_IN_PLACE`). Neither engine rebuilds the player.
- Settings change is limited to un-hiding Remember audio delay per device for MPV so the existing per-route delay actually applies.
- Does not add a new audio-route feature; it stops rebuilding the player and makes the existing delay path work on MPV.
- Per-device audio-delay persistence is the existing store; the route callback already used it for ExoPlayer and now also applies it on MPV after a route change or Bluetooth device switch.
- Unrelated test-compile fixes only: `TmdbSettingsDataStore.settings` is now a `StateFlow`, and `SearchViewModel` requires `MetaRepository`. Mocks were updated so the unit-test source set compiles. No production search/TMDB behavior change.

## Testing

- Added `BluetoothAudioRoutePolicyTest`:
  - Bluetooth device types match Media3 (A2DP, SCO, BLE headset/speaker/broadcast); HDMI and built-in speaker are not Bluetooth.
  - Bluetooth force-PCM rejects E-AC3, TrueHD, DTS-HD, and AC3 direct sink support.
  - Without the Bluetooth flag, AAC remains directly supported.
  - Speed change alone still forces PCM for surround without the Bluetooth flag.
  - ExoPlayer connect/disconnect never asks to reinitialize the player (`UPDATE_SINK_IN_PLACE` only).
  - MPV connect/disconnect uses `UPDATE_MPV_IN_PLACE` (no rebuild).
  - Switching from one Bluetooth speaker to another also updates in place on both engines.
  - MPV Bluetooth forces stereo channels and clears encoded passthrough; leaving Bluetooth returns to auto channels.
  - Audio delay milliseconds map to mpv seconds and clamp to ±3s.
  - Mid-session Bluetooth connect flips E-AC3 to PCM on the live Exo sink.
  - HDMI-started session restores passthrough after Bluetooth disconnect.
  - Session built for Bluetooth stays on PCM after disconnect.
- Updated unit-test mocks so the suite compiles after the `StateFlow` / `MetaRepository` API changes on `dev`.
- `BluetoothAudioRoutePolicyTest` compiled and passed on `fullDebugUnitTest`.

## Screenshots / Video

Settings: Remember audio delay per device is now visible when Libmpv is selected. No other layout change.

## Breaking changes

None.

## Linked issues

Discord and Reddit notified. No GitHub issue created.
