### PR TITLE
fix(player): play non-faststart MP4s on the default path via session-owned chunks

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -111,7 +111,48 @@ internal class ParallelRangeDataSource(
             return configuredDepth.coerceAtMost(rateLimitDepth).coerceAtLeast(1)
         }
 
-        private const val EVICTION_TOUCH_GUARD_MS = 2_000L
+        private const val TAIL_CHUNK_COUNT = 4L
+
+        internal fun isTailChunk(chunkIndex: Long, totalChunks: Long): Boolean {
+            return totalChunks > 0L && chunkIndex >= totalChunks - TAIL_CHUNK_COUNT
+        }
+
+        internal fun shouldMoveMainCursor(
+            lastReadChunkIndex: Long,
+            chunkIndex: Long,
+            prefetchWindow: Int,
+            sequentialOpen: Boolean,
+            currentChunkComplete: Boolean,
+            totalChunks: Long
+        ): Boolean {
+            if (isTailChunk(chunkIndex, totalChunks)) {
+                if (lastReadChunkIndex < 0L) return false
+                val delta = chunkIndex - lastReadChunkIndex
+                val distance = if (delta >= 0L) delta else -delta
+                return distance <= prefetchWindow.toLong()
+            }
+            if (lastReadChunkIndex < 0L) return true
+            val delta = chunkIndex - lastReadChunkIndex
+            val distance = if (delta >= 0L) delta else -delta
+            if (distance <= prefetchWindow.toLong()) return true
+            return sequentialOpen && currentChunkComplete
+        }
+
+        private const val EVICTION_TOUCH_GUARD_MS = 15_000L
+        private const val PLAYHEAD_BACK_CHUNKS = 2L
+        private const val MAX_PINNED_SIDE_CHUNKS = 2
+
+        internal fun isInPlayheadWindow(
+            readerIdx: Long,
+            chunkIndex: Long,
+            prefetchWindow: Int,
+            backChunks: Long = PLAYHEAD_BACK_CHUNKS
+        ): Boolean {
+            if (readerIdx < 0L) return false
+            val floor = (readerIdx - backChunks).coerceAtLeast(0L)
+            val ceil = readerIdx + prefetchWindow.toLong()
+            return chunkIndex in floor..ceil
+        }
         private const val RATE_LIMIT_MAX_BACKOFF_RETRIES = 3
         private const val RATE_LIMIT_BACKOFF_BASE_MS = 500L
         private const val RATE_LIMIT_BACKOFF_CYCLE_CAP_MS = 3_000L
@@ -145,10 +186,37 @@ internal class ParallelRangeDataSource(
             }
 
             @Volatile var lastReadChunkIndex: Long = -1L
+            val pinnedSideChunks: MutableSet<Long> = java.util.concurrent.ConcurrentHashMap.newKeySet()
 
-            fun noteRead(chunkIndex: Long) {
+            fun noteRead(
+                chunkIndex: Long,
+                sequentialOpen: Boolean,
+                currentChunkComplete: Boolean,
+                totalChunks: Long
+            ) {
                 touch(chunkIndex)
-                lastReadChunkIndex = chunkIndex
+                if (shouldMoveMainCursor(
+                        lastReadChunkIndex,
+                        chunkIndex,
+                        prefetchWindow,
+                        sequentialOpen,
+                        currentChunkComplete,
+                        totalChunks
+                    )
+                ) {
+                    lastReadChunkIndex = chunkIndex
+                    pinnedSideChunks.remove(chunkIndex)
+                } else {
+                    pinSideChunk(chunkIndex)
+                }
+            }
+
+            fun pinSideChunk(chunkIndex: Long) {
+                pinnedSideChunks.add(chunkIndex)
+                while (pinnedSideChunks.size > MAX_PINNED_SIDE_CHUNKS) {
+                    val drop = pinnedSideChunks.minByOrNull { lastTouch[it] ?: 0L } ?: break
+                    if (!pinnedSideChunks.remove(drop)) break
+                }
             }
 
             val rateLimitDepthCap = AtomicInteger(Int.MAX_VALUE)
@@ -234,6 +302,7 @@ internal class ParallelRangeDataSource(
         ) {
             val future = session.futures.remove(chunkIndex) ?: return
             session.lastTouch.remove(chunkIndex)
+            session.pinnedSideChunks.remove(chunkIndex)
             if (!future.cancel(true) && future.isDone && !future.isCancelled) {
                 try {
                     releaseSessionBuffer(future.get().buffer, session.chunkSize, poolCap)
@@ -254,6 +323,7 @@ internal class ParallelRangeDataSource(
             }
             session.futures.clear()
             session.lastTouch.clear()
+            session.pinnedSideChunks.clear()
         }
 
         private fun obtainSession(
@@ -295,18 +365,40 @@ internal class ParallelRangeDataSource(
             synchronized(session) {
                 while (session.futures.size > session.chunkCap) {
                     val now = SystemClock.uptimeMillis()
-                    val hardOver = session.futures.size > session.chunkCap + 2
                     val readerIdx = session.lastReadChunkIndex
-                    val eligible = session.futures.keys
+                    val totalChunks = if (session.totalLength > 0L && session.chunkSize > 0L) {
+                        (session.totalLength + session.chunkSize - 1L) / session.chunkSize
+                    } else {
+                        0L
+                    }
+                    val evictable = session.futures.keys
                         .filter { it != protectIndex }
-                        .filter { hardOver || now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
-                    val nearAheadFloor = if (readerIdx >= 0L) readerIdx else Long.MIN_VALUE
-                    val nearAheadCeil = if (readerIdx >= 0L) readerIdx + session.prefetchWindow else Long.MIN_VALUE
-                    val evictable = eligible.filter { it < nearAheadFloor || it > nearAheadCeil }
+                        .filter { it != readerIdx }
+                        .filter { now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
+                        .filter { !isInPlayheadWindow(readerIdx, it, session.prefetchWindow) }
+                        .filter { !isTailChunk(it, totalChunks) }
+                        .filter { !session.pinnedSideChunks.contains(it) }
+                        .filter { index ->
+                            val future = session.futures[index]
+                            future == null || (future.isDone && !future.isCancelled)
+                        }
                     val victim = evictable
                         .filter { readerIdx >= 0L && it < readerIdx }
                         .minByOrNull { session.lastTouch[it] ?: 0L }
                         ?: evictable.maxOrNull()
+                        ?: if (session.futures.size > session.chunkCap + 8) {
+                            session.futures.keys
+                                .filter { it != protectIndex && it != readerIdx }
+                                .filter { !isInPlayheadWindow(readerIdx, it, session.prefetchWindow) }
+                                .filter { !isTailChunk(it, totalChunks) }
+                                .filter { index ->
+                                    val future = session.futures[index]
+                                    future != null && future.isDone && !future.isCancelled
+                                }
+                                .minByOrNull { session.lastTouch[it] ?: 0L }
+                        } else {
+                            null
+                        }
                         ?: return
                     evictFuture(session, victim, poolCap)
                 }
@@ -633,13 +725,14 @@ internal class ParallelRangeDataSource(
             val activeSession = session ?: return C.RESULT_END_OF_INPUT
             ensureChunkScheduled(chunkIndex)
             val future = activeSession.futures[chunkIndex] ?: return C.RESULT_END_OF_INPUT
-            activeSession.noteRead(chunkIndex)
+            noteSessionRead(activeSession, chunkIndex)
             try {
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
                 if (activeSession.futures.remove(chunkIndex, future)) {
                     activeSession.lastTouch.remove(chunkIndex)
+                    activeSession.pinnedSideChunks.remove(chunkIndex)
                     if (!future.cancel(true) && future.isDone && !future.isCancelled) {
                         try {
                             releaseSessionBuffer(future.get().buffer, activeSession.chunkSize, maxPoolSize)
@@ -675,9 +768,26 @@ internal class ParallelRangeDataSource(
         position += readSize
         bytesRemaining -= readSize
         bytesServedThisOpen += readSize
-        session?.noteRead(chunkIndex)
+        noteSessionRead(session, chunkIndex)
 
         return readSize
+    }
+
+    private fun noteSessionRead(activeSession: ChunkSession?, chunkIndex: Long) {
+        val currentComplete = activeSession?.futures?.get(chunkIndex)?.let { future ->
+            future.isDone && !future.isCancelled && !future.isCompletedExceptionally
+        } == true
+        val totalChunks = if (activeSession != null && activeSession.totalLength > 0L && chunkSize > 0L) {
+            (activeSession.totalLength + chunkSize - 1L) / chunkSize
+        } else {
+            0L
+        }
+        activeSession?.noteRead(
+            chunkIndex,
+            bytesServedThisOpen >= EARNED_PREFETCH_BYTES,
+            currentComplete,
+            totalChunks
+        )
     }
 
     private fun scheduleChunks() {
@@ -709,6 +819,23 @@ internal class ParallelRangeDataSource(
 
     private fun ensureChunkScheduled(chunkIndex: Long) {
         val activeSession = session ?: return
+        val totalChunks = if (activeSession.totalLength > 0L && chunkSize > 0L) {
+            (activeSession.totalLength + chunkSize - 1L) / chunkSize
+        } else {
+            0L
+        }
+        if (isTailChunk(chunkIndex, totalChunks) ||
+            !shouldMoveMainCursor(
+                activeSession.lastReadChunkIndex,
+                chunkIndex,
+                activeSession.prefetchWindow,
+                sequentialOpen = false,
+                currentChunkComplete = false,
+                totalChunks = totalChunks
+            )
+        ) {
+            activeSession.pinSideChunk(chunkIndex)
+        }
         enforceSessionCap(activeSession, protectIndex = chunkIndex, poolCap = maxPoolSize)
         activeSession.futures.computeIfAbsent(chunkIndex) {
             val future = CompletableFuture<DownloadedChunk>()
@@ -720,6 +847,8 @@ internal class ParallelRangeDataSource(
                         val result = downloadChunk(activeSession, chunkIndex, future)
                         if (!future.complete(result)) {
                             releaseBuffer(result.buffer)
+                        } else {
+                            activeSession.touch(chunkIndex)
                         }
                     } else if (future.isCancelled) {
                         // no-op: never started
@@ -1036,7 +1165,12 @@ internal class ParallelRangeDataSource(
 
             val active = activeInstances.decrementAndGet()
             if (active <= 0) {
-                clearGlobalPool()
+                val sessionLive = synchronized(sessionLock) {
+                    currentChunkSession?.abandoned?.get() == false
+                }
+                if (!sessionLive) {
+                    clearGlobalPool()
+                }
             }
         }
     }
@@ -1121,13 +1255,14 @@ internal class ParallelRangeDataSource(
             val activeSession = session ?: return C.RESULT_END_OF_INPUT
             ensureChunkScheduled(chunkIndex)
             val future = activeSession.futures[chunkIndex] ?: return C.RESULT_END_OF_INPUT
-            activeSession.noteRead(chunkIndex)
+            noteSessionRead(activeSession, chunkIndex)
             try {
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
                 if (activeSession.futures.remove(chunkIndex, future)) {
                     activeSession.lastTouch.remove(chunkIndex)
+                    activeSession.pinnedSideChunks.remove(chunkIndex)
                     if (!future.cancel(true) && future.isDone && !future.isCancelled) {
                         try {
                             releaseSessionBuffer(future.get().buffer, activeSession.chunkSize, maxPoolSize)
@@ -1164,7 +1299,7 @@ internal class ParallelRangeDataSource(
         position += readSize
         bytesRemaining -= readSize
         bytesServedThisOpen += readSize
-        session?.noteRead(chunkIndex)
+        noteSessionRead(session, chunkIndex)
 
         return readSize
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import java.io.InterruptedIOException
@@ -21,6 +22,7 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import com.nuvio.tv.data.local.PlayerSettings
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import android.os.SystemClock
 
 import java.nio.ByteBuffer
@@ -116,6 +118,33 @@ internal class ParallelRangeDataSource(
         // Never evict a chunk touched in the last 2 s: closes the narrow race
         // where an overlapping old instance is still copying from the buffer.
         private const val EVICTION_TOUCH_GUARD_MS = 2_000L
+
+        // Rate-limit (HTTP 429/503) handling. A 429 is the server's explicit
+        // "slow down", so the response is shaped like congestion control:
+        // back off before retrying (honouring Retry-After when the server
+        // states one), reduce in-flight depth multiplicatively, and recover
+        // additively once the server goes quiet — so each session converges
+        // just under whatever request budget the provider actually enforces
+        // instead of oscillating between extremes. All state is per-session:
+        // providers differ, so every title probes fresh.
+        private const val RATE_LIMIT_MAX_BACKOFF_RETRIES = 3
+        private const val RATE_LIMIT_BACKOFF_BASE_MS = 500L
+        // Cap for GUESSED waits in a first episode. Deliberately short:
+        // playback is real-time, so long speculative sleeps on a download
+        // thread trade a maybe-429 for a certain stall.
+        private const val RATE_LIMIT_BACKOFF_CYCLE_CAP_MS = 3_000L
+        // Absolute ceiling for any single wait, including a server-stated
+        // Retry-After — a broken or hostile header must never camp a
+        // real-time pipeline.
+        private const val RATE_LIMIT_WAIT_HARD_CAP_MS = 15_000L
+        private const val RATE_LIMIT_BACKOFF_JITTER_MS = 250L
+        private const val RATE_LIMIT_SLEEP_SLICE_MS = 100L
+        // Additive-recovery probe cadence: +1 depth per quiet interval; the
+        // interval doubles on every fresh trip (gentler probing of a strict
+        // provider) and resets once the cap fully clears.
+        private const val RATE_LIMIT_DEPTH_STEP_BASE_MS = 10_000L
+        private const val RATE_LIMIT_DEPTH_STEP_MAX_MS = 60_000L
+        private const val RATE_LIMIT_ESCALATION_MAX = 5
         // A conforming DataSource blocks rather than returning 0 for a
         // positive-length read; tolerate a few zero-progress reads, then fail
         // the chunk instead of spinning forever.
@@ -157,6 +186,94 @@ internal class ParallelRangeDataSource(
             fun noteRead(chunkIndex: Long) {
                 touch(chunkIndex)
                 lastReadChunkIndex = chunkIndex
+            }
+
+            // --- Rate-limit (429/503) state: AIMD depth + escalating waits ---
+            // Multiplicative-decrease ceiling on prefetch depth;
+            // Int.MAX_VALUE = uncapped. Halved (never below 1) once per
+            // rate-limited episode, stepped +1 per quiet probe interval, and
+            // cleared once it climbs past the configured depth again.
+            val rateLimitDepthCap = AtomicInteger(Int.MAX_VALUE)
+            @Volatile var lastRateLimitAtMs: Long = 0L
+            @Volatile var lastDepthHalveAtMs: Long = 0L
+            @Volatile var lastDepthStepAtMs: Long = 0L
+            @Volatile var depthStepIntervalMs: Long = RATE_LIMIT_DEPTH_STEP_BASE_MS
+            // Escalation persists across backoff CYCLES: the per-attempt
+            // ladder alone resets every time the outer retry machinery
+            // re-enters it, which is exactly how a hard limiter produces an
+            // indefinite fixed-period hammer. Repeated episodes therefore
+            // start from longer waits; quiet recovery walks the level back
+            // down one notch per depth step.
+            val rateLimitEscalation = AtomicInteger(0)
+
+            /** Stamp an observed 429/503 so quiet time restarts. */
+            fun noteRateLimitHit() {
+                lastRateLimitAtMs = SystemClock.uptimeMillis()
+            }
+
+            /**
+             * Record the start of one rate-limited episode: stamp, bump the
+             * wait escalation, and apply ONE multiplicative depth decrease
+             * (guarded so a burst of concurrent 429s across download threads
+             * counts as a single congestion event, not a cascade to 1).
+             * Returns the escalation level this episode's waits should use
+             * (the pre-bump value, so a first-ever episode still starts from
+             * the short ladder).
+             */
+            fun beginRateLimitEpisode(configuredDepth: Int): Int {
+                val now = SystemClock.uptimeMillis()
+                lastRateLimitAtMs = now
+                val escalation = rateLimitEscalation.getAndUpdate {
+                    (it + 1).coerceAtMost(RATE_LIMIT_ESCALATION_MAX)
+                }
+                if (now - lastDepthHalveAtMs >= 1_000L) {
+                    val alreadyCapped = rateLimitDepthCap.get() < configuredDepth
+                    val effective = rateLimitDepthCap.get().coerceAtMost(configuredDepth)
+                    val halved = (effective / 2).coerceAtLeast(1)
+                    if (halved < effective) {
+                        rateLimitDepthCap.set(halved)
+                        lastDepthHalveAtMs = now
+                        // Gentler probing only when the provider pushes back
+                        // AGAIN during the climb: the first trip keeps the base
+                        // cadence, a re-trip doubles the interval.
+                        if (alreadyCapped) {
+                            depthStepIntervalMs =
+                                (depthStepIntervalMs * 2).coerceAtMost(RATE_LIMIT_DEPTH_STEP_MAX_MS)
+                        }
+                        Log.w(TAG, "Rate-limited; prefetch depth halved to " +
+                            "$halved/$configuredDepth (probe interval ${depthStepIntervalMs}ms)")
+                    }
+                }
+                return escalation
+            }
+
+            /**
+             * Current allowed prefetch depth. Uncapped sessions pay nothing.
+             * A capped session steps +1 after each probe interval of quiet
+             * (no 429/503 observed) and clears the cap — resetting the probe
+             * interval and decaying the wait escalation — once it climbs past
+             * the configured depth again.
+             */
+            fun currentAllowedDepth(configuredDepth: Int): Int {
+                val cap = rateLimitDepthCap.get()
+                if (cap >= configuredDepth) return configuredDepth
+                val now = SystemClock.uptimeMillis()
+                if (now - lastRateLimitAtMs >= depthStepIntervalMs &&
+                    now - lastDepthStepAtMs >= depthStepIntervalMs) {
+                    val stepped = cap + 1
+                    if (rateLimitDepthCap.compareAndSet(cap, stepped)) {
+                        lastDepthStepAtMs = now
+                        rateLimitEscalation.updateAndGet { (it - 1).coerceAtLeast(0) }
+                        if (stepped >= configuredDepth) {
+                            rateLimitDepthCap.set(Int.MAX_VALUE)
+                            depthStepIntervalMs = RATE_LIMIT_DEPTH_STEP_BASE_MS
+                            Log.i(TAG, "Rate-limit depth cap cleared; parallel prefetch fully restored")
+                        } else {
+                            Log.i(TAG, "Rate-limit quiet; prefetch depth stepped to $stepped/$configuredDepth")
+                        }
+                    }
+                }
+                return rateLimitDepthCap.get().coerceAtMost(configuredDepth)
             }
         }
 
@@ -725,7 +842,13 @@ internal class ParallelRangeDataSource(
         // meaningful sequential run. Side cursors (a few bytes per open on
         // scatter-read files) fetch only the chunk they actually need, instead
         // of fanning out connections+1 chunks of dead prefetch per visit.
-        val maxAhead = if (bytesServedThisOpen >= EARNED_PREFETCH_BYTES) parallelConnections + 1 else 1
+        val earnedAhead = if (bytesServedThisOpen >= EARNED_PREFETCH_BYTES) parallelConnections + 1 else 1
+        // AIMD: a rate-limited session halves its depth cap and recovers +1
+        // per quiet probe interval (ChunkSession.currentAllowedDepth), so a
+        // provider that 429s converges just under its actual request budget
+        // instead of pinning the whole session to a single connection.
+        val maxAhead = session?.currentAllowedDepth(parallelConnections + 1)?.coerceAtMost(earnedAhead)
+            ?: earnedAhead
 
         for (i in 0 until maxAhead) {
             val ci = currentChunkIdx + i
@@ -772,6 +895,15 @@ internal class ParallelRangeDataSource(
                 // Downloads belong to the session, not the instance —
                 // only future cancellation or session teardown aborts them.
                 if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
+                // HTTP 429/503 is the server rate-limiting, not a stalled
+                // download: hand the chunk to the dedicated backoff path,
+                // which waits (honouring Retry-After), reduces depth, and
+                // retries — instead of the immediate re-request below, which
+                // against a hard limiter just converts into more 429s.
+                val rlError = e.findRateLimitException()
+                if (rlError != null) {
+                    return downloadChunkWithRateLimitBackoff(activeSession, chunkIndex, future, rlError)
+                }
                 lastException = e
                 if (attempt == 0) {
                     if (e.isTransientInterruption()) {
@@ -829,6 +961,121 @@ internal class ParallelRangeDataSource(
         if (this is InterruptedIOException || this is InterruptedException) return true
         val cause = cause
         return cause is InterruptedIOException || cause is InterruptedException
+    }
+
+    /** Walk the cause chain for an HTTP 429/503 (rate-limit) response. */
+    private fun Throwable.findRateLimitException(): HttpDataSource.InvalidResponseCodeException? {
+        var cause: Throwable? = this
+        var depth = 0
+        while (cause != null && depth < 6) {
+            val c = cause
+            if (c is HttpDataSource.InvalidResponseCodeException &&
+                (c.responseCode == 429 || c.responseCode == 503)) {
+                return c
+            }
+            cause = c.cause
+            depth++
+        }
+        return null
+    }
+
+    /**
+     * Dedicated handling for a rate-limited chunk. One invocation = one
+     * congestion episode: one multiplicative depth decrease and one wait
+     * escalation, then up to RATE_LIMIT_MAX_BACKOFF_RETRIES properly-spaced
+     * retries. Bounded and cancellation-aware (a stop/seek aborts any wait
+     * within a sleep slice); when the budget is spent it throws and the
+     * existing failure handling and auto-recovery take over — never worse
+     * than before.
+     */
+    private fun downloadChunkWithRateLimitBackoff(
+        activeSession: ChunkSession,
+        chunkIndex: Long,
+        future: CompletableFuture<*>,
+        firstError: HttpDataSource.InvalidResponseCodeException
+    ): DownloadedChunk {
+        var rl: HttpDataSource.InvalidResponseCodeException = firstError
+        var lastException: Exception = firstError
+        val escalation = activeSession.beginRateLimitEpisode(parallelConnections + 1)
+        var attempt = 0
+        while (attempt < RATE_LIMIT_MAX_BACKOFF_RETRIES) {
+            val waitMs = rateLimitWaitMs(attempt, escalation, rl)
+            Log.w(TAG, "Chunk $chunkIndex rate-limited (HTTP ${rl.responseCode}); backing off ${waitMs}ms " +
+                "(attempt ${attempt + 1}/$RATE_LIMIT_MAX_BACKOFF_RETRIES, escalation $escalation)")
+            if (!sleepInterruptibly(waitMs, future, activeSession)) {
+                throw IOException("Cancelled during rate-limit backoff")
+            }
+            if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
+            try {
+                return downloadChunkOnce(activeSession, chunkIndex, future)
+            } catch (e: Exception) {
+                if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
+                lastException = e
+                // A non-rate-limit error after a 429 is a different failure: surface it.
+                rl = e.findRateLimitException() ?: throw e
+                activeSession.noteRateLimitHit()
+                attempt++
+            }
+        }
+        throw IOException(
+            "Chunk $chunkIndex still rate-limited after $RATE_LIMIT_MAX_BACKOFF_RETRIES backoffs",
+            lastException
+        )
+    }
+
+    /**
+     * Wait before retrying a rate-limited chunk. A server-stated Retry-After
+     * (delta-seconds or HTTP-date, via ParallelRangeRetryAfter) is honoured
+     * up to a hard cap — the server knows its own limiter, but a broken or
+     * hostile header must never camp a real-time pipeline. With no usable
+     * header the wait is exponential per attempt from a base that itself
+     * escalates with repeated episodes, so a hard limiter produces
+     * progressively longer waits across cycles instead of the indefinite
+     * fixed-period retry a self-resetting ladder degenerates into. Jitter
+     * decorrelates concurrent retries.
+     */
+    private fun rateLimitWaitMs(
+        attempt: Int,
+        escalation: Int,
+        rl: HttpDataSource.InvalidResponseCodeException
+    ): Long {
+        val jitter = (Math.random() * RATE_LIMIT_BACKOFF_JITTER_MS).toLong()
+        val header = rl.headerFields.entries
+            .firstOrNull { it.key?.equals("Retry-After", ignoreCase = true) == true }
+            ?.value?.firstOrNull()?.trim()
+        val headerMs = ParallelRangeRetryAfter.parseHeaderMs(header)
+        if (headerMs != null) {
+            return headerMs.coerceAtMost(RATE_LIMIT_WAIT_HARD_CAP_MS) + jitter
+        }
+        val cycleCapMs = (RATE_LIMIT_BACKOFF_CYCLE_CAP_MS shl escalation.coerceIn(0, RATE_LIMIT_ESCALATION_MAX))
+            .coerceAtMost(RATE_LIMIT_WAIT_HARD_CAP_MS)
+        val base = RATE_LIMIT_BACKOFF_BASE_MS shl (attempt + escalation).coerceIn(0, 6)
+        return base.coerceIn(RATE_LIMIT_BACKOFF_BASE_MS, cycleCapMs) + jitter
+    }
+
+    /**
+     * Sleep in short slices so a stop/seek aborts the backoff promptly.
+     * Watches future cancellation and session teardown only — not the
+     * instance closed flag — to stay consistent with the session-owned
+     * download model. Returns false if the wait should abort.
+     */
+    private fun sleepInterruptibly(
+        totalMs: Long,
+        future: CompletableFuture<*>,
+        activeSession: ChunkSession
+    ): Boolean {
+        var slept = 0L
+        while (slept < totalMs) {
+            if (future.isCancelled || activeSession.abandoned.get()) return false
+            val slice = minOf(RATE_LIMIT_SLEEP_SLICE_MS, totalMs - slept)
+            try {
+                Thread.sleep(slice)
+            } catch (_: InterruptedException) {
+                return false
+            }
+            slept += slice
+        }
+        return !(future.isCancelled || activeSession.abandoned.get())
     }
 
     /** Read from an already-opened DataSource into a pooled chunk buffer. */

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -96,58 +96,31 @@ internal class ParallelRangeDataSource(
             }
         }
 
-        // ── Session-owned chunk downloads ───────────────────────────────────
-        // ExoPlayer creates a new instance of this class for every seek,
-        // closing the old one. Previously each close cancelled all in-flight
-        // chunk downloads and each open re-probed the URL and re-downloaded
-        // data. On scatter-read files (poorly interleaved, moov-at-end MP4s
-        // whose track layout forces several distant concurrent read cursors)
-        // this measured as ~66% of transfer discarded — the same 32 MB chunks
-        // restarting up to 30 times inside two minutes (192 chunk starts /
-        // 66 completions), presenting as constant rebuffering.
-        // Downloads therefore belong to a companion-level session: futures
-        // (completed AND in-flight) survive the close→open boundary, run to
-        // completion regardless of instance lifetime, and instances are thin
-        // readers over the shared session. Eviction is touch-LRU under a
-        // memory-tiered cap; teardown happens on stream change, idle TTL, or
-        // player shutdown.
         private const val RETAINED_SESSION_TTL_MS = 45_000L
-        // Earned prefetch: sequential bytes an open must serve before
-        // lookahead prefetch is granted.
         private const val EARNED_PREFETCH_BYTES = 1L * 1024L * 1024L
-        // Never evict a chunk touched in the last 2 s: closes the narrow race
-        // where an overlapping old instance is still copying from the buffer.
-        private const val EVICTION_TOUCH_GUARD_MS = 2_000L
 
-        // Rate-limit (HTTP 429/503) handling. A 429 is the server's explicit
-        // "slow down", so the response is shaped like congestion control:
-        // back off before retrying (honouring Retry-After when the server
-        // states one), reduce in-flight depth multiplicatively, and recover
-        // additively once the server goes quiet — so each session converges
-        // just under whatever request budget the provider actually enforces
-        // instead of oscillating between extremes. All state is per-session:
-        // providers differ, so every title probes fresh.
+        internal fun lookaheadDepth(
+            bytesServedThisOpen: Long,
+            earnedPrefetchBytes: Long,
+            currentChunkComplete: Boolean,
+            configuredDepth: Int,
+            rateLimitDepth: Int
+        ): Int {
+            if (bytesServedThisOpen < earnedPrefetchBytes) return 1
+            if (!currentChunkComplete) return 1
+            return configuredDepth.coerceAtMost(rateLimitDepth).coerceAtLeast(1)
+        }
+
+        private const val EVICTION_TOUCH_GUARD_MS = 2_000L
         private const val RATE_LIMIT_MAX_BACKOFF_RETRIES = 3
         private const val RATE_LIMIT_BACKOFF_BASE_MS = 500L
-        // Cap for GUESSED waits in a first episode. Deliberately short:
-        // playback is real-time, so long speculative sleeps on a download
-        // thread trade a maybe-429 for a certain stall.
         private const val RATE_LIMIT_BACKOFF_CYCLE_CAP_MS = 3_000L
-        // Absolute ceiling for any single wait, including a server-stated
-        // Retry-After — a broken or hostile header must never camp a
-        // real-time pipeline.
         private const val RATE_LIMIT_WAIT_HARD_CAP_MS = 15_000L
         private const val RATE_LIMIT_BACKOFF_JITTER_MS = 250L
         private const val RATE_LIMIT_SLEEP_SLICE_MS = 100L
-        // Additive-recovery probe cadence: +1 depth per quiet interval; the
-        // interval doubles on every fresh trip (gentler probing of a strict
-        // provider) and resets once the cap fully clears.
         private const val RATE_LIMIT_DEPTH_STEP_BASE_MS = 10_000L
         private const val RATE_LIMIT_DEPTH_STEP_MAX_MS = 60_000L
         private const val RATE_LIMIT_ESCALATION_MAX = 5
-        // A conforming DataSource blocks rather than returning 0 for a
-        // positive-length read; tolerate a few zero-progress reads, then fail
-        // the chunk instead of spinning forever.
         private const val MAX_CONSECUTIVE_ZERO_READS = 3
 
         private class ChunkSession(
@@ -155,9 +128,6 @@ internal class ParallelRangeDataSource(
             val requestHeaders: Map<String, String>,
             val chunkSize: Long,
             val chunkCap: Int,
-            // Size of the live prefetch window (maxAhead in scheduleChunks).
-            // Chunks in reader+1..reader+prefetchWindow are imminent and are
-            // excluded from eviction so the reader never re-downloads them.
             val prefetchWindow: Int
         ) {
             @Volatile var resolvedUri: Uri? = null
@@ -174,13 +144,6 @@ internal class ParallelRangeDataSource(
                 lastUsedAtMs = now
             }
 
-            // Chunk index most recently SERVED to a reader. Creation-time
-            // touches in ensureChunkScheduled deliberately do not update this;
-            // only the read paths do, so eviction can distinguish "behind the
-            // cursor" from "prefetched ahead". Last-write-wins on purpose: a
-            // transient side-cursor read may move it for one read and the main
-            // cursor restores it immediately after; the 2 s touch guard covers
-            // that window.
             @Volatile var lastReadChunkIndex: Long = -1L
 
             fun noteRead(chunkIndex: Long) {
@@ -188,38 +151,17 @@ internal class ParallelRangeDataSource(
                 lastReadChunkIndex = chunkIndex
             }
 
-            // --- Rate-limit (429/503) state: AIMD depth + escalating waits ---
-            // Multiplicative-decrease ceiling on prefetch depth;
-            // Int.MAX_VALUE = uncapped. Halved (never below 1) once per
-            // rate-limited episode, stepped +1 per quiet probe interval, and
-            // cleared once it climbs past the configured depth again.
             val rateLimitDepthCap = AtomicInteger(Int.MAX_VALUE)
             @Volatile var lastRateLimitAtMs: Long = 0L
             @Volatile var lastDepthHalveAtMs: Long = 0L
             @Volatile var lastDepthStepAtMs: Long = 0L
             @Volatile var depthStepIntervalMs: Long = RATE_LIMIT_DEPTH_STEP_BASE_MS
-            // Escalation persists across backoff CYCLES: the per-attempt
-            // ladder alone resets every time the outer retry machinery
-            // re-enters it, which is exactly how a hard limiter produces an
-            // indefinite fixed-period hammer. Repeated episodes therefore
-            // start from longer waits; quiet recovery walks the level back
-            // down one notch per depth step.
             val rateLimitEscalation = AtomicInteger(0)
 
-            /** Stamp an observed 429/503 so quiet time restarts. */
             fun noteRateLimitHit() {
                 lastRateLimitAtMs = SystemClock.uptimeMillis()
             }
 
-            /**
-             * Record the start of one rate-limited episode: stamp, bump the
-             * wait escalation, and apply ONE multiplicative depth decrease
-             * (guarded so a burst of concurrent 429s across download threads
-             * counts as a single congestion event, not a cascade to 1).
-             * Returns the escalation level this episode's waits should use
-             * (the pre-bump value, so a first-ever episode still starts from
-             * the short ladder).
-             */
             fun beginRateLimitEpisode(configuredDepth: Int): Int {
                 val now = SystemClock.uptimeMillis()
                 lastRateLimitAtMs = now
@@ -233,9 +175,6 @@ internal class ParallelRangeDataSource(
                     if (halved < effective) {
                         rateLimitDepthCap.set(halved)
                         lastDepthHalveAtMs = now
-                        // Gentler probing only when the provider pushes back
-                        // AGAIN during the climb: the first trip keeps the base
-                        // cadence, a re-trip doubles the interval.
                         if (alreadyCapped) {
                             depthStepIntervalMs =
                                 (depthStepIntervalMs * 2).coerceAtMost(RATE_LIMIT_DEPTH_STEP_MAX_MS)
@@ -247,13 +186,6 @@ internal class ParallelRangeDataSource(
                 return escalation
             }
 
-            /**
-             * Current allowed prefetch depth. Uncapped sessions pay nothing.
-             * A capped session steps +1 after each probe interval of quiet
-             * (no 429/503 observed) and clears the cap — resetting the probe
-             * interval and decaying the wait escalation — once it climbs past
-             * the configured depth again.
-             */
             fun currentAllowedDepth(configuredDepth: Int): Int {
                 val cap = rateLimitDepthCap.get()
                 if (cap >= configuredDepth) return configuredDepth
@@ -280,7 +212,6 @@ internal class ParallelRangeDataSource(
         private val sessionLock = Any()
         private var currentChunkSession: ChunkSession? = null
 
-        /** Release one session buffer: recycle to the pool, or free directly on teardown. */
         private fun releaseSessionBuffer(buffer: PooledBuffer, chunkSz: Long, poolCap: Int) {
             if (poolCap > 0) {
                 val pool = globalBufferPool.computeIfAbsent(chunkSz) { ConcurrentLinkedDeque() }
@@ -296,12 +227,6 @@ internal class ParallelRangeDataSource(
             }
         }
 
-        /**
-         * Evict one future from a session. Handles the complete-vs-cancel race:
-         * if cancel() loses because the download just completed, the buffer is
-         * released via the completed value; if cancel() wins, the download
-         * loop's cancellation checks release the buffer on its own thread.
-         */
         private fun evictFuture(
             session: ChunkSession,
             chunkIndex: Long,
@@ -331,10 +256,6 @@ internal class ParallelRangeDataSource(
             session.lastTouch.clear()
         }
 
-        /**
-         * Get the shared session for this request URI, creating (and tearing
-         * down any stale/mismatched predecessor) as needed.
-         */
         private fun obtainSession(
             requestUri: Uri,
             requestHeaders: Map<String, String>,
@@ -362,11 +283,6 @@ internal class ParallelRangeDataSource(
             }
         }
 
-        /**
-         * Explicit teardown, wired into PlayerMediaSourceFactory.shutdown() so
-         * chunk buffers and downloads never outlive the player. Buffers are
-         * freed directly (poolCap = 0) — playback is over.
-         */
         internal fun releaseRetainedSession() {
             synchronized(sessionLock) {
                 currentChunkSession?.let { teardownSessionLocked(it, poolCap = 0) }
@@ -374,48 +290,16 @@ internal class ParallelRangeDataSource(
             }
         }
 
-        /**
-         * Enforce the session's chunk cap with touch-LRU eviction. Never
-         * evicts [protectIndex] (the chunk being read) or anything touched in
-         * the last EVICTION_TOUCH_GUARD_MS.
-         */
         private fun enforceSessionCap(session: ChunkSession, protectIndex: Long, poolCap: Int) {
             if (session.futures.size <= session.chunkCap) return
             synchronized(session) {
                 while (session.futures.size > session.chunkCap) {
                     val now = SystemClock.uptimeMillis()
-                    // The 2 s touch guard makes the cap soft — when every
-                    // candidate is recently touched the loop bails and an
-                    // active file can hold ~cap+2–3 chunks. Beyond cap+2 the
-                    // ceiling is hard: evict the oldest-touched candidate
-                    // regardless of the guard.
                     val hardOver = session.futures.size > session.chunkCap + 2
-                    // Position-aware victim selection. Touch-LRU alone
-                    // systematically evicted PREFETCHED chunks: ahead-of-reader
-                    // entries are touched only at creation, so once the reader
-                    // is a few chunks past that moment they are always the
-                    // oldest-touched entries — evicted seconds before the
-                    // reader arrives, then re-downloaded in full (measured on a
-                    // scatter-read remux: 118 of 133 chunks fetched twice, ~47%
-                    // of session bandwidth). Prefer chunks BEHIND the read
-                    // cursor (touch-LRU among them); only when none are
-                    // eligible fall back to the FARTHEST-ahead chunk, which is
-                    // needed latest. Soft-cap bail, the 2 s guard and the
-                    // cap+2 hard ceiling are unchanged.
                     val readerIdx = session.lastReadChunkIndex
                     val eligible = session.futures.keys
                         .filter { it != protectIndex }
                         .filter { hardOver || now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
-                    // The entire in-flight prefetch window reader+1..reader+
-                    // prefetchWindow is about to be read within seconds, so it
-                    // is excluded from eviction: when only in-window chunks
-                    // remain, bail (as the soft-cap does) and let the pool sit
-                    // transiently at cap+2 rather than evict-then-refetch.
-                    // Behind and beyond-window chunks stay evictable (hardOver
-                    // drops the touch guard for them), so the pool stays
-                    // bounded; beyond-window chunks (stale prefetch after a
-                    // backward seek) are the farthest-ahead evictable and go
-                    // first.
                     val nearAheadFloor = if (readerIdx >= 0L) readerIdx else Long.MIN_VALUE
                     val nearAheadCeil = if (readerIdx >= 0L) readerIdx + session.prefetchWindow else Long.MIN_VALUE
                     val evictable = eligible.filter { it < nearAheadFloor || it > nearAheadCeil }
@@ -428,7 +312,6 @@ internal class ParallelRangeDataSource(
                 }
             }
         }
-        // ── end session ─────────────────────────────────────────────────────
 
         private fun clearGlobalPool() {
             globalBufferPool.values.forEach { pool ->
@@ -497,14 +380,8 @@ internal class ParallelRangeDataSource(
     // Fallback: if parallel mode fails, use a single upstream DataSource
     private var fallbackSource: OkHttpDataSource? = null
 
-    // Shared download session (null on subtitle/fallback paths).
     private var session: ChunkSession? = null
-    // Earned prefetch: lookahead is granted only after this open has
-    // demonstrated sequential consumption, so side-cursor opens (tiny reads,
-    // then reopen) never trigger the connections+1 chunk prefetch fan-out.
     private var bytesServedThisOpen: Long = 0L
-    // Memory-tiered chunk cap: low-RAM devices keep the pre-existing
-    // ceiling (connections + 2); high-RAM gets two extra chunks of headroom.
     private val sessionChunkCap: Int = parallelConnections +
         if (com.nuvio.tv.ui.screens.settings.MemoryBudget.isLowRamTier) 2 else 4
 
@@ -566,8 +443,6 @@ internal class ParallelRangeDataSource(
         continuationSource?.close()
         continuationSource = null
         continuationEndPositionExclusive = C.TIME_UNSET
-        // A fresh open must not inherit fallback/length state from a previous
-        // open on this instance; every path below re-establishes both fields.
         fallbackSource?.close()
         fallbackSource = null
         totalFileLength = C.LENGTH_UNSET.toLong()
@@ -576,14 +451,6 @@ internal class ParallelRangeDataSource(
         resetLocalReadState()
         bytesServedThisOpen = 0L
 
-        // Attach to the shared download session for this URI. Downloads
-        // (done AND in-flight) belong to the session and survive the
-        // close→open cycle ExoPlayer performs on every seek. When the session
-        // is warm (length + resolved URI known) the probe request is skipped.
-        // If an adopted CDN URL has expired, chunk downloads fail, ExoPlayer
-        // re-opens, the failed futures are gone, and downloads retry against
-        // the session's URI — with the full probe as the eventual fallback via
-        // session teardown on TTL.
         val attachedSession = obtainSession(dataSpec.uri, dataSpec.httpRequestHeaders, chunkSize, sessionChunkCap, maxPoolSize, parallelConnections + 1)
         session = attachedSession
         val warmLength = attachedSession.totalLength
@@ -614,7 +481,6 @@ internal class ParallelRangeDataSource(
             bootstrapChunk = DownloadedChunk(PooledBuffer(null, ByteBuffer.wrap(cached.bootstrapData)), cached.bootstrapSize)
             bootstrapStartPosition = cached.startPosition
             bootstrapPrefetchDeferred = true
-            // Publish to the session so the next reopen is warm.
             attachedSession.resolvedUri = resolvedUri
             attachedSession.totalLength = totalFileLength
             Log.d(
@@ -650,8 +516,6 @@ internal class ParallelRangeDataSource(
             // Can't determine length or server doesn't support ranges — reuse probe as single connection
             Log.w(TAG, "Falling back to single connection (length=${openLength}, acceptsRanges=$acceptsRanges)")
             fallbackSource = probeSource
-            // Keep state consistent with the subtitle fallback path (position is
-            // already set above): known length gives a real total, unknown stays unset.
             totalFileLength = if (openLength != C.LENGTH_UNSET.toLong()) {
                 position + openLength
             } else {
@@ -664,7 +528,6 @@ internal class ParallelRangeDataSource(
         totalFileLength = position + openLength
         bytesRemaining = openLength
 
-        // Publish to the session so every subsequent reopen is warm.
         attachedSession.resolvedUri = resolvedUri
         attachedSession.totalLength = totalFileLength
 
@@ -775,13 +638,6 @@ internal class ParallelRangeDataSource(
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
-                // A failed download is not retryable by waiting — drop
-                // the future so the next attempt schedules a fresh one.
-                // Cancel before dropping: an orphaned in-flight download
-                // otherwise completes into a pooled native buffer nothing will
-                // ever release. Ownership-gated on the two-arg remove so a
-                // future already evicted by another thread is never
-                // double-released.
                 if (activeSession.futures.remove(chunkIndex, future)) {
                     activeSession.lastTouch.remove(chunkIndex)
                     if (!future.cancel(true) && future.isDone && !future.isCancelled) {
@@ -796,9 +652,6 @@ internal class ParallelRangeDataSource(
             currentChunkIndex = chunkIndex
             currentChunkReadOffset = (position % chunkSize).toInt()
 
-            // LRU cap enforcement lives in ensureChunkScheduled; behind-
-            // chunks are not eagerly released (they serve the backward
-            // cursors on scatter-read files).
             scheduleChunks()
         }
 
@@ -815,9 +668,6 @@ internal class ParallelRangeDataSource(
         }
 
         val readSize = minOf(toRead, available)
-        // Session chunks are shared across instances — mutating the shared
-        // buffer's position races concurrent readers of the same chunk. Read
-        // through a duplicate, as the ByteBuffer read path does.
         val readBuf = chunk.buffer.byteBuffer.duplicate()
         readBuf.position(currentChunkReadOffset)
         readBuf.get(buffer, offset, readSize)
@@ -838,17 +688,17 @@ internal class ParallelRangeDataSource(
             } else {
                 position / chunkSize
             }
-        // Earned prefetch: lookahead only after this open has served a
-        // meaningful sequential run. Side cursors (a few bytes per open on
-        // scatter-read files) fetch only the chunk they actually need, instead
-        // of fanning out connections+1 chunks of dead prefetch per visit.
-        val earnedAhead = if (bytesServedThisOpen >= EARNED_PREFETCH_BYTES) parallelConnections + 1 else 1
-        // AIMD: a rate-limited session halves its depth cap and recovers +1
-        // per quiet probe interval (ChunkSession.currentAllowedDepth), so a
-        // provider that 429s converges just under its actual request budget
-        // instead of pinning the whole session to a single connection.
-        val maxAhead = session?.currentAllowedDepth(parallelConnections + 1)?.coerceAtMost(earnedAhead)
-            ?: earnedAhead
+        val configuredDepth = parallelConnections + 1
+        val currentComplete = session?.futures?.get(currentChunkIdx)?.let { future ->
+            future.isDone && !future.isCancelled && !future.isCompletedExceptionally
+        } == true
+        val maxAhead = lookaheadDepth(
+            bytesServedThisOpen = bytesServedThisOpen,
+            earnedPrefetchBytes = EARNED_PREFETCH_BYTES,
+            currentChunkComplete = currentComplete,
+            configuredDepth = configuredDepth,
+            rateLimitDepth = session?.currentAllowedDepth(configuredDepth) ?: configuredDepth
+        )
 
         for (i in 0 until maxAhead) {
             val ci = currentChunkIdx + i
@@ -859,7 +709,6 @@ internal class ParallelRangeDataSource(
 
     private fun ensureChunkScheduled(chunkIndex: Long) {
         val activeSession = session ?: return
-        // Make room under the memory-tiered cap before growing the map.
         enforceSessionCap(activeSession, protectIndex = chunkIndex, poolCap = maxPoolSize)
         activeSession.futures.computeIfAbsent(chunkIndex) {
             val future = CompletableFuture<DownloadedChunk>()
@@ -892,14 +741,7 @@ internal class ParallelRangeDataSource(
             try {
                 return downloadChunkOnce(activeSession, chunkIndex, future)
             } catch (e: Exception) {
-                // Downloads belong to the session, not the instance —
-                // only future cancellation or session teardown aborts them.
                 if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
-                // HTTP 429/503 is the server rate-limiting, not a stalled
-                // download: hand the chunk to the dedicated backoff path,
-                // which waits (honouring Retry-After), reduces depth, and
-                // retries — instead of the immediate re-request below, which
-                // against a hard limiter just converts into more 429s.
                 val rlError = e.findRateLimitException()
                 if (rlError != null) {
                     return downloadChunkWithRateLimitBackoff(activeSession, chunkIndex, future, rlError)
@@ -944,9 +786,6 @@ internal class ParallelRangeDataSource(
             if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
             Log.d(TAG, "Starting chunk download: idx=$chunkIndex, range=$start-$end")
             ds.open(spec)
-            // With a known session length the requested range is exact — a
-            // chunk that comes back short must fail (and retry) rather than be
-            // cached as if complete.
             val expectedBytes = if (sessionLength > 0L) end - start else -1L
             val chunk = readIntoChunk(activeSession, ds, future, expectedBytes)
             Log.d(TAG, "Successfully downloaded chunk $chunkIndex, size=${chunk.size} bytes")
@@ -963,7 +802,6 @@ internal class ParallelRangeDataSource(
         return cause is InterruptedIOException || cause is InterruptedException
     }
 
-    /** Walk the cause chain for an HTTP 429/503 (rate-limit) response. */
     private fun Throwable.findRateLimitException(): HttpDataSource.InvalidResponseCodeException? {
         var cause: Throwable? = this
         var depth = 0
@@ -979,15 +817,6 @@ internal class ParallelRangeDataSource(
         return null
     }
 
-    /**
-     * Dedicated handling for a rate-limited chunk. One invocation = one
-     * congestion episode: one multiplicative depth decrease and one wait
-     * escalation, then up to RATE_LIMIT_MAX_BACKOFF_RETRIES properly-spaced
-     * retries. Bounded and cancellation-aware (a stop/seek aborts any wait
-     * within a sleep slice); when the budget is spent it throws and the
-     * existing failure handling and auto-recovery take over — never worse
-     * than before.
-     */
     private fun downloadChunkWithRateLimitBackoff(
         activeSession: ChunkSession,
         chunkIndex: Long,
@@ -1011,7 +840,6 @@ internal class ParallelRangeDataSource(
             } catch (e: Exception) {
                 if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
                 lastException = e
-                // A non-rate-limit error after a 429 is a different failure: surface it.
                 rl = e.findRateLimitException() ?: throw e
                 activeSession.noteRateLimitHit()
                 attempt++
@@ -1023,17 +851,6 @@ internal class ParallelRangeDataSource(
         )
     }
 
-    /**
-     * Wait before retrying a rate-limited chunk. A server-stated Retry-After
-     * (delta-seconds or HTTP-date, via ParallelRangeRetryAfter) is honoured
-     * up to a hard cap — the server knows its own limiter, but a broken or
-     * hostile header must never camp a real-time pipeline. With no usable
-     * header the wait is exponential per attempt from a base that itself
-     * escalates with repeated episodes, so a hard limiter produces
-     * progressively longer waits across cycles instead of the indefinite
-     * fixed-period retry a self-resetting ladder degenerates into. Jitter
-     * decorrelates concurrent retries.
-     */
     private fun rateLimitWaitMs(
         attempt: Int,
         escalation: Int,
@@ -1053,12 +870,6 @@ internal class ParallelRangeDataSource(
         return base.coerceIn(RATE_LIMIT_BACKOFF_BASE_MS, cycleCapMs) + jitter
     }
 
-    /**
-     * Sleep in short slices so a stop/seek aborts the backoff promptly.
-     * Watches future cancellation and session teardown only — not the
-     * instance closed flag — to stay consistent with the session-owned
-     * download model. Returns false if the wait should abort.
-     */
     private fun sleepInterruptibly(
         totalMs: Long,
         future: CompletableFuture<*>,
@@ -1096,9 +907,6 @@ internal class ParallelRangeDataSource(
                 null
             }
 
-            // The loop does not watch the instance's closed flag —
-            // downloads run to completion across ExoPlayer's seek reopens and
-            // abort only on future cancellation or session teardown.
             while (!activeSession.abandoned.get()) {
                 if (future.isCancelled) {
                     throw IOException("Chunk download cancelled")
@@ -1119,9 +927,6 @@ internal class ParallelRangeDataSource(
                 }
 
                 if (read == C.RESULT_END_OF_INPUT) break
-                // A positive-length read returning 0 violates the DataSource
-                // contract; bail after a few rather than busy-spinning until
-                // cancellation.
                 if (read == 0) {
                     if (++consecutiveZeroReads >= MAX_CONSECUTIVE_ZERO_READS) {
                         throw IOException(
@@ -1134,9 +939,6 @@ internal class ParallelRangeDataSource(
                 }
                 totalRead += read
             }
-            // A premature EOF inside a known range must not produce a cached
-            // "complete" chunk — a short non-final chunk otherwise dead-ends
-            // both read paths at the phantom chunk boundary.
             if (expectedBytes > 0L && totalRead < expectedBytes && !activeSession.abandoned.get()) {
                 throw IOException("Short chunk: read $totalRead of $expectedBytes bytes")
             }
@@ -1213,12 +1015,6 @@ internal class ParallelRangeDataSource(
         }
     }
 
-    /**
-     * Detach instance-local read state. Session chunks (and in-flight
-     * downloads) are untouched — they belong to the shared session and their
-     * buffers are owned by the session's futures. Releasing anything here
-     * would double-free; eviction and teardown are the session's job.
-     */
     private fun resetLocalReadState() {
         currentChunk = null
         currentChunkIndex = -1
@@ -1235,7 +1031,6 @@ internal class ParallelRangeDataSource(
             continuationSource = null
             continuationEndPositionExclusive = C.TIME_UNSET
 
-            // Downloads survive this close — detach references only.
             resetLocalReadState()
             session = null
 
@@ -1331,8 +1126,6 @@ internal class ParallelRangeDataSource(
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
-                // Mirror of the byte-array path: cancel before dropping,
-                // ownership-gated release if the download won the race.
                 if (activeSession.futures.remove(chunkIndex, future)) {
                     activeSession.lastTouch.remove(chunkIndex)
                     if (!future.cancel(true) && future.isDone && !future.isCancelled) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -103,11 +103,14 @@ internal class ParallelRangeDataSource(
             bytesServedThisOpen: Long,
             earnedPrefetchBytes: Long,
             currentChunkComplete: Boolean,
+            nextChunkComplete: Boolean,
             configuredDepth: Int,
             rateLimitDepth: Int
         ): Int {
             if (bytesServedThisOpen < earnedPrefetchBytes) return 1
-            if (!currentChunkComplete) return 1
+            if (!currentChunkComplete || !nextChunkComplete) {
+                return 2.coerceAtMost(configuredDepth).coerceAtMost(rateLimitDepth).coerceAtLeast(1)
+            }
             return configuredDepth.coerceAtMost(rateLimitDepth).coerceAtLeast(1)
         }
 
@@ -799,13 +802,15 @@ internal class ParallelRangeDataSource(
                 position / chunkSize
             }
         val configuredDepth = parallelConnections + 1
-        val currentComplete = session?.futures?.get(currentChunkIdx)?.let { future ->
-            future.isDone && !future.isCancelled && !future.isCompletedExceptionally
-        } == true
+        fun chunkComplete(index: Long): Boolean {
+            val future = session?.futures?.get(index) ?: return false
+            return future.isDone && !future.isCancelled && !future.isCompletedExceptionally
+        }
         val maxAhead = lookaheadDepth(
             bytesServedThisOpen = bytesServedThisOpen,
             earnedPrefetchBytes = EARNED_PREFETCH_BYTES,
-            currentChunkComplete = currentComplete,
+            currentChunkComplete = chunkComplete(currentChunkIdx),
+            nextChunkComplete = chunkComplete(currentChunkIdx + 1),
             configuredDepth = configuredDepth,
             rateLimitDepth = session?.currentAllowedDepth(configuredDepth) ?: configuredDepth
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSource.kt
@@ -94,6 +94,225 @@ internal class ParallelRangeDataSource(
             }
         }
 
+        // ── Session-owned chunk downloads ───────────────────────────────────
+        // ExoPlayer creates a new instance of this class for every seek,
+        // closing the old one. Previously each close cancelled all in-flight
+        // chunk downloads and each open re-probed the URL and re-downloaded
+        // data. On scatter-read files (poorly interleaved, moov-at-end MP4s
+        // whose track layout forces several distant concurrent read cursors)
+        // this measured as ~66% of transfer discarded — the same 32 MB chunks
+        // restarting up to 30 times inside two minutes (192 chunk starts /
+        // 66 completions), presenting as constant rebuffering.
+        // Downloads therefore belong to a companion-level session: futures
+        // (completed AND in-flight) survive the close→open boundary, run to
+        // completion regardless of instance lifetime, and instances are thin
+        // readers over the shared session. Eviction is touch-LRU under a
+        // memory-tiered cap; teardown happens on stream change, idle TTL, or
+        // player shutdown.
+        private const val RETAINED_SESSION_TTL_MS = 45_000L
+        // Earned prefetch: sequential bytes an open must serve before
+        // lookahead prefetch is granted.
+        private const val EARNED_PREFETCH_BYTES = 1L * 1024L * 1024L
+        // Never evict a chunk touched in the last 2 s: closes the narrow race
+        // where an overlapping old instance is still copying from the buffer.
+        private const val EVICTION_TOUCH_GUARD_MS = 2_000L
+        // A conforming DataSource blocks rather than returning 0 for a
+        // positive-length read; tolerate a few zero-progress reads, then fail
+        // the chunk instead of spinning forever.
+        private const val MAX_CONSECUTIVE_ZERO_READS = 3
+
+        private class ChunkSession(
+            val requestUri: Uri,
+            val requestHeaders: Map<String, String>,
+            val chunkSize: Long,
+            val chunkCap: Int,
+            // Size of the live prefetch window (maxAhead in scheduleChunks).
+            // Chunks in reader+1..reader+prefetchWindow are imminent and are
+            // excluded from eviction so the reader never re-downloads them.
+            val prefetchWindow: Int
+        ) {
+            @Volatile var resolvedUri: Uri? = null
+            @Volatile var totalLength: Long = -1L
+            val futures = ConcurrentHashMap<Long, CompletableFuture<DownloadedChunk>>()
+            val lastTouch = ConcurrentHashMap<Long, Long>()
+            val abandoned = AtomicBoolean(false)
+            val activeSources: MutableSet<DataSource> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+            @Volatile var lastUsedAtMs: Long = SystemClock.uptimeMillis()
+
+            fun touch(chunkIndex: Long) {
+                val now = SystemClock.uptimeMillis()
+                lastTouch[chunkIndex] = now
+                lastUsedAtMs = now
+            }
+
+            // Chunk index most recently SERVED to a reader. Creation-time
+            // touches in ensureChunkScheduled deliberately do not update this;
+            // only the read paths do, so eviction can distinguish "behind the
+            // cursor" from "prefetched ahead". Last-write-wins on purpose: a
+            // transient side-cursor read may move it for one read and the main
+            // cursor restores it immediately after; the 2 s touch guard covers
+            // that window.
+            @Volatile var lastReadChunkIndex: Long = -1L
+
+            fun noteRead(chunkIndex: Long) {
+                touch(chunkIndex)
+                lastReadChunkIndex = chunkIndex
+            }
+        }
+
+        private val sessionLock = Any()
+        private var currentChunkSession: ChunkSession? = null
+
+        /** Release one session buffer: recycle to the pool, or free directly on teardown. */
+        private fun releaseSessionBuffer(buffer: PooledBuffer, chunkSz: Long, poolCap: Int) {
+            if (poolCap > 0) {
+                val pool = globalBufferPool.computeIfAbsent(chunkSz) { ConcurrentLinkedDeque() }
+                if (pool.size < poolCap) {
+                    pool.offerLast(buffer)
+                    return
+                }
+            }
+            if (buffer.allocation != null) {
+                androidx.media3.exoplayer.upstream.DefaultAllocatorNative.freeAllocation(buffer.allocation)
+            } else if (buffer.byteBuffer.isDirect) {
+                freeDirectBuffer(buffer.byteBuffer)
+            }
+        }
+
+        /**
+         * Evict one future from a session. Handles the complete-vs-cancel race:
+         * if cancel() loses because the download just completed, the buffer is
+         * released via the completed value; if cancel() wins, the download
+         * loop's cancellation checks release the buffer on its own thread.
+         */
+        private fun evictFuture(
+            session: ChunkSession,
+            chunkIndex: Long,
+            poolCap: Int
+        ) {
+            val future = session.futures.remove(chunkIndex) ?: return
+            session.lastTouch.remove(chunkIndex)
+            if (!future.cancel(true) && future.isDone && !future.isCancelled) {
+                try {
+                    releaseSessionBuffer(future.get().buffer, session.chunkSize, poolCap)
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        private fun teardownSessionLocked(session: ChunkSession, poolCap: Int) {
+            session.abandoned.set(true)
+            session.activeSources.forEach { ds ->
+                try { ds.close() } catch (_: Exception) {}
+            }
+            session.activeSources.clear()
+            val indices = session.futures.keys.toList()
+            for (index in indices) {
+                evictFuture(session, index, poolCap)
+            }
+            session.futures.clear()
+            session.lastTouch.clear()
+        }
+
+        /**
+         * Get the shared session for this request URI, creating (and tearing
+         * down any stale/mismatched predecessor) as needed.
+         */
+        private fun obtainSession(
+            requestUri: Uri,
+            requestHeaders: Map<String, String>,
+            chunkSz: Long,
+            chunkCap: Int,
+            poolCap: Int,
+            prefetchWindow: Int
+        ): ChunkSession {
+            synchronized(sessionLock) {
+                val existing = currentChunkSession
+                if (existing != null) {
+                    val fresh = SystemClock.uptimeMillis() - existing.lastUsedAtMs <= RETAINED_SESSION_TTL_MS
+                    if (fresh && !existing.abandoned.get() &&
+                        existing.requestUri == requestUri && existing.chunkSize == chunkSz &&
+                        existing.requestHeaders == requestHeaders
+                    ) {
+                        existing.lastUsedAtMs = SystemClock.uptimeMillis()
+                        return existing
+                    }
+                    teardownSessionLocked(existing, poolCap)
+                }
+                val created = ChunkSession(requestUri, requestHeaders, chunkSz, chunkCap, prefetchWindow)
+                currentChunkSession = created
+                return created
+            }
+        }
+
+        /**
+         * Explicit teardown, wired into PlayerMediaSourceFactory.shutdown() so
+         * chunk buffers and downloads never outlive the player. Buffers are
+         * freed directly (poolCap = 0) — playback is over.
+         */
+        internal fun releaseRetainedSession() {
+            synchronized(sessionLock) {
+                currentChunkSession?.let { teardownSessionLocked(it, poolCap = 0) }
+                currentChunkSession = null
+            }
+        }
+
+        /**
+         * Enforce the session's chunk cap with touch-LRU eviction. Never
+         * evicts [protectIndex] (the chunk being read) or anything touched in
+         * the last EVICTION_TOUCH_GUARD_MS.
+         */
+        private fun enforceSessionCap(session: ChunkSession, protectIndex: Long, poolCap: Int) {
+            if (session.futures.size <= session.chunkCap) return
+            synchronized(session) {
+                while (session.futures.size > session.chunkCap) {
+                    val now = SystemClock.uptimeMillis()
+                    // The 2 s touch guard makes the cap soft — when every
+                    // candidate is recently touched the loop bails and an
+                    // active file can hold ~cap+2–3 chunks. Beyond cap+2 the
+                    // ceiling is hard: evict the oldest-touched candidate
+                    // regardless of the guard.
+                    val hardOver = session.futures.size > session.chunkCap + 2
+                    // Position-aware victim selection. Touch-LRU alone
+                    // systematically evicted PREFETCHED chunks: ahead-of-reader
+                    // entries are touched only at creation, so once the reader
+                    // is a few chunks past that moment they are always the
+                    // oldest-touched entries — evicted seconds before the
+                    // reader arrives, then re-downloaded in full (measured on a
+                    // scatter-read remux: 118 of 133 chunks fetched twice, ~47%
+                    // of session bandwidth). Prefer chunks BEHIND the read
+                    // cursor (touch-LRU among them); only when none are
+                    // eligible fall back to the FARTHEST-ahead chunk, which is
+                    // needed latest. Soft-cap bail, the 2 s guard and the
+                    // cap+2 hard ceiling are unchanged.
+                    val readerIdx = session.lastReadChunkIndex
+                    val eligible = session.futures.keys
+                        .filter { it != protectIndex }
+                        .filter { hardOver || now - (session.lastTouch[it] ?: 0L) >= EVICTION_TOUCH_GUARD_MS }
+                    // The entire in-flight prefetch window reader+1..reader+
+                    // prefetchWindow is about to be read within seconds, so it
+                    // is excluded from eviction: when only in-window chunks
+                    // remain, bail (as the soft-cap does) and let the pool sit
+                    // transiently at cap+2 rather than evict-then-refetch.
+                    // Behind and beyond-window chunks stay evictable (hardOver
+                    // drops the touch guard for them), so the pool stays
+                    // bounded; beyond-window chunks (stale prefetch after a
+                    // backward seek) are the farthest-ahead evictable and go
+                    // first.
+                    val nearAheadFloor = if (readerIdx >= 0L) readerIdx else Long.MIN_VALUE
+                    val nearAheadCeil = if (readerIdx >= 0L) readerIdx + session.prefetchWindow else Long.MIN_VALUE
+                    val evictable = eligible.filter { it < nearAheadFloor || it > nearAheadCeil }
+                    val victim = evictable
+                        .filter { readerIdx >= 0L && it < readerIdx }
+                        .minByOrNull { session.lastTouch[it] ?: 0L }
+                        ?: evictable.maxOrNull()
+                        ?: return
+                    evictFuture(session, victim, poolCap)
+                }
+            }
+        }
+        // ── end session ─────────────────────────────────────────────────────
+
         private fun clearGlobalPool() {
             globalBufferPool.values.forEach { pool ->
                 while (true) {
@@ -143,9 +362,6 @@ internal class ParallelRangeDataSource(
     private var bytesRemaining: Long = C.LENGTH_UNSET.toLong()
     private val closed = AtomicBoolean(false)
 
-    // Chunk download state
-    private val chunks = ConcurrentHashMap<Long, CompletableFuture<DownloadedChunk>>()
-
     // Buffer pool limit
     private val maxPoolSize = parallelConnections + 2
 
@@ -157,7 +373,6 @@ internal class ParallelRangeDataSource(
     private var bootstrapChunk: DownloadedChunk? = null
     private var bootstrapStartPosition: Long = C.TIME_UNSET
     private var continuationSource: OkHttpDataSource? = null
-    private val activeDataSources = java.util.concurrent.ConcurrentHashMap.newKeySet<DataSource>()
     private var continuationEndPositionExclusive: Long = C.TIME_UNSET
 
     private val transferListeners = mutableListOf<TransferListener>()
@@ -165,11 +380,22 @@ internal class ParallelRangeDataSource(
     // Fallback: if parallel mode fails, use a single upstream DataSource
     private var fallbackSource: OkHttpDataSource? = null
 
+    // Shared download session (null on subtitle/fallback paths).
+    private var session: ChunkSession? = null
+    // Earned prefetch: lookahead is granted only after this open has
+    // demonstrated sequential consumption, so side-cursor opens (tiny reads,
+    // then reopen) never trigger the connections+1 chunk prefetch fan-out.
+    private var bytesServedThisOpen: Long = 0L
+    // Memory-tiered chunk cap: low-RAM devices keep the pre-existing
+    // ceiling (connections + 2); high-RAM gets two extra chunks of headroom.
+    private val sessionChunkCap: Int = parallelConnections +
+        if (com.nuvio.tv.ui.screens.settings.MemoryBudget.isLowRamTier) 2 else 4
+
     override fun open(dataSpec: DataSpec): Long {
         val isSubtitle = dataSpec.uri.getQueryParameter("nuvio_type") == "subtitle"
         if (isSubtitle) {
             closed.set(false)
-            cancelAllChunks()
+            resetLocalReadState()
             
             // Clean the custom query parameter from the subtitle URL before requesting
             val cleanedUri = dataSpec.uri.buildUpon().clearQuery().let { builder ->
@@ -199,6 +425,7 @@ internal class ParallelRangeDataSource(
 
         val wasClosed = closed.get()
         val isReopen = !wasClosed && 
+                       fallbackSource == null &&
                        originalDataSpec != null && 
                        originalDataSpec?.uri == dataSpec.uri && 
                        position == dataSpec.position &&
@@ -222,8 +449,45 @@ internal class ParallelRangeDataSource(
         continuationSource?.close()
         continuationSource = null
         continuationEndPositionExclusive = C.TIME_UNSET
+        // A fresh open must not inherit fallback/length state from a previous
+        // open on this instance; every path below re-establishes both fields.
+        fallbackSource?.close()
+        fallbackSource = null
+        totalFileLength = C.LENGTH_UNSET.toLong()
+        bytesRemaining = C.LENGTH_UNSET.toLong()
 
-        cancelAllChunks()
+        resetLocalReadState()
+        bytesServedThisOpen = 0L
+
+        // Attach to the shared download session for this URI. Downloads
+        // (done AND in-flight) belong to the session and survive the
+        // close→open cycle ExoPlayer performs on every seek. When the session
+        // is warm (length + resolved URI known) the probe request is skipped.
+        // If an adopted CDN URL has expired, chunk downloads fail, ExoPlayer
+        // re-opens, the failed futures are gone, and downloads retry against
+        // the session's URI — with the full probe as the eventual fallback via
+        // session teardown on TTL.
+        val attachedSession = obtainSession(dataSpec.uri, dataSpec.httpRequestHeaders, chunkSize, sessionChunkCap, maxPoolSize, parallelConnections + 1)
+        session = attachedSession
+        val warmLength = attachedSession.totalLength
+        if (warmLength > 0L && dataSpec.position in 0 until warmLength) {
+            resolvedUri = attachedSession.resolvedUri
+            onResolvedUri(resolvedUri)
+            totalFileLength = warmLength
+            val remaining = (totalFileLength - position).coerceAtLeast(0L)
+            bytesRemaining = if (dataSpec.length != C.LENGTH_UNSET.toLong()) {
+                minOf(dataSpec.length, remaining)
+            } else {
+                remaining
+            }
+            bootstrapPrefetchDeferred = true
+            Log.d(
+                TAG,
+                "Attached to warm session for reopen at $position, " +
+                    "file=${totalFileLength / 1024 / 1024}MB, held=${attachedSession.futures.size} chunk(s) (probe skipped)"
+            )
+            return bytesRemaining
+        }
 
         consumeBootstrapCache(dataSpec)?.let { cached ->
             resolvedUri = cached.resolvedUri
@@ -233,6 +497,9 @@ internal class ParallelRangeDataSource(
             bootstrapChunk = DownloadedChunk(PooledBuffer(null, ByteBuffer.wrap(cached.bootstrapData)), cached.bootstrapSize)
             bootstrapStartPosition = cached.startPosition
             bootstrapPrefetchDeferred = true
+            // Publish to the session so the next reopen is warm.
+            attachedSession.resolvedUri = resolvedUri
+            attachedSession.totalLength = totalFileLength
             Log.d(
                 TAG,
                 "Reusing bootstrap window for immediate reopen at ${cached.startPosition}, " +
@@ -266,11 +533,23 @@ internal class ParallelRangeDataSource(
             // Can't determine length or server doesn't support ranges — reuse probe as single connection
             Log.w(TAG, "Falling back to single connection (length=${openLength}, acceptsRanges=$acceptsRanges)")
             fallbackSource = probeSource
+            // Keep state consistent with the subtitle fallback path (position is
+            // already set above): known length gives a real total, unknown stays unset.
+            totalFileLength = if (openLength != C.LENGTH_UNSET.toLong()) {
+                position + openLength
+            } else {
+                C.LENGTH_UNSET.toLong()
+            }
+            bytesRemaining = openLength
             return openLength
         }
 
         totalFileLength = position + openLength
         bytesRemaining = openLength
+
+        // Publish to the session so every subsequent reopen is warm.
+        attachedSession.resolvedUri = resolvedUri
+        attachedSession.totalLength = totalFileLength
 
         Log.d(TAG, "Parallel mode: ${parallelConnections} connections, ${chunkSize / 1024 / 1024}MB chunks, " +
                 "file=${totalFileLength / 1024 / 1024}MB, resolved=${resolvedUri?.host}")
@@ -371,19 +650,38 @@ internal class ParallelRangeDataSource(
 
         // Load the chunk for the current position
         if (currentChunkIndex != chunkIndex || currentChunk == null) {
+            val activeSession = session ?: return C.RESULT_END_OF_INPUT
             ensureChunkScheduled(chunkIndex)
-            val future = chunks[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            val future = activeSession.futures[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            activeSession.noteRead(chunkIndex)
             try {
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
+                // A failed download is not retryable by waiting — drop
+                // the future so the next attempt schedules a fresh one.
+                // Cancel before dropping: an orphaned in-flight download
+                // otherwise completes into a pooled native buffer nothing will
+                // ever release. Ownership-gated on the two-arg remove so a
+                // future already evicted by another thread is never
+                // double-released.
+                if (activeSession.futures.remove(chunkIndex, future)) {
+                    activeSession.lastTouch.remove(chunkIndex)
+                    if (!future.cancel(true) && future.isDone && !future.isCancelled) {
+                        try {
+                            releaseSessionBuffer(future.get().buffer, activeSession.chunkSize, maxPoolSize)
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
                 throw IOException("Failed to download chunk $chunkIndex", e)
             }
             currentChunkIndex = chunkIndex
             currentChunkReadOffset = (position % chunkSize).toInt()
 
-            // Clean up old chunks (returns buffers to pool) and schedule new ones
-            cleanupOldChunks(chunkIndex)
+            // LRU cap enforcement lives in ensureChunkScheduled; behind-
+            // chunks are not eagerly released (they serve the backward
+            // cursors on scatter-read files).
             scheduleChunks()
         }
 
@@ -400,12 +698,17 @@ internal class ParallelRangeDataSource(
         }
 
         val readSize = minOf(toRead, available)
-        val readBuf = chunk.buffer.byteBuffer
+        // Session chunks are shared across instances — mutating the shared
+        // buffer's position races concurrent readers of the same chunk. Read
+        // through a duplicate, as the ByteBuffer read path does.
+        val readBuf = chunk.buffer.byteBuffer.duplicate()
         readBuf.position(currentChunkReadOffset)
         readBuf.get(buffer, offset, readSize)
         currentChunkReadOffset += readSize
         position += readSize
         bytesRemaining -= readSize
+        bytesServedThisOpen += readSize
+        session?.noteRead(chunkIndex)
 
         return readSize
     }
@@ -418,7 +721,11 @@ internal class ParallelRangeDataSource(
             } else {
                 position / chunkSize
             }
-        val maxAhead = parallelConnections + 1
+        // Earned prefetch: lookahead only after this open has served a
+        // meaningful sequential run. Side cursors (a few bytes per open on
+        // scatter-read files) fetch only the chunk they actually need, instead
+        // of fanning out connections+1 chunks of dead prefetch per visit.
+        val maxAhead = if (bytesServedThisOpen >= EARNED_PREFETCH_BYTES) parallelConnections + 1 else 1
 
         for (i in 0 until maxAhead) {
             val ci = currentChunkIdx + i
@@ -428,16 +735,24 @@ internal class ParallelRangeDataSource(
     }
 
     private fun ensureChunkScheduled(chunkIndex: Long) {
-        chunks.computeIfAbsent(chunkIndex) {
+        val activeSession = session ?: return
+        // Make room under the memory-tiered cap before growing the map.
+        enforceSessionCap(activeSession, protectIndex = chunkIndex, poolCap = maxPoolSize)
+        activeSession.futures.computeIfAbsent(chunkIndex) {
             val future = CompletableFuture<DownloadedChunk>()
+            activeSession.touch(chunkIndex)
             Log.d(TAG, "Scheduling chunk $chunkIndex")
             sharedExecutor.execute {
                 try {
-                    if (!future.isCancelled) {
-                        val result = downloadChunk(chunkIndex, future)
+                    if (!future.isCancelled && !activeSession.abandoned.get()) {
+                        val result = downloadChunk(activeSession, chunkIndex, future)
                         if (!future.complete(result)) {
                             releaseBuffer(result.buffer)
                         }
+                    } else if (future.isCancelled) {
+                        // no-op: never started
+                    } else {
+                        future.completeExceptionally(IOException("Session abandoned"))
                     }
                 } catch (e: Exception) {
                     future.completeExceptionally(e)
@@ -447,14 +762,16 @@ internal class ParallelRangeDataSource(
         }
     }
 
-    private fun downloadChunk(chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
+    private fun downloadChunk(activeSession: ChunkSession, chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
         var lastException: Exception? = null
         for (attempt in 0..1) {
-            if (future.isCancelled) throw IOException("Cancelled")
+            if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
             try {
-                return downloadChunkOnce(chunkIndex, future)
+                return downloadChunkOnce(activeSession, chunkIndex, future)
             } catch (e: Exception) {
-                if (closed.get() || future.isCancelled) throw IOException("DataSource closed or cancelled")
+                // Downloads belong to the session, not the instance —
+                // only future cancellation or session teardown aborts them.
+                if (activeSession.abandoned.get() || future.isCancelled) throw IOException("Session abandoned or cancelled")
                 lastException = e
                 if (attempt == 0) {
                     if (e.isTransientInterruption()) {
@@ -472,33 +789,38 @@ internal class ParallelRangeDataSource(
         throw IOException("Failed to download chunk $chunkIndex after 2 attempts", lastException)
     }
 
-    private fun downloadChunkOnce(chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
+    private fun downloadChunkOnce(activeSession: ChunkSession, chunkIndex: Long, future: CompletableFuture<*>): DownloadedChunk {
+        val sessionLength = activeSession.totalLength
         val start = chunkIndex * chunkSize
-        val end = if (totalFileLength != C.LENGTH_UNSET.toLong()) {
-            minOf(start + chunkSize, totalFileLength)
+        val end = if (sessionLength > 0L) {
+            minOf(start + chunkSize, sessionLength)
         } else {
             start + chunkSize
         }
 
         val ds = upstreamFactory.createDataSource()
         transferListeners.forEach { ds.addTransferListener(it) }
-        activeDataSources.add(ds)
+        activeSession.activeSources.add(ds)
         try {
-            val uri = resolvedUri ?: originalDataSpec?.uri ?: throw IOException("No URI available")
+            val uri = activeSession.resolvedUri ?: activeSession.requestUri
             val spec = DataSpec.Builder()
                 .setUri(uri)
                 .setPosition(start)
                 .setLength(end - start)
                 .build()
 
-            if (future.isCancelled) throw IOException("Cancelled")
+            if (future.isCancelled || activeSession.abandoned.get()) throw IOException("Cancelled")
             Log.d(TAG, "Starting chunk download: idx=$chunkIndex, range=$start-$end")
             ds.open(spec)
-            val chunk = readIntoChunk(ds, future)
+            // With a known session length the requested range is exact — a
+            // chunk that comes back short must fail (and retry) rather than be
+            // cached as if complete.
+            val expectedBytes = if (sessionLength > 0L) end - start else -1L
+            val chunk = readIntoChunk(activeSession, ds, future, expectedBytes)
             Log.d(TAG, "Successfully downloaded chunk $chunkIndex, size=${chunk.size} bytes")
             return chunk
         } finally {
-            activeDataSources.remove(ds)
+            activeSession.activeSources.remove(ds)
             try { ds.close() } catch (_: Exception) {}
         }
     }
@@ -510,10 +832,16 @@ internal class ParallelRangeDataSource(
     }
 
     /** Read from an already-opened DataSource into a pooled chunk buffer. */
-    private fun readIntoChunk(ds: DataSource, future: CompletableFuture<*>): DownloadedChunk {
+    private fun readIntoChunk(
+        activeSession: ChunkSession,
+        ds: DataSource,
+        future: CompletableFuture<*>,
+        expectedBytes: Long
+    ): DownloadedChunk {
         val buffer = acquireBuffer()
         val tempArray = readBufferLocal.get()!!
         var totalRead = 0
+        var consecutiveZeroReads = 0
         try {
             val byteBufferReader = if (useNativeMemory && ds is androidx.media3.common.ByteBufferDataReader && ds.supportsByteBufferRead()) {
                 ds
@@ -521,7 +849,10 @@ internal class ParallelRangeDataSource(
                 null
             }
 
-            while (!closed.get()) {
+            // The loop does not watch the instance's closed flag —
+            // downloads run to completion across ExoPlayer's seek reopens and
+            // abort only on future cancellation or session teardown.
+            while (!activeSession.abandoned.get()) {
                 if (future.isCancelled) {
                     throw IOException("Chunk download cancelled")
                 }
@@ -541,16 +872,35 @@ internal class ParallelRangeDataSource(
                 }
 
                 if (read == C.RESULT_END_OF_INPUT) break
+                // A positive-length read returning 0 violates the DataSource
+                // contract; bail after a few rather than busy-spinning until
+                // cancellation.
+                if (read == 0) {
+                    if (++consecutiveZeroReads >= MAX_CONSECUTIVE_ZERO_READS) {
+                        throw IOException(
+                            "No read progress after $MAX_CONSECUTIVE_ZERO_READS attempts " +
+                                "(read $totalRead of $expectedBytes bytes)"
+                        )
+                    }
+                } else {
+                    consecutiveZeroReads = 0
+                }
                 totalRead += read
+            }
+            // A premature EOF inside a known range must not produce a cached
+            // "complete" chunk — a short non-final chunk otherwise dead-ends
+            // both read paths at the phantom chunk boundary.
+            if (expectedBytes > 0L && totalRead < expectedBytes && !activeSession.abandoned.get()) {
+                throw IOException("Short chunk: read $totalRead of $expectedBytes bytes")
             }
         } catch (e: Exception) {
             releaseBuffer(buffer)
-            if (closed.get()) throw IOException("DataSource closed")
+            if (activeSession.abandoned.get()) throw IOException("Session abandoned")
             throw e
         }
-        if (closed.get()) {
+        if (activeSession.abandoned.get()) {
             releaseBuffer(buffer)
-            throw IOException("DataSource closed")
+            throw IOException("Session abandoned")
         }
         buffer.byteBuffer.flip()
         return DownloadedChunk(buffer, totalRead)
@@ -616,54 +966,18 @@ internal class ParallelRangeDataSource(
         }
     }
 
-    private fun cleanupOldChunks(currentChunkIndex: Long) {
-        val iter = chunks.entries.iterator()
-        while (iter.hasNext()) {
-            val entry = iter.next()
-            if (entry.key < currentChunkIndex) {
-                val future = entry.value
-                if (future.isDone && !future.isCancelled) {
-                    try { releaseBuffer(future.get().buffer) } catch (_: Exception) {}
-                }
-                future.cancel(true)
-                iter.remove()
-            }
-        }
-    }
-
-    /** Cancel and clean up all in-flight chunks, returning buffers to the pool. */
-    private fun cancelAllChunks() {
-        val releasedBuffers = java.util.Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap<PooledBuffer, Boolean>())
-
-        currentChunk?.let {
-            if (it !== bootstrapChunk) {
-                if (releasedBuffers.add(it.buffer)) {
-                    releaseBuffer(it.buffer)
-                }
-            }
-        }
+    /**
+     * Detach instance-local read state. Session chunks (and in-flight
+     * downloads) are untouched — they belong to the shared session and their
+     * buffers are owned by the session's futures. Releasing anything here
+     * would double-free; eviction and teardown are the session's job.
+     */
+    private fun resetLocalReadState() {
         currentChunk = null
         currentChunkIndex = -1
+        currentChunkReadOffset = 0
         bootstrapChunk = null
         bootstrapStartPosition = C.TIME_UNSET
-
-        activeDataSources.forEach { ds ->
-            try { ds.close() } catch (_: Exception) {}
-        }
-        activeDataSources.clear()
-
-        chunks.values.forEach { future ->
-            if (future.isDone && !future.isCancelled) {
-                try {
-                    val chunk = future.get()
-                    if (releasedBuffers.add(chunk.buffer)) {
-                        releaseBuffer(chunk.buffer)
-                    }
-                } catch (_: Exception) {}
-            }
-            future.cancel(true)
-        }
-        chunks.clear()
     }
 
     override fun close() {
@@ -674,7 +988,9 @@ internal class ParallelRangeDataSource(
             continuationSource = null
             continuationEndPositionExclusive = C.TIME_UNSET
 
-            cancelAllChunks()
+            // Downloads survive this close — detach references only.
+            resetLocalReadState()
+            session = null
 
             val active = activeInstances.decrementAndGet()
             if (active <= 0) {
@@ -760,18 +1076,30 @@ internal class ParallelRangeDataSource(
         }
 
         if (currentChunkIndex != chunkIndex || currentChunk == null) {
+            val activeSession = session ?: return C.RESULT_END_OF_INPUT
             ensureChunkScheduled(chunkIndex)
-            val future = chunks[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            val future = activeSession.futures[chunkIndex] ?: return C.RESULT_END_OF_INPUT
+            activeSession.noteRead(chunkIndex)
             try {
                 currentChunk = future.get(60, TimeUnit.SECONDS)
             } catch (e: Exception) {
                 if (closed.get()) return C.RESULT_END_OF_INPUT
+                // Mirror of the byte-array path: cancel before dropping,
+                // ownership-gated release if the download won the race.
+                if (activeSession.futures.remove(chunkIndex, future)) {
+                    activeSession.lastTouch.remove(chunkIndex)
+                    if (!future.cancel(true) && future.isDone && !future.isCancelled) {
+                        try {
+                            releaseSessionBuffer(future.get().buffer, activeSession.chunkSize, maxPoolSize)
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
                 throw IOException("Failed to download chunk $chunkIndex", e)
             }
             currentChunkIndex = chunkIndex
             currentChunkReadOffset = (position % chunkSize).toInt()
 
-            cleanupOldChunks(chunkIndex)
             scheduleChunks()
         }
 
@@ -795,6 +1123,8 @@ internal class ParallelRangeDataSource(
         currentChunkReadOffset += readSize
         position += readSize
         bytesRemaining -= readSize
+        bytesServedThisOpen += readSize
+        session?.noteRead(chunkIndex)
 
         return readSize
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeRetryAfter.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeRetryAfter.kt
@@ -4,7 +4,6 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-// HTTP Retry-After → remaining wait ms (delta-seconds or RFC 1123 date).
 internal object ParallelRangeRetryAfter {
     fun parseHeaderMs(
         header: String?,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeRetryAfter.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/ParallelRangeRetryAfter.kt
@@ -1,0 +1,27 @@
+package com.nuvio.tv.ui.screens.player
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+// HTTP Retry-After → remaining wait ms (delta-seconds or RFC 1123 date).
+internal object ParallelRangeRetryAfter {
+    fun parseHeaderMs(
+        header: String?,
+        nowEpochMs: Long = System.currentTimeMillis()
+    ): Long? {
+        if (header.isNullOrEmpty()) return null
+        header.toLongOrNull()?.let { seconds ->
+            return (seconds * 1000L).coerceAtLeast(0L)
+        }
+        return try {
+            val target = ZonedDateTime.parse(
+                header,
+                DateTimeFormatter.RFC_1123_DATE_TIME.withLocale(Locale.US)
+            )
+            (target.toInstant().toEpochMilli() - nowEpochMs).coerceAtLeast(0L)
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -132,7 +132,16 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
             ParallelRangeDataSource.Factory(
                 okHttpFactory,
                 if (mp4SessionMode) 1 else parallelConnectionCount,
-                if (mp4SessionMode) MP4_SESSION_CHUNK_BYTES else parallelChunkSizeKb.toLong() * 1024L,
+                if (mp4SessionMode) {
+                    MP4_SESSION_CHUNK_BYTES
+                } else {
+                    // Runtime enforcement of the tier chunk cap: a value
+                    // persisted before the cap existed (or on another device)
+                    // must not bypass it.
+                    parallelChunkSizeKb
+                        .coerceAtMost(com.nuvio.tv.ui.screens.settings.MemoryBudget.tierMaxChunkMb * 1024)
+                        .toLong() * 1024L
+                },
                 useNativeMemory = nuvioPerformanceModeEnabled,
                 shouldAllowBackgroundPrefetch = { parallelStartupPrefetchUnlocked.get() },
                 onResolvedUri = { resolved -> currentVodCacheResolvedUrl = resolved?.toString() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.player
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.datasource.DataSource
@@ -111,18 +112,38 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
         val mediaItem = mediaItemBuilder.build()
 
-        // 1. Parallel connections (opt-in). ParallelRangeDataSource needs a concrete
-        // OkHttpDataSource.Factory, so build one only on this path.
-        parallelStartupPrefetchUnlocked.set(!(useParallelConnections && !isHls && !isDash))
-        val progressiveUpstreamFactory: DataSource.Factory = if (useParallelConnections && !isHls && !isDash) {
+        // 1. Chunk-session source: parallel connections (opt-in), or MP4 session
+        // mode. Non-faststart / poorly interleaved MP4s force scatter reads, and
+        // ExoPlayer recreates the data source on every seek; the session-owned
+        // chunks in ParallelRangeDataSource are what survive that boundary. That
+        // fix used to be reachable only behind the parallel-connections opt-in,
+        // so progressive MP4 now engages the session source even with parallel
+        // off — pinned to a single connection and an 8 MB chunk, which holds
+        // request concurrency and retained memory at plain-path levels (earned
+        // prefetch caps lookahead at two chunks; side cursors fetch only the
+        // chunk they touch). HLS/DASH, non-MP4 progressive, and parallel-on
+        // behaviour are unchanged.
+        val mp4SessionMode = !useParallelConnections && !isHls && !isDash &&
+            resolvedMimeType == MimeTypes.VIDEO_MP4
+        val useChunkSessionSource = (useParallelConnections || mp4SessionMode) && !isHls && !isDash
+        parallelStartupPrefetchUnlocked.set(!useChunkSessionSource)
+        val progressiveUpstreamFactory: DataSource.Factory = if (useChunkSessionSource) {
+            if (mp4SessionMode) {
+                Log.i(
+                    "PlayerMediaSourceFactory",
+                    "MP4_SESSION engaged: single-connection chunk session " +
+                        "(${MP4_SESSION_CHUNK_BYTES / (1024L * 1024L)} MB chunks) " +
+                        "for progressive MP4 with parallel connections off"
+                )
+            }
             val okHttpFactory = OkHttpDataSource.Factory(playbackHttpClient).apply {
                 setDefaultRequestProperties(sanitizedHeaders)
                 setUserAgent(DEFAULT_USER_AGENT)
             }
             ParallelRangeDataSource.Factory(
                 okHttpFactory,
-                parallelConnectionCount,
-                parallelChunkSizeKb.toLong() * 1024L,
+                if (mp4SessionMode) 1 else parallelConnectionCount,
+                if (mp4SessionMode) MP4_SESSION_CHUNK_BYTES else parallelChunkSizeKb.toLong() * 1024L,
                 useNativeMemory = nuvioPerformanceModeEnabled,
                 shouldAllowBackgroundPrefetch = { true },
                 onResolvedUri = { resolved -> currentVodCacheResolvedUrl = resolved?.toString() }
@@ -188,7 +209,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
         return wrapAudioDelay(mediaSource = mediaSource, audioDelayUsProvider = audioDelayUsProvider)
     }
 
-    fun shutdown() = Unit
+    fun shutdown() {
+        // Free any chunk buffers retained across seek reopens so native
+        // allocations never outlive the player.
+        ParallelRangeDataSource.releaseRetainedSession()
+    }
 
     private fun buildVodCacheDataSourceFactory(upstreamFactory: DataSource.Factory, cache: SimpleCache): DataSource.Factory {
         val dataSinkFactory = CacheDataSink.Factory().setCache(cache).setFragmentSize(2L * 1024L * 1024L)
@@ -235,6 +260,11 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
     companion object {
         private const val MIME_VIDEO_QUICK_TIME = "video/quicktime"
+        // MP4 session mode: fixed 8 MB chunk, independent of the user's parallel
+        // chunk-size setting — small enough that scatter-read side cursors waste
+        // little per touch, and the retained set (session cap 3 chunks on the
+        // low-RAM tier, 5 otherwise) stays a few tens of MB.
+        private const val MP4_SESSION_CHUNK_BYTES = 8L * 1024L * 1024L
         private const val ENABLE_VOD_CACHE = true
         private const val VOD_CACHE_FREE_SPACE_RESERVE_BYTES = 1024L * 1024L * 1024L
         internal const val DEFAULT_USER_AGENT =

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -112,17 +112,6 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
         val mediaItem = mediaItemBuilder.build()
 
-        // 1. Chunk-session source: parallel connections (opt-in), or MP4 session
-        // mode. Non-faststart / poorly interleaved MP4s force scatter reads, and
-        // ExoPlayer recreates the data source on every seek; the session-owned
-        // chunks in ParallelRangeDataSource are what survive that boundary. That
-        // fix used to be reachable only behind the parallel-connections opt-in,
-        // so progressive MP4 now engages the session source even with parallel
-        // off — pinned to a single connection and an 8 MB chunk, which holds
-        // request concurrency and retained memory at plain-path levels (earned
-        // prefetch caps lookahead at two chunks; side cursors fetch only the
-        // chunk they touch). HLS/DASH, non-MP4 progressive, and parallel-on
-        // behaviour are unchanged.
         val mp4SessionMode = !useParallelConnections && !isHls && !isDash &&
             resolvedMimeType == MimeTypes.VIDEO_MP4
         val useChunkSessionSource = (useParallelConnections || mp4SessionMode) && !isHls && !isDash
@@ -145,7 +134,7 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
                 if (mp4SessionMode) 1 else parallelConnectionCount,
                 if (mp4SessionMode) MP4_SESSION_CHUNK_BYTES else parallelChunkSizeKb.toLong() * 1024L,
                 useNativeMemory = nuvioPerformanceModeEnabled,
-                shouldAllowBackgroundPrefetch = { true },
+                shouldAllowBackgroundPrefetch = { parallelStartupPrefetchUnlocked.get() },
                 onResolvedUri = { resolved -> currentVodCacheResolvedUrl = resolved?.toString() }
             )
         } else {
@@ -210,8 +199,6 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
     }
 
     fun shutdown() {
-        // Free any chunk buffers retained across seek reopens so native
-        // allocations never outlive the player.
         ParallelRangeDataSource.releaseRetainedSession()
     }
 
@@ -260,10 +247,6 @@ internal class PlayerMediaSourceFactory(private val context: Context) {
 
     companion object {
         private const val MIME_VIDEO_QUICK_TIME = "video/quicktime"
-        // MP4 session mode: fixed 8 MB chunk, independent of the user's parallel
-        // chunk-size setting — small enough that scatter-read side cursors waste
-        // little per touch, and the retained set (session cap 3 chunks on the
-        // low-RAM tier, 5 otherwise) stays a few tens of MB.
         private const val MP4_SESSION_CHUNK_BYTES = 8L * 1024L * 1024L
         private const val ENABLE_VOD_CACHE = true
         private const val VOD_CACHE_FREE_SPACE_RESERVE_BYTES = 1024L * 1024L * 1024L

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1025,7 +1025,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                             "playbackState=$playbackState playWhenReady=$playWhenReady isPlaying=$isPlaying " +
                                 "userPaused=$userPausedManually"
                         )
-                        if (playbackState == Player.STATE_BUFFERING || playbackState == Player.STATE_READY) {
+                        if (playbackState == Player.STATE_READY) {
                             mediaSourceFactory.unlockStartupPrefetch()
                         }
                         val playerDuration = duration

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
@@ -22,7 +22,12 @@ object MemoryBudget {
     private const val LOW_HEAP_RESERVE_MB = 210L
 
     /** ParallelRangeDataSource schedules maxAhead = parallelConnections + 1 chunks concurrently */
-    private const val BUFFER_OVERHEAD = 1
+    // Matches ParallelRangeDataSource reality: the download session holds up
+    // to connections + 2 chunks on low-RAM devices (connections + 4 on
+    // high-RAM; that extra headroom is deliberately not advertised so the
+    // enforcement maths stays conservative). Was 1, which under-stated the
+    // actual ceiling by one chunk.
+    private const val BUFFER_OVERHEAD = 2
 
     const val MIN_CONNECTIONS = 2
     const val MAX_CONNECTIONS = 4

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
@@ -28,6 +28,13 @@ object MemoryBudget {
     const val MAX_CONNECTIONS = 4
     const val MIN_CHUNK_MB = 8
     const val MAX_CHUNK_MB = 128
+    // Low-RAM devices (1-2 GB class): the session's protected set (playhead
+    // window + tail moov chunks + pinned side chunks) puts the worst-case
+    // retained floor at roughly connections + 10 chunks on a scatter-heavy
+    // file, so chunk size is hard-capped at 16 MB on that tier — above it
+    // the floor alone exceeds what those devices can hold. Applies in
+    // performance mode too; the cap is a tier property, not a budget one.
+    private const val LOW_RAM_MAX_CHUNK_MB = 16
     const val BUFFER_STEP_MB = 25
     const val MIN_BUFFER_MB = 25
     const val MAX_BUFFER_MB = 1024 * 4
@@ -43,6 +50,9 @@ object MemoryBudget {
 
     /** True when the app heap is below the high-RAM threshold (Fire TV / TV-stick class). */
     val isLowRamTier: Boolean = maxHeapMb < HIGH_HEAP_THRESHOLD_MB
+
+    /** Hard chunk-size ceiling for this device tier; binds everywhere, including performance mode. */
+    val tierMaxChunkMb: Int = if (isLowRamTier) LOW_RAM_MAX_CHUNK_MB else MAX_CHUNK_MB
 
     // Pre-cap ratio budget; conversionBudgetMb derives from this so DV7 headroom isn't cut by the cap.
     private val rawBudgetMb: Int =
@@ -73,7 +83,7 @@ object MemoryBudget {
 
     /** Max chunk size that fits budget given current buffer size */
     fun maxChunkMb(bufferMb: Int, connectionCount: Int): Int =
-        ((budgetMb - bufferMb) / bufferCount(connectionCount)).coerceIn(MIN_CHUNK_MB, MAX_CHUNK_MB)
+        ((budgetMb - bufferMb) / bufferCount(connectionCount)).coerceIn(MIN_CHUNK_MB, tierMaxChunkMb)
 
     /** Max buffer size that fits budget given current parallel overhead */
     fun maxBufferMb(parallelOverheadMb: Int): Int =

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
@@ -51,9 +51,6 @@ object MemoryBudget {
     /** True when the app heap is below the high-RAM threshold (Fire TV / TV-stick class). */
     val isLowRamTier: Boolean = maxHeapMb < HIGH_HEAP_THRESHOLD_MB
 
-    /** Hard chunk-size ceiling for this device tier; binds everywhere, including performance mode. */
-    val tierMaxChunkMb: Int = if (isLowRamTier) LOW_RAM_MAX_CHUNK_MB else MAX_CHUNK_MB
-
     // Pre-cap ratio budget; conversionBudgetMb derives from this so DV7 headroom isn't cut by the cap.
     private val rawBudgetMb: Int =
         (maxHeapMb * (if (isLowRamTier) LOW_HEAP_RATIO else HIGH_HEAP_RATIO)).toInt()
@@ -80,6 +77,9 @@ object MemoryBudget {
 
     fun totalUsageMb(bufferMb: Int, connectionCount: Int, chunkSizeMb: Int, parallelEnabled: Boolean): Int =
         bufferMb + if (parallelEnabled) parallelOverheadMb(connectionCount, chunkSizeMb) else 0
+
+    /** Hard chunk-size ceiling for this device tier; binds everywhere, including performance mode. */
+    val tierMaxChunkMb: Int = if (isLowRamTier) LOW_RAM_MAX_CHUNK_MB else MAX_CHUNK_MB
 
     /** Max chunk size that fits budget given current buffer size */
     fun maxChunkMb(bufferMb: Int, connectionCount: Int): Int =

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MemoryBudget.kt
@@ -22,11 +22,6 @@ object MemoryBudget {
     private const val LOW_HEAP_RESERVE_MB = 210L
 
     /** ParallelRangeDataSource schedules maxAhead = parallelConnections + 1 chunks concurrently */
-    // Matches ParallelRangeDataSource reality: the download session holds up
-    // to connections + 2 chunks on low-RAM devices (connections + 4 on
-    // high-RAM; that extra headroom is deliberately not advertised so the
-    // enforcement maths stays conservative). Was 1, which under-stated the
-    // actual ceiling by one chunk.
     private const val BUFFER_OVERHEAD = 2
 
     const val MIN_CONNECTIONS = 2

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackBufferNetworkSettings.kt
@@ -500,7 +500,7 @@ internal fun LazyListScope.bufferAndNetworkSettingsItems(
             item(key = "buffer_net_parallel_chunk_size") {
                 val effectiveBufferMb = MemoryBudget.effectiveBufferMb(playerSettings.bufferSettings.targetBufferSizeMb)
                 val maxChunkSizeMb = if (playerSettings.nuvioPerformanceModeEnabled) {
-                    MemoryBudget.MAX_CHUNK_MB
+                    MemoryBudget.tierMaxChunkMb
                 } else {
                     MemoryBudget.maxChunkMb(effectiveBufferMb, playerSettings.parallelConnectionCount)
                 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
@@ -1,0 +1,50 @@
+package com.nuvio.tv.ui.screens.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+class ParallelRangeDataSourceTest {
+
+    @Test
+    fun `parseRetryAfterHeaderMs reads delta-seconds`() {
+        assertEquals(30_000L, ParallelRangeRetryAfter.parseHeaderMs("30"))
+        assertEquals(0L, ParallelRangeRetryAfter.parseHeaderMs("0"))
+        assertEquals(1_000L, ParallelRangeRetryAfter.parseHeaderMs("1"))
+    }
+
+    @Test
+    fun `parseRetryAfterHeaderMs reads RFC1123 HTTP-date`() {
+        val now = 1_700_000_000_000L // fixed epoch for determinism
+        val target = Instant.ofEpochMilli(now + 45_000L)
+        val header = DateTimeFormatter.RFC_1123_DATE_TIME
+            .withLocale(Locale.US)
+            .withZone(ZoneOffset.UTC)
+            .format(target)
+
+        assertEquals(45_000L, ParallelRangeRetryAfter.parseHeaderMs(header, nowEpochMs = now))
+    }
+
+    @Test
+    fun `parseRetryAfterHeaderMs returns null for missing or garbage`() {
+        assertNull(ParallelRangeRetryAfter.parseHeaderMs(null))
+        assertNull(ParallelRangeRetryAfter.parseHeaderMs(""))
+        assertNull(ParallelRangeRetryAfter.parseHeaderMs("not-a-date"))
+    }
+
+    @Test
+    fun `parseRetryAfterHeaderMs clamps past HTTP-date to zero`() {
+        val now = 1_700_000_000_000L
+        val past = Instant.ofEpochMilli(now - 60_000L)
+        val header = DateTimeFormatter.RFC_1123_DATE_TIME
+            .withLocale(Locale.US)
+            .withZone(ZoneOffset.UTC)
+            .format(past)
+
+        assertEquals(0L, ParallelRangeRetryAfter.parseHeaderMs(header, nowEpochMs = now))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
@@ -47,4 +47,62 @@ class ParallelRangeDataSourceTest {
 
         assertEquals(0L, ParallelRangeRetryAfter.parseHeaderMs(header, nowEpochMs = now))
     }
+
+    @Test
+    fun `lookahead stays at current chunk until sequential run and current chunk complete`() {
+        assertEquals(
+            1,
+            ParallelRangeDataSource.lookaheadDepth(
+                bytesServedThisOpen = 0L,
+                earnedPrefetchBytes = 1L * 1024L * 1024L,
+                currentChunkComplete = false,
+                configuredDepth = 4,
+                rateLimitDepth = 4
+            )
+        )
+        assertEquals(
+            1,
+            ParallelRangeDataSource.lookaheadDepth(
+                bytesServedThisOpen = 1L * 1024L * 1024L,
+                earnedPrefetchBytes = 1L * 1024L * 1024L,
+                currentChunkComplete = false,
+                configuredDepth = 4,
+                rateLimitDepth = 4
+            )
+        )
+        assertEquals(
+            1,
+            ParallelRangeDataSource.lookaheadDepth(
+                bytesServedThisOpen = 512L * 1024L,
+                earnedPrefetchBytes = 1L * 1024L * 1024L,
+                currentChunkComplete = true,
+                configuredDepth = 4,
+                rateLimitDepth = 4
+            )
+        )
+    }
+
+    @Test
+    fun `lookahead uses configured depth after current chunk is complete`() {
+        assertEquals(
+            4,
+            ParallelRangeDataSource.lookaheadDepth(
+                bytesServedThisOpen = 1L * 1024L * 1024L,
+                earnedPrefetchBytes = 1L * 1024L * 1024L,
+                currentChunkComplete = true,
+                configuredDepth = 4,
+                rateLimitDepth = 4
+            )
+        )
+        assertEquals(
+            2,
+            ParallelRangeDataSource.lookaheadDepth(
+                bytesServedThisOpen = 1L * 1024L * 1024L,
+                earnedPrefetchBytes = 1L * 1024L * 1024L,
+                currentChunkComplete = true,
+                configuredDepth = 4,
+                rateLimitDepth = 2
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
@@ -105,4 +105,145 @@ class ParallelRangeDataSourceTest {
             )
         )
     }
+
+    @Test
+    fun `side cursor does not move main read cursor`() {
+        assertEquals(
+            false,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = -1L,
+                chunkIndex = 1389L,
+                prefetchWindow = 4,
+                sequentialOpen = false,
+                currentChunkComplete = false,
+                totalChunks = 1390L
+            )
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = -1L,
+                chunkIndex = 35L,
+                prefetchWindow = 4,
+                sequentialOpen = false,
+                currentChunkComplete = false,
+                totalChunks = 1390L
+            )
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.isTailChunk(1389L, 1392L)
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.isTailChunk(1388L, 1392L)
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.isTailChunk(1387L, 1392L)
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.isTailChunk(105L, 1392L)
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = 35L,
+                chunkIndex = 36L,
+                prefetchWindow = 4,
+                sequentialOpen = false,
+                currentChunkComplete = false,
+                totalChunks = 1390L
+            )
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = 35L,
+                chunkIndex = 1389L,
+                prefetchWindow = 4,
+                sequentialOpen = false,
+                currentChunkComplete = false,
+                totalChunks = 1390L
+            )
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = 35L,
+                chunkIndex = 1389L,
+                prefetchWindow = 4,
+                sequentialOpen = true,
+                currentChunkComplete = true,
+                totalChunks = 1390L
+            )
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = 35L,
+                chunkIndex = 80L,
+                prefetchWindow = 4,
+                sequentialOpen = true,
+                currentChunkComplete = false,
+                totalChunks = 1390L
+            )
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.shouldMoveMainCursor(
+                lastReadChunkIndex = 35L,
+                chunkIndex = 80L,
+                prefetchWindow = 4,
+                sequentialOpen = true,
+                currentChunkComplete = true,
+                totalChunks = 1390L
+            )
+        )
+    }
+
+    @Test
+    fun `playhead window keeps two chunks behind the reader`() {
+        assertEquals(
+            true,
+            ParallelRangeDataSource.isInPlayheadWindow(
+                readerIdx = 253L,
+                chunkIndex = 251L,
+                prefetchWindow = 4
+            )
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.isInPlayheadWindow(
+                readerIdx = 255L,
+                chunkIndex = 255L,
+                prefetchWindow = 4
+            )
+        )
+        assertEquals(
+            true,
+            ParallelRangeDataSource.isInPlayheadWindow(
+                readerIdx = 251L,
+                chunkIndex = 255L,
+                prefetchWindow = 4
+            )
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.isInPlayheadWindow(
+                readerIdx = 255L,
+                chunkIndex = 251L,
+                prefetchWindow = 4
+            )
+        )
+        assertEquals(
+            false,
+            ParallelRangeDataSource.isInPlayheadWindow(
+                readerIdx = -1L,
+                chunkIndex = 251L,
+                prefetchWindow = 4
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/ParallelRangeDataSourceTest.kt
@@ -56,16 +56,18 @@ class ParallelRangeDataSourceTest {
                 bytesServedThisOpen = 0L,
                 earnedPrefetchBytes = 1L * 1024L * 1024L,
                 currentChunkComplete = false,
+                nextChunkComplete = false,
                 configuredDepth = 4,
                 rateLimitDepth = 4
             )
         )
         assertEquals(
-            1,
+            2,
             ParallelRangeDataSource.lookaheadDepth(
                 bytesServedThisOpen = 1L * 1024L * 1024L,
                 earnedPrefetchBytes = 1L * 1024L * 1024L,
                 currentChunkComplete = false,
+                nextChunkComplete = false,
                 configuredDepth = 4,
                 rateLimitDepth = 4
             )
@@ -76,6 +78,7 @@ class ParallelRangeDataSourceTest {
                 bytesServedThisOpen = 512L * 1024L,
                 earnedPrefetchBytes = 1L * 1024L * 1024L,
                 currentChunkComplete = true,
+                nextChunkComplete = true,
                 configuredDepth = 4,
                 rateLimitDepth = 4
             )
@@ -83,13 +86,25 @@ class ParallelRangeDataSourceTest {
     }
 
     @Test
-    fun `lookahead uses configured depth after current chunk is complete`() {
+    fun `lookahead uses configured depth after current and next chunks are complete`() {
+        assertEquals(
+            2,
+            ParallelRangeDataSource.lookaheadDepth(
+                bytesServedThisOpen = 1L * 1024L * 1024L,
+                earnedPrefetchBytes = 1L * 1024L * 1024L,
+                currentChunkComplete = true,
+                nextChunkComplete = false,
+                configuredDepth = 4,
+                rateLimitDepth = 4
+            )
+        )
         assertEquals(
             4,
             ParallelRangeDataSource.lookaheadDepth(
                 bytesServedThisOpen = 1L * 1024L * 1024L,
                 earnedPrefetchBytes = 1L * 1024L * 1024L,
                 currentChunkComplete = true,
+                nextChunkComplete = true,
                 configuredDepth = 4,
                 rateLimitDepth = 4
             )
@@ -100,6 +115,7 @@ class ParallelRangeDataSourceTest {
                 bytesServedThisOpen = 1L * 1024L * 1024L,
                 earnedPrefetchBytes = 1L * 1024L * 1024L,
                 currentChunkComplete = true,
+                nextChunkComplete = true,
                 configuredDepth = 4,
                 rateLimitDepth = 2
             )

--- a/app/src/test/java/com/nuvio/tv/ui/screens/settings/MemoryBudgetTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/settings/MemoryBudgetTest.kt
@@ -16,10 +16,10 @@ class MemoryBudgetTest {
         assertEquals(50, MemoryBudget.totalUsageMb(50, 4, 32, false))
         
         // case 2: parallel enabled
-        // bufferCount(4) = 4 + 1 = 5
-        // overhead = 5 * 32 = 160
-        // total = 50 + 160 = 210
-        assertEquals(210, MemoryBudget.totalUsageMb(50, 4, 32, true))
+        // bufferCount(4) = 4 + 2 = 6
+        // overhead = 6 * 32 = 192
+        // total = 50 + 192 = 242
+        assertEquals(242, MemoryBudget.totalUsageMb(50, 4, 32, true))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Progressive MP4 files whose `moov` atom sits at the end of the file (non-faststart, common in web-DL releases) fail to play smoothly on the default playback path — they either never reach a first frame or rebuffer constantly. This PR makes them play by giving the chunk-download session a lifetime that survives ExoPlayer's per-seek data-source recreation, and by engaging that session for progressive MP4 even when parallel connections are off (pinned to a single connection and an 8 MB chunk, so request concurrency and retained memory stay at plain-path levels).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

A non-faststart MP4 has its `moov` atom (the track index a player must read before it can decode) at the tail of the file. To start playback the extractor must seek to the end for the `moov`, then back to the front for `mdat`, and it continues to scatter-read as it demuxes. ExoPlayer recreates the progressive `DataSource` on every seek, closing the previous one.

On the default single-connection path each of those recreations previously cancelled all in-flight downloads and re-probed the URL, retaining nothing across the seek. The scatter-read pattern these files force therefore never stabilises: the same ranges restart repeatedly and the buffer cannot fill, presenting as an unstartable stream or constant rebuffering.

Delivery is not the cause — `ffprobe`, `curl`, and AVFoundation-based players range-seek to the tail `moov` and play the same files fine, and the CDN honours range requests (HTTP 206). The fix is to make the downloaded chunks (completed *and* in-flight) belong to a companion-level session that survives the close/open boundary, so the seek back to the front reuses the tail read instead of discarding it, and to route progressive MP4 through that session on the default path where it previously used the plain source.

## Issue or approval

Fixes #3100

## Reproduction steps

1. Install a stock build and leave **Parallel Connections OFF** (the default).
2. Play a large non-faststart MP4 (moov atom at the file tail) over HTTP.
3. Observe playback fails to reach a first frame, or starts and then rebuffers continuously.

`ffprobe -v trace` on a representative file shows atom order `ftyp` → `mdat` → `moov`, with the `moov` at ~99.9% of the file.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR ports only the minimal mechanism that makes non-faststart MP4 playable on the default path, plus the small correctness fixes that mechanism needs:

- **Included:** session-owned chunk downloads that survive the per-seek data-source recreation; single-connection MP4 session mode for progressive MP4 when parallel connections are off; reads through a duplicated `ByteBuffer` on both read paths (shared chunks are read concurrently); rejection of short/EOF-truncated chunks and a zero-progress read guard; cancel-before-drop of failed chunk futures with an ownership-gated release; length-state consistency on the non-range fallback and on fresh reopen; request headers folded into the session identity; touch-LRU eviction bounded at cap+2 with position-aware victim selection that never evicts the imminent prefetch window. `MemoryBudget.BUFFER_OVERHEAD` is corrected `1 → 2` so the settings-screen memory estimate matches the data source's actual retained-chunk ceiling (with its unit test updated).
- **Not included:** no new settings, UI, or user-facing options. HLS/DASH, non-MP4 progressive, subtitle, and the plain single-connection path for other containers are unchanged. The parallel-on path gains the same session survival but is otherwise unchanged.
- **Deliberately held back for a separate follow-up:** buffer lifetime here is protected by a short touch-guard on eviction, which is adequate for the common case and has been in downstream production use. A structurally stronger approach — reference-counting the session buffers with epoch invalidation (as explored in #2630) — eliminates the free-during-read race by construction rather than by timing and is the better long-term fix, but it is a larger change that warrants its own soak testing and focused review. It is intentionally out of scope here to keep this the smallest change that fixes #3100, and is intended as a follow-up crediting @halibiram's design. The core mechanism in this PR is the same one reviewed in #2544.

## Testing

**Device:** Ugoos AM9 Pro (Amlogic, `arm64-v8a`), Android 14, internal player, default settings (Parallel Connections **off**).

**Build / unit tests (branch off current `dev`):**
- `./gradlew assembleFullDebug` → **BUILD SUCCESSFUL**.
- `./gradlew testFullDebugUnitTest` → 12 failures, but a control run on unmodified `dev` produced the **identical 12 failures** (same test names and line numbers, 863 total / 12 failed / 1 skipped both ways). None are in files this PR touches; they are pre-existing on `dev`. The one test this PR modifies (`MemoryBudgetTest`) passes.

**On-device, before/after — same file, same settings, same single connection.** Test file: a ~17.7 GB non-faststart MP4 (`moov` atom at ~99.9% of file), ~20 Mbps, well within single-connection bandwidth. Buffer-ahead and rebuffering sampled from the player over ~2 minutes of playback:

| | Rebuffer events | Total rebuffering | Buffering stalls | Buffer-ahead behaviour |
|---|---|---|---|---|
| **Stock (`dev`)** | 7 | ~62 s | 14 | Oscillates 1–20 s, repeatedly collapses; never stabilises |
| **This PR** | 0 | 0 s | 0 | Climbs to ~47 s ahead and holds flat for the whole run |

Because both runs use one connection at the same bitrate, the difference is not bandwidth — stock's default path cannot build a buffer because it pays the data-source reopen cost on every seek the non-faststart file forces; with the session-owned chunks it builds and holds a ~47 s buffer and plays without a single stall. Logs confirm the session engages (`MP4_SESSION engaged`), performs the tail `moov` read (reopen near the end of the file), then streams the front sequentially with each chunk fetched once.

The underlying mechanism (session survival + the review fixes above) has been running in a downstream fork build in daily use for several weeks; this PR rebases that proven mechanism onto current `dev` and adds the position-aware eviction fix.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3100