### PR TITLE
Fix anime movies for Simkl

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -1396,6 +1396,8 @@ class ExternalPlaybackTracker @Inject constructor(
         )
             .takeIf { media ->
                 media.hasResolvableIdentity &&
-                    (media.kind == TrackingMediaKind.MOVIE || media.episode != null)
+                    (media.kind == TrackingMediaKind.MOVIE ||
+                        media.kind == TrackingMediaKind.ANIME ||
+                        media.episode != null)
             }
 }

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingMedia.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingMedia.kt
@@ -102,10 +102,10 @@ fun parseTrackingExternalIds(rawValue: String?): TrackingExternalIds {
 
 fun trackingMediaKind(contentType: String, ids: TrackingExternalIds = TrackingExternalIds()): TrackingMediaKind {
     val normalized = contentType.trim().lowercase()
+    val hasAnimeIds = ids.mal != null || ids.anidb != null || ids.anilist != null || ids.kitsu != null
     return when {
+        hasAnimeIds || normalized == "anime" -> TrackingMediaKind.ANIME
         normalized in setOf("movie", "film") -> TrackingMediaKind.MOVIE
-        normalized == "anime" || ids.mal != null || ids.anidb != null ||
-            ids.anilist != null || ids.kitsu != null -> TrackingMediaKind.ANIME
         else -> TrackingMediaKind.SHOW
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklContinueWatchingDiagnostics.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklContinueWatchingDiagnostics.kt
@@ -127,7 +127,7 @@ internal fun buildSimklSeedDiagnosticReport(
         .groupBy { item -> item.contentId.diagnosticKey() }
     val seedsByContent = seeds.associateBy { progress -> progress.contentId.diagnosticKey() }
     val playbackByContent = snapshot.playback
-        .mapNotNull(SimklPlaybackSession::toWatchProgress)
+        .mapNotNull { session -> session.toWatchProgress(snapshot.entries) }
         .groupBy { progress -> progress.contentId.diagnosticKey() }
     val seedOrder = seeds.withIndex().associate { (index, seed) ->
         seed.contentId.diagnosticKey() to index

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMediaProjections.kt
@@ -71,7 +71,7 @@ fun SimklSyncSnapshot.toSimklWatchedProjection(): SimklWatchedProjection {
 }
 
 fun SimklSyncSnapshot.toSimklProgressEntries(): List<WatchProgress> = playback
-    .mapNotNull(SimklPlaybackSession::toWatchProgress)
+    .mapNotNull { session -> session.toWatchProgress(entries) }
     .groupBy(::simklProgressKey)
     .mapNotNull { (_, candidates) -> candidates.maxByOrNull(WatchProgress::lastWatched) }
     .sortedByDescending(WatchProgress::lastWatched)
@@ -237,11 +237,19 @@ private fun SimklLibraryEntry.toWatchedItem(
     trackingSourceUrl = buildSimklSourceUrl(mediaType, media)
 )
 
-internal fun SimklPlaybackSession.toWatchProgress(): WatchProgress? {
+internal fun SimklPlaybackSession.toWatchProgress(
+    libraryEntries: List<SimklLibraryEntry> = emptyList()
+): WatchProgress? {
     val media = media ?: return null
     val parentId = media.canonicalContentId() ?: return null
+    val isAnimeMovie = mediaType == SimklMediaType.ANIME && libraryEntries.any { entry ->
+        entry.mediaType == SimklMediaType.ANIME &&
+            entry.animeType == "movie" &&
+            entry.media?.toTrackingExternalIds()?.sharesIdentityWith(media.toTrackingExternalIds()) == true
+    }
     val isMovie = mediaType == SimklMediaType.MOVIES ||
-        (mediaType == SimklMediaType.ANIME && episode == null)
+        (mediaType == SimklMediaType.ANIME && episode == null) ||
+        isAnimeMovie
     val season = episode?.tvdbSeason ?: episode?.season
     val episodeNumber = episode?.tvdbNumber ?: episode?.number
     if (!isMovie && episodeNumber == null) return null
@@ -325,6 +333,13 @@ private fun daysInMonths(year: Int): IntArray = if (year.isLeapYear()) {
  */
 fun TrackingMediaReference.resolveAnimeEpisodeForSimkl(): TrackingMediaReference {
     if (kind != TrackingMediaKind.ANIME) return this
+    if (episode == null) {
+        val videoId = catalog?.videoId
+        val parsed = videoId?.let { parseSimklAnimeVideoId(it) }
+        if (parsed?.episodeNumber == null) {
+            return copy(episode = TrackingEpisode(season = null, number = 1))
+        }
+    }
     val videoId = catalog?.videoId ?: return stripAnimeIdsIfSeasoned()
     val parsed = parseSimklAnimeVideoId(videoId) ?: return stripAnimeIdsIfSeasoned()
     val videoEpisodeNumber = parsed.episodeNumber ?: return stripAnimeIdsIfSeasoned()

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklPlaybackReconciliation.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklPlaybackReconciliation.kt
@@ -7,7 +7,7 @@ internal fun SimklSyncSnapshot.reconcileWatchedPlayback(): SimklSyncSnapshot {
     if (playback.isEmpty()) return this
     val watchedItems = toSimklWatchedProjection().items
     val retainedPlayback = playback.filterNot { session ->
-        session.toWatchProgress()?.let { progress ->
+        session.toWatchProgress(entries)?.let { progress ->
             entries.any { entry -> entry.hidesPlayback(progress) } ||
                 watchedItems.any { watched -> watched.supersedes(progress) }
         } == true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -769,7 +769,9 @@ internal fun PlayerRuntimeController.buildScrobbleItem(): TrackingMediaReference
     )
     return reference.takeIf { media ->
         media.hasResolvableIdentity &&
-            (media.kind == TrackingMediaKind.MOVIE || media.episode != null)
+            (media.kind == TrackingMediaKind.MOVIE ||
+                media.kind == TrackingMediaKind.ANIME ||
+                media.episode != null)
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1792,7 +1792,9 @@ class StreamScreenViewModel @Inject constructor(
         )
         return reference.takeIf { media ->
             media.hasResolvableIdentity &&
-                (media.kind == TrackingMediaKind.MOVIE || media.episode != null)
+                (media.kind == TrackingMediaKind.MOVIE ||
+                    media.kind == TrackingMediaKind.ANIME ||
+                    media.episode != null)
         }
     }
 


### PR DESCRIPTION
## Summary

Fix anime-movie Simkl scrobble: content with anime IDs (MAL/Kitsu/AniDB/AniList) and contentType "movie" was treated as MOVIE kind, causing Simkl to reject scrobbles with 404 id_err. Also fixes anime-movie from Simkl playback being classified as "series" in Continue Watching.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. trackingMediaKind() prioritized contentType "movie" over anime ID presence. Anime movies were sent to Simkl with "movie" wrapper instead of "anime" -> Simkl rejected with 404.
2. Anime movies without episode in videoId failed the scrobble guard (kind=ANIME && episode==null -> no_scrobble_item).
3. SimklPlaybackSession.toWatchProgress() classified anime-movies as series because Simkl always returns episode!=null for anime, but didn't check animeType=="movie" 

## Issue or approval

User-reported: Simkl scrobble not working for anime movies (404 id_err).
User-reported: anime-movies showing as series in Continue Watching.

## Reproduction steps

Bug 1-2: Play OVA/Special episode that is an anime movie in meta addon -> Simkl scrobble fails with 404 or no_scrobble_item
Bug 3: Have anime-movie in Simkl playback -> appears in CW as series instead of movie

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- trackingMediaKind: anime IDs now take priority over contentType. Only affects Simkl/Trakt scrobble kind detection, not UI display or navigation.
- resolveAnimeEpisodeForSimkl: adds episode=1 fallback for anime without episode in videoId (covers null videoId, non-anime prefix, and anime prefix without episode number).
- Scrobble item guards (PlayerRuntimeController, StreamScreenViewModel, ExternalPlaybackTracker): allow ANIME kind through without episode (episode is added later by resolveAnimeEpisodeForSimkl).
- SimklMediaProjections.toWatchProgress: accepts libraryEntries to check animeType=="movie". Only changes classification, not data flow.
- No changes to UI, player logic, or stream selection.

## Testing

- Verified Special Episode anime scrobbles to Simkl without 404
- Verified regular anime series scrobble still works (season/episode from videoId)
- Verified western movie (IMDB only, no anime IDs) still scrobbles as movie kind
- Verified anime-movie in Simkl playback shows as movie in CW (not series)
- Verified anime movie scrobbles correctly
- Tested on TCL Android TV via ADB

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

User-reported Simkl scrobble failure for anime movies.
