### PR TITLE
feat(detail): show episode still as options overlay backdrop

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
@@ -21,11 +21,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -88,6 +91,7 @@ internal fun EpisodeOptionsOverlay(
     val context = LocalContext.current
     val density = LocalDensity.current
     val configuration = LocalConfiguration.current
+    val overlayColor = Color(0xFF050505)
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val primaryFocusRequester = remember { FocusRequester() }
     val title = episode.title.localizeEpisodeTitle(context)
@@ -122,19 +126,6 @@ internal fun EpisodeOptionsOverlay(
                 blur = blurUnwatchedBackdrop
             )
         }
-    }
-    val overlayBrush = remember(isRtl) {
-        Brush.horizontalGradient(
-            colorStops = arrayOf(
-                0.00f to Color(0xF2050505),
-                0.28f to Color(0xE6050505),
-                0.48f to Color(0xB8050505),
-                0.70f to Color(0x80050505),
-                1.00f to Color(0x66050505)
-            ),
-            startX = if (isRtl) Float.POSITIVE_INFINITY else 0f,
-            endX = if (isRtl) 0f else Float.POSITIVE_INFINITY
-        )
     }
     val ratingLabel = remember(imdbRating) {
         imdbRating?.takeIf { it > 0.0 }?.let { String.format(Locale.US, "%.1f", it) }
@@ -244,7 +235,9 @@ internal fun EpisodeOptionsOverlay(
                 AsyncImage(
                     model = thumbnailRequest,
                     contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
                     contentScale = ContentScale.Crop,
                     alignment = Alignment.Center,
                     filterQuality = FilterQuality.High
@@ -253,7 +246,23 @@ internal fun EpisodeOptionsOverlay(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(overlayBrush)
+                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                    .drawWithCache {
+                        val brush = Brush.horizontalGradient(
+                            colorStops = arrayOf(
+                                0.00f to overlayColor.copy(alpha = 0.95f),
+                                0.28f to overlayColor.copy(alpha = 0.90f),
+                                0.48f to overlayColor.copy(alpha = 0.72f),
+                                0.70f to overlayColor.copy(alpha = 0.50f),
+                                1.00f to overlayColor.copy(alpha = 0.40f)
+                            ),
+                            startX = if (isRtl) size.width else 0f,
+                            endX = if (isRtl) 0f else size.width
+                        )
+                        onDrawBehind {
+                            drawRect(brush = brush)
+                        }
+                    }
             )
             Row(
                 modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
@@ -47,10 +47,12 @@ import androidx.tv.material3.Text
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import coil3.request.transformations
 import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.ui.components.ImdbRatingSourceLabel
 import com.nuvio.tv.ui.theme.NuvioTheme
+import com.nuvio.tv.ui.util.BlurTransformation
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import java.util.Locale
 
@@ -66,6 +68,7 @@ internal fun EpisodeOptionsOverlay(
     episode: Video,
     imdbRating: Double? = null,
     isWatched: Boolean,
+    blurUnwatchedEpisodes: Boolean = false,
     isPending: Boolean,
     isSeasonFullyWatched: Boolean = false,
     hasPreviousEpisodes: Boolean = false,
@@ -89,8 +92,13 @@ internal fun EpisodeOptionsOverlay(
     val primaryFocusRequester = remember { FocusRequester() }
     val title = episode.title.localizeEpisodeTitle(context)
     val description = episode.overview?.trim().orEmpty()
-    val thumbnailUrl = remember(episode.thumbnail) {
-        episodeOverlayBackdropUrl(episode.thumbnail)
+    val blurUnwatchedBackdrop = blurUnwatchedEpisodes && !isWatched
+    val thumbnailUrl = remember(episode.thumbnail, blurUnwatchedBackdrop) {
+        if (blurUnwatchedBackdrop) {
+            episode.thumbnail?.takeIf { it.isNotBlank() }
+        } else {
+            episodeOverlayBackdropUrl(episode.thumbnail)
+        }
     }
     val backdropWidthPx = remember(configuration, density) {
         with(density) { configuration.screenWidthDp.dp.roundToPx() }
@@ -98,9 +106,21 @@ internal fun EpisodeOptionsOverlay(
     val backdropHeightPx = remember(configuration, density) {
         with(density) { configuration.screenHeightDp.dp.roundToPx() }
     }
-    val thumbnailRequest = remember(context, thumbnailUrl, backdropWidthPx, backdropHeightPx) {
+    val thumbnailRequest = remember(
+        context,
+        thumbnailUrl,
+        backdropWidthPx,
+        backdropHeightPx,
+        blurUnwatchedBackdrop
+    ) {
         thumbnailUrl?.let { url ->
-            episodeOverlayBackdropRequest(context, url, backdropWidthPx, backdropHeightPx)
+            episodeOverlayBackdropRequest(
+                context,
+                url,
+                backdropWidthPx,
+                backdropHeightPx,
+                blur = blurUnwatchedBackdrop
+            )
         }
     }
     val overlayBrush = remember(isRtl) {
@@ -336,28 +356,52 @@ private fun isSelectKey(keyCode: Int): Boolean {
 }
 
 private const val TMDB_IMAGE_SIZE_PREFIX = "/t/p/"
+private const val OVERLAY_BLUR_MAX_WIDTH_PX = 480
 
 internal fun episodeOverlayBackdropUrl(thumbnail: String?): String? {
     return thumbnail?.takeIf { it.isNotBlank() }?.let(::upgradeTmdbImageUrl)
 }
 
-internal fun episodeOverlayBackdropMemoryCacheKey(url: String, widthPx: Int, heightPx: Int): String {
-    return "${url}_${widthPx}x${heightPx}"
+internal fun episodeOverlayBackdropDecodeSize(
+    screenWidthPx: Int,
+    screenHeightPx: Int,
+    blur: Boolean
+): Pair<Int, Int> {
+    val width = screenWidthPx.coerceAtLeast(1)
+    val height = screenHeightPx.coerceAtLeast(1)
+    if (!blur) return width to height
+    val blurredWidth = (width / 4).coerceIn(1, OVERLAY_BLUR_MAX_WIDTH_PX)
+    val blurredHeight = ((height.toLong() * blurredWidth) / width).toInt().coerceAtLeast(1)
+    return blurredWidth to blurredHeight
+}
+
+internal fun episodeOverlayBackdropMemoryCacheKey(
+    url: String,
+    widthPx: Int,
+    heightPx: Int,
+    blur: Boolean
+): String {
+    return "${url}_${widthPx}x${heightPx}_blur$blur"
 }
 
 internal fun episodeOverlayBackdropRequest(
     context: Context,
     url: String,
-    widthPx: Int,
-    heightPx: Int
+    screenWidthPx: Int,
+    screenHeightPx: Int,
+    blur: Boolean = false
 ): ImageRequest {
-    val cacheKey = episodeOverlayBackdropMemoryCacheKey(url, widthPx, heightPx)
+    val (widthPx, heightPx) = episodeOverlayBackdropDecodeSize(screenWidthPx, screenHeightPx, blur)
+    val cacheKey = episodeOverlayBackdropMemoryCacheKey(url, widthPx, heightPx, blur)
     return ImageRequest.Builder(context)
         .data(url)
         .memoryCacheKey(cacheKey)
         .diskCacheKey(url)
         .crossfade(true)
-        .size(width = widthPx.coerceAtLeast(1), height = heightPx.coerceAtLeast(1))
+        .size(width = widthPx, height = heightPx)
+        .apply {
+            if (blur) transformations(BlurTransformation())
+        }
         .build()
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.ui.screens.detail
 
+import android.content.Context
 import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
@@ -24,11 +25,17 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -37,6 +44,9 @@ import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.ui.components.ImdbRatingSourceLabel
@@ -73,9 +83,39 @@ internal fun EpisodeOptionsOverlay(
     onMarkPreviousEpisodesWatched: () -> Unit = {}
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val primaryFocusRequester = remember { FocusRequester() }
     val title = episode.title.localizeEpisodeTitle(context)
     val description = episode.overview?.trim().orEmpty()
+    val thumbnailUrl = remember(episode.thumbnail) {
+        episodeOverlayBackdropUrl(episode.thumbnail)
+    }
+    val backdropWidthPx = remember(configuration, density) {
+        with(density) { configuration.screenWidthDp.dp.roundToPx() }
+    }
+    val backdropHeightPx = remember(configuration, density) {
+        with(density) { configuration.screenHeightDp.dp.roundToPx() }
+    }
+    val thumbnailRequest = remember(context, thumbnailUrl, backdropWidthPx, backdropHeightPx) {
+        thumbnailUrl?.let { url ->
+            episodeOverlayBackdropRequest(context, url, backdropWidthPx, backdropHeightPx)
+        }
+    }
+    val overlayBrush = remember(isRtl) {
+        Brush.horizontalGradient(
+            colorStops = arrayOf(
+                0.00f to Color(0xF2050505),
+                0.28f to Color(0xE6050505),
+                0.48f to Color(0xB8050505),
+                0.70f to Color(0x80050505),
+                1.00f to Color(0x66050505)
+            ),
+            startX = if (isRtl) Float.POSITIVE_INFINITY else 0f,
+            endX = if (isRtl) 0f else Float.POSITIVE_INFINITY
+        )
+    }
     val ratingLabel = remember(imdbRating) {
         imdbRating?.takeIf { it > 0.0 }?.let { String.format(Locale.US, "%.1f", it) }
     }
@@ -166,15 +206,7 @@ internal fun EpisodeOptionsOverlay(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(
-                    Brush.horizontalGradient(
-                        colors = listOf(
-                            Color(0xFF050505),
-                            Color(0xFF090909),
-                            Color(0xFF111111)
-                        )
-                    )
-                )
+                .background(Color(0xFF050505))
                 .onPreviewKeyEvent { event ->
                     val native = event.nativeKeyEvent
                     if (isSelectKey(native.keyCode)) {
@@ -188,6 +220,21 @@ internal fun EpisodeOptionsOverlay(
                     false
                 }
         ) {
+            if (thumbnailRequest != null) {
+                AsyncImage(
+                    model = thumbnailRequest,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.Center,
+                    filterQuality = FilterQuality.High
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(overlayBrush)
+            )
             Row(
                 modifier = Modifier
                     .fillMaxSize()
@@ -286,4 +333,41 @@ private fun isSelectKey(keyCode: Int): Boolean {
     return keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
         keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
         keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
+}
+
+private const val TMDB_IMAGE_SIZE_PREFIX = "/t/p/"
+
+internal fun episodeOverlayBackdropUrl(thumbnail: String?): String? {
+    return thumbnail?.takeIf { it.isNotBlank() }?.let(::upgradeTmdbImageUrl)
+}
+
+internal fun episodeOverlayBackdropMemoryCacheKey(url: String, widthPx: Int, heightPx: Int): String {
+    return "${url}_${widthPx}x${heightPx}"
+}
+
+internal fun episodeOverlayBackdropRequest(
+    context: Context,
+    url: String,
+    widthPx: Int,
+    heightPx: Int
+): ImageRequest {
+    val cacheKey = episodeOverlayBackdropMemoryCacheKey(url, widthPx, heightPx)
+    return ImageRequest.Builder(context)
+        .data(url)
+        .memoryCacheKey(cacheKey)
+        .diskCacheKey(url)
+        .crossfade(true)
+        .size(width = widthPx.coerceAtLeast(1), height = heightPx.coerceAtLeast(1))
+        .build()
+}
+
+internal fun upgradeTmdbImageUrl(url: String, size: String = "w1280"): String {
+    val sizeStart = url.indexOf(TMDB_IMAGE_SIZE_PREFIX, ignoreCase = true)
+        .takeIf { it >= 0 }
+        ?.plus(TMDB_IMAGE_SIZE_PREFIX.length)
+        ?: return url
+    val sizeEnd = url.indexOf('/', sizeStart).takeIf { it > sizeStart } ?: return url
+    val currentSize = url.substring(sizeStart, sizeEnd)
+    if (currentSize.equals(size, ignoreCase = true)) return url
+    return url.substring(0, sizeStart) + size + url.substring(sizeEnd)
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -74,6 +74,8 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import coil3.compose.AsyncImage
+import coil3.imageLoader
+import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.request.transformations
@@ -99,6 +101,7 @@ import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 private const val EPISODE_CARD_CONTENT_TYPE = "episode_card"
 private const val EPISODE_SCROLL_REPEAT_THROTTLE_MS = 80L
 private const val EPISODE_RESTORE_FALLBACK_MS = 250L
+private const val EPISODE_OVERLAY_PREFETCH_DELAY_MS = 120L
 
 @OptIn(ExperimentalTvMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
@@ -485,6 +488,7 @@ private fun EpisodeCard(
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
     val formattedDate = remember(episode.released) {
         episode.released?.let(::formatEpisodeCardDate).orEmpty()
     }
@@ -585,6 +589,36 @@ private fun EpisodeCard(
                 }
             }
             .build()
+    }
+    val overlayBackdropUrl = remember(episode.thumbnail) {
+        episodeOverlayBackdropUrl(episode.thumbnail)
+    }
+    val overlayBackdropWidthPx = remember(configuration, density) {
+        with(density) { configuration.screenWidthDp.dp.roundToPx() }
+    }
+    val overlayBackdropHeightPx = remember(configuration, density) {
+        with(density) { configuration.screenHeightDp.dp.roundToPx() }
+    }
+    val imageLoader = context.imageLoader
+    LaunchedEffect(isFocused, overlayBackdropUrl, overlayBackdropWidthPx, overlayBackdropHeightPx) {
+        if (!isFocused) return@LaunchedEffect
+        val url = overlayBackdropUrl ?: return@LaunchedEffect
+        if (overlayBackdropWidthPx <= 0 || overlayBackdropHeightPx <= 0) return@LaunchedEffect
+        delay(EPISODE_OVERLAY_PREFETCH_DELAY_MS)
+        val cacheKey = episodeOverlayBackdropMemoryCacheKey(
+            url,
+            overlayBackdropWidthPx,
+            overlayBackdropHeightPx
+        )
+        if (imageLoader.memoryCache?.get(MemoryCache.Key(cacheKey)) != null) return@LaunchedEffect
+        imageLoader.enqueue(
+            episodeOverlayBackdropRequest(
+                context,
+                url,
+                overlayBackdropWidthPx,
+                overlayBackdropHeightPx
+            )
+        )
     }
     val strEpisode = stringResource(R.string.episodes_episode)
     val strUnavailable = stringResource(R.string.episodes_unavailable)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -419,6 +419,7 @@ fun EpisodesRow(
                 selectedEpisode.episode?.let { episode -> episodeRatings[season to episode] }
             },
             isWatched = selectedWatched,
+            blurUnwatchedEpisodes = blurUnwatchedEpisodes,
             isPending = isPending,
             isSeasonFullyWatched = isSeasonFullyWatched,
             hasPreviousEpisodes = hasPreviousEpisodes,
@@ -600,15 +601,34 @@ private fun EpisodeCard(
         with(density) { configuration.screenHeightDp.dp.roundToPx() }
     }
     val imageLoader = context.imageLoader
-    LaunchedEffect(isFocused, overlayBackdropUrl, overlayBackdropWidthPx, overlayBackdropHeightPx) {
+    val overlayPrefetchUrl = remember(episode.thumbnail, shouldBlur) {
+        if (shouldBlur) {
+            episode.thumbnail?.takeIf { it.isNotBlank() }
+        } else {
+            overlayBackdropUrl
+        }
+    }
+    LaunchedEffect(
+        isFocused,
+        overlayPrefetchUrl,
+        overlayBackdropWidthPx,
+        overlayBackdropHeightPx,
+        shouldBlur
+    ) {
         if (!isFocused) return@LaunchedEffect
-        val url = overlayBackdropUrl ?: return@LaunchedEffect
+        val url = overlayPrefetchUrl ?: return@LaunchedEffect
         if (overlayBackdropWidthPx <= 0 || overlayBackdropHeightPx <= 0) return@LaunchedEffect
         delay(EPISODE_OVERLAY_PREFETCH_DELAY_MS)
+        val (decodeWidthPx, decodeHeightPx) = episodeOverlayBackdropDecodeSize(
+            overlayBackdropWidthPx,
+            overlayBackdropHeightPx,
+            shouldBlur
+        )
         val cacheKey = episodeOverlayBackdropMemoryCacheKey(
             url,
-            overlayBackdropWidthPx,
-            overlayBackdropHeightPx
+            decodeWidthPx,
+            decodeHeightPx,
+            shouldBlur
         )
         if (imageLoader.memoryCache?.get(MemoryCache.Key(cacheKey)) != null) return@LaunchedEffect
         imageLoader.enqueue(
@@ -616,7 +636,8 @@ private fun EpisodeCard(
                 context,
                 url,
                 overlayBackdropWidthPx,
-                overlayBackdropHeightPx
+                overlayBackdropHeightPx,
+                blur = shouldBlur
             )
         )
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -285,6 +285,7 @@ fun EpisodesRow(
     val dedupedEpisodes = remember(episodes) { episodes.distinctBy { it.id } }
     val restoreTargetRequester = restoreEpisodeId?.let { episodeFocusRequesters[it] }
     var optionsEpisode by remember { mutableStateOf<Video?>(null) }
+    val isOverlayOpen = optionsEpisode != null
     val cardMetrics = rememberEpisodeCardMetrics()
     val density = LocalDensity.current
     val rowPrefetchStrategy = remember { LazyListPrefetchStrategy(nestedPrefetchItemCount = 2) }
@@ -387,6 +388,7 @@ fun EpisodesRow(
                 imdbRating = imdbRating,
                 isMarkedWatched = isMarkedWatched,
                 blurUnwatched = blurUnwatchedEpisodes,
+                suppressMarquee = isOverlayOpen,
                 cardMetrics = cardMetrics,
                 onClick = episodeOnClick,
                 onLongPress = episodeOnLongPress,
@@ -477,6 +479,7 @@ private fun EpisodeCard(
     imdbRating: Double? = null,
     isMarkedWatched: Boolean = false,
     blurUnwatched: Boolean = false,
+    suppressMarquee: Boolean = false,
     cardMetrics: EpisodeCardMetrics,
     onClick: () -> Unit,
     onLongPress: () -> Unit,
@@ -813,7 +816,7 @@ private fun EpisodeCard(
 
                 FocusMarqueeText(
                     text = episode.title.localizeEpisodeTitle(context),
-                    focused = isFocused,
+                    focused = isFocused && !suppressMarquee,
                     style = titleStyle,
                     color = textPrimary,
                 )


### PR DESCRIPTION
## Summary

The detail-screen episode options overlay (long-press on an episode) was a solid dark fullscreen with title, description, and actions only. It now shows the episode still as a fullscreen backdrop.

TMDB card thumbnails stay at `w500`. The overlay loads `w1280`, with a left-to-right scrim so text and buttons stay readable. Focusing an episode card prefetches that same `w1280` request (120 ms settle delay) so the overlay can open from Coil cache instead of waiting on the network.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Long-pressing an episode opened a blank dark overlay with no episode artwork. The still that already exists for the card was not shown, so the overlay lost visual context for the selected episode. Stretching the card `w500` still to fullscreen also looked soft on TV, so the overlay uses `w1280` and warms that image on focus.

## Issue or approval

No linked issue.

## Reproduction steps

1. Open a series detail screen with episodes that have stills.
2. Focus an episode card, then long-press (or Menu) to open the options overlay.
3. Before this change: fullscreen overlay is a dark gradient only; no episode still.
4. After this change: the episode still fills the overlay behind title, description, and actions, with a dark scrim for contrast.
5. Move focus across a few episode cards, then long-press the focused one and confirm the backdrop appears without a long blank wait (prefetch).
6. Confirm episode row cards still use the smaller thumbnail and season scrolling is unchanged.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Only the existing long-press overlay backdrop is filled. Actions, focus, and episode-card artwork are unchanged.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Limited to `EpisodeOptionsOverlay` and episode-card focus prefetch in `EpisodesSection`.
- Does not change episode card thumbnail size (`w500`), detail hero, player overlays, or playback.
- Does not add settings, new actions, or overlay layout redesign beyond the backdrop.
- Non-TMDB thumbnail URLs are left as-is (no size upgrade).

## Testing

- Built `fullBenchmark` and installed over the existing `com.nuvio.tv.debug` package on a physical Android TV (`G10` / `Smart_TV_Pro`, `armeabi-v7a`, adb `192.168.2.13:5555`).
- Opened a series detail screen, focused episode cards, long-pressed to open the overlay.
- Confirmed S9 E1 overlay shows the episode still behind title, overview, and actions (Mark as watched / Mark season as watched / Play / Play manually), with the left scrim keeping text readable.
- Confirmed D-pad focus still lands on the first enabled action; Back dismisses the overlay.
- Episode row cards still render `w500` stills; only the overlay uses `w1280`.

## Screenshots / Video

After (Android TV): episode options overlay for S9 E1 "There's Something About Morty" with the episode still as fullscreen backdrop, left-side title/overview, and action buttons on the right.
<img width="1920" height="1080" alt="tv-screenshot-20260820-141921" src="https://github.com/user-attachments/assets/71b04c39-c042-49c7-b98b-41be498e6d1c" />


Before: same overlay was a solid dark gradient with no episode artwork.

## Breaking changes

None

## Linked issues

No linked issue.
