### PR TITLE
fix(Library): Library Search Jitter and Focus Trap

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.focusable
@@ -47,14 +48,18 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -69,9 +74,11 @@ import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Border
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import com.nuvio.tv.core.cloud.CloudLibraryFile
 import com.nuvio.tv.core.cloud.CloudLibraryItem
@@ -752,19 +759,10 @@ private fun CloudLibraryItemType.localizedLabel(): String =
         CloudLibraryItemType.File -> stringResource(R.string.cloud_library_type_files)
     }
 
-private fun isCloudSearchSelectKey(keyCode: Int): Boolean {
-    return keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
-        keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
-        keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
-}
-
 /**
  * Free-text filter over the already-loaded cloud library. Purely local: it never triggers a
  * provider request, it just narrows [LibraryUiState.visibleCloudItems]. Filtering is applied on
  * every keystroke, so results narrow live as you type.
- *
- * Follows the same D-pad text-entry pattern as the list editor dialog: the field stays read-only
- * until SELECT is pressed, so arrow keys keep navigating the grid instead of moving a caret.
  */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -774,49 +772,101 @@ private fun CloudLibrarySearchRow(
 ) {
     var editing by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+    val fieldFocusRequester = remember { FocusRequester() }
+    val editorFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(editing) {
+        if (editing) {
+            editorFocusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
 
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
         verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
     ) {
-        androidx.compose.material3.OutlinedTextField(
-            value = query,
-            onValueChange = onQueryChange,
+        Surface(
+            onClick = { editing = true },
             modifier = Modifier
                 .weight(1f)
-                .onFocusChanged { if (!it.isFocused) editing = false }
-                .onPreviewKeyEvent { event ->
-                    val native = event.nativeKeyEvent
-                    if (native.action == AndroidKeyEvent.ACTION_DOWN && isCloudSearchSelectKey(native.keyCode)) {
-                        editing = true
-                        keyboardController?.show()
-                    }
-                    false
-                },
-            readOnly = !editing,
-            singleLine = true,
-            maxLines = 1,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(
-                onDone = {
-                    editing = false
-                    keyboardController?.hide()
-                }
+                .focusRequester(fieldFocusRequester),
+            colors = ClickableSurfaceDefaults.colors(
+                containerColor = NuvioTheme.colors.BackgroundCard,
+                focusedContainerColor = NuvioTheme.colors.BackgroundCard
             ),
-            label = { androidx.compose.material3.Text(stringResource(R.string.cloud_library_search_label)) },
-            colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
-                focusedTextColor = NuvioTheme.colors.TextPrimary,
-                unfocusedTextColor = NuvioTheme.colors.TextPrimary,
-                focusedContainerColor = NuvioTheme.colors.BackgroundCard,
-                unfocusedContainerColor = NuvioTheme.colors.BackgroundCard,
-                focusedBorderColor = NuvioTheme.colors.FocusRing,
-                unfocusedBorderColor = NuvioTheme.colors.Border,
-                focusedLabelColor = NuvioTheme.colors.TextSecondary,
-                unfocusedLabelColor = NuvioTheme.colors.TextTertiary,
-                cursorColor = NuvioTheme.colors.FocusRing
+            border = ClickableSurfaceDefaults.border(
+                border = Border(
+                    border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
+                    shape = RoundedCornerShape(NuvioTheme.radii.md)
+                ),
+                focusedBorder = Border(
+                    border = NuvioTheme.focusRing.border(NuvioTheme.spacing.xxs),
+                    shape = RoundedCornerShape(NuvioTheme.radii.md)
+                )
+            ),
+            shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md)),
+            scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
+        ) {
+            BasicTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = NuvioTheme.spacing.lg, vertical = 14.dp)
+                    .focusRequester(editorFocusRequester)
+                    .focusProperties { canFocus = editing }
+                    .onFocusChanged {
+                        if (!it.isFocused && editing) {
+                            editing = false
+                            keyboardController?.hide()
+                        }
+                    }
+                    .onPreviewKeyEvent { event ->
+                        val native = event.nativeKeyEvent
+                        if (native.action != AndroidKeyEvent.ACTION_DOWN) {
+                            return@onPreviewKeyEvent false
+                        }
+                        val direction = when (native.keyCode) {
+                            AndroidKeyEvent.KEYCODE_DPAD_UP -> FocusDirection.Up
+                            AndroidKeyEvent.KEYCODE_DPAD_DOWN -> FocusDirection.Down
+                            else -> return@onPreviewKeyEvent false
+                        }
+                        editing = false
+                        keyboardController?.hide()
+                        focusManager.moveFocus(direction)
+                        true
+                    },
+                readOnly = !editing,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        editing = false
+                        keyboardController?.hide()
+                        fieldFocusRequester.requestFocus()
+                    }
+                ),
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    color = NuvioTheme.colors.TextPrimary
+                ),
+                cursorBrush = SolidColor(
+                    if (editing) NuvioTheme.colors.FocusRing else Color.Transparent
+                ),
+                decorationBox = { innerTextField ->
+                    if (query.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.cloud_library_search_label),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = NuvioTheme.colors.TextTertiary
+                        )
+                    }
+                    innerTextField()
+                }
             )
-        )
+        }
 
         if (query.isNotEmpty()) {
             Button(


### PR DESCRIPTION
## Summary

Fixes Cloud Library search jitter and a D pad focus trap on affected Android TV and Google TV devices. The inactive search field now uses a stable TV focus target and only hands focus to the text editor after Select is pressed. Up or Down exits text entry, hides the keyboard, and returns navigation to the surrounding Library screen.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The Material text field could consume remote navigation and repeatedly request that its cursor be brought into view. This made the Library page shift while the search row was focused, and on some Google TV devices it trapped users in the editor so visible Cloud Library results could not be selected.

## Issue or approval

Fixes #3173

Original user report: https://www.reddit.com/r/Nuvio/comments/1vw4i5c/help_google_os/

## Reproduction steps

1. Open Library.
2. Switch to Cloud.
3. Focus Search Cloud Library.
4. Enter a query or press Down toward a result.
5. On affected devices, observe the page jitter or focus remaining trapped in the search editor.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes the existing Cloud Library search row and its focus lifecycle. Search remains local and filters the already loaded Cloud Library items as text changes. Cloud providers, refresh behavior, catalogs, playback, and other Library screens are unchanged. No new feature or visual polish is included.

## Testing

- Built and installed the full debug variant on an NVIDIA Shield TV.
- Confirmed the search row no longer jitters when focused.
- Confirmed Select still opens text entry and live filtering still updates results.
- Confirmed Up and Down leave text entry and return D pad navigation to the screen.
- Confirmed the Clear action still clears the query.
- Ran `./gradlew :app:compileFullDebugKotlin` successfully.
- Ran `git diff --check` successfully.

The project does not currently define a Detekt Gradle task.

## Screenshots / Video

No layout redesign. The external report documenting the affected flow is linked here: https://www.reddit.com/r/Nuvio/comments/1vw4i5c/help_google_os/

## Breaking changes

None.

## Linked issues

Fixes #3173