### PR TITLE
fix(player): honor external Start From Beginning (minor bug fix)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -280,6 +280,7 @@ class ExternalPlaybackTracker @Inject constructor(
     fun startTracking(
         metadata: ExternalPlaybackMetadata,
         autoLaunch: Boolean = false,
+        startFromBeginning: Boolean = false,
         nextEpisodeSnapshot: ExternalNextEpisodeSnapshot? = null,
         autoNextEnabled: Boolean? = null,
         cloudSessionToken: String? = null
@@ -328,7 +329,7 @@ class ExternalPlaybackTracker @Inject constructor(
 
         // On Zidoo devices, start REST API polling
         if (ZidooPlayerMonitor.isZidooDevice()) {
-            startZidooMonitor(metadata)
+            startZidooMonitor(metadata, startFromBeginning)
         }
     }
 
@@ -350,6 +351,7 @@ class ExternalPlaybackTracker @Inject constructor(
      * @param title Display title
      * @param headers HTTP headers for the stream
      * @param resumePositionMs Position to resume from (ms), 0 to auto-fetch
+     * @param startFromBeginning Skip saved progress and explicitly start at zero
      * @param context Fallback context for fire-and-forget launch
      */
     suspend fun launchPlayer(
@@ -358,6 +360,7 @@ class ExternalPlaybackTracker @Inject constructor(
         title: String?,
         headers: Map<String, String>?,
         resumePositionMs: Long = 0L,
+        startFromBeginning: Boolean = false,
         subtitles: List<SubtitleInput>? = null,
         autoLaunch: Boolean = false,
         nextEpisodeSnapshot: ExternalNextEpisodeSnapshot? = null,
@@ -377,6 +380,7 @@ class ExternalPlaybackTracker @Inject constructor(
         startTracking(
             metadata = metadata,
             autoLaunch = autoLaunch,
+            startFromBeginning = startFromBeginning,
             nextEpisodeSnapshot = nextEpisodeSnapshot,
             autoNextEnabled = autoNextEnabled,
             cloudSessionToken = cloudSessionToken
@@ -387,7 +391,11 @@ class ExternalPlaybackTracker @Inject constructor(
         // and is cached, so an auto-next chain pays it only once.
         val launched = coroutineScope {
             val positionDeferred = async {
-                if (resumePositionMs > 0L) resumePositionMs else getResumePosition(metadata)
+                when {
+                    startFromBeginning -> 0L
+                    resumePositionMs > 0L -> resumePositionMs
+                    else -> getResumePosition(metadata)
+                }
             }
             val skipSegmentsDeferred = async {
                 resolveSkipSegmentsJson(metadata)
@@ -399,7 +407,16 @@ class ExternalPlaybackTracker @Inject constructor(
                 false
             } else {
                 withContext(Dispatchers.Main.immediate) {
-                    doLaunch(url, title, headers, position, subtitles, skipSegmentsJson, context)
+                    doLaunch(
+                        url = url,
+                        title = title,
+                        headers = headers,
+                        resumePositionMs = position,
+                        startFromBeginning = startFromBeginning,
+                        subtitles = subtitles,
+                        skipSegmentsJson = skipSegmentsJson,
+                        context = context
+                    )
                 }
             }
         }
@@ -473,6 +490,7 @@ class ExternalPlaybackTracker @Inject constructor(
         title: String?,
         headers: Map<String, String>?,
         resumePositionMs: Long,
+        startFromBeginning: Boolean,
         subtitles: List<SubtitleInput>?,
         skipSegmentsJson: String?,
         context: Context
@@ -483,6 +501,7 @@ class ExternalPlaybackTracker @Inject constructor(
             title = title,
             headers = headers,
             resumePositionMs = resumePositionMs,
+            startFromBeginning = startFromBeginning,
             subtitles = subtitles,
             skipSegmentsJson = skipSegmentsJson
         )
@@ -495,6 +514,7 @@ class ExternalPlaybackTracker @Inject constructor(
                 title = title,
                 headers = headers,
                 resumePositionMs = resumePositionMs,
+                startFromBeginning = startFromBeginning,
                 subtitles = subtitles,
                 skipSegmentsJson = skipSegmentsJson
             )
@@ -513,6 +533,7 @@ class ExternalPlaybackTracker @Inject constructor(
                         title = title,
                         headers = headers,
                         resumePositionMs = resumePositionMs,
+                        startFromBeginning = startFromBeginning,
                         subtitles = subtitles,
                         skipSegmentsJson = skipSegmentsJson
                     )
@@ -525,6 +546,7 @@ class ExternalPlaybackTracker @Inject constructor(
                     title = title,
                     headers = headers,
                     resumePositionMs = resumePositionMs,
+                    startFromBeginning = startFromBeginning,
                     subtitles = subtitles,
                     skipSegmentsJson = skipSegmentsJson
                 )
@@ -1271,10 +1293,13 @@ class ExternalPlaybackTracker @Inject constructor(
         Log.d(TAG, "Dismissed overlay only (Zidoo monitor still running)")
     }
 
-    private fun startZidooMonitor(metadata: ExternalPlaybackMetadata) {
+    private fun startZidooMonitor(
+        metadata: ExternalPlaybackMetadata,
+        startFromBeginning: Boolean
+    ) {
         zidooMonitorJob?.cancel()
         zidooMonitorJob = scope.launch(Dispatchers.Default) {
-            val resumePosition = getResumePosition(metadata)
+            val resumePosition = if (startFromBeginning) 0L else getResumePosition(metadata)
             val result = ZidooPlayerMonitor.awaitPlaybackEnd(resumePositionMs = resumePosition)
             if (result != null) {
                 Log.d(TAG, "Zidoo monitor: pos=${result.positionMs}ms, dur=${result.durationMs}ms")

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerLauncher.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerLauncher.kt
@@ -18,6 +18,7 @@ object ExternalPlayerLauncher {
         title: String? = null,
         headers: Map<String, String>? = null,
         resumePositionMs: Long = 0L,
+        startFromBeginning: Boolean = false,
         subtitles: List<SubtitleInput>? = null,
         skipSegmentsJson: String? = null
     ): Boolean {
@@ -41,7 +42,13 @@ object ExternalPlayerLauncher {
                     }
                 }
 
-                if (resumePositionMs > 0L) {
+                if (startFromBeginning) {
+                    putExtra("position", 0)
+                    putExtra("extra_position", 0L)
+                    putExtra("startfrom", 0)
+                    putExtra("forceresume", false)
+                    putExtra("from_start", true)
+                } else if (resumePositionMs > 0L) {
                     putExtra("position", resumePositionMs.toInt())
                     putExtra("startfrom", resumePositionMs.toInt())
                     putExtra("forceresume", true)  // Vimu: enable resume for network streams
@@ -108,6 +115,7 @@ object ExternalPlayerLauncher {
         title: String? = null,
         headers: Map<String, String>? = null,
         resumePositionMs: Long = 0L,
+        startFromBeginning: Boolean = false,
         subtitles: List<SubtitleInput>? = null,
         skipSegmentsJson: String? = null
     ): ExternalPlayerInput = ExternalPlayerInput(
@@ -115,6 +123,7 @@ object ExternalPlayerLauncher {
         title = title,
         headers = headers,
         resumePositionMs = resumePositionMs,
+        startFromBeginning = startFromBeginning,
         subtitles = subtitles,
         skipSegmentsJson = skipSegmentsJson
     )

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlayerResultContract.kt
@@ -23,6 +23,7 @@ data class ExternalPlayerInput(
     val title: String? = null,
     val headers: Map<String, String>? = null,
     val resumePositionMs: Long = 0L,
+    val startFromBeginning: Boolean = false,
     val subtitles: List<SubtitleInput>? = null,
     // Pre-resolved intro/outro skip segments as a JSON array string
     // (`[{"type","start","end"}]`, times in seconds). Read by mpvNova.
@@ -72,7 +73,13 @@ class ExternalPlayerResultContract : ActivityResultContract<ExternalPlayerInput,
             }
 
             // Resume position — supported by MX Player, VLC, Just Player, mpv-android, Vimu
-            if (input.resumePositionMs > 0L) {
+            if (input.startFromBeginning) {
+                putExtra("position", 0)
+                putExtra("extra_position", 0L)
+                putExtra("startfrom", 0)
+                putExtra("forceresume", false)
+                putExtra("from_start", true)
+            } else if (input.resumePositionMs > 0L) {
                 putExtra("position", input.resumePositionMs.toInt())  // MX Player / Just Player / mpv (Int ms)
                 putExtra("extra_position", input.resumePositionMs)    // VLC (Long ms)
                 putExtra("startfrom", input.resumePositionMs.toInt()) // Vimu Player (Int ms)

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -480,6 +480,7 @@ fun NuvioNavHost(
                 ?.getString("startFromBeginning")
                 ?.toBooleanStrictOrNull() == true
             StreamScreen(
+                startFromBeginning = startFromBeginning,
                 onBackPress = {
                     val streamContentType = streamArgs?.getString("contentType").orEmpty()
                     val streamContentId = streamArgs?.getString("contentId").orEmpty()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -116,6 +116,7 @@ import android.util.Log
 @Composable
 fun StreamScreen(
     viewModel: StreamScreenViewModel = hiltViewModel(),
+    startFromBeginning: Boolean = false,
     onBackPress: () -> Unit,
     onStreamSelected: (StreamPlaybackInfo) -> Unit,
     onAutoPlayResolved: (StreamPlaybackInfo) -> Unit
@@ -145,6 +146,7 @@ fun StreamScreen(
             viewModel.launchExternalPlayer(
                 playbackInfo = playbackInfo,
                 url = url,
+                startFromBeginning = startFromBeginning,
                 context = context
             )
         }
@@ -162,7 +164,8 @@ fun StreamScreen(
                 context = context,
                 url = url,
                 title = playbackInfo.title,
-                headers = playbackInfo.headers
+                headers = playbackInfo.headers,
+                startFromBeginning = startFromBeginning
             )
         }
         return true
@@ -221,6 +224,7 @@ fun StreamScreen(
                             viewModel.launchExternalPlayer(
                                 playbackInfo = playbackInfo,
                                 url = urlString,
+                                startFromBeginning = startFromBeginning,
                                 autoLaunch = true,
                                 context = context
                             )
@@ -315,6 +319,7 @@ fun StreamScreen(
                         viewModel.launchExternalPlayer(
                             playbackInfo = playbackInfo,
                             url = urlString,
+                            startFromBeginning = startFromBeginning,
                             autoLaunch = true,
                             context = context
                         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -1406,6 +1406,7 @@ class StreamScreenViewModel @Inject constructor(
         playbackInfo: StreamPlaybackInfo,
         url: String,
         resumePositionMs: Long = 0L,
+        startFromBeginning: Boolean = false,
         autoLaunch: Boolean = false,
         context: android.content.Context
     ) {
@@ -1611,6 +1612,7 @@ class StreamScreenViewModel @Inject constructor(
             title = metadata.buildPlayerTitle(),
             headers = playbackInfo.headers,
             resumePositionMs = resumePositionMs,
+            startFromBeginning = startFromBeginning,
             subtitles = subtitleInputs,
             autoLaunch = autoLaunch,
             nextEpisodeSnapshot = playbackMetaVideos?.let { videos ->


### PR DESCRIPTION
## Summary

Start From Beginning now reaches the external player handoff instead of being lost when the Stream screen opens. Nuvio skips its saved progress lookup for that explicit action and sends a zero start position through the supported external launch paths.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The navigation route already carried the Start From Beginning choice and internal playback respected it. The Stream screen did not pass that choice to ExternalPlaybackTracker, where a requested position of zero normally means to look up saved progress. External players therefore resumed at the saved position instead of starting at 00:00.

## Issue or approval

Fixes #3148

## Reproduction steps

1. Play part of an episode with an external player so Nuvio stores progress.
2. Return to Nuvio and choose Start From Beginning for the same episode.
3. Resolve and launch a source with the external player.
4. Before this fix, the external player resumes at the saved position.
5. After this fix, that explicit launch starts at 00:00.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes external launches that originate from the existing Start From Beginning action. Normal resume, auto next, binge group continuity, completion tracking, subtitle forwarding, skip data, and internal playback are unchanged. No UI, dependency, schema, refactor, or test files are included.

## Testing

- Ran `.\gradlew.bat :app:compileFullDebugKotlin :app:assembleFullDebug`.
- Built the latest upstream `dev` full debug APK successfully.
- Installed a full debug build on an NVIDIA Shield TV running Android 11 for verification.
- Confirmed the pre-fix launch trace sent the saved 304846 ms position after Start From Beginning.
- Audited the ActivityResult, fire-and-forget, browser fallback, and Zidoo external launch paths for explicit zero handling.
- Audited ordinary resume and external auto next call sites to confirm they retain the existing default behavior.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3148