### PR TITLE
fix(home): hide orphan divider when overall ratings are off

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeHero.kt
@@ -553,7 +553,10 @@ private fun HeroTitleContent(
                     )
                 }
                 if (secondaryHighlightText != null && (hasSecondaryBadge || reserveImdbInSecondary || secondaryDetails.isNotEmpty())) {
-                    HeroMetaDivider(metaScale)
+                    HeroMetaDivider(
+                        scale = metaScale,
+                        visible = hasSecondaryBadge || showImdbInSecondary || secondaryDetails.isNotEmpty()
+                    )
                 }
                 if (ageRatingBadge != null && statusBadge != null) {
                     HeroCombinedMetaBadge(


### PR DESCRIPTION
## Summary

Hide the orphan metadata divider in the Modern home hero when **Overall Ratings** is disabled and a Continue Watching card is focused.

The divider remains composed in its reserved slot but becomes transparent when the hidden IMDb value is the only following metadata. This preserves the existing row height, line positions, spacing, and allocated space for Continue Watching, Movie, and Series heroes.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

This is the closest applicable template category for a documented visible regression.

## Why

PR #2384 reserved space for IMDb metadata so toggling/fetching ratings would not shift the home hero layout. When **Overall Ratings** is disabled, the IMDb value is intentionally hidden, but its preceding divider remained visible if there was no other secondary metadata. Continue Watching therefore displayed an orphan dot after the time-left label.

The fix changes only that divider's visibility. It does not remove its allocation or alter metadata layout.

## Issue or approval

No standalone issue was opened. [Nedelio's report on PR #2384](https://github.com/NuvioMedia/NuvioTV/pull/2384#issuecomment-5376102447) documents the regression and is treated as the issue-equivalent report for this direct follow-up.

### `CONTRIBUTING.md` compliance

- [x] Reproducible, documented UI regression
- [x] Issue-equivalent report linked above
- [x] Before/after emulator evidence included
- [x] Smallest localized fix: one production file, four added lines and one replaced line
- [x] No feature, redesign, dependency, architecture, refactor, formatting, or generated-file changes
- [ ] Standalone GitHub issue link — not available; the linked PR comment is the issue-equivalent report

## Reproduction steps

1. Use the Modern home layout.
2. Disable **Settings → Layout → Home Content → Overall Ratings**.
3. Start a movie, leave it partially watched, and return to Home.
4. Focus its card in **Continue Watching**.
5. Observe the orphan divider after the time-left text in clean 0.8.7.
6. Install the patched debug build and reproduce the same state.
7. Observe that the divider is hidden while the hero's spacing and line positions remain unchanged.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue-equivalent report, reproduction steps, and testing notes as a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

- No changes to hero row height, metadata line locations, allocated space, metadata order, or focus position.
- No changes to Movie, Series, or Continue Watching card/layout behavior.
- No changes to age/status badges, runtime/year metadata, enrichment, or ratings-enabled rendering.
- No changes to Classic or Grid home layouts.
- No extra UI polish or behavior changes.

## Testing

- `.\gradlew.bat :app:testFullDebugUnitTest --tests com.nuvio.tv.domain.model.ImdbRatingVisibilityTest --no-daemon` — passed.
- `.\gradlew.bat :app:assembleFullDebug --no-daemon` — passed.
- Android TV emulator (`sdk_google_atv64_x86_64`, Android 16), driven through ADB:
  - Clean official 0.8.7 x86_64 release installed first.
  - Overall Ratings disabled; the focused Obsession Continue Watching card showed `13M LEFT` followed by the orphan divider.
  - Patched x86_64 debug app installed in parallel and placed at the same home location, selection, content, and progress label.
  - The divider was hidden, with the remaining hero metadata and spacing unchanged.
- Physical device (user-performed): patched build visually verified on a Google TV Streamer 4K.

## Screenshots / Video

Both emulator captures use the same Modern home screen location, focused Continue Watching item, content, and `13M LEFT` state with Overall Ratings disabled.

| Before — clean official 0.8.7 | After — patched debug build |
| --- | --- |
| ![Before: orphan divider visible after 13M LEFT](https://raw.githubusercontent.com/liongalahad/NuvioTV/pr-evidence-cw-divider-20260824/pr-evidence/continue-watching-divider-before.png) | ![After: divider hidden with layout preserved](https://raw.githubusercontent.com/liongalahad/NuvioTV/pr-evidence-cw-divider-20260824/pr-evidence/continue-watching-divider-after.png) |

## Breaking changes

None.

## Linked issues

- Issue-equivalent report: [Nedelio's comment on PR #2384](https://github.com/NuvioMedia/NuvioTV/pull/2384#issuecomment-5376102447)
- Related implementation: #2384
