### PR TITLE
perf(sync): reduce redundant backend requests

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -304,6 +304,11 @@ class PluginManager @Inject constructor(
             }
 
             val sanitizedUrl = resolvedUrl.trimEnd('/')
+            val existingRepository = dataStore.repositories.first()
+                .find { normalizeUrl(it.url) == normalizeUrl(sanitizedUrl) }
+            if (existingRepository != null) {
+                return@withContext Result.success(existingRepository)
+            }
             val filename = sanitizedUrl.substringAfterLast("/")
             val isExplicitJsonFile = filename.endsWith(".json", ignoreCase = true)
                     && !filename.equals("manifest.json", ignoreCase = true)

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -124,7 +124,6 @@ import com.nuvio.tv.core.auth.DeviceSessionRegistration
 import com.nuvio.tv.core.deeplink.DeepLinkHandler
 import com.nuvio.tv.core.deeplink.DeepLinkParser
 import com.nuvio.tv.core.profile.ProfileManager
-import com.nuvio.tv.core.sync.ProfileSettingsSyncService
 import com.nuvio.tv.core.sync.ProfileSyncService
 import com.nuvio.tv.core.sync.StartupSyncService
 import com.nuvio.tv.core.tracking.TrackingProgressRefreshCoordinator
@@ -243,9 +242,6 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var androidTvChannelSyncService: com.nuvio.tv.core.sync.androidtv.AndroidTvChannelSyncService
-
-    @Inject
-    lateinit var profileSettingsSyncService: ProfileSettingsSyncService
 
     @Inject
     lateinit var profileSyncService: ProfileSyncService
@@ -1022,7 +1018,6 @@ class MainActivity : ComponentActivity() {
         externalPlaybackTracker.raiseAutoNextOverlayOnReturn()
         super.onStart()
         startupSyncService.startPeriodicSurfacePulls()
-        profileSettingsSyncService.requestForegroundPull()
         androidTvChannelSyncService.onForegroundChanged(true)
     }
 

--- a/app/src/main/java/com/nuvio/tv/core/di/SupabaseModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/SupabaseModule.kt
@@ -3,6 +3,11 @@ package com.nuvio.tv.core.di
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.core.auth.TransientAuthRefreshException
 import com.nuvio.tv.core.auth.shouldRetryAuthRefreshResponse
+import com.nuvio.tv.core.network.BackendRateLimitCoordinator
+import com.nuvio.tv.core.network.BackendRateLimitPlugin
+import com.nuvio.tv.core.network.backendRetryDelayMillis
+import com.nuvio.tv.core.network.isRetryableBackendResponse
+import com.nuvio.tv.core.network.isSafeBackendRetryRequest
 import com.nuvio.tv.data.local.ServerConfigurationStore
 import com.nuvio.tv.domain.model.ServerConfiguration
 import dagger.Module
@@ -19,6 +24,7 @@ import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.storage.Storage
 import io.github.jan.supabase.storage.storage
 import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.statement.request
 import io.ktor.http.HttpHeaders
@@ -43,11 +49,34 @@ object SupabaseModule {
         serverConfiguration: ServerConfiguration
     ): SupabaseClient = runBlocking(Dispatchers.IO) {
         val userAgent = "NuvioTV/${BuildConfig.VERSION_NAME.ifBlank { "dev" }}"
+        val rateLimitCoordinator = BackendRateLimitCoordinator()
         createSupabaseClient(
             supabaseUrl = serverConfiguration.backendUrl,
             supabaseKey = serverConfiguration.publishableKey
         ) {
             httpConfig {
+                install(BackendRateLimitPlugin) {
+                    coordinator = rateLimitCoordinator
+                }
+                install(HttpRequestRetry) {
+                    retryIf(maxRetries = 1) { request, response ->
+                        isSafeBackendRetryRequest(
+                            method = request.method.value,
+                            encodedPath = request.url.encodedPath
+                        ) && isRetryableBackendResponse(response.status.value)
+                    }
+                    delayMillis(respectRetryAfterHeader = false) { retryCount ->
+                        val retryResponse = response
+                        if (retryResponse != null && isRetryableBackendResponse(retryResponse.status.value)) {
+                            backendRetryDelayMillis(
+                                retryCount = retryCount,
+                                retryAfterHeader = retryResponse.headers[HttpHeaders.RetryAfter]
+                            )
+                        } else {
+                            0L
+                        }
+                    }
+                }
                 defaultRequest {
                     headers.append(HttpHeaders.UserAgent, userAgent)
                 }

--- a/app/src/main/java/com/nuvio/tv/core/network/BackendRateLimit.kt
+++ b/app/src/main/java/com/nuvio/tv/core/network/BackendRateLimit.kt
@@ -1,0 +1,131 @@
+package com.nuvio.tv.core.network
+
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.http.HttpHeaders
+import io.ktor.http.fromHttpToGmtDate
+import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.random.Random
+
+private const val DefaultRetryDelayMs = 1_000L
+private const val MaximumFallbackDelayMs = 30_000L
+private const val MaximumJitterMs = 1_000L
+
+internal class BackendRateLimitCoordinator(
+    private val currentTimeMillis: () -> Long = System::currentTimeMillis,
+    private val pause: suspend (Long) -> Unit = { delay(it) }
+) {
+    private val cooldownUntilEpochMs = AtomicLong(0L)
+
+    fun record(retryAfterHeader: String?) {
+        val now = currentTimeMillis()
+        val delayMs = retryAfterDelayMillis(
+            retryAfterHeader = retryAfterHeader,
+            nowEpochMs = now
+        )
+        val candidate = saturatedAdd(now, delayMs)
+        while (true) {
+            val current = cooldownUntilEpochMs.get()
+            if (candidate <= current || cooldownUntilEpochMs.compareAndSet(current, candidate)) return
+        }
+    }
+
+    suspend fun awaitPermission() {
+        while (true) {
+            val waitMs = cooldownUntilEpochMs.get() - currentTimeMillis()
+            if (waitMs <= 0L) return
+            pause(waitMs)
+        }
+    }
+}
+
+internal class BackendRateLimitPluginConfig {
+    lateinit var coordinator: BackendRateLimitCoordinator
+}
+
+internal val BackendRateLimitPlugin = createClientPlugin(
+    name = "BackendRateLimit",
+    createConfiguration = ::BackendRateLimitPluginConfig
+) {
+    val coordinator = pluginConfig.coordinator
+
+    onRequest { _, _ ->
+        coordinator.awaitPermission()
+    }
+    onResponse { response ->
+        val retryAfterHeader = response.headers[HttpHeaders.RetryAfter]
+        if (shouldApplyBackendCooldown(response.status.value, retryAfterHeader)) {
+            coordinator.record(retryAfterHeader)
+        }
+    }
+}
+
+internal fun isRetryableBackendResponse(statusCode: Int): Boolean =
+    statusCode == 429 || statusCode == 503
+
+internal fun shouldApplyBackendCooldown(statusCode: Int, retryAfterHeader: String?): Boolean =
+    statusCode == 429 || (statusCode == 503 && !retryAfterHeader.isNullOrBlank())
+
+internal fun isSafeBackendRetryRequest(method: String, encodedPath: String): Boolean {
+    if (method.equals("GET", ignoreCase = true) || method.equals("HEAD", ignoreCase = true)) return true
+    if (!method.equals("POST", ignoreCase = true)) return false
+
+    val rpcName = encodedPath.substringAfter("/rpc/", missingDelimiterValue = "")
+        .substringBefore('/')
+        .substringBefore('?')
+    return rpcName.startsWith("sync_pull_") ||
+        rpcName.startsWith("sync_get_") ||
+        rpcName in safeReadRpcNames
+}
+
+internal fun retryAfterDelayMillis(
+    retryAfterHeader: String?,
+    nowEpochMs: Long,
+    fallbackDelayMs: Long = DefaultRetryDelayMs
+): Long {
+    val value = retryAfterHeader?.trim().orEmpty()
+    val secondsDelay = value.toLongOrNull()
+        ?.coerceAtLeast(0L)
+        ?.let { seconds -> saturatedMultiply(seconds, 1_000L) }
+    val dateDelay = if (secondsDelay == null && value.isNotEmpty()) {
+        runCatching { value.fromHttpToGmtDate().timestamp - nowEpochMs }
+            .getOrNull()
+            ?.coerceAtLeast(0L)
+    } else {
+        null
+    }
+    return secondsDelay ?: dateDelay ?: fallbackDelayMs.coerceAtLeast(0L)
+}
+
+internal fun backendRetryDelayMillis(
+    retryCount: Int,
+    retryAfterHeader: String?,
+    nowEpochMs: Long = System.currentTimeMillis(),
+    jitterMs: Long = Random.nextLong(MaximumJitterMs + 1L)
+): Long {
+    val exponentialDelay = (DefaultRetryDelayMs shl retryCount.coerceIn(0, 5))
+        .coerceAtMost(MaximumFallbackDelayMs)
+    val retryDelay = retryAfterDelayMillis(
+        retryAfterHeader = retryAfterHeader,
+        nowEpochMs = nowEpochMs,
+        fallbackDelayMs = exponentialDelay
+    )
+    return saturatedAdd(retryDelay, jitterMs.coerceIn(0L, MaximumJitterMs))
+}
+
+private fun saturatedAdd(left: Long, right: Long): Long =
+    if (right > 0L && left > Long.MAX_VALUE - right) Long.MAX_VALUE else left + right
+
+private fun saturatedMultiply(left: Long, right: Long): Long =
+    if (left > Long.MAX_VALUE / right) Long.MAX_VALUE else left * right
+
+private val safeReadRpcNames = setOf(
+    "get_avatar_catalog",
+    "get_member_profile_avatar_catalog",
+    "get_member_profile_background_catalog",
+    "get_my_member_access",
+    "get_my_membership_overview",
+    "get_sync_code",
+    "get_sync_overview",
+    "get_sync_owner"
+)

--- a/app/src/main/java/com/nuvio/tv/core/sync/HomeCatalogSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/HomeCatalogSettingsSyncService.kt
@@ -6,6 +6,7 @@ import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.CollectionsDataStore
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.remote.supabase.SupabaseHomeCatalogSettingsBlob
+import com.nuvio.tv.domain.model.AuthState
 import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.domain.repository.AddonRepository
 import io.github.jan.supabase.postgrest.Postgrest
@@ -29,10 +30,8 @@ import javax.inject.Singleton
 
 private const val TAG = "HomeCatalogSettingsSyncService"
 private const val HOME_CATALOG_SHARED_SYNC_PLATFORM = "home_catalog_shared"
-private const val TV_LEGACY_SETTINGS_SYNC_PLATFORM = "tv"
 private const val PAYLOAD_SAMPLE_LIMIT = 5
 private const val HIDE_UNRELEASED_CONTENT_KEY = "hide_unreleased_content"
-private val HOME_CATALOG_LEGACY_SYNC_PLATFORMS = listOf(TV_LEGACY_SETTINGS_SYNC_PLATFORM, "mobile")
 
 @Serializable
 data class SyncCatalogItem(
@@ -52,11 +51,23 @@ data class SyncHomeCatalogPayload(
     val items: List<SyncCatalogItem> = emptyList(),
 )
 
-private data class RemoteHomeCatalogSettings(
-    val payload: SyncHomeCatalogPayload,
-    val updatedAt: String?,
-    val hasHideUnreleasedContent: Boolean
+private data class HomeCatalogSyncScope(
+    val userId: String,
+    val profileId: Int
 )
+
+private data class CachedSharedSettings(
+    val scope: HomeCatalogSyncScope,
+    val settingsJson: JsonObject
+)
+
+internal fun mergeHomeCatalogSettingsJson(
+    remoteJson: JsonObject?,
+    localJson: JsonObject
+): JsonObject = buildJsonObject {
+    remoteJson?.forEach { (key, value) -> put(key, value) }
+    localJson.forEach { (key, value) -> put(key, value) }
+}
 
 @Singleton
 class HomeCatalogSettingsSyncService @Inject constructor(
@@ -78,6 +89,8 @@ class HomeCatalogSettingsSyncService @Inject constructor(
     var isSyncingFromRemote: Boolean = false
 
     private var pushJob: Job? = null
+    @Volatile
+    private var cachedSharedSettings: CachedSharedSettings? = null
 
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
         return try {
@@ -91,9 +104,11 @@ class HomeCatalogSettingsSyncService @Inject constructor(
     suspend fun pushToRemote(reason: String = "unspecified"): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val profileId = profileManager.activeProfileId.value
+            val syncScope = currentScope(profileId)
+                ?: return@withContext Result.success(Unit)
             val payload = loadLocalPayload()
             Log.d(TAG, "Push start profile=$profileId reason=$reason ${payload.summary()}")
-            pushPayload(profileId, payload)
+            pushPayload(syncScope, payload)
 
             Log.d(TAG, "Push success profile=$profileId reason=$reason")
             Result.success(Unit)
@@ -106,6 +121,8 @@ class HomeCatalogSettingsSyncService @Inject constructor(
     suspend fun pullFromRemote(): Result<Boolean> = withContext(Dispatchers.IO) {
         try {
             val profileId = profileManager.activeProfileId.value
+            val syncScope = currentScope(profileId)
+                ?: return@withContext Result.success(false)
             val localState = layoutPreferenceDataStore.getHomeCatalogSettingsState()
             Log.d(TAG, "Pull start profile=$profileId ${localState.summary()}")
 
@@ -124,13 +141,24 @@ class HomeCatalogSettingsSyncService @Inject constructor(
             }
 
             val localPayload = loadLocalPayload()
-            val remote = fetchBestRemotePayload(profileId, localPayload)
-            if (remote == null) {
+            val remoteBlob = fetchRemoteBlob(profileId)
+            if (currentScope(profileId) != syncScope) {
+                return@withContext Result.success(false)
+            }
+            cachedSharedSettings = CachedSharedSettings(
+                scope = syncScope,
+                settingsJson = remoteBlob?.settingsJson ?: buildJsonObject { }
+            )
+            if (remoteBlob == null) {
                 Log.d(TAG, "No remote row profile=$profileId; preserving local (startup is pull-only)")
                 return@withContext Result.success(false)
             }
 
-            val remotePayload = remote.payload
+            val remotePayload = decodePayloadPreservingLocalDefaults(remoteBlob.settingsJson, localPayload)
+            if (remotePayload == null) {
+                Log.w(TAG, "Pull parse failure profile=$profileId")
+                return@withContext Result.success(false)
+            }
             Log.d(TAG, "Pull remote payload profile=$profileId ${remotePayload.summary()}")
 
             if (remotePayload.items.isEmpty()) {
@@ -169,11 +197,11 @@ class HomeCatalogSettingsSyncService @Inject constructor(
         return layoutPreferenceDataStore.exportCatalogSettingsToSyncPayload(addons, collections)
     }
 
-    private suspend fun pushPayload(profileId: Int, payload: SyncHomeCatalogPayload) {
-        val jsonElement = mergedSharedPayloadJson(profileId, payload)
+    private suspend fun pushPayload(syncScope: HomeCatalogSyncScope, payload: SyncHomeCatalogPayload) {
+        val jsonElement = mergedSharedPayloadJson(syncScope, payload)
 
         val params = buildJsonObject {
-            put("p_profile_id", profileId)
+            put("p_profile_id", syncScope.profileId)
             put("p_settings_json", jsonElement)
             put("p_platform", HOME_CATALOG_SHARED_SYNC_PLATFORM)
             putSyncOriginClientId(syncClientIdentity)
@@ -182,79 +210,13 @@ class HomeCatalogSettingsSyncService @Inject constructor(
         withJwtRefreshRetry {
             postgrest.rpc("sync_push_home_catalog_settings", params)
         }
+        cachedSharedSettings = CachedSharedSettings(scope = syncScope, settingsJson = jsonElement)
     }
 
-    private suspend fun fetchBestRemotePayload(
-        profileId: Int,
-        localPayload: SyncHomeCatalogPayload
-    ): RemoteHomeCatalogSettings? {
-        val shared = fetchRemotePayload(
-            profileId = profileId,
-            platform = HOME_CATALOG_SHARED_SYNC_PLATFORM,
-            localPayload = localPayload
-        )
-        val legacyRows = HOME_CATALOG_LEGACY_SYNC_PLATFORMS
-            .mapNotNull { platform ->
-                fetchRemotePayload(
-                    profileId = profileId,
-                    platform = platform,
-                    localPayload = localPayload
-                )
-            }
-        val rows = listOfNotNull(shared) + legacyRows
-        val selected = if (shared?.payload?.items?.isNotEmpty() == true) {
-            shared
-        } else {
-            legacyRows
-                .filter { it.payload.items.isNotEmpty() }
-                .maxByOrNull { it.updatedAt.orEmpty() }
-                ?: shared
-                ?: legacyRows.maxByOrNull { it.updatedAt.orEmpty() }
-        }
-
-        return selected?.withNewestStandaloneSettings(rows)
-    }
-
-    private suspend fun fetchRemotePayload(
-        profileId: Int,
-        platform: String,
-        localPayload: SyncHomeCatalogPayload
-    ): RemoteHomeCatalogSettings? {
-        val blob = fetchRemoteBlob(profileId, platform) ?: return null
-        val payload = decodePayloadPreservingLocalDefaults(blob.settingsJson, localPayload)
-        if (payload == null) {
-            Log.w(TAG, "Pull parse failure profile=$profileId platform=$platform")
-            return null
-        }
-        return RemoteHomeCatalogSettings(
-            payload = payload,
-            updatedAt = blob.updatedAt,
-            hasHideUnreleasedContent = blob.settingsJson.containsKey(HIDE_UNRELEASED_CONTENT_KEY)
-        )
-    }
-
-    private fun RemoteHomeCatalogSettings.withNewestStandaloneSettings(
-        rows: List<RemoteHomeCatalogSettings>
-    ): RemoteHomeCatalogSettings {
-        val hideUnreleasedSource = rows
-            .filter { it.hasHideUnreleasedContent }
-            .maxByOrNull { it.updatedAt.orEmpty() }
-
-        return copy(
-            payload = payload.copy(
-                hideUnreleasedContent = hideUnreleasedSource?.payload?.hideUnreleasedContent
-                    ?: payload.hideUnreleasedContent
-            )
-        )
-    }
-
-    private suspend fun fetchRemoteBlob(
-        profileId: Int,
-        platform: String
-    ): SupabaseHomeCatalogSettingsBlob? {
+    private suspend fun fetchRemoteBlob(profileId: Int): SupabaseHomeCatalogSettingsBlob? {
         val params = buildJsonObject {
             put("p_profile_id", profileId)
-            put("p_platform", platform)
+            put("p_platform", HOME_CATALOG_SHARED_SYNC_PLATFORM)
         }
         val response = withJwtRefreshRetry {
             postgrest.rpc("sync_pull_home_catalog_settings", params)
@@ -276,16 +238,21 @@ class HomeCatalogSettingsSyncService @Inject constructor(
         )
     }.getOrNull()
 
-    private suspend fun mergedSharedPayloadJson(
-        profileId: Int,
+    private fun mergedSharedPayloadJson(
+        syncScope: HomeCatalogSyncScope,
         payload: SyncHomeCatalogPayload
     ): JsonObject {
         val localJson = json.encodeToJsonElement(SyncHomeCatalogPayload.serializer(), payload).jsonObject
-        val remoteJson = fetchRemoteBlob(profileId, HOME_CATALOG_SHARED_SYNC_PLATFORM)?.settingsJson
-        return buildJsonObject {
-            remoteJson?.forEach { (key, value) -> put(key, value) }
-            localJson.forEach { (key, value) -> put(key, value) }
-        }
+        val remoteJson = cachedSharedSettings
+            ?.takeIf { cached -> cached.scope == syncScope }
+            ?.settingsJson
+        return mergeHomeCatalogSettingsJson(remoteJson, localJson)
+    }
+
+    private fun currentScope(profileId: Int): HomeCatalogSyncScope? {
+        val state = authManager.authState.value as? AuthState.FullAccount ?: return null
+        if (profileManager.activeProfileId.value != profileId) return null
+        return HomeCatalogSyncScope(userId = state.userId, profileId = profileId)
     }
 
 }

--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSyncService.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.core.sync
 
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.profile.ProfileManager
@@ -8,9 +9,12 @@ import com.nuvio.tv.data.remote.supabase.SupabaseProfileLockState
 import com.nuvio.tv.data.remote.supabase.SupabaseProfile
 import com.nuvio.tv.data.remote.supabase.SupabaseProfilePinVerifyResult
 import com.nuvio.tv.domain.model.UserProfile
+import com.nuvio.tv.domain.model.AuthState
 import io.github.jan.supabase.postgrest.Postgrest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -19,6 +23,19 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "ProfileSyncService"
+private const val PROFILE_PULL_MIN_INTERVAL_MS = 10_000L
+
+internal data class ProfilePullFreshness(
+    val userId: String? = null,
+    val pulledAtMs: Long = 0L
+) {
+    fun isRecent(candidateUserId: String, nowMs: Long): Boolean {
+        return userId == candidateUserId &&
+            pulledAtMs > 0L &&
+            nowMs >= pulledAtMs &&
+            nowMs - pulledAtMs < PROFILE_PULL_MIN_INTERVAL_MS
+    }
+}
 
 sealed class SetProfilePinResult {
     object Success : SetProfilePinResult()
@@ -34,6 +51,10 @@ class ProfileSyncService @Inject constructor(
     private val profileManager: ProfileManager,
     private val syncClientIdentity: SyncClientIdentity
 ) {
+    private val pullMutex = Mutex()
+    private var pullFreshness = ProfilePullFreshness()
+    private var lastPulledProfiles = emptyList<UserProfile>()
+
     private suspend fun <T> withJwtRefreshRetry(block: suspend () -> T): T {
         return try {
             block()
@@ -78,38 +99,53 @@ class ProfileSyncService @Inject constructor(
         }
     }
 
-    suspend fun pullFromRemote(): Result<List<UserProfile>> = withContext(Dispatchers.IO) {
-        try {
-            val response = withJwtRefreshRetry {
-                postgrest.rpc("sync_pull_profiles")
+    suspend fun pullFromRemote(force: Boolean = false): Result<List<UserProfile>> = withContext(Dispatchers.IO) {
+        pullMutex.withLock {
+            val userId = (authManager.authState.value as? AuthState.FullAccount)?.userId
+            val now = SystemClock.elapsedRealtime()
+            if (!force && userId != null && pullFreshness.isRecent(userId, now)) {
+                return@withLock Result.success(lastPulledProfiles)
             }
-            val remote = response.decodeList<SupabaseProfile>()
+            try {
+                val response = withJwtRefreshRetry {
+                    postgrest.rpc("sync_pull_profiles")
+                }
+                val remote = response.decodeList<SupabaseProfile>()
 
-            Log.d(TAG, "pullFromRemote: fetched ${remote.size} profiles from Supabase")
+                Log.d(TAG, "pullFromRemote: fetched ${remote.size} profiles from Supabase")
 
-            val profiles = remote.map { entry ->
-                UserProfile(
-                    id = entry.profileIndex,
-                    name = entry.name,
-                    avatarColorHex = entry.avatarColorHex,
-                    usesPrimaryAddons = entry.usesPrimaryAddons,
-                    usesPrimaryPlugins = entry.usesPrimaryPlugins,
-                    avatarId = entry.avatarId,
-                    avatarUrl = entry.avatarUrl,
-                    profileBackgroundId = entry.profileBackgroundId,
-                    profileBackgroundUrl = entry.profileBackgroundUrl
-                )
+                val profiles = remote.map { entry ->
+                    UserProfile(
+                        id = entry.profileIndex,
+                        name = entry.name,
+                        avatarColorHex = entry.avatarColorHex,
+                        usesPrimaryAddons = entry.usesPrimaryAddons,
+                        usesPrimaryPlugins = entry.usesPrimaryPlugins,
+                        avatarId = entry.avatarId,
+                        avatarUrl = entry.avatarUrl,
+                        profileBackgroundId = entry.profileBackgroundId,
+                        profileBackgroundUrl = entry.profileBackgroundUrl
+                    )
+                }
+
+                if (profiles.isNotEmpty()) {
+                    profileDataStore.replaceAllProfiles(profiles)
+                    Log.d(TAG, "Merged ${profiles.size} remote profiles into local store")
+                }
+
+                val currentUserId = (authManager.authState.value as? AuthState.FullAccount)?.userId
+                if (userId != null && currentUserId == userId) {
+                    lastPulledProfiles = profiles
+                    pullFreshness = ProfilePullFreshness(
+                        userId = userId,
+                        pulledAtMs = SystemClock.elapsedRealtime()
+                    )
+                }
+                Result.success(profiles)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to pull profiles from remote", e)
+                Result.failure(e)
             }
-
-            if (profiles.isNotEmpty()) {
-                profileDataStore.replaceAllProfiles(profiles)
-                Log.d(TAG, "Merged ${profiles.size} remote profiles into local store")
-            }
-
-            Result.success(profiles)
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to pull profiles from remote", e)
-            Result.failure(e)
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/core/sync/ProviderCredentialModels.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProviderCredentialModels.kt
@@ -45,3 +45,11 @@ internal data class ProviderCredentialSnapshot(
         )
     }
 }
+
+internal fun shouldSeedProviderCredentials(
+    snapshot: ProviderCredentialSnapshot,
+    rows: List<SupabaseProviderCredential>
+): Boolean {
+    val remoteProviders = rows.mapTo(mutableSetOf()) { row -> row.provider.lowercase() }
+    return snapshot.values.any { credential -> credential.provider.lowercase() !in remoteProviders }
+}

--- a/app/src/main/java/com/nuvio/tv/core/sync/ProviderCredentialSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProviderCredentialSyncService.kt
@@ -101,8 +101,10 @@ class ProviderCredentialSyncService @Inject constructor(
                     }
                 }
 
-                seedSnapshot(localSnapshot)
                 val rows = pullRows(profileId)
+                if (shouldSeedProviderCredentials(localSnapshot, rows)) {
+                    seedSnapshot(localSnapshot)
+                }
                 requireCurrentScope(credentialScope)
                 val remoteSnapshot = localSnapshot.mergeRemote(rows)
                 val applied = remoteSnapshot != localSnapshot

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -28,8 +28,21 @@ import javax.inject.Singleton
 private const val TAG = "StartupSyncService"
 private const val FORCE_RESYNC_MIN_INTERVAL_MS = 30_000L
 private const val FULL_STARTUP_PULL_TTL_MS = 6 * 60 * 60 * 1000L
-private const val PERIODIC_WATCH_STATE_PULL_INTERVAL_MS = 120_000L
-private const val PERIODIC_LIBRARY_PULL_INTERVAL_MS = 240_000L
+private const val FOREGROUND_ACTIVITY_PULL_DELAY_MS = 2_500L
+private const val FOREGROUND_ACTIVITY_PULL_MIN_INTERVAL_MS = 2 * 60_000L
+private const val PERIODIC_SURFACE_PULL_INTERVAL_MS = 15 * 60_000L
+
+internal data class SurfacePullFreshness(
+    val key: String? = null,
+    val pulledAtMs: Long = 0L
+) {
+    fun isRecent(candidateKey: String, nowMs: Long, minIntervalMs: Long): Boolean {
+        return key == candidateKey &&
+            pulledAtMs > 0L &&
+            nowMs >= pulledAtMs &&
+            nowMs - pulledAtMs < minIntervalMs
+    }
+}
 
 @Singleton
 class StartupSyncService @Inject constructor(
@@ -55,11 +68,12 @@ class StartupSyncService @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var startupPullJob: Job? = null
-    private var periodicWatchStatePullJob: Job? = null
-    private var periodicLibraryPullJob: Job? = null
+    private var activityPullJob: Job? = null
+    private var periodicSurfacePullJob: Job? = null
     private var lastPulledKey: String? = null
     private var lastPulledIncludedProfileSettings: Boolean = false
     private var lastPulledAtMs: Long = 0L
+    private var activityPullFreshness = SurfacePullFreshness()
     @Volatile
     private var forceSyncRequested: Boolean = false
     @Volatile
@@ -86,9 +100,14 @@ class StartupSyncService @Inject constructor(
                     is AuthState.SignedOut -> {
                         startupPullJob?.cancel()
                         startupPullJob = null
+                        activityPullJob?.cancel()
+                        activityPullJob = null
+                        periodicSurfacePullJob?.cancel()
+                        periodicSurfacePullJob = null
                         lastPulledKey = null
                         lastPulledIncludedProfileSettings = false
                         lastPulledAtMs = 0L
+                        activityPullFreshness = SurfacePullFreshness()
                         forceSyncRequested = false
                         forceSyncIncludesProfileSettings = true
                         pendingResyncKey = null
@@ -101,41 +120,18 @@ class StartupSyncService @Inject constructor(
     }
 
     fun startPeriodicSurfacePulls() {
-        if (periodicWatchStatePullJob?.isActive != true) {
-            periodicWatchStatePullJob = scope.launch {
-                while (true) {
-                    delay(PERIODIC_WATCH_STATE_PULL_INTERVAL_MS)
-                    try {
-                        pullPeriodicWatchState()
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Periodic watch state pull failed", e)
-                    }
-                }
-            }
-        }
-        if (periodicLibraryPullJob?.isActive != true) {
-            periodicLibraryPullJob = scope.launch {
-                while (true) {
-                    delay(PERIODIC_LIBRARY_PULL_INTERVAL_MS)
-                    try {
-                        pullPeriodicLibrary()
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Periodic library pull failed", e)
-                    }
-                }
+        if (periodicSurfacePullJob?.isActive == true) return
+        periodicSurfacePullJob = scope.launch {
+            while (true) {
+                delay(PERIODIC_SURFACE_PULL_INTERVAL_MS)
+                scheduleActivityPull(reason = "periodic")
             }
         }
     }
 
     fun stopPeriodicSurfacePulls() {
-        periodicWatchStatePullJob?.cancel()
-        periodicWatchStatePullJob = null
-        periodicLibraryPullJob?.cancel()
-        periodicLibraryPullJob = null
+        periodicSurfacePullJob?.cancel()
+        periodicSurfacePullJob = null
     }
 
     fun requestSyncNow(includeProfileSettings: Boolean = true) {
@@ -155,17 +151,11 @@ class StartupSyncService @Inject constructor(
     }
 
     fun requestForegroundSync() {
-        when (val state = authManager.authState.value) {
-            is AuthState.FullAccount -> {
-                scheduleStartupPull(
-                    userId = state.userId,
-                    force = false,
-                    includeProfileSettings = true,
-                    allowWarmRepeat = true
-                )
-            }
-            else -> Unit
-        }
+        scheduleActivityPull(
+            reason = "foreground",
+            delayMs = FOREGROUND_ACTIVITY_PULL_DELAY_MS,
+            minIntervalMs = FOREGROUND_ACTIVITY_PULL_MIN_INTERVAL_MS
+        )
     }
 
     fun requestAddonSyncNow() {
@@ -271,8 +261,41 @@ class StartupSyncService @Inject constructor(
         }
     }
 
-    private suspend fun pullPeriodicWatchState() {
-        if (authManager.authState.value !is AuthState.FullAccount) return
+    private fun scheduleActivityPull(
+        reason: String,
+        delayMs: Long = 0L,
+        minIntervalMs: Long = 0L
+    ): Boolean {
+        val state = authManager.authState.value as? AuthState.FullAccount ?: return false
+        val key = pullKey(state.userId)
+        val now = SystemClock.elapsedRealtime()
+        if (startupPullJob?.isActive == true || activityPullJob?.isActive == true) return false
+        if (activityPullFreshness.isRecent(key, now, minIntervalMs)) return false
+
+        activityPullJob = scope.launch {
+            if (delayMs > 0L) delay(delayMs)
+            val currentState = authManager.authState.value as? AuthState.FullAccount ?: return@launch
+            if (pullKey(currentState.userId) != key || startupPullJob?.isActive == true) return@launch
+            val profileId = profileManager.activeProfileId.value
+            Log.d(TAG, "Activity sync started profile=$profileId reason=$reason")
+            val succeeded = coroutineScope {
+                val watchState = async { pullPeriodicWatchState() }
+                val library = async { pullPeriodicLibrary() }
+                watchState.await() && library.await()
+            }
+            if (succeeded) {
+                activityPullFreshness = SurfacePullFreshness(
+                    key = key,
+                    pulledAtMs = SystemClock.elapsedRealtime()
+                )
+            }
+            Log.d(TAG, "Activity sync completed profile=$profileId reason=$reason succeeded=$succeeded")
+        }
+        return true
+    }
+
+    private suspend fun pullPeriodicWatchState(): Boolean {
+        if (authManager.authState.value !is AuthState.FullAccount) return false
 
         val profileId = profileManager.activeProfileId.value
         val shouldUseSupabaseWatchProgressSync = watchProgressSyncService.shouldUseSupabaseWatchProgressSync()
@@ -284,25 +307,27 @@ class StartupSyncService @Inject constructor(
         )
 
         if (shouldUseSupabaseWatchProgressSync) {
-            pullWatchedItemsDelta(profileId)
-            syncWatchProgressDelta(
+            val watchedItemsSucceeded = pullWatchedItemsDelta(profileId)
+            val watchProgressSucceeded = syncWatchProgressDelta(
                 profileId = profileId,
                 pushUnsynced = true,
                 failureMessage = "Periodic watch progress pull failed"
-            )
+            ).isSuccess
+            return watchedItemsSucceeded && watchProgressSucceeded
         } else {
             watchProgressRepository.hasCompletedInitialPull = true
             watchProgressRepository.hasCompletedInitialWatchedItemsPull = true
             Log.d(TAG, "Skipping periodic Supabase watch state pull for profile $profileId because a tracking provider is active")
+            return true
         }
     }
 
-    private suspend fun pullPeriodicLibrary() {
-        if (authManager.authState.value !is AuthState.FullAccount) return
+    private suspend fun pullPeriodicLibrary(): Boolean {
+        if (authManager.authState.value !is AuthState.FullAccount) return false
 
         val profileId = profileManager.activeProfileId.value
         Log.d(TAG, "Periodic library pull requested profile=$profileId")
-        pullNuvioLibrary(profileId)
+        return pullNuvioLibrary(profileId)
     }
 
     private fun pullKey(userId: String): String {
@@ -313,14 +338,13 @@ class StartupSyncService @Inject constructor(
     private fun scheduleStartupPull(
         userId: String,
         force: Boolean = false,
-        includeProfileSettings: Boolean = true,
-        allowWarmRepeat: Boolean = false
+        includeProfileSettings: Boolean = true
     ): Boolean {
         val key = pullKey(userId)
         val now = SystemClock.elapsedRealtime()
         val sameKey = lastPulledKey == key
         val coversProfileSettings = !includeProfileSettings || lastPulledIncludedProfileSettings
-        if (!force && sameKey && coversProfileSettings && !allowWarmRepeat) {
+        if (!force && sameKey && coversProfileSettings) {
             return false
         }
         if (
@@ -342,6 +366,8 @@ class StartupSyncService @Inject constructor(
             }
             return false
         }
+        activityPullJob?.cancel()
+        activityPullJob = null
 
         startupPullJob = scope.launch {
             val maxAttempts = 3
@@ -356,6 +382,10 @@ class StartupSyncService @Inject constructor(
                     lastPulledKey = key
                     lastPulledIncludedProfileSettings = includeProfileSettings
                     lastPulledAtMs = SystemClock.elapsedRealtime()
+                    activityPullFreshness = SurfacePullFreshness(
+                        key = key,
+                        pulledAtMs = lastPulledAtMs
+                    )
                     syncCompleted = true
                     break
                 }
@@ -609,16 +639,16 @@ class StartupSyncService @Inject constructor(
         }
     }
 
-    private suspend fun pullNuvioLibrary(profileId: Int) {
+    private suspend fun pullNuvioLibrary(profileId: Int): Boolean {
         val isTrackingLibrary = libraryRepository.sourceMode.first() != LibrarySourceMode.LOCAL
         if (isTrackingLibrary) {
             libraryRepository.hasCompletedInitialPull = true
             Log.d(TAG, "Skipping Nuvio library pull for profile $profileId because a tracking library provider is active")
-            return
+            return true
         }
 
         libraryRepository.isSyncingFromRemote = true
-        try {
+        return try {
             val result = librarySyncService.syncFromRemote(profileId).getOrElse { throw it }
             libraryRepository.hasCompletedInitialPull = true
             Log.d(
@@ -626,9 +656,11 @@ class StartupSyncService @Inject constructor(
                 "Library delta pull completed profile=$profileId snapshot=${result.usedSnapshot} " +
                     "upserts=${result.appliedUpserts} deletes=${result.appliedDeletes}"
             )
+            true
         } catch (e: Exception) {
             libraryRepository.hasCompletedInitialPull = true
             Log.e(TAG, "Periodic Nuvio library pull failed profile=$profileId", e)
+            false
         } finally {
             libraryRepository.isSyncingFromRemote = false
         }
@@ -670,8 +702,8 @@ class StartupSyncService @Inject constructor(
     private suspend fun pullWatchedItemsDelta(
         profileId: Int,
         pushUnsynced: Boolean = true
-    ) {
-        try {
+    ): Boolean {
+        return try {
             Log.d(TAG, "Starting watched items delta sync for profile $profileId")
             val watchedItemsResult = watchedItemsSyncService.syncDeltaFromRemote(profileId).getOrElse { throw it }
             watchProgressRepository.hasCompletedInitialWatchedItemsPull = true
@@ -683,8 +715,10 @@ class StartupSyncService @Inject constructor(
                 Log.d(TAG, "Detected unsynced watched items, pushing to remote")
                 watchedItemsSyncService.pushToRemote(profileId)
             }
+            true
         } catch (e: Exception) {
             Log.e(TAG, "Failed to pull watched items, continuing with other syncs", e)
+            false
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -248,7 +248,7 @@ class StartupSyncService @Inject constructor(
                         }
                 }
                 "profiles" -> {
-                    profileSyncService.pullFromRemote()
+                    profileSyncService.pullFromRemote(force = true)
                         .onSuccess { profiles ->
                             Log.d(TAG, "Realtime profiles pull completed count=${profiles.size}")
                         }

--- a/app/src/main/java/com/nuvio/tv/data/local/AddonPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/AddonPreferences.kt
@@ -95,9 +95,10 @@ class AddonPreferences @Inject constructor(
         }
     }
 
-    suspend fun addAddon(url: String) {
+    suspend fun addAddon(url: String): Boolean {
            val active = profileManager.activeProfile
-           if (active != null && !active.isPrimary && active.usesPrimaryAddons) return
+           if (active != null && !active.isPrimary && active.usesPrimaryAddons) return false
+        var changed = false
         store().edit { preferences ->
             val current = getCurrentList(preferences)
             val normalizedUrl = canonicalizeUrl(url)
@@ -106,12 +107,15 @@ class AddonPreferences @Inject constructor(
             val states = getCurrentEnabledStates(preferences).toMutableMap()
             states[normalizedUrl] = true
             preferences[addonEnabledStatesKey] = gson.toJson(states)
+            changed = true
         }
+        return changed
     }
 
-    suspend fun removeAddon(url: String) {
+    suspend fun removeAddon(url: String): Boolean {
            val active = profileManager.activeProfile
-           if (active != null && !active.isPrimary && active.usesPrimaryAddons) return
+           if (active != null && !active.isPrimary && active.usesPrimaryAddons) return false
+        var changed = false
         store().edit { preferences ->
             val current = getCurrentList(preferences).toMutableList()
             val normalizedUrl = canonicalizeUrl(url)
@@ -122,34 +126,47 @@ class AddonPreferences @Inject constructor(
             if (indexToRemove != -1) {
                 current.removeAt(indexToRemove)
             }
+            if (indexToRemove == -1) return@edit
             preferences[orderedUrlsKey] = gson.toJson(current)
             val states = getCurrentEnabledStates(preferences).toMutableMap()
             states.remove(normalizedUrl)
             preferences[addonEnabledStatesKey] = gson.toJson(states)
+            changed = true
         }
+        return changed
     }
 
-    suspend fun setAddonOrder(urls: List<String>) {
+    suspend fun setAddonOrder(urls: List<String>): Boolean {
             val active = profileManager.activeProfile
-            if (active != null && !active.isPrimary && active.usesPrimaryAddons) return
+            if (active != null && !active.isPrimary && active.usesPrimaryAddons) return false
+        var changed = false
         store().edit { preferences ->
             val orderedUrls = urls.map(::canonicalizeUrl)
+            val currentUrls = getCurrentList(preferences).map(::canonicalizeUrl)
+            if (orderedUrls == currentUrls) return@edit
             preferences[orderedUrlsKey] = gson.toJson(orderedUrls)
             val currentStates = getCurrentEnabledStates(preferences)
             preferences[addonEnabledStatesKey] = gson.toJson(
                 orderedUrls.associateWith { url -> currentStates[url] ?: true }
             )
+            changed = true
         }
+        return changed
     }
 
-    suspend fun setAddonEnabled(url: String, enabled: Boolean) {
+    suspend fun setAddonEnabled(url: String, enabled: Boolean): Boolean {
         val active = profileManager.activeProfile
-        if (active != null && !active.isPrimary && active.usesPrimaryAddons) return
+        if (active != null && !active.isPrimary && active.usesPrimaryAddons) return false
+        var changed = false
         store().edit { preferences ->
             val states = getCurrentEnabledStates(preferences).toMutableMap()
-            states[canonicalizeUrl(url)] = enabled
+            val normalizedUrl = canonicalizeUrl(url)
+            if ((states[normalizedUrl] ?: true) == enabled) return@edit
+            states[normalizedUrl] = enabled
             preferences[addonEnabledStatesKey] = gson.toJson(states)
+            changed = true
         }
+        return changed
     }
 
     suspend fun setAddonEnabledStates(states: Map<String, Boolean>) {

--- a/app/src/main/java/com/nuvio/tv/data/remote/supabase/AvatarRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/supabase/AvatarRepository.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.remote.supabase
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.data.local.MemberCatalogStorage
 import com.nuvio.tv.domain.model.ServerConfiguration
@@ -27,6 +28,13 @@ import javax.inject.Singleton
 
 private const val MemberAvatarBucket = "membership-profile-avatars"
 private const val MemberAvatarTag = "MemberAvatars"
+private const val AvatarCatalogRefreshIntervalMs = 15 * 60_000L
+
+internal fun isAvatarCatalogRefreshDue(lastRefreshAtMs: Long, nowMs: Long): Boolean {
+    return lastRefreshAtMs <= 0L ||
+        nowMs < lastRefreshAtMs ||
+        nowMs - lastRefreshAtMs >= AvatarCatalogRefreshIntervalMs
+}
 
 @Serializable
 private data class StoredAvatarCatalogPayload(
@@ -73,6 +81,8 @@ class AvatarRepository @Inject constructor(
     }
     private var standardRefreshJob: Job? = null
     private var memberRefreshJob: Job? = null
+    private var lastStandardRefreshAtMs = 0L
+    private var lastMemberRefreshAtMs = 0L
 
     suspend fun getAvatarCatalog(hasMemberAccess: Boolean = false): List<AvatarCatalogItem> {
         val hadStandardCache = cachedStandardCatalog != null
@@ -97,6 +107,7 @@ class AvatarRepository @Inject constructor(
         standardCatalogLoaded = true
         val catalog = remote.map(::toStandardCatalogItem)
         cachedStandardCatalog = catalog
+        lastStandardRefreshAtMs = SystemClock.elapsedRealtime()
         saveStoredCatalog()
         return catalog
     }
@@ -118,6 +129,7 @@ class AvatarRepository @Inject constructor(
         }
         memberMetadata = remote
         memberCatalogLoaded = true
+        lastMemberRefreshAtMs = SystemClock.elapsedRealtime()
         saveStoredCatalog()
         val catalog = coroutineScope {
             remote.map { item ->
@@ -153,10 +165,13 @@ class AvatarRepository @Inject constructor(
         memberMetadata = emptyList()
         standardCatalogLoaded = false
         memberCatalogLoaded = false
+        lastStandardRefreshAtMs = 0L
+        lastMemberRefreshAtMs = 0L
     }
 
     private fun refreshStandardCatalogInBackground() {
         if (standardRefreshJob?.isActive == true) return
+        if (!isAvatarCatalogRefreshDue(lastStandardRefreshAtMs, SystemClock.elapsedRealtime())) return
         standardRefreshJob = scope.launch {
             try {
                 fetchStandardAvatarCatalog()
@@ -170,6 +185,7 @@ class AvatarRepository @Inject constructor(
 
     private fun refreshMemberCatalogInBackground() {
         if (memberRefreshJob?.isActive == true) return
+        if (!isAvatarCatalogRefreshDue(lastMemberRefreshAtMs, SystemClock.elapsedRealtime())) return
         memberRefreshJob = scope.launch {
             try {
                 fetchMemberAvatarCatalog()

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -242,28 +242,28 @@ class AddonRepositoryImpl @Inject constructor(
 
     override suspend fun addAddon(url: String) {
         val cleanUrl = canonicalizeUrl(url)
-        preferences.addAddon(cleanUrl)
+        if (!preferences.addAddon(cleanUrl)) return
         triggerRemoteSync()
     }
 
     override suspend fun removeAddon(url: String) {
         val cleanUrl = canonicalizeUrl(url)
+        if (!preferences.removeAddon(cleanUrl)) return
         if (removeCachedManifest(cleanUrl)) {
             persistManifestCacheToDisk()
             bumpManifestCacheRevision()
         }
-        preferences.removeAddon(cleanUrl)
         triggerRemoteSync()
     }
 
     override suspend fun setAddonOrder(urls: List<String>) {
-        preferences.setAddonOrder(urls)
+        if (!preferences.setAddonOrder(urls)) return
         triggerRemoteSync()
     }
 
     override suspend fun setAddonEnabled(url: String, enabled: Boolean) {
         val cleanUrl = canonicalizeUrl(url)
-        preferences.setAddonEnabled(cleanUrl, enabled)
+        if (!preferences.setAddonEnabled(cleanUrl, enabled)) return
         if (enabled && getCachedManifest(cleanUrl) == null) {
             fetchAddon(cleanUrl)
         }

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.sync.WatchProgressSyncService
 import com.nuvio.tv.core.sync.WatchedItemsSyncService
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressSource
@@ -61,6 +62,44 @@ import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.async
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val REMOTE_PROGRESS_WRITE_DEDUP_WINDOW_MS = 5_000L
+
+private data class RemoteProgressWriteKey(
+    val profileId: Int,
+    val progressKey: String
+)
+
+private data class RemoteProgressWrite(
+    val progress: WatchProgress,
+    val sentAtMs: Long
+)
+
+internal class RemoteProgressWriteDeduplicator(
+    private val windowMs: Long = REMOTE_PROGRESS_WRITE_DEDUP_WINDOW_MS
+) {
+    private val lock = Any()
+    private val recentWrites = mutableMapOf<RemoteProgressWriteKey, RemoteProgressWrite>()
+
+    fun shouldSend(
+        profileId: Int,
+        progressKey: String,
+        progress: WatchProgress,
+        nowMs: Long
+    ): Boolean = synchronized(lock) {
+        recentWrites.entries.removeAll { (_, write) ->
+            val elapsedMs = nowMs - write.sentAtMs
+            elapsedMs < 0L || elapsedMs >= windowMs
+        }
+        val key = RemoteProgressWriteKey(profileId, progressKey)
+        val normalizedProgress = progress.copy(lastWatched = 0L)
+        if (recentWrites[key]?.progress == normalizedProgress) {
+            return@synchronized false
+        }
+        recentWrites[key] = RemoteProgressWrite(normalizedProgress, nowMs)
+        true
+    }
+}
 
 internal fun resolveProviderEpisodeProgress(
     contentId: String,
@@ -122,6 +161,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
     private var watchedItemsSyncJob: Job? = null
     private val pendingWatchedItemsLock = Any()
     private val pendingWatchedItems = linkedMapOf<WatchedItemSyncKey, WatchedItem>()
+    private val remoteProgressWriteDeduplicator = RemoteProgressWriteDeduplicator()
     var isSyncingFromRemote = false
     var hasCompletedInitialPull = false
     var hasCompletedInitialWatchedItemsPull = false
@@ -673,12 +713,21 @@ class WatchProgressRepositoryImpl @Inject constructor(
             traktSettingsDataStore.removeDismissedNextUpKeysForContent(progress.contentId)
         }
         val profileId = profileManager.activeProfileId.value
+        val progressKey = progressKey(progress)
+        val shouldPushRemote = syncRemote &&
+            authManager.isAuthenticated &&
+            remoteProgressWriteDeduplicator.shouldSend(
+                profileId = profileId,
+                progressKey = progressKey,
+                progress = progress,
+                nowMs = SystemClock.elapsedRealtime()
+            )
         activeProgressProvider()?.applyOptimisticProgress(progress, quiet = !syncRemote)
         watchProgressPreferences.saveProgress(progress, profileId = profileId)
 
-        if (syncRemote && authManager.isAuthenticated) {
+        if (shouldPushRemote) {
             syncScope.launch(NonCancellable) {
-                watchProgressSyncService.pushSingleToRemote(progressKey(progress), progress, profileId)
+                watchProgressSyncService.pushSingleToRemote(progressKey, progress, profileId)
                     .onFailure { error ->
                         Log.w(TAG, "Failed single progress push; falling back to full sync next cycle", error)
                     }
@@ -688,7 +737,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
         if (progress.isCompleted()) {
             val watchedItem = progress.toWatchedItem()
             watchedItemsPreferences.markAsWatched(watchedItem, profileId = profileId)
-            if (syncRemote && authManager.isAuthenticated) {
+            if (shouldPushRemote) {
                 triggerWatchedItemsSync(listOf(watchedItem), profileId = profileId)
             }
             // Emit optimistic continue-watching update so the next episode

--- a/app/src/test/java/com/nuvio/tv/core/network/BackendRateLimitTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/network/BackendRateLimitTest.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.core.network
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackendRateLimitTest {
+    @Test
+    fun retryAfterSupportsSecondsAndHttpDates() {
+        assertEquals(30_000L, retryAfterDelayMillis("30", nowEpochMs = 0L))
+        assertEquals(
+            10_000L,
+            retryAfterDelayMillis(
+                retryAfterHeader = "Wed, 21 Oct 2015 07:28:00 GMT",
+                nowEpochMs = 1_445_412_470_000L
+            )
+        )
+        assertEquals(1_000L, retryAfterDelayMillis("invalid", nowEpochMs = 0L))
+    }
+
+    @Test
+    fun retryDelayUsesBoundedFallbackAndAddsJitter() {
+        assertEquals(1_250L, backendRetryDelayMillis(0, null, nowEpochMs = 0L, jitterMs = 250L))
+        assertEquals(30_500L, backendRetryDelayMillis(10, null, nowEpochMs = 0L, jitterMs = 500L))
+        assertEquals(60_250L, backendRetryDelayMillis(0, "60", nowEpochMs = 0L, jitterMs = 250L))
+    }
+
+    @Test
+    fun automaticRetriesAreLimitedToReads() {
+        assertTrue(isSafeBackendRetryRequest("GET", "/rest/v1/plugins"))
+        assertTrue(isSafeBackendRetryRequest("POST", "/rest/v1/rpc/sync_pull_library_delta"))
+        assertTrue(isSafeBackendRetryRequest("POST", "/rest/v1/rpc/get_my_member_access"))
+        assertFalse(isSafeBackendRetryRequest("POST", "/rest/v1/rpc/sync_push_watch_progress"))
+        assertFalse(isSafeBackendRetryRequest("POST", "/rest/v1/rpc/verify_profile_pin"))
+        assertFalse(isSafeBackendRetryRequest("DELETE", "/rest/v1/library"))
+    }
+
+    @Test
+    fun cooldownUsesRetryAfterForServiceUnavailableResponses() {
+        assertTrue(shouldApplyBackendCooldown(429, null))
+        assertTrue(shouldApplyBackendCooldown(503, "10"))
+        assertFalse(shouldApplyBackendCooldown(503, null))
+        assertFalse(shouldApplyBackendCooldown(500, "10"))
+    }
+
+    @Test
+    fun coordinatorDelaysRequestsUntilLongestCooldownExpires() = runBlocking {
+        var now = 1_000L
+        val waits = mutableListOf<Long>()
+        val coordinator = BackendRateLimitCoordinator(
+            currentTimeMillis = { now },
+            pause = { waitMs ->
+                waits += waitMs
+                now += waitMs
+            }
+        )
+
+        coordinator.record("2")
+        coordinator.record("5")
+        coordinator.record("1")
+        coordinator.awaitPermission()
+
+        assertEquals(listOf(5_000L), waits)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/sync/HomeCatalogSettingsSyncServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/HomeCatalogSettingsSyncServiceTest.kt
@@ -1,0 +1,25 @@
+package com.nuvio.tv.core.sync
+
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeCatalogSettingsSyncServiceTest {
+    @Test
+    fun sharedSettingsMergePreservesUnknownRemoteFields() {
+        val remote = buildJsonObject {
+            put("future_setting", "preserved")
+            put("hide_unreleased_content", false)
+        }
+        val local = buildJsonObject {
+            put("hide_unreleased_content", true)
+        }
+
+        val merged = mergeHomeCatalogSettingsJson(remote, local)
+
+        assertEquals("preserved", merged.getValue("future_setting").jsonPrimitive.content)
+        assertEquals(true, merged.getValue("hide_unreleased_content").jsonPrimitive.content.toBoolean())
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/sync/ProfilePullFreshnessTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/ProfilePullFreshnessTest.kt
@@ -1,0 +1,23 @@
+package com.nuvio.tv.core.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProfilePullFreshnessTest {
+    @Test
+    fun recentMatchingAccountPullIsFresh() {
+        val freshness = ProfilePullFreshness(userId = "user", pulledAtMs = 1_000L)
+
+        assertTrue(freshness.isRecent("user", nowMs = 10_999L))
+    }
+
+    @Test
+    fun differentExpiredOrFuturePullIsNotFresh() {
+        val freshness = ProfilePullFreshness(userId = "user", pulledAtMs = 1_000L)
+
+        assertFalse(freshness.isRecent("other", nowMs = 2_000L))
+        assertFalse(freshness.isRecent("user", nowMs = 11_000L))
+        assertFalse(freshness.isRecent("user", nowMs = 999L))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/sync/ProviderCredentialModelsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/ProviderCredentialModelsTest.kt
@@ -4,9 +4,53 @@ import com.nuvio.tv.data.remote.supabase.SupabaseProviderCredential
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ProviderCredentialModelsTest {
+    @Test
+    fun completeRemoteSnapshotDoesNotRequireSeeding() {
+        val snapshot = ProviderCredentialSnapshot(
+            profileId = 1,
+            values = listOf(
+                ProviderCredentialValue("debrid:torbox", "api_key", "local-torbox"),
+                ProviderCredentialValue("animeskip", "client_id", "local-anime")
+            )
+        )
+        val rows = listOf(
+            SupabaseProviderCredential(
+                provider = "DEBRID:TORBOX",
+                credentialJson = buildJsonObject { put("api_key", "remote") }
+            ),
+            SupabaseProviderCredential(
+                provider = "animeskip",
+                credentialJson = buildJsonObject { put("client_id", "remote") }
+            )
+        )
+
+        assertFalse(shouldSeedProviderCredentials(snapshot, rows))
+    }
+
+    @Test
+    fun missingRemoteProviderRequiresSeeding() {
+        val snapshot = ProviderCredentialSnapshot(
+            profileId = 1,
+            values = listOf(
+                ProviderCredentialValue("debrid:torbox", "api_key", "local-torbox"),
+                ProviderCredentialValue("animeskip", "client_id", "local-anime")
+            )
+        )
+        val rows = listOf(
+            SupabaseProviderCredential(
+                provider = "debrid:torbox",
+                credentialJson = buildJsonObject { put("api_key", "remote") }
+            )
+        )
+
+        assertTrue(shouldSeedProviderCredentials(snapshot, rows))
+    }
+
     @Test
     fun `remote values replace only supported local providers`() {
         val local = ProviderCredentialSnapshot(

--- a/app/src/test/java/com/nuvio/tv/core/sync/SurfacePullFreshnessTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/SurfacePullFreshnessTest.kt
@@ -1,0 +1,23 @@
+package com.nuvio.tv.core.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SurfacePullFreshnessTest {
+    @Test
+    fun recentMatchingPullIsFresh() {
+        val freshness = SurfacePullFreshness(key = "user_p1", pulledAtMs = 1_000L)
+
+        assertTrue(freshness.isRecent("user_p1", nowMs = 1_999L, minIntervalMs = 1_000L))
+    }
+
+    @Test
+    fun differentExpiredOrFuturePullIsNotFresh() {
+        val freshness = SurfacePullFreshness(key = "user_p1", pulledAtMs = 1_000L)
+
+        assertFalse(freshness.isRecent("user_p2", nowMs = 1_500L, minIntervalMs = 1_000L))
+        assertFalse(freshness.isRecent("user_p1", nowMs = 2_000L, minIntervalMs = 1_000L))
+        assertFalse(freshness.isRecent("user_p1", nowMs = 999L, minIntervalMs = 1_000L))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/remote/supabase/AvatarCatalogRefreshTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/remote/supabase/AvatarCatalogRefreshTest.kt
@@ -1,0 +1,23 @@
+package com.nuvio.tv.data.remote.supabase
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AvatarCatalogRefreshTest {
+    @Test
+    fun recentCatalogDoesNotRequireRefresh() {
+        val nowMs = 20 * 60_000L
+
+        assertFalse(isAvatarCatalogRefreshDue(lastRefreshAtMs = nowMs - 60_000L, nowMs = nowMs))
+    }
+
+    @Test
+    fun staleUninitializedOrFutureCatalogRequiresRefresh() {
+        val nowMs = 20 * 60_000L
+
+        assertTrue(isAvatarCatalogRefreshDue(lastRefreshAtMs = 0L, nowMs = nowMs))
+        assertTrue(isAvatarCatalogRefreshDue(lastRefreshAtMs = nowMs - 15 * 60_000L, nowMs = nowMs))
+        assertTrue(isAvatarCatalogRefreshDue(lastRefreshAtMs = nowMs + 1L, nowMs = nowMs))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/RemoteProgressWriteDeduplicatorTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/RemoteProgressWriteDeduplicatorTest.kt
@@ -1,0 +1,72 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.domain.model.WatchProgress
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteProgressWriteDeduplicatorTest {
+    @Test
+    fun identicalProgressIsSuppressedInsideWindow() {
+        val deduplicator = RemoteProgressWriteDeduplicator(windowMs = 5_000L)
+        val progress = progress(position = 30_000L, lastWatched = 1_000L)
+
+        assertTrue(deduplicator.shouldSend(1, "tt123_s1e1", progress, nowMs = 1_000L))
+        assertFalse(
+            deduplicator.shouldSend(
+                1,
+                "tt123_s1e1",
+                progress.copy(lastWatched = 1_100L),
+                nowMs = 1_100L
+            )
+        )
+    }
+
+    @Test
+    fun changedProgressIsSentInsideWindow() {
+        val deduplicator = RemoteProgressWriteDeduplicator(windowMs = 5_000L)
+        val progress = progress(position = 30_000L, lastWatched = 1_000L)
+
+        assertTrue(deduplicator.shouldSend(1, "tt123_s1e1", progress, nowMs = 1_000L))
+        assertTrue(
+            deduplicator.shouldSend(
+                1,
+                "tt123_s1e1",
+                progress.copy(position = 31_000L, lastWatched = 1_100L),
+                nowMs = 1_100L
+            )
+        )
+    }
+
+    @Test
+    fun identicalProgressIsSentAfterWindow() {
+        val deduplicator = RemoteProgressWriteDeduplicator(windowMs = 5_000L)
+        val progress = progress(position = 30_000L, lastWatched = 1_000L)
+
+        assertTrue(deduplicator.shouldSend(1, "tt123_s1e1", progress, nowMs = 1_000L))
+        assertTrue(
+            deduplicator.shouldSend(
+                1,
+                "tt123_s1e1",
+                progress.copy(lastWatched = 6_000L),
+                nowMs = 6_000L
+            )
+        )
+    }
+
+    private fun progress(position: Long, lastWatched: Long) = WatchProgress(
+        contentId = "tt123",
+        contentType = "series",
+        name = "Show",
+        poster = null,
+        backdrop = null,
+        logo = null,
+        videoId = "tt123:1:1",
+        season = 1,
+        episode = 1,
+        episodeTitle = "Episode",
+        position = position,
+        duration = 60_000L,
+        lastWatched = lastWatched
+    )
+}


### PR DESCRIPTION
## Summary

Reduce unnecessary backend traffic from sync work.

Updated areas:

- Startup and foreground sync now group watch-state and library pulls, avoid overlapping jobs, and reuse recent results.
- Periodic surface sync now runs every 15 minutes instead of using separate watch-state and library schedules.
- Profile pulls reuse results for 10 seconds, while avatar catalog refreshes wait 15 minutes.
- Addon, plugin, provider credential, and watch-progress updates skip writes when nothing changed.
- Home catalog sync reads only the shared settings row and preserves unknown fields when pushing updates.
- Safe read requests retry once after `429` or `503` responses and respect `Retry-After`.

## PR type

- [x] Behavior bug/regression fix

## Why

Returning to the app could start overlapping sync pulls. Some update paths also wrote the same data again even when nothing had changed, and home catalog sync still fetched legacy platform rows.

This caused extra backend traffic and grouped too many requests around startup and foreground events.

## Issue or approval

No linked issue - backend sync efficiency and rate-limit handling fix.

## UI / behavior impact

- No UI change.
- Foreground and periodic sync make fewer backend requests.
- Explicit sync requests and realtime profile updates can still force an immediate pull.
- Automatic retries only apply to safe read requests. Write requests are not retried.

## Policy check

- [x] This PR is focused on reducing redundant backend requests.
- [x] This PR does not include unrelated UI changes or refactors.
- [x] This PR does not add dependencies, migrations, or architecture changes.
- [x] Testing performed is listed below.

## Scope boundaries

- Does not change backend schemas or RPC contracts.
- Does not change local sync payload formats.
- Does not automatically retry write requests.
- Does not change the visible UI.

## Testing

Targeted Full Debug unit tests pass for:

- `BackendRateLimitTest`
- `HomeCatalogSettingsSyncServiceTest`
- `ProfilePullFreshnessTest`
- `ProviderCredentialModelsTest`
- `SurfacePullFreshnessTest`
- `AvatarCatalogRefreshTest`
- `RemoteProgressWriteDeduplicatorTest`

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - backend sync efficiency and rate-limit handling fix.
