### PR TITLE
CW channel plays directly + show progress for synced items

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,8 +104,8 @@ android {
         applicationId = "com.nuvio.tv"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1047
-        versionName = "0.8.6-beta"
+        versionCode = 1048
+        versionName = "0.8.7-beta"
 
         buildConfigField("String", "PARENTAL_GUIDE_API_URL", "\"${localProperties.getProperty("PARENTAL_GUIDE_API_URL", "")}\"")
         buildConfigField("String", "INTRODB_API_URL", "\"${localProperties.getProperty("INTRODB_API_URL", "")}\"")

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -330,6 +330,15 @@ class MainActivity : ComponentActivity() {
         // Extract extras set by the Continue Watching launcher channel preview programs.
         val launchContentId = intent?.getStringExtra("contentId")
         val launchContentType = intent?.getStringExtra("contentType")
+        val launchMode = intent?.getStringExtra("launchMode")
+        val launchVideoId = intent?.getStringExtra("videoId")
+        val launchName = intent?.getStringExtra("name")
+        val launchPoster = intent?.getStringExtra("poster")
+        val launchBackdrop = intent?.getStringExtra("backdrop")
+        val launchLogo = intent?.getStringExtra("logo")
+        val launchSeason = intent?.getIntExtra("season", -1)?.takeIf { it >= 0 }
+        val launchEpisode = intent?.getIntExtra("episode", -1)?.takeIf { it >= 0 }
+        val launchEpisodeTitle = intent?.getStringExtra("episodeTitle")
         captureDeepLinkIntent(intent)
 
         setContent {
@@ -712,12 +721,32 @@ class MainActivity : ComponentActivity() {
                     // Navigate to content when launched from the Continue Watching channel row.
                     LaunchedEffect(navController) {
                         if (launchContentId != null && launchContentType != null && layoutChosen) {
-                            navController.navigate(
-                                Screen.Detail.createRoute(
-                                    itemId = launchContentId,
-                                    itemType = launchContentType
+                            if (launchMode == "stream" && launchVideoId != null && launchName != null) {
+                                navController.navigate(
+                                    Screen.Stream.createRoute(
+                                        videoId = launchVideoId,
+                                        contentType = launchContentType,
+                                        title = launchName,
+                                        poster = launchPoster,
+                                        backdrop = launchBackdrop,
+                                        logo = launchLogo,
+                                        season = launchSeason,
+                                        episode = launchEpisode,
+                                        episodeName = launchEpisodeTitle,
+                                        contentId = launchContentId,
+                                        contentName = launchName,
+                                        returnToDetailOnBack = launchContentType.equals("series", ignoreCase = true),
+                                        returnToHomeOnBack = true
+                                    )
                                 )
-                            )
+                            } else {
+                                navController.navigate(
+                                    Screen.Detail.createRoute(
+                                        itemId = launchContentId,
+                                        itemType = launchContentType
+                                    )
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
@@ -49,8 +49,18 @@ class ProgramBuilder @Inject constructor(
         }
 
         if (progress.duration > 0) {
-            builder.setLastPlaybackPositionMillis(progress.position.toInt())
+            val positionMs = if (progress.position > 0) {
+                progress.position.toInt()
+            } else {
+                (progress.progressPercent?.let { it / 100f * progress.duration }?.toLong() ?: 0L).toInt()
+            }
+            builder.setLastPlaybackPositionMillis(positionMs)
             builder.setDurationMillis(progress.duration.toInt())
+        } else if (progress.progressPercent != null && progress.progressPercent > 0f) {
+            val syntheticDuration = 100_000
+            val syntheticPosition = (progress.progressPercent / 100f * syntheticDuration).toInt()
+            builder.setDurationMillis(syntheticDuration)
+            builder.setLastPlaybackPositionMillis(syntheticPosition)
         }
 
         if (!isMovie) {

--- a/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
+++ b/app/src/main/java/com/nuvio/tv/core/recommendations/ProgramBuilder.kt
@@ -218,6 +218,15 @@ class ProgramBuilder @Inject constructor(
                 action = Intent.ACTION_VIEW
                 putExtra("contentId", progress.contentId)
                 putExtra("contentType", progress.contentType)
+                putExtra("videoId", progress.videoId)
+                putExtra("name", progress.name)
+                putExtra("poster", progress.poster)
+                putExtra("backdrop", progress.backdrop)
+                putExtra("logo", progress.logo)
+                progress.season?.let { putExtra("season", it) }
+                progress.episode?.let { putExtra("episode", it) }
+                progress.episodeTitle?.let { putExtra("episodeTitle", it) }
+                putExtra("launchMode", "stream")
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }.toUri(Intent.URI_INTENT_SCHEME)
         )

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
@@ -310,10 +310,16 @@ class AndroidTvChannelManager @Inject constructor(
             val positionMs = if (progress.position > 0) {
                 progress.position.toInt()
             } else {
-                // Trakt items may have duration (from runtime hydration) but position=0 with only progressPercent.
                 (progress.progressPercent?.let { it / 100f * progress.duration }?.toLong() ?: 0L).toInt()
             }
             builder.setLastPlaybackPositionMillis(positionMs)
+        } else if (progress.progressPercent != null && progress.progressPercent > 0f) {
+            // No real duration known (e.g. Simkl/Trakt sync), but we have a percent.
+            // Use synthetic values so the launcher can render a progress bar.
+            val syntheticDuration = 100_000
+            val syntheticPosition = (progress.progressPercent / 100f * syntheticDuration).toInt()
+            builder.setDurationMillis(syntheticDuration)
+            builder.setLastPlaybackPositionMillis(syntheticPosition)
         }
 
         if (type == TvContractCompat.PreviewPrograms.TYPE_TV_EPISODE) {
@@ -336,7 +342,7 @@ class AndroidTvChannelManager @Inject constructor(
             }
             // Clear duration/position when unknown so stale values (e.g. previous 1hr fallback)
             // don't persist across UPDATE cycles.
-            if (progress.duration <= 0) {
+            if (progress.duration <= 0 && (progress.progressPercent == null || progress.progressPercent <= 0f)) {
                 it.putNull("duration_millis")
                 it.putNull("last_playback_position_millis")
             }

--- a/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/androidtv/AndroidTvChannelManager.kt
@@ -267,6 +267,15 @@ class AndroidTvChannelManager @Inject constructor(
                 action = Intent.ACTION_VIEW
                 putExtra("contentId", progress.contentId)
                 putExtra("contentType", progress.contentType)
+                putExtra("videoId", progress.videoId)
+                putExtra("name", progress.name)
+                putExtra("poster", progress.poster)
+                putExtra("backdrop", progress.backdrop)
+                putExtra("logo", progress.logo)
+                progress.season?.let { putExtra("season", it) }
+                progress.episode?.let { putExtra("episode", it) }
+                progress.episodeTitle?.let { putExtra("episodeTitle", it) }
+                putExtra("launchMode", "stream")
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }.toUri(Intent.URI_INTENT_SCHEME)
         )


### PR DESCRIPTION
## Summary

1. Launcher CW channel now navigates to Stream screen (like in-app CW click) instead of Detail screen
2. Progress bar shown for items with only progressPercent (Simkl/Trakt sync) using synthetic duration values

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. Clicking CW from launcher opened Detail screen - user had to manually click play. Should behave like in-app CW: go directly to stream selection respecting user settings (binge group, manual selection).
2. Items synced from Simkl/Trakt have progressPercent but no duration/position. Channel never showed progress bar for these despite having valid percent data. Uses synthetic duration (100s) to give launcher a correct ratio for rendering the bar.

## Issue or approval

User-reported: launcher CW doesn't play directly.
User-reported: dedicated channel missing progress bar while system WatchNext has it.

## Reproduction steps

Bug 1: Add items to CW -> Go to launcher -> Click item in Nuvio channel -> Opens Detail instead of Stream
Bug 2: Watch a film partially (synced via Simkl) -> Return to launcher -> System WatchNext shows progress bar, Nuvio channel does not

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- ProgramBuilder: added extras to intent, added synthetic duration fallback from progressPercent
- AndroidTvChannelManager.buildProgramValues: same intent extras, same synthetic duration fallback, fixed putNull guard to not clear synthetic values
- MainActivity: added extraction of new extras, navigates to Stream when launchMode=stream, falls back to Detail for old-format intents
- No changes to Stream screen, player, or CW pipeline logic

## Testing

- Verified launcher CW click navigates to Stream screen with correct parameters
- Verified user stream selection settings (manual, binge group) are respected from launcher launch
- Verified progress bar appears for Simkl-synced items (progressPercent only, no duration)
- Verified items with real duration still show correct progress bar
- Verified NextUp items (no progress) correctly show no bar
- Verified old-format intents (pre-update programs) fall back to Detail screen
- Tested on TCL Android TV via ADB

## Screenshots / Video

Not a UI change.

## Breaking changes

None. Old launcher intents without launchMode extra fall back to previous Detail navigation.

## Linked issues

User-reported launcher CW navigation and missing progress bar.
