### PR TITLE
fix(network): don't mark 304 and redirect responses no-store

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -128,7 +128,7 @@ object NetworkModule {
             // Prevent OkHttp from caching error responses (4xx/5xx).
             .addNetworkInterceptor { chain ->
                 val response = chain.proceed(chain.request())
-                if (!response.isSuccessful) {
+                if (response.code in 400..599) {
                     response.newBuilder()
                         .header("Cache-Control", "no-store")
                         .build()


### PR DESCRIPTION
## Summary

The cache interceptor tests `!response.isSuccessful`, which is true for anything outside
200-299, so `304 Not Modified` and 3xx redirects were stamped `Cache-Control: no-store`
alongside the 4xx/5xx responses its comment describes. One line, narrowing the test to
`400..599`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

It runs as a **network** interceptor, so it sees the raw 304 before OkHttp merges it with the
stored entry. Marking that 304 no-store means the entry cannot be reused, and the body is
downloaded again right after the server confirmed the cached copy was still current. HTTP
revalidation is therefore defeated for every response that carries a validator.

The client is shared by every Retrofit instance, so this covers addon catalogs and metadata,
TMDB, the GitHub release check, IntroDB, AniSkip and the subtitle cache. Image loading has its
own client and is not affected.

Measured against the endpoints the app actually calls:

| Upstream | Headers | Body vs 304 |
|---|---|---|
| AIOMetadata | `no-cache, must-revalidate` + `ETag` | 91,071 bytes vs 0 — it asks to be revalidated on every request |
| Cinemeta | `Last-Modified`, and a `307` carrying `max-age=10800` | 134,272 bytes vs 0, plus a redirect that is re-issued every time and accounts for ~70% of the request time (165 ms of 239 ms) |
| GitHub releases | `max-age=60` + `ETag` | 12,356 bytes vs 0 on every update check |
| TMDB `/movie/{id}` | `max-age=300`, no validator | unaffected, there is no 304 to break |

## Issue or approval

No linked issue: found while profiling catalog requests. The interceptor's own commit message
(dc85ba93, "Don't cache failed requests") and its code comment ("4xx/5xx") both state the
intent that the predicate does not match. Happy to open an issue first if preferred.

## Reproduction steps

1. Launch the app so the GitHub release check runs and its response is cached.
2. Wait for the entry to go stale (`max-age=60`).
3. Trigger the check again and inspect the request.

Expected: a conditional request answered with `304` and no body.
Actual: the 304 arrives, is stamped `no-store`, and the full 12 KB body is downloaded again.

The same is observable on any addon that sends an `ETag` or `Last-Modified`, and can be
confirmed outside the app:

```
curl -sI https://api.github.com/repos/NuvioMedia/NuvioTV/releases/latest   # note the ETag
curl -s -o /dev/null -w '%{http_code} %{size_download}\n' \
     -H 'If-None-Match: <etag>' https://api.github.com/repos/NuvioMedia/NuvioTV/releases/latest
# 304 0
```

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

Cached responses are reused after a 304 instead of being re-downloaded. Content shown to the
user is identical; only the number of bytes transferred changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the predicate changes. The interceptor keeps its position in the chain, error responses
are still kept out of the cache, and no cache configuration, header injection or request
policy is touched. No UI polish or behavior tweaks are bundled in.

## Testing

Built `fullDebug` and ran it on a TCL Google TV (Android 12, `armeabi-v7a`) with Cinemeta,
AIOMetadata and two other addons installed.

- Catalog requests: verified through logcat that responses come back revalidated rather than
  re-downloaded after their `max-age` elapses.
- Verified the upstream side with `curl`: AIOMetadata and GitHub answer `If-None-Match` with
  `304` and no body; Cinemeta answers `If-Modified-Since` the same way.
- Checked error responses are still excluded: 4xx and 5xx continue to be marked `no-store`.
- Home, search, detail and playback exercised manually with no visible change.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - see "Issue or approval" above.
