### PR TITLE
Fix trailer preview audio playing in the wrong language

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
@@ -50,7 +50,7 @@ private data class WatchConfig(
     val visitorData: String?
 )
 
-private data class StreamCandidate(
+internal data class StreamCandidate(
     val client: String,
     val priority: Int,
     val url: String,
@@ -59,7 +59,11 @@ private data class StreamCandidate(
     val itag: String,
     val height: Int,
     val fps: Int,
-    val ext: String
+    val ext: String,
+    // Only meaningful for audio candidates: false means this format is an
+    // alternate-language dub track, not the video's original/default audio.
+    // Always true for video/progressive candidates, so it never affects them.
+    val isDefaultAudioTrack: Boolean = true
 )
 
 private data class ManifestBestVariant(
@@ -376,6 +380,12 @@ class InAppYouTubeExtractor @Inject constructor() {
                             ?: format.numberValue("averageBitrate")
                             ?: 0.0
                         val asr = format.numberValue("audioSampleRate") ?: 0.0
+                        // Multi-language uploads (common for major-studio trailers)
+                        // expose each dub as a separate adaptiveFormats entry with an
+                        // audioTrack.audioIsDefault flag. Formats with no audioTrack
+                        // are the only audio for that video, so treat them as default.
+                        val isDefaultAudioTrack = format.mapValue("audioTrack")
+                            ?.booleanValue("audioIsDefault") ?: true
 
                         adaptiveAudio += StreamCandidate(
                             client = client.key,
@@ -386,7 +396,8 @@ class InAppYouTubeExtractor @Inject constructor() {
                             itag = format.stringValue("itag").orEmpty(),
                             height = 0,
                             fps = 0,
-                            ext = if (mimeType.contains("webm")) "webm" else "m4a"
+                            ext = if (mimeType.contains("webm")) "webm" else "m4a",
+                            isDefaultAudioTrack = isDefaultAudioTrack
                         )
                     }
                 }
@@ -680,9 +691,10 @@ class InAppYouTubeExtractor @Inject constructor() {
         return bitrate * 1_000_000.0 + audioSampleRate
     }
 
-    private fun sortCandidates(items: List<StreamCandidate>): List<StreamCandidate> {
+    internal fun sortCandidates(items: List<StreamCandidate>): List<StreamCandidate> {
         return items.sortedWith(
-            compareByDescending<StreamCandidate> { it.score }
+            compareBy<StreamCandidate> { if (it.isDefaultAudioTrack) 0 else 1 }
+                .thenByDescending { it.score }
                 .thenBy { if (it.hasN) 1 else 0 }
                 .thenBy { containerPreference(it.ext) }
                 .thenBy { it.priority }
@@ -851,6 +863,10 @@ private fun Map<*, *>.listMapValue(key: String): List<Map<*, *>> {
 private fun Map<*, *>.stringValue(key: String): String? {
     val value = this[key] ?: return null
     return value.toString()
+}
+
+private fun Map<*, *>.booleanValue(key: String): Boolean? {
+    return this[key] as? Boolean
 }
 
 private fun Map<*, *>.numberValue(key: String): Double? {

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -150,7 +150,7 @@ class TrailerService(
             "tv" -> fetchTmdbTvVideos(numericTmdbId, tmdbLanguage)
             else -> fetchTmdbMovieVideos(numericTmdbId, tmdbLanguage) + fetchTmdbTvVideos(numericTmdbId, tmdbLanguage)
         }
-        rankTmdbVideoCandidates(tmdbResults)
+        rankTmdbVideoCandidates(tmdbResults, preferredLanguageCode = tmdbLanguage)
             .firstOrNull()
             ?.key
             ?.trim()
@@ -182,7 +182,7 @@ class TrailerService(
             else -> fetchTmdbMovieVideos(numericTmdbId, tmdbLanguage) + fetchTmdbTvVideos(numericTmdbId, tmdbLanguage)
         }
 
-        val candidates = rankTmdbVideoCandidates(tmdbResults)
+        val candidates = rankTmdbVideoCandidates(tmdbResults, preferredLanguageCode = tmdbLanguage)
         Log.d(TAG, "TMDB candidate count: ${candidates.size}")
 
         for (candidate in candidates) {
@@ -487,7 +487,26 @@ internal fun normalizeTmdbMediaType(type: String?): String? {
     }
 }
 
-internal fun rankTmdbVideoCandidates(results: List<TmdbVideoResult>): List<TmdbVideoResult> {
+/**
+ * Ranks candidates for the user's chosen TMDB trailer language first (e.g. "en-US",
+ * "fr-FR"), falling back to English as a safety net when nothing matches that
+ * language, and only then to whatever else is available.
+ */
+internal fun rankTmdbVideoCandidates(
+    results: List<TmdbVideoResult>,
+    preferredLanguageCode: String = TMDB_TRAILER_FALLBACK_LANGUAGE
+): List<TmdbVideoResult> {
+    val preferredLanguage = preferredLanguageCode.substringBefore('-').lowercase()
+
+    fun languageRank(iso6391: String?): Int {
+        val lang = iso6391?.trim()?.lowercase()
+        return when {
+            lang == preferredLanguage -> 0
+            lang == "en" -> 1
+            else -> 2
+        }
+    }
+
     return results
         .asSequence()
         .filter { (it.site ?: "").equals("YouTube", ignoreCase = true) }
@@ -496,8 +515,10 @@ internal fun rankTmdbVideoCandidates(results: List<TmdbVideoResult>): List<TmdbV
             val normalizedType = it.type?.trim()?.lowercase()
             normalizedType == "trailer" || normalizedType == "teaser"
         }
+        .distinctBy { it.key }
         .sortedWith(
             compareBy<TmdbVideoResult> { videoTypePriority(it.type) }
+                .thenBy { languageRank(it.iso6391) }
                 .thenBy { if (it.official == true) 0 else 1 }
                 .thenByDescending { it.size ?: 0 }
                 .thenByDescending { parsePublishedAtEpoch(it.publishedAt) }

--- a/app/src/test/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractorAudioTrackTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractorAudioTrackTest.kt
@@ -1,0 +1,47 @@
+package com.nuvio.tv.data.trailer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InAppYouTubeExtractorAudioTrackTest {
+
+    @Test
+    fun `default audio track is preferred over a higher-bitrate alternate-language dub`() {
+        val extractor = InAppYouTubeExtractor()
+        val englishDefault = audioCandidate(url = "english", score = 64_000.0, isDefaultAudioTrack = true)
+        val higherBitrateDub = audioCandidate(url = "french-dub", score = 128_000.0, isDefaultAudioTrack = false)
+
+        val ranked = extractor.sortCandidates(listOf(higherBitrateDub, englishDefault))
+
+        assertEquals(listOf("english", "french-dub"), ranked.map { it.url })
+    }
+
+    @Test
+    fun `single-track audio with no audioTrack flag is treated as default`() {
+        val extractor = InAppYouTubeExtractor()
+        val onlyTrack = audioCandidate(url = "only-track", score = 64_000.0, isDefaultAudioTrack = true)
+
+        val ranked = extractor.sortCandidates(listOf(onlyTrack))
+
+        assertEquals(listOf("only-track"), ranked.map { it.url })
+    }
+
+    private fun audioCandidate(
+        url: String,
+        score: Double,
+        isDefaultAudioTrack: Boolean
+    ): StreamCandidate {
+        return StreamCandidate(
+            client = "android",
+            priority = 1,
+            url = url,
+            score = score,
+            hasN = false,
+            itag = "140",
+            height = 0,
+            fps = 0,
+            ext = "m4a",
+            isDefaultAudioTrack = isDefaultAudioTrack
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceCandidateRankingTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceCandidateRankingTest.kt
@@ -1,0 +1,208 @@
+package com.nuvio.tv.data.trailer
+
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TmdbVideoResult
+import com.nuvio.tv.data.remote.api.TmdbVideosResponse
+import com.nuvio.tv.data.remote.api.TrailerApi
+import com.nuvio.tv.domain.model.TmdbSettings
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+class TrailerServiceCandidateRankingTest {
+
+    @Test
+    fun `video type remains higher priority than resolution`() {
+        val lowResolutionTrailer = youtubeVideo(
+            key = LOW_RESOLUTION_KEY,
+            type = "Trailer",
+            size = 480,
+            official = false
+        )
+        val highResolutionTeaser = youtubeVideo(
+            key = HIGH_RESOLUTION_KEY,
+            type = "Teaser",
+            size = 2160,
+            official = true
+        )
+
+        val ranked = rankTmdbVideoCandidates(
+            listOf(highResolutionTeaser, lowResolutionTrailer)
+        )
+
+        assertEquals(
+            listOf(LOW_RESOLUTION_KEY, HIGH_RESOLUTION_KEY),
+            ranked.map { it.key }
+        )
+    }
+
+    @Test
+    fun `default english preference outranks higher resolution non-matching-language candidate`() {
+        val higherResolutionForeign = youtubeVideo(
+            key = FOREIGN_KEY,
+            size = 2160,
+            official = true,
+            iso6391 = "hi"
+        )
+        val lowerResolutionEnglish = youtubeVideo(
+            key = HIGH_RESOLUTION_KEY,
+            size = 1080,
+            official = true,
+            iso6391 = "en"
+        )
+
+        val ranked = rankTmdbVideoCandidates(
+            listOf(higherResolutionForeign, lowerResolutionEnglish)
+        )
+
+        assertEquals(
+            listOf(HIGH_RESOLUTION_KEY, FOREIGN_KEY),
+            ranked.map { it.key }
+        )
+    }
+
+    @Test
+    fun `ranking prefers the requested language over a higher resolution english upload`() {
+        val matchingLanguage = youtubeVideo(
+            key = FOREIGN_KEY,
+            size = 1080,
+            official = true,
+            iso6391 = "hi"
+        )
+        val higherResolutionEnglish = youtubeVideo(
+            key = HIGH_RESOLUTION_KEY,
+            size = 2160,
+            official = true,
+            iso6391 = "en"
+        )
+
+        val ranked = rankTmdbVideoCandidates(
+            listOf(higherResolutionEnglish, matchingLanguage),
+            preferredLanguageCode = "hi"
+        )
+
+        assertEquals(
+            listOf(FOREIGN_KEY, HIGH_RESOLUTION_KEY),
+            ranked.map { it.key }
+        )
+    }
+
+    @Test
+    fun `trailer selection follows the tmdb enrichment language setting`() = runTest {
+        val trailerApi = mockk<TrailerApi>(relaxed = true)
+        val tmdbApi = mockk<TmdbApi>()
+        val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
+        val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
+            every { settings } returns MutableStateFlow(TmdbSettings(language = "hi", useTrailers = true))
+        }
+        val tmdbService = mockk<TmdbService> {
+            every { apiKey() } returns "tmdb-key"
+        }
+        coEvery {
+            tmdbApi.getMovieVideos(movieId = 123, apiKey = "tmdb-key", language = "hi")
+        } returns Response.success(
+            TmdbVideosResponse(
+                id = 123,
+                results = listOf(
+                    youtubeVideo(key = FOREIGN_KEY, size = 1080, official = true, iso6391 = "hi")
+                )
+            )
+        )
+        coEvery {
+            tmdbApi.getMovieVideos(movieId = 123, apiKey = "tmdb-key", language = "en-US")
+        } returns Response.success(
+            TmdbVideosResponse(
+                id = 123,
+                results = listOf(
+                    youtubeVideo(key = HIGH_RESOLUTION_KEY, size = 2160, official = true, iso6391 = "en")
+                )
+            )
+        )
+        val service = TrailerService(
+            trailerApi = trailerApi,
+            tmdbApi = tmdbApi,
+            inAppYouTubeExtractor = extractor,
+            tmdbSettingsDataStore = tmdbSettingsDataStore,
+            tmdbService = tmdbService
+        )
+
+        val result = service.getExternalTrailerUrl(tmdbId = "123", type = "movie")
+
+        // The Hindi upload wins even though the English one is higher resolution,
+        // because the user's TMDB enrichment language is set to Hindi.
+        assertEquals("https://www.youtube.com/watch?v=$FOREIGN_KEY", result)
+        coVerify(exactly = 1) {
+            tmdbApi.getMovieVideos(movieId = 123, apiKey = "tmdb-key", language = "hi")
+        }
+    }
+
+    @Test
+    fun `falls back to english when the tmdb language setting has no trailer available`() = runTest {
+        val trailerApi = mockk<TrailerApi>(relaxed = true)
+        val tmdbApi = mockk<TmdbApi>()
+        val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
+        val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
+            every { settings } returns MutableStateFlow(TmdbSettings(language = "hi", useTrailers = true))
+        }
+        val tmdbService = mockk<TmdbService> {
+            every { apiKey() } returns "tmdb-key"
+        }
+        coEvery {
+            tmdbApi.getMovieVideos(movieId = 123, apiKey = "tmdb-key", language = "hi")
+        } returns Response.success(TmdbVideosResponse(id = 123, results = emptyList()))
+        coEvery {
+            tmdbApi.getMovieVideos(movieId = 123, apiKey = "tmdb-key", language = "en-US")
+        } returns Response.success(
+            TmdbVideosResponse(
+                id = 123,
+                results = listOf(
+                    youtubeVideo(key = HIGH_RESOLUTION_KEY, size = 1080, official = true, iso6391 = "en")
+                )
+            )
+        )
+        val service = TrailerService(
+            trailerApi = trailerApi,
+            tmdbApi = tmdbApi,
+            inAppYouTubeExtractor = extractor,
+            tmdbSettingsDataStore = tmdbSettingsDataStore,
+            tmdbService = tmdbService
+        )
+
+        val result = service.getExternalTrailerUrl(tmdbId = "123", type = "movie")
+
+        assertEquals("https://www.youtube.com/watch?v=$HIGH_RESOLUTION_KEY", result)
+    }
+
+    private fun youtubeVideo(
+        key: String,
+        type: String = "Trailer",
+        size: Int,
+        official: Boolean,
+        publishedAt: String = "2026-01-01T00:00:00Z",
+        iso6391: String? = null
+    ): TmdbVideoResult {
+        return TmdbVideoResult(
+            key = key,
+            site = "YouTube",
+            size = size,
+            type = type,
+            official = official,
+            publishedAt = publishedAt,
+            iso6391 = iso6391
+        )
+    }
+
+    private companion object {
+        const val LOW_RESOLUTION_KEY = "lowres00001"
+        const val HIGH_RESOLUTION_KEY = "highres0001"
+        const val FOREIGN_KEY = "foreign0001"
+    }
+}


### PR DESCRIPTION
## Summary
Two related fixes so the trailer preview always plays the correct language:
- TMDB trailer-candidate ranking now follows the TMDB enrichment language
  setting (falling back to English, then anything else), instead of
  ignoring language entirely.
- The YouTube extractor now respects YouTube's default-audio-track flag,
  so a bundled alternate-language dub can no longer outrank the correct
  audio track just by having a higher bitrate.

## PR type
- [x] Critical bug fix

## Why
Trailer previews could play in an unexpected language even with correct
settings - e.g. Prisoners (2013) plays a non-English dub despite the
video track being the correct English trailer, because the audio-track
selection only looked at bitrate, never at which track was the default.

## Issue or approval
Fixes #3131

## Reproduction steps
See linked issue.

## UI / behavior impact
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries
Does not touch trailer resolution/adaptive-fallback selection - only
trailer language ranking and default audio-track selection.

## Testing
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.data.trailer.*"` — all 11 trailer tests passing, including 4 new tests for language ranking and 2 new tests for default-audio-track preference.
- `./gradlew :app:assembleFullDebug` — builds successfully.
- Manually verified on-device: Prisoners (2013) trailer now plays with correct audio.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #3131