### PR TITLE
fix: per-episode rating from addon metadata is never parsed

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/mapper/MetaMapper.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mapper/MetaMapper.kt
@@ -75,6 +75,7 @@ fun VideoDto.toDomain(episodeLabel: String = "Episode"): Video {
         episode = episode ?: number,
         overview = overview ?: description,
         runtime = parseEpisodeRuntimeMinutes(runtime),
+        rating = rating?.trim()?.toDoubleOrNull()?.takeIf { it > 0.0 },
         available = available
     )
 }

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/MetaResponseDto.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/MetaResponseDto.kt
@@ -87,6 +87,7 @@ data class VideoDto(
     @Json(name = "overview") val overview: String? = null,
     @Json(name = "description") val description: String? = null,
     @Json(name = "runtime") val runtime: String? = null,
+    @Json(name = "rating") val rating: String? = null,
     @Json(name = "available") val available: Boolean? = null
 )
 

--- a/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Meta.kt
@@ -181,6 +181,8 @@ data class Video(
     val episode: Int?,
     val overview: String?,
     val runtime: Int? = null, // episode runtime in minutes
+    /** Per-episode rating supplied by the addon, when it provides one. */
+    val rating: Double? = null,
     val available: Boolean? = null
 )
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1343,6 +1343,15 @@ class MetaDetailsViewModel @Inject constructor(
                 )
             }
 
+            // Ratings the addon supplied on meta.videos[].rating. The repository below
+            // still wins wherever it has an entry.
+            val addonRatings: Map<Pair<Int, Int>, Double> = meta.videos.mapNotNull { video ->
+                val season = video.season ?: return@mapNotNull null
+                val episode = video.episode ?: return@mapNotNull null
+                val rating = video.rating ?: return@mapNotNull null
+                (season to episode) to rating
+            }.toMap()
+
             try {
                 val tmdbContentType = resolveTmdbContentType(meta)
                 if (tmdbContentType !in listOf(ContentType.SERIES, ContentType.TV)) {
@@ -1368,9 +1377,13 @@ class MetaDetailsViewModel @Inject constructor(
                             state
                         } else {
                             state.copy(
-                                episodeImdbRatings = emptyMap(),
+                                episodeImdbRatings = addonRatings,
                                 isEpisodeRatingsLoading = false,
-                                episodeRatingsError = localizedContext.getString(R.string.ratings_unavailable)
+                                episodeRatingsError = if (addonRatings.isEmpty()) {
+                                    localizedContext.getString(R.string.ratings_unavailable)
+                                } else {
+                                    null
+                                }
                             )
                         }
                     }
@@ -1387,7 +1400,7 @@ class MetaDetailsViewModel @Inject constructor(
                         state
                     } else {
                         state.copy(
-                            episodeImdbRatings = ratings,
+                            episodeImdbRatings = addonRatings + ratings,
                             isEpisodeRatingsLoading = false,
                             episodeRatingsError = null
                         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -1357,7 +1357,7 @@ class MetaDetailsViewModel @Inject constructor(
                 if (tmdbContentType !in listOf(ContentType.SERIES, ContentType.TV)) {
                     _uiState.update {
                         it.copy(
-                            episodeImdbRatings = emptyMap(),
+                            episodeImdbRatings = addonRatings,
                             isEpisodeRatingsLoading = false,
                             episodeRatingsError = null
                         )
@@ -1415,9 +1415,13 @@ class MetaDetailsViewModel @Inject constructor(
                         state
                     } else {
                         state.copy(
-                            episodeImdbRatings = emptyMap(),
+                            episodeImdbRatings = addonRatings,
                             isEpisodeRatingsLoading = false,
-                            episodeRatingsError = localizedContext.getString(R.string.ratings_load_error)
+                            episodeRatingsError = if (addonRatings.isEmpty()) {
+                                localizedContext.getString(R.string.ratings_load_error)
+                            } else {
+                                null
+                            }
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

`VideoDto` has no field for `rating`, so a per-episode rating sent by a metadata addon is dropped at deserialization. This adds it, parses it in `MetaMapper`, and seeds `episodeImdbRatings` from `meta.videos` so both the episode cards and the Ratings tab can use it.

## PR type

- [x] Critical bug fix

## Why

Cinemeta and the TMDB addon both send `rating` on `meta.videos[]`. Because `VideoDto` never declares it, the value is discarded and episode ratings can only come from `ImdbEpisodeRatingsRepository`, which needs an IMDb or TMDB id.

That covers most series, so the gap only appears with addons that use their own ids. `MetaDetailsViewModel` resolves neither id, sets `episodeImdbRatings = emptyMap()`, and two things go blank even though the addon sent a rating for every episode: the episode cards, and the Ratings tab, which shows "Episode ratings are unavailable."

Discussed in #3129, where the change was reviewed favourably.

## Issue or approval

Fixes #3129

Worth flagging honestly: this template offers "Translation/localization only" or "Critical bug fix", and neither is an exact fit — the change adds a nullable field so existing addon data reaches the UI. I have ticked the closer of the two and am happy to change it, split it, or hold it if you would rather categorise it differently.

## Reproduction steps

1. Install NuvioTV 0.8.7 from GitHub Releases.
2. Add an addon that uses its own ids and provides per-episode ratings. I used One Pace Premium: https://stremio-addons.net/addons/one-pace-rd
3. Open any series from that addon and open a season's episode list.
4. No rating on any episode card.
5. Open the Ratings tab — "Episode ratings are unavailable."
6. Compare against the addon's meta response, which has a `rating` on every entry in `meta.videos[]`.

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

The rating badge and the Ratings tab already exist and already render whenever the repository returns values. This only fills them when it returns none, so no layout changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Four files. Deliberately not included:

- No change to `ImdbEpisodeRatingsRepository` or to how the series graph is called. It keeps priority: `addonRatings + ratings` lets the right side override, so any episode the repository covers is unaffected.
- No new UI, no layout or styling changes.
- No change to how ratings are formatted. `%.1f` in both places already rounds the three-decimal values TMDB sends, so `8.519` shows as `8.5`.
- The same defect is on NuvioDesktop (NuvioMedia/NuvioDesktop#443, open), NuvioWeb (NuvioMedia/NuvioWeb#690) and NuvioMobile. Nothing here depends on those.

## Testing

Built with `:app:assembleFullDebug` and installed on LDPlayer 9 (Android 9), alongside the 0.8.7 release APK for the before/after.

- An addon using its own ids — cards blank and Ratings tab unavailable before; both populated after.
- Breaking Bad — ratings from Cinemeta's `meta.videos[].rating`. Note a debug build has no rating API URLs, so the repository returns nothing and these come from the addon.
- Unrated series are unaffected: `"0"`, `"0.0"`, `"0.000"`, `"-1"`, `""` and a missing field are all dropped by `takeIf { it > 0.0 }` in the mapper and never enter the map.
- `compileFullDebugKotlin` passes with no new warnings.

I checked metadata display only, not playback.

## Screenshots / Video

Before, on the 0.8.7 release APK. One Pace Premium sends a `rating` for every episode; the cards are blank and the Ratings tab reports them unavailable:

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/e281c1c7-68d3-4cac-9afb-af125a0c55e8" />

After, same addon on a build with the change:

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/a5261675-ee2f-4f15-8e50-29574e7f919d" />

Stranger Things on the patched build. Cinemeta sends `"rating": "0"` for all 70 of its videos and the existing `takeIf { it > 0.0 }` keeps them blank, so series without ratings are unchanged:

<img width="1920" height="1080" alt="Screenshot_20260822-153752" src="https://github.com/user-attachments/assets/7e26b03b-c614-4db5-9fc6-5c8269e6b47e" />

## Breaking changes

None. `rating` is a new nullable field with a default, and the addon value is only read where the repository returned nothing.

## Linked issues

Fixes #3129