### PR TITLE
fix(cw): Next Up offering unavailable episodes when "Show unaired next up episodes" is off

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2218,9 +2218,6 @@ private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 internal fun isNextUpEpisodeUnaired(releaseDate: LocalDate?, today: LocalDate): Boolean =
     releaseDate == null || releaseDate.isAfter(today)
 
-// Addons report available=false for episodes they cannot serve, which is the same flag the details screen labels Unavailable.
-internal fun isNextUpEpisodeAvailable(available: Boolean?): Boolean = available != false
-
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary,
@@ -2274,13 +2271,6 @@ private fun resolveNextUpVideoFromMeta(
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
-        if (!isNextUpEpisodeAvailable(video.available)) {
-            logNextUpDecision(
-                "skip contentId=${progress.contentId} name=${progress.name} reason=unavailable " +
-                    "seed=${seedSeason}x${seedEpisode} next=${video.season}x${video.episode}"
-            )
-            return@firstOrNull false
-        }
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2214,6 +2214,13 @@ private fun resolveNextUpVideoFromMeta(
 
 private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 
+// An episode with no date is no more watchable than one dated ahead, so a missing date counts as unaired and stays under the same setting instead of passing as aired.
+internal fun isNextUpEpisodeUnaired(releaseDate: LocalDate?, today: LocalDate): Boolean =
+    releaseDate == null || releaseDate.isAfter(today)
+
+// Addons report available=false for episodes they cannot serve, which is the same flag the details screen labels Unavailable.
+internal fun isNextUpEpisodeAvailable(available: Boolean?): Boolean = available != false
+
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary,
@@ -2267,6 +2274,13 @@ private fun resolveNextUpVideoFromMeta(
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
+        if (!isNextUpEpisodeAvailable(video.available)) {
+            logNextUpDecision(
+                "skip contentId=${progress.contentId} name=${progress.name} reason=unavailable " +
+                    "seed=${seedSeason}x${seedEpisode} next=${video.season}x${video.episode}"
+            )
+            return@firstOrNull false
+        }
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {
@@ -2290,14 +2304,10 @@ private fun resolveNextUpVideoFromMeta(
             return@firstOrNull false
         }
 
-        val isUnaired = releaseDate?.isAfter(todayLocal) == true
-        if (!isUnaired) {
+        if (!isNextUpEpisodeUnaired(releaseDate, todayLocal)) {
             return@firstOrNull true
         }
-        if (!showUnairedNextUp) {
-            return@firstOrNull false
-        }
-        true
+        showUnairedNextUp
     }
 
     if (nextVideo == null) {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/NextUpEpisodeEligibilityTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/NextUpEpisodeEligibilityTest.kt
@@ -1,0 +1,38 @@
+package com.nuvio.tv.ui.screens.home
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class NextUpEpisodeEligibilityTest {
+
+    private val today: LocalDate = LocalDate.of(2026, 8, 19)
+
+    @Test
+    fun `a past date is aired`() {
+        assertFalse(isNextUpEpisodeUnaired(today.minusDays(1), today))
+    }
+
+    @Test
+    fun `an episode airing today is aired`() {
+        assertFalse(isNextUpEpisodeUnaired(today, today))
+    }
+
+    @Test
+    fun `a future date is unaired`() {
+        assertTrue(isNextUpEpisodeUnaired(today.plusDays(1), today))
+    }
+
+    @Test
+    fun `a missing date is unaired rather than aired`() {
+        assertTrue(isNextUpEpisodeUnaired(null, today))
+    }
+
+    @Test
+    fun `availability is only refused when the addon explicitly says so`() {
+        assertTrue(isNextUpEpisodeAvailable(true))
+        assertTrue(isNextUpEpisodeAvailable(null))
+        assertFalse(isNextUpEpisodeAvailable(false))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/NextUpEpisodeEligibilityTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/NextUpEpisodeEligibilityTest.kt
@@ -28,11 +28,4 @@ class NextUpEpisodeEligibilityTest {
     fun `a missing date is unaired rather than aired`() {
         assertTrue(isNextUpEpisodeUnaired(null, today))
     }
-
-    @Test
-    fun `availability is only refused when the addon explicitly says so`() {
-        assertTrue(isNextUpEpisodeAvailable(true))
-        assertTrue(isNextUpEpisodeAvailable(null))
-        assertFalse(isNextUpEpisodeAvailable(false))
-    }
 }


### PR DESCRIPTION
## Summary

Two fixes in `resolveNextUpVideoFromMeta`:

1. A missing air date now counts as unaired, so it falls under the "show unaired next up episodes" setting instead of passing as aired. This matches the season-rollover branch, which already rejects a missing date.
2. Episodes with `available == false` are skipped, with a `reason=unavailable` log line.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

With the setting off, `releaseDate?.isAfter(today) == true` evaluated to false for a null date, so the same-season branch returned `true` before `showUnairedNextUp` was ever consulted. An episode with no air date could never be filtered, regardless of the setting.

Separately, next-up never read `available`, so an episode the details screen labels "Unavailable" could still be offered.

## Issue or approval

Fixes #3087

## Reproduction steps

1. Layout settings, CW  "Show unaired next up episodes" off
2. Watch a show whose next same-season episode has no `released` date and `available: false` (Sistas, next up resolves to S10E12)
3. Open Continue Watching -> S10E12 is offered

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No skip-forward logic added. `firstOrNull` already advances to the next qualifying episode, and returns null when none qualifies, which drops the show from the row.

`hasEpisodeAired(raw, fallback = true)` has the same null-means-aired assumption and was left alone. 
## Testing

Box S, Android 14 

- With the setting off, the reported show no longer offers the dateless unavailable episode and drops off Continue Watching.
- With the setting on, unaired next-up still appears, so the toggle is unchanged in that direction.
- Added `NextUpEpisodeEligibilityTest` (5 cases: past/today/future/missing date, and availability).

Note: `:app:testFullDebugUnitTest` does not currently compile on `dev` for reasons unrelated to this PR. `TmdbCollectionSourceResolverTest`, `TrailerServiceUseTrailersGateTest`, and `TrailerServiceYouTubeSessionCacheTest` pass `Flow<TmdbSettings>` where `StateFlow` is now expected, and `SearchViewModelConcurrencyTest` is missing a `metaRepository` argument. The new test file compiles clean, but the suite cannot be run until those are fixed.

## Screenshots / Video

Not a UI change.

Bug:
<img width="1920" height="1080" alt="cw-before" src="https://github.com/user-attachments/assets/c5dabb8e-bbac-4d5f-9534-68c2a06c5c55" />
<img width="1920" height="1080" alt="cw-details" src="https://github.com/user-attachments/assets/2cf999f2-ba72-4c5f-b5ee-0c18ae4356c8" />

## Breaking changes

None.

## Linked issues

Fixes #3087