### PR TITLE
fix(player): restore source picker selection after internal playback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -470,6 +470,10 @@ fun NuvioNavHost(
             )
         ) { backStackEntry ->
             val streamArgs = backStackEntry.arguments
+            val streamSavedState = backStackEntry.savedStateHandle
+            val restoreSourceSelection by streamSavedState.getStateFlow(
+                SOURCE_SELECTION_RESTORE_STATE_KEY, false
+            ).collectAsState()
             val returnToDetailOnBack = streamArgs
                 ?.getString("returnToDetailOnBack")
                 ?.toBooleanStrictOrNull() == true
@@ -481,6 +485,10 @@ fun NuvioNavHost(
                 ?.toBooleanStrictOrNull() == true
             StreamScreen(
                 startFromBeginning = startFromBeginning,
+                restoreSourceSelection = restoreSourceSelection,
+                onSourceSelectionRestoreHandled = {
+                    streamSavedState[SOURCE_SELECTION_RESTORE_STATE_KEY] = false
+                },
                 onBackPress = {
                     val streamContentType = streamArgs?.getString("contentType").orEmpty()
                     val streamContentId = streamArgs?.getString("contentId").orEmpty()
@@ -739,6 +747,23 @@ fun NuvioNavHost(
                 }
             )
         ) { backStackEntry ->
+            fun popBackToStream(): Boolean {
+                val autoPlayNavigation = backStackEntry.arguments
+                    ?.getString("autoPlayNav")
+                    ?.toBooleanStrictOrNull() == true
+                val restoreEntry = navController.previousBackStackEntry?.takeIf { previousEntry ->
+                    shouldArmSourceSelectionRestore(
+                        autoPlayNavigation = autoPlayNavigation,
+                        previousRoute = previousEntry.destination.route
+                    )
+                }
+                val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
+                if (returnedToStream && restoreEntry != null) {
+                    restoreEntry.savedStateHandle[SOURCE_SELECTION_RESTORE_STATE_KEY] = true
+                }
+                return returnedToStream
+            }
+
             PlayerScreen(
                 onBackPress = { currentVideoId, currentSeason, currentEpisode, autoPlayEnabled, playbackCompleted ->
                     val args = backStackEntry.arguments
@@ -829,7 +854,7 @@ fun NuvioNavHost(
                             if (skipStreamScreen) {
                                 returnToDetail()
                             } else {
-                                val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
+                                val returnedToStream = popBackToStream()
                                 if (!returnedToStream) {
                                     if (returnToDetailOnBack && contentType.equals("series", ignoreCase = true) && contentId.isNotBlank()) {
                                         returnToDetail()
@@ -952,7 +977,7 @@ fun NuvioNavHost(
                     }
                 },
                 onPlaybackErrorBack = {
-                    val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
+                    val returnedToStream = popBackToStream()
                     if (!returnedToStream) {
                         val args = backStackEntry.arguments
                         val videoId = args?.getString("videoId").orEmpty()

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/SourceSelectionRestorePolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/SourceSelectionRestorePolicy.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.ui.navigation
+
+internal const val SOURCE_SELECTION_RESTORE_STATE_KEY = "restoreSourceSelection"
+
+internal fun shouldArmSourceSelectionRestore(
+    autoPlayNavigation: Boolean,
+    previousRoute: String?
+): Boolean {
+    return !autoPlayNavigation && previousRoute.orEmpty().startsWith("stream/")
+}
+
+internal fun sourceSelectionRestoreTarget(
+    focusedStreamIndex: Int,
+    streamCount: Int
+): Int? {
+    if (streamCount <= 0) return null
+    return focusedStreamIndex.coerceIn(0, streamCount - 1)
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -94,6 +94,7 @@ import com.nuvio.tv.ui.components.StreamsSkeletonList
 import com.nuvio.tv.ui.screens.player.LoadingOverlay
 import com.nuvio.tv.ui.screens.player.AddonFilterChips
 import com.nuvio.tv.ui.theme.NuvioTheme
+import com.nuvio.tv.ui.navigation.sourceSelectionRestoreTarget
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.delay as coroutineDelay
@@ -111,6 +112,8 @@ import android.util.Log
 fun StreamScreen(
     viewModel: StreamScreenViewModel = hiltViewModel(),
     startFromBeginning: Boolean = false,
+    restoreSourceSelection: Boolean = false,
+    onSourceSelectionRestoreHandled: () -> Unit = {},
     onBackPress: () -> Unit,
     onStreamSelected: (StreamPlaybackInfo) -> Unit,
     onAutoPlayResolved: (StreamPlaybackInfo) -> Unit
@@ -133,6 +136,13 @@ fun StreamScreen(
         initialValue = StreamBadgeSettings()
     )
     val scope = rememberCoroutineScope()
+
+    LaunchedEffect(restoreSourceSelection) {
+        if (restoreSourceSelection) {
+            pendingRestoreOnResume = false
+            restoreFocusedStream = true
+        }
+    }
 
     fun launchExternalPlayer(playbackInfo: StreamPlaybackInfo) {
         val url = playbackInfo.url ?: if (playbackInfo.isTorrent) "torrent://${playbackInfo.infoHash}" else return
@@ -444,7 +454,12 @@ fun StreamScreen(
                     },
                     focusedStreamIndex = focusedStreamIndex,
                     shouldRestoreFocusedStream = restoreFocusedStream,
-                    onRestoreFocusedStreamHandled = { restoreFocusedStream = false },
+                    onRestoreFocusedStreamHandled = {
+                        restoreFocusedStream = false
+                        if (restoreSourceSelection) {
+                            onSourceSelectionRestoreHandled()
+                        }
+                    },
                     onRetry = { viewModel.onEvent(StreamScreenEvent.OnRetry) },
                     modifier = Modifier
                         .weight(0.6f)
@@ -1024,12 +1039,15 @@ private fun StreamsList(
 
     LaunchedEffect(shouldRestoreFocusedStream, focusedStreamIndex, streams.size) {
         if (!shouldRestoreFocusedStream) return@LaunchedEffect
-        if (streams.isEmpty()) {
+        val targetIndex = sourceSelectionRestoreTarget(focusedStreamIndex, streams.size)
+        if (targetIndex == null) {
             onRestoreFocusedStreamHandled()
             return@LaunchedEffect
         }
         repeat(2) { withFrameNanos { } }
         try {
+            streamListState.scrollToItem(targetIndex)
+            withFrameNanos { }
             restoreFocusRequester.requestFocus()
         } catch (_: Exception) {
         }

--- a/app/src/test/java/com/nuvio/tv/ui/navigation/SourceSelectionRestorePolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/navigation/SourceSelectionRestorePolicyTest.kt
@@ -1,0 +1,49 @@
+package com.nuvio.tv.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SourceSelectionRestorePolicyTest {
+    @Test
+    fun `manual player return from stream arms restoration`() {
+        assertTrue(
+            shouldArmSourceSelectionRestore(
+                autoPlayNavigation = false,
+                previousRoute = "stream/{videoId}/{contentType}/{title}"
+            )
+        )
+    }
+
+    @Test
+    fun `autoplay and non-stream returns do not arm restoration`() {
+        assertFalse(
+            shouldArmSourceSelectionRestore(
+                autoPlayNavigation = true,
+                previousRoute = "stream/{videoId}/{contentType}/{title}"
+            )
+        )
+        assertFalse(
+            shouldArmSourceSelectionRestore(
+                autoPlayNavigation = false,
+                previousRoute = "detail/{itemId}/{itemType}"
+            )
+        )
+        assertFalse(
+            shouldArmSourceSelectionRestore(
+                autoPlayNavigation = false,
+                previousRoute = null
+            )
+        )
+    }
+
+    @Test
+    fun `restore target is clamped to the current stream list`() {
+        assertEquals(0, sourceSelectionRestoreTarget(-1, 10))
+        assertEquals(4, sourceSelectionRestoreTarget(4, 10))
+        assertEquals(9, sourceSelectionRestoreTarget(40, 10))
+        assertNull(sourceSelectionRestoreTarget(4, 0))
+    }
+}


### PR DESCRIPTION
## Summary

Restore the source picker to the source the user opened when returning from Nuvio's internal player.

The existing selected index is kept for the current source screen. On return, the list scrolls that source into view before restoring focus. The restoration is one-shot and is cleared after it is handled.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Fixes the source-selection focus bug documented in #3183.

Users usually return from the player to the source list because they want to try another source, such as a different quality, provider, audio option, or a source that works better.

Before this fix, returning from the internal player reset the list to the top and focused the first result. With a long source list, users had to repeatedly scroll back to the source they had just played before they could try a nearby alternative.

Source selection is part of the core playback flow, and this behavior made changing sources unnecessarily frustrating and time-consuming.

## Issue or approval

Fixes #3183

## Reproduction steps

1. Open a movie or episode and let its source results load.
2. Scroll down and select a source other than the first result.
3. Open that source with Nuvio's internal player.
4. After playback starts, press Back to return to the source picker.
5. Before this fix, the picker returns to the top and focuses the first source.
6. After this fix, the source that was opened is visible and focused.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Applies only when returning directly from a manually selected source in the internal player.
- Auto-play navigation is unchanged.
- Existing external-player restoration remains unchanged.
- Player exits that return to the detail screen or advance to another episode do not request source restoration.
- Source reloads and addon-filter changes retain their existing behavior.
- The saved index is clamped if the source list changes while playback is open.
- No source URLs, headers, provider results, content IDs, or cross-title source history are stored.
- No UI, settings, dependencies, schemas, or unrelated playback behavior are changed.

## Testing

- Ran the focused policy tests:

  `.\gradlew.bat :app:testFullDebugUnitTest --tests com.nuvio.tv.ui.navigation.SourceSelectionRestorePolicyTest --no-daemon`

  Result: 3 tests passed with no failures or skips.

- Built the full debug APK:

  `.\gradlew.bat :app:assembleFullDebug --no-daemon`

  Result: `BUILD SUCCESSFUL`.

- Installed the x86_64 debug APK side-by-side on an Android TV emulator:
  - AVD: `Television_4K`
  - Device model: `sdk_google_atv64_x86_64`
  - Android 16 / API 36
  - Package: `com.nuviodebug.com`

- Confirmed the app installed, launched, and remained running without a fatal startup exception.
- User-tested the source-return flow on the emulator.
- Ran `git diff --check` successfully.

- The full local unit suite was also attempted:
  - 965 tests executed
  - 951 passed
  - 1 skipped
  - 13 failed in unrelated networking, allocator, Dolby Vision, Matroska, sync, collections, airing-rule, and performance tests
  - The new source-selection tests remained green, and none of the failures referenced the changed files.

## Screenshots / Video

Screenshots added in [comment below](https://github.com/NuvioMedia/NuvioTV/pull/3184#issuecomment-5404097581)

## Breaking changes

None.

## Linked issues

Fixes #3183