### PR TITLE
RTL navigation fixes for Subtitle Delay overlay (Reset/Sync Line + slider)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -531,11 +531,6 @@ fun PlayerScreen(
                     if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
                         when (subtitleDelayFocusTarget) {
                             SubtitleDelayFocusTarget.SLIDER -> {
-                                // The track/thumb are laid out with CenterStart + a
-                                // direction-aware offset, so Compose auto-mirrors them in RTL:
-                                // the fill direction flips visually. To keep the physical
-                                // Left/Right keys moving the thumb the way they're pressed,
-                                // the increase/decrease mapping must flip with them.
                                 val decreaseDelayKey = if (isRtl) {
                                     KeyEvent.KEYCODE_DPAD_RIGHT
                                 } else {
@@ -2731,11 +2726,13 @@ private fun SubtitleDelayOverlay(
                 style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
                 color = Color.White
             )
-            Text(
-                text = formatSubtitleDelay(subtitleDelayMs),
-                style = MaterialTheme.typography.titleLarge,
-                color = Color.White.copy(alpha = 0.95f)
-            )
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                Text(
+                    text = formatSubtitleDelay(subtitleDelayMs),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = Color.White.copy(alpha = 0.95f)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(18.dp))

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -531,22 +531,12 @@ fun PlayerScreen(
                     if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
                         when (subtitleDelayFocusTarget) {
                             SubtitleDelayFocusTarget.SLIDER -> {
-                                val decreaseDelayKey = if (isRtl) {
-                                    KeyEvent.KEYCODE_DPAD_RIGHT
-                                } else {
-                                    KeyEvent.KEYCODE_DPAD_LEFT
-                                }
-                                val increaseDelayKey = if (isRtl) {
-                                    KeyEvent.KEYCODE_DPAD_LEFT
-                                } else {
-                                    KeyEvent.KEYCODE_DPAD_RIGHT
-                                }
                                 when (keyEvent.nativeKeyEvent.keyCode) {
-                                    decreaseDelayKey -> {
+                                    KeyEvent.KEYCODE_DPAD_LEFT -> {
                                         viewModel.onEvent(PlayerEvent.OnAdjustSubtitleDelay(-SUBTITLE_DELAY_STEP_MS))
                                         return@onKeyEvent true
                                     }
-                                    increaseDelayKey -> {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
                                         viewModel.onEvent(PlayerEvent.OnAdjustSubtitleDelay(SUBTITLE_DELAY_STEP_MS))
                                         return@onKeyEvent true
                                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -531,12 +531,27 @@ fun PlayerScreen(
                     if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
                         when (subtitleDelayFocusTarget) {
                             SubtitleDelayFocusTarget.SLIDER -> {
+                                // The track/thumb are laid out with CenterStart + a
+                                // direction-aware offset, so Compose auto-mirrors them in RTL:
+                                // the fill direction flips visually. To keep the physical
+                                // Left/Right keys moving the thumb the way they're pressed,
+                                // the increase/decrease mapping must flip with them.
+                                val decreaseDelayKey = if (isRtl) {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT
+                                } else {
+                                    KeyEvent.KEYCODE_DPAD_LEFT
+                                }
+                                val increaseDelayKey = if (isRtl) {
+                                    KeyEvent.KEYCODE_DPAD_LEFT
+                                } else {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT
+                                }
                                 when (keyEvent.nativeKeyEvent.keyCode) {
-                                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                    decreaseDelayKey -> {
                                         viewModel.onEvent(PlayerEvent.OnAdjustSubtitleDelay(-SUBTITLE_DELAY_STEP_MS))
                                         return@onKeyEvent true
                                     }
-                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                    increaseDelayKey -> {
                                         viewModel.onEvent(PlayerEvent.OnAdjustSubtitleDelay(SUBTITLE_DELAY_STEP_MS))
                                         return@onKeyEvent true
                                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -146,6 +146,7 @@ fun PlayerScreen(
     val uiState by viewModel.uiState.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val containerFocusRequester = remember { FocusRequester() }
     val playPauseFocusRequester = remember { FocusRequester() }
     val progressBarFocusRequester = remember { FocusRequester() }
@@ -540,7 +541,7 @@ fun PlayerScreen(
                                         return@onKeyEvent true
                                     }
                                     KeyEvent.KEYCODE_DPAD_DOWN -> {
-                                        subtitleDelayFocusTarget = SubtitleDelayFocusTarget.RESET
+                                        subtitleDelayFocusTarget = SubtitleDelayFocusTarget.SYNC_LINE
                                         return@onKeyEvent true
                                     }
                                     KeyEvent.KEYCODE_DPAD_CENTER,
@@ -552,6 +553,20 @@ fun PlayerScreen(
                                 }
                             }
                             SubtitleDelayFocusTarget.RESET -> {
+                                // Reset is laid out before Sync Line, so it renders on the
+                                // leading side of the row: start-side in LTR, end-side in RTL.
+                                // The key that moves focus "toward" Sync Line therefore flips
+                                // with layout direction.
+                                val towardSyncLine = if (isRtl) {
+                                    KeyEvent.KEYCODE_DPAD_LEFT
+                                } else {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT
+                                }
+                                val awayFromSyncLine = if (isRtl) {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT
+                                } else {
+                                    KeyEvent.KEYCODE_DPAD_LEFT
+                                }
                                 when (keyEvent.nativeKeyEvent.keyCode) {
                                     KeyEvent.KEYCODE_DPAD_CENTER,
                                     KeyEvent.KEYCODE_ENTER,
@@ -564,17 +579,30 @@ fun PlayerScreen(
                                         subtitleDelayFocusTarget = SubtitleDelayFocusTarget.SLIDER
                                         return@onKeyEvent true
                                     }
-                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                    towardSyncLine -> {
                                         subtitleDelayFocusTarget = SubtitleDelayFocusTarget.SYNC_LINE
                                         return@onKeyEvent true
                                     }
                                     KeyEvent.KEYCODE_DPAD_DOWN,
-                                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                    awayFromSyncLine -> {
                                         return@onKeyEvent true
                                     }
                                 }
                             }
                             SubtitleDelayFocusTarget.SYNC_LINE -> {
+                                // Sync Line renders on the trailing side of the row: end-side
+                                // in LTR, start-side in RTL. The key that moves focus "toward"
+                                // Reset therefore flips with layout direction.
+                                val towardReset = if (isRtl) {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT
+                                } else {
+                                    KeyEvent.KEYCODE_DPAD_LEFT
+                                }
+                                val awayFromReset = if (isRtl) {
+                                    KeyEvent.KEYCODE_DPAD_LEFT
+                                } else {
+                                    KeyEvent.KEYCODE_DPAD_RIGHT
+                                }
                                 when (keyEvent.nativeKeyEvent.keyCode) {
                                     KeyEvent.KEYCODE_DPAD_CENTER,
                                     KeyEvent.KEYCODE_ENTER,
@@ -590,12 +618,12 @@ fun PlayerScreen(
                                         subtitleDelayFocusTarget = SubtitleDelayFocusTarget.SLIDER
                                         return@onKeyEvent true
                                     }
-                                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                    towardReset -> {
                                         subtitleDelayFocusTarget = SubtitleDelayFocusTarget.RESET
                                         return@onKeyEvent true
                                     }
                                     KeyEvent.KEYCODE_DPAD_DOWN,
-                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                    awayFromReset -> {
                                         return@onKeyEvent true
                                     }
                                 }


### PR DESCRIPTION
## Summary

Fixes three related D-pad navigation bugs in Playback → Subtitle Settings → Delay:

- RTL: Left/Right between Reset and Sync Line buttons was backwards/broken.
- RTL: Left/Right on the delay slider adjusted the value in the wrong direction.

#2977 Follow-up.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

Users of RTL layout suffer from incorrect remote navigation direction.

## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

#2993 