### PR TITLE
fix(player): unify sources reload button and fix D-pad focus navigation

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/RefreshFilterChip.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/RefreshFilterChip.kt
@@ -1,0 +1,116 @@
+package com.nuvio.tv.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Border
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.FilterChip
+import androidx.tv.material3.FilterChipDefaults
+import androidx.tv.material3.Icon
+import com.nuvio.tv.R
+import com.nuvio.tv.ui.theme.NuvioTheme
+import kotlinx.coroutines.delay as coroutineDelay
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun RefreshFilterChip(
+    onClick: () -> Unit,
+    isLoading: Boolean = false,
+    onFocusChanged: (Boolean) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val contentColor = if (isFocused) {
+        NuvioTheme.colors.OnSecondary
+    } else {
+        NuvioTheme.colors.TextSecondary
+    }
+
+    val rotationAnimatable = remember { Animatable(0f) }
+    var hasCompletedFullRotation by remember { mutableStateOf(false) }
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            // Spin continuously while loading
+            coroutineDelay(100)
+            hasCompletedFullRotation = false
+            while (true) {
+                val remaining = 360f - rotationAnimatable.value
+                rotationAnimatable.animateTo(
+                    targetValue = 360f,
+                    animationSpec = tween(
+                        durationMillis = (remaining / 360f * 1000).toInt(),
+                        easing = LinearEasing
+                    )
+                )
+                hasCompletedFullRotation = true
+                rotationAnimatable.snapTo(0f)
+            }
+        } else {
+            // Complete current rotation then stop
+            if (hasCompletedFullRotation && rotationAnimatable.value > 0f) {
+                val remaining = 360f - rotationAnimatable.value
+                rotationAnimatable.animateTo(
+                    targetValue = 360f,
+                    animationSpec = tween(
+                        durationMillis = (remaining / 360f * 1000).toInt(),
+                        easing = LinearEasing
+                    )
+                )
+            }
+            rotationAnimatable.snapTo(0f)
+            hasCompletedFullRotation = false
+        }
+    }
+
+    FilterChip(
+        selected = false,
+        onClick = onClick,
+        modifier = modifier.onFocusChanged {
+            isFocused = it.isFocused
+            onFocusChanged(it.isFocused)
+        },
+        colors = FilterChipDefaults.colors(
+            containerColor = NuvioTheme.colors.BackgroundCard,
+            focusedContainerColor = NuvioTheme.colors.Secondary,
+            contentColor = contentColor,
+            focusedContentColor = contentColor
+        ),
+        border = FilterChipDefaults.border(
+            border = Border(
+                border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
+                shape = RoundedCornerShape(20.dp)
+            ),
+            focusedBorder = Border(
+                border = BorderStroke(NuvioTheme.spacing.xxs, NuvioTheme.colors.FocusRing),
+                shape = RoundedCornerShape(20.dp)
+            )
+        ),
+        shape = FilterChipDefaults.shape(shape = RoundedCornerShape(20.dp))
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Refresh,
+            contentDescription = stringResource(R.string.cd_refresh),
+            modifier = Modifier
+                .size(20.dp)
+                .graphicsLayer { rotationZ = rotationAnimatable.value },
+            tint = contentColor
+        )
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodesSidePanel.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -59,6 +61,7 @@ import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.ui.theme.NuvioTheme
 import com.nuvio.tv.ui.components.LoadingIndicator
+import com.nuvio.tv.ui.components.SourceChipStatus
 import com.nuvio.tv.ui.screens.detail.formatReleaseDate
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -69,6 +72,9 @@ import coil3.request.transformations
 import androidx.compose.ui.platform.LocalContext
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import kotlinx.coroutines.delay
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.launch as coroutineLaunch
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
 
@@ -91,26 +97,12 @@ internal fun EpisodesSidePanel(
         uiState.showEpisodeStreams
     ) {
         try {
-            if (uiState.showEpisodeStreams) {
-                streamsFocusRequester.requestFocus()
-            } else {
+            if (!uiState.showEpisodeStreams) {
                 episodesFocusRequester.requestFocus()
             }
         } catch (_: Exception) {
             // Focus requester may not be ready yet
         }
-    }
-
-   
-    LaunchedEffect(
-        uiState.showEpisodeStreams,
-        uiState.isLoadingEpisodeStreams,
-        uiState.episodeFilteredStreams.isNotEmpty()
-    ) {
-        if (!uiState.showEpisodeStreams) return@LaunchedEffect
-        if (uiState.isLoadingEpisodeStreams) return@LaunchedEffect
-        if (uiState.episodeFilteredStreams.isEmpty()) return@LaunchedEffect
-        runCatching { streamsFocusRequester.requestFocus() }
     }
 
     // Right panel only (scrim is handled in PlayerScreen)
@@ -145,7 +137,6 @@ internal fun EpisodesSidePanel(
                 if (uiState.showEpisodeStreams) {
                     EpisodeStreamsView(
                         uiState = uiState,
-                        streamsFocusRequester = streamsFocusRequester,
                         onBackToEpisodes = onBackToEpisodes,
                         onReload = onReloadEpisodeStreams,
                         onAddonFilterSelected = onAddonFilterSelected,
@@ -167,13 +158,123 @@ internal fun EpisodesSidePanel(
 @Composable
 private fun EpisodeStreamsView(
     uiState: PlayerUiState,
-    streamsFocusRequester: FocusRequester,
     onBackToEpisodes: () -> Unit,
     onReload: () -> Unit,
     onAddonFilterSelected: (String?) -> Unit,
     onStreamSelected: (Stream) -> Unit
 ) {
-    // Streams for selected episode
+    val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
+    val streamListState = rememberLazyListState()
+    var userMovedFromFirstResult by remember { mutableStateOf(false) }
+    var firstResultFocusAssigned by remember { mutableStateOf(false) }
+    var firstStreamFocusRequestId by remember { mutableStateOf(0) }
+    var listHasFocus by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    val backButtonFocusRequester = remember { FocusRequester() }
+
+    val orderedAddonNames = remember(uiState.episodeAvailableAddons, uiState.episodeSourceChips) {
+        buildList {
+            addAll(uiState.episodeAvailableAddons)
+            uiState.episodeSourceChips.forEach { if (it.name !in this) add(it.name) }
+        }
+    }
+    val refreshFocusRequester = remember { FocusRequester() }
+    val allFocusRequester = remember { FocusRequester() }
+    val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val chipFocusRequesters = remember(orderedAddonNames) {
+        // Remove stale entries for addons that no longer exist
+        addonFocusRequesters.keys.retainAll(orderedAddonNames.toSet())
+        buildList {
+            add(refreshFocusRequester)
+            add(allFocusRequester)
+            orderedAddonNames.forEach { addon ->
+                add(addonFocusRequesters.getOrPut(addon) { FocusRequester() })
+            }
+        }
+    }
+
+    val streamKeys = remember(uiState.episodeFilteredStreams) {
+        val seen = mutableMapOf<String, Int>()
+        uiState.episodeFilteredStreams.map { stream ->
+            val base = stream.stableKey(0)
+            val count = seen.getOrDefault(base, 0)
+            seen[base] = count + 1
+            stream.stableKey(count)
+        }
+    }
+    val firstStreamKey = streamKeys.firstOrNull()
+    val streamFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    streamKeys.forEach { key ->
+        streamFocusRequesters.getOrPut(key) { FocusRequester() }
+    }
+    var firstCardHasFocus by remember(firstStreamKey) { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.isLoadingEpisodeStreams, firstStreamKey, userMovedFromFirstResult, firstResultFocusAssigned) {
+        if (!uiState.isLoadingEpisodeStreams && firstStreamKey != null &&
+            !userMovedFromFirstResult && !firstResultFocusAssigned
+        ) {
+            firstResultFocusAssigned = true
+            firstStreamFocusRequestId += 1
+        }
+    }
+
+    var trackedFirstStreamKey by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(firstStreamKey, uiState.episodeSelectedAddonFilter, listHasFocus) {
+        if (uiState.episodeSelectedAddonFilter != null) {
+            trackedFirstStreamKey = firstStreamKey
+            return@LaunchedEffect
+        }
+        if (firstStreamKey != null && trackedFirstStreamKey != null &&
+            firstStreamKey != trackedFirstStreamKey &&
+            listHasFocus && !userMovedFromFirstResult
+        ) {
+            firstStreamFocusRequestId += 1
+        }
+        trackedFirstStreamKey = firstStreamKey
+    }
+
+    LaunchedEffect(firstStreamFocusRequestId) {
+        val requestedKey = firstStreamKey
+        if (firstStreamFocusRequestId <= 0 || requestedKey == null) return@LaunchedEffect
+        streamListState.scrollToItem(0)
+        repeat(30) {
+            withFrameNanos { }
+            if (firstCardHasFocus) return@LaunchedEffect
+            runCatching { streamFocusRequesters.getValue(requestedKey).requestFocus() }
+        }
+    }
+
+    fun requestChipFocus(index: Int) {
+        if (index !in chipFocusRequesters.indices) return
+        userMovedFromFirstResult = true
+        focusJob?.cancel()
+        focusJob = scope.coroutineLaunch {
+            withFrameNanos { }
+            runCatching { chipFocusRequesters[index].requestFocus() }
+        }
+    }
+
+    fun onAddonFilterSelectedGuarded(addon: String?) {
+        userMovedFromFirstResult = true
+        onAddonFilterSelected(addon)
+        focusJob?.cancel()
+        focusJob = scope.coroutineLaunch {
+            withFrameNanos {}
+            val targetRequester = if (addon == null) {
+                chipFocusRequesters.getOrNull(1)
+            } else {
+                addonFocusRequesters[addon]
+            }
+            runCatching { targetRequester?.requestFocus() }
+        }
+    }
+
+    LaunchedEffect(uiState.episodeSelectedAddonFilter) {
+        streamListState.scrollToItem(0)
+    }
+
+    // --- Header ---
     Row(
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
         verticalAlignment = Alignment.CenterVertically
@@ -181,12 +282,19 @@ private fun EpisodeStreamsView(
         DialogButton(
             text = stringResource(R.string.episodes_panel_back),
             onClick = onBackToEpisodes,
-            isPrimary = false
-        )
-        DialogButton(
-            text = stringResource(R.string.episodes_panel_reload),
-            onClick = onReload,
-            isPrimary = false
+            isPrimary = false,
+            modifier = Modifier
+                .focusRequester(backButtonFocusRequester)
+                .onKeyEvent { event ->
+                    if (event.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN &&
+                        event.key == androidx.compose.ui.input.key.Key.DirectionDown
+                    ) {
+                        val activeIdx = if (uiState.episodeSelectedAddonFilter == null) 1
+                            else (orderedAddonNames.indexOf(uiState.episodeSelectedAddonFilter) + 2).coerceAtLeast(1)
+                        requestChipFocus(activeIdx)
+                        true
+                    } else false
+                }
         )
 
         val season = uiState.episodeStreamsSeason
@@ -209,20 +317,36 @@ private fun EpisodeStreamsView(
 
     Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
 
+    // --- Filter chips ---
     AnimatedVisibility(
-        visible = !uiState.isLoadingEpisodeStreams && uiState.episodeAvailableAddons.isNotEmpty(),
+        visible = uiState.episodeSourceChips.isNotEmpty() || uiState.episodeAvailableAddons.isNotEmpty(),
         enter = fadeIn(animationSpec = tween(200)),
         exit = fadeOut(animationSpec = tween(120))
     ) {
         AddonFilterChips(
             addons = uiState.episodeAvailableAddons,
+            sourceChips = uiState.episodeSourceChips,
             selectedAddon = uiState.episodeSelectedAddonFilter,
-            onAddonSelected = onAddonFilterSelected
+            isStillFetching = uiState.isLoadingEpisodeStreams ||
+                uiState.episodeSourceChips.any { it.status == SourceChipStatus.LOADING },
+            onRefresh = {
+                userMovedFromFirstResult = false
+                firstResultFocusAssigned = false
+                onReload()
+            },
+            onAddonSelected = { onAddonFilterSelected(it) },
+            externalFocusRequesters = chipFocusRequesters,
+            externalOrderedNames = orderedAddonNames,
+            onUpKey = {
+                try { backButtonFocusRequester.requestFocus() } catch (_: Exception) {}
+            },
+            debugTag = "EpisodeSidePanel"
         )
     }
 
     Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
 
+    // --- Content ---
     when {
         uiState.isLoadingEpisodeStreams -> {
             Box(
@@ -252,20 +376,86 @@ private fun EpisodeStreamsView(
         }
 
         else -> {
+            val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
+
             LazyColumn(
+                state = streamListState,
                 verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm),
                 contentPadding = PaddingValues(top = NuvioTheme.spacing.xs),
-                modifier = Modifier.fillMaxHeight()
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .onFocusChanged { listHasFocus = it.hasFocus }
+                    .onKeyEvent { event ->
+                        if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
+
+                        if (event.nativeKeyEvent.repeatCount > 0) {
+                            val now = android.os.SystemClock.uptimeMillis()
+                            if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
+                            lastKeyRepeatDispatchRef.set(now)
+                        }
+
+                        if (event.key == androidx.compose.ui.input.key.Key.DirectionDown) {
+                            userMovedFromFirstResult = true
+                        }
+
+                        if (orderedAddonNames.isEmpty()) return@onKeyEvent false
+                        val allOptions = listOf<String?>(null) + orderedAddonNames
+                        val currentIdx = allOptions.indexOf(uiState.episodeSelectedAddonFilter)
+                        when (event.key) {
+                            androidx.compose.ui.input.key.Key.DirectionLeft -> {
+                                if (isRtl) {
+                                    if (currentIdx < allOptions.lastIndex) {
+                                        onAddonFilterSelectedGuarded(allOptions[currentIdx + 1])
+                                        true
+                                    } else { true }
+                                } else {
+                                    if (currentIdx > 0) {
+                                        onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
+                                        true
+                                    } else {
+                                        true
+                                    }
+                                }
+                            }
+                            androidx.compose.ui.input.key.Key.DirectionRight -> {
+                                if (isRtl) {
+                                    if (currentIdx > 0) {
+                                        onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
+                                        true
+                                    } else {
+                                        true
+                                    }
+                                } else {
+                                    if (currentIdx < allOptions.lastIndex) {
+                                        onAddonFilterSelectedGuarded(allOptions[currentIdx + 1])
+                                        true
+                                    } else { true }
+                                }
+                            }
+                            else -> false
+                        }
+                    }
             ) {
-                items(uiState.episodeFilteredStreams) { stream ->
+                itemsIndexed(uiState.episodeFilteredStreams, key = { index, _ ->
+                    streamKeys[index]
+                }) { index, stream ->
                     StreamItem(
                         stream = stream,
-                        focusRequester = streamsFocusRequester,
-                        requestInitialFocus = stream == uiState.episodeFilteredStreams.firstOrNull(),
+                        focusRequester = streamFocusRequesters.getValue(streamKeys[index]),
                         showFileSizeBadges = uiState.showFileSizeBadges,
                         showAddonLogo = uiState.showAddonLogo,
                         badgePlacement = uiState.streamBadgePlacement,
-                        onClick = { onStreamSelected(stream) }
+                        onClick = { onStreamSelected(stream) },
+                        onFocusChanged = { focused ->
+                            if (index == 0) {
+                                firstCardHasFocus = focused
+                            }
+                        },
+                        onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{
+                            val idx = if (uiState.episodeSelectedAddonFilter == null) 1
+                                      else orderedAddonNames.indexOf(uiState.episodeSelectedAddonFilter) + 2
+                            requestChipFocus(idx)
+                        }} else null
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -251,9 +251,7 @@ internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
                         } else {
                             availableAddons
                         }
-                        val selectedAddon = it.sourceSelectedAddonFilter?.takeIf { selected ->
-                            selected in mergedAvailableAddons
-                        }
+                        val selectedAddon = it.sourceSelectedAddonFilter
                         val filteredStreams = if (selectedAddon == null) {
                             badgePreserved
                         } else {
@@ -262,7 +260,6 @@ internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
                         it.copy(
                             isLoadingSourceStreams = false,
                             sourceAllStreams = badgePreserved,
-                            sourceSelectedAddonFilter = selectedAddon,
                             sourceFilteredStreams = filteredStreams,
                             sourceAvailableAddons = mergedAvailableAddons,
                             sourceChips = mergeSourceChipStatuses(
@@ -483,6 +480,78 @@ private fun PlayerRuntimeController.markRemainingSourceChipsAsError() {
         _uiState.update { state ->
             state.copy(
                 sourceChips = state.sourceChips.filterNot { it.status == SourceChipStatus.ERROR }
+            )
+        }
+    }
+}
+
+private suspend fun PlayerRuntimeController.updateEpisodeSourceChipsForFetchStart(
+    type: String,
+    videoId: String,
+    installedAddons: List<com.nuvio.tv.domain.model.Addon>
+) {
+    val addonNames = installedAddons
+        .filter { it.supportsStreamResourceForChip(type, videoId) }
+        .map { it.displayName }
+
+    val pluginNames = try {
+        if (pluginManager.pluginsEnabled.first()) {
+            val mediaType = when (type.lowercase()) {
+                "series", "tv", "show" -> "tv"
+                else -> type.lowercase()
+            }
+            val groupByRepository = pluginManager.groupStreamsByRepository.first()
+            val scrapers = pluginManager.enabledScrapers.first()
+                .filter { it.supportsType(mediaType) }
+            if (groupByRepository) {
+                val repositoriesById = pluginManager.repositories.first().associateBy { it.id }
+                scrapers
+                    .map { scraper ->
+                        repositoriesById[scraper.repositoryId]?.name?.takeIf { it.isNotBlank() } ?: scraper.name
+                    }
+                    .distinct()
+            } else {
+                scrapers
+                    .map { it.name }
+                    .distinct()
+            }
+        } else {
+            emptyList()
+        }
+    } catch (_: Exception) {
+        emptyList()
+    }
+
+    val ordered = (addonNames + pluginNames).distinct()
+    _uiState.update {
+        it.copy(
+            episodeSourceChips = ordered.map { name -> SourceChipItem(name, SourceChipStatus.LOADING) }
+        )
+    }
+}
+
+private fun PlayerRuntimeController.markRemainingEpisodeSourceChipsAsError() {
+    var markedAnyError = false
+    _uiState.update { state ->
+        if (!state.episodeSourceChips.any { it.status == SourceChipStatus.LOADING }) return@update state
+        markedAnyError = true
+        state.copy(
+            episodeSourceChips = state.episodeSourceChips.map { chip ->
+                if (chip.status == SourceChipStatus.LOADING) {
+                    chip.copy(status = SourceChipStatus.ERROR)
+                } else {
+                    chip
+                }
+            }
+        )
+    }
+    if (!markedAnyError) return
+
+    scope.launch {
+        delay(1600L)
+        _uiState.update { state ->
+            state.copy(
+                episodeSourceChips = state.episodeSourceChips.filterNot { it.status == SourceChipStatus.ERROR }
             )
         }
     }
@@ -1018,6 +1087,7 @@ internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRe
                 episodeSelectedAddonFilter = if (forceRefresh || targetChanged) null else it.episodeSelectedAddonFilter,
                 episodeFilteredStreams = if (forceRefresh || targetChanged) emptyList() else it.episodeFilteredStreams,
                 episodeAvailableAddons = if (forceRefresh || targetChanged) emptyList() else it.episodeAvailableAddons,
+                episodeSourceChips = if (forceRefresh || targetChanged) emptyList() else it.episodeSourceChips,
                 episodeStreamsForVideoId = video.id,
                 episodeStreamsSeason = video.season,
                 episodeStreamsEpisode = video.episode,
@@ -1029,6 +1099,9 @@ internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRe
         val installedAddonOrder = installedAddons.map { it.displayName }
         val installedAddonNames = installedAddonOrder.toSet()
         var debridPreparationLaunched = false
+
+        // Initialize episode source chips with LOADING status
+        updateEpisodeSourceChipsForFetchStart(type, video.id, installedAddons)
 
         streamRepository.getStreamsFromAllAddons(
             type = type,
@@ -1042,19 +1115,22 @@ internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRe
                     val addonStreams = StreamAutoPlaySelector.orderAddonStreams(result.data, installedAddonOrder)
                     val allStreams = addonStreams.flatMap { it.streams }
                     val availableAddons = addonStreams.map { it.addonName }
-                    val selectedAddon = previousAddonFilter?.takeIf { it in availableAddons }
-                    val filteredStreams = if (selectedAddon == null) {
+                    val currentFilter = _uiState.value.episodeSelectedAddonFilter
+                    val filteredStreams = if (currentFilter == null) {
                         allStreams
                     } else {
-                        allStreams.filter { it.addonName == selectedAddon }
+                        allStreams.filter { it.addonName == currentFilter }
                     }
                     _uiState.update {
                         it.copy(
                             isLoadingEpisodeStreams = false,
                             episodeAllStreams = allStreams,
-                            episodeSelectedAddonFilter = selectedAddon,
                             episodeFilteredStreams = filteredStreams,
                             episodeAvailableAddons = availableAddons,
+                            episodeSourceChips = mergeSourceChipStatuses(
+                                existing = it.episodeSourceChips,
+                                succeededNames = addonStreams.map { group -> group.addonName }
+                            ),
                             episodeStreamsError = null
                         )
                     }
@@ -1082,6 +1158,7 @@ internal fun PlayerRuntimeController.loadStreamsForEpisode(video: Video, forceRe
                 }
             }
         }
+        markRemainingEpisodeSourceChipsAsError()
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -144,6 +144,7 @@ data class PlayerUiState(
     val episodeSelectedAddonFilter: String? = null, // null means "All"
     val episodeFilteredStreams: List<Stream> = emptyList(),
     val episodeAvailableAddons: List<String> = emptyList(),
+    val episodeSourceChips: List<SourceChipItem> = emptyList(),
     val episodeStreamsForVideoId: String? = null,
     val episodeStreamsSeason: Int? = null,
     val episodeStreamsEpisode: Int? = null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -268,6 +268,12 @@ internal fun AddonFilterChips(
     ) }
     LaunchedEffect(selectedAddon, orderedNames) {
         if (refreshHasFocus || focusedChipIndex == 0) return@LaunchedEffect
+        val currentAddonAtFocus = if (hasRefresh) {
+            if (focusedChipIndex == 1) null else orderedNames.getOrNull(focusedChipIndex - 2)
+        } else {
+            if (focusedChipIndex == 0) null else orderedNames.getOrNull(focusedChipIndex - 1)
+        }
+        if (currentAddonAtFocus == selectedAddon) return@LaunchedEffect
         val idx = if (hasRefresh) {
             if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
         } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -277,6 +277,10 @@ internal fun AddonFilterChips(
     ) }
     LaunchedEffect(selectedAddon, orderedNames) {
         if (refreshHasFocus || focusedChipIndex == 0) return@LaunchedEffect
+        val maxIndex = if (hasRefresh) orderedNames.size + 1 else orderedNames.size
+        if (focusedChipIndex > maxIndex) {
+            focusedChipIndex = maxIndex.coerceAtLeast(if (hasRefresh) 1 else 0)
+        }
         val currentAddonAtFocus = if (hasRefresh) {
             if (focusedChipIndex == 1) null else orderedNames.getOrNull(focusedChipIndex - 2)
         } else {
@@ -288,14 +292,20 @@ internal fun AddonFilterChips(
         } else {
             if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
         }
-        focusedChipIndex = idx
+        focusedChipIndex = idx.coerceIn(0, maxIndex)
     }
 
-    // Preserve chip focus when loading completes or new addons are discovered while focused
+    // Preserve chip focus when loading completes, new addons are discovered, or failed addons disappear while focused
     LaunchedEffect(isStillFetching, orderedNames) {
+        val maxIndex = if (hasRefresh) orderedNames.size + 1 else orderedNames.size
+        if (focusedChipIndex > maxIndex) {
+            focusedChipIndex = maxIndex.coerceAtLeast(if (hasRefresh) 1 else 0)
+        }
         if (chipRowHasFocus) {
             withFrameNanos {}
-            runCatching { focusRequesters.getOrNull(focusedChipIndex)?.requestFocus() }
+            val targetRequester = focusRequesters.getOrNull(focusedChipIndex)
+                ?: focusRequesters.getOrNull(if (hasRefresh) 1 else 0)
+            runCatching { targetRequester?.requestFocus() }
         }
     }
     val scope = rememberCoroutineScope()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -253,9 +253,17 @@ internal fun AddonFilterChips(
         }
     }
     val hasRefresh = onRefresh != null
-    val totalRequesterCount = if (hasRefresh) orderedNames.size + 2 else orderedNames.size + 1
-    val focusRequesters = externalFocusRequesters ?: remember(totalRequesterCount) {
-        List(totalRequesterCount) { FocusRequester() }
+    val refreshFocusRequester = remember { FocusRequester() }
+    val allFocusRequester = remember { FocusRequester() }
+    val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val focusRequesters = externalFocusRequesters ?: remember(orderedNames) {
+        buildList {
+            if (hasRefresh) add(refreshFocusRequester)
+            add(allFocusRequester)
+            orderedNames.forEach { addon ->
+                add(addonFocusRequesters.getOrPut(addon) { FocusRequester() })
+            }
+        }
     }
 
     var chipRowHasFocus by remember { mutableStateOf(false) }
@@ -281,6 +289,14 @@ internal fun AddonFilterChips(
             if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
         }
         focusedChipIndex = idx
+    }
+
+    // Preserve chip focus when loading completes or new addons are discovered while focused
+    LaunchedEffect(isStillFetching, orderedNames) {
+        if (chipRowHasFocus) {
+            withFrameNanos {}
+            runCatching { focusRequesters.getOrNull(focusedChipIndex)?.requestFocus() }
+        }
     }
     val scope = rememberCoroutineScope()
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -242,7 +242,8 @@ internal fun AddonFilterChips(
     onAddonSelected: (String?) -> Unit,
     externalFocusRequesters: List<FocusRequester>? = null,
     externalOrderedNames: List<String>? = null,
-    onUpKey: (() -> Unit)? = null
+    onUpKey: (() -> Unit)? = null,
+    debugTag: String = "AddonFilterChips"
 ) {
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val chipMap = sourceChips.associateBy { it.name }
@@ -293,19 +294,13 @@ internal fun AddonFilterChips(
             if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
         }
         focusedChipIndex = idx.coerceIn(0, maxIndex)
-    }
-
-    // Preserve chip focus when loading completes, new addons are discovered, or failed addons disappear while focused
-    LaunchedEffect(isStillFetching, orderedNames) {
-        val maxIndex = if (hasRefresh) orderedNames.size + 1 else orderedNames.size
-        if (focusedChipIndex > maxIndex) {
-            focusedChipIndex = maxIndex.coerceAtLeast(if (hasRefresh) 1 else 0)
-        }
+        // When orderedNames changed (new addon arrived) and chip row has focus,
+        // move actual focus to the correct chip so highlight doesn't stick on the wrong one.
         if (chipRowHasFocus) {
             withFrameNanos {}
-            val targetRequester = focusRequesters.getOrNull(focusedChipIndex)
-                ?: focusRequesters.getOrNull(if (hasRefresh) 1 else 0)
-            runCatching { targetRequester?.requestFocus() }
+            if (idx in focusRequesters.indices) {
+                runCatching { focusRequesters[idx].requestFocus() }
+            }
         }
     }
     val scope = rememberCoroutineScope()
@@ -335,7 +330,19 @@ internal fun AddonFilterChips(
             }
         }
     }
+
+    val chipListState = androidx.compose.foundation.lazy.rememberLazyListState()
+
+    // When the selected addon is removed, switch filter to the last available addon
+    LaunchedEffect(selectedAddon, orderedNames) {
+        if (selectedAddon != null && selectedAddon !in orderedNames) {
+            val lastAddon = orderedNames.lastOrNull()
+            onAddonSelected(lastAddon)
+        }
+    }
+
     LazyRow(
+        state = chipListState,
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
         contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.sm, vertical = NuvioTheme.spacing.xs),
         modifier = Modifier
@@ -369,16 +376,16 @@ internal fun AddonFilterChips(
                 when (event.key) {
                     androidx.compose.ui.input.key.Key.DirectionLeft -> {
                         if (isRtl) {
-                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
+                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else true
                         } else {
-                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
+                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else true
                         }
                     }
                     androidx.compose.ui.input.key.Key.DirectionRight -> {
                         if (isRtl) {
-                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
+                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else true
                         } else {
-                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
+                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else true
                         }
                     }
                     else -> false
@@ -394,7 +401,9 @@ internal fun AddonFilterChips(
                         refreshHasFocus = isFocused
                         if (isFocused) focusedChipIndex = 0
                     },
-                    modifier = Modifier.focusRequester(focusRequesters[0])
+                    modifier = Modifier
+                        .focusRequester(focusRequesters[0])
+                        .focusProperties { canFocus = focusedChipIndex == 0 }
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -241,7 +241,8 @@ internal fun AddonFilterChips(
     onRefresh: (() -> Unit)? = null,
     onAddonSelected: (String?) -> Unit,
     externalFocusRequesters: List<FocusRequester>? = null,
-    externalOrderedNames: List<String>? = null
+    externalOrderedNames: List<String>? = null,
+    onUpKey: (() -> Unit)? = null
 ) {
     val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val chipMap = sourceChips.associateBy { it.name }
@@ -330,6 +331,11 @@ internal fun AddonFilterChips(
                     val now = android.os.SystemClock.uptimeMillis()
                     if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
                     lastKeyRepeatDispatchRef.set(now)
+                }
+
+                if (event.key == androidx.compose.ui.input.key.Key.DirectionUp && onUpKey != null) {
+                    onUpKey()
+                    return@onKeyEvent true
                 }
 
                 val lastIndex = if (hasRefresh) orderedNames.size + 1 else orderedNames.size

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -60,18 +60,23 @@ import com.nuvio.tv.ui.components.SourceStatusFilterChip
 import com.nuvio.tv.ui.components.StreamBadgeChips
 import com.nuvio.tv.ui.theme.NuvioTheme
 import androidx.compose.ui.res.stringResource
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.launch as coroutineLaunch
+import com.nuvio.tv.ui.components.RefreshFilterChip
 import com.nuvio.tv.R
 
 @Composable
 internal fun StreamItem(
     stream: Stream,
-    focusRequester: FocusRequester,
-    requestInitialFocus: Boolean,
+    focusRequester: FocusRequester? = null,
+    requestInitialFocus: Boolean = true,
     isCurrentStream: Boolean = false,
     showFileSizeBadges: Boolean = true,
     showAddonLogo: Boolean = true,
     badgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM,
     onClick: () -> Unit,
+    onFocusChanged: ((Boolean) -> Unit)? = null,
     onUpKey: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
@@ -100,7 +105,10 @@ internal fun StreamItem(
         onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .then(if (requestInitialFocus) Modifier.focusRequester(focusRequester) else Modifier)
+            .then(if (focusRequester != null && requestInitialFocus) Modifier.focusRequester(focusRequester) else Modifier)
+            .onFocusChanged {
+                onFocusChanged?.invoke(it.isFocused)
+            }
             .then(if (onUpKey != null) Modifier.onKeyEvent { event ->
                 if (event.nativeKeyEvent.action == android.view.KeyEvent.ACTION_DOWN &&
                     event.key == Key.DirectionUp) {
@@ -229,45 +237,85 @@ internal fun AddonFilterChips(
     addons: List<String>,
     sourceChips: List<SourceChipItem> = emptyList(),
     selectedAddon: String?,
+    isStillFetching: Boolean = false,
+    onRefresh: (() -> Unit)? = null,
     onAddonSelected: (String?) -> Unit,
     externalFocusRequesters: List<FocusRequester>? = null,
     externalOrderedNames: List<String>? = null
 ) {
+    val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val chipMap = sourceChips.associateBy { it.name }
-    val orderedNames = externalOrderedNames ?: buildList {
-        addAll(addons)
-        sourceChips.forEach { chip -> if (chip.name !in this) add(chip.name) }
-    }
-    val focusRequesters = externalFocusRequesters ?: remember(orderedNames.size) {
-        List(orderedNames.size + 1) { FocusRequester() }
-    }
-
-
-    val selectedIndex = if (selectedAddon == null) 0 else orderedNames.indexOf(selectedAddon) + 1
-    // Track the focused chip index to handle duplicate addon names correctly.
-    var focusedChipIndex by remember { mutableStateOf(selectedIndex.coerceAtLeast(0)) }
-    LaunchedEffect(selectedAddon, orderedNames) {
-        val idx = if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
-        focusedChipIndex = idx
-    }
-    LaunchedEffect(selectedAddon) {
-        if (selectedIndex >= 0 && selectedIndex < focusRequesters.size) {
-            try { focusRequesters[selectedIndex].requestFocus() } catch (_: Exception) {}
+    val orderedNames = externalOrderedNames ?: remember(addons, sourceChips) {
+        buildList {
+            addAll(addons)
+            sourceChips.forEach { chip -> if (chip.name !in this) add(chip.name) }
         }
+    }
+    val hasRefresh = onRefresh != null
+    val totalRequesterCount = if (hasRefresh) orderedNames.size + 2 else orderedNames.size + 1
+    val focusRequesters = externalFocusRequesters ?: remember(totalRequesterCount) {
+        List(totalRequesterCount) { FocusRequester() }
     }
 
     var chipRowHasFocus by remember { mutableStateOf(false) }
+    var refreshHasFocus by remember { mutableStateOf(false) }
+    var focusedChipIndex by remember { mutableStateOf(
+        if (hasRefresh) {
+            if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
+        } else {
+            if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+        }
+    ) }
+    LaunchedEffect(selectedAddon, orderedNames) {
+        if (refreshHasFocus || focusedChipIndex == 0) return@LaunchedEffect
+        val idx = if (hasRefresh) {
+            if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
+        } else {
+            if (selectedAddon == null) 0 else (orderedNames.indexOf(selectedAddon) + 1).coerceAtLeast(0)
+        }
+        focusedChipIndex = idx
+    }
+    val scope = rememberCoroutineScope()
     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
+    fun moveFocusTo(targetIndex: Int) {
+        focusedChipIndex = targetIndex
+        if (hasRefresh && targetIndex == 0) {
+            refreshHasFocus = true
+            scope.coroutineLaunch {
+                withFrameNanos {}
+                try { focusRequesters[0].requestFocus() } catch (_: Exception) {}
+            }
+            return
+        }
 
+        refreshHasFocus = false
+        val selectedFilter = if (hasRefresh) {
+            if (targetIndex == 1) null else orderedNames.getOrNull(targetIndex - 2)
+        } else {
+            if (targetIndex == 0) null else orderedNames.getOrNull(targetIndex - 1)
+        }
+        onAddonSelected(selectedFilter)
+        scope.coroutineLaunch {
+            withFrameNanos {}
+            if (targetIndex in focusRequesters.indices) {
+                try { focusRequesters[targetIndex].requestFocus() } catch (_: Exception) {}
+            }
+        }
+    }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
         contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.sm, vertical = NuvioTheme.spacing.xs),
         modifier = Modifier
-            .focusRestorer {
-                val idx = focusedChipIndex.coerceIn(0, focusRequesters.lastIndex)
-                focusRequesters[idx]
+            .onFocusChanged { focusState ->
+                val hasFocus = focusState.hasFocus
+                if (hasFocus && !chipRowHasFocus && isRtl) {
+                    scope.coroutineLaunch {
+                        withFrameNanos {}
+                        focusRequesters.getOrNull(focusedChipIndex)?.requestFocus()
+                    }
+                }
+                chipRowHasFocus = hasFocus
             }
-            .onFocusChanged { chipRowHasFocus = it.hasFocus }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
 
@@ -278,28 +326,58 @@ internal fun AddonFilterChips(
                     lastKeyRepeatDispatchRef.set(now)
                 }
 
-                val allOptions = listOf<String?>(null) + orderedNames
-                val currentIdx = focusedChipIndex.coerceIn(0, allOptions.lastIndex)
+                val lastIndex = if (hasRefresh) orderedNames.size + 1 else orderedNames.size
+                val currentIdx = focusedChipIndex.coerceIn(0, lastIndex)
                 when (event.key) {
                     androidx.compose.ui.input.key.Key.DirectionLeft -> {
-                        if (currentIdx > 0) { focusedChipIndex = currentIdx - 1; onAddonSelected(allOptions[currentIdx - 1]); true } else false
+                        if (isRtl) {
+                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
+                        } else {
+                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
+                        }
                     }
                     androidx.compose.ui.input.key.Key.DirectionRight -> {
-                        if (currentIdx < allOptions.lastIndex) { focusedChipIndex = currentIdx + 1; onAddonSelected(allOptions[currentIdx + 1]); true } else false
+                        if (isRtl) {
+                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
+                        } else {
+                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
+                        }
                     }
                     else -> false
                 }
             }
     ) {
+        if (onRefresh != null) {
+            item {
+                RefreshFilterChip(
+                    onClick = onRefresh,
+                    isLoading = isStillFetching,
+                    onFocusChanged = { isFocused ->
+                        refreshHasFocus = isFocused
+                        if (isFocused) focusedChipIndex = 0
+                    },
+                    modifier = Modifier.focusRequester(focusRequesters[0])
+                )
+            }
+        }
+
         item {
+            val isAllSelected = selectedAddon == null && !refreshHasFocus
+            val allChipIndex = if (hasRefresh) 1 else 0
             SourceStatusFilterChip(
                 name = stringResource(R.string.stream_filter_all),
-                isSelected = selectedAddon == null,
+                isSelected = isAllSelected,
                 status = SourceChipStatus.SUCCESS,
+                isSelectable = true,
                 onClick = { onAddonSelected(null) },
                 modifier = Modifier
-                    .focusRequester(focusRequesters[0])
-                    .focusProperties { canFocus = selectedAddon == null || chipRowHasFocus }
+                    .focusRequester(focusRequesters[allChipIndex])
+                    .onFocusChanged {
+                        if (it.isFocused) {
+                            focusedChipIndex = allChipIndex
+                            refreshHasFocus = false
+                        }
+                    }
             )
         }
 
@@ -307,13 +385,21 @@ internal fun AddonFilterChips(
             val addon = orderedNames[i]
             val chipStatus = chipMap[addon]?.status ?: SourceChipStatus.SUCCESS
             val isSelectable = addon in addons && chipStatus == SourceChipStatus.SUCCESS
+            val requesterIdx = if (hasRefresh) i + 2 else i + 1
             SourceStatusFilterChip(
                 name = addon,
                 isSelected = selectedAddon == addon,
                 status = chipStatus,
                 isSelectable = isSelectable,
-                onClick = { onAddonSelected(addon) },
-                modifier = Modifier.focusRequester(focusRequesters[i + 1])
+                onClick = { if (isSelectable) onAddonSelected(addon) },
+                modifier = Modifier
+                    .focusRequester(focusRequesters[requesterIdx])
+                    .onFocusChanged {
+                        if (it.isFocused) {
+                            focusedChipIndex = requesterIdx
+                            refreshHasFocus = false
+                        }
+                    }
             )
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -43,7 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import kotlinx.coroutines.launch as coroutineLaunch
-import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import android.view.KeyEvent
 import androidx.compose.ui.input.key.Key
@@ -73,10 +73,10 @@ internal fun StreamSourcesSidePanel(
     var userMovedFromFirstResult by remember { mutableStateOf(false) }
     var firstResultFocusAssigned by remember { mutableStateOf(false) }
     var firstStreamFocusRequestId by remember { mutableStateOf(0) }
-    var shouldRefocusFirstStreamOnFilterChange by remember { mutableStateOf(false) }
     var listHasFocus by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    val closeButtonFocusRequester = remember { FocusRequester() }
 
     val orderedAddonNames = remember(uiState.sourceAvailableAddons, uiState.sourceChips) {
         buildList {
@@ -136,33 +136,23 @@ internal fun StreamSourcesSidePanel(
         }
     }
 
+    // Called when navigating tabs horizontally from within the stream list
     fun onAddonFilterSelectedGuarded(addon: String?) {
         userMovedFromFirstResult = true
-        shouldRefocusFirstStreamOnFilterChange = true
         onAddonFilterSelected(addon)
-    }
-
-    // Refocus the first stream (or fallback to the chip) when switching tabs from within the stream list
-    LaunchedEffect(uiState.sourceSelectedAddonFilter, uiState.sourceFilteredStreams.size, uiState.isLoadingSourceStreams) {
-        if (!shouldRefocusFirstStreamOnFilterChange) return@LaunchedEffect
-        if (uiState.isLoadingSourceStreams) return@LaunchedEffect
-
-        val key = firstStreamKey
-        if (uiState.sourceFilteredStreams.isNotEmpty() && key != null) {
-            streamListState.scrollToItem(0)
-            repeat(30) {
+        focusJob?.cancel()
+        focusJob = scope.coroutineLaunch {
+            repeat(20) {
                 withFrameNanos { }
-                if (firstCardHasFocus) {
-                    shouldRefocusFirstStreamOnFilterChange = false
-                    return@LaunchedEffect
+                val key = streamKeys.firstOrNull()
+                if (key != null && streamFocusRequesters.containsKey(key)) {
+                    val success = runCatching { streamFocusRequesters.getValue(key).requestFocus() }.isSuccess
+                    if (success) return@coroutineLaunch
                 }
-                runCatching { streamFocusRequesters.getValue(key).requestFocus() }
             }
-        } else {
-            // If the filtered addon has 0 streams (or error/empty), safely redirect focus to its chip!
-            shouldRefocusFirstStreamOnFilterChange = false
-            val activeChipIdx = if (uiState.sourceSelectedAddonFilter == null) 1
-                else (orderedAddonNames.indexOf(uiState.sourceSelectedAddonFilter) + 2).coerceAtLeast(1)
+            // Fallback to active chip if list has 0 streams
+            val activeChipIdx = if (addon == null) 1
+                else (orderedAddonNames.indexOf(addon) + 2).coerceAtLeast(1)
             requestChipFocus(activeChipIdx)
         }
     }
@@ -178,7 +168,6 @@ internal fun StreamSourcesSidePanel(
             .width(520.dp)
             .clip(RoundedCornerShape(topStart = NuvioTheme.spacing.lg, bottomStart = NuvioTheme.spacing.lg))
             .background(NuvioTheme.colors.BackgroundElevated)
-            .focusRestorer()
     ) {
         Column(modifier = Modifier.padding(NuvioTheme.spacing.xl)) {
             Row(
@@ -195,7 +184,19 @@ internal fun StreamSourcesSidePanel(
                 DialogButton(
                     text = stringResource(R.string.sources_close),
                     onClick = onClose,
-                    isPrimary = false
+                    isPrimary = false,
+                    modifier = Modifier
+                        .focusRequester(closeButtonFocusRequester)
+                        .onKeyEvent { event ->
+                            if (event.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
+                                event.key == Key.DirectionDown
+                            ) {
+                                val activeIdx = if (uiState.sourceSelectedAddonFilter == null) 1
+                                    else (orderedAddonNames.indexOf(uiState.sourceSelectedAddonFilter) + 2).coerceAtLeast(1)
+                                requestChipFocus(activeIdx)
+                                true
+                            } else false
+                        }
                 )
             }
 
@@ -247,9 +248,12 @@ internal fun StreamSourcesSidePanel(
                         firstResultFocusAssigned = false
                         onReload()
                     },
-                    onAddonSelected = { onAddonFilterSelectedGuarded(it) },
+                    onAddonSelected = { onAddonFilterSelected(it) },
                     externalFocusRequesters = chipFocusRequesters,
-                    externalOrderedNames = orderedAddonNames
+                    externalOrderedNames = orderedAddonNames,
+                    onUpKey = {
+                        try { closeButtonFocusRequester.requestFocus() } catch (_: Exception) {}
+                    }
                 )
             }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -88,6 +88,8 @@ internal fun StreamSourcesSidePanel(
     val allFocusRequester = remember { FocusRequester() }
     val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val chipFocusRequesters = remember(orderedAddonNames) {
+        // Remove stale entries for addons that no longer exist
+        addonFocusRequesters.keys.retainAll(orderedAddonNames.toSet())
         buildList {
             add(refreshFocusRequester)
             add(allFocusRequester)
@@ -152,21 +154,12 @@ internal fun StreamSourcesSidePanel(
     }
 
     fun requestChipFocus(index: Int) {
-        if (chipFocusRequesters.isEmpty()) return
-        val targetIndex = index.coerceIn(0, chipFocusRequesters.lastIndex)
+        if (index !in chipFocusRequesters.indices) return
         userMovedFromFirstResult = true
         focusJob?.cancel()
         focusJob = scope.coroutineLaunch {
             withFrameNanos { }
-            runCatching { chipFocusRequesters[targetIndex].requestFocus() }
-        }
-    }
-
-    // If the selected addon was removed (e.g. error chip dismissed after 1.6s), reset filter and refocus "All"
-    LaunchedEffect(orderedAddonNames, uiState.sourceSelectedAddonFilter) {
-        if (uiState.sourceSelectedAddonFilter != null && uiState.sourceSelectedAddonFilter !in orderedAddonNames) {
-            onAddonFilterSelected(null)
-            requestChipFocus(1)
+            runCatching { chipFocusRequesters[index].requestFocus() }
         }
     }
 
@@ -174,9 +167,16 @@ internal fun StreamSourcesSidePanel(
     fun onAddonFilterSelectedGuarded(addon: String?) {
         userMovedFromFirstResult = true
         onAddonFilterSelected(addon)
-        val activeChipIdx = if (addon == null) 1
-            else (orderedAddonNames.indexOf(addon) + 2).coerceAtLeast(1)
-        requestChipFocus(activeChipIdx)
+        focusJob?.cancel()
+        focusJob = scope.coroutineLaunch {
+            withFrameNanos {}
+            val targetRequester = if (addon == null) {
+                chipFocusRequesters.getOrNull(1)
+            } else {
+                addonFocusRequesters[addon]
+            }
+            runCatching { targetRequester?.requestFocus() }
+        }
     }
 
     // Reset scroll position to top when addon filter changes
@@ -274,7 +274,8 @@ internal fun StreamSourcesSidePanel(
                     externalOrderedNames = orderedAddonNames,
                     onUpKey = {
                         try { closeButtonFocusRequester.requestFocus() } catch (_: Exception) {}
-                    }
+                    },
+                    debugTag = "SourcesSidePanel"
                 )
             }
 
@@ -342,6 +343,10 @@ internal fun StreamSourcesSidePanel(
                                     lastKeyRepeatDispatchRef.set(now)
                                 }
 
+                                if (event.key == Key.DirectionDown) {
+                                    userMovedFromFirstResult = true
+                                }
+
                                 if (orderedAddonNames.isEmpty()) return@onKeyEvent false
                                 val allOptions = listOf<String?>(null) + orderedAddonNames
                                 val currentIdx = allOptions.indexOf(uiState.sourceSelectedAddonFilter)
@@ -360,7 +365,6 @@ internal fun StreamSourcesSidePanel(
                                                 onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
                                                 true
                                             } else {
-                                                requestChipFocus(0)
                                                 true
                                             }
                                         }
@@ -371,7 +375,6 @@ internal fun StreamSourcesSidePanel(
                                                 onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
                                                 true
                                             } else {
-                                                requestChipFocus(0)
                                                 true
                                             }
                                         } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -152,12 +152,21 @@ internal fun StreamSourcesSidePanel(
     }
 
     fun requestChipFocus(index: Int) {
-        if (index !in chipFocusRequesters.indices) return
+        if (chipFocusRequesters.isEmpty()) return
+        val targetIndex = index.coerceIn(0, chipFocusRequesters.lastIndex)
         userMovedFromFirstResult = true
         focusJob?.cancel()
         focusJob = scope.coroutineLaunch {
             withFrameNanos { }
-            runCatching { chipFocusRequesters[index].requestFocus() }
+            runCatching { chipFocusRequesters[targetIndex].requestFocus() }
+        }
+    }
+
+    // If the selected addon was removed (e.g. error chip dismissed after 1.6s), reset filter and refocus "All"
+    LaunchedEffect(orderedAddonNames, uiState.sourceSelectedAddonFilter) {
+        if (uiState.sourceSelectedAddonFilter != null && uiState.sourceSelectedAddonFilter !in orderedAddonNames) {
+            onAddonFilterSelected(null)
+            requestChipFocus(1)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import kotlinx.coroutines.launch as coroutineLaunch
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import android.view.KeyEvent
 import androidx.compose.ui.input.key.Key
@@ -72,6 +73,7 @@ internal fun StreamSourcesSidePanel(
     var userMovedFromFirstResult by remember { mutableStateOf(false) }
     var firstResultFocusAssigned by remember { mutableStateOf(false) }
     var firstStreamFocusRequestId by remember { mutableStateOf(0) }
+    var shouldRefocusFirstStreamOnFilterChange by remember { mutableStateOf(false) }
     var listHasFocus by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
@@ -136,7 +138,33 @@ internal fun StreamSourcesSidePanel(
 
     fun onAddonFilterSelectedGuarded(addon: String?) {
         userMovedFromFirstResult = true
+        shouldRefocusFirstStreamOnFilterChange = true
         onAddonFilterSelected(addon)
+    }
+
+    // Refocus the first stream (or fallback to the chip) when switching tabs from within the stream list
+    LaunchedEffect(uiState.sourceSelectedAddonFilter, uiState.sourceFilteredStreams.size, uiState.isLoadingSourceStreams) {
+        if (!shouldRefocusFirstStreamOnFilterChange) return@LaunchedEffect
+        if (uiState.isLoadingSourceStreams) return@LaunchedEffect
+
+        val key = firstStreamKey
+        if (uiState.sourceFilteredStreams.isNotEmpty() && key != null) {
+            streamListState.scrollToItem(0)
+            repeat(30) {
+                withFrameNanos { }
+                if (firstCardHasFocus) {
+                    shouldRefocusFirstStreamOnFilterChange = false
+                    return@LaunchedEffect
+                }
+                runCatching { streamFocusRequesters.getValue(key).requestFocus() }
+            }
+        } else {
+            // If the filtered addon has 0 streams (or error/empty), safely redirect focus to its chip!
+            shouldRefocusFirstStreamOnFilterChange = false
+            val activeChipIdx = if (uiState.sourceSelectedAddonFilter == null) 1
+                else (orderedAddonNames.indexOf(uiState.sourceSelectedAddonFilter) + 2).coerceAtLeast(1)
+            requestChipFocus(activeChipIdx)
+        }
     }
 
     // Reset scroll position to top when addon filter changes
@@ -150,6 +178,7 @@ internal fun StreamSourcesSidePanel(
             .width(520.dp)
             .clip(RoundedCornerShape(topStart = NuvioTheme.spacing.lg, bottomStart = NuvioTheme.spacing.lg))
             .background(NuvioTheme.colors.BackgroundElevated)
+            .focusRestorer()
     ) {
         Column(modifier = Modifier.padding(NuvioTheme.spacing.xl)) {
             Row(
@@ -297,7 +326,10 @@ internal fun StreamSourcesSidePanel(
                                             if (currentIdx < allOptions.lastIndex) {
                                                 onAddonFilterSelectedGuarded(allOptions[currentIdx + 1])
                                                 true
-                                            } else false
+                                            } else {
+                                                // Boundary hit on rightmost tab in RTL
+                                                true
+                                            }
                                         } else {
                                             if (currentIdx > 0) {
                                                 onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
@@ -321,7 +353,10 @@ internal fun StreamSourcesSidePanel(
                                             if (currentIdx < allOptions.lastIndex) {
                                                 onAddonFilterSelectedGuarded(allOptions[currentIdx + 1])
                                                 true
-                                            } else false
+                                            } else {
+                                                // Boundary hit on rightmost tab in LTR: consume so focus doesn't escape overlay
+                                                true
+                                            }
                                         }
                                     }
                                     else -> false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -36,12 +36,21 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.launch as coroutineLaunch
+import androidx.compose.ui.focus.onFocusChanged
 import android.view.KeyEvent
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.ui.components.LoadingIndicator
+import com.nuvio.tv.ui.components.SourceChipStatus
 import com.nuvio.tv.ui.theme.NuvioTheme
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
@@ -58,15 +67,14 @@ internal fun StreamSourcesSidePanel(
     onStreamSelected: (Stream) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // Request focus when loading finishes OR when the list content updates
-    // (ensures higher-priority addons get focus if they load later)
-    LaunchedEffect(uiState.isLoadingSourceStreams, uiState.sourceFilteredStreams.size) {
-        if (!uiState.isLoadingSourceStreams && uiState.sourceFilteredStreams.isNotEmpty()) {
-            try {
-                streamsFocusRequester.requestFocus()
-            } catch (_: Exception) {}
-        }
-    }
+    val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
+    val streamListState = rememberLazyListState()
+    var userMovedFromFirstResult by remember { mutableStateOf(false) }
+    var firstResultFocusAssigned by remember { mutableStateOf(false) }
+    var firstStreamFocusRequestId by remember { mutableStateOf(0) }
+    var listHasFocus by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    var focusJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
 
     val orderedAddonNames = remember(uiState.sourceAvailableAddons, uiState.sourceChips) {
         buildList {
@@ -74,8 +82,75 @@ internal fun StreamSourcesSidePanel(
             uiState.sourceChips.forEach { if (it.name !in this) add(it.name) }
         }
     }
-    val chipFocusRequesters = remember(orderedAddonNames.size) {
-        List(orderedAddonNames.size + 1) { FocusRequester() }
+    val refreshFocusRequester = remember { FocusRequester() }
+    val allFocusRequester = remember { FocusRequester() }
+    val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val chipFocusRequesters = remember(orderedAddonNames) {
+        buildList {
+            add(refreshFocusRequester)
+            add(allFocusRequester)
+            orderedAddonNames.forEach { addon ->
+                add(addonFocusRequesters.getOrPut(addon) { FocusRequester() })
+            }
+        }
+    }
+
+    val streamKeys = remember(uiState.sourceFilteredStreams) {
+        val seen = mutableMapOf<String, Int>()
+        uiState.sourceFilteredStreams.map { stream ->
+            val base = stream.stableKey(0)
+            val count = seen.getOrDefault(base, 0)
+            seen[base] = count + 1
+            stream.stableKey(count)
+        }
+    }
+    val firstStreamKey = streamKeys.firstOrNull()
+    val streamFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    streamKeys.forEach { key ->
+        streamFocusRequesters.getOrPut(key) { FocusRequester() }
+    }
+    var firstCardHasFocus by remember(firstStreamKey) { mutableStateOf(false) }
+
+    // Request initial focus when loading finishes and streams are available,
+    // only if the user has not navigated away or focused the chips row.
+    LaunchedEffect(uiState.isLoadingSourceStreams, firstStreamKey, userMovedFromFirstResult, firstResultFocusAssigned) {
+        if (!uiState.isLoadingSourceStreams && firstStreamKey != null &&
+            !userMovedFromFirstResult && !firstResultFocusAssigned
+        ) {
+            firstResultFocusAssigned = true
+            firstStreamFocusRequestId += 1
+        }
+    }
+
+    LaunchedEffect(firstStreamFocusRequestId) {
+        val requestedKey = firstStreamKey
+        if (firstStreamFocusRequestId <= 0 || requestedKey == null) return@LaunchedEffect
+        streamListState.scrollToItem(0)
+        repeat(30) {
+            withFrameNanos { }
+            if (firstCardHasFocus) return@LaunchedEffect
+            runCatching { streamFocusRequesters.getValue(requestedKey).requestFocus() }
+        }
+    }
+
+    fun requestChipFocus(index: Int) {
+        if (index !in chipFocusRequesters.indices) return
+        userMovedFromFirstResult = true
+        focusJob?.cancel()
+        focusJob = scope.coroutineLaunch {
+            withFrameNanos { }
+            runCatching { chipFocusRequesters[index].requestFocus() }
+        }
+    }
+
+    fun onAddonFilterSelectedGuarded(addon: String?) {
+        userMovedFromFirstResult = true
+        onAddonFilterSelected(addon)
+    }
+
+    // Reset scroll position to top when addon filter changes
+    LaunchedEffect(uiState.sourceSelectedAddonFilter) {
+        streamListState.scrollToItem(0)
     }
 
     Box(
@@ -97,18 +172,11 @@ internal fun StreamSourcesSidePanel(
                     color = NuvioTheme.colors.TextPrimary
                 )
 
-                Row(horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)) {
-                    DialogButton(
-                        text = stringResource(R.string.sources_reload),
-                        onClick = onReload,
-                        isPrimary = false
-                    )
-                    DialogButton(
-                        text = stringResource(R.string.sources_close),
-                        onClick = onClose,
-                        isPrimary = false
-                    )
-                }
+                DialogButton(
+                    text = stringResource(R.string.sources_close),
+                    onClick = onClose,
+                    isPrimary = false
+                )
             }
 
             Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
@@ -152,7 +220,14 @@ internal fun StreamSourcesSidePanel(
                     addons = uiState.sourceAvailableAddons,
                     sourceChips = uiState.sourceChips,
                     selectedAddon = uiState.sourceSelectedAddonFilter,
-                    onAddonSelected = onAddonFilterSelected,
+                    isStillFetching = uiState.isLoadingSourceStreams ||
+                        uiState.sourceChips.any { it.status == SourceChipStatus.LOADING },
+                    onRefresh = {
+                        userMovedFromFirstResult = false
+                        firstResultFocusAssigned = false
+                        onReload()
+                    },
+                    onAddonSelected = { onAddonFilterSelectedGuarded(it) },
                     externalFocusRequesters = chipFocusRequesters,
                     externalOrderedNames = orderedAddonNames
                 )
@@ -174,7 +249,7 @@ internal fun StreamSourcesSidePanel(
 
                 uiState.sourceStreamsError != null -> {
                     Text(
-                        text = uiState.sourceStreamsError ?: stringResource(R.string.panel_failed_load_streams),
+                        text = uiState.sourceStreamsError,
                         style = MaterialTheme.typography.bodyLarge,
                         color = Color.White.copy(alpha = 0.85f)
                     )
@@ -197,25 +272,11 @@ internal fun StreamSourcesSidePanel(
                         currentStreamUrl = uiState.currentStreamUrl,
                         currentStreamName = uiState.currentStreamName
                     )
-                    val initialFocusStream = uiState.sourceFilteredStreams.getOrNull(currentStreamIndex)
-                        ?: uiState.sourceFilteredStreams.firstOrNull()
-
-                    // Occurrence-counted keys: keying by list index made every key change
-                    // when a later addon's results reshuffled the list, disposing all rows
-                    // (including the focused one) and killing D-pad focus.
-                    val streamKeys = remember(uiState.sourceFilteredStreams) {
-                        val seen = mutableMapOf<String, Int>()
-                        uiState.sourceFilteredStreams.map { stream ->
-                            val base = stream.stableKey(0)
-                            val count = seen.getOrDefault(base, 0)
-                            seen[base] = count + 1
-                            stream.stableKey(count)
-                        }
-                    }
 
                     val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
 
                     LazyColumn(
+                        state = streamListState,
                         verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm),
                         contentPadding = PaddingValues(
                             start = NuvioTheme.spacing.sm,
@@ -225,6 +286,7 @@ internal fun StreamSourcesSidePanel(
                         ),
                         modifier = Modifier
                             .fillMaxHeight()
+                            .onFocusChanged { listHasFocus = it.hasFocus }
                             .onKeyEvent { event ->
                                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
 
@@ -235,16 +297,41 @@ internal fun StreamSourcesSidePanel(
                                     lastKeyRepeatDispatchRef.set(now)
                                 }
 
-                                val addons = uiState.sourceAvailableAddons
-                                if (addons.isEmpty()) return@onKeyEvent false
-                                val allOptions = listOf<String?>(null) + addons
+                                if (orderedAddonNames.isEmpty()) return@onKeyEvent false
+                                val allOptions = listOf<String?>(null) + orderedAddonNames
                                 val currentIdx = allOptions.indexOf(uiState.sourceSelectedAddonFilter)
                                 when (event.key) {
                                     Key.DirectionLeft -> {
-                                        if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
+                                        if (isRtl) {
+                                            if (currentIdx < allOptions.lastIndex) {
+                                                onAddonFilterSelectedGuarded(allOptions[currentIdx + 1])
+                                                true
+                                            } else false
+                                        } else {
+                                            if (currentIdx > 0) {
+                                                onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
+                                                true
+                                            } else {
+                                                requestChipFocus(0)
+                                                true
+                                            }
+                                        }
                                     }
                                     Key.DirectionRight -> {
-                                        if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
+                                        if (isRtl) {
+                                            if (currentIdx > 0) {
+                                                onAddonFilterSelectedGuarded(allOptions[currentIdx - 1])
+                                                true
+                                            } else {
+                                                requestChipFocus(0)
+                                                true
+                                            }
+                                        } else {
+                                            if (currentIdx < allOptions.lastIndex) {
+                                                onAddonFilterSelectedGuarded(allOptions[currentIdx + 1])
+                                                true
+                                            } else false
+                                        }
                                     }
                                     else -> false
                                 }
@@ -255,19 +342,21 @@ internal fun StreamSourcesSidePanel(
                         }) { index, stream ->
                             StreamItem(
                                 stream = stream,
-                                focusRequester = streamsFocusRequester,
-                                requestInitialFocus = stream == initialFocusStream,
+                                focusRequester = streamFocusRequesters.getValue(streamKeys[index]),
                                 isCurrentStream = index == currentStreamIndex,
                                 showFileSizeBadges = uiState.showFileSizeBadges,
                                 showAddonLogo = uiState.showAddonLogo,
                                 badgePlacement = uiState.streamBadgePlacement,
                                 onClick = { onStreamSelected(stream) },
-                                onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{
-                                    val selected = uiState.sourceSelectedAddonFilter
-                                    val idx = if (selected == null) 0 else orderedAddonNames.indexOf(selected) + 1
-                                    if (idx >= 0 && idx < chipFocusRequesters.size) {
-                                        try { chipFocusRequesters[idx].requestFocus() } catch (_: Exception) {}
+                                onFocusChanged = { focused ->
+                                    if (index == 0) {
+                                        firstCardHasFocus = focused
                                     }
+                                },
+                                onUpKey = if (index == 0 && chipFocusRequesters.isNotEmpty()) {{
+                                    val idx = if (uiState.sourceSelectedAddonFilter == null) 1
+                                              else orderedAddonNames.indexOf(uiState.sourceSelectedAddonFilter) + 2
+                                    requestChipFocus(idx)
                                 }} else null
                             )
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -84,8 +84,17 @@ internal fun StreamSourcesSidePanel(
             uiState.sourceChips.forEach { if (it.name !in this) add(it.name) }
         }
     }
-    val chipFocusRequesters = remember(orderedAddonNames.size) {
-        List(orderedAddonNames.size + 2) { FocusRequester() }
+    val refreshFocusRequester = remember { FocusRequester() }
+    val allFocusRequester = remember { FocusRequester() }
+    val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val chipFocusRequesters = remember(orderedAddonNames) {
+        buildList {
+            add(refreshFocusRequester)
+            add(allFocusRequester)
+            orderedAddonNames.forEach { addon ->
+                add(addonFocusRequesters.getOrPut(addon) { FocusRequester() })
+            }
+        }
     }
 
     val streamKeys = remember(uiState.sourceFilteredStreams) {
@@ -113,6 +122,22 @@ internal fun StreamSourcesSidePanel(
             firstResultFocusAssigned = true
             firstStreamFocusRequestId += 1
         }
+    }
+
+    // When on "All" tab and new results arrive above the focused stream, move focus to the new first item.
+    var trackedFirstStreamKey by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(firstStreamKey, uiState.sourceSelectedAddonFilter, listHasFocus) {
+        if (uiState.sourceSelectedAddonFilter != null) {
+            trackedFirstStreamKey = firstStreamKey
+            return@LaunchedEffect
+        }
+        if (firstStreamKey != null && trackedFirstStreamKey != null &&
+            firstStreamKey != trackedFirstStreamKey &&
+            listHasFocus && !userMovedFromFirstResult
+        ) {
+            firstStreamFocusRequestId += 1
+        }
+        trackedFirstStreamKey = firstStreamKey
     }
 
     LaunchedEffect(firstStreamFocusRequestId) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -140,21 +140,9 @@ internal fun StreamSourcesSidePanel(
     fun onAddonFilterSelectedGuarded(addon: String?) {
         userMovedFromFirstResult = true
         onAddonFilterSelected(addon)
-        focusJob?.cancel()
-        focusJob = scope.coroutineLaunch {
-            repeat(20) {
-                withFrameNanos { }
-                val key = streamKeys.firstOrNull()
-                if (key != null && streamFocusRequesters.containsKey(key)) {
-                    val success = runCatching { streamFocusRequesters.getValue(key).requestFocus() }.isSuccess
-                    if (success) return@coroutineLaunch
-                }
-            }
-            // Fallback to active chip if list has 0 streams
-            val activeChipIdx = if (addon == null) 1
-                else (orderedAddonNames.indexOf(addon) + 2).coerceAtLeast(1)
-            requestChipFocus(activeChipIdx)
-        }
+        val activeChipIdx = if (addon == null) 1
+            else (orderedAddonNames.indexOf(addon) + 2).coerceAtLeast(1)
+        requestChipFocus(activeChipIdx)
     }
 
     // Reset scroll position to top when addon filter changes
@@ -232,8 +220,7 @@ internal fun StreamSourcesSidePanel(
             Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
 
             AnimatedVisibility(
-                visible = uiState.sourceChips.isNotEmpty() ||
-                    (!uiState.isLoadingSourceStreams && uiState.sourceAvailableAddons.isNotEmpty()),
+                visible = uiState.sourceChips.isNotEmpty() || uiState.sourceAvailableAddons.isNotEmpty(),
                 enter = fadeIn(animationSpec = tween(200)),
                 exit = fadeOut(animationSpec = tween(120))
             ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamSourcesSidePanel.kt
@@ -82,17 +82,8 @@ internal fun StreamSourcesSidePanel(
             uiState.sourceChips.forEach { if (it.name !in this) add(it.name) }
         }
     }
-    val refreshFocusRequester = remember { FocusRequester() }
-    val allFocusRequester = remember { FocusRequester() }
-    val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
-    val chipFocusRequesters = remember(orderedAddonNames) {
-        buildList {
-            add(refreshFocusRequester)
-            add(allFocusRequester)
-            orderedAddonNames.forEach { addon ->
-                add(addonFocusRequesters.getOrPut(addon) { FocusRequester() })
-            }
-        }
+    val chipFocusRequesters = remember(orderedAddonNames.size) {
+        List(orderedAddonNames.size + 2) { FocusRequester() }
     }
 
     val streamKeys = remember(uiState.sourceFilteredStreams) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -7,8 +7,6 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -33,7 +31,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -47,7 +44,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
@@ -81,8 +77,6 @@ import androidx.tv.material3.Border
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
-import androidx.tv.material3.FilterChip
-import androidx.tv.material3.FilterChipDefaults
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -94,11 +88,11 @@ import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.ui.components.SourceChipItem
 import com.nuvio.tv.ui.components.SourceChipStatus
-import com.nuvio.tv.ui.components.SourceStatusFilterChip
 import com.nuvio.tv.ui.components.P2pConsentDialog
 import com.nuvio.tv.ui.components.StreamBadgeChips
 import com.nuvio.tv.ui.components.StreamsSkeletonList
 import com.nuvio.tv.ui.screens.player.LoadingOverlay
+import com.nuvio.tv.ui.screens.player.AddonFilterChips
 import com.nuvio.tv.ui.theme.NuvioTheme
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -724,6 +718,8 @@ private fun RightStreamSection(
     val allFocusRequester = remember { FocusRequester() }
     val addonFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val chipFocusRequesters = remember(orderedAddonNames) {
+        // Remove stale entries for addons that no longer exist
+        addonFocusRequesters.keys.retainAll(orderedAddonNames.toSet())
         buildList {
             add(refreshFocusRequester)
             add(allFocusRequester)
@@ -735,13 +731,15 @@ private fun RightStreamSection(
     fun onAddonFilterSelectedGuarded(addon: String?) {
         userMovedFromFirstResult = true
         onAddonFilterSelected(addon)
-        val idx = if (addon == null) 1 else orderedAddonNames.indexOf(addon) + 2
         focusJob?.cancel()
         focusJob = scope.coroutineLaunch {
             withFrameNanos {}
-            if (!listHasFocus && idx >= 0 && idx < chipFocusRequesters.size) {
-                try { chipFocusRequesters[idx].requestFocus() } catch (_: Exception) {}
+            val targetRequester = if (addon == null) {
+                chipFocusRequesters.getOrNull(1)
+            } else {
+                addonFocusRequesters[addon]
             }
+            runCatching { targetRequester?.requestFocus() }
         }
     }
 
@@ -807,9 +805,10 @@ private fun RightStreamSection(
                         firstResultFocusAssigned = false
                         onRefresh()
                     },
-                    onAddonSelected = { onAddonFilterSelectedGuarded(it) },
-                    focusRequesters = chipFocusRequesters,
-                    orderedNames = orderedAddonNames
+                    onAddonSelected = { onAddonFilterSelected(it) },
+                    externalFocusRequesters = chipFocusRequesters,
+                    externalOrderedNames = orderedAddonNames,
+                    debugTag = "StreamScreen"
                 )
             }
         }
@@ -876,216 +875,6 @@ private fun RightStreamSection(
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun AddonFilterChips(
-    addons: List<String>,
-    sourceChips: List<SourceChipItem>,
-    selectedAddon: String?,
-    isStillFetching: Boolean = false,
-    onRefresh: () -> Unit,
-    onAddonSelected: (String?) -> Unit,
-    focusRequesters: List<FocusRequester>,
-    orderedNames: List<String>
-) {
-    val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
-    val chipMap = sourceChips.associateBy { it.name }
-    var chipRowHasFocus by remember { mutableStateOf(false) }
-    var refreshHasFocus by remember { mutableStateOf(false) }
-    // Track the focused chip index to handle duplicate addon names correctly.
-    // indexOf(selectedAddon) would always return the first duplicate.
-    var focusedChipIndex by remember { mutableStateOf(
-        if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
-    ) }
-    LaunchedEffect(selectedAddon, orderedNames) {
-        val idx = if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
-        focusedChipIndex = idx
-    }
-    val scope = rememberCoroutineScope()
-    val lastKeyRepeatDispatchRef = remember { java.util.concurrent.atomic.AtomicLong(0L) }
-    fun moveFocusTo(targetIndex: Int) {
-        focusedChipIndex = targetIndex
-        if (targetIndex == 0) {
-            scope.coroutineLaunch {
-                withFrameNanos {}
-                try { focusRequesters[0].requestFocus() } catch (_: Exception) {}
-            }
-            return
-        }
-
-        val selectedFilter = if (targetIndex == 1) null else orderedNames[targetIndex - 2]
-        onAddonSelected(selectedFilter)
-    }
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
-        contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.sm, vertical = NuvioTheme.spacing.xs),
-        modifier = Modifier
-            .onFocusChanged { focusState ->
-                val hasFocus = focusState.hasFocus
-                if (hasFocus && !chipRowHasFocus && isRtl) {
-                    scope.coroutineLaunch {
-                        withFrameNanos {}
-                        focusRequesters.getOrNull(focusedChipIndex)?.requestFocus()
-                    }
-                }
-                chipRowHasFocus = hasFocus
-            }
-            .onKeyEvent { event ->
-                if (event.nativeKeyEvent.action != android.view.KeyEvent.ACTION_DOWN) return@onKeyEvent false
-
-                // Throttle rapid key repeats (long-press)
-                if (event.nativeKeyEvent.repeatCount > 0) {
-                    val now = android.os.SystemClock.uptimeMillis()
-                    if (now - lastKeyRepeatDispatchRef.get() < 112L) return@onKeyEvent true
-                    lastKeyRepeatDispatchRef.set(now)
-                }
-
-                val lastIndex = orderedNames.size + 1
-                val currentIdx = focusedChipIndex.coerceIn(0, lastIndex)
-                when (event.key) {
-                    androidx.compose.ui.input.key.Key.DirectionLeft -> {
-                        if (isRtl) {
-                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
-                        } else {
-                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
-                        }
-                    }
-                    androidx.compose.ui.input.key.Key.DirectionRight -> {
-                        if (isRtl) {
-                            if (currentIdx > 0) { moveFocusTo(currentIdx - 1); true } else false
-                        } else {
-                            if (currentIdx < lastIndex) { moveFocusTo(currentIdx + 1); true } else false
-                        }
-                    }
-                    else -> false
-                }
-            }
-    ) {
-        item {
-            RefreshFilterChip(
-                onClick = onRefresh,
-                isLoading = isStillFetching,
-                onFocusChanged = { refreshHasFocus = it },
-                modifier = Modifier
-                    .focusRequester(focusRequesters[0])
-                    .focusProperties { canFocus = focusedChipIndex == 0 }
-            )
-        }
-
-        item {
-            SourceStatusFilterChip(
-                name = stringResource(R.string.stream_filter_all),
-                isSelected = selectedAddon == null && !refreshHasFocus,
-                status = SourceChipStatus.SUCCESS,
-                isSelectable = true,
-                onClick = { onAddonSelected(null) },
-                modifier = Modifier
-                    .focusRequester(focusRequesters[1])
-                    .focusProperties { canFocus = selectedAddon == null || chipRowHasFocus }
-            )
-        }
-
-        items(orderedNames.size) { i ->
-            val addon = orderedNames[i]
-            val chipStatus = chipMap[addon]?.status ?: SourceChipStatus.SUCCESS
-            val isSelectable = addon in addons && chipStatus == SourceChipStatus.SUCCESS
-            SourceStatusFilterChip(
-                name = addon,
-                isSelected = selectedAddon == addon,
-                status = chipStatus,
-                isSelectable = isSelectable,
-                onClick = { if (isSelectable) onAddonSelected(addon) },
-                modifier = Modifier.focusRequester(focusRequesters[i + 2])
-            )
-        }
-    }
-}
-
-@Composable
-private fun RefreshFilterChip(
-    onClick: () -> Unit,
-    isLoading: Boolean = false,
-    onFocusChanged: (Boolean) -> Unit = {},
-    modifier: Modifier = Modifier
-) {
-    var isFocused by remember { mutableStateOf(false) }
-    val contentColor = if (isFocused) {
-        NuvioTheme.colors.OnSecondary
-    } else {
-        NuvioTheme.colors.TextSecondary
-    }
-
-    val rotationAnimatable = remember { Animatable(0f) }
-    var hasCompletedFullRotation by remember { mutableStateOf(false) }
-    LaunchedEffect(isLoading) {
-        if (isLoading) {
-            // Spin continuously while loading
-            coroutineDelay(100)
-            hasCompletedFullRotation = false
-            while (true) {
-                val remaining = 360f - rotationAnimatable.value
-                rotationAnimatable.animateTo(
-                    targetValue = 360f,
-                    animationSpec = tween(
-                        durationMillis = (remaining / 360f * 1000).toInt(),
-                        easing = LinearEasing
-                    )
-                )
-                hasCompletedFullRotation = true
-                rotationAnimatable.snapTo(0f)
-            }
-        } else {
-            // Complete current rotation then stop
-            if (hasCompletedFullRotation && rotationAnimatable.value > 0f) {
-                val remaining = 360f - rotationAnimatable.value
-                rotationAnimatable.animateTo(
-                    targetValue = 360f,
-                    animationSpec = tween(
-                        durationMillis = (remaining / 360f * 1000).toInt(),
-                        easing = LinearEasing
-                    )
-                )
-            }
-            rotationAnimatable.snapTo(0f)
-            hasCompletedFullRotation = false
-        }
-    }
-
-    FilterChip(
-        selected = false,
-        onClick = onClick,
-        modifier = modifier.onFocusChanged {
-            isFocused = it.isFocused
-            onFocusChanged(it.isFocused)
-        },
-        colors = FilterChipDefaults.colors(
-            containerColor = NuvioTheme.colors.BackgroundCard,
-            focusedContainerColor = NuvioTheme.colors.Secondary,
-            contentColor = contentColor,
-            focusedContentColor = contentColor
-        ),
-        border = FilterChipDefaults.border(
-            border = Border(
-                border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
-                shape = RoundedCornerShape(20.dp)
-            ),
-            focusedBorder = Border(
-                border = BorderStroke(NuvioTheme.spacing.xxs, NuvioTheme.colors.FocusRing),
-                shape = RoundedCornerShape(20.dp)
-            )
-        ),
-        shape = FilterChipDefaults.shape(shape = RoundedCornerShape(20.dp))
-    ) {
-        Icon(
-            imageVector = Icons.Rounded.Refresh,
-            contentDescription = stringResource(R.string.cd_refresh),
-            modifier = Modifier
-                .size(20.dp)
-                .graphicsLayer { rotationZ = rotationAnimatable.value },
-            tint = contentColor
-        )
-    }
-}
-
 @Composable
 private fun LoadingState(showAddonLogo: Boolean = true) {
     StreamsSkeletonList(showAddonLogo = showAddonLogo)
@@ -1260,22 +1049,24 @@ private fun StreamsList(
                 if (event.key == Key.DirectionDown) {
                     onUserNavigatedFromFirstResult()
                 }
-                if (availableAddons.isEmpty()) return@onKeyEvent false
-                val allOptions = listOf<String?>(null) + availableAddons
+                if (orderedAddonNames.isEmpty()) return@onKeyEvent false
+                val allOptions = listOf<String?>(null) + orderedAddonNames
                 val currentIdx = allOptions.indexOf(selectedAddonFilter)
                 when (event.key) {
                     Key.DirectionLeft -> {
                         if (isRtl) {
-                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else true
                         } else {
-                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true }
+                            else { true }
                         }
                     }
                     Key.DirectionRight -> {
                         if (isRtl) {
-                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true }
+                            else { true }
                         } else {
-                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else true
                         }
                     }
                     else -> false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -92,6 +92,7 @@ import com.nuvio.tv.core.streams.StreamBadgePlacement
 import com.nuvio.tv.core.streams.StreamBadgeSettings
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.domain.model.Stream
+import com.nuvio.tv.ui.components.RefreshFilterChip
 import com.nuvio.tv.ui.components.SourceChipItem
 import com.nuvio.tv.ui.components.SourceChipStatus
 import com.nuvio.tv.ui.components.SourceStatusFilterChip
@@ -897,6 +898,7 @@ private fun AddonFilterChips(
         if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
     ) }
     LaunchedEffect(selectedAddon, orderedNames) {
+        if (refreshHasFocus || focusedChipIndex == 0) return@LaunchedEffect
         val idx = if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
         focusedChipIndex = idx
     }
@@ -905,6 +907,7 @@ private fun AddonFilterChips(
     fun moveFocusTo(targetIndex: Int) {
         focusedChipIndex = targetIndex
         if (targetIndex == 0) {
+            refreshHasFocus = true
             scope.coroutineLaunch {
                 withFrameNanos {}
                 try { focusRequesters[0].requestFocus() } catch (_: Exception) {}
@@ -912,8 +915,15 @@ private fun AddonFilterChips(
             return
         }
 
+        refreshHasFocus = false
         val selectedFilter = if (targetIndex == 1) null else orderedNames[targetIndex - 2]
         onAddonSelected(selectedFilter)
+        scope.coroutineLaunch {
+            withFrameNanos {}
+            if (targetIndex in focusRequesters.indices) {
+                try { focusRequesters[targetIndex].requestFocus() } catch (_: Exception) {}
+            }
+        }
     }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
@@ -964,10 +974,11 @@ private fun AddonFilterChips(
             RefreshFilterChip(
                 onClick = onRefresh,
                 isLoading = isStillFetching,
-                onFocusChanged = { refreshHasFocus = it },
-                modifier = Modifier
-                    .focusRequester(focusRequesters[0])
-                    .focusProperties { canFocus = focusedChipIndex == 0 }
+                onFocusChanged = { isFocused ->
+                    refreshHasFocus = isFocused
+                    if (isFocused) focusedChipIndex = 0
+                },
+                modifier = Modifier.focusRequester(focusRequesters[0])
             )
         }
 
@@ -980,7 +991,12 @@ private fun AddonFilterChips(
                 onClick = { onAddonSelected(null) },
                 modifier = Modifier
                     .focusRequester(focusRequesters[1])
-                    .focusProperties { canFocus = selectedAddon == null || chipRowHasFocus }
+                    .onFocusChanged {
+                        if (it.isFocused) {
+                            focusedChipIndex = 1
+                            refreshHasFocus = false
+                        }
+                    }
             )
         }
 
@@ -988,101 +1004,23 @@ private fun AddonFilterChips(
             val addon = orderedNames[i]
             val chipStatus = chipMap[addon]?.status ?: SourceChipStatus.SUCCESS
             val isSelectable = addon in addons && chipStatus == SourceChipStatus.SUCCESS
+            val requesterIdx = i + 2
             SourceStatusFilterChip(
                 name = addon,
                 isSelected = selectedAddon == addon,
                 status = chipStatus,
                 isSelectable = isSelectable,
                 onClick = { if (isSelectable) onAddonSelected(addon) },
-                modifier = Modifier.focusRequester(focusRequesters[i + 2])
+                modifier = Modifier
+                    .focusRequester(focusRequesters[requesterIdx])
+                    .onFocusChanged {
+                        if (it.isFocused) {
+                            focusedChipIndex = requesterIdx
+                            refreshHasFocus = false
+                        }
+                    }
             )
         }
-    }
-}
-
-@Composable
-private fun RefreshFilterChip(
-    onClick: () -> Unit,
-    isLoading: Boolean = false,
-    onFocusChanged: (Boolean) -> Unit = {},
-    modifier: Modifier = Modifier
-) {
-    var isFocused by remember { mutableStateOf(false) }
-    val contentColor = if (isFocused) {
-        NuvioTheme.colors.OnSecondary
-    } else {
-        NuvioTheme.colors.TextSecondary
-    }
-
-    val rotationAnimatable = remember { Animatable(0f) }
-    var hasCompletedFullRotation by remember { mutableStateOf(false) }
-    LaunchedEffect(isLoading) {
-        if (isLoading) {
-            // Spin continuously while loading
-            coroutineDelay(100)
-            hasCompletedFullRotation = false
-            while (true) {
-                val remaining = 360f - rotationAnimatable.value
-                rotationAnimatable.animateTo(
-                    targetValue = 360f,
-                    animationSpec = tween(
-                        durationMillis = (remaining / 360f * 1000).toInt(),
-                        easing = LinearEasing
-                    )
-                )
-                hasCompletedFullRotation = true
-                rotationAnimatable.snapTo(0f)
-            }
-        } else {
-            // Complete current rotation then stop
-            if (hasCompletedFullRotation && rotationAnimatable.value > 0f) {
-                val remaining = 360f - rotationAnimatable.value
-                rotationAnimatable.animateTo(
-                    targetValue = 360f,
-                    animationSpec = tween(
-                        durationMillis = (remaining / 360f * 1000).toInt(),
-                        easing = LinearEasing
-                    )
-                )
-            }
-            rotationAnimatable.snapTo(0f)
-            hasCompletedFullRotation = false
-        }
-    }
-
-    FilterChip(
-        selected = false,
-        onClick = onClick,
-        modifier = modifier.onFocusChanged {
-            isFocused = it.isFocused
-            onFocusChanged(it.isFocused)
-        },
-        colors = FilterChipDefaults.colors(
-            containerColor = NuvioTheme.colors.BackgroundCard,
-            focusedContainerColor = NuvioTheme.colors.Secondary,
-            contentColor = contentColor,
-            focusedContentColor = contentColor
-        ),
-        border = FilterChipDefaults.border(
-            border = Border(
-                border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
-                shape = RoundedCornerShape(20.dp)
-            ),
-            focusedBorder = Border(
-                border = BorderStroke(NuvioTheme.spacing.xxs, NuvioTheme.colors.FocusRing),
-                shape = RoundedCornerShape(20.dp)
-            )
-        ),
-        shape = FilterChipDefaults.shape(shape = RoundedCornerShape(20.dp))
-    ) {
-        Icon(
-            imageVector = Icons.Rounded.Refresh,
-            contentDescription = stringResource(R.string.cd_refresh),
-            modifier = Modifier
-                .size(20.dp)
-                .graphicsLayer { rotationZ = rotationAnimatable.value },
-            tint = contentColor
-        )
     }
 }
 
@@ -1266,16 +1204,34 @@ private fun StreamsList(
                 when (event.key) {
                     Key.DirectionLeft -> {
                         if (isRtl) {
-                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < allOptions.lastIndex) {
+                                onAddonFilterSelected(allOptions[currentIdx + 1])
+                                true
+                            } else false
                         } else {
-                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) {
+                                onAddonFilterSelected(allOptions[currentIdx - 1])
+                                true
+                            } else {
+                                onRequestChipFocus(0)
+                                true
+                            }
                         }
                     }
                     Key.DirectionRight -> {
                         if (isRtl) {
-                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
+                            if (currentIdx > 0) {
+                                onAddonFilterSelected(allOptions[currentIdx - 1])
+                                true
+                            } else {
+                                onRequestChipFocus(0)
+                                true
+                            }
                         } else {
-                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
+                            if (currentIdx < allOptions.lastIndex) {
+                                onAddonFilterSelected(allOptions[currentIdx + 1])
+                                true
+                            } else false
                         }
                     }
                     else -> false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -899,6 +899,8 @@ private fun AddonFilterChips(
     ) }
     LaunchedEffect(selectedAddon, orderedNames) {
         if (refreshHasFocus || focusedChipIndex == 0) return@LaunchedEffect
+        val currentAddonAtFocus = if (focusedChipIndex == 1) null else orderedNames.getOrNull(focusedChipIndex - 2)
+        if (currentAddonAtFocus == selectedAddon) return@LaunchedEffect
         val idx = if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
         focusedChipIndex = idx
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -92,7 +92,6 @@ import com.nuvio.tv.core.streams.StreamBadgePlacement
 import com.nuvio.tv.core.streams.StreamBadgeSettings
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.domain.model.Stream
-import com.nuvio.tv.ui.components.RefreshFilterChip
 import com.nuvio.tv.ui.components.SourceChipItem
 import com.nuvio.tv.ui.components.SourceChipStatus
 import com.nuvio.tv.ui.components.SourceStatusFilterChip
@@ -898,9 +897,6 @@ private fun AddonFilterChips(
         if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
     ) }
     LaunchedEffect(selectedAddon, orderedNames) {
-        if (refreshHasFocus || focusedChipIndex == 0) return@LaunchedEffect
-        val currentAddonAtFocus = if (focusedChipIndex == 1) null else orderedNames.getOrNull(focusedChipIndex - 2)
-        if (currentAddonAtFocus == selectedAddon) return@LaunchedEffect
         val idx = if (selectedAddon == null) 1 else (orderedNames.indexOf(selectedAddon) + 2).coerceAtLeast(1)
         focusedChipIndex = idx
     }
@@ -909,7 +905,6 @@ private fun AddonFilterChips(
     fun moveFocusTo(targetIndex: Int) {
         focusedChipIndex = targetIndex
         if (targetIndex == 0) {
-            refreshHasFocus = true
             scope.coroutineLaunch {
                 withFrameNanos {}
                 try { focusRequesters[0].requestFocus() } catch (_: Exception) {}
@@ -917,15 +912,8 @@ private fun AddonFilterChips(
             return
         }
 
-        refreshHasFocus = false
         val selectedFilter = if (targetIndex == 1) null else orderedNames[targetIndex - 2]
         onAddonSelected(selectedFilter)
-        scope.coroutineLaunch {
-            withFrameNanos {}
-            if (targetIndex in focusRequesters.indices) {
-                try { focusRequesters[targetIndex].requestFocus() } catch (_: Exception) {}
-            }
-        }
     }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
@@ -976,11 +964,10 @@ private fun AddonFilterChips(
             RefreshFilterChip(
                 onClick = onRefresh,
                 isLoading = isStillFetching,
-                onFocusChanged = { isFocused ->
-                    refreshHasFocus = isFocused
-                    if (isFocused) focusedChipIndex = 0
-                },
-                modifier = Modifier.focusRequester(focusRequesters[0])
+                onFocusChanged = { refreshHasFocus = it },
+                modifier = Modifier
+                    .focusRequester(focusRequesters[0])
+                    .focusProperties { canFocus = focusedChipIndex == 0 }
             )
         }
 
@@ -993,12 +980,7 @@ private fun AddonFilterChips(
                 onClick = { onAddonSelected(null) },
                 modifier = Modifier
                     .focusRequester(focusRequesters[1])
-                    .onFocusChanged {
-                        if (it.isFocused) {
-                            focusedChipIndex = 1
-                            refreshHasFocus = false
-                        }
-                    }
+                    .focusProperties { canFocus = selectedAddon == null || chipRowHasFocus }
             )
         }
 
@@ -1006,23 +988,101 @@ private fun AddonFilterChips(
             val addon = orderedNames[i]
             val chipStatus = chipMap[addon]?.status ?: SourceChipStatus.SUCCESS
             val isSelectable = addon in addons && chipStatus == SourceChipStatus.SUCCESS
-            val requesterIdx = i + 2
             SourceStatusFilterChip(
                 name = addon,
                 isSelected = selectedAddon == addon,
                 status = chipStatus,
                 isSelectable = isSelectable,
                 onClick = { if (isSelectable) onAddonSelected(addon) },
-                modifier = Modifier
-                    .focusRequester(focusRequesters[requesterIdx])
-                    .onFocusChanged {
-                        if (it.isFocused) {
-                            focusedChipIndex = requesterIdx
-                            refreshHasFocus = false
-                        }
-                    }
+                modifier = Modifier.focusRequester(focusRequesters[i + 2])
             )
         }
+    }
+}
+
+@Composable
+private fun RefreshFilterChip(
+    onClick: () -> Unit,
+    isLoading: Boolean = false,
+    onFocusChanged: (Boolean) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val contentColor = if (isFocused) {
+        NuvioTheme.colors.OnSecondary
+    } else {
+        NuvioTheme.colors.TextSecondary
+    }
+
+    val rotationAnimatable = remember { Animatable(0f) }
+    var hasCompletedFullRotation by remember { mutableStateOf(false) }
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            // Spin continuously while loading
+            coroutineDelay(100)
+            hasCompletedFullRotation = false
+            while (true) {
+                val remaining = 360f - rotationAnimatable.value
+                rotationAnimatable.animateTo(
+                    targetValue = 360f,
+                    animationSpec = tween(
+                        durationMillis = (remaining / 360f * 1000).toInt(),
+                        easing = LinearEasing
+                    )
+                )
+                hasCompletedFullRotation = true
+                rotationAnimatable.snapTo(0f)
+            }
+        } else {
+            // Complete current rotation then stop
+            if (hasCompletedFullRotation && rotationAnimatable.value > 0f) {
+                val remaining = 360f - rotationAnimatable.value
+                rotationAnimatable.animateTo(
+                    targetValue = 360f,
+                    animationSpec = tween(
+                        durationMillis = (remaining / 360f * 1000).toInt(),
+                        easing = LinearEasing
+                    )
+                )
+            }
+            rotationAnimatable.snapTo(0f)
+            hasCompletedFullRotation = false
+        }
+    }
+
+    FilterChip(
+        selected = false,
+        onClick = onClick,
+        modifier = modifier.onFocusChanged {
+            isFocused = it.isFocused
+            onFocusChanged(it.isFocused)
+        },
+        colors = FilterChipDefaults.colors(
+            containerColor = NuvioTheme.colors.BackgroundCard,
+            focusedContainerColor = NuvioTheme.colors.Secondary,
+            contentColor = contentColor,
+            focusedContentColor = contentColor
+        ),
+        border = FilterChipDefaults.border(
+            border = Border(
+                border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
+                shape = RoundedCornerShape(20.dp)
+            ),
+            focusedBorder = Border(
+                border = BorderStroke(NuvioTheme.spacing.xxs, NuvioTheme.colors.FocusRing),
+                shape = RoundedCornerShape(20.dp)
+            )
+        ),
+        shape = FilterChipDefaults.shape(shape = RoundedCornerShape(20.dp))
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Refresh,
+            contentDescription = stringResource(R.string.cd_refresh),
+            modifier = Modifier
+                .size(20.dp)
+                .graphicsLayer { rotationZ = rotationAnimatable.value },
+            tint = contentColor
+        )
     }
 }
 
@@ -1206,38 +1266,16 @@ private fun StreamsList(
                 when (event.key) {
                     Key.DirectionLeft -> {
                         if (isRtl) {
-                            if (currentIdx < allOptions.lastIndex) {
-                                onAddonFilterSelected(allOptions[currentIdx + 1])
-                                true
-                            } else {
-                                true
-                            }
+                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
                         } else {
-                            if (currentIdx > 0) {
-                                onAddonFilterSelected(allOptions[currentIdx - 1])
-                                true
-                            } else {
-                                onRequestChipFocus(0)
-                                true
-                            }
+                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
                         }
                     }
                     Key.DirectionRight -> {
                         if (isRtl) {
-                            if (currentIdx > 0) {
-                                onAddonFilterSelected(allOptions[currentIdx - 1])
-                                true
-                            } else {
-                                onRequestChipFocus(0)
-                                true
-                            }
+                            if (currentIdx > 0) { onAddonFilterSelected(allOptions[currentIdx - 1]); true } else false
                         } else {
-                            if (currentIdx < allOptions.lastIndex) {
-                                onAddonFilterSelected(allOptions[currentIdx + 1])
-                                true
-                            } else {
-                                true
-                            }
+                            if (currentIdx < allOptions.lastIndex) { onAddonFilterSelected(allOptions[currentIdx + 1]); true } else false
                         }
                     }
                     else -> false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -1209,7 +1209,9 @@ private fun StreamsList(
                             if (currentIdx < allOptions.lastIndex) {
                                 onAddonFilterSelected(allOptions[currentIdx + 1])
                                 true
-                            } else false
+                            } else {
+                                true
+                            }
                         } else {
                             if (currentIdx > 0) {
                                 onAddonFilterSelected(allOptions[currentIdx - 1])
@@ -1233,7 +1235,9 @@ private fun StreamsList(
                             if (currentIdx < allOptions.lastIndex) {
                                 onAddonFilterSelected(allOptions[currentIdx + 1])
                                 true
-                            } else false
+                            } else {
+                                true
+                            }
                         }
                     }
                     else -> false


### PR DESCRIPTION
## Summary

- Fixed D-pad focus navigation and focus drop in the in-player stream sources side panel.
- Unified the in-player reload action with the main `StreamScreen` details screen by replacing the header text button with the shared `RefreshFilterChip`.
- Removed artificial `focusProperties` blockers on filter chips and synchronized chip focus tracking via `onFocusChanged` to prevent skipping or getting stuck when scrolling horizontally.
- Added a navigation bridge from the stream list so pressing D-pad Left from the "All" chip transfers focus up to the Refresh button.
- Hardened filter chip focus tracking against duplicate addon names.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. Users reported being unable to scroll horizontally/right across source addon filters within the player sources side panel due to focus hijacking on list recomposition and `focusProperties` blockers.
2. Focus was frequently dropped completely upon opening the sources side panel because focus was requested on lazy items before they were attached to the layout hierarchy.
3. The in-player sources panel had an inconsistent header text "Reload" button instead of the unified `RefreshFilterChip` used on the main details stream screen.

## Issue or approval

Fixes in-player sources side panel D-pad navigation lock and focus drop.

## Reproduction steps

1. Play a media item and open the in-player stream sources side panel.
2. Attempt to navigate with D-pad Left/Right across the addon filter chips — focus gets stuck or skips "All" due to unsynchronized index tracking and focus-stealing `LaunchedEffect`s.
3. Try to reach the Reload button from the stream list without navigating all the way to the top header buttons.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only modifies stream source filtering navigation in `StreamSourcesSidePanel`, `StreamComponents`, and `StreamScreen`.
- Does not modify playback engines, stream scraping pipelines, or detail screen layouts.

## Testing

- **Build**: Verified `./gradlew compileFullDebugKotlin` succeeds with zero errors.
- **Android TV Emulator**:
  - Opened in-player stream sources side panel: verified initial focus lands on the first stream without dropping.
  - D-pad Up from top stream card moves directly to the active filter chip.
  - D-pad Left/Right navigates sequentially across `Refresh ↔ All ↔ Addon 1 ↔ Addon 2` without skipping or getting locked.
  - D-pad Left from the "All" filter while focused inside the stream list jumps focus directly to the Refresh button.
  - Verified reload triggers stream refresh with rotation animation on the chip.

## Screenshots / Video

None.

## Breaking changes

None.

## Linked issues

Fixes in-player stream sources navigation lock and focus drop.