### PR TITLE
Batch of small fixes - #3057, #3095, #3077, #3125, #2957, #3056

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbService.kt
@@ -24,11 +24,11 @@ private val TMDB_API_KEY = BuildConfig.TMDB_API_KEY
 class TmdbService @Inject constructor(
     private val tmdbApi: TmdbApi
 ) {
-    // Cache: IMDB ID -> TMDB ID
+    // Cache: IMDB ID -> TMDB ID (keyed by "$imdbId:$mediaType")
     private val imdbToTmdbCache = ConcurrentHashMap<String, Int>()
     
-    // Cache: TMDB ID -> IMDB ID  
-    private val tmdbToImdbCache = ConcurrentHashMap<Int, String>()
+    // Cache: TMDB ID -> IMDB ID (keyed by "$tmdbId:$mediaType")
+    private val tmdbToImdbCache = ConcurrentHashMap<String, String>()
 
     private val imdbToTmdbInFlight = ConcurrentHashMap<String, CompletableDeferred<Int?>>()
     private val tmdbToImdbInFlight = ConcurrentHashMap<String, CompletableDeferred<String?>>()
@@ -50,14 +50,16 @@ class TmdbService @Inject constructor(
             return@withContext null
         }
         
+        val normalizedType = normalizeMediaType(mediaType)
+        val cacheKey = "$imdbId:$normalizedType"
+
         // Check cache first
-        imdbToTmdbCache[imdbId]?.let { cached ->
-            Log.d(TAG, "Cache hit: IMDB $imdbId -> TMDB $cached")
+        imdbToTmdbCache[cacheKey]?.let { cached ->
+            Log.d(TAG, "Cache hit: IMDB $imdbId ($normalizedType) -> TMDB $cached")
             return@withContext cached
         }
         
-        val normalizedType = normalizeMediaType(mediaType)
-        val requestKey = "$imdbId:$normalizedType"
+        val requestKey = cacheKey
         val requestDeferred = CompletableDeferred<Int?>()
         imdbToTmdbInFlight.putIfAbsent(requestKey, requestDeferred)?.let { existing ->
             return@withContext existing.await()
@@ -96,8 +98,8 @@ class TmdbService @Inject constructor(
                 
                 // Cache both directions
                 cacheMutex.withLock {
-                    imdbToTmdbCache[imdbId] = found.id
-                    tmdbToImdbCache[found.id] = imdbId
+                    imdbToTmdbCache[cacheKey] = found.id
+                    tmdbToImdbCache["${found.id}:$normalizedType"] = imdbId
                 }
 
                 requestDeferred.complete(found.id)
@@ -129,14 +131,16 @@ class TmdbService @Inject constructor(
      * @return The IMDB ID, or null if not found
      */
     suspend fun tmdbToImdb(tmdbId: Int, mediaType: String): String? = withContext(Dispatchers.IO) {
+        val normalizedType = normalizeMediaType(mediaType)
+        val cacheKey = "$tmdbId:$normalizedType"
+
         // Check cache first
-        tmdbToImdbCache[tmdbId]?.let { cached ->
-            Log.d(TAG, "Cache hit: TMDB $tmdbId -> IMDB $cached")
+        tmdbToImdbCache[cacheKey]?.let { cached ->
+            Log.d(TAG, "Cache hit: TMDB $tmdbId ($normalizedType) -> IMDB $cached")
             return@withContext cached
         }
         
-        val normalizedType = normalizeMediaType(mediaType)
-        val requestKey = "$tmdbId:$normalizedType"
+        val requestKey = cacheKey
         val requestDeferred = CompletableDeferred<String?>()
         tmdbToImdbInFlight.putIfAbsent(requestKey, requestDeferred)?.let { existing ->
             return@withContext existing.await()
@@ -168,8 +172,8 @@ class TmdbService @Inject constructor(
                 
                 // Cache both directions
                 cacheMutex.withLock {
-                    tmdbToImdbCache[tmdbId] = imdbId
-                    imdbToTmdbCache[imdbId] = tmdbId
+                    tmdbToImdbCache[cacheKey] = imdbId
+                    imdbToTmdbCache["$imdbId:$normalizedType"] = tmdbId
                 }
 
                 requestDeferred.complete(imdbId)
@@ -256,13 +260,15 @@ class TmdbService @Inject constructor(
     /**
      * Pre-populate cache with known mappings
      */
-    fun preCacheMapping(imdbId: String, tmdbId: Int) {
-        imdbToTmdbCache[imdbId] = tmdbId
-        tmdbToImdbCache[tmdbId] = imdbId
+    fun preCacheMapping(imdbId: String, tmdbId: Int, mediaType: String = "movie") {
+        val normalizedType = normalizeMediaType(mediaType)
+        imdbToTmdbCache["$imdbId:$normalizedType"] = tmdbId
+        tmdbToImdbCache["$tmdbId:$normalizedType"] = imdbId
     }
 
     /** Returns the cached TMDB ID for an IMDB ID without making any network call. */
-    fun cachedTmdbId(imdbId: String): Int? = imdbToTmdbCache[imdbId]
+    fun cachedTmdbId(imdbId: String): Int? =
+        imdbToTmdbCache["$imdbId:movie"] ?: imdbToTmdbCache["$imdbId:tv"]
 
     fun apiKey(): String = TMDB_API_KEY
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/AudioSelectionOverlay.kt
@@ -414,6 +414,14 @@ private fun AudioControlsContent(
         canIncreaseCenterMix -> centerPlusFocusRequester
         else -> persistFocusRequester
     }
+    val persistUpFocusRequester = when {
+        canDecreaseCenterMix -> centerMinusFocusRequester
+        canIncreaseCenterMix -> centerPlusFocusRequester
+        canDecreaseAmp -> ampMinusFocusRequester
+        canIncreaseAmp -> ampPlusFocusRequester
+        canDecreaseDelay -> delayMinusFocusRequester
+        else -> delayPlusFocusRequester
+    }
     val delayPlusLeftFocusRequester = if (canDecreaseDelay) {
         delayMinusFocusRequester
     } else {
@@ -571,7 +579,7 @@ private fun AudioControlsContent(
                     .focusRequester(persistFocusRequester)
                     .focusProperties {
                         left = persistLeftFocusRequester
-                        up = firstCenterFocusRequester
+                        up = persistUpFocusRequester
                     },
                 colors = CardDefaults.colors(
                     containerColor = if (persistAmplification) NuvioTheme.colors.Secondary else Color.Transparent,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
@@ -66,15 +66,26 @@ internal fun PlayerRuntimeController.updateMediaSessionMetadata() {
     try {
         // Media3 MediaSession reads metadata from the player's current MediaItem.
         // Setting mediaMetadata on the player propagates to the session automatically.
-        _exoPlayer?.let { player ->
-            val current = player.currentMediaItem ?: return@let
-            val updated = current.buildUpon()
-                .apply {
-                    mediaId?.let(::setMediaId)
-                }
-                .setMediaMetadata(metadata)
-                .build()
-            player.replaceMediaItem(player.currentMediaItemIndex, updated)
+        val player = _exoPlayer
+        if (player != null) {
+            val current = player.currentMediaItem
+            if (current != null) {
+                val updated = current.buildUpon()
+                    .apply {
+                        mediaId?.let(::setMediaId)
+                    }
+                    .setMediaMetadata(metadata)
+                    .build()
+                player.replaceMediaItem(player.currentMediaItemIndex, updated)
+            } else {
+                // No current MediaItem yet (e.g. player just built, source not set).
+                // Set a placeholder MediaItem so the session advertises metadata immediately.
+                val placeholder = androidx.media3.common.MediaItem.Builder()
+                    .apply { mediaId?.let(::setMediaId) }
+                    .setMediaMetadata(metadata)
+                    .build()
+                player.setMediaItem(placeholder)
+            }
         }
         Log.d(
             PlayerRuntimeController.TAG,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1092,7 +1092,7 @@ internal fun PlayerRuntimeController.schedulePauseOverlay() {
         val anyPanelOpen = s.showSubtitleOverlay || s.showSubtitleStylePanel ||
             s.showSpeedDialog || s.showMoreDialog || s.showEpisodesPanel ||
             s.showSourcesPanel || s.showAudioOverlay || s.showStreamInfoOverlay ||
-            s.showSubtitleTimingDialog
+            s.showSubtitleTimingDialog || s.showSubtitleDelayOverlay
         if (!s.isPlaying && s.pauseOverlayEnabled && s.error == null && !anyPanelOpen) {
             _uiState.update { it.copy(showPauseOverlay = true, showControls = false) }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -922,7 +922,8 @@ private fun SearchInputField(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = NuvioTheme.spacing.xxxl),
+            .padding(horizontal = NuvioTheme.spacing.xxxl)
+            .focusGroup(),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (showDiscoverButton) {

--- a/app/src/main/java/com/nuvio/tv/ui/util/LanguageUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/LanguageUtils.kt
@@ -12,6 +12,12 @@ fun String.localizeEpisodeTitle(appContext: Context): String {
     return "${appContext.getString(R.string.episodes_episode)} $number"
 }
 
+internal val LANGUAGE_DISPLAY_OVERRIDES = mapOf(
+    "id" to "Indonesia",
+    "in" to "Indonesia",
+    "ind" to "Indonesia"
+)
+
 internal val LANGUAGE_OVERRIDES = mapOf(
     "pt" to "pt",
     "pt-pt" to "pt",
@@ -134,7 +140,9 @@ fun languageCodeToName(code: String): String {
     if (lowerCode == "und" || lowerCode == "unknown" || lowerCode == "unk") {
         return "Unknown"
     }
+    LANGUAGE_DISPLAY_OVERRIDES[lowerCode]?.let { return it }
     val bcp47 = LANGUAGE_OVERRIDES[lowerCode] ?: lowerCode
+    LANGUAGE_DISPLAY_OVERRIDES[bcp47]?.let { return it }
     return try {
         val locale = Locale.forLanguageTag(bcp47)
         val name = if (locale.country.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Six focused fixes for reported bugs:

1. TMDB cache now includes media type in keys, preventing movie/TV ID collisions (#3057)
2. Search screen: pressing Left from recent searches navigates to sidebar instead of Discover button (#3095)
3. Indonesian language no longer mislabeled as "Melayu" in subtitle/audio selectors (#3077)
4. Pause overlay no longer appears while adjusting subtitle delay (#3125)
5. Audio settings: Up navigation from "Persist between sessions" toggle now works (#2957)
6. MediaSession metadata update when currentMediaItem is null (partial fix for #3056)

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

1. **#3057** - TMDB movie and TV IDs use separate namespaces. Same numeric ID (e.g. 70793) can be a movie ("Le Grand Soir") and a TV show ("Oasis"). Cache stored bare numeric key without media type, causing cross-contamination.
2. **#3095** - Discover button in the search input Row intercepted Left focus from recent searches below due to Compose focus search finding it before exiting to the sidebar.
3. **#3077** - Android's `Locale.forLanguageTag("id").getDisplayLanguage()` returns "Melayu" on some devices due to legacy Java `id`/`in` aliasing. Explicit display override fixes this.
4. **#3125** - `schedulePauseOverlay()` checked for open panels but missed `showSubtitleDelayOverlay`, causing the pause overlay to appear while user adjusts subtitle timing.
5. **#2957** - Persist toggle's `up` focusProperty pointed to `firstCenterFocusRequester` which resolved to itself when center mix was unavailable.
6. **#3056** - `updateMediaSessionMetadata()` silently skipped when `currentMediaItem` was null during initial player setup. Now sets a placeholder MediaItem with metadata.

## Issue or approval

Fixes #3057, #3095, #3077, #3125, #2957. Partial fix for #3056.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Each fix is isolated to the minimal change required.
- No refactors, formatting, or drive-by changes.
- #3056 is a partial fix (ExoPlayer path only); MPV MediaSession requires larger architecture work.

## Testing

- #3057: Verified `tmdbToImdb(70793, "movie")` and `tmdbToImdb(70793, "tv")` return independent results.
- #3095: Verified Left from recent search goes to sidebar with Discover button visible.
- #3077: Verified "id" code displays "Indonesia" instead of "Melayu".
- #3125: Verified pause overlay does not appear while subtitle delay overlay is active.
- #2957: Verified Up from persist toggle moves focus to amplification controls when center mix is unavailable.
- #3056: Verified MediaSession metadata is set on initial player build even when no MediaItem exists yet.
- Tested on TCL Android TV

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3057, #3095, #3077, #3125, #2957
Partial fix for #3056
